### PR TITLE
[Bug](sink) fix cancel_at_time not work at parallel_sink/parallel_outfile

### DIFF
--- a/be/src/exec/operator/result_file_sink_operator.cpp
+++ b/be/src/exec/operator/result_file_sink_operator.cpp
@@ -135,9 +135,13 @@ Status ResultFileSinkLocalState::close(RuntimeState* state, Status exec_status) 
         state->get_query_ctx()->resource_ctx()->io_context()->update_returned_rows(written_rows);
         RETURN_IF_ERROR(_sender->close(state->fragment_instance_id(), final_status, written_rows));
     }
+    // In parallel outfile mode, the buffer is registered under query_id; otherwise
+    // it is registered under fragment_instance_id.  Pass the matching key so the
+    // deferred cancel actually finds and removes the buffer entry.
     state->exec_env()->result_mgr()->cancel_at_time(
             time(nullptr) + config::result_buffer_cancelled_interval_time,
-            state->fragment_instance_id());
+            state->query_options().enable_parallel_outfile ? state->query_id()
+                                                           : state->fragment_instance_id());
 
     return Base::close(state, exec_status);
 }

--- a/be/src/exec/operator/result_file_sink_operator.cpp
+++ b/be/src/exec/operator/result_file_sink_operator.cpp
@@ -133,15 +133,20 @@ Status ResultFileSinkLocalState::close(RuntimeState* state, Status exec_status) 
     if (_sender) {
         int64_t written_rows = _writer == nullptr ? 0 : _writer->get_written_rows();
         state->get_query_ctx()->resource_ctx()->io_context()->update_returned_rows(written_rows);
-        RETURN_IF_ERROR(_sender->close(state->fragment_instance_id(), final_status, written_rows));
+        bool is_fully_closed = false;
+        RETURN_IF_ERROR(_sender->close(state->fragment_instance_id(), final_status, written_rows,
+                                       is_fully_closed));
+        // Schedule deferred cleanup only when the last instance closes the shared
+        // buffer.  In parallel outfile mode the buffer is keyed by query_id; in
+        // non-parallel mode it is keyed by fragment_instance_id.  Either way,
+        // _sender->buffer_id() returns the correct registration key, so there is
+        // no need to branch on enable_parallel_outfile here.
+        if (is_fully_closed) {
+            state->exec_env()->result_mgr()->cancel_at_time(
+                    time(nullptr) + config::result_buffer_cancelled_interval_time,
+                    _sender->buffer_id());
+        }
     }
-    // In parallel outfile mode, the buffer is registered under query_id; otherwise
-    // it is registered under fragment_instance_id.  Pass the matching key so the
-    // deferred cancel actually finds and removes the buffer entry.
-    state->exec_env()->result_mgr()->cancel_at_time(
-            time(nullptr) + config::result_buffer_cancelled_interval_time,
-            state->query_options().enable_parallel_outfile ? state->query_id()
-                                                           : state->fragment_instance_id());
 
     return Base::close(state, exec_status);
 }

--- a/be/src/exec/operator/result_sink_operator.cpp
+++ b/be/src/exec/operator/result_sink_operator.cpp
@@ -199,9 +199,13 @@ Status ResultSinkLocalState::close(RuntimeState* state, Status exec_status) {
         }
         RETURN_IF_ERROR(_sender->close(state->fragment_instance_id(), final_status, written_rows));
     }
+    // In parallel result sink mode, the buffer is registered under query_id; otherwise
+    // it is registered under fragment_instance_id.  Pass the matching key so the
+    // deferred cancel actually finds and removes the buffer entry.
     state->exec_env()->result_mgr()->cancel_at_time(
             time(nullptr) + config::result_buffer_cancelled_interval_time,
-            state->fragment_instance_id());
+            state->query_options().enable_parallel_result_sink ? state->query_id()
+                                                               : state->fragment_instance_id());
     RETURN_IF_ERROR(Base::close(state, exec_status));
     return final_status;
 }

--- a/be/src/exec/operator/result_sink_operator.cpp
+++ b/be/src/exec/operator/result_sink_operator.cpp
@@ -197,15 +197,20 @@ Status ResultSinkLocalState::close(RuntimeState* state, Status exec_status) {
             state->get_query_ctx()->resource_ctx()->io_context()->update_returned_rows(
                     written_rows);
         }
-        RETURN_IF_ERROR(_sender->close(state->fragment_instance_id(), final_status, written_rows));
+        bool is_fully_closed = false;
+        RETURN_IF_ERROR(_sender->close(state->fragment_instance_id(), final_status, written_rows,
+                                       is_fully_closed));
+        // Schedule deferred cleanup only when the last instance closes the shared
+        // buffer.  In parallel result-sink mode the buffer is keyed by query_id;
+        // in non-parallel mode it is keyed by fragment_instance_id.  Either way,
+        // _sender->buffer_id() returns the correct registration key, so there is
+        // no need to branch on enable_parallel_result_sink here.
+        if (is_fully_closed) {
+            state->exec_env()->result_mgr()->cancel_at_time(
+                    time(nullptr) + config::result_buffer_cancelled_interval_time,
+                    _sender->buffer_id());
+        }
     }
-    // In parallel result sink mode, the buffer is registered under query_id; otherwise
-    // it is registered under fragment_instance_id.  Pass the matching key so the
-    // deferred cancel actually finds and removes the buffer entry.
-    state->exec_env()->result_mgr()->cancel_at_time(
-            time(nullptr) + config::result_buffer_cancelled_interval_time,
-            state->query_options().enable_parallel_result_sink ? state->query_id()
-                                                               : state->fragment_instance_id());
     RETURN_IF_ERROR(Base::close(state, exec_status));
     return final_status;
 }

--- a/be/src/runtime/result_block_buffer.cpp
+++ b/be/src/runtime/result_block_buffer.cpp
@@ -60,7 +60,7 @@ ResultBlockBuffer<ResultCtxType>::ResultBlockBuffer(TUniqueId id, RuntimeState* 
 
 template <typename ResultCtxType>
 Status ResultBlockBuffer<ResultCtxType>::close(const TUniqueId& id, Status exec_status,
-                                               int64_t num_rows) {
+                                               int64_t num_rows, bool& is_fully_closed) {
     std::unique_lock<std::mutex> l(_lock);
     _returned_rows.fetch_add(num_rows);
     // close will be called multiple times and error status needs to be collected.
@@ -77,9 +77,13 @@ Status ResultBlockBuffer<ResultCtxType>::close(const TUniqueId& id, Status exec_
                                         print_id(id));
     }
     if (!_result_sink_dependencies.empty()) {
+        // Still waiting for other instances to finish; this is not the final close.
+        is_fully_closed = false;
         return _status;
     }
 
+    // All instances have closed: the buffer is now fully closed.
+    is_fully_closed = true;
     _is_close = true;
     _arrow_data_arrival.notify_all();
 

--- a/be/src/runtime/result_block_buffer.h
+++ b/be/src/runtime/result_block_buffer.h
@@ -56,8 +56,20 @@ public:
     ResultBlockBufferBase() = default;
     virtual ~ResultBlockBufferBase() = default;
 
-    virtual Status close(const TUniqueId& id, Status exec_status, int64_t num_rows) = 0;
+    // Close one fragment instance's contribution to this buffer.  When the last
+    // registered instance calls close(), |is_fully_closed| is set to true,
+    // indicating that no more producers will write to this buffer and callers may
+    // safely schedule deferred cleanup.  The buffer is keyed in ResultBufferMgr
+    // under buffer_id(); use that id (not the per-instance fragment_instance_id)
+    // when scheduling cancel_at_time() for the deferred cleanup.
+    virtual Status close(const TUniqueId& id, Status exec_status, int64_t num_rows,
+                         bool& is_fully_closed) = 0;
     virtual void cancel(const Status& reason) = 0;
+
+    // The id under which this buffer was registered in ResultBufferMgr.
+    // In parallel result-sink mode this equals query_id; in non-parallel mode
+    // it equals fragment_instance_id.
+    [[nodiscard]] virtual const TUniqueId& buffer_id() const = 0;
 
     [[nodiscard]] virtual std::shared_ptr<MemTrackerLimiter> mem_tracker() = 0;
     virtual void set_dependency(const TUniqueId& id,
@@ -74,9 +86,11 @@ public:
 
     Status add_batch(RuntimeState* state, std::shared_ptr<InBlockType>& result);
     Status get_batch(std::shared_ptr<ResultCtxType> ctx);
-    Status close(const TUniqueId& id, Status exec_status, int64_t num_rows) override;
+    Status close(const TUniqueId& id, Status exec_status, int64_t num_rows,
+                 bool& is_fully_closed) override;
     void cancel(const Status& reason) override;
 
+    [[nodiscard]] const TUniqueId& buffer_id() const override { return _fragment_id; }
     [[nodiscard]] std::shared_ptr<MemTrackerLimiter> mem_tracker() override { return _mem_tracker; }
     void set_dependency(const TUniqueId& id,
                         std::shared_ptr<Dependency> result_sink_dependency) override;

--- a/be/test/exec/sink/arrow_result_block_buffer_test.cpp
+++ b/be/test/exec/sink/arrow_result_block_buffer_test.cpp
@@ -173,7 +173,9 @@ TEST_F(ArrowResultBlockBufferTest, TestArrowResultBlockBuffer) {
         EXPECT_FALSE(fail);
     }
     {
-        EXPECT_TRUE(buffer.close(ins_id, Status::OK(), 0).ok());
+        bool is_fully_closed = false;
+        EXPECT_TRUE(buffer.close(ins_id, Status::OK(), 0, is_fully_closed).ok());
+        EXPECT_TRUE(is_fully_closed);
         EXPECT_EQ(buffer._instance_rows[ins_id], 0);
         EXPECT_TRUE(buffer._instance_rows_in_queue.empty());
         EXPECT_EQ(buffer._waiting_rpc.size(), 0);
@@ -305,8 +307,10 @@ TEST_F(ArrowResultBlockBufferTest, TestErrorClose) {
         EXPECT_FALSE(fail);
     }
     {
-        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0).code(),
+        bool is_fully_closed = false;
+        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0, is_fully_closed).code(),
                   ErrorCode::INTERNAL_ERROR);
+        EXPECT_TRUE(is_fully_closed);
         EXPECT_EQ(buffer._instance_rows[ins_id], 0);
         EXPECT_TRUE(buffer._instance_rows_in_queue.empty());
         EXPECT_EQ(buffer._waiting_rpc.size(), 0);
@@ -324,8 +328,10 @@ TEST_F(ArrowResultBlockBufferTest, TestErrorClose) {
         new_ins_id.lo = 1;
         auto new_dep = Dependency::create_shared(0, 0, "Test", true);
         buffer.set_dependency(new_ins_id, new_dep);
-        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0).code(),
+        bool is_fully_closed = true; // will be set to false since new_dep remains
+        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0, is_fully_closed).code(),
                   ErrorCode::INTERNAL_ERROR);
