### PR TITLE
[refactor](fe) Extract Iceberg batch planning split producer abstraction

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/DistributedPlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/DistributedPlanningSplitProducer.java
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+
+/**
+ * Placeholder for future distributed metadata planning.
+ */
+public class DistributedPlanningSplitProducer implements PlanningSplitProducer {
+    @Override
+    public void start(int numBackends, SplitSink sink) throws UserException {
+        throw new UserException("DistributedPlanningSplitProducer is not implemented");
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -110,8 +110,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.Executor;
 
 public class IcebergScanNode extends FileQueryScanNode {
 
@@ -158,6 +157,7 @@ public class IcebergScanNode extends FileQueryScanNode {
     private String cachedFsIdentifier;
 
     private Boolean isBatchMode = null;
+    private PlanningSplitProducer planningSplitProducer;
 
     // ReferencedDataFile path -> List<DeleteFile> / List<TIcebergDeleteFileDesc> (exclude equal delete)
     public Map<String, List<DeleteFile>> deleteFilesByReferencedDataFile = new HashMap<>();
@@ -465,55 +465,7 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public void startSplit(int numBackends) throws UserException {
-        try {
-            preExecutionAuthenticator.execute(() -> {
-                doStartSplit();
-                return null;
-            });
-        } catch (Exception e) {
-            throw new UserException(e.getMessage(), e);
-        }
-    }
-
-    public void doStartSplit() throws UserException {
-        TableScan scan = createTableScan();
-        CompletableFuture.runAsync(() -> {
-            AtomicReference<CloseableIterable<FileScanTask>> taskRef = new AtomicReference<>();
-            try {
-                preExecutionAuthenticator.execute(
-                        () -> {
-                            CloseableIterable<FileScanTask> fileScanTasks = planFileScanTask(scan);
-                            taskRef.set(fileScanTasks);
-
-                            CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
-                            while (splitAssignment.needMoreSplit() && iterator.hasNext()) {
-                                try {
-                                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(iterator.next())));
-                                } catch (UserException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
-                        }
-                );
-                splitAssignment.finishSchedule();
-                recordManifestCacheProfile();
-            } catch (Exception e) {
-                Optional<NotSupportedException> opt = checkNotSupportedException(e);
-                if (opt.isPresent()) {
-                    splitAssignment.setException(new UserException(opt.get().getMessage(), opt.get()));
-                } else {
-                    splitAssignment.setException(new UserException(e.getMessage(), e));
-                }
-            } finally {
-                if (taskRef.get() != null) {
-                    try {
-                        taskRef.get().close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
-            }
-        }, Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor());
+        getPlanningSplitProducer().start(numBackends, new SplitAssignmentSink(splitAssignment));
     }
 
     @VisibleForTesting
@@ -899,6 +851,10 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public boolean isBatchMode() {
+        return getPlanningSplitProducer().isBatchMode();
+    }
+
+    private boolean isBatchModeInternal() {
         Boolean cached = isBatchMode;
         if (cached != null) {
             return cached;
@@ -958,6 +914,87 @@ public class IcebergScanNode extends FileQueryScanNode {
             } else {
                 throw new RuntimeException(ExceptionUtils.getRootCauseMessage(e), e);
             }
+        }
+    }
+
+    @Override
+    public int numApproximateSplits() {
+        return getPlanningSplitProducer().numApproximateSplits();
+    }
+
+    private int numApproximateSplitsInternal() {
+        return NUM_SPLITS_PER_PARTITION * partitionMapInfos.size() > 0 ? partitionMapInfos.size() : 1;
+    }
+
+    @Override
+    public void stop() {
+        if (planningSplitProducer != null) {
+            planningSplitProducer.stop();
+        }
+        super.stop();
+    }
+
+    private PlanningSplitProducer getPlanningSplitProducer() {
+        if (planningSplitProducer == null) {
+            planningSplitProducer = createPlanningSplitProducer();
+        }
+        return planningSplitProducer;
+    }
+
+    @VisibleForTesting
+    protected PlanningSplitProducer createPlanningSplitProducer() {
+        return new LocalParallelPlanningSplitProducer(new IcebergPlanningContext());
+    }
+
+    @VisibleForTesting
+    void setPlanningSplitProducer(PlanningSplitProducer planningSplitProducer) {
+        this.planningSplitProducer = planningSplitProducer;
+    }
+
+    private class IcebergPlanningContext implements LocalParallelPlanningSplitProducer.PlanningContext {
+        @Override
+        public boolean isBatchMode() {
+            return isBatchModeInternal();
+        }
+
+        @Override
+        public int numApproximateSplits() {
+            return numApproximateSplitsInternal();
+        }
+
+        @Override
+        public TableScan createTableScan() throws UserException {
+            return IcebergScanNode.this.createTableScan();
+        }
+
+        @Override
+        public CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) {
+            return IcebergScanNode.this.planFileScanTask(scan);
+        }
+
+        @Override
+        public Split createSplit(FileScanTask task) {
+            return createIcebergSplit(task);
+        }
+
+        @Override
+        public void recordManifestCacheProfile() {
+            IcebergScanNode.this.recordManifestCacheProfile();
+        }
+
+        @Override
+        public Optional<NotSupportedException> checkNotSupportedException(Exception e) {
+            return IcebergScanNode.this.checkNotSupportedException(e);
+        }
+
+        @Override
+        public ExecutionAuthenticator getExecutionAuthenticator() {
+            return preExecutionAuthenticator;
+        }
+
+        @Override
+        public Executor getScheduleExecutor() {
+            return Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor();
         }
     }
 
@@ -1121,11 +1158,6 @@ public class IcebergScanNode extends FileQueryScanNode {
             ((IcebergSplit) splits.get(i)).setTableLevelRowCount(countPerSplit);
         }
         ((IcebergSplit) splits.get(size - 1)).setTableLevelRowCount(countPerSplit + totalCount % size);
-    }
-
-    @Override
-    public int numApproximateSplits() {
-        return NUM_SPLITS_PER_PARTITION * partitionMapInfos.size() > 0 ? partitionMapInfos.size() : 1;
     }
 
     private Optional<NotSupportedException> checkNotSupportedException(Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducer.java
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
+import org.apache.doris.spi.Split;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Local FE async planning producer that reuses current Iceberg planning flow.
+ */
+public class LocalParallelPlanningSplitProducer implements PlanningSplitProducer {
+    private static final Logger LOG = LogManager.getLogger(LocalParallelPlanningSplitProducer.class);
+
+    /**
+     * Runtime context required by local split planning.
+     */
+    public interface PlanningContext {
+        boolean isBatchMode();
+
+        int numApproximateSplits();
+
+        TableScan createTableScan() throws UserException;
+
+        CloseableIterable<FileScanTask> planFileScanTask(TableScan scan);
+
+        Split createSplit(FileScanTask task);
+
+        void recordManifestCacheProfile();
+
+        Optional<NotSupportedException> checkNotSupportedException(Exception e);
+
+        ExecutionAuthenticator getExecutionAuthenticator();
+
+        Executor getScheduleExecutor();
+    }
+
+    private final PlanningContext context;
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private final AtomicReference<CompletableFuture<Void>> runningTask = new AtomicReference<>();
+
+    public LocalParallelPlanningSplitProducer(PlanningContext context) {
+        this.context = Preconditions.checkNotNull(context, "planningContext is null");
+    }
+
+    @Override
+    public boolean isBatchMode() {
+        return context.isBatchMode();
+    }
+
+    @Override
+    public int numApproximateSplits() {
+        return context.numApproximateSplits();
+    }
+
+    @Override
+    public void start(int numBackends, SplitSink sink) throws UserException {
+        stopped.set(false);
+        final TableScan scan;
+        try {
+            scan = context.getExecutionAuthenticator().execute(() -> context.createTableScan());
+        } catch (Exception e) {
+            throw new UserException(e.getMessage(), e);
+        }
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+            AtomicReference<CloseableIterable<FileScanTask>> taskRef = new AtomicReference<>();
+            try {
+                context.getExecutionAuthenticator().execute(() -> {
+                    CloseableIterable<FileScanTask> fileScanTasks = context.planFileScanTask(scan);
+                    taskRef.set(fileScanTasks);
+                    CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
+                    while (!stopped.get() && sink.needMore() && iterator.hasNext()) {
+                        sink.addBatch(Lists.newArrayList(context.createSplit(iterator.next())));
+                    }
+                    return null;
+                });
+                sink.finish();
+                context.recordManifestCacheProfile();
+            } catch (Exception e) {
+                if (stopped.get()) {
+                    LOG.debug("Iceberg local split planning is stopped");
+                    return;
+                }
+                Optional<NotSupportedException> opt = context.checkNotSupportedException(e);
+                if (opt.isPresent()) {
+                    sink.fail(new UserException(opt.get().getMessage(), opt.get()));
+                } else {
+                    sink.fail(new UserException(e.getMessage(), e));
+                }
+            } finally {
+                closeTaskIterable(taskRef.get());
+            }
+        }, context.getScheduleExecutor());
+        runningTask.set(future);
+    }
+
+    @Override
+    public void stop() {
+        if (!stopped.compareAndSet(false, true)) {
+            return;
+        }
+        CompletableFuture<Void> task = runningTask.get();
+        if (task != null) {
+            task.cancel(true);
+        }
+    }
+
+    private void closeTaskIterable(CloseableIterable<FileScanTask> tasks) {
+        if (tasks == null) {
+            return;
+        }
+        try {
+            tasks.close();
+        } catch (IOException e) {
+            LOG.warn("close file scan task iterable failed: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/PlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/PlanningSplitProducer.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+
+/**
+ * FE-side split production strategy for Iceberg planning.
+ */
+public interface PlanningSplitProducer {
+
+    default boolean isBatchMode() {
+        return false;
+    }
+
+    default int numApproximateSplits() {
+        return -1;
+    }
+
+    void start(int numBackends, SplitSink sink) throws UserException;
+
+    default void stop() {
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSink.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.SplitAssignment;
+import org.apache.doris.spi.Split;
+
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+/**
+ * Adapter that bridges {@link SplitSink} with existing {@link SplitAssignment}.
+ */
+public class SplitAssignmentSink implements SplitSink {
+    private final SplitAssignment splitAssignment;
+
+    public SplitAssignmentSink(SplitAssignment splitAssignment) {
+        this.splitAssignment = Preconditions.checkNotNull(splitAssignment, "splitAssignment is null");
+    }
+
+    @Override
+    public void addBatch(List<Split> splits) throws UserException {
+        splitAssignment.addToQueue(splits);
+    }
+
+    @Override
+    public boolean needMore() {
+        return splitAssignment.needMoreSplit();
+    }
+
+    @Override
+    public void finish() {
+        splitAssignment.finishSchedule();
+    }
+
+    @Override
+    public void fail(UserException e) {
+        splitAssignment.setException(e);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitSink.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.spi.Split;
+
+import java.util.List;
+
+/**
+ * Sink abstraction consumed by planning split producers.
+ */
+public interface SplitSink {
+    void addBatch(List<Split> splits) throws UserException;
+
+    boolean needMore();
+
+    void finish();
+
+    void fail(UserException e);
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.datasource.iceberg.source;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.common.util.LocationPath;
+import org.apache.doris.datasource.SplitAssignment;
 import org.apache.doris.datasource.TableFormatType;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
@@ -50,6 +51,47 @@ public class IcebergScanNodeTest {
         @Override
         public boolean isBatchMode() {
             return false;
+        }
+    }
+
+    private static class ProducerAwareIcebergScanNode extends IcebergScanNode {
+        ProducerAwareIcebergScanNode(SessionVariable sv) {
+            super(new PlanNodeId(0), new TupleDescriptor(new TupleId(0)), sv, ScanContext.EMPTY);
+        }
+
+        void setSplitAssignmentForTest(SplitAssignment splitAssignment) {
+            this.splitAssignment = splitAssignment;
+        }
+    }
+
+    private static class RecordingPlanningSplitProducer implements PlanningSplitProducer {
+        private int startCalls = 0;
+        private int stopCalls = 0;
+        private int lastNumBackends = -1;
+        private SplitSink lastSink;
+        private boolean batchMode = false;
+        private int approximateSplits = 1;
+
+        @Override
+        public boolean isBatchMode() {
+            return batchMode;
+        }
+
+        @Override
+        public int numApproximateSplits() {
+            return approximateSplits;
+        }
+
+        @Override
+        public void start(int numBackends, SplitSink sink) {
+            startCalls++;
+            lastNumBackends = numBackends;
+            lastSink = sink;
+        }
+
+        @Override
+        public void stop() {
+            stopCalls++;
         }
     }
 
@@ -142,5 +184,28 @@ public class IcebergScanNodeTest {
                 .getDeleteFiles()
                 .get(0);
         Assert.assertEquals(org.apache.doris.thrift.TFileFormatType.FORMAT_ORC, deleteFileDesc.getFileFormat());
+    }
+
+    @Test
+    public void testPlanningSplitProducerDelegationAndStop() throws Exception {
+        SessionVariable sv = new SessionVariable();
+        ProducerAwareIcebergScanNode node = new ProducerAwareIcebergScanNode(sv);
+        RecordingPlanningSplitProducer producer = new RecordingPlanningSplitProducer();
+        node.setPlanningSplitProducer(producer);
+        node.setSplitAssignmentForTest(Mockito.mock(SplitAssignment.class));
+
+        node.startSplit(3);
+        Assert.assertEquals(1, producer.startCalls);
+        Assert.assertEquals(3, producer.lastNumBackends);
+        Assert.assertTrue(producer.lastSink instanceof SplitAssignmentSink);
+
+        producer.batchMode = true;
+        Assert.assertTrue(node.isBatchMode());
+        producer.approximateSplits = 7;
+        Assert.assertEquals(7, node.numApproximateSplits());
+
+        node.setSplitAssignmentForTest(null);
+        node.stop();
+        Assert.assertEquals(1, producer.stopCalls);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducerTest.java
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.spi.Split;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+public class LocalParallelPlanningSplitProducerTest {
+    private static final ExecutionAuthenticator NOOP_AUTHENTICATOR = new ExecutionAuthenticator() {
+    };
+
+    @Test
+    public void testStartSuccess() throws Exception {
+        LocalParallelPlanningSplitProducer.PlanningContext context = Mockito.mock(
+                LocalParallelPlanningSplitProducer.PlanningContext.class);
+        SplitSink sink = Mockito.mock(SplitSink.class);
+        TableScan scan = Mockito.mock(TableScan.class);
+        FileScanTask task = Mockito.mock(FileScanTask.class);
+        Split split = Mockito.mock(Split.class);
+
+        Mockito.when(context.isBatchMode()).thenReturn(true);
+        Mockito.when(context.numApproximateSplits()).thenReturn(1);
+        Mockito.when(context.getExecutionAuthenticator()).thenReturn(NOOP_AUTHENTICATOR);
+        Mockito.when(context.getScheduleExecutor()).thenReturn(Runnable::run);
+        Mockito.when(context.createTableScan()).thenReturn(scan);
+        Mockito.when(context.planFileScanTask(scan))
+                .thenReturn(CloseableIterable.withNoopClose(Collections.singletonList(task)));
+        Mockito.when(context.createSplit(task)).thenReturn(split);
+        Mockito.when(context.checkNotSupportedException(Mockito.any(Exception.class))).thenReturn(Optional.empty());
+        Mockito.when(sink.needMore()).thenReturn(true);
+
+        LocalParallelPlanningSplitProducer producer = new LocalParallelPlanningSplitProducer(context);
+        producer.start(1, sink);
+
+        ArgumentCaptor<java.util.List<Split>> splitCaptor = ArgumentCaptor.forClass(java.util.List.class);
+        Mockito.verify(sink).addBatch(splitCaptor.capture());
+        Assertions.assertEquals(1, splitCaptor.getValue().size());
+        Assertions.assertEquals(split, splitCaptor.getValue().get(0));
+        Mockito.verify(sink).finish();
+        Mockito.verify(sink, Mockito.never()).fail(Mockito.any());
+        Mockito.verify(context).recordManifestCacheProfile();
+    }
+
+    @Test
+    public void testStartFail() throws Exception {
+        LocalParallelPlanningSplitProducer.PlanningContext context = Mockito.mock(
+                LocalParallelPlanningSplitProducer.PlanningContext.class);
+        SplitSink sink = Mockito.mock(SplitSink.class);
+        RuntimeException expected = new RuntimeException("boom");
+
+        Mockito.when(context.getExecutionAuthenticator()).thenReturn(NOOP_AUTHENTICATOR);
+        Mockito.when(context.getScheduleExecutor()).thenReturn(Runnable::run);
+        Mockito.when(context.createTableScan()).thenThrow(expected);
+
+        LocalParallelPlanningSplitProducer producer = new LocalParallelPlanningSplitProducer(context);
+        UserException userException = Assertions.assertThrows(UserException.class, () -> producer.start(1, sink));
+        Assertions.assertTrue(userException.getMessage().contains("boom"));
+        Mockito.verify(sink, Mockito.never()).fail(Mockito.any());
+        Mockito.verify(sink, Mockito.never()).finish();
+    }
+
+    @Test
+    public void testStopOnSinkNeedMoreFalse() throws Exception {
+        LocalParallelPlanningSplitProducer.PlanningContext context = Mockito.mock(
+                LocalParallelPlanningSplitProducer.PlanningContext.class);
+        SplitSink sink = Mockito.mock(SplitSink.class);
+        TableScan scan = Mockito.mock(TableScan.class);
+        FileScanTask task1 = Mockito.mock(FileScanTask.class);
+        FileScanTask task2 = Mockito.mock(FileScanTask.class);
+
+        Mockito.when(context.getExecutionAuthenticator()).thenReturn(NOOP_AUTHENTICATOR);
+        Mockito.when(context.getScheduleExecutor()).thenReturn(Runnable::run);
+        Mockito.when(context.createTableScan()).thenReturn(scan);
+        Mockito.when(context.planFileScanTask(scan))
+                .thenReturn(CloseableIterable.withNoopClose(Arrays.asList(task1, task2)));
+        Mockito.when(context.checkNotSupportedException(Mockito.any(Exception.class))).thenReturn(Optional.empty());
+        Mockito.when(sink.needMore()).thenReturn(false);
+
+        LocalParallelPlanningSplitProducer producer = new LocalParallelPlanningSplitProducer(context);
+        producer.start(1, sink);
+
+        Mockito.verify(sink, Mockito.never()).addBatch(Mockito.anyList());
+        Mockito.verify(sink).finish();
+        Mockito.verify(context).recordManifestCacheProfile();
+    }
+
+    @Test
+    public void testStopIdempotent() throws Exception {
+        LocalParallelPlanningSplitProducer.PlanningContext context = Mockito.mock(
+                LocalParallelPlanningSplitProducer.PlanningContext.class);
+        SplitSink sink = Mockito.mock(SplitSink.class);
+        TableScan scan = Mockito.mock(TableScan.class);
+
+        Mockito.when(context.getExecutionAuthenticator()).thenReturn(NOOP_AUTHENTICATOR);
+        Mockito.when(context.getScheduleExecutor()).thenReturn(Runnable::run);
+        Mockito.when(context.createTableScan()).thenReturn(scan);
+        Mockito.when(context.planFileScanTask(scan))
+                .thenReturn(CloseableIterable.withNoopClose(Collections.emptyList()));
+        Mockito.when(context.checkNotSupportedException(Mockito.any(Exception.class))).thenReturn(Optional.empty());
+        Mockito.when(sink.needMore()).thenReturn(false);
+
+        LocalParallelPlanningSplitProducer producer = new LocalParallelPlanningSplitProducer(context);
+        producer.start(1, sink);
+        Assertions.assertDoesNotThrow(() -> {
+            producer.stop();
+            producer.stop();
+        });
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSinkTest.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.SplitAssignment;
+import org.apache.doris.spi.Split;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SplitAssignmentSinkTest {
+    @Test
+    public void testDelegateToSplitAssignment() throws Exception {
+        SplitAssignment splitAssignment = Mockito.mock(SplitAssignment.class);
+        Split split = Mockito.mock(Split.class);
+        List<Split> splits = Collections.singletonList(split);
+        UserException userException = new UserException("test");
+        Mockito.when(splitAssignment.needMoreSplit()).thenReturn(true);
+
+        SplitAssignmentSink sink = new SplitAssignmentSink(splitAssignment);
+        sink.addBatch(splits);
+        sink.finish();
+        sink.fail(userException);
+
+        Assertions.assertTrue(sink.needMore());
+        Mockito.verify(splitAssignment).addToQueue(splits);
+        Mockito.verify(splitAssignment).finishSchedule();
+        Mockito.verify(splitAssignment).setException(userException);
+        Mockito.verify(splitAssignment).needMoreSplit();
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:
- Refactor Iceberg async batch split planning by extracting split production into producer/sink abstractions.
- Keep existing SplitAssignment + SplitSource consumption path unchanged.
- Preserve current local async planning behavior while reserving a distributed producer extension point.

### Release note

None

### Check List (For Author)

- Test: FE compile and test-compile
    - Unit Test: Added/updated FE unit tests (`LocalParallelPlanningSplitProducerTest`, `SplitAssignmentSinkTest`, `IcebergScanNodeTest`)
- Behavior changed: No
- Does this need documentation: No

### Main Changes

1. Introduce `PlanningSplitProducer` and `SplitSink` abstractions for Iceberg planning split production.
2. Add `SplitAssignmentSink` to bridge producer output into existing `SplitAssignment`.
3. Add `LocalParallelPlanningSplitProducer` with current FE local async planning logic and idempotent stop.
4. Add placeholder `DistributedPlanningSplitProducer` for future distributed planning.
5. Refactor `IcebergScanNode` to delegate `startSplit`, `isBatchMode`, and `numApproximateSplits` through producer selection and manage producer lifecycle in `stop()`.
