### PR TITLE
[fix](agg) fix be crash when double type be key in agg table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
@@ -19,6 +19,10 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -61,6 +65,14 @@ public class AddColumnsClause extends AlterTableClause {
             throw new AnalysisException("Columns is empty in add columns clause.");
         }
         for (ColumnDef colDef : columnDefs) {
+            if (tableName != null) {
+                Table table = Env.getCurrentInternalCatalog().getDbOrAnalysisException(tableName.getDb())
+                        .getTableOrAnalysisException(tableName.getTbl());
+                if (table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.AGG_KEYS
+                        && colDef.getAggregateType() == null) {
+                    colDef.setIsKey(true);
+                }
+            }
             colDef.analyze(true);
 
             if (!colDef.isAllowNull() && colDef.getDefaultValue() == null) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61797

Related PR: #xxx

Problem Summary:
be crash when double type be key in agg table

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