+        EXPECT_FALSE(is_fully_closed);
         EXPECT_FALSE(data);
         EXPECT_FALSE(close);
         EXPECT_FALSE(fail);

--- a/be/test/exec/sink/result_block_buffer_test.cpp
+++ b/be/test/exec/sink/result_block_buffer_test.cpp
@@ -160,7 +160,9 @@ TEST_F(MysqlResultBlockBufferTest, TestMySQLResultBlockBuffer) {
         EXPECT_FALSE(fail);
     }
     {
-        EXPECT_TRUE(buffer.close(ins_id, Status::OK(), 0).ok());
+        bool is_fully_closed = false;
+        EXPECT_TRUE(buffer.close(ins_id, Status::OK(), 0, is_fully_closed).ok());
+        EXPECT_TRUE(is_fully_closed);
         EXPECT_EQ(buffer._instance_rows[ins_id], 0);
         EXPECT_TRUE(buffer._instance_rows_in_queue.empty());
         EXPECT_EQ(buffer._waiting_rpc.size(), 0);
@@ -289,8 +291,10 @@ TEST_F(MysqlResultBlockBufferTest, TestErrorClose) {
         EXPECT_FALSE(fail);
     }
     {
-        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0).code(),
+        bool is_fully_closed = false;
+        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0, is_fully_closed).code(),
                   ErrorCode::INTERNAL_ERROR);
+        EXPECT_TRUE(is_fully_closed);
         EXPECT_EQ(buffer._instance_rows[ins_id], 0);
         EXPECT_TRUE(buffer._instance_rows_in_queue.empty());
         EXPECT_EQ(buffer._waiting_rpc.size(), 0);
@@ -308,8 +312,10 @@ TEST_F(MysqlResultBlockBufferTest, TestErrorClose) {
         new_ins_id.lo = 1;
         auto new_dep = Dependency::create_shared(0, 0, "Test", true);
         buffer.set_dependency(new_ins_id, new_dep);
-        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0).code(),
+        bool is_fully_closed = true; // will be set to false since new_dep remains
+        EXPECT_EQ(buffer.close(ins_id, Status::InternalError(""), 0, is_fully_closed).code(),
                   ErrorCode::INTERNAL_ERROR);
