### PR TITLE
[fix](build) Fix compilation errors with implicit conversions and unnecessary virtual keywords

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -428,7 +428,10 @@ endif()
 #   -DNDEBUG: Turn off dchecks/asserts/debug only code.
 set(CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 message(STATUS "UBSAN_IGNORELIST is ${UBSAN_IGNORELIST}")
-set(CXX_FLAGS_ASAN "-O0 -fsanitize=address -fsanitize=undefined -fno-sanitize=float-cast-overflow -fsanitize-ignorelist=${UBSAN_IGNORELIST} -DUNDEFINED_BEHAVIOR_SANITIZER -DADDRESS_SANITIZER")
+set(CXX_FLAGS_ASAN "-O0 -fsanitize=address -fsanitize=undefined -fno-sanitize=float-cast-overflow -DUNDEFINED_BEHAVIOR_SANITIZER -DADDRESS_SANITIZER")
+if (COMPILER_CLANG)
+    set(CXX_FLAGS_ASAN "${CXX_FLAGS_ASAN} -fsanitize-ignorelist=${UBSAN_IGNORELIST}")
+endif()
 set(CXX_FLAGS_LSAN "-O0 -fsanitize=leak -DLEAK_SANITIZER")
 ## Use for BE-UT
 set(CXX_FLAGS_ASAN_UT "-O0 -fsanitize=address -DADDRESS_SANITIZER")

--- a/be/src/core/memcmp_small.h
+++ b/be/src/core/memcmp_small.h
@@ -58,7 +58,7 @@ inline int memcmp_small_allow_overflow15(const uint8_t* a, size_t a_size, const 
         uint16_t mask = static_cast<uint16_t>(_mm_movemask_epi8(
                 _mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(a + offset)),
                                _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + offset)))));
-        mask = ~mask;
+        mask = static_cast<uint16_t>(~mask);
 
         if (mask) {
             offset += __builtin_ctz(mask);
@@ -80,7 +80,7 @@ inline int memcmp_small_allow_overflow15(const uint8_t* a, const uint8_t* b, siz
         uint16_t mask = static_cast<uint16_t>(_mm_movemask_epi8(
                 _mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(a + offset)),
                                _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + offset)))));
-        mask = ~mask;
+        mask = static_cast<uint16_t>(~mask);
 
         if (mask) {
             offset += __builtin_ctz(mask);
@@ -104,7 +104,7 @@ inline bool memequal_small_allow_overflow15(const uint8_t* a, size_t a_size, con
         uint16_t mask = static_cast<uint16_t>(_mm_movemask_epi8(
                 _mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(a + offset)),
                                _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + offset)))));
-        mask = ~mask;
+        mask = static_cast<uint16_t>(~mask);
 
         if (mask) {
             offset += __builtin_ctz(mask);
@@ -122,7 +122,7 @@ inline int memcmp_small_multiple_of16(const uint8_t* a, const uint8_t* b, size_t
         uint16_t mask = static_cast<uint16_t>(_mm_movemask_epi8(
                 _mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(a + offset)),
                                _mm_loadu_si128(reinterpret_cast<const __m128i*>(b + offset)))));
-        mask = ~mask;
+        mask = static_cast<uint16_t>(~mask);
 
         if (mask) {
             offset += __builtin_ctz(mask);
@@ -139,7 +139,7 @@ inline int memcmp16(const uint8_t* a, const uint8_t* b) {
     uint16_t mask = static_cast<uint16_t>(_mm_movemask_epi8(
             _mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(a)),
                            _mm_loadu_si128(reinterpret_cast<const __m128i*>(b)))));
