### PR TITLE
[fix](fe) Track external gensrc inputs in FE Maven build cache config

### DIFF
--- a/fe/.mvn/maven-build-cache-config.xml
+++ b/fe/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0
+                           https://maven.apache.org/xsd/build-cache-config-1.0.0.xsd">
+    <configuration>
+        <enabled>true</enabled>
+        <hashAlgorithm>XX</hashAlgorithm>
+    </configuration>
+    <input>
+        <global>
+            <glob>{*.java,*.g4,*.xml,*.properties}</glob>
+            <includes>
+                <include>src/</include>
+                <!-- External source directories under gensrc/ are referenced by plugins via
+                     Maven properties (e.g. ${project.parent.basedir}/../gensrc/thrift).
+                     The cache extension's tagScanConfig cannot resolve these Maven properties,
+                     so we must include these directories globally. This means all modules'
+                     cache keys include these files. In practice, this causes some additional
+                     cache invalidations for modules that are unaffected by gensrc changes, but
+                     the overall impact on build performance has been evaluated as minor.
+                     See: https://issues.apache.org/jira/browse/MBUILDCACHE-83 -->
+                <include glob="*.thrift" recursive="true">../../gensrc/thrift</include>
+                <include glob="*.proto" recursive="true">../../gensrc/proto</include>
+                <include glob="{*.sh,*.py,Makefile}" recursive="true">../../gensrc/script</include>
+            </includes>
+        </global>
+    </input>
+</cache>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: The maven-build-cache-extension used in the FE build does not automatically discover source files outside module directories. Specifically:
- thrift-maven-plugin reads .thrift files from gensrc/thrift/ via a Maven property (${project.parent.basedir}/../gensrc/thrift) that the cache extension cannot resolve
- protoc-jar-maven-plugin reads .proto files from gensrc/proto/
- exec-maven-plugin runs scripts from gensrc/script/

None of these external inputs were included in the cache key calculation, causing stale cache hits when .thrift, .proto, or build scripts changed.

### Release note

None

### Check List (For Author)

- Test: Manual test - verified via mvn validate -X that all 27 .thrift, 12 .proto, and 2 script files appear in cache Src input
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