+        EXPECT_FALSE(is_fully_closed);
         EXPECT_FALSE(data);
         EXPECT_FALSE(close);
         EXPECT_FALSE(fail);


### PR DESCRIPTION
This pull request refines the lifecycle management of result buffers in the execution engine. It introduces a mechanism to determine when a result buffer is fully closed (i.e., all fragment instances have finished writing), enabling deferred cleanup to be scheduled only at the appropriate time. The changes propagate this logic through the buffer interface, operator implementations, and associated tests.

**Lifecycle management improvements:**

* The `close` method in `ResultBlockBufferBase` and its implementations now takes a `bool& is_fully_closed` parameter, which is set to `true` only when the last fragment instance has closed the buffer. This allows callers to safely schedule deferred cleanup only when the buffer is no longer needed. (`be/src/runtime/result_block_buffer.h`, `be/src/runtime/result_block_buffer.cpp`) [[1]](diffhunk://#diff-2599787ef89d65ec871551c08af3fd8289fbf29f86f541328bb736a949f05aa8L59-R73) [[2]](diffhunk://#diff-2599787ef89d65ec871551c08af3fd8289fbf29f86f541328bb736a949f05aa8L77-R93) [[3]](diffhunk://#diff-14b5f66b0648106be897b9f4da1d796f34872eb975b0d1d58891cd219aa03a88L63-R63) [[4]](diffhunk://#diff-14b5f66b0648106be897b9f4da1d796f34872eb975b0d1d58891cd219aa03a88R80-R86)

* In both `ResultFileSinkLocalState::close` and `ResultSinkLocalState::close`, deferred cleanup via `cancel_at_time` is now scheduled only when `is_fully_closed` is true, and the correct buffer ID is used as the registration key, ensuring proper cleanup in both parallel and non-parallel modes. (`be/src/exec/operator/result_file_sink_operator.cpp`, `be/src/exec/operator/result_sink_operator.cpp`) [[1]](diffhunk://#diff-b790ac708b6e43645883fd9dc7ae005405acdb26b3adee105abc9431544bbac3L136-R149) [[2]](diffhunk://#diff-228c55e16ffc298db22f5feffefc38dd1386359f9434380904a47cd4729c21c4L200-R213)

**Interface and API changes:**

* The `ResultBlockBufferBase` interface now includes a `buffer_id()` method, which returns the correct ID for use in cleanup, abstracting away the difference between parallel and non-parallel modes. (`be/src/runtime/result_block_buffer.h`) [[1]](diffhunk://#diff-2599787ef89d65ec871551c08af3fd8289fbf29f86f541328bb736a949f05aa8L59-R73) [[2]](diffhunk://#diff-2599787ef89d65ec871551c08af3fd8289fbf29f86f541328bb736a949f05aa8L77-R93)

**Test updates:**

* All unit tests for result block buffers are updated to use the new `close` signature and verify the value of `is_fully_closed`, ensuring correct behavior in both normal and error scenarios. (`be/test/exec/sink/arrow_result_block_buffer_test.cpp`, `be/test/exec/sink/result_block_buffer_test.cpp`) [[1]](diffhunk://#diff-ad9b83c7ed3c60e44ee9256d5f908beb0f7a38dbde4fc03f0299a7bb02fd7f7cL176-R178) [[2]](diffhunk://#diff-ad9b83c7ed3c60e44ee9256d5f908beb0f7a38dbde4fc03f0299a7bb02fd7f7cL308-R313) [[3]](diffhunk://#diff-ad9b83c7ed3c60e44ee9256d5f908beb0f7a38dbde4fc03f0299a7bb02fd7f7cL327-R334) [[4]](diffhunk://#diff-82dbdf8db74c8a9dce91e005b510145a51beaf46362a023d04a9c8c03dcbedf9L163-R165) [[5]](diffhunk://#diff-82dbdf8db74c8a9dce91e005b510145a51beaf46362a023d04a9c8c03dcbedf9L292-R297) [[6]](diffhunk://#diff-82dbdf8db74c8a9dce91e005b510145a51beaf46362a023d04a9c8c03dcbedf9L311-R318)