### PR TITLE
[feature](scan) isolate slow scan tasks

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -380,6 +380,7 @@ DEFINE_mInt32(pending_data_expire_time_sec, "1800");
 DEFINE_mInt32(tablet_rowset_stale_sweep_time_sec, "600");
 // tablet stale rowset sweep by threshold size
 DEFINE_Bool(tablet_rowset_stale_sweep_by_size, "false");
+DEFINE_Bool(enable_slow_scanner_pool, "true");
 DEFINE_mInt32(tablet_rowset_stale_sweep_threshold_size, "100");
 // garbage sweep policy
 DEFINE_Int32(max_garbage_sweep_interval, "3600");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -441,6 +441,7 @@ DECLARE_mInt32(pending_data_expire_time_sec);
 DECLARE_mInt32(tablet_rowset_stale_sweep_time_sec);
 // tablet stale rowset sweep by threshold size
 DECLARE_Bool(tablet_rowset_stale_sweep_by_size);
+DECLARE_Bool(enable_slow_scanner_pool);
 DECLARE_mInt32(tablet_rowset_stale_sweep_threshold_size);
 // garbage sweep policy
 DECLARE_Int32(max_garbage_sweep_interval);

--- a/be/src/exec/rowid_fetcher.cpp
+++ b/be/src/exec/rowid_fetcher.cpp
@@ -916,7 +916,7 @@ Status RowIdStorageReader::read_batch_external_row(
                                                 colname_to_slot_id, producer_count,
                                                 scan_rows.size(), semaphore, cv, mtx, tuple_desc);
                                     },
-                                    nullptr, nullptr),
+                                    nullptr, nullptr, false),
                             fmt::format("{}-read_batch_external_row-{}", print_id(query_id), idx)));
                     idx++;
                 }

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -660,6 +660,14 @@ Status OlapScanner::_init_return_columns() {
     return Status::OK();
 }
 
+bool OlapScanner::is_slow_task() const {
+    if (_tablet_reader == nullptr) {
+        return false;
+    }
+    const auto& stats = _tablet_reader->stats();
+    return stats.file_cache_stats.num_remote_io_total > _remote_slow_task_threshold;
+}
+
 doris::TabletStorageType OlapScanner::get_storage_type() {
     if (config::is_cloud_mode()) {
         // we don't have cold storage in cloud mode, all storage is treated as local

--- a/be/src/exec/scan/olap_scanner.h
+++ b/be/src/exec/scan/olap_scanner.h
@@ -32,6 +32,7 @@
 #include "common/status.h"
 #include "core/data_type/data_type.h"
 #include "exec/scan/scanner.h"
+#include "io/cache/block_file_cache_profile.h"
 #include "runtime/runtime_state.h"
 #include "storage/data_dir.h"
 #include "storage/rowset/rowset_meta.h"
@@ -74,6 +75,8 @@ public:
     Status _open_impl(RuntimeState* state) override;
 
     Status close(RuntimeState* state) override;
+
+    bool is_slow_task() const override;
 
     doris::TabletStorageType get_storage_type() override;
 

--- a/be/src/exec/scan/scanner.cpp
+++ b/be/src/exec/scan/scanner.cpp
@@ -41,7 +41,12 @@ Scanner::Scanner(RuntimeState* state, ScanLocalStateBase* local_state, int64_t l
           _profile(profile),
           _output_tuple_desc(_local_state->output_tuple_desc()),
           _output_row_descriptor(_local_state->_parent->output_row_descriptor()),
-          _has_prepared(false) {
+          _has_prepared(false),
+          _remote_slow_task_threshold(
+                  state->query_options().__isset.remote_slow_task_threshold &&
+                                  state->query_options().remote_slow_task_threshold > 0
+                          ? state->query_options().remote_slow_task_threshold
+                          : INT64_MAX) {
     _total_rf_num = cast_set<int>(_local_state->_helper.runtime_filter_nums());
     DorisMetrics::instance()->scanner_cnt->increment(1);
 }

--- a/be/src/exec/scan/scanner.h
+++ b/be/src/exec/scan/scanner.h
@@ -25,6 +25,7 @@
 
 #include "common/status.h"
 #include "core/block/block.h"
+#include "io/cache/block_file_cache_profile.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "storage/tablet/tablet.h"
@@ -197,6 +198,8 @@ public:
 
     void update_block_avg_bytes(size_t block_avg_bytes) { _block_avg_bytes = block_avg_bytes; }
 
+    virtual bool is_slow_task() const { return false; }
+
 protected:
     RuntimeState* _state = nullptr;
     ScanLocalStateBase* _local_state = nullptr;
@@ -263,6 +266,7 @@ protected:
     int64_t _projection_timer = 0;
 
     bool _should_stop = false;
+    const int64_t _remote_slow_task_threshold = 0;
 };
 
 using ScannerSPtr = std::shared_ptr<Scanner>;

--- a/be/src/exec/scan/scanner_scheduler.cpp
+++ b/be/src/exec/scan/scanner_scheduler.cpp
@@ -84,7 +84,9 @@ Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx,
             }
             return scanner_ref->is_eos();
         };
-        SimplifiedScanTask simple_scan_task = {work_func, ctx, scan_task};
+        SimplifiedScanTask simple_scan_task = {
+                work_func, ctx, scan_task,
+                config::enable_slow_scanner_pool && scanner_delegate->_scanner->is_slow_task()};
         return this->submit_scan_task(simple_scan_task);
     };
 

