### PR TITLE
[Enhancement](test) Add TPC-H SF10 MOR unique key regression tests

### DIFF
--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS customer (
+    c_custkey     int NOT NULL,
+    c_name        VARCHAR(25) NOT NULL,
+    c_address     VARCHAR(40) NOT NULL,
+    c_nationkey   int NOT NULL,
+    c_phone       VARCHAR(15) NOT NULL,
+    c_acctbal     decimal(15, 2)   NOT NULL,
+    c_mktsegment  VARCHAR(10) NOT NULL,
+    c_comment     VARCHAR(117) NOT NULL
+)ENGINE=OLAP
+UNIQUE KEY(`c_custkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer_dup.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS customer_dup (
+    c_custkey     int NOT NULL,
+    c_name        VARCHAR(25) NOT NULL,
+    c_address     VARCHAR(40) NOT NULL,
+    c_nationkey   int NOT NULL,
+    c_phone       VARCHAR(15) NOT NULL,
+    c_acctbal     decimal(15, 2)   NOT NULL,
+    c_mktsegment  VARCHAR(10) NOT NULL,
+    c_comment     VARCHAR(117) NOT NULL
+)ENGINE=OLAP
+DUPLICATE KEY(`c_custkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24
+PROPERTIES (
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/customer.tbl")
+    INTO TABLE customer_dup
+    COLUMNS TERMINATED BY "|"
+    (c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/customer_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/customer.tbl")
+    INTO TABLE customer
+    COLUMNS TERMINATED BY "|"
+    (c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS lineitem (
+    l_shipdate    DATE NOT NULL,
+    l_orderkey    bigint NOT NULL,
+    l_linenumber  int not null,
+    l_partkey     int NOT NULL,
+    l_suppkey     int not null,
+    l_quantity    decimal(15, 2) NOT NULL,
+    l_extendedprice  decimal(15, 2) NOT NULL,
+    l_discount    decimal(15, 2) NOT NULL,
+    l_tax         decimal(15, 2) NOT NULL,
+    l_returnflag  VARCHAR(1) NOT NULL,
+    l_linestatus  VARCHAR(1) NOT NULL,
+    l_commitdate  DATE NOT NULL,
+    l_receiptdate DATE NOT NULL,
+    l_shipinstruct VARCHAR(25) NOT NULL,
+    l_shipmode     VARCHAR(10) NOT NULL,
+    l_comment      VARCHAR(44) NOT NULL
+)ENGINE=OLAP
+UNIQUE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem_dup.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS lineitem_dup (
+    l_shipdate    DATE NOT NULL,
+    l_orderkey    bigint NOT NULL,
+    l_linenumber  int not null,
+    l_partkey     int NOT NULL,
+    l_suppkey     int not null,
+    l_quantity    decimal(15, 2) NOT NULL,
+    l_extendedprice  decimal(15, 2) NOT NULL,
+    l_discount    decimal(15, 2) NOT NULL,
+    l_tax         decimal(15, 2) NOT NULL,
+    l_returnflag  VARCHAR(1) NOT NULL,
+    l_linestatus  VARCHAR(1) NOT NULL,
+    l_commitdate  DATE NOT NULL,
+    l_receiptdate DATE NOT NULL,
+    l_shipinstruct VARCHAR(25) NOT NULL,
+    l_shipmode     VARCHAR(10) NOT NULL,
+    l_comment      VARCHAR(44) NOT NULL
+)ENGINE=OLAP
+DUPLICATE KEY(`l_shipdate`, `l_orderkey`,`l_linenumber`,`l_partkey`,`l_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/lineitem.tbl.*")
+    INTO TABLE lineitem_dup
+    COLUMNS TERMINATED BY "|"
+    (l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag,l_linestatus, l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment,temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/lineitem_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/lineitem.tbl.*")
+    INTO TABLE lineitem
+    COLUMNS TERMINATED BY "|"
+    (l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag,l_linestatus, l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment,temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS nation  (
+    `n_nationkey` int(11) NOT NULL,
+    `n_name`      varchar(25) NOT NULL,
+    `n_regionkey` int(11) NOT NULL,
+    `n_comment`   varchar(152) NULL
+) ENGINE=OLAP
+UNIQUE KEY(`N_NATIONKEY`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+);

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation_dup.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS nation_dup  (
+    `n_nationkey` int(11) NOT NULL,
+    `n_name`      varchar(25) NOT NULL,
+    `n_regionkey` int(11) NOT NULL,
+    `n_comment`   varchar(152) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`N_NATIONKEY`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "3"
+);

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/nation.tbl")
+    INTO TABLE nation_dup
+    COLUMNS TERMINATED BY "|"
+    (n_nationkey, n_name, n_regionkey, n_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/nation_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/nation.tbl")
+    INTO TABLE nation
+    COLUMNS TERMINATED BY "|"
+    (n_nationkey, n_name, n_regionkey, n_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS orders  (
+    o_orderkey       bigint NOT NULL,
+    o_orderdate      DATE NOT NULL,
+    o_custkey        int NOT NULL,
+    o_orderstatus    VARCHAR(1) NOT NULL,
+    o_totalprice     decimal(15, 2) NOT NULL,
+    o_orderpriority  VARCHAR(15) NOT NULL,
+    o_clerk          VARCHAR(15) NOT NULL,
+    o_shippriority   int NOT NULL,
+    o_comment        VARCHAR(79) NOT NULL
+)ENGINE=OLAP
+UNIQUE KEY(`o_orderkey`, `o_orderdate`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders_dup.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS orders_dup  (
+    o_orderkey       bigint NOT NULL,
+    o_orderdate      DATE NOT NULL,
+    o_custkey        int NOT NULL,
+    o_orderstatus    VARCHAR(1) NOT NULL,
+    o_totalprice     decimal(15, 2) NOT NULL,
+    o_orderpriority  VARCHAR(15) NOT NULL,
+    o_clerk          VARCHAR(15) NOT NULL,
+    o_shippriority   int NOT NULL,
+    o_comment        VARCHAR(79) NOT NULL
+)ENGINE=OLAP
+DUPLICATE KEY(`o_orderkey`, `o_orderdate`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 96
+PROPERTIES (
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/orders.tbl.*")
+    INTO TABLE orders_dup
+    COLUMNS TERMINATED BY "|"
+    (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/orders_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/orders.tbl.*")
+    INTO TABLE orders
+    COLUMNS TERMINATED BY "|"
+    (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS part (
+    p_partkey     int NOT NULL,
+    p_name        VARCHAR(55) NOT NULL,
+    p_mfgr        VARCHAR(25) NOT NULL,
+    p_brand       VARCHAR(10) NOT NULL,
+    p_type        VARCHAR(25) NOT NULL,
+    p_size        int NOT NULL,
+    p_container   VARCHAR(10) NOT NULL,
+    p_retailprice decimal(15, 2) NOT NULL,
+    p_comment     VARCHAR(23) NOT NULL
+)ENGINE=OLAP
+UNIQUE KEY(`p_partkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part_dup.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS part_dup (
+    p_partkey     int NOT NULL,
+    p_name        VARCHAR(55) NOT NULL,
+    p_mfgr        VARCHAR(25) NOT NULL,
+    p_brand       VARCHAR(10) NOT NULL,
+    p_type        VARCHAR(25) NOT NULL,
+    p_size        int NOT NULL,
+    p_container   VARCHAR(10) NOT NULL,
+    p_retailprice decimal(15, 2) NOT NULL,
+    p_comment     VARCHAR(23) NOT NULL
+)ENGINE=OLAP
+DUPLICATE KEY(`p_partkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 24
+PROPERTIES (
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/part.tbl")
+    INTO TABLE part_dup
+    COLUMNS TERMINATED BY "|"
+    (p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/part_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/part.tbl")
+    INTO TABLE part
+    COLUMNS TERMINATED BY "|"
+    (p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS partsupp (
+    ps_partkey     int NOT NULL,
+    ps_suppkey     int NOT NULL,
+    ps_availqty    int NOT NULL,
+    ps_supplycost  decimal(15, 2)  NOT NULL,
+    ps_comment     VARCHAR(199) NOT NULL
+)ENGINE=OLAP
+UNIQUE KEY(`ps_partkey`,`ps_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp_dup.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS partsupp_dup (
+    ps_partkey     int NOT NULL,
+    ps_suppkey     int NOT NULL,
+    ps_availqty    int NOT NULL,
+    ps_supplycost  decimal(15, 2)  NOT NULL,
+    ps_comment     VARCHAR(199) NOT NULL
+)ENGINE=OLAP
+DUPLICATE KEY(`ps_partkey`,`ps_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 24
+PROPERTIES (
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/partsupp.tbl.*")
+    INTO TABLE partsupp_dup
+    COLUMNS TERMINATED BY "|"
+    (ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/partsupp_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/partsupp.tbl.*")
+    INTO TABLE partsupp
+    COLUMNS TERMINATED BY "|"
+    (ps_partkey, ps_suppkey, ps_availqty, ps_supplycost, ps_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS region (
+    r_regionkey  int NOT NULL,
+    r_name       VARCHAR(25) NOT NULL,
+    r_comment    VARCHAR(152)
+)ENGINE=OLAP
+UNIQUE KEY(`r_regionkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region_dup.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS region_dup (
+    r_regionkey  int NOT NULL,
+    r_name       VARCHAR(25) NOT NULL,
+    r_comment    VARCHAR(152)
+)ENGINE=OLAP
+DUPLICATE KEY(`r_regionkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/region.tbl")
+    INTO TABLE region_dup
+    COLUMNS TERMINATED BY "|"
+    (r_regionkey, r_name, r_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/region_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/region.tbl")
+    INTO TABLE region
+    COLUMNS TERMINATED BY "|"
+    (r_regionkey, r_name, r_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS supplier (
+    s_suppkey     int NOT NULL,
+    s_name        VARCHAR(25) NOT NULL,
+    s_address     VARCHAR(40) NOT NULL,
+    s_nationkey   int NOT NULL,
+    s_phone       VARCHAR(15) NOT NULL,
+    s_acctbal     decimal(15, 2) NOT NULL,
+    s_comment     VARCHAR(101) NOT NULL
+)ENGINE=OLAP
+UNIQUE KEY(`s_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
+PROPERTIES (
+    "enable_unique_key_merge_on_write" = "false",
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier_dup.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier_dup.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS supplier_dup (
+    s_suppkey     int NOT NULL,
+    s_name        VARCHAR(25) NOT NULL,
+    s_address     VARCHAR(40) NOT NULL,
+    s_nationkey   int NOT NULL,
+    s_phone       VARCHAR(15) NOT NULL,
+    s_acctbal     decimal(15, 2) NOT NULL,
+    s_comment     VARCHAR(101) NOT NULL
+)ENGINE=OLAP
+DUPLICATE KEY(`s_suppkey`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "3"
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier_dup_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier_dup_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/supplier.tbl")
+    INTO TABLE supplier_dup
+    COLUMNS TERMINATED BY "|"
+    (s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier_load.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/ddl/supplier_load.sql
@@ -1,0 +1,6 @@
+LOAD LABEL ${loadLabel} (
+    DATA INFILE("s3://${s3BucketName}/regression/tpch/sf10/supplier.tbl")
+    INTO TABLE supplier
+    COLUMNS TERMINATED BY "|"
+    (s_suppkey, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, temp)
+)

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/load.groovy
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/load.groovy
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Most of the cases are copied from https://github.com/trinodb/trino/tree/master
+// /testing/trino-product-tests/src/main/resources/sql-tests/testcases
+// and modified by Doris.
+
+// Note: To filter out tables from sql files, use the following one-liner comamnd
+// sed -nr 's/.*tables: (.*)$/\1/gp' /path/to/*.sql | sed -nr 's/,/\n/gp' | sort | uniq
+suite("load") {
+    // Map[tableName, rowCount]
+    def tables = [customer: 1500000, lineitem: 59986052, nation: 25, orders: 15000000, part: 2000000, partsupp: 8000000, region: 5, supplier: 100000]
+    def s3BucketName = getS3BucketName()
+    def s3WithProperties = """WITH S3 (
+        |"AWS_ACCESS_KEY" = "${getS3AK()}",
+        |"AWS_SECRET_KEY" = "${getS3SK()}",
+        |"AWS_ENDPOINT" = "${getS3Endpoint()}",
+        |"AWS_REGION" = "${getS3Region()}",
+        |"provider" = "${getS3Provider()}")
+        |PROPERTIES(
+        |"exec_mem_limit" = "8589934592",
+        |"load_parallelism" = "3")""".stripMargin()
+    // set fe configuration
+    sql "ADMIN SET FRONTEND CONFIG ('max_bytes_per_broker_scanner' = '161061273600')"
+
+    def uniqueID = Math.abs(UUID.randomUUID().hashCode()).toString()
+    def loadAndWait = { String loadLabel, String loadSql ->
+        sql loadSql
+        while (true) {
+            def stateResult = sql "show load where Label = '${loadLabel}'"
+            logger.info("load result is ${stateResult}")
+            def loadState = stateResult[stateResult.size() - 1][2].toString()
+            if ("CANCELLED".equalsIgnoreCase(loadState)) {
+                throw new IllegalStateException("load ${loadLabel} failed.")
+            } else if ("FINISHED".equalsIgnoreCase(loadState)) {
+                break
+            }
+            sleep(5000)
+        }
+    }
+
+    // Load data twice to create overlapping rowsets with duplicate keys,
+    // which triggers the MOR (Merge-On-Read) unique key merge semantics.
+    // Also load DUP tables twice for read_mor_as_dup result comparison.
+    for (int loadRound = 1; loadRound <= 2; loadRound++) {
+        tables.each { table, rows ->
+            if (loadRound == 1) {
+                // drop and recreate MOR table on first round
+                sql "DROP TABLE IF EXISTS ${table}"
+                sql new File("""${context.file.parent}/ddl/${table}.sql""").text
+                // drop and recreate DUP table on first round
+                sql "DROP TABLE IF EXISTS ${table}_dup"
+                sql new File("""${context.file.parent}/ddl/${table}_dup.sql""").text
+            }
+            // load MOR table
+            def morLabel = table + "_round${loadRound}_" + uniqueID
+            def morSql = new File("""${context.file.parent}/ddl/${table}_load.sql""").text.replaceAll("\\\$\\{s3BucketName\\}", s3BucketName)
+            morSql = morSql.replaceAll("\\\$\\{loadLabel\\}", morLabel) + s3WithProperties
+            loadAndWait(morLabel, morSql)
+
+            // load DUP table
+            def dupLabel = table + "_dup_round${loadRound}_" + uniqueID
+            def dupSql = new File("""${context.file.parent}/ddl/${table}_dup_load.sql""").text.replaceAll("\\\$\\{s3BucketName\\}", s3BucketName)
+            dupSql = dupSql.replaceAll("\\\$\\{loadLabel\\}", dupLabel) + s3WithProperties
+            loadAndWait(dupLabel, dupSql)
+        }
+    }
+
+    Thread.sleep(70000) // wait for row count report of the tables just loaded
+    tables.each { table, rows ->
+        sql """SET query_timeout = 1800"""
+        // verify MOR row count equals single-copy count (MOR merge deduplicates)
+        def morRowCount = sql "select count(*) from ${table}"
+        logger.info("MOR table ${table} row count after double load: ${morRowCount[0][0]}, expected: ${rows}")
+        assertTrue(morRowCount[0][0] == rows, "MOR table ${table} row count ${morRowCount[0][0]} != expected ${rows} after MOR dedup")
+        sql """ ANALYZE TABLE $table WITH SYNC """
+        // verify DUP row count equals 2x (DUP keeps all rows)
+        def dupRowCount = sql "select count(*) from ${table}_dup"
+        logger.info("DUP table ${table}_dup row count after double load: ${dupRowCount[0][0]}, expected: ${rows * 2}")
+        assertTrue(dupRowCount[0][0] == rows * 2, "DUP table ${table}_dup row count ${dupRowCount[0][0]} != expected ${rows * 2}")
+        sql """ ANALYZE TABLE ${table}_dup WITH SYNC """
+    }
+}

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q01.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q01.sql
@@ -1,0 +1,23 @@
+-- tables: lineitem
+SELECT
+
+  l_returnflag,
+  l_linestatus,
+  sum(l_quantity)                                       AS sum_qty,
+  sum(l_extendedprice)                                  AS sum_base_price,
+  sum(l_extendedprice * (1 - l_discount))               AS sum_disc_price,
+  sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+  avg(l_quantity)                                       AS avg_qty,
+  avg(l_extendedprice)                                  AS avg_price,
+  avg(l_discount)                                       AS avg_disc,
+  count(*)                                              AS count_order
+FROM
+  lineitem
+WHERE
+  l_shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+GROUP BY
+l_returnflag,
+l_linestatus
+ORDER BY
+l_returnflag,
+l_linestatus

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q02.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q02.sql
@@ -1,0 +1,42 @@
+-- tables: part,supplier,partsupp,nation,region
+SELECT
+  s_acctbal,
+  s_name,
+  n_name,
+  p_partkey,
+  p_mfgr,
+  s_address,
+  s_phone,
+  s_comment
+FROM
+  part,
+  supplier,
+  partsupp,
+  nation,
+  region
+WHERE
+  p_partkey = ps_partkey
+  AND s_suppkey = ps_suppkey
+  AND p_size = 15
+  AND p_type LIKE '%BRASS'
+  AND s_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND r_name = 'EUROPE'
+  AND ps_supplycost = (
+    SELECT min(ps_supplycost)
+    FROM
+      partsupp, supplier,
+      nation, region
+    WHERE
+      p_partkey = ps_partkey
+      AND s_suppkey = ps_suppkey
+      AND s_nationkey = n_nationkey
+      AND n_regionkey = r_regionkey
+      AND r_name = 'EUROPE'
+  )
+ORDER BY
+  s_acctbal DESC,
+  n_name,
+  s_name,
+  p_partkey
+LIMIT 100

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q03.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q03.sql
@@ -1,0 +1,24 @@
+-- tables: customer,orders,lineitem
+SELECT
+  l_orderkey,
+  sum(l_extendedprice * (1 - l_discount)) AS revenue,
+  o_orderdate,
+  o_shippriority
+FROM
+  customer,
+  orders,
+  lineitem
+WHERE
+  c_mktsegment = 'BUILDING'
+  AND c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND o_orderdate < DATE '1995-03-15'
+  AND l_shipdate > DATE '1995-03-15'
+GROUP BY
+  l_orderkey,
+  o_orderdate,
+  o_shippriority
+ORDER BY
+  revenue DESC,
+  o_orderdate
+LIMIT 10

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q04.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q04.sql
@@ -1,0 +1,19 @@
+-- tables: orders,lineitem
+SELECT
+  o_orderpriority,
+  count(*) AS order_count
+FROM orders
+WHERE
+  o_orderdate >= DATE '1993-07-01'
+  AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' MONTH
+AND EXISTS (
+SELECT *
+FROM lineitem
+WHERE
+l_orderkey = o_orderkey
+AND l_commitdate < l_receiptdate
+)
+GROUP BY
+o_orderpriority
+ORDER BY
+o_orderpriority

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q05.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q05.sql
@@ -1,0 +1,25 @@
+-- tables: customer,orders,lineitem,supplier,nation,region
+SELECT
+  n_name,
+  sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+  customer,
+  orders,
+  lineitem,
+  supplier,
+  nation,
+  region
+WHERE
+  c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND l_suppkey = s_suppkey
+  AND c_nationkey = s_nationkey
+  AND s_nationkey = n_nationkey
+  AND n_regionkey = r_regionkey
+  AND r_name = 'ASIA'
+  AND o_orderdate >= DATE '1994-01-01'
+  AND o_orderdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+GROUP BY
+n_name
+ORDER BY
+revenue DESC

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q06.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q06.sql
@@ -1,0 +1,11 @@
+-- tables: lineitem
+
+SELECT sum(l_extendedprice * l_discount) AS revenue
+FROM
+  lineitem
+WHERE
+  l_shipdate >= DATE '1994-01-01'
+  AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+AND l_discount BETWEEN 0.06 - 0.01 AND .06 + 0.01
+AND l_quantity < 24
+

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q07.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q07.sql
@@ -1,0 +1,39 @@
+-- tables: supplier,lineitem,orders,customer,nation
+SELECT
+  supp_nation,
+  cust_nation,
+  l_year,
+  sum(volume) AS revenue
+FROM (
+       SELECT
+         n1.n_name                          AS supp_nation,
+         n2.n_name                          AS cust_nation,
+         extract(YEAR FROM l_shipdate)      AS l_year,
+         l_extendedprice * (1 - l_discount) AS volume
+       FROM
+         supplier,
+         lineitem,
+         orders,
+         customer,
+         nation n1,
+         nation n2
+       WHERE
+         s_suppkey = l_suppkey
+         AND o_orderkey = l_orderkey
+         AND c_custkey = o_custkey
+         AND s_nationkey = n1.n_nationkey
+         AND c_nationkey = n2.n_nationkey
+         AND (
+           (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+           OR (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+         )
+         AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+     ) AS shipping
+GROUP BY
+  supp_nation,
+  cust_nation,
+  l_year
+ORDER BY
+  supp_nation,
+  cust_nation,
+  l_year

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q08.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q08.sql
@@ -1,0 +1,38 @@
+-- tables: part,supplier,lineitem,orders,customer,nation,region
+SELECT
+  o_year,
+  sum(CASE
+      WHEN nation = 'BRAZIL'
+        THEN volume
+      ELSE 0
+      END) / sum(volume) AS mkt_share
+FROM (
+       SELECT
+         extract(YEAR FROM o_orderdate)     AS o_year,
+         l_extendedprice * (1 - l_discount) AS volume,
+         n2.n_name                          AS nation
+       FROM
+         part,
+         supplier,
+         lineitem,
+         orders,
+         customer,
+         nation n1,
+         nation n2,
+         region
+       WHERE
+         p_partkey = l_partkey
+         AND s_suppkey = l_suppkey
+         AND l_orderkey = o_orderkey
+         AND o_custkey = c_custkey
+         AND c_nationkey = n1.n_nationkey
+         AND n1.n_regionkey = r_regionkey
+         AND r_name = 'AMERICA'
+         AND s_nationkey = n2.n_nationkey
+         AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+         AND p_type = 'ECONOMY ANODIZED STEEL'
+     ) AS all_nations
+GROUP BY
+  o_year
+ORDER BY
+  o_year

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q09.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q09.sql
@@ -1,0 +1,32 @@
+-- tables: part,supplier,lineitem,partsupp,orders,nation
+SELECT
+  nation,
+  o_year,
+  sum(amount) AS sum_profit
+FROM (
+       SELECT
+         n_name                                                          AS nation,
+         extract(YEAR FROM o_orderdate)                                  AS o_year,
+         l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+       FROM
+         part,
+         supplier,
+         lineitem,
+         partsupp,
+         orders,
+         nation
+       WHERE
+         s_suppkey = l_suppkey
+         AND ps_suppkey = l_suppkey
+         AND ps_partkey = l_partkey
+         AND p_partkey = l_partkey
+         AND o_orderkey = l_orderkey
+         AND s_nationkey = n_nationkey
+         AND p_name LIKE '%green%'
+     ) AS profit
+GROUP BY
+  nation,
+  o_year
+ORDER BY
+  nation,
+  o_year DESC

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q10.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q10.sql
@@ -1,0 +1,33 @@
+-- tables: customer,orders,lineitem,nation
+SELECT
+  c_custkey,
+  c_name,
+  sum(l_extendedprice * (1 - l_discount)) AS revenue,
+  c_acctbal,
+  n_name,
+  c_address,
+  c_phone,
+  c_comment
+FROM
+  customer,
+  orders,
+  lineitem,
+  nation
+WHERE
+  c_custkey = o_custkey
+  AND l_orderkey = o_orderkey
+  AND o_orderdate >= DATE '1993-10-01'
+  AND o_orderdate < DATE '1993-10-01' + INTERVAL '3' MONTH
+  AND l_returnflag = 'R'
+  AND c_nationkey = n_nationkey
+GROUP BY
+  c_custkey,
+  c_name,
+  c_acctbal,
+  c_phone,
+  n_name,
+  c_address,
+  c_comment
+ORDER BY
+  revenue DESC
+LIMIT 20

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q11.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q11.sql
@@ -1,0 +1,28 @@
+-- tables: partsupp,supplier,nation
+SELECT
+  ps_partkey,
+  sum(ps_supplycost * ps_availqty) AS value
+FROM
+  partsupp,
+  supplier,
+  nation
+WHERE
+  ps_suppkey = s_suppkey
+  AND s_nationkey = n_nationkey
+  AND n_name = 'GERMANY'
+GROUP BY
+  ps_partkey
+HAVING
+  sum(ps_supplycost * ps_availqty) > (
+    SELECT sum(ps_supplycost * ps_availqty) * 0.0001
+    FROM
+      partsupp,
+      supplier,
+      nation
+    WHERE
+      ps_suppkey = s_suppkey
+      AND s_nationkey = n_nationkey
+      AND n_name = 'GERMANY'
+  )
+ORDER BY
+  value DESC

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q12.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q12.sql
@@ -1,0 +1,29 @@
+-- tables: orders,lineitem
+SELECT
+  l_shipmode,
+  sum(CASE
+      WHEN o_orderpriority = '1-URGENT'
+           OR o_orderpriority = '2-HIGH'
+        THEN 1
+      ELSE 0
+      END) AS high_line_count,
+  sum(CASE
+      WHEN o_orderpriority <> '1-URGENT'
+           AND o_orderpriority <> '2-HIGH'
+        THEN 1
+      ELSE 0
+      END) AS low_line_count
+FROM
+  orders,
+  lineitem
+WHERE
+  o_orderkey = l_orderkey
+  AND l_shipmode IN ('MAIL', 'SHIP')
+  AND l_commitdate < l_receiptdate
+  AND l_shipdate < l_commitdate
+  AND l_receiptdate >= DATE '1994-01-01'
+  AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+GROUP BY
+  l_shipmode
+ORDER BY
+  l_shipmode

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q13.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q13.sql
@@ -1,0 +1,21 @@
+-- tables: customer
+SELECT
+  c_count,
+  count(*) AS custdist
+FROM (
+       SELECT
+         c_custkey,
+         count(o_orderkey) AS c_count
+       FROM
+         customer
+         LEFT OUTER JOIN orders ON
+                                  c_custkey = o_custkey
+                                  AND o_comment NOT LIKE '%special%requests%'
+       GROUP BY
+         c_custkey
+     ) AS c_orders
+GROUP BY
+  c_count
+ORDER BY
+  custdist DESC,
+  c_count DESC

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q14.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q14.sql
@@ -1,0 +1,13 @@
+-- tables: lineitem,part
+SELECT 100.00 * sum(CASE
+                    WHEN p_type LIKE 'PROMO%'
+                      THEN l_extendedprice * (1 - l_discount)
+                    ELSE 0
+                    END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
+  lineitem,
+  part
+WHERE
+  l_partkey = p_partkey
+  AND l_shipdate >= DATE '1995-09-01'
+  AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' MONTH

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q15.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q15.sql
@@ -1,0 +1,29 @@
+-- tables: lineitem,supplier
+WITH revenue1 AS(
+  SELECT
+    l_suppkey AS supplier_no,
+    sum(l_extendedprice * (1 - l_discount)) AS total_revenue
+  FROM
+    lineitem
+  WHERE
+    l_shipdate >= DATE '1996-01-01'
+    AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' MONTH
+  GROUP BY l_suppkey)
+
+SELECT
+  s_suppkey,
+  s_name,
+  s_address,
+  s_phone,
+  total_revenue
+FROM
+  supplier,
+  revenue1
+WHERE
+  s_suppkey = supplier_no
+  AND total_revenue = (
+    SELECT max(total_revenue)
+    FROM revenue1
+  )
+ORDER BY
+  s_suppkey

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q16.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q16.sql
@@ -1,0 +1,30 @@
+-- tables: partsupp,part,supplier
+SELECT
+  p_brand,
+  p_type,
+  p_size,
+  count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
+  partsupp,
+  part
+WHERE
+  p_partkey = ps_partkey
+  AND p_brand <> 'Brand#45'
+  AND p_type NOT LIKE 'MEDIUM POLISHED%'
+  AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+  AND ps_suppkey NOT IN (
+    SELECT s_suppkey
+    FROM
+      supplier
+    WHERE
+      s_comment LIKE '%Customer%Complaints%'
+  )
+GROUP BY
+  p_brand,
+  p_type,
+  p_size
+ORDER BY
+  supplier_cnt DESC,
+  p_brand,
+  p_type,
+  p_size

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q17.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q17.sql
@@ -1,0 +1,16 @@
+-- tables: lineitem,part
+SELECT sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+  lineitem,
+  part
+WHERE
+  p_partkey = l_partkey
+  AND p_brand = 'Brand#23'
+  AND p_container = 'MED BOX'
+  AND l_quantity < (
+    SELECT 0.2 * avg(l_quantity)
+    FROM
+      lineitem
+    WHERE
+      l_partkey = p_partkey
+  )

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q18.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q18.sql
@@ -1,0 +1,34 @@
+-- tables: customer,orders,lineitem
+SELECT
+  c_name,
+  c_custkey,
+  o_orderkey,
+  o_orderdate,
+  o_totalprice,
+  sum(l_quantity)
+FROM
+  customer,
+  orders,
+  lineitem
+WHERE
+  o_orderkey IN (
+    SELECT l_orderkey
+    FROM
+      lineitem
+    GROUP BY
+      l_orderkey
+    HAVING
+      sum(l_quantity) > 300
+  )
+  AND c_custkey = o_custkey
+  AND o_orderkey = l_orderkey
+GROUP BY
+  c_name,
+  c_custkey,
+  o_orderkey,
+  o_orderdate,
+  o_totalprice
+ORDER BY
+  o_totalprice DESC,
+  o_orderdate
+LIMIT 100

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q19.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q19.sql
@@ -1,0 +1,35 @@
+-- tables: lineitem,part
+SELECT sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+  lineitem,
+  part
+WHERE
+  (
+    p_partkey = l_partkey
+    AND p_brand = 'Brand#12'
+    AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+    AND l_quantity >= 1 AND l_quantity <= 1 + 10
+    AND p_size BETWEEN 1 AND 5
+    AND l_shipmode IN ('AIR', 'AIR REG')
+    AND l_shipinstruct = 'DELIVER IN PERSON'
+  )
+  OR
+  (
+    p_partkey = l_partkey
+    AND p_brand = 'Brand#23'
+    AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+    AND l_quantity >= 10 AND l_quantity <= 10 + 10
+    AND p_size BETWEEN 1 AND 10
+    AND l_shipmode IN ('AIR', 'AIR REG')
+    AND l_shipinstruct = 'DELIVER IN PERSON'
+  )
+  OR
+  (
+    p_partkey = l_partkey
+    AND p_brand = 'Brand#34'
+    AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+    AND l_quantity >= 20 AND l_quantity <= 20 + 10
+    AND p_size BETWEEN 1 AND 15
+    AND l_shipmode IN ('AIR', 'AIR REG')
+    AND l_shipinstruct = 'DELIVER IN PERSON'
+  )

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q20.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q20.sql
@@ -1,0 +1,33 @@
+-- tables: supplier,nation,partsupp,lineitem,part
+SELECT
+  s_name,
+  s_address
+FROM
+  supplier, nation
+WHERE
+  s_suppkey IN (
+    SELECT ps_suppkey
+    FROM
+      partsupp
+    WHERE
+      ps_partkey IN (
+        SELECT p_partkey
+        FROM
+          part
+        WHERE
+          p_name LIKE 'forest%'
+      )
+      AND ps_availqty > (
+        SELECT 0.5 * sum(l_quantity)
+        FROM
+          lineitem
+        WHERE
+          l_partkey = ps_partkey
+          AND l_suppkey = ps_suppkey
+          AND l_shipdate >= date('1994-01-01')
+          AND l_shipdate < date('1994-01-01') + interval '1' YEAR
+)
+)
+AND s_nationkey = n_nationkey
+AND n_name = 'CANADA'
+ORDER BY s_name

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q21.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q21.sql
@@ -1,0 +1,33 @@
+-- tables: supplier,lineitem,orders,nation
+select
+s_name, count(*) as numwait
+from orders join
+(
+  select * from
+  lineitem l2 right semi join
+  (
+    select * from
+    lineitem l3 right anti join
+    (
+      select * from
+      lineitem l1 join
+      (
+        select * from
+        supplier join nation
+        where s_nationkey = n_nationkey
+          and n_name = 'SAUDI ARABIA'
+      ) t1
+      where t1.s_suppkey = l1.l_suppkey and l1.l_receiptdate > l1.l_commitdate
+    ) t2
+    on l3.l_orderkey = t2.l_orderkey and l3.l_suppkey <> t2.l_suppkey and l3.l_receiptdate > l3.l_commitdate
+  ) t3
+  on l2.l_orderkey = t3.l_orderkey and l2.l_suppkey <> t3.l_suppkey
+) t4
+on o_orderkey = t4.l_orderkey and o_orderstatus = 'F'
+group by
+    t4.s_name
+order by
+    numwait desc,
+    t4.s_name
+limit 100;
+

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q22.sql
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/sql/q22.sql
@@ -1,0 +1,35 @@
+-- tables: orders,customer
+SELECT
+  cntrycode,
+  count(*)       AS numcust,
+  sum(c_acctbal) AS totacctbal
+FROM (
+       SELECT
+         substr(c_phone, 1, 2) AS cntrycode,
+         c_acctbal
+       FROM
+         customer
+       WHERE
+         substr(c_phone, 1, 2) IN
+         ('13', '31', '23', '29', '30', '18', '17')
+         AND c_acctbal > (
+           SELECT avg(c_acctbal)
+           FROM
+             customer
+           WHERE
+             c_acctbal > 0.00
+             AND substr(c_phone, 1, 2) IN
+                 ('13', '31', '23', '29', '30', '18', '17')
+         )
+         AND NOT exists(
+           SELECT *
+           FROM
+             orders
+           WHERE
+             o_custkey = c_custkey
+         )
+     ) AS custsale
+GROUP BY
+  cntrycode
+ORDER BY
+  cntrycode

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/test_mor_value_predicate_pushdown.groovy
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/test_mor_value_predicate_pushdown.groovy
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This test runs all 22 TPC-H queries on MOR (Merge-On-Read) unique key tables
+// with enable_mor_value_predicate_pushdown_tables enabled. On insert-only data
+// (no updates/deletes), enabling value predicate pushdown for MOR tables should
+// produce identical results to standard MOR queries.
+// This validates the feature at scale against the TPC-H SF10 dataset.
+
+suite("test_mor_value_predicate_pushdown") {
+    sql "SET enable_mor_value_predicate_pushdown_tables = '*'"
+    sql "SET query_timeout = 1800"
+
+    def sqlDir = new File("${context.file.parent}/sql")
+    def queryFiles = sqlDir.listFiles().findAll { it.name.endsWith('.sql') }.sort { it.name }
+    for (def queryFile : queryFiles) {
+        def queryName = queryFile.name.replace('.sql', '')
+        def querySql = queryFile.text
+        this."qt_${queryName}" querySql
+    }
+}

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/test_mor_value_predicate_pushdown.groovy
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/test_mor_value_predicate_pushdown.groovy
@@ -16,13 +16,13 @@
 // under the License.
 
 // This test runs all 22 TPC-H queries on MOR (Merge-On-Read) unique key tables
-// with enable_mor_value_predicate_pushdown_tables enabled. On insert-only data
-// (no updates/deletes), enabling value predicate pushdown for MOR tables should
-// produce identical results to standard MOR queries.
-// This validates the feature at scale against the TPC-H SF10 dataset.
+// with enable_mor_value_predicate_pushdown_tables enabled, and compares the
+// results against standard MOR queries (pushdown disabled).
+// On insert-only data (no updates/deletes), standard MOR merge produces the
+// same results as MOW. Enabling value predicate pushdown should not change
+// query results — this validates correctness at scale against TPC-H SF10.
 
 suite("test_mor_value_predicate_pushdown") {
-    sql "SET enable_mor_value_predicate_pushdown_tables = '*'"
     sql "SET query_timeout = 1800"
 
     def sqlDir = new File("${context.file.parent}/sql")
@@ -30,6 +30,20 @@ suite("test_mor_value_predicate_pushdown") {
     for (def queryFile : queryFiles) {
         def queryName = queryFile.name.replace('.sql', '')
         def querySql = queryFile.text
-        this."qt_${queryName}" querySql
+
+        // Run on MOR tables without pushdown (standard merge = same as MOW)
+        sql "SET enable_mor_value_predicate_pushdown_tables = ''"
+        def mowResult = sql querySql
+
+        // Run on MOR tables with pushdown enabled
+        sql "SET enable_mor_value_predicate_pushdown_tables = '*'"
+        def pushdownResult = sql querySql
+
+        // Compare — pushdown should produce identical results to standard MOR/MOW
+        logger.info("Query ${queryName}: MOW rows=${mowResult.size()}, pushdown rows=${pushdownResult.size()}")
+        assertEquals(mowResult.size(), pushdownResult.size(),
+                "Query ${queryName}: row count mismatch, MOW=${mowResult.size()}, pushdown=${pushdownResult.size()}")
+        assertEquals(mowResult, pushdownResult,
+                "Query ${queryName}: MOR pushdown result differs from standard MOW result")
     }
 }

--- a/regression-test/suites/tpch_sf10_unique_mor_p2/test_read_mor_as_dup.groovy
+++ b/regression-test/suites/tpch_sf10_unique_mor_p2/test_read_mor_as_dup.groovy
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This test runs all 22 TPC-H queries on MOR (Merge-On-Read) unique key tables
+// with read_mor_as_dup_tables enabled, and compares the results against actual
+// DUPLICATE KEY tables loaded with the same data (loaded twice).
+// MOR tables with read_mor_as_dup should produce identical results to DUP tables
+// since both skip merge and expose all row versions.
+
+suite("test_read_mor_as_dup") {
+    sql "SET query_timeout = 1800"
+
+    // Table name mapping: replace longest names first to avoid partial matches
+    // (e.g. "partsupp" must be replaced before "part")
+    def tableNames = ["partsupp", "lineitem", "customer", "supplier", "orders", "nation", "region", "part"]
+
+    def sqlDir = new File("${context.file.parent}/sql")
+    def queryFiles = sqlDir.listFiles().findAll { it.name.endsWith('.sql') }.sort { it.name }
+    for (def queryFile : queryFiles) {
+        def queryName = queryFile.name.replace('.sql', '')
+        def querySql = queryFile.text
+
+        // Run on MOR tables with read_mor_as_dup_tables enabled
+        sql "SET read_mor_as_dup_tables = '*'"
+        def morResult = sql querySql
+
+        // Run the same query on actual DUP tables (replace table names with _dup suffix)
+        sql "SET read_mor_as_dup_tables = ''"
+        def dupSql = querySql
+        for (def tbl : tableNames) {
+            dupSql = dupSql.replaceAll("\\b${tbl}\\b", "${tbl}_dup")
+        }
+        def dupResult = sql dupSql
+
+        // Compare results — MOR-as-DUP should produce identical results to actual DUP tables
+        logger.info("Query ${queryName}: MOR-as-DUP rows=${morResult.size()}, DUP rows=${dupResult.size()}")
+        assertEquals(dupResult.size(), morResult.size(),
+                "Query ${queryName}: row count mismatch, MOR-as-DUP=${morResult.size()}, DUP=${dupResult.size()}")
+        assertEquals(dupResult, morResult,
+                "Query ${queryName}: MOR-as-DUP result differs from actual DUP table result")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `tpch_sf10_unique_mor_p2` test suite for Merge-On-Read (MOR) unique key tables, filling the MOR coverage gap in existing `tpch_sf100_unique_p2` which only tests MOW
- Creates MOR tables (`enable_unique_key_merge_on_write=false`) and loads data **twice** to create overlapping rowsets that trigger merge-on-read dedup semantics
- `test_read_mor_as_dup`: runs all 22 TPC-H queries with `read_mor_as_dup_tables='*'` and compares results against actual DUPLICATE KEY tables to verify behavioral equivalence
- `test_mor_value_predicate_pushdown`: runs all 22 TPC-H queries with `enable_mor_value_predicate_pushdown_tables='*'` to validate value predicate pushdown on MOR tables at scale

## Test plan
- [ ] Run `tpch_sf10_unique_mor_p2/load` to verify double-load creates correct row counts (MOR dedup = 1x, DUP = 2x)
- [ ] Run `test_read_mor_as_dup` to verify MOR-as-DUP results match actual DUP table results for all 22 TPC-H queries
- [ ] Run `test_mor_value_predicate_pushdown` to verify predicate pushdown produces correct results on all 22 TPC-H queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)