### PR TITLE
[refactor](fe) Replace TFunctionBinaryType with Function.BinaryType to decouple from Thrift

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
@@ -18,7 +18,6 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.util.URI;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -77,7 +76,7 @@ public class AggregateFunction extends Function {
             URI location, String updateFnSymbol, String initFnSymbol,
             String serializeFnSymbol, String mergeFnSymbol, String getValueFnSymbol,
             String removeFnSymbol, String finalizeFnSymbol, boolean ignoresDistinct,
-            boolean isAnalyticFn, boolean returnsNonNullOnEmpty, TFunctionBinaryType binaryType,
+            boolean isAnalyticFn, boolean returnsNonNullOnEmpty, BinaryType binaryType,
             boolean userVisible, boolean vectorized, NullableMode nullableMode) {
         // only `count` is always not nullable, other aggregate function is always nullable
         super(0, fnName, argTypes, retType, hasVarArgs, binaryType, userVisible, vectorized, nullableMode);
@@ -129,7 +128,7 @@ public class AggregateFunction extends Function {
     }
 
     public static class AggregateFunctionBuilder {
-        TFunctionBinaryType binaryType;
+        BinaryType binaryType;
         FunctionName name;
         Type[] argTypes;
         Type retType;
@@ -145,12 +144,12 @@ public class AggregateFunction extends Function {
         String getValueFnSymbol;
         String symbolName;
 
-        private AggregateFunctionBuilder(TFunctionBinaryType binaryType) {
+        private AggregateFunctionBuilder(BinaryType binaryType) {
             this.binaryType = binaryType;
         }
 
         public static AggregateFunctionBuilder createUdfBuilder() {
-            return new AggregateFunctionBuilder(TFunctionBinaryType.JAVA_UDF);
+            return new AggregateFunctionBuilder(BinaryType.JAVA_UDF);
         }
 
         public AggregateFunctionBuilder name(FunctionName name) {
@@ -218,7 +217,7 @@ public class AggregateFunction extends Function {
             return this;
         }
 
-        public AggregateFunctionBuilder binaryType(TFunctionBinaryType binaryType) {
+        public AggregateFunctionBuilder binaryType(BinaryType binaryType) {
             this.binaryType = binaryType;
             return this;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AliasFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AliasFunction.java
@@ -18,7 +18,6 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.Expr;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
@@ -62,7 +61,7 @@ public class AliasFunction extends Function {
     public static AliasFunction createFunction(FunctionName functionName, Type[] argTypes, Type retType,
             boolean hasVarArgs, List<String> parameters, Expr originFunction, Map<String, String> sessionVariables) {
         AliasFunction aliasFunction = new AliasFunction(functionName, Arrays.asList(argTypes), retType, hasVarArgs);
-        aliasFunction.setBinaryType(TFunctionBinaryType.JAVA_UDF);
+        aliasFunction.setBinaryType(BinaryType.JAVA_UDF);
         aliasFunction.setUserVisible(true);
         aliasFunction.originFunction = originFunction;
         aliasFunction.parameters = parameters;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -22,7 +22,6 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.URI;
 import org.apache.doris.persist.gson.GsonUtils;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
@@ -52,6 +51,17 @@ public class Function implements Writable {
         ALWAYS_NOT_NULLABLE
     }
 
+    public enum BinaryType {
+        BUILTIN,
+        HIVE,
+        NATIVE,
+        IR,
+        RPC,
+        JAVA_UDF,
+        AGG_STATE,
+        PYTHON_UDF
+    }
+
     // Function id, every function has a unique id. Now all built-in functions' id is 0
     @SerializedName("id")
     private long id = 0;
@@ -79,7 +89,7 @@ public class Function implements Writable {
     @SerializedName("l")
     private URI location;
     @SerializedName("bt")
-    private TFunctionBinaryType binaryType;
+    private BinaryType binaryType;
 
     @SerializedName("nm")
     protected NullableMode nullableMode = NullableMode.DEPEND_ON_ARGUMENT;
@@ -119,7 +129,7 @@ public class Function implements Writable {
     }
 
     public Function(long id, FunctionName name, List<Type> argTypes, Type retType, boolean hasVarArgs,
-            TFunctionBinaryType binaryType, boolean userVisible, boolean vectorized, NullableMode mode) {
+            BinaryType binaryType, boolean userVisible, boolean vectorized, NullableMode mode) {
         this.id = id;
         this.name = name;
         this.hasVarArgs = hasVarArgs;
@@ -137,7 +147,7 @@ public class Function implements Writable {
 
     public Function(long id, FunctionName name, List<Type> argTypes, Type retType,
             boolean hasVarArgs, boolean vectorized, NullableMode mode) {
-        this(id, name, argTypes, retType, hasVarArgs, TFunctionBinaryType.BUILTIN, true, vectorized, mode);
+        this(id, name, argTypes, retType, hasVarArgs, BinaryType.BUILTIN, true, vectorized, mode);
     }
 
     public Function(Function other) {
@@ -215,11 +225,11 @@ public class Function implements Writable {
         this.name = name;
     }
 
-    public TFunctionBinaryType getBinaryType() {
+    public BinaryType getBinaryType() {
         return binaryType;
     }
 
-    public void setBinaryType(TFunctionBinaryType type) {
+    public void setBinaryType(BinaryType type) {
         binaryType = type;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionToSqlConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionToSqlConverter.java
@@ -22,7 +22,6 @@ import org.apache.doris.analysis.ExprToSqlVisitor;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.ToSqlParams;
 import org.apache.doris.catalog.Function.NullableMode;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,7 +70,7 @@ public class FunctionToSqlConverter {
             sb.append(",\n  \"CLOSE_FN\"=").append("\"" + fn.getCloseFnSymbol() + "\"");
         }
 
-        if (fn.getBinaryType() == TFunctionBinaryType.JAVA_UDF) {
+        if (fn.getBinaryType() == Function.BinaryType.JAVA_UDF) {
             sb.append(",\n  \"FILE\"=")
                     .append("\"" + (fn.getLocation() == null ? "" : fn.getLocation().toString()) + "\"");
             boolean isReturnNull = fn.getNullableMode() == NullableMode.ALWAYS_NULLABLE;
@@ -106,7 +105,7 @@ public class FunctionToSqlConverter {
         }
 
         sb.append(" PROPERTIES (");
-        if (fn.getBinaryType() != TFunctionBinaryType.JAVA_UDF) {
+        if (fn.getBinaryType() != Function.BinaryType.JAVA_UDF) {
             sb.append("\n  \"INIT_FN\"=\"" + fn.getInitFnSymbol() + "\",")
                     .append("\n  \"UPDATE_FN\"=\"" + fn.getUpdateFnSymbol() + "\",")
                     .append("\n  \"MERGE_FN\"=\"" + fn.getMergeFnSymbol() + "\",");
@@ -121,7 +120,7 @@ public class FunctionToSqlConverter {
             sb.append("\n  \"SYMBOL\"=\"" + fn.getSymbolName() + "\",");
         }
 
-        if (fn.getBinaryType() == TFunctionBinaryType.JAVA_UDF) {
+        if (fn.getBinaryType() == Function.BinaryType.JAVA_UDF) {
             sb.append("\n  \"FILE\"=")
                     .append("\"" + (fn.getLocation() == null ? "" : fn.getLocation().toString()) + "\",");
             boolean isReturnNull = fn.getNullableMode() == NullableMode.ALWAYS_NULLABLE;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionToThriftConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionToThriftConverter.java
@@ -32,6 +32,40 @@ import com.google.common.collect.Lists;
 public class FunctionToThriftConverter {
 
     /**
+     * Converts a {@link Function.BinaryType} to its Thrift representation.
+     */
+    public static TFunctionBinaryType toThriftBinaryType(Function.BinaryType binaryType) {
+        switch (binaryType) {
+            case BUILTIN:    return TFunctionBinaryType.BUILTIN;
+            case HIVE:       return TFunctionBinaryType.HIVE;
+            case NATIVE:     return TFunctionBinaryType.NATIVE;
+            case IR:         return TFunctionBinaryType.IR;
+            case RPC:        return TFunctionBinaryType.RPC;
+            case JAVA_UDF:   return TFunctionBinaryType.JAVA_UDF;
+            case AGG_STATE:  return TFunctionBinaryType.AGG_STATE;
+            case PYTHON_UDF: return TFunctionBinaryType.PYTHON_UDF;
+            default: throw new IllegalArgumentException("Unknown BinaryType: " + binaryType);
+        }
+    }
+
+    /**
+     * Converts a Thrift {@link TFunctionBinaryType} to {@link Function.BinaryType}.
+     */
+    public static Function.BinaryType fromThriftBinaryType(TFunctionBinaryType thriftType) {
+        switch (thriftType) {
+            case BUILTIN:    return Function.BinaryType.BUILTIN;
+            case HIVE:       return Function.BinaryType.HIVE;
+            case NATIVE:     return Function.BinaryType.NATIVE;
+            case IR:         return Function.BinaryType.IR;
+            case RPC:        return Function.BinaryType.RPC;
+            case JAVA_UDF:   return Function.BinaryType.JAVA_UDF;
+            case AGG_STATE:  return Function.BinaryType.AGG_STATE;
+            case PYTHON_UDF: return Function.BinaryType.PYTHON_UDF;
+            default: throw new IllegalArgumentException("Unknown TFunctionBinaryType: " + thriftType);
+        }
+    }
+
+    /**
      * Converts a {@link Function} (or subclass) to its Thrift representation.
      * Uses instanceof checks to dispatch to the appropriate subclass handler.
      */
@@ -52,13 +86,13 @@ public class FunctionToThriftConverter {
             Boolean[] realArgTypeNullables) {
         TFunction tfn = toThriftBase(fn, realReturnType, realArgTypes, realArgTypeNullables);
         tfn.setScalarFn(new TScalarFunction());
-        if (fn.getBinaryType() == TFunctionBinaryType.JAVA_UDF || fn.getBinaryType() == TFunctionBinaryType.RPC
-                || fn.getBinaryType() == TFunctionBinaryType.PYTHON_UDF) {
+        if (fn.getBinaryType() == Function.BinaryType.JAVA_UDF || fn.getBinaryType() == Function.BinaryType.RPC
+                || fn.getBinaryType() == Function.BinaryType.PYTHON_UDF) {
             tfn.getScalarFn().setSymbol(fn.getSymbolName());
         } else {
             tfn.getScalarFn().setSymbol("");
         }
-        if (fn.getBinaryType() == TFunctionBinaryType.PYTHON_UDF) {
+        if (fn.getBinaryType() == Function.BinaryType.PYTHON_UDF) {
             if (!Strings.isNullOrEmpty(fn.getFunctionCode())) {
                 tfn.setFunctionCode(fn.getFunctionCode());
             }
@@ -105,7 +139,7 @@ public class FunctionToThriftConverter {
         tfn.setAggregateFn(aggFn);
 
         // Set runtime_version and function_code for Python UDAF
-        if (fn.getBinaryType() == TFunctionBinaryType.PYTHON_UDF) {
+        if (fn.getBinaryType() == Function.BinaryType.PYTHON_UDF) {
             if (!Strings.isNullOrEmpty(fn.getFunctionCode())) {
                 tfn.setFunctionCode(fn.getFunctionCode());
             }
@@ -123,7 +157,7 @@ public class FunctionToThriftConverter {
         tName.setDbName(fn.getFunctionName().getDb());
         tName.setFunctionName(fn.getFunctionName().getFunction());
         tfn.setName(tName);
-        tfn.setBinaryType(fn.getBinaryType());
+        tfn.setBinaryType(toThriftBinaryType(fn.getBinaryType()));
         if (fn.getLocation() != null) {
             tfn.setHdfsLocation(fn.getLocation().getLocation());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
@@ -29,7 +29,6 @@ import org.apache.doris.nereids.trees.expressions.functions.udf.PythonUdaf;
 import org.apache.doris.nereids.trees.expressions.functions.udf.PythonUdf;
 import org.apache.doris.nereids.trees.expressions.functions.udf.PythonUdtf;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -195,22 +194,22 @@ public class FunctionUtil {
             AliasUdf.translateToNereidsFunction(dbName, ((AliasFunction) function));
         } else if (function instanceof ScalarFunction) {
             if (function.isUDTFunction()) {
-                if (function.getBinaryType() == TFunctionBinaryType.JAVA_UDF) {
+                if (function.getBinaryType() == Function.BinaryType.JAVA_UDF) {
                     JavaUdtf.translateToNereidsFunction(dbName, ((ScalarFunction) function));
-                } else if (function.getBinaryType() == TFunctionBinaryType.PYTHON_UDF) {
+                } else if (function.getBinaryType() == Function.BinaryType.PYTHON_UDF) {
                     PythonUdtf.translateToNereidsFunction(dbName, ((ScalarFunction) function));
                 }
             } else {
-                if (function.getBinaryType() == TFunctionBinaryType.JAVA_UDF) {
+                if (function.getBinaryType() == Function.BinaryType.JAVA_UDF) {
                     JavaUdf.translateToNereidsFunction(dbName, ((ScalarFunction) function));
-                } else if (function.getBinaryType() == TFunctionBinaryType.PYTHON_UDF) {
+                } else if (function.getBinaryType() == Function.BinaryType.PYTHON_UDF) {
                     PythonUdf.translateToNereidsFunction(dbName, (ScalarFunction) function);
                 }
             }
         } else if (function instanceof AggregateFunction) {
-            if (function.getBinaryType() == TFunctionBinaryType.JAVA_UDF) {
+            if (function.getBinaryType() == Function.BinaryType.JAVA_UDF) {
                 JavaUdaf.translateToNereidsFunction(dbName, ((AggregateFunction) function));
-            } else if (function.getBinaryType() == TFunctionBinaryType.PYTHON_UDF) {
+            } else if (function.getBinaryType() == Function.BinaryType.PYTHON_UDF) {
                 PythonUdaf.translateToNereidsFunction(dbName, ((AggregateFunction) function));
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarFunction.java
@@ -19,7 +19,6 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.common.util.URI;
 import org.apache.doris.thrift.TDictFunction;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
@@ -53,16 +52,16 @@ public class ScalarFunction extends Function {
 
     public ScalarFunction(FunctionName fnName, List<Type> argTypes, Type retType, boolean hasVarArgs,
             boolean userVisible) {
-        this(fnName, argTypes, retType, hasVarArgs, TFunctionBinaryType.BUILTIN, userVisible, true);
+        this(fnName, argTypes, retType, hasVarArgs, BinaryType.BUILTIN, userVisible, true);
     }
 
     public ScalarFunction(FunctionName fnName, List<Type> argTypes, Type retType, boolean hasVarArgs,
             boolean userVisible, boolean isVec) {
-        this(fnName, argTypes, retType, hasVarArgs, TFunctionBinaryType.BUILTIN, userVisible, isVec);
+        this(fnName, argTypes, retType, hasVarArgs, BinaryType.BUILTIN, userVisible, isVec);
     }
 
     public ScalarFunction(FunctionName fnName, List<Type> argTypes, Type retType, boolean hasVarArgs,
-            TFunctionBinaryType binaryType, boolean userVisible, boolean isVec) {
+            BinaryType binaryType, boolean userVisible, boolean isVec) {
         super(0, fnName, argTypes, retType, hasVarArgs, binaryType, userVisible, isVec,
                 NullableMode.DEPEND_ON_ARGUMENT);
     }
@@ -71,7 +70,7 @@ public class ScalarFunction extends Function {
      * nerieds custom scalar function
      */
     public ScalarFunction(FunctionName fnName, List<Type> argTypes, Type retType, boolean hasVarArgs, String symbolName,
-            TFunctionBinaryType binaryType, boolean userVisible, boolean isVec, NullableMode nullableMode) {
+            BinaryType binaryType, boolean userVisible, boolean isVec, NullableMode nullableMode) {
         super(0, fnName, argTypes, retType, hasVarArgs, binaryType, userVisible, isVec, nullableMode);
         this.symbolName = symbolName;
     }
@@ -150,7 +149,7 @@ public class ScalarFunction extends Function {
     }
 
     public static ScalarFunction createUdf(
-            TFunctionBinaryType binaryType,
+            BinaryType binaryType,
             FunctionName name, Type[] args,
             Type returnType, boolean isVariadic,
             URI location, String symbol, String prepareFnSymbol, String closeFnSymbol) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -110,7 +110,6 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.thrift.TDictFunction;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -484,7 +483,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
                 function.hasVarArguments(),
                 null, "", "", null, "",
                 null, "", null, false,
-                isAnalyticFunction, false, TFunctionBinaryType.BUILTIN,
+                isAnalyticFunction, false, Function.BinaryType.BUILTIN,
                 true, true, nullableMode
         );
 
@@ -621,7 +620,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
         org.apache.doris.catalog.ScalarFunction catalogFunction = new org.apache.doris.catalog.ScalarFunction(
                 new FunctionName(dictGet.getName()), argTypes, signature.returnType.toCatalogDataType(),
-                dictGet.hasVarArguments(), "", TFunctionBinaryType.BUILTIN, true, true,
+                dictGet.hasVarArguments(), "", Function.BinaryType.BUILTIN, true, true,
                 NullableMode.ALWAYS_NOT_NULLABLE);
 
         // set special fields
@@ -648,7 +647,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
         org.apache.doris.catalog.ScalarFunction catalogFunction = new org.apache.doris.catalog.ScalarFunction(
                 new FunctionName(dictGetMany.getName()), argTypes, signature.returnType.toCatalogDataType(),
-                dictGetMany.hasVarArguments(), "", TFunctionBinaryType.BUILTIN, true, true,
+                dictGetMany.hasVarArguments(), "", Function.BinaryType.BUILTIN, true, true,
                 NullableMode.ALWAYS_NOT_NULLABLE);
 
         // set special fields
@@ -712,7 +711,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         org.apache.doris.catalog.ScalarFunction catalogFunction = new org.apache.doris.catalog.ScalarFunction(
                 new FunctionName(function.getName()), argTypes,
                 function.getDataType().toCatalogDataType(), function.hasVarArguments(),
-                "", TFunctionBinaryType.BUILTIN, true, true, nullableMode);
+                "", Function.BinaryType.BUILTIN, true, true, nullableMode);
 
         // create catalog FunctionCallExpr without analyze again
         return new FunctionCallExpr(catalogFunction, new FunctionParams(false, arguments), function.nullable());
@@ -757,7 +756,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         org.apache.doris.catalog.ScalarFunction catalogFunction = new org.apache.doris.catalog.ScalarFunction(
                 new FunctionName(function.getName()), argTypes,
                 function.getDataType().toCatalogDataType(), function.hasVarArguments(),
-                "", TFunctionBinaryType.BUILTIN, true, true, nullableMode);
+                "", Function.BinaryType.BUILTIN, true, true, nullableMode);
 
         // create catalog FunctionCallExpr without analyze again
         return new FunctionCallExpr(catalogFunction, new FunctionParams(false, arguments), function.nullable());
@@ -827,7 +826,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
                         argTypes, argNullables, returnNullable),
                 aggFunction.hasVarArgs(), aggFunction.isUserVisible());
         fn.setNullableMode(NullableMode.ALWAYS_NOT_NULLABLE);
-        fn.setBinaryType(TFunctionBinaryType.AGG_STATE);
+        fn.setBinaryType(Function.BinaryType.AGG_STATE);
         return new FunctionCallExpr(fn, new FunctionParams(fnCall.getChildren()), false);
     }
 
@@ -845,7 +844,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         Function aggFunction = fnCall.getFn();
         aggFunction.setName(new FunctionName(name));
         aggFunction.setArgs(Arrays.asList(fnCall.getChildren().get(0).getType()));
-        aggFunction.setBinaryType(TFunctionBinaryType.AGG_STATE);
+        aggFunction.setBinaryType(Function.BinaryType.AGG_STATE);
         return fnCall;
     }
 
@@ -863,7 +862,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         Function aggFunction = fnCall.getFn();
         aggFunction.setName(new FunctionName(name));
         aggFunction.setArgs(Arrays.asList(fnCall.getChildren().get(0).getType()));
-        aggFunction.setBinaryType(TFunctionBinaryType.AGG_STATE);
+        aggFunction.setBinaryType(Function.BinaryType.AGG_STATE);
         aggFunction.setNullableMode(NullableMode.ALWAYS_NOT_NULLABLE);
         aggFunction.setReturnType(fnCall.getChildren().get(0).getType());
         fnCall.setType(fnCall.getChildren().get(0).getType());
@@ -910,7 +909,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
                 argTypes,
                 function.getDataType().toCatalogDataType(), function.getIntermediateTypes().toCatalogDataType(),
                 function.hasVarArguments(), null, "", "", null, "", null, "", null, false, false, false,
-                TFunctionBinaryType.BUILTIN, true, true,
+                Function.BinaryType.BUILTIN, true, true,
                 function.nullable() ? NullableMode.ALWAYS_NULLABLE : NullableMode.ALWAYS_NOT_NULLABLE);
 
         return new FunctionCallExpr(catalogFunction,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdaf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdaf.java
@@ -32,7 +32,6 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -47,7 +46,7 @@ import java.util.stream.Collectors;
 public class JavaUdaf extends AggregateFunction implements ExplicitlyCastableSignature, Udf {
     private final String dbName;
     private final long functionId;
-    private final TFunctionBinaryType binaryType;
+    private final Function.BinaryType binaryType;
     private final FunctionSignature signature;
     private final DataType intermediateType;
     private final NullableMode nullableMode;
@@ -67,7 +66,7 @@ public class JavaUdaf extends AggregateFunction implements ExplicitlyCastableSig
     /**
      * Constructor of UDAF
      */
-    public JavaUdaf(String name, long functionId, String dbName, TFunctionBinaryType binaryType,
+    public JavaUdaf(String name, long functionId, String dbName, Function.BinaryType binaryType,
             FunctionSignature signature,
             DataType intermediateType, NullableMode nullableMode,
             String objectFile, String symbol,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdf.java
@@ -32,7 +32,6 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ScalarFunction;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -47,7 +46,7 @@ import java.util.stream.Collectors;
 public class JavaUdf extends ScalarFunction implements ExplicitlyCastableSignature, Udf {
     private final String dbName;
     private final long functionId;
-    private final TFunctionBinaryType binaryType;
+    private final Function.BinaryType binaryType;
     private final FunctionSignature signature;
     private final NullableMode nullableMode;
     private final String objectFile;
@@ -61,7 +60,7 @@ public class JavaUdf extends ScalarFunction implements ExplicitlyCastableSignatu
     /**
      * Constructor of UDF
      */
-    public JavaUdf(String name, long functionId, String dbName, TFunctionBinaryType binaryType,
+    public JavaUdf(String name, long functionId, String dbName, Function.BinaryType binaryType,
             FunctionSignature signature,
             NullableMode nullableMode, String objectFile, String symbol, String prepareFn, String closeFn,
             String checkSum, boolean isStaticLoad, long expirationTime, Expression... args) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtf.java
@@ -32,7 +32,6 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -47,7 +46,7 @@ import java.util.stream.Collectors;
 public class JavaUdtf extends TableGeneratingFunction implements ExplicitlyCastableSignature, Udf {
     private final String dbName;
     private final long functionId;
-    private final TFunctionBinaryType binaryType;
+    private final Function.BinaryType binaryType;
     private final FunctionSignature signature;
     private final NullableMode nullableMode;
     private final String objectFile;
@@ -61,7 +60,7 @@ public class JavaUdtf extends TableGeneratingFunction implements ExplicitlyCasta
     /**
      * Constructor of UDTF
      */
-    public JavaUdtf(String name, long functionId, String dbName, TFunctionBinaryType binaryType,
+    public JavaUdtf(String name, long functionId, String dbName, Function.BinaryType binaryType,
             FunctionSignature signature,
             NullableMode nullableMode, String objectFile, String symbol, String prepareFn, String closeFn,
             String checkSum, boolean isStaticLoad, long expirationTime, Expression... args) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdaf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdaf.java
@@ -32,7 +32,6 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -47,7 +46,7 @@ import java.util.stream.Collectors;
 public class PythonUdaf extends AggregateFunction implements ExplicitlyCastableSignature, Udf {
     private final String dbName;
     private final long functionId;
-    private final TFunctionBinaryType binaryType;
+    private final Function.BinaryType binaryType;
     private final FunctionSignature signature;
     private final DataType intermediateType;
     private final NullableMode nullableMode;
@@ -69,7 +68,7 @@ public class PythonUdaf extends AggregateFunction implements ExplicitlyCastableS
     /**
      * Constructor of UDAF
      */
-    public PythonUdaf(String name, long functionId, String dbName, TFunctionBinaryType binaryType,
+    public PythonUdaf(String name, long functionId, String dbName, Function.BinaryType binaryType,
                       FunctionSignature signature,
                       DataType intermediateType, NullableMode nullableMode,
                       String objectFile, String symbol,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdf.java
@@ -32,7 +32,6 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ScalarFunction;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -47,7 +46,7 @@ import java.util.stream.Collectors;
 public class PythonUdf extends ScalarFunction implements ExplicitlyCastableSignature, Udf {
     private final String dbName;
     private final long functionId;
-    private final TFunctionBinaryType binaryType;
+    private final Function.BinaryType binaryType;
     private final FunctionSignature signature;
     private final NullableMode nullableMode;
     private final String objectFile;
@@ -63,7 +62,7 @@ public class PythonUdf extends ScalarFunction implements ExplicitlyCastableSigna
     /**
      * Constructor of UDF
      */
-    public PythonUdf(String name, long functionId, String dbName, TFunctionBinaryType binaryType,
+    public PythonUdf(String name, long functionId, String dbName, Function.BinaryType binaryType,
                      FunctionSignature signature,
                      NullableMode nullableMode, String objectFile, String symbol, String prepareFn, String closeFn,
                      String checkSum, boolean isStaticLoad, long expirationTime,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdtf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdtf.java
@@ -32,7 +32,6 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -47,7 +46,7 @@ import java.util.stream.Collectors;
 public class PythonUdtf extends TableGeneratingFunction implements ExplicitlyCastableSignature, Udf {
     private final String dbName;
     private final long functionId;
-    private final TFunctionBinaryType binaryType;
+    private final Function.BinaryType binaryType;
     private final FunctionSignature signature;
     private final NullableMode nullableMode;
     private final String objectFile;
@@ -63,7 +62,7 @@ public class PythonUdtf extends TableGeneratingFunction implements ExplicitlyCas
     /**
      * Constructor of Python UDTF
      */
-    public PythonUdtf(String name, long functionId, String dbName, TFunctionBinaryType binaryType,
+    public PythonUdtf(String name, long functionId, String dbName, Function.BinaryType binaryType,
             FunctionSignature signature,
             NullableMode nullableMode, String objectFile, String symbol, String prepareFn, String closeFn,
             String checkSum, boolean isStaticLoad, long expirationTime,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
@@ -82,7 +82,6 @@ import org.apache.doris.proto.Types;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectContextUtil;
 import org.apache.doris.qe.StmtExecutor;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -166,7 +165,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
     private final Map<String, String> properties;
     private final List<String> parameters;
     private final Expression originFunction;
-    private TFunctionBinaryType binaryType = TFunctionBinaryType.JAVA_UDF;
+    private Function.BinaryType binaryType = Function.BinaryType.JAVA_UDF;
     // needed item set after analyzed
     private String userFile;
     private String originalUserFile; // Keep original jar name for BE
@@ -320,10 +319,10 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         userFile = properties.getOrDefault(FILE_KEY, properties.get(OBJECT_FILE_KEY));
         originalUserFile = userFile; // Keep original jar name for BE
         // Convert userFile to realUrl only for FE checksum calculation
-        if (!Strings.isNullOrEmpty(userFile) && binaryType != TFunctionBinaryType.RPC) {
+        if (!Strings.isNullOrEmpty(userFile) && binaryType != Function.BinaryType.RPC) {
             userFile = getRealUrl(userFile);
         }
-        if (!Strings.isNullOrEmpty(userFile) && binaryType != TFunctionBinaryType.RPC) {
+        if (!Strings.isNullOrEmpty(userFile) && binaryType != Function.BinaryType.RPC) {
             try {
                 computeObjectChecksum();
             } catch (IOException | NoSuchAlgorithmException e) {
@@ -334,7 +333,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
                 throw new AnalysisException("library's checksum is not equal with input, checksum=" + checksum);
             }
         }
-        if (binaryType == TFunctionBinaryType.JAVA_UDF) {
+        if (binaryType == Function.BinaryType.JAVA_UDF) {
             FunctionUtil.checkEnableJavaUdf();
 
             // always_nullable the default value is true, equal null means true
@@ -348,7 +347,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
                 isStaticLoad = true;
             }
             extractExpirationTime();
-        } else if (binaryType == TFunctionBinaryType.PYTHON_UDF) {
+        } else if (binaryType == Function.BinaryType.PYTHON_UDF) {
             FunctionUtil.checkEnablePythonUdf();
 
             // always_nullable the default value is true, equal null means true
@@ -457,9 +456,9 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         if (!returnType.isArrayType()) {
             throw new AnalysisException("JAVA_UDTF OR PYTHON_UDTF return type must be array type");
         }
-        if (binaryType == TFunctionBinaryType.JAVA_UDF) {
+        if (binaryType == Function.BinaryType.JAVA_UDF) {
             analyzeJavaUdf(symbol);
-        } else if (binaryType == TFunctionBinaryType.PYTHON_UDF) {
+        } else if (binaryType == Function.BinaryType.PYTHON_UDF) {
             analyzePythonUdtf(symbol);
         }
         URI location;
@@ -494,19 +493,19 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
                 .hasVarArgs(argsDef.isVariadic()).intermediateType(intermediateType.toCatalogDataType())
                 .location(location);
         String initFnSymbol = properties.get(INIT_KEY);
-        if (initFnSymbol == null && !(binaryType == TFunctionBinaryType.JAVA_UDF
-                || binaryType == TFunctionBinaryType.PYTHON_UDF
-                || binaryType == TFunctionBinaryType.RPC)) {
+        if (initFnSymbol == null && !(binaryType == Function.BinaryType.JAVA_UDF
+                || binaryType == Function.BinaryType.PYTHON_UDF
+                || binaryType == Function.BinaryType.RPC)) {
             throw new AnalysisException("No 'init_fn' in properties");
         }
         String updateFnSymbol = properties.get(UPDATE_KEY);
-        if (updateFnSymbol == null && !(binaryType == TFunctionBinaryType.JAVA_UDF
-                || binaryType == TFunctionBinaryType.PYTHON_UDF)) {
+        if (updateFnSymbol == null && !(binaryType == Function.BinaryType.JAVA_UDF
+                || binaryType == Function.BinaryType.PYTHON_UDF)) {
             throw new AnalysisException("No 'update_fn' in properties");
         }
         String mergeFnSymbol = properties.get(MERGE_KEY);
-        if (mergeFnSymbol == null && !(binaryType == TFunctionBinaryType.JAVA_UDF
-                || binaryType == TFunctionBinaryType.PYTHON_UDF)) {
+        if (mergeFnSymbol == null && !(binaryType == Function.BinaryType.JAVA_UDF
+                || binaryType == Function.BinaryType.PYTHON_UDF)) {
             throw new AnalysisException("No 'merge_fn' in properties");
         }
         String serializeFnSymbol = properties.get(SERIALIZE_KEY);
@@ -514,7 +513,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         String getValueFnSymbol = properties.get(GET_VALUE_KEY);
         String removeFnSymbol = properties.get(REMOVE_KEY);
         String symbol = properties.get(SYMBOL_KEY);
-        if (binaryType == TFunctionBinaryType.RPC && !userFile.contains("://")) {
+        if (binaryType == Function.BinaryType.RPC && !userFile.contains("://")) {
             if (initFnSymbol != null) {
                 checkRPCUdf(initFnSymbol);
             }
@@ -532,12 +531,12 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
             if (removeFnSymbol != null) {
                 checkRPCUdf(removeFnSymbol);
             }
-        } else if (binaryType == TFunctionBinaryType.JAVA_UDF) {
+        } else if (binaryType == Function.BinaryType.JAVA_UDF) {
             if (Strings.isNullOrEmpty(symbol)) {
                 throw new AnalysisException("No 'symbol' in properties of java-udaf");
             }
             analyzeJavaUdaf(symbol);
-        } else if (binaryType == TFunctionBinaryType.PYTHON_UDF) {
+        } else if (binaryType == Function.BinaryType.PYTHON_UDF) {
             analyzePythonUdaf(symbol);
         }
         function = builder.initFnSymbol(initFnSymbol).updateFnSymbol(updateFnSymbol).mergeFnSymbol(mergeFnSymbol)
@@ -562,14 +561,14 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         String closeFnSymbol = properties.get(CLOSE_SYMBOL_KEY);
         // TODO(yangzhg) support check function in FE when function service behind load balancer
         // the format for load balance can ref https://github.com/apache/incubator-brpc/blob/master/docs/en/client.md#connect-to-a-cluster
-        if (binaryType == TFunctionBinaryType.RPC && !userFile.contains("://")) {
+        if (binaryType == Function.BinaryType.RPC && !userFile.contains("://")) {
             if (StringUtils.isNotBlank(prepareFnSymbol) || StringUtils.isNotBlank(closeFnSymbol)) {
                 throw new AnalysisException("prepare and close in RPC UDF are not supported.");
             }
             checkRPCUdf(symbol);
-        } else if (binaryType == TFunctionBinaryType.JAVA_UDF) {
+        } else if (binaryType == Function.BinaryType.JAVA_UDF) {
             analyzeJavaUdf(symbol);
-        } else if (binaryType == TFunctionBinaryType.PYTHON_UDF) {
+        } else if (binaryType == Function.BinaryType.PYTHON_UDF) {
             analyzePythonUdf(symbol);
         }
         URI location;
@@ -1037,10 +1036,10 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         return typeBuilder.build();
     }
 
-    private TFunctionBinaryType getFunctionBinaryType(String type) {
-        TFunctionBinaryType binaryType = null;
+    private Function.BinaryType getFunctionBinaryType(String type) {
+        Function.BinaryType binaryType = null;
         try {
-            binaryType = TFunctionBinaryType.valueOf(type);
+            binaryType = Function.BinaryType.valueOf(type);
         } catch (IllegalArgumentException e) {
             // ignore enum Exception
         }
@@ -1258,7 +1257,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
             org.apache.doris.catalog.ScalarFunction catalogFunction = new org.apache.doris.catalog.ScalarFunction(
                     new FunctionName(name), argTypes,
                     expression.getDataType().toCatalogDataType(), hasVarArguments,
-                    "", TFunctionBinaryType.BUILTIN, true, true, nullableMode);
+                    "", Function.BinaryType.BUILTIN, true, true, nullableMode);
 
             // create catalog FunctionCallExpr without analyze again
             return new FunctionCallExpr(catalogFunction, new FunctionParams(false, arguments), expression.nullable());

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/FunctionToSqlConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/FunctionToSqlConverterTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.catalog.Function.BinaryType;
 import org.apache.doris.catalog.Function.NullableMode;
-import org.apache.doris.thrift.TFunctionBinaryType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_javaUdf_basicSql() {
         FunctionName name = new FunctionName("testDb", "my_add");
         Type[] argTypes = {Type.INT, Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "com.example.MyAdd", null, null);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
@@ -54,7 +54,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_javaUdf_alwaysNullable() {
         FunctionName name = new FunctionName("testDb", "nullable_fn");
         Type[] argTypes = {Type.STRING};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.STRING, false, null, "com.example.NullFn", null, null);
         fn.setNullableMode(NullableMode.ALWAYS_NULLABLE);
 
@@ -67,7 +67,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_javaUdf_dependOnArgument() {
         FunctionName name = new FunctionName("testDb", "notnull_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "com.example.NotNullFn", null, null);
         // Default NullableMode is DEPEND_ON_ARGUMENT
 
@@ -80,7 +80,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_javaUdf_withPrepareFnAndCloseFn() {
         FunctionName name = new FunctionName("testDb", "prepared_fn");
         Type[] argTypes = {Type.DOUBLE};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.DOUBLE, false, null, "com.example.Fn", "com.example.Prepare", "com.example.Close");
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
@@ -93,7 +93,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_javaUdf_withoutPrepareFnAndCloseFn() {
         FunctionName name = new FunctionName("testDb", "simple_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "sym", null, null);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
@@ -108,7 +108,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_ifNotExists() {
         FunctionName name = new FunctionName("testDb", "my_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "sym", null, null);
 
         String sql = FunctionToSqlConverter.toSql(fn, true);
@@ -123,7 +123,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_native_usesObjectFile() {
         FunctionName name = new FunctionName("testDb", "native_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.NATIVE, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.NATIVE, name, argTypes,
                 Type.INT, false, null, "native_sym", null, null);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
@@ -140,7 +140,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_global() {
         FunctionName name = new FunctionName("testDb", "global_fn");
         Type[] argTypes = {Type.BIGINT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.BIGINT, false, null, "com.example.GlobalFn", null, null);
         fn.setGlobal(true);
 
@@ -153,7 +153,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_global_ifNotExists() {
         FunctionName name = new FunctionName("testDb", "global_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "sym", null, null);
         fn.setGlobal(true);
 
@@ -222,7 +222,7 @@ public class FunctionToSqlConverterTest {
                 "my_init", "my_update", "my_merge",
                 "my_serialize", "my_finalize",
                 "my_get_value", "my_remove");
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
 
@@ -246,7 +246,7 @@ public class FunctionToSqlConverterTest {
                 Type.INT, null,
                 "init_fn", "update_fn", "merge_fn",
                 null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
 
@@ -266,7 +266,7 @@ public class FunctionToSqlConverterTest {
                 Type.STRING, null,
                 "init", "update", "merge",
                 null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
 
@@ -284,7 +284,7 @@ public class FunctionToSqlConverterTest {
                 Type.BIGINT, null,
                 "init", "update", "merge",
                 null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
 
@@ -342,7 +342,7 @@ public class FunctionToSqlConverterTest {
     void testDispatcher_routesScalarFunction() {
         FunctionName name = new FunctionName("testDb", "dispatch_scalar");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "sym", null, null);
 
         // Call via the dispatcher overload: toSql(Function, boolean)
@@ -393,7 +393,7 @@ public class FunctionToSqlConverterTest {
                 Type.INT, null,
                 "init", "update", "merge",
                 null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
         fn.setSymbolName("native_sym");
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
@@ -410,7 +410,7 @@ public class FunctionToSqlConverterTest {
                 Type.INT, null,
                 "init", "update", "merge",
                 null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
         // symbolName is null by default
 
         String sql = FunctionToSqlConverter.toSql(fn, false);
@@ -424,7 +424,7 @@ public class FunctionToSqlConverterTest {
     void testScalarFunction_sqlEndsWithSemicolon() {
         FunctionName name = new FunctionName("testDb", "end_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "sym", null, null);
 
         String sql = FunctionToSqlConverter.toSql(fn, false);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/FunctionToThriftConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/FunctionToThriftConverterTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.catalog.Function.BinaryType;
 import org.apache.doris.thrift.TAggregateFunction;
 import org.apache.doris.thrift.TFunction;
 import org.apache.doris.thrift.TFunctionBinaryType;
@@ -32,7 +33,7 @@ public class FunctionToThriftConverterTest {
     void testScalarFunctionJavaUdf_symbolIsPopulated() {
         FunctionName name = new FunctionName("db1", "java_udf_fn");
         Type[] argTypes = {Type.INT, Type.STRING};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.DOUBLE, false, null, "com.example.MyFn", null, null);
 
         TFunction result = FunctionToThriftConverter.toThrift(
@@ -47,7 +48,7 @@ public class FunctionToThriftConverterTest {
     void testScalarFunctionRpc_symbolIsPopulated() {
         FunctionName name = new FunctionName("db1", "rpc_fn");
         Type[] argTypes = {Type.BIGINT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.RPC, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.RPC, name, argTypes,
                 Type.INT, false, null, "rpc_symbol_name", null, null);
 
         TFunction result = FunctionToThriftConverter.toThrift(
@@ -61,7 +62,7 @@ public class FunctionToThriftConverterTest {
     void testScalarFunctionNative_symbolIsEmpty() {
         FunctionName name = new FunctionName("db1", "native_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.NATIVE, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.NATIVE, name, argTypes,
                 Type.INT, false, null, "ignored_symbol", null, null);
 
         TFunction result = FunctionToThriftConverter.toThrift(
@@ -82,7 +83,7 @@ public class FunctionToThriftConverterTest {
                 Type.BIGINT, null,
                 "init_fn", "update_fn", "merge_fn",
                 "serialize_fn", "finalize_fn", "get_value_fn", "remove_fn");
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         TFunction result = FunctionToThriftConverter.toThrift(
                 fn, Type.BIGINT, argTypes, new Boolean[]{true});
@@ -108,7 +109,7 @@ public class FunctionToThriftConverterTest {
                 name, argTypes, Type.BIGINT, false,
                 Type.STRING, null,
                 "init", "update", "merge", null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         TFunction result = FunctionToThriftConverter.toThrift(
                 fn, Type.BIGINT, argTypes, new Boolean[]{true});
@@ -126,7 +127,7 @@ public class FunctionToThriftConverterTest {
                 name, argTypes, Type.BIGINT, false,
                 Type.BIGINT, null,
                 "init", "update", "merge", null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
         // Clear intermediateType so the converter falls back to returnType
         fn.setIntermediateType(null);
 
@@ -147,7 +148,7 @@ public class FunctionToThriftConverterTest {
                 Type.DOUBLE, null,
                 "init", "update", "merge",
                 null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         TFunction result = FunctionToThriftConverter.toThrift(
                 fn, Type.DOUBLE, argTypes, new Boolean[]{true});
@@ -169,7 +170,7 @@ public class FunctionToThriftConverterTest {
     void testBaseFields_nameHandling() {
         FunctionName name = new FunctionName("test_db", "test_func");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "sym", null, null);
 
         TFunction result = FunctionToThriftConverter.toThrift(
@@ -184,7 +185,7 @@ public class FunctionToThriftConverterTest {
     void testBaseFields_signatureAndBinaryType() {
         FunctionName name = new FunctionName("db1", "sig_fn");
         Type[] argTypes = {Type.INT, Type.DOUBLE};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.STRING, false, null, "sym", null, null);
 
         TFunction result = FunctionToThriftConverter.toThrift(
@@ -199,7 +200,7 @@ public class FunctionToThriftConverterTest {
     void testBaseFields_functionProperties() {
         FunctionName name = new FunctionName("db1", "prop_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, true, null, "sym", null, null);
         fn.setId(42L);
         fn.setChecksum("abc123");
@@ -222,7 +223,7 @@ public class FunctionToThriftConverterTest {
     void testBaseFields_emptyChecksum_notSet() {
         FunctionName name = new FunctionName("db1", "no_checksum_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.NATIVE, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.NATIVE, name, argTypes,
                 Type.INT, false, null, "", null, null);
         // Default checksum is "" — should NOT be set on the thrift object
 
@@ -238,7 +239,7 @@ public class FunctionToThriftConverterTest {
     void testRealReturnTypeWithPrecision_usesRealReturnType() {
         FunctionName name = new FunctionName("db1", "decimal_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.NATIVE, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.NATIVE, name, argTypes,
                 Type.DOUBLE, false, null, "", null, null);
 
         ScalarType realReturnType = ScalarType.createDecimalV3Type(18, 6);
@@ -254,7 +255,7 @@ public class FunctionToThriftConverterTest {
     void testRealReturnTypeWithoutPrecision_usesFunctionReturnType() {
         FunctionName name = new FunctionName("db1", "simple_fn");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.NATIVE, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.NATIVE, name, argTypes,
                 Type.DOUBLE, false, null, "", null, null);
 
         // Type.INT does not contain precision, so fn.getReturnType() (DOUBLE) should be used
@@ -270,7 +271,7 @@ public class FunctionToThriftConverterTest {
     void testDispatcher_routesScalarFunctionCorrectly() {
         FunctionName name = new FunctionName("db1", "dispatch_scalar");
         Type[] argTypes = {Type.INT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.JAVA_UDF, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.JAVA_UDF, name, argTypes,
                 Type.INT, false, null, "sym", null, null);
 
         // Call the dispatcher overload that takes Function (not ScalarFunction)
@@ -290,7 +291,7 @@ public class FunctionToThriftConverterTest {
                 name, argTypes, Type.INT, false,
                 Type.INT, null,
                 "init", "update", "merge", null, null, null, null);
-        fn.setBinaryType(TFunctionBinaryType.NATIVE);
+        fn.setBinaryType(BinaryType.NATIVE);
 
         // Call the dispatcher overload that takes Function (not AggregateFunction)
         TFunction result = FunctionToThriftConverter.toThrift(
@@ -306,7 +307,7 @@ public class FunctionToThriftConverterTest {
     void testArgTypes_realArgTypesSameLength() {
         FunctionName name = new FunctionName("db1", "arg_fn");
         Type[] argTypes = {Type.INT, Type.BIGINT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.NATIVE, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.NATIVE, name, argTypes,
                 Type.INT, false, null, "", null, null);
 
         Type[] realArgTypes = {Type.INT, Type.BIGINT};
@@ -321,7 +322,7 @@ public class FunctionToThriftConverterTest {
     void testArgTypes_realArgTypesDifferentLength() {
         FunctionName name = new FunctionName("db1", "vararg_fn");
         Type[] argTypes = {Type.INT, Type.BIGINT};
-        ScalarFunction fn = ScalarFunction.createUdf(TFunctionBinaryType.NATIVE, name, argTypes,
+        ScalarFunction fn = ScalarFunction.createUdf(BinaryType.NATIVE, name, argTypes,
                 Type.INT, true, null, "", null, null);
 
         // Pass different number of realArgTypes to trigger the alternate branch


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`Function` and its subclasses were tightly coupled to the Thrift class `TFunctionBinaryType`. This refactoring introduces a pure-Java `BinaryType` enum inside `Function`, replaces all internal usages of `TFunctionBinaryType` with it, and confines Thrift conversion to `FunctionToThriftConverter` only.

**Changes:**
- Added `Function.BinaryType` enum (pure Java, no Thrift dependency) with 8 values: BUILTIN, HIVE, NATIVE, IR, RPC, JAVA_UDF, AGG_STATE, PYTHON_UDF
- Added `toThriftBinaryType()` and `fromThriftBinaryType()` conversion methods in `FunctionToThriftConverter`
- Updated 17 files to replace `TFunctionBinaryType` with `Function.BinaryType`
- `TFunctionBinaryType` now only appears in `FunctionToThriftConverter.java` (the Thrift serialization boundary)

### Release note

None

### Check List (For Author)

- Test: No need to test (pure refactoring, no behavioral change — only enum type replacement with identical values)
- Behavior changed: No
- Does this need documentation: No