### PR TITLE
[opt](load) disable enable_strict_consistency_dml by default in cloud mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -146,7 +146,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
 
     @Override
     public Void visitPhysicalOlapTableSink(PhysicalOlapTableSink<? extends Plan> olapTableSink, PlanContext context) {
-        if (connectContext != null && !connectContext.getSessionVariable().enableStrictConsistencyDml) {
+        if (connectContext != null && !connectContext.getSessionVariable().isEnableStrictConsistencyDml()) {
             addRequestPropertyToChildren(PhysicalProperties.ANY);
         } else {
             addRequestPropertyToChildren(olapTableSink.getRequirePhysicalProperties());
@@ -156,7 +156,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
 
     @Override
     public Void visitPhysicalHiveTableSink(PhysicalHiveTableSink<? extends Plan> hiveTableSink, PlanContext context) {
-        if (connectContext != null && !connectContext.getSessionVariable().enableStrictConsistencyDml) {
+        if (connectContext != null && !connectContext.getSessionVariable().isEnableStrictConsistencyDml()) {
             addRequestPropertyToChildren(PhysicalProperties.ANY);
         } else {
             addRequestPropertyToChildren(hiveTableSink.getRequirePhysicalProperties());
@@ -167,7 +167,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
     @Override
     public Void visitPhysicalIcebergTableSink(
             PhysicalIcebergTableSink<? extends Plan> icebergTableSink, PlanContext context) {
-        if (connectContext != null && !connectContext.getSessionVariable().enableStrictConsistencyDml) {
+        if (connectContext != null && !connectContext.getSessionVariable().isEnableStrictConsistencyDml()) {
             addRequestPropertyToChildren(PhysicalProperties.ANY);
         } else {
             addRequestPropertyToChildren(icebergTableSink.getRequirePhysicalProperties());
@@ -178,7 +178,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
     @Override
     public Void visitPhysicalMaxComputeTableSink(
             PhysicalMaxComputeTableSink<? extends Plan> mcTableSink, PlanContext context) {
-        if (connectContext != null && !connectContext.getSessionVariable().enableStrictConsistencyDml) {
+        if (connectContext != null && !connectContext.getSessionVariable().isEnableStrictConsistencyDml()) {
             addRequestPropertyToChildren(PhysicalProperties.ANY);
         } else {
             addRequestPropertyToChildren(mcTableSink.getRequirePhysicalProperties());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -5717,6 +5717,11 @@ public class SessionVariable implements Serializable, Writable {
     }
 
     public boolean isEnableStrictConsistencyDml() {
+        // In cloud mode (store-compute separation), there is only a single copy of data,
+        // so multi-replica consistency is not a concern. Default to false.
+        if (Config.isCloudMode()) {
+            return false;
+        }
         return this.enableStrictConsistencyDml;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.utframe.TestWithFeService;
 
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -135,5 +138,38 @@ public class SessionVariablesTest extends TestWithFeService {
         sv.enableMorValuePredicatePushdownTables = "ctl1.db1.tbl1";
         Assertions.assertTrue(sv.isMorValuePredicatePushdownEnabled("db1", "tbl1"));
         Assertions.assertFalse(sv.isMorValuePredicatePushdownEnabled("db2", "tbl1"));
+    }
+
+    @Test
+    public void testEnableStrictConsistencyDmlDefaultsToFalseInCloudMode() {
+        new MockUp<Config>() {
+            @Mock
+            public boolean isCloudMode() {
+                return true;
+            }
+        };
+        SessionVariable sv = new SessionVariable();
+        // In cloud mode, enable_strict_consistency_dml should always return false
+        // because store-compute separation has no multi-replica consistency concern.
+        Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
+        // Even if the field is set to true, cloud mode overrides it.
+        sv.enableStrictConsistencyDml = true;
+        Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
+    }
+
+    @Test
+    public void testEnableStrictConsistencyDmlDefaultsTrueInNonCloudMode() {
+        new MockUp<Config>() {
+            @Mock
+            public boolean isCloudMode() {
+                return false;
+            }
+        };
+        SessionVariable sv = new SessionVariable();
+        // In non-cloud mode, default is true (multi-replica consistency is needed).
+        Assertions.assertTrue(sv.isEnableStrictConsistencyDml());
+        // Users can disable it.
+        sv.enableStrictConsistencyDml = false;
+        Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
     }
 }

--- a/regression-test/suites/insert_p0/test_insert_tablet_sink.groovy
+++ b/regression-test/suites/insert_p0/test_insert_tablet_sink.groovy
@@ -60,9 +60,13 @@ suite("test_insert_tablet_sink") {
 
 
     sql """ insert into table_largeint select k1,c_varchar,cast(rand() * 50000000 as bigint) from tmp_varchar where k1>=3; """
-    explain {
-        sql "insert into table_largeint select k1,c_varchar,cast(rand() * 50000000 as bigint) from tmp_varchar;"
-        contains "OLAP_TABLE_SINK_HASH_PARTITIONED"
+    // In cloud mode (store-compute separation), enable_strict_consistency_dml defaults to false,
+    // so no hash-partitioned sink is required for multi-replica consistency.
+    if (!isCloudMode()) {
+        explain {
+            sql "insert into table_largeint select k1,c_varchar,cast(rand() * 50000000 as bigint) from tmp_varchar;"
+            contains "OLAP_TABLE_SINK_HASH_PARTITIONED"
+        }
     }
     
     sql """ insert into table_largeint select k1,c_varchar,cast(rand() * 50000000 as bigint) from tmp_varchar; """


### PR DESCRIPTION
## Problem
`enable_strict_consistency_dml` is designed to handle multi-replica consistency for DML
operations. In cloud mode (store-compute separation), data has only a single copy, so
there is no multi-replica consistency concern. Keeping this variable `true` in cloud mode
causes unnecessary data shuffling overhead.

## Solution
Override `isEnableStrictConsistencyDml()` to return `false` when running in cloud mode
(`Config.isCloudMode()`), regardless of the session variable's value. This follows the
same pattern as `isDisableFileCache()`.

Update all call sites in `RequestPropertyDeriver` to use the getter instead of direct
field access so the cloud-mode check takes effect.

## Tests
Added two unit tests in `SessionVariablesTest`:
- Verify `isEnableStrictConsistencyDml()` returns `false` in cloud mode (even when field is `true`)
- Verify `isEnableStrictConsistencyDml()` follows the field value in non-cloud mode