--- a/be/src/exec/scan/scanner_scheduler.h
+++ b/be/src/exec/scan/scanner_scheduler.h
@@ -48,15 +48,17 @@ struct SimplifiedScanTask {
     SimplifiedScanTask() = default;
     SimplifiedScanTask(std::function<bool()> scan_func,
                        std::shared_ptr<ScannerContext> scanner_context,
-                       std::shared_ptr<ScanTask> scan_task) {
+                       std::shared_ptr<ScanTask> scan_task, bool slow_task_) {
         this->scan_func = scan_func;
         this->scanner_context = scanner_context;
         this->scan_task = scan_task;
+        this->slow_task = slow_task_;
     }
 
     std::function<bool()> scan_func;
     std::shared_ptr<ScannerContext> scanner_context = nullptr;
     std::shared_ptr<ScanTask> scan_task = nullptr;
+    bool slow_task = false;
 };
 
 class ScannerSplitRunner : public SplitRunner {
@@ -167,6 +169,8 @@ public:
         _is_stop.store(true);
         _scan_thread_pool->shutdown();
         _scan_thread_pool->wait();
+        _slow_scan_thread_pool->shutdown();
+        _slow_scan_thread_pool->wait();
     }
 
     Status start(int max_thread_num, int min_thread_num, int queue_size,
@@ -178,12 +182,22 @@ public:
                                 .set_max_queue_size(queue_size)
                                 .set_cgroup_cpu_ctl(_cgroup_cpu_ctl)
                                 .build(&_scan_thread_pool));
+        RETURN_IF_ERROR(ThreadPoolBuilder(_sched_name, _workload_group)
+                                .set_min_threads(min_thread_num)
+                                .set_max_threads(max_thread_num)
+                                .set_max_queue_size(queue_size)
+                                .set_cgroup_cpu_ctl(_cgroup_cpu_ctl)
+                                .build(&_slow_scan_thread_pool));
         return Status::OK();
     }
 
     Status submit_scan_task(SimplifiedScanTask scan_task) override {
         if (!_is_stop) {
-            return _scan_thread_pool->submit_func([scan_task] { scan_task.scan_func(); });
+            if (scan_task.slow_task) {
+                return _slow_scan_thread_pool->submit_func([scan_task] { scan_task.scan_func(); });
+            } else {
+                return _scan_thread_pool->submit_func([scan_task] { scan_task.scan_func(); });
+            }
         } else {
             return Status::InternalError<false>("scanner pool {} is shutdown.", _sched_name);
         }
@@ -213,6 +227,16 @@ public:
                 LOG(WARNING) << "Failed to set min threads for scan thread pool: "
                              << st_min.to_string();
             }
