### PR TITLE
[fix](agg) fix be crash when double type be key in agg table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnsClause.java
@@ -19,6 +19,10 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -61,6 +65,14 @@ public class AddColumnsClause extends AlterTableClause {
             throw new AnalysisException("Columns is empty in add columns clause.");
         }
         for (ColumnDef colDef : columnDefs) {
+            if (tableName != null) {
+                Table table = Env.getCurrentInternalCatalog().getDbOrAnalysisException(tableName.getDb())
+                        .getTableOrAnalysisException(tableName.getTbl());
+                if (table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.AGG_KEYS
+                        && colDef.getAggregateType() == null) {
+                    colDef.setIsKey(true);
+                }
+            }
             colDef.analyze(true);
 
             if (!colDef.isAllowNull() && colDef.getDefaultValue() == null) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #61797

Related PR: #61798

Problem Summary:
be crash when double type be key in agg table

Reproduce issue:

Create a agg table:
<img width="317" height="140" alt="image" src="https://github.com/user-attachments/assets/303322e3-6934-427c-92ae-3170082c9045" />
Add a key column and Load some data failed:
<img width="1832" height="82" alt="image" src="https://github.com/user-attachments/assets/bf4a0c07-4547-4ac2-9135-cdf2a7a84349" />
Cause some BE crash:
<img width="1200" height="314" alt="image" src="https://github.com/user-attachments/assets/ef0d6213-4179-4ea9-b5c0-59a6792f1d16" />
*** Query id: 87829b77dc5146bc-b83d8ff9a23f3414 ***
*** is nereids: 0 ***
*** tablet id: 14007 ***
*** Aborted at 1774869662 (unix time) try "date -d @1774869662" if you are using GNU date ***
*** Current BE git commitID: d84ef32c71 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 1734613 (TID 1747110 OR 0x7fe71cd61640) from PID 0; stack trace: ***
 0# 0x0000562265D0134E in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
 1# PosixSignals::chained_handler(int, siginfo_t*, void*) in /opt/huawei/Bigdata/common/runtime0/jdk-21.0.8//lib/server/libjvm.so
 2# JVM_handle_linux_signal in /opt/huawei/Bigdata/common/runtime0/jdk-21.0.8//lib/server/libjvm.so
 3# 0x00007FEF8363C070 in /usr/lib64/libc.so.6 
 4# doris::segment_v2::VerticalSegmentWriter::_full_encode_keys[abi:cxx11](std::vector<doris::vectorized::IOlapColumnDataAccessor*, std::allocator<doris::vectorized::IOlapColumnDataAccessor*> > const&, unsigned long) in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
 5# doris::segment_v2::VerticalSegmentWriter::write_batch() in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
 6# doris::SegmentFlusher::flush_single_block(doris::vectorized::Block const*, int, long*) in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
 7# doris::SegmentCreator::flush_single_block(doris::vectorized::Block const*, int, long*) in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
 8# doris::BetaRowsetWriterV2::flush_memtable(doris::vectorized::Block*, int, long*) in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
 9# doris::FlushToken::_do_flush_memtable(doris::MemTable*, int, long*) in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
10# doris::FlushToken::_flush_memtable(std::unique_ptr<doris::MemTable, std::default_delete<doris::MemTable> >, int, long) in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
11# doris::MemtableFlushTask::run() in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
12# doris::ThreadPool::dispatch_thread() in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
13# doris::Thread::supervise_thread(void*) in /opt/huawei/Bigdata/FusionInsight_Doris_8.6.0.1/install/FusionInsight-Doris-2.1.7/doris-be/lib/doris_be
14# 0x00007FEF8368632A in /usr/lib64/libc.so.6
15# 0x00007FEF83708370 in /usr/lib64/libc.so.6


We expect result is that Key columns of type float or double cannot be added to the Agg table, and such operations should be strictly restricted.
The correct result should be:
<img width="672" height="36" alt="image" src="https://github.com/user-attachments/assets/15a18140-09f9-4273-a3a1-d533da22de5e" />


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