-    mask = ~mask;
+    mask = static_cast<uint16_t>(~mask);
 
     if (mask) {
         auto offset = __builtin_ctz(mask);
@@ -165,7 +165,7 @@ inline bool memory_is_zero_small_allow_overflow15(const void* data, size_t size)
         uint16_t mask = static_cast<uint16_t>(_mm_movemask_epi8(
                 _mm_cmpeq_epi8(zero16, _mm_loadu_si128(reinterpret_cast<const __m128i*>(
                                                reinterpret_cast<const char*>(data) + offset)))));
-        mask = ~mask;
+        mask = static_cast<uint16_t>(~mask);
 
         if (mask) {
             offset += __builtin_ctz(mask);

--- a/be/src/core/value/ip_address_cidr.h
+++ b/be/src/core/value/ip_address_cidr.h
@@ -116,7 +116,7 @@ inline bool match_ipv6_subnet(const uint8_t* addr, const uint8_t* cidr_addr, uin
     uint16_t mask = (uint16_t)_mm_movemask_epi8(
             _mm_cmpeq_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(addr)),
                            _mm_loadu_si128(reinterpret_cast<const __m128i*>(cidr_addr))));
-    mask = ~mask;
+    mask = static_cast<uint16_t>(~mask);
 
     if (mask) {
         const auto offset = std::countl_zero(mask);

--- a/be/src/exec/common/ipv6_to_binary.h
+++ b/be/src/exec/common/ipv6_to_binary.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "exec/common/format_ip.h"
 
 namespace doris {
@@ -29,18 +31,15 @@ namespace doris {
 constexpr size_t IPV6_MASKS_COUNT = 256;
 using RawMaskArrayV6 = std::array<uint8_t, IPV6_BINARY_LENGTH>;
 
-template <typename RawMaskArrayT>
-static constexpr RawMaskArrayT generate_bit_mask(size_t prefix) {
-    RawMaskArrayT arr {0};
-    if (prefix >= arr.size() * 8) {
-        prefix = arr.size() * 8;
-    }
+static constexpr RawMaskArrayV6 generate_bit_mask(size_t prefix) {
+    RawMaskArrayV6 arr {0};
+    prefix = std::min(prefix, arr.size() * 8);
     int8_t i = IPV6_BINARY_LENGTH - 1;
     for (; prefix >= 8; --i, prefix -= 8) {
         arr[i] = 0xff;
     }
     if (prefix > 0) {
-        arr[i--] = ~(0xff >> prefix);
+        arr[i--] = static_cast<uint8_t>(~(0xff >> prefix));
     }
     while (i >= 0) {
         arr[i--] = 0x00;
@@ -48,11 +47,10 @@ static constexpr RawMaskArrayT generate_bit_mask(size_t prefix) {
     return arr;
 }
 
-template <typename RawMaskArrayT, size_t masksCount>
-static constexpr std::array<RawMaskArrayT, masksCount> generate_bit_masks() {
-    std::array<RawMaskArrayT, masksCount> arr {};
-    for (size_t i = 0; i < masksCount; ++i) {
-        arr[i] = generate_bit_mask<RawMaskArrayT>(i);
+static constexpr std::array<RawMaskArrayV6, IPV6_MASKS_COUNT> generate_bit_masks() {
+    std::array<RawMaskArrayV6, IPV6_MASKS_COUNT> arr {};
+    for (size_t i = 0; i < IPV6_MASKS_COUNT; ++i) {
+        arr[i] = generate_bit_mask(i);
     }
     return arr;
 }
@@ -62,8 +60,7 @@ static constexpr std::array<RawMaskArrayT, masksCount> generate_bit_masks() {
 /// The reference is valid during all program execution time.
 /// Values of prefix_len greater than 128 interpreted as 128 exactly.
 inline const std::array<uint8_t, 16>& get_cidr_mask_ipv6(uint8_t prefix_len) {
-    static constexpr auto IPV6_RAW_MASK_ARRAY =
-            generate_bit_masks<RawMaskArrayV6, IPV6_MASKS_COUNT>();
+    static constexpr auto IPV6_RAW_MASK_ARRAY = generate_bit_masks();
     return IPV6_RAW_MASK_ARRAY[prefix_len];
 }
 

--- a/be/src/exprs/function/url/find_symbols.h
+++ b/be/src/exprs/function/url/find_symbols.h
@@ -151,7 +151,7 @@ constexpr uint16_t maybe_negate(uint16_t x) {
     if constexpr (positive)
         return x;
     else
-        return ~x;
+        return static_cast<uint16_t>(~x);
 }
 
 enum class ReturnMode : uint8_t {

--- a/be/src/storage/task/engine_batch_load_task.h
+++ b/be/src/storage/task/engine_batch_load_task.h
@@ -39,13 +39,13 @@ public:
     Status execute() override;
 
 private:
-    virtual Status _init();
+    Status _init();
 
     // The process of push data to olap engine
     //
     // Output parameters:
     // * tablet_infos: The info of pushed tablet after push data
-    virtual Status _process();
+    Status _process();
 
     // Delete data of specified tablet according to delete conditions,
     // once delete_data command submit success, deleted data is not visible,
@@ -55,7 +55,7 @@ private:
     // @param [out] tablet_info_vec return tablet last status, which
     //              include version info, row count, data size, etc
     // @return OK if submit delete_data success
-    virtual Status _delete_data(const TPushReq& request, std::vector<TTabletInfo>* tablet_info_vec);
+    Status _delete_data(const TPushReq& request, std::vector<TTabletInfo>* tablet_info_vec);
 
     Status _get_tmp_file_dir(const std::string& root_path, std::string* local_path);
     Status _push(const TPushReq& request, std::vector<TTabletInfo>* tablet_info_vec);

--- a/be/src/storage/task/engine_clone_task.h
+++ b/be/src/storage/task/engine_clone_task.h
@@ -63,8 +63,8 @@ public:
 private:
     Status _do_clone();
 
-    virtual Status _finish_clone(Tablet* tablet, const std::string& clone_dir, int64_t version,
-                                 bool is_incremental_clone);
+    Status _finish_clone(Tablet* tablet, const std::string& clone_dir, int64_t version,
+                         bool is_incremental_clone);
 
     Status _finish_incremental_clone(Tablet* tablet, const TabletMetaSharedPtr& cloned_tablet_meta,
                                      int64_t version);


### PR DESCRIPTION
- Restrict `-fsanitize-ignorelist` flag to Clang only in ASAN build flags, as GCC does not support this option
- Add explicit `static_cast<uint16_t>` for bitwise NOT operations to fix implicit conversion warnings in memcmp_small.h, ip_address_cidr.h, and find_symbols.h
- Add explicit cast in ipv6_to_binary.h mask generation and simplify template usage
- Remove unnecessary `virtual` keywords

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