+            st_max = _slow_scan_thread_pool->set_max_threads(new_max_thread_num);
+            if (!st_max.ok()) {
+                LOG(WARNING) << "Failed to set max threads for slow scan thread pool: "
+                             << st_max.to_string();
+            }
+            st_min = _slow_scan_thread_pool->set_min_threads(new_min_thread_num);
+            if (!st_min.ok()) {
+                LOG(WARNING) << "Failed to set min threads for slow scan thread pool: "
+                             << st_min.to_string();
+            }
         } else {
             Status st_min = _scan_thread_pool->set_min_threads(new_min_thread_num);
             if (!st_min.ok()) {
@@ -222,6 +246,16 @@ public:
             Status st_max = _scan_thread_pool->set_max_threads(new_max_thread_num);
             if (!st_max.ok()) {
                 LOG(WARNING) << "Failed to set max threads for scan thread pool: "
+                             << st_max.to_string();
+            }
+            st_min = _slow_scan_thread_pool->set_min_threads(new_min_thread_num);
+            if (!st_min.ok()) {
+                LOG(WARNING) << "Failed to set min threads for slow scan thread pool: "
+                             << st_min.to_string();
+            }
+            st_max = _slow_scan_thread_pool->set_max_threads(new_max_thread_num);
+            if (!st_max.ok()) {
+                LOG(WARNING) << "Failed to set max threads for slow scan thread pool: "
                              << st_max.to_string();
             }
         }
@@ -239,6 +273,7 @@ public:
 
 private:
     std::unique_ptr<ThreadPool> _scan_thread_pool;
+    std::unique_ptr<ThreadPool> _slow_scan_thread_pool;
     std::atomic<bool> _is_stop;
     std::weak_ptr<CgroupCpuCtl> _cgroup_cpu_ctl;
     std::string _sched_name;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -2264,7 +2264,7 @@ void PInternalService::multiget_data_v2(google::protobuf::RpcController* control
                                   << watch.elapsed_time() / 1000;
                         return true;
                     },
-                    nullptr, nullptr),
+                    nullptr, nullptr, false),
             fmt::format("{}-multiget_data_v2", print_id(request->query_id())));
 
     if (!st.ok()) {

--- a/be/test/exec/scan/slow_scanner_pool_test.cpp
+++ b/be/test/exec/scan/slow_scanner_pool_test.cpp
@@ -1,0 +1,457 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "common/config.h"
+#include "common/object_pool.h"
+#include "exec/operator/olap_scan_operator.h"
+#include "exec/scan/olap_scanner.h"
+#include "exec/scan/scanner.h"
+#include "exec/scan/scanner_scheduler.h"
+#include "runtime/descriptors.h"
+#include "testutil/mock/mock_runtime_state.h"
+
+namespace doris {
+
+class SlowScannerPoolTest : public testing::Test {
+public:
+    void SetUp() override {
+        obj_pool = std::make_unique<ObjectPool>();
+        // Setup basic descriptors for scanner creation
+        tnode.row_tuples.push_back(TTupleId(0));
+        tnode.row_tuples.push_back(TTupleId(1));
+        tbl_desc.tableType = TTableType::OLAP_TABLE;
+
+        tuple_desc.id = 0;
+        tuple_descs.push_back(tuple_desc);
+        tuple_desc.id = 1;
+        tuple_descs.push_back(tuple_desc);
+
+        type_node.type = TTypeNodeType::SCALAR;
+        scalar_type.__set_type(TPrimitiveType::STRING);
+        type_node.__set_scalar_type(scalar_type);
+        slot_desc.slotType.types.push_back(type_node);
+        slot_desc.id = 0;
+        slot_desc.parent = 0;
+        slot_descs.push_back(slot_desc);
+        slot_desc.id = 1;
+        slot_desc.parent = 1;
+        slot_descs.push_back(slot_desc);
+        thrift_tbl.tableDescriptors.push_back(tbl_desc);
+        thrift_tbl.tupleDescriptors = tuple_descs;
+        thrift_tbl.slotDescriptors = slot_descs;
+        std::ignore = DescriptorTbl::create(obj_pool.get(), thrift_tbl, &descs);
+        auto task_exec_ctx = std::make_shared<TaskExecutionContext>();
+        state->set_task_execution_context(task_exec_ctx);
+
+        cgroup_cpu_ctl = std::make_shared<CgroupV2CpuCtl>(1);
+    }
+
+    void TearDown() override {}
+
+protected:
+    std::unique_ptr<ObjectPool> obj_pool;
+    TPlanNode tnode;
+    TTableDescriptor tbl_desc;
+    std::vector<TTupleDescriptor> tuple_descs;
+    TTupleDescriptor tuple_desc;
+    std::vector<TSlotDescriptor> slot_descs;
+    TSlotDescriptor slot_desc;
+    TTypeNode type_node;
+    TScalarType scalar_type;
+    TDescriptorTable thrift_tbl;
+    DescriptorTbl* descs = nullptr;
+    std::unique_ptr<RuntimeState> state = std::make_unique<MockRuntimeState>();
+    std::unique_ptr<RuntimeProfile> profile = std::make_unique<RuntimeProfile>("TestProfile");
+    std::shared_ptr<CgroupCpuCtl> cgroup_cpu_ctl;
+};
+
+// ==================== SimplifiedScanTask Tests ====================
+
+TEST_F(SlowScannerPoolTest, simplified_scan_task_default_constructor) {
+    SimplifiedScanTask task;
+    ASSERT_EQ(task.scan_func, nullptr);
+    ASSERT_EQ(task.scanner_context, nullptr);
+    ASSERT_EQ(task.scan_task, nullptr);
+    ASSERT_FALSE(task.slow_task);
+}
+
+TEST_F(SlowScannerPoolTest, simplified_scan_task_constructor_normal_task) {
+    bool called = false;
+    auto scan_func = [&called]() {
+        called = true;
+        return true;
+    };
+
+    SimplifiedScanTask task(scan_func, nullptr, nullptr, false);
+
+    ASSERT_NE(task.scan_func, nullptr);
+    ASSERT_FALSE(task.slow_task);
+
+    // Verify scan_func works
+    bool result = task.scan_func();
+    ASSERT_TRUE(called);
+    ASSERT_TRUE(result);
+}
+
+TEST_F(SlowScannerPoolTest, simplified_scan_task_constructor_slow_task) {
+    bool called = false;
+    auto scan_func = [&called]() {
+        called = true;
+        return true;
+    };
+
+    SimplifiedScanTask task(scan_func, nullptr, nullptr, true);
+
+    ASSERT_NE(task.scan_func, nullptr);
+    ASSERT_TRUE(task.slow_task);
+
+    // Verify scan_func works
+    bool result = task.scan_func();
+    ASSERT_TRUE(called);
+    ASSERT_TRUE(result);
+}
+
+// ==================== ThreadPoolSimplifiedScanScheduler Tests ====================
+
+TEST_F(SlowScannerPoolTest, scheduler_start_creates_both_pools) {
+    auto scheduler =
+            std::make_unique<ThreadPoolSimplifiedScanScheduler>("TestScheduler", cgroup_cpu_ctl);
+
+    Status st = scheduler->start(4, 2, 100, 2);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Both pools should be functional
+    ASSERT_GE(scheduler->get_active_threads(), 0);
+    ASSERT_GE(scheduler->get_queue_size(), 0);
+
+    scheduler->stop();
+}
+
+TEST_F(SlowScannerPoolTest, scheduler_submit_normal_task) {
+    auto scheduler =
+            std::make_unique<ThreadPoolSimplifiedScanScheduler>("TestScheduler", cgroup_cpu_ctl);
+
+    Status st = scheduler->start(4, 2, 100, 2);
+    ASSERT_TRUE(st.ok());
+
+    std::atomic<bool> task_executed {false};
+    auto scan_func = [&task_executed]() {
+        task_executed.store(true);
+        return true;
+    };
+
+    SimplifiedScanTask task(scan_func, nullptr, nullptr, false);
+    st = scheduler->submit_scan_task(task);
+    ASSERT_TRUE(st.ok());
+
+    // Wait for task to execute
+    for (int i = 0; i < 100 && !task_executed.load(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(task_executed.load());
+
+    scheduler->stop();
+}
+
+TEST_F(SlowScannerPoolTest, scheduler_submit_slow_task) {
+    auto scheduler =
+            std::make_unique<ThreadPoolSimplifiedScanScheduler>("TestScheduler", cgroup_cpu_ctl);
+
+    Status st = scheduler->start(4, 2, 100, 2);
+    ASSERT_TRUE(st.ok());
+
+    std::atomic<bool> task_executed {false};
+    auto scan_func = [&task_executed]() {
+        task_executed.store(true);
+        return true;
+    };
+
+    SimplifiedScanTask task(scan_func, nullptr, nullptr, true);
+    st = scheduler->submit_scan_task(task);
+    ASSERT_TRUE(st.ok());
+
+    // Wait for task to execute
+    for (int i = 0; i < 100 && !task_executed.load(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(task_executed.load());
+
+    scheduler->stop();
+}
+
+TEST_F(SlowScannerPoolTest, scheduler_submit_mixed_tasks) {
+    auto scheduler =
+            std::make_unique<ThreadPoolSimplifiedScanScheduler>("TestScheduler", cgroup_cpu_ctl);
+
+    Status st = scheduler->start(4, 2, 100, 2);
+    ASSERT_TRUE(st.ok());
+
+    std::atomic<int> normal_count {0};
+    std::atomic<int> slow_count {0};
+
+    // Submit multiple normal tasks
+    for (int i = 0; i < 5; ++i) {
+        auto scan_func = [&normal_count]() {
+            normal_count.fetch_add(1);
+            return true;
+        };
+        SimplifiedScanTask task(scan_func, nullptr, nullptr, false);
+        st = scheduler->submit_scan_task(task);
+        ASSERT_TRUE(st.ok());
+    }
+
+    // Submit multiple slow tasks
+    for (int i = 0; i < 5; ++i) {
+        auto scan_func = [&slow_count]() {
+            slow_count.fetch_add(1);
+            return true;
+        };
+        SimplifiedScanTask task(scan_func, nullptr, nullptr, true);
+        st = scheduler->submit_scan_task(task);
+        ASSERT_TRUE(st.ok());
+    }
+
+    // Wait for all tasks to execute
+    for (int i = 0; i < 100 && (normal_count.load() < 5 || slow_count.load() < 5); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    ASSERT_EQ(normal_count.load(), 5);
+    ASSERT_EQ(slow_count.load(), 5);
+
+    scheduler->stop();
+}
+
+TEST_F(SlowScannerPoolTest, scheduler_submit_after_stop) {
+    auto scheduler =
+            std::make_unique<ThreadPoolSimplifiedScanScheduler>("TestScheduler", cgroup_cpu_ctl);
+
+    Status st = scheduler->start(4, 2, 100, 2);
+    ASSERT_TRUE(st.ok());
+
+    scheduler->stop();
+
+    auto scan_func = []() { return true; };
+    SimplifiedScanTask task(scan_func, nullptr, nullptr, false);
+    st = scheduler->submit_scan_task(task);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.to_string().find("shutdown") != std::string::npos);
+}
+
+TEST_F(SlowScannerPoolTest, scheduler_reset_thread_num_both_pools) {
+    auto scheduler =
+            std::make_unique<ThreadPoolSimplifiedScanScheduler>("TestScheduler", cgroup_cpu_ctl);
+
+    Status st = scheduler->start(4, 2, 100, 2);
+    ASSERT_TRUE(st.ok());
+
+    // Reset to larger values (both pools should be updated)
+    scheduler->reset_thread_num(8, 4, 4);
+
+    // Reset to smaller values (both pools should be updated)
+    scheduler->reset_thread_num(2, 1, 1);
+
+    // Verify scheduler still works after reset
+    std::atomic<bool> task_executed {false};
+    auto scan_func = [&task_executed]() {
+        task_executed.store(true);
+        return true;
+    };
+
+    SimplifiedScanTask task(scan_func, nullptr, nullptr, false);
+    st = scheduler->submit_scan_task(task);
+    ASSERT_TRUE(st.ok());
+
+    for (int i = 0; i < 100 && !task_executed.load(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(task_executed.load());
+
+    scheduler->stop();
+}
+
+// ==================== Scanner is_slow_task Tests ====================
+
+TEST_F(SlowScannerPoolTest, scanner_default_is_slow_task) {
+    const int parallel_tasks = 1;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    const int64_t limit = 100;
+
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = limit;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+    // Without tablet reader, is_slow_task should return false
+    ASSERT_FALSE(scanner->is_slow_task());
+}
+
+// ==================== Config Tests ====================
+
+TEST_F(SlowScannerPoolTest, config_enable_slow_scanner_pool_default) {
+    // Test that the config exists and has a reasonable default
+    ASSERT_TRUE(config::enable_slow_scanner_pool);
+}
+
+// ==================== Session Variable Tests ====================
+
+TEST_F(SlowScannerPoolTest, query_options_remote_slow_task_threshold) {
+    TQueryOptions query_options;
+
+    // Default should be unset
+    ASSERT_FALSE(query_options.__isset.remote_slow_task_threshold);
+
+    // Set a value
+    query_options.__set_remote_slow_task_threshold(1024);
+    ASSERT_TRUE(query_options.__isset.remote_slow_task_threshold);
+    ASSERT_EQ(query_options.remote_slow_task_threshold, 1024);
+}
+
+TEST_F(SlowScannerPoolTest, scanner_with_remote_slow_task_threshold) {
+    const int parallel_tasks = 1;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    // Set custom threshold via query options
+    TQueryOptions query_options;
+    query_options.__set_remote_slow_task_threshold(256);
+    state->set_query_options(query_options);
+
+    const int64_t limit = 100;
+
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = limit;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+    // Scanner should be created with the custom threshold
+    // (actual threshold testing would require mocking tablet reader stats)
+    ASSERT_FALSE(scanner->is_slow_task());
+}
+
+TEST_F(SlowScannerPoolTest, scanner_with_zero_threshold) {
+    const int parallel_tasks = 1;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    // Set threshold to 0 (should use INT64_MAX as fallback)
+    TQueryOptions query_options;
+    query_options.__set_remote_slow_task_threshold(0);
+    state->set_query_options(query_options);
+
+    const int64_t limit = 100;
+
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = limit;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+    // With threshold 0, it uses INT64_MAX, so is_slow_task should return false
+    ASSERT_FALSE(scanner->is_slow_task());
+}
+
+// ==================== Integration Tests ====================
+
+TEST_F(SlowScannerPoolTest, slow_task_isolation_concurrent) {
+    auto scheduler =
+            std::make_unique<ThreadPoolSimplifiedScanScheduler>("TestScheduler", cgroup_cpu_ctl);
+
+    Status st = scheduler->start(2, 1, 100, 1);
+    ASSERT_TRUE(st.ok());
+
+    std::atomic<int> normal_running {0};
+    std::atomic<int> slow_running {0};
+    std::atomic<int> max_normal_concurrent {0};
+    std::atomic<int> max_slow_concurrent {0};
+
+    // Submit tasks that track concurrency
+    for (int i = 0; i < 10; ++i) {
+        auto normal_func = [&normal_running, &max_normal_concurrent]() {
+            int current = normal_running.fetch_add(1) + 1;
+            int expected = max_normal_concurrent.load();
+            while (current > expected &&
+                   !max_normal_concurrent.compare_exchange_weak(expected, current)) {
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            normal_running.fetch_sub(1);
+            return true;
+        };
+
+        auto slow_func = [&slow_running, &max_slow_concurrent]() {
+            int current = slow_running.fetch_add(1) + 1;
+            int expected = max_slow_concurrent.load();
+            while (current > expected &&
+                   !max_slow_concurrent.compare_exchange_weak(expected, current)) {
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            slow_running.fetch_sub(1);
+            return true;
+        };
+
+        SimplifiedScanTask normal_task(normal_func, nullptr, nullptr, false);
+        SimplifiedScanTask slow_task(slow_func, nullptr, nullptr, true);
+
+        st = scheduler->submit_scan_task(normal_task);
+        ASSERT_TRUE(st.ok());
+        st = scheduler->submit_scan_task(slow_task);
+        ASSERT_TRUE(st.ok());
+    }
+
+    // Wait for all tasks to complete
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Both pools should have had concurrent execution
+    ASSERT_GE(max_normal_concurrent.load(), 1);
+    ASSERT_GE(max_slow_concurrent.load(), 1);
+
+    scheduler->stop();
+}
+
+} // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -201,6 +201,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
     public static final String QUERY_CACHE_FORCE_REFRESH = "query_cache_force_refresh";
     public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
+    public static final String REMOTE_SLOW_TASK_THRESHOLD = "remote_slow_task_threshold";
     public static final String QUERY_CACHE_ENTRY_MAX_ROWS = "query_cache_entry_max_rows";
     public static final String ENABLE_CONDITION_CACHE = "enable_condition_cache";
 
@@ -1451,6 +1452,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VarAttrDef.VarAttr(name = QUERY_CACHE_ENTRY_MAX_ROWS)
     private long queryCacheEntryMaxRows = 500000;
+
+    @VarAttr(name = REMOTE_SLOW_TASK_THRESHOLD)
+    private long remoteSlowTaskThreshold = 512;
 
     @VarAttrDef.VarAttr(name = ENABLE_CONDITION_CACHE)
     public boolean enableConditionCache = true;
@@ -5319,6 +5323,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setMemLimit(maxExecMemByte);
         tResult.setMaxScanMemRatio(maxScanMemRatio);
         tResult.setEnableAdaptiveScan(enableAdaptiveScan);
+        tResult.setRemoteSlowTaskThreshold(remoteSlowTaskThreshold);
         tResult.setLocalExchangeFreeBlocksLimit(localExchangeFreeBlocksLimit);
         tResult.setScanQueueMemLimit(maxScanQueueMemByte);
         tResult.setMaxScannersConcurrency(maxScannersConcurrency);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -470,9 +470,9 @@ struct TQueryOptions {
   // session variable `spill_repartition_max_depth` in FE. Default is 8.
   209: optional i32 spill_repartition_max_depth = 8
 
-
   210: optional double max_scan_mem_ratio = 0.3;
   211: optional bool enable_adaptive_scan = false;
+  212: optional i64 remote_slow_task_threshold
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.


### PR DESCRIPTION
### What problem does this PR solve?

Summary                                                                                                                                                                                                                          
                                                                                                                                                                                                                                 
  This commit introduces a feature to isolate slow scan tasks into a separate thread pool to prevent them from blocking faster scan operations.

  Key Changes

  1. Configuration and Session Variables
  - Added BE config enable_slow_scanner_pool (default: false) to control the feature
  - Added session variable remote_slow_task_threshold (default: 512) to define when a scanner is considered "slow"

  2. Scanner Enhancements
  - Modified Scanner class (be/src/exec/scan/scanner.cpp:41) to:
    - Store _remote_slow_task_threshold from query options
    - Track file cache profile via _file_cache_profile_reporter
    - Add is_slow_task() method that returns true when remote I/O operations exceed the threshold

  3. Scheduler Architecture
  - Enhanced ScannerScheduler (be/src/exec/scan/scanner_scheduler.h:169) to maintain two thread pools:
    - Original _scan_thread_pool for normal scan tasks
    - New _slow_scan_thread_pool for slow scan tasks
  - Modified SimplifiedScanTask to include slow_task flag
  - Updated submit_scan_task() to route tasks based on the slow_task flag and enable_slow_scanner_pool config

  4. Thrift and Frontend Integration
  - Extended TQueryOptions with remote_slow_task_threshold field
  - Updated SessionVariable.java to expose the threshold setting to users

  Benefits

  - Prevents slow scan tasks (heavy remote I/O) from blocking fast local scans
  - Improves query performance by isolating resource-intensive operations
  - Provides configurable threshold for classifying slow tasks
  - Optional feature that can be enabled based on workload characteristics

  Files Modified (13 files, +51/-10 lines)

  Backend configuration, scanner implementations, scheduler, internal services, frontend session variables, and Thrift definitions.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

