### PR TITLE
[fix](azure) Fix incorrect modification timestamps in AzureObjStorage

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/AzureObjStorage.java
@@ -425,7 +425,8 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
                                 !isPrefix,
                                 isPrefix ? -1 : blobItem.getProperties().getContentLength(),
                                 isPrefix ? -1 : blobItem.getProperties().getContentLength(),
-                                isPrefix ? 0 : blobItem.getProperties().getLastModified().getSecond());
+                                isPrefix ? 0 : blobItem.getProperties().getLastModified()
+                                        .toInstant().toEpochMilli());
                         result.add(remoteFile);
 
                         blobPath = blobPath.getParent();
@@ -500,7 +501,7 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
                             props.getBlobSize(),
                             props.getBlobSize(),
                             props.getLastModified() != null
-                                    ? props.getLastModified().toEpochSecond() : 0
+                                    ? props.getLastModified().toInstant().toEpochMilli() : 0
                     );
                     result.add(remoteFile);
 
@@ -561,7 +562,7 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
                             false,
                             props.getContentLength(),
                             props.getContentLength(),
-                            props.getLastModified().getSecond(),
+                            props.getLastModified().toInstant().toEpochMilli(),
                             null);
                     result.add(file);
                 }


### PR DESCRIPTION
## Summary

Fix incorrect modification timestamps in `AzureObjStorage` across three code paths:

- **`globList` LIST path**: Used `getLastModified().getSecond()` which returns the second-of-minute (0–59), not an epoch timestamp
- **`globListByGetProperties` HEAD path**: Used `toEpochSecond()` which returns epoch seconds — off by 1000× from S3's `toEpochMilli()`
- **`listFiles` path**: Same `getSecond()` bug as the glob path

All three are fixed to use `.toInstant().toEpochMilli()`, consistent with `S3ObjStorage` which uses `Instant.toEpochMilli()`.

Found via review of #61775 (cherry-pick of #60414).

## Test plan
- [ ] Verify Azure blob listing returns correct modification timestamps in epoch milliseconds
- [ ] Confirm consistency between S3 and Azure storage backends for `RemoteFile.modifiedTime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)