### PR TITLE
[feat](profile) add Is Profile Collection Completed marker in profile text

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -567,6 +567,7 @@ public class Profile {
         }
 
         if (!hasReportingProfile) {
+            summaryProfile.markCollectionCompleted();
             return true;
         } else {
             long currentTimeMillis = System.currentTimeMillis();
@@ -582,6 +583,7 @@ public class Profile {
                                 "This profile is not complete, since its collection does not finish in time."
                                 + " Maybe increase profile_waiting_time_for_spill_secs in fe.conf current val: "
                                 + String.valueOf(Config.profile_waiting_time_for_spill_seconds));
+                summaryProfile.markCollectionCompleted();
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -113,6 +113,10 @@ public class SummaryProfile {
     public static final String READ_BYTES_PER_SECOND = "Read Bytes Per Second";
     public static final String REMOTE_READ_BYTES_PER_SECOND = "Remote Read Bytes Per Second";
 
+    // Written last in queryFinished(), after all BE fragment profiles are merged.
+    // Readers can poll for this field to know the profile is fully collected.
+    public static final String IS_PROFILE_COLLECTION_COMPLETED = "Is Profile Collection Completed";
+
     public static final String PARSE_SQL_TIME = "Parse SQL Time";
     public static final String NEREIDS_LOCK_TABLE_TIME = "Nereids Lock Table Time";
     public static final String NEREIDS_ANALYSIS_TIME = "Nereids Analysis Time";
@@ -508,6 +512,10 @@ public class SummaryProfile {
     // This method is used to display the final data status when the overall query ends.
     // This can avoid recalculating some strings and so on every time during the update process.
     public void queryFinished() {
+        // Mark profile collection as complete. This is written last, after all BE fragment
+        // profiles have been merged (called post-waitForFragmentsDone). Pollers can wait for
+        // this field to avoid reading a partial profile.
+        executionSummaryProfile.addInfoString(IS_PROFILE_COLLECTION_COMPLETED, "true");
         if (assignedWeightPerBackend != null) {
             Map<String, Long> m = assignedWeightPerBackend.entrySet().stream()
                     .sorted(Map.Entry.comparingByValue())

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -113,8 +113,6 @@ public class SummaryProfile {
     public static final String READ_BYTES_PER_SECOND = "Read Bytes Per Second";
     public static final String REMOTE_READ_BYTES_PER_SECOND = "Remote Read Bytes Per Second";
 
-    // Written last in queryFinished(), after all BE fragment profiles are merged.
-    // Readers can poll for this field to know the profile is fully collected.
     public static final String IS_PROFILE_COLLECTION_COMPLETED = "Is Profile Collection Completed";
 
     public static final String PARSE_SQL_TIME = "Parse SQL Time";
@@ -512,10 +510,6 @@ public class SummaryProfile {
     // This method is used to display the final data status when the overall query ends.
     // This can avoid recalculating some strings and so on every time during the update process.
     public void queryFinished() {
-        // Mark profile collection as complete. This is written last, after all BE fragment
-        // profiles have been merged (called post-waitForFragmentsDone). Pollers can wait for
-        // this field to avoid reading a partial profile.
-        executionSummaryProfile.addInfoString(IS_PROFILE_COLLECTION_COMPLETED, "true");
         if (assignedWeightPerBackend != null) {
             Map<String, Long> m = assignedWeightPerBackend.entrySet().stream()
                     .sorted(Map.Entry.comparingByValue())
@@ -529,6 +523,10 @@ public class SummaryProfile {
                     SPLITS_ASSIGNMENT_WEIGHT,
                     new GsonBuilder().create().toJson(m));
         }
+    }
+
+    public void markCollectionCompleted() {
+        executionSummaryProfile.addInfoString(IS_PROFILE_COLLECTION_COMPLETED, "true");
     }
 
     private void updateSummaryProfile(Map<String, String> infos) {

--- a/regression-test/suites/query_profile/test_profile_collection_completed.groovy
+++ b/regression-test/suites/query_profile/test_profile_collection_completed.groovy
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Verifies that SummaryProfile.queryFinished() writes the
+ * "Is Profile Collection Completed: true" field into the profile text.
+ *
+ * This field is written after Coordinator.waitForFragmentsDone() returns,
+ * guaranteeing all BE pipeline task profiles are merged. It allows pollers
+ * to detect profile readiness without fixed sleeps or heuristics.
+ */
+suite("test_profile_collection_completed") {
+
+    def getProfileText = { String queryId ->
+        def addr = context.config.feHttpAddress
+        def user = context.config.feHttpUser ?: "root"
+        def pass = context.config.feHttpPassword ?: ""
+        def encoding = Base64.getEncoder().encodeToString("${user}:${pass}".getBytes("UTF-8"))
+        def conn = new URL("http://${addr}/api/profile/text?query_id=${queryId}").openConnection()
+        conn.setRequestMethod("GET")
+        conn.setRequestProperty("Authorization", "Basic ${encoding}")
+        conn.setConnectTimeout(5000)
+        conn.setReadTimeout(10000)
+        try {
+            return conn.getInputStream().getText()
+        } catch (Exception e) {
+            return ""
+        }
+    }
+
+    // Poll until the completion marker appears, or timeout after 10 s.
+    def waitForCompletionMarker = { String queryId ->
+        def marker = "Is Profile Collection Completed: true"
+        def maxAttempts = 33   // 33 × 300 ms ≈ 10 s
+        for (int i = 0; i < maxAttempts; i++) {
+            Thread.sleep(300)
+            def text = getProfileText(queryId)
+            if (text.contains(marker)) {
+                return text
+            }
+        }
+        return getProfileText(queryId)
+    }
+
+    sql "SET enable_profile = true"
+    sql "SET enable_sql_cache = false"
+
+    // Use a multi-instance query so the fragment pipeline is exercised
+    // and a proper execution profile is written (simple SET statements are skipped).
+    sql "DROP TABLE IF EXISTS test_profile_complete_t"
+    sql """
+        CREATE TABLE test_profile_complete_t (
+            k1 INT NOT NULL,
+            v1 INT
+        ) ENGINE=OLAP
+        DUPLICATE KEY(k1)
+        DISTRIBUTED BY HASH(k1) BUCKETS 4
+        PROPERTIES ("replication_num" = "1")
+    """
+
+    sql "INSERT INTO test_profile_complete_t VALUES (1, 10), (2, 20), (3, 30)"
+
+    sql "SELECT count(*) FROM test_profile_complete_t"
+
+    def queryIdResult = sql "SELECT last_query_id()"
+    def queryId = queryIdResult[0][0].toString()
+    logger.info("query_id for completion marker test: ${queryId}")
+
+    def profileText = waitForCompletionMarker(queryId)
+
+    assertTrue(
+        profileText.contains("Is Profile Collection Completed: true"),
+        "Expected 'Is Profile Collection Completed: true' in profile for query ${queryId}. " +
+        "Profile length=${profileText.length()}, first 500 chars: ${profileText.take(500)}"
+    )
+
+    logger.info("'Is Profile Collection Completed: true' verified in profile for query ${queryId}")
+
+    sql "DROP TABLE IF EXISTS test_profile_complete_t"
+}

--- a/regression-test/suites/query_profile/test_profile_collection_completed.groovy
+++ b/regression-test/suites/query_profile/test_profile_collection_completed.groovy
@@ -16,12 +16,9 @@
 // under the License.
 
 /**
- * Verifies that SummaryProfile.queryFinished() writes the
- * "Is Profile Collection Completed: true" field into the profile text.
- *
- * This field is written after Coordinator.waitForFragmentsDone() returns,
- * guaranteeing all BE pipeline task profiles are merged. It allows pollers
- * to detect profile readiness without fixed sleeps or heuristics.
+ * Verifies that the "Is Profile Collection Completed: true" field
+ * appears in the profile text once all BE fragment profiles have
+ * been collected (or the collection timeout has elapsed).
  */
 suite("test_profile_collection_completed") {
 
@@ -89,6 +86,4 @@ suite("test_profile_collection_completed") {
     )
 
     logger.info("'Is Profile Collection Completed: true' verified in profile for query ${queryId}")
-
-    sql "DROP TABLE IF EXISTS test_profile_complete_t"
 }

--- a/regression-test/suites/query_profile/test_profile_collection_completed.groovy
+++ b/regression-test/suites/query_profile/test_profile_collection_completed.groovy
@@ -39,10 +39,10 @@ suite("test_profile_collection_completed") {
         }
     }
 
-    // Poll until the completion marker appears, or timeout after 10 s.
+    // Poll until the completion marker appears, or timeout after 30 s.
     def waitForCompletionMarker = { String queryId ->
         def marker = "Is Profile Collection Completed: true"
-        def maxAttempts = 33   // 33 × 300 ms ≈ 10 s
+        def maxAttempts = 100   // 100 × 300 ms = 30 s
         for (int i = 0; i < maxAttempts; i++) {
             Thread.sleep(300)
             def text = getProfileText(queryId)


### PR DESCRIPTION
Add IS_PROFILE_COLLECTION_COMPLETED field to SummaryProfile, written by
Profile.shouldStoreToStorage() when all ExecutionProfile.isCompleted()
return true (i.e., all BE fragment profiles have been collected), or when
the collection timeout has elapsed. Readers can poll for this field
instead of using a fixed sleep to determine when the profile is fully
populated.

Add regression test test_profile_collection_completed to verify the marker
appears in the profile text within a reasonable timeout after query execution.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->