### PR TITLE
[fix](build) add -dead_strip on macOS to fix dyld cache crash for large BE binary

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -706,6 +706,11 @@ else()
         -lresolv
         -liconv
     )
+    # On macOS arm64, large binaries (>2GB) can cause the virtual address space
+    # to overlap with the dyld shared cache region, resulting in "dyld cache not
+    # loaded: syscall to map cache into shared region failed". Use -dead_strip to
+    # remove unreachable code/data and reduce binary size.
+    add_link_options(-Wl,-dead_strip)
 endif()
 
 


### PR DESCRIPTION
On macOS arm64, the doris_be binary (~2.2GB) has a virtual address space of ~6.7GB (4GB __PAGEZERO + 2.7GB segments), which overlaps with the dyld shared cache region. This causes "dyld cache not loaded: syscall to map cache into shared region failed", making all system libraries (libresolv, libiconv, CoreFoundation, etc.) fail to load and the BE process crash on startup.

Adding -Wl,-dead_strip removes unreachable code and data, reducing the binary to ~1.7GB and the virtual address space to ~6.1GB, which avoids the dyld shared cache conflict.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

