### PR TITLE
[refactor](fe) Upgrade remote storage FileSystem to SPI (Phase 1)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/AcidUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/AcidUtil.java
@@ -22,7 +22,7 @@ import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.hive.AcidInfo.DeleteDeltaInfo;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache.FileCacheValue;
 import org.apache.doris.datasource.property.storage.StorageProperties;
-import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.LegacyFileSystem;
 import org.apache.doris.fs.remote.RemoteFile;
 
 import lombok.EqualsAndHashCode;
@@ -132,7 +132,7 @@ public class AcidUtil {
     }
 
 
-    private static boolean isValidMetaDataFile(FileSystem fileSystem, String baseDir)
+    private static boolean isValidMetaDataFile(LegacyFileSystem fileSystem, String baseDir)
             throws IOException {
         String fileLocation = baseDir + "_metadata_acid";
         Status status = fileSystem.exists(fileLocation);
@@ -162,7 +162,7 @@ public class AcidUtil {
         return true;
     }
 
-    private static boolean isValidBase(FileSystem fileSystem, String baseDir,
+    private static boolean isValidBase(LegacyFileSystem fileSystem, String baseDir,
             ParsedBase base, ValidWriteIdList writeIdList) throws IOException {
         if (base.writeId == Long.MIN_VALUE) {
             //Ref: https://issues.apache.org/jira/browse/HIVE-13369
@@ -239,7 +239,7 @@ public class AcidUtil {
     //Since the hive3 library cannot read the hive4 transaction table normally, and there are many problems
     // when using the Hive 4 library directly, this method is implemented.
     //Ref: hive/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java#getAcidState
-    public static FileCacheValue getAcidState(FileSystem fileSystem, HivePartition partition,
+    public static FileCacheValue getAcidState(LegacyFileSystem fileSystem, HivePartition partition,
             Map<String, String> txnValidIds, Map<StorageProperties.Type, StorageProperties> storagePropertiesMap,
                                               boolean isFullAcid) throws Exception {
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -28,7 +28,7 @@ import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.statistics.CommonStatistics;
 import org.apache.doris.foundation.util.PathUtils;
-import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.LegacyFileSystem;
 import org.apache.doris.fs.FileSystemProvider;
 import org.apache.doris.fs.FileSystemUtil;
 import org.apache.doris.fs.remote.ObjFileSystem;
@@ -90,7 +90,7 @@ import java.util.stream.Collectors;
 public class HMSTransaction implements Transaction {
     private static final Logger LOG = LogManager.getLogger(HMSTransaction.class);
     private final HiveMetadataOps hiveOps;
-    private final FileSystem fs;
+    private final LegacyFileSystem fs;
     private Optional<SummaryProfile> summaryProfile = Optional.empty();
     private String queryId;
     private boolean isOverwrite = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateFileIO.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateFileIO.java
@@ -17,11 +17,10 @@
 
 package org.apache.doris.datasource.iceberg.fileio;
 
-import org.apache.doris.backup.Status;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.fs.FileSystem;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.fs.Location;
 
 import com.google.common.collect.Iterables;
 import org.apache.iceberg.DataFile;
@@ -80,7 +79,7 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public InputFile newInputFile(String path) {
-        return new DelegateInputFile(fileSystem.newInputFile(new ParsedPath(path)));
+        return new DelegateInputFile(fileSystem.newInputFile(Location.of(path)));
     }
 
     /**
@@ -92,7 +91,7 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public InputFile newInputFile(String path, long length) {
-        return new DelegateInputFile(fileSystem.newInputFile(new ParsedPath(path), length));
+        return new DelegateInputFile(fileSystem.newInputFile(Location.of(path), length));
     }
 
     /**
@@ -103,7 +102,7 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public OutputFile newOutputFile(String path) {
-        return new DelegateOutputFile(fileSystem, new ParsedPath(path));
+        return new DelegateOutputFile(fileSystem, Location.of(path));
     }
 
     // ===================== File Deletion Methods =====================
@@ -116,10 +115,11 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public void deleteFile(String path) {
-        Status status = fileSystem.delete(path);
-        if (!status.ok()) {
+        try {
+            fileSystem.deleteFile(Location.of(path));
+        } catch (IOException e) {
             throw new UncheckedIOException(
-                    new IOException("Failed to delete file: " + path + ", " + status.toString()));
+                    "Failed to delete file: " + path, e);
         }
     }
 
@@ -165,9 +165,13 @@ public class DelegateFileIO implements SupportsBulkOperations {
      * @param filesToDelete list of file paths to delete
      */
     private void deleteBatch(List<String> filesToDelete) {
-        Status status = fileSystem.deleteAll(filesToDelete);
-        if (!status.ok()) {
-            throw new UncheckedIOException(new IOException("Failed to delete some or all files: " + status.toString()));
+        for (String path : filesToDelete) {
+            try {
+                fileSystem.deleteFile(Location.of(path));
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to delete file: " + path, e);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateInputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateInputFile.java
@@ -69,7 +69,7 @@ public class DelegateInputFile implements InputFile {
      */
     @Override
     public String location() {
-        return inputFile.path().toString();
+        return inputFile.location().toString();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateOutputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateOutputFile.java
@@ -18,8 +18,8 @@
 package org.apache.doris.datasource.iceberg.fileio;
 
 import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.Location;
 import org.apache.doris.fs.io.DorisOutputFile;
-import org.apache.doris.fs.io.ParsedPath;
 
 import com.google.common.io.CountingOutputStream;
 import org.apache.iceberg.io.InputFile;
@@ -50,11 +50,11 @@ public class DelegateOutputFile implements OutputFile {
      * Constructs a DelegateOutputFile with the specified FileSystem and ParsedPath.
      *
      * @param fileSystem the Doris file system to delegate operations to
-     * @param path the ParsedPath representing the file location
+     * @param location the Location representing the file location
      */
-    public DelegateOutputFile(FileSystem fileSystem, ParsedPath path) {
+    public DelegateOutputFile(FileSystem fileSystem, Location location) {
         this.fileSystem = Objects.requireNonNull(fileSystem, "fileSystem is null");
-        this.outputFile = fileSystem.newOutputFile(path);
+        this.outputFile = fileSystem.newOutputFile(location);
     }
 
     // ===================== File Creation Methods =====================
@@ -96,7 +96,7 @@ public class DelegateOutputFile implements OutputFile {
      */
     @Override
     public String location() {
-        return outputFile.path().toString();
+        return outputFile.location().toString();
     }
 
     /**
@@ -106,7 +106,7 @@ public class DelegateOutputFile implements OutputFile {
      */
     @Override
     public InputFile toInputFile() {
-        return new DelegateInputFile(fileSystem.newInputFile(outputFile.path()));
+        return new DelegateInputFile(fileSystem.newInputFile(outputFile.location()));
     }
 
     // ===================== Object Methods =====================

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/DirectoryLister.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/DirectoryLister.java
@@ -24,6 +24,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.fs.remote.RemoteFile;
 
 public interface DirectoryLister {
-    RemoteIterator<RemoteFile> listFiles(FileSystem fs, boolean recursive, TableIf table, String location)
+    RemoteIterator<RemoteFile> listFiles(LegacyFileSystem fs, boolean recursive, TableIf table, String location)
             throws FileSystemIOException;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileEntry.java
@@ -1,0 +1,243 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.fs.remote.RemoteFile;
+
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable file/directory metadata. Zero Hadoop dependency in its public API.
+ * Replaces {@link RemoteFile}.
+ *
+ * <p>For HDFS files, optional {@link BlockInfo} records are available for data locality
+ * optimization. Blob-storage files do not need block information.
+ */
+public final class FileEntry {
+
+    private final Location location;
+    private final boolean isDirectory;
+    private final long length;        // file size in bytes; -1 for directories
+    private final long lastModified;  // epoch millis
+    private final List<BlockInfo> blocks; // nullable, only for HDFS
+
+    public FileEntry(Location location, boolean isDirectory, long length, long lastModified) {
+        this(location, isDirectory, length, lastModified, null);
+    }
+
+    public FileEntry(Location location, boolean isDirectory, long length,
+                     long lastModified, List<BlockInfo> blocks) {
+        this.location = Objects.requireNonNull(location, "location is null");
+        this.isDirectory = isDirectory;
+        this.length = length;
+        this.lastModified = lastModified;
+        this.blocks = blocks == null ? null : Collections.unmodifiableList(new ArrayList<>(blocks));
+    }
+
+    // ====== Getters ======
+
+    public Location location() {
+        return location;
+    }
+
+    public boolean isFile() {
+        return !isDirectory;
+    }
+
+    public boolean isDirectory() {
+        return isDirectory;
+    }
+
+    public long length() {
+        return length;
+    }
+
+    public long lastModified() {
+        return lastModified;
+    }
+
+    /**
+     * Returns the file name — shortcut for {@code location().fileName()}.
+     */
+    public String fileName() {
+        return location.fileName();
+    }
+
+    /**
+     * Returns the optional block information. Only HDFS files typically have blocks.
+     */
+    public Optional<List<BlockInfo>> blocks() {
+        return Optional.ofNullable(blocks);
+    }
+
+    // ====== HDFS block information ======
+
+    /**
+     * Block information for data locality optimization.
+     * Blob storage does not need this.
+     */
+    public static final class BlockInfo {
+        private final List<String> hosts;
+        private final long offset;
+        private final long length;
+
+        public BlockInfo(List<String> hosts, long offset, long length) {
+            this.hosts = hosts == null ? Collections.emptyList()
+                    : Collections.unmodifiableList(new ArrayList<>(hosts));
+            this.offset = offset;
+            this.length = length;
+        }
+
+        public List<String> hosts() {
+            return hosts;
+        }
+
+        public long offset() {
+            return offset;
+        }
+
+        public long length() {
+            return length;
+        }
+
+        @Override
+        public String toString() {
+            return "BlockInfo{hosts=" + hosts + ", offset=" + offset + ", length=" + length + "}";
+        }
+    }
+
+    // ====== Backward-compatible conversions ======
+
+    /**
+     * Converts this FileEntry to a legacy {@link RemoteFile}.
+     *
+     * @return a RemoteFile
+     * @deprecated Use FileEntry instead of RemoteFile
+     */
+    @Deprecated
+    public RemoteFile toRemoteFile() {
+        BlockLocation[] blockLocations = null;
+        if (blocks != null && !blocks.isEmpty()) {
+            blockLocations = new BlockLocation[blocks.size()];
+            for (int i = 0; i < blocks.size(); i++) {
+                BlockInfo bi = blocks.get(i);
+                blockLocations[i] = new BlockLocation(
+                        null, // names
+                        bi.hosts().toArray(new String[0]),
+                        bi.offset(),
+                        bi.length());
+            }
+        }
+        return new RemoteFile(
+                location.fileName(),
+                new Path(location.toString()),
+                !isDirectory,
+                isDirectory,
+                length,
+                0, // blockSize — not tracked in FileEntry
+                lastModified,
+                blockLocations);
+    }
+
+    /**
+     * Creates a FileEntry from a legacy {@link RemoteFile}.
+     *
+     * <p>The basePath is used to reconstruct the full location when RemoteFile only
+     * has the file name without the full path.
+     *
+     * @param rf the RemoteFile to convert
+     * @param basePath the base path to prepend if RemoteFile has no full path
+     * @return a new FileEntry
+     * @deprecated Use FileEntry directly
+     */
+    @Deprecated
+    public static FileEntry fromRemoteFile(RemoteFile rf, String basePath) {
+        // Determine the full location string
+        String locationStr;
+        if (rf.getPath() != null) {
+            locationStr = rf.getPath().toString();
+        } else {
+            // RemoteFile only has a name, combine with basePath
+            String base = basePath.endsWith("/") ? basePath : basePath + "/";
+            locationStr = base + rf.getName();
+        }
+
+        // Convert block locations if present
+        List<BlockInfo> blocks = null;
+        if (rf.getBlockLocations() != null && rf.getBlockLocations().length > 0) {
+            blocks = new ArrayList<>();
+            for (BlockLocation bl : rf.getBlockLocations()) {
+                try {
+                    blocks.add(new BlockInfo(
+                            Arrays.asList(bl.getHosts()),
+                            bl.getOffset(),
+                            bl.getLength()));
+                } catch (IOException e) {
+                    // BlockLocation.getHosts() should not throw for standard Hadoop implementation
+                    throw new RuntimeException("Failed to get block hosts", e);
+                }
+            }
+        }
+
+        return new FileEntry(
+                Location.of(locationStr),
+                rf.isDirectory(),
+                rf.getSize(),
+                rf.getModificationTime(),
+                blocks);
+    }
+
+    @Override
+    public String toString() {
+        return "FileEntry{"
+                + "location=" + location
+                + ", isDirectory=" + isDirectory
+                + ", length=" + length
+                + ", lastModified=" + lastModified
+                + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FileEntry that = (FileEntry) o;
+        return isDirectory == that.isDirectory
+                && length == that.length
+                && lastModified == that.lastModified
+                && Objects.equals(location, that.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(location, isDirectory, length, lastModified);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileIterator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileIterator.java
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Lazy file iterator.
+ *
+ * <p>{@link #hasNext()} and {@link #next()} may throw {@link IOException},
+ * which distinguishes this from {@link java.util.Iterator}.
+ *
+ * <p>References Trino's {@code FileIterator}.
+ *
+ * <p>This is an independent interface (recommended approach A from design doc),
+ * not extending the existing {@code RemoteIterator<T>}. The existing {@code RemoteIterator}
+ * will be migrated to this interface in a later phase.
+ */
+public interface FileIterator {
+
+    /**
+     * Returns {@code true} if there are more file entries.
+     *
+     * @throws IOException if an I/O error occurs while checking
+     */
+    boolean hasNext() throws IOException;
+
+    /**
+     * Returns the next file entry.
+     *
+     * @throws IOException if an I/O error occurs while fetching
+     * @throws NoSuchElementException if no more elements
+     */
+    FileEntry next() throws IOException;
+
+    /**
+     * Returns an empty iterator.
+     */
+    static FileIterator empty() {
+        return new FileIterator() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public FileEntry next() {
+                throw new NoSuchElementException("empty iterator");
+            }
+        };
+    }
+
+    /**
+     * Creates a FileIterator backed by a pre-fetched list.
+     * Useful for wrapping legacy list-based results.
+     *
+     * @param entries the list of file entries
+     * @return a FileIterator over the given list
+     */
+    static FileIterator fromList(List<FileEntry> entries) {
+        Iterator<FileEntry> delegate = entries.iterator();
+        return new FileIterator() {
+            @Override
+            public boolean hasNext() {
+                return delegate.hasNext();
+            }
+
+            @Override
+            public FileEntry next() {
+                if (!delegate.hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return delegate.next();
+            }
+        };
+    }
+
+    /**
+     * Convenience method: collects all remaining entries into a List.
+     * Use only for small result sets — large listings should consume entries lazily.
+     *
+     * @return a list of all remaining file entries
+     * @throws IOException if an I/O error occurs during iteration
+     */
+    default List<FileEntry> collectAll() throws IOException {
+        List<FileEntry> result = new ArrayList<>();
+        while (hasNext()) {
+            result.add(next());
+        }
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystem.java
@@ -17,131 +17,143 @@
 
 package org.apache.doris.fs;
 
-import org.apache.doris.backup.Status;
 import org.apache.doris.fs.io.DorisInputFile;
 import org.apache.doris.fs.io.DorisOutputFile;
-import org.apache.doris.fs.io.ParsedPath;
-import org.apache.doris.fs.remote.RemoteFile;
 
-import java.util.List;
-import java.util.Map;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Set;
 
 /**
- * File system interface.
- * All file operations should use DFSFileSystem.
- * @see org.apache.doris.fs.remote.dfs.DFSFileSystem
- * If the file system use the object storage's SDK, use ObjStorage
- * @see org.apache.doris.fs.remote.ObjFileSystem
- * Read and Write operation put in FileOperations
- * @see org.apache.doris.fs.operations.FileOperations
+ * Doris file system core interface.
+ *
+ * <p>Design principles (referencing Trino TrinoFileSystem):
+ * <ol>
+ *   <li>Minimal API: only expose operations Doris actually needs</li>
+ *   <li>IO via {@link DorisInputFile}/{@link DorisOutputFile}</li>
+ *   <li>Errors propagated via {@link IOException} (no more {@link org.apache.doris.backup.Status})</li>
+ *   <li>Paths use {@link Location} strong-typed value objects</li>
+ * </ol>
+ *
+ * <p>Backward compatibility: The old Status-based interface is renamed to
+ * {@link LegacyFileSystem}, with {@link LegacyFileSystemAdapter} bridging them.
+ *
+ * @see LegacyFileSystem
+ * @see LegacyFileSystemAdapter
  */
-public interface FileSystem {
-    Map<String, String> getProperties();
+public interface FileSystem extends Closeable {
 
-    Status exists(String remotePath);
+    // ====== IO Entry Points ======
 
-    default Status directoryExists(String dir) {
-        return exists(dir);
-    }
+    /**
+     * Creates an input file handle for the given location.
+     */
+    DorisInputFile newInputFile(Location location);
 
-    Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize);
+    /**
+     * Creates an input file handle with a known length (skips HEAD request).
+     */
+    DorisInputFile newInputFile(Location location, long length);
 
-    Status upload(String localPath, String remotePath);
+    /**
+     * Creates an output file handle for the given location.
+     */
+    DorisOutputFile newOutputFile(Location location);
 
-    Status directUpload(String content, String remoteFile);
+    // ====== File Operations ======
 
-    Status rename(String origFilePath, String destFilePath);
+    /**
+     * Checks if a file or directory exists.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    boolean exists(Location location) throws IOException;
 
-    default Status renameDir(String origFilePath, String destFilePath) {
-        return renameDir(origFilePath, destFilePath, () -> {});
-    }
+    /**
+     * Deletes a single file.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void deleteFile(Location location) throws IOException;
 
-    default Status renameDir(String origFilePath,
-                             String destFilePath,
-                             Runnable runWhenPathNotExist) {
-        throw new UnsupportedOperationException("Unsupported operation rename dir on current file system.");
-    }
-
-    default Status deleteAll(List<String> remotePaths) {
-        for (String remotePath : remotePaths) {
-            Status deleteStatus = delete(remotePath);
-            if (!deleteStatus.ok()) {
-                return deleteStatus;
-            }
+    /**
+     * Deletes multiple files. Default implementation loops over {@link #deleteFile}.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    default void deleteFiles(Collection<Location> locations) throws IOException {
+        for (Location location : locations) {
+            deleteFile(location);
         }
-        return Status.OK;
     }
 
-    Status delete(String remotePath);
+    /**
+     * Renames a file.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void renameFile(Location source, Location target) throws IOException;
 
-    default Status deleteDirectory(String dir) {
-        return delete(dir);
-    }
+    // ====== Directory Operations ======
 
-    Status makeDir(String remotePath);
+    /**
+     * Deletes a directory and all its contents.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void deleteDirectory(Location location) throws IOException;
 
-    /*
-     * List files in remotePath
-     * @param remotePath remote path
+    /**
+     * Creates a directory (and any necessary parent directories).
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void createDirectory(Location location) throws IOException;
+
+    /**
+     * Renames a directory.
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void renameDirectory(Location source, Location target) throws IOException;
+
+    // ====== Listing ======
+
+    /**
+     * Lists files under the given location.
+     *
+     * @param location the directory to list
      * @param recursive whether to list files recursively
-     * <pre>
-     * If the path is a directory,
-     *   if recursive is false, returns files in the directory;
-     *   if recursive is true, return files in the subtree rooted at the path.
-     * If the path is a file, return the file's status and block locations.
-     * </pre>
-     * */
-    Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result);
+     * @return a lazy iterator over file entries
+     * @throws IOException if an I/O error occurs
+     */
+    FileIterator listFiles(Location location, boolean recursive) throws IOException;
 
     /**
-     * List files in remotePath by wildcard <br/>
-     * The {@link RemoteFile}'name will only contain file name (Not full path)
-     * @param remotePath remote path
-     * @param result All eligible files under the path
-     * @return
+     * Lists direct subdirectories of the given location.
+     *
+     * @param location the directory to list
+     * @return a set of subdirectory locations
+     * @throws IOException if an I/O error occurs
      */
-    default Status globList(String remotePath, List<RemoteFile> result) {
-        return globList(remotePath, result, true);
-    }
+    Set<Location> listDirectories(Location location) throws IOException;
 
     /**
-     * List files in remotePath by wildcard <br/>
-     * @param remotePath remote path
-     * @param result All eligible files under the path
-     * @param fileNameOnly for {@link RemoteFile}'name: whether the full path is included.<br/>
-     *                     true: only contains file name, false: contains full path<br/>
-     * @return
+     * Lists files matching a glob pattern.
+     * Default implementation throws {@link UnsupportedOperationException}.
+     *
+     * @param pattern a glob pattern (e.g. {@code s3://bucket/prefix/*.parquet})
+     * @return a lazy iterator over matching file entries
+     * @throws IOException if an I/O error occurs
      */
-    Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly);
-
-    /**
-     * List files in remotePath <br/>
-     * @param remotePath remote path
-     * @param result All eligible files under the path
-     * @param startFile start file name
-     * @param fileSizeLimit limit the total size of files to be listed.
-     * @param fileNumLimit limit the total number of files to be listed.
-     * @return
-     */
-    default GlobListResult globListWithLimit(String remotePath, List<RemoteFile> result,
-            String startFile, long fileSizeLimit, long fileNumLimit) {
-        throw new UnsupportedOperationException("Unsupported operation glob list with limit on current file system.");
+    default FileIterator globFiles(Location pattern) throws IOException {
+        throw new UnsupportedOperationException("glob not supported by " + getClass().getSimpleName());
     }
 
-    default Status listDirectories(String remotePath, Set<String> result) {
-        throw new UnsupportedOperationException("Unsupported operation list directories on current file system.");
-    }
+    // ====== Default close ======
 
-    default DorisOutputFile newOutputFile(ParsedPath path) {
-        throw new UnsupportedOperationException("Unsupported operation new output file on current file system.");
-    }
-
-    default DorisInputFile newInputFile(ParsedPath path) {
-        return newInputFile(path, -1);
-    }
-
-    default DorisInputFile newInputFile(ParsedPath path, long length) {
-        throw new UnsupportedOperationException("Unsupported operation new input file on current file system.");
+    @Override
+    default void close() throws IOException {
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDirectoryLister.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDirectoryLister.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class FileSystemDirectoryLister implements DirectoryLister {
-    public RemoteIterator<RemoteFile> listFiles(FileSystem fs, boolean recursive, TableIf table, String location)
+    public RemoteIterator<RemoteFile> listFiles(LegacyFileSystem fs, boolean recursive, TableIf table, String location)
             throws FileSystemIOException {
         List<RemoteFile> result = new ArrayList<>();
         Status status = fs.listFiles(location, recursive, result);

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemProvider.java
@@ -20,5 +20,5 @@ package org.apache.doris.fs;
 import org.apache.doris.datasource.SessionContext;
 
 public interface FileSystemProvider {
-    FileSystem get(SessionContext ctx);
+    LegacyFileSystem get(SessionContext ctx);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemProviderImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemProviderImpl.java
@@ -36,7 +36,7 @@ public class FileSystemProviderImpl implements FileSystemProvider {
     }
 
     @Override
-    public FileSystem get(SessionContext ctx) {
+    public LegacyFileSystem get(SessionContext ctx) {
         return new SwitchingFileSystem(extMetaCacheMgr, storagePropertiesMap);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemUtil.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FileSystemUtil {
 
-    public static void asyncRenameFiles(FileSystem fs,
+    public static void asyncRenameFiles(LegacyFileSystem fs,
                                         Executor executor,
                                         List<CompletableFuture<?>> renameFileFutures,
                                         AtomicBoolean cancelled,
@@ -50,7 +50,7 @@ public class FileSystemUtil {
         }
     }
 
-    public static void asyncRenameDir(FileSystem fs,
+    public static void asyncRenameDir(LegacyFileSystem fs,
                                       Executor executor,
                                       List<CompletableFuture<?>> renameFileFutures,
                                       AtomicBoolean cancelled,

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/LegacyFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/LegacyFileSystem.java
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.fs.io.DorisOutputFile;
+import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.fs.remote.RemoteFile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Legacy file system interface using {@link Status} return values.
+ *
+ * <p>This interface is the renamed version of the original {@code FileSystem} interface.
+ * It is retained for backward compatibility during the gradual migration to
+ * the new {@link FileSystem} interface which uses {@code IOException}-based error handling
+ * and {@link Location}-based path types.
+ *
+ * @deprecated Use {@link FileSystem} instead. This interface will be removed once all
+ *     callers are migrated to the new API.
+ * @see FileSystem
+ * @see LegacyFileSystemAdapter
+ */
+@Deprecated
+public interface LegacyFileSystem {
+    Map<String, String> getProperties();
+
+    Status exists(String remotePath);
+
+    default Status directoryExists(String dir) {
+        return exists(dir);
+    }
+
+    Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize);
+
+    Status upload(String localPath, String remotePath);
+
+    Status directUpload(String content, String remoteFile);
+
+    Status rename(String origFilePath, String destFilePath);
+
+    default Status renameDir(String origFilePath, String destFilePath) {
+        return renameDir(origFilePath, destFilePath, () -> {});
+    }
+
+    default Status renameDir(String origFilePath,
+                             String destFilePath,
+                             Runnable runWhenPathNotExist) {
+        throw new UnsupportedOperationException("Unsupported operation rename dir on current file system.");
+    }
+
+    default Status deleteAll(List<String> remotePaths) {
+        for (String remotePath : remotePaths) {
+            Status deleteStatus = delete(remotePath);
+            if (!deleteStatus.ok()) {
+                return deleteStatus;
+            }
+        }
+        return Status.OK;
+    }
+
+    Status delete(String remotePath);
+
+    default Status deleteDirectory(String dir) {
+        return delete(dir);
+    }
+
+    Status makeDir(String remotePath);
+
+    Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result);
+
+    default Status globList(String remotePath, List<RemoteFile> result) {
+        return globList(remotePath, result, true);
+    }
+
+    Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly);
+
+    default GlobListResult globListWithLimit(String remotePath, List<RemoteFile> result,
+            String startFile, long fileSizeLimit, long fileNumLimit) {
+        throw new UnsupportedOperationException("Unsupported operation glob list with limit on current file system.");
+    }
+
+    default Status listDirectories(String remotePath, Set<String> result) {
+        throw new UnsupportedOperationException("Unsupported operation list directories on current file system.");
+    }
+
+    default DorisOutputFile newOutputFile(ParsedPath path) {
+        throw new UnsupportedOperationException("Unsupported operation new output file on current file system.");
+    }
+
+    default DorisInputFile newInputFile(ParsedPath path) {
+        return newInputFile(path, -1);
+    }
+
+    default DorisInputFile newInputFile(ParsedPath path, long length) {
+        throw new UnsupportedOperationException("Unsupported operation new input file on current file system.");
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/LegacyFileSystemAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/LegacyFileSystemAdapter.java
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.backup.Status;
+import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.fs.io.DorisOutputFile;
+import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.fs.remote.RemoteFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Adapter that bridges the new {@link FileSystem} interface with the legacy
+ * {@link LegacyFileSystem} interface.
+ *
+ * <p>Subclasses implement the legacy Status-based methods. This adapter provides
+ * default implementations of the new IOException-based {@link FileSystem} methods
+ * by delegating to the legacy methods and converting Status to exceptions.
+ *
+ * <p>All existing {@link org.apache.doris.fs.remote.RemoteFileSystem} subclasses
+ * transition through this adapter, so both old and new callers can use them.
+ *
+ * @see FileSystem
+ * @see LegacyFileSystem
+ */
+public abstract class LegacyFileSystemAdapter implements FileSystem, LegacyFileSystem {
+
+    // ====== FileSystem → LegacyFileSystem bridging ======
+
+    @Override
+    public DorisInputFile newInputFile(Location location) {
+        return newInputFile(new ParsedPath(location.toString()));
+    }
+
+    @Override
+    public DorisInputFile newInputFile(Location location, long length) {
+        return newInputFile(new ParsedPath(location.toString()), length);
+    }
+
+    @Override
+    public DorisOutputFile newOutputFile(Location location) {
+        return newOutputFile(new ParsedPath(location.toString()));
+    }
+
+    @Override
+    public boolean exists(Location location) throws IOException {
+        Status status = exists(location.toString());
+        if (status.ok()) {
+            return true;
+        }
+        if (status.getErrCode() == Status.ErrCode.NOT_FOUND) {
+            return false;
+        }
+        throw new IOException("Failed to check existence of " + location + ": " + status.getErrMsg());
+    }
+
+    @Override
+    public void deleteFile(Location location) throws IOException {
+        Status status = delete(location.toString());
+        if (!status.ok()) {
+            throw new IOException("Failed to delete " + location + ": " + status.getErrMsg());
+        }
+    }
+
+    @Override
+    public void deleteDirectory(Location location) throws IOException {
+        Status status = deleteDirectory(location.toString());
+        if (!status.ok()) {
+            throw new IOException("Failed to delete directory " + location + ": " + status.getErrMsg());
+        }
+    }
+
+    @Override
+    public void createDirectory(Location location) throws IOException {
+        Status status = makeDir(location.toString());
+        if (!status.ok()) {
+            throw new IOException("Failed to create directory " + location + ": " + status.getErrMsg());
+        }
+    }
+
+    @Override
+    public void renameFile(Location source, Location target) throws IOException {
+        Status status = rename(source.toString(), target.toString());
+        if (!status.ok()) {
+            throw new IOException("Failed to rename " + source + " to " + target + ": " + status.getErrMsg());
+        }
+    }
+
+    @Override
+    public void renameDirectory(Location source, Location target) throws IOException {
+        Status status = renameDir(source.toString(), target.toString());
+        if (!status.ok()) {
+            throw new IOException("Failed to rename dir " + source + " to " + target + ": " + status.getErrMsg());
+        }
+    }
+
+    @Override
+    public FileIterator listFiles(Location location, boolean recursive) throws IOException {
+        List<RemoteFile> result = new ArrayList<>();
+        Status status = listFiles(location.toString(), recursive, result);
+        if (!status.ok()) {
+            throw new IOException("Failed to list files at " + location + ": " + status.getErrMsg());
+        }
+        List<FileEntry> entries = result.stream()
+                .map(rf -> FileEntry.fromRemoteFile(rf, location.toString()))
+                .collect(Collectors.toList());
+        return FileIterator.fromList(entries);
+    }
+
+    @Override
+    public Set<Location> listDirectories(Location location) throws IOException {
+        Set<String> result = new HashSet<>();
+        Status status = listDirectories(location.toString(), result);
+        if (!status.ok()) {
+            throw new IOException("Failed to list directories at " + location + ": " + status.getErrMsg());
+        }
+        return result.stream().map(Location::of).collect(Collectors.toSet());
+    }
+
+    @Override
+    public FileIterator globFiles(Location pattern) throws IOException {
+        List<RemoteFile> result = new ArrayList<>();
+        Status status = globList(pattern.toString(), result, false);
+        if (!status.ok()) {
+            throw new IOException("Glob failed for " + pattern + ": " + status.getErrMsg());
+        }
+        List<FileEntry> entries = result.stream()
+                .map(rf -> FileEntry.fromRemoteFile(rf, pattern.toString()))
+                .collect(Collectors.toList());
+        return FileIterator.fromList(entries);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/LocalDfsFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/LocalDfsFileSystem.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class LocalDfsFileSystem implements FileSystem {
+public class LocalDfsFileSystem extends LegacyFileSystemAdapter {
 
     public LocalFileSystem fs = LocalFileSystem.getLocal(new Configuration());
 

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/Location.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/Location.java
@@ -1,0 +1,312 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable file/directory location identifier.
+ *
+ * <p>Format: {@code scheme://[userInfo@]host[:port]/path}
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>{@code s3://bucket/prefix/file.parquet}</li>
+ *   <li>{@code hdfs://nameservice1/user/doris/backup}</li>
+ *   <li>{@code abfss://container@account.dfs.core.windows.net/dir/file}</li>
+ *   <li>{@code /local/path}</li>
+ * </ul>
+ *
+ * <p>Differences from Trino Location:
+ * <ul>
+ *   <li>Provides {@link #bucket()} / {@link #key()} convenience methods for object storage</li>
+ *   <li>Retains {@link #toHadoopPath()} for the migration period</li>
+ * </ul>
+ *
+ * <p>Immutable and thread-safe.
+ */
+public final class Location {
+
+    private final String location; // original complete string
+
+    // Lazily parsed and cached fields
+    private volatile boolean parsed;
+    private String scheme;    // nullable: "s3", "hdfs", "abfss", etc.
+    private String authority; // nullable: host[:port] or bucket or userInfo@host
+    private String path;      // path portion: may or may not start with /
+
+    // ====== Construction ======
+
+    private Location(String location) {
+        Preconditions.checkArgument(location != null && !location.isEmpty(),
+                "location is null or empty");
+        // Do not allow whitespace-only strings
+        Preconditions.checkArgument(!location.trim().isEmpty(),
+                "location is blank");
+        this.location = location;
+    }
+
+    /**
+     * Creates a Location from the given URI string.
+     *
+     * @param location a URI string such as {@code s3://bucket/key} or {@code /local/path}
+     * @return a new Location
+     * @throws IllegalArgumentException if location is null or empty
+     */
+    public static Location of(String location) {
+        return new Location(location);
+    }
+
+    // ====== Lazy parsing ======
+
+    private void ensureParsed() {
+        if (!parsed) {
+            synchronized (this) {
+                if (!parsed) {
+                    doParse();
+                    parsed = true;
+                }
+            }
+        }
+    }
+
+    private void doParse() {
+        String remaining = location;
+
+        // 1. Extract scheme
+        int colonSlashSlash = remaining.indexOf("://");
+        if (colonSlashSlash >= 0) {
+            this.scheme = remaining.substring(0, colonSlashSlash);
+            remaining = remaining.substring(colonSlashSlash + 3);
+
+            // 2. Extract authority (everything before the first '/')
+            int firstSlash = remaining.indexOf('/');
+            if (firstSlash >= 0) {
+                this.authority = remaining.substring(0, firstSlash);
+                this.path = remaining.substring(firstSlash + 1); // strip the leading '/'
+            } else {
+                // No slash after authority, e.g. "s3://bucket"
+                this.authority = remaining;
+                this.path = "";
+            }
+        } else {
+            // No scheme — local path
+            this.scheme = null;
+            this.authority = null;
+            this.path = remaining;
+        }
+    }
+
+    // ====== Query ======
+
+    /**
+     * Returns the scheme (e.g. "s3", "hdfs", "abfss"), or empty if no scheme.
+     */
+    public Optional<String> scheme() {
+        ensureParsed();
+        return Optional.ofNullable(scheme);
+    }
+
+    /**
+     * Returns the authority portion (host[:port] or bucket), or empty if not present.
+     */
+    public Optional<String> host() {
+        ensureParsed();
+        return Optional.ofNullable(authority);
+    }
+
+    /**
+     * Returns the path portion of the location.
+     * For URIs with a scheme, this is the part after {@code scheme://authority/}.
+     * For local paths, this is the entire string.
+     */
+    public String path() {
+        ensureParsed();
+        return path;
+    }
+
+    /**
+     * Returns the file name — the part after the last '/'.
+     * Returns the entire path if no '/' is present.
+     */
+    public String fileName() {
+        ensureParsed();
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash >= 0) {
+            return path.substring(lastSlash + 1);
+        }
+        return path;
+    }
+
+    // ====== Navigation ======
+
+    /**
+     * Returns the parent directory of this location.
+     *
+     * @throws IllegalStateException if this location has no parent (e.g. root)
+     */
+    public Location parentDirectory() {
+        ensureParsed();
+        String p = path;
+        // Remove trailing slash if present
+        if (p.endsWith("/")) {
+            p = p.substring(0, p.length() - 1);
+        }
+        int lastSlash = p.lastIndexOf('/');
+        if (lastSlash < 0) {
+            // Path is something like "file.txt" under the authority root
+            if (scheme != null) {
+                return Location.of(scheme + "://" + (authority != null ? authority : "") + "/");
+            }
+            throw new IllegalStateException("Location has no parent: " + location);
+        }
+        String parentPath = p.substring(0, lastSlash);
+        if (scheme != null) {
+            return Location.of(scheme + "://" + (authority != null ? authority : "") + "/" + parentPath);
+        }
+        return Location.of(parentPath);
+    }
+
+    /**
+     * Appends a path element separated by '/'.
+     *
+     * @param element the path element to append
+     * @return a new Location with the element appended
+     */
+    public Location appendPath(String element) {
+        Preconditions.checkArgument(element != null && !element.isEmpty(),
+                "path element is null or empty");
+        String base = location;
+        if (base.endsWith("/")) {
+            return Location.of(base + element);
+        }
+        return Location.of(base + "/" + element);
+    }
+
+    /**
+     * Appends a suffix directly (no '/' separator).
+     *
+     * @param suffix the suffix to append
+     * @return a new Location with the suffix appended
+     */
+    public Location appendSuffix(String suffix) {
+        Preconditions.checkArgument(suffix != null && !suffix.isEmpty(),
+                "suffix is null or empty");
+        return Location.of(location + suffix);
+    }
+
+    /**
+     * Returns a sibling location — same parent directory, different name.
+     *
+     * @param name the new file/directory name
+     * @return a new Location with the given name under the same parent
+     */
+    public Location sibling(String name) {
+        return parentDirectory().appendPath(name);
+    }
+
+    // ====== Validation ======
+
+    /**
+     * Verifies this is a valid file location (path is non-empty and does not end with '/').
+     *
+     * @throws IllegalStateException if this is not a valid file location
+     */
+    public void verifyValidFileLocation() {
+        ensureParsed();
+        Preconditions.checkState(!path.isEmpty(),
+                "Location path is empty: %s", location);
+        Preconditions.checkState(!path.endsWith("/"),
+                "File location path must not end with '/': %s", location);
+    }
+
+    // ====== Object storage convenience methods ======
+
+    /**
+     * Extracts the bucket name from the authority (e.g. for {@code s3://bucket/key},
+     * returns "bucket").
+     *
+     * @return the bucket name
+     * @throws IllegalStateException if no authority is present
+     */
+    public String bucket() {
+        ensureParsed();
+        Preconditions.checkState(authority != null && !authority.isEmpty(),
+                "Location has no bucket/authority: %s", location);
+        // For schemes like abfss://container@account.dfs.core.windows.net/path,
+        // the bucket is the container part before '@'
+        int atSign = authority.indexOf('@');
+        if (atSign >= 0) {
+            return authority.substring(0, atSign);
+        }
+        return authority;
+    }
+
+    /**
+     * Returns the object key, which is the path portion for object storage.
+     *
+     * @return the object key
+     */
+    public String key() {
+        ensureParsed();
+        return path;
+    }
+
+    // ====== Transition compatibility ======
+
+    /**
+     * Converts this Location to a Hadoop Path.
+     *
+     * @return a Hadoop Path
+     * @deprecated Use Location API instead of Hadoop Path
+     */
+    @Deprecated
+    public org.apache.hadoop.fs.Path toHadoopPath() {
+        return new org.apache.hadoop.fs.Path(location);
+    }
+
+    // ====== Standard methods ======
+
+    /**
+     * Returns the original location string.
+     */
+    @Override
+    public String toString() {
+        return location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Location that = (Location) o;
+        return Objects.equals(location, that.location);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(location);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/MemoryFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/MemoryFileSystem.java
@@ -1,0 +1,384 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.fs.io.DorisInput;
+import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.fs.io.DorisInputStream;
+import org.apache.doris.fs.io.DorisOutputFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory file system for unit testing.
+ *
+ * <p>All data is stored in a {@link ConcurrentHashMap}, making this implementation
+ * thread-safe and suitable for concurrent test scenarios.
+ *
+ * <p>This directly implements the new {@link FileSystem} interface (IOException-based,
+ * Location-typed) without going through the legacy adapter.
+ */
+public class MemoryFileSystem implements FileSystem {
+
+    private final Map<String, byte[]> files = new ConcurrentHashMap<>();
+
+    // ====== IO Entry Points ======
+
+    @Override
+    public DorisInputFile newInputFile(Location location) {
+        return new MemoryInputFile(location, -1);
+    }
+
+    @Override
+    public DorisInputFile newInputFile(Location location, long length) {
+        return new MemoryInputFile(location, length);
+    }
+
+    @Override
+    public DorisOutputFile newOutputFile(Location location) {
+        return new MemoryOutputFile(location);
+    }
+
+    // ====== File Operations ======
+
+    @Override
+    public boolean exists(Location location) {
+        String key = normalize(location);
+        return files.containsKey(key) || isDirectory(key);
+    }
+
+    @Override
+    public void deleteFile(Location location) throws IOException {
+        String key = normalize(location);
+        if (files.remove(key) == null) {
+            throw new FileNotFoundException("File not found: " + location);
+        }
+    }
+
+    @Override
+    public void renameFile(Location source, Location target) throws IOException {
+        String srcKey = normalize(source);
+        byte[] data = files.remove(srcKey);
+        if (data == null) {
+            throw new FileNotFoundException("Source not found: " + source);
+        }
+        files.put(normalize(target), data);
+    }
+
+    // ====== Directory Operations ======
+
+    @Override
+    public void deleteDirectory(Location location) throws IOException {
+        String prefix = normalize(location);
+        if (!prefix.endsWith("/")) {
+            prefix = prefix + "/";
+        }
+        String dirPrefix = prefix;
+        files.keySet().removeIf(key -> key.startsWith(dirPrefix));
+    }
+
+    @Override
+    public void createDirectory(Location location) {
+        // No-op: directories are implicit in a flat key-value store
+    }
+
+    @Override
+    public void renameDirectory(Location source, Location target) throws IOException {
+        String srcPrefix = normalize(source);
+        if (!srcPrefix.endsWith("/")) {
+            srcPrefix = srcPrefix + "/";
+        }
+        String dstPrefix = normalize(target);
+        if (!dstPrefix.endsWith("/")) {
+            dstPrefix = dstPrefix + "/";
+        }
+        String finalSrcPrefix = srcPrefix;
+        String finalDstPrefix = dstPrefix;
+        // Collect keys first to avoid ConcurrentModificationException
+        Set<String> matchingKeys = files.keySet().stream()
+                .filter(key -> key.startsWith(finalSrcPrefix))
+                .collect(Collectors.toSet());
+        for (String key : matchingKeys) {
+            byte[] data = files.remove(key);
+            if (data != null) {
+                String newKey = finalDstPrefix + key.substring(finalSrcPrefix.length());
+                files.put(newKey, data);
+            }
+        }
+    }
+
+    // ====== Listing ======
+
+    @Override
+    public FileIterator listFiles(Location location, boolean recursive) {
+        String prefix = normalize(location);
+        if (!prefix.endsWith("/")) {
+            prefix = prefix + "/";
+        }
+        String dirPrefix = prefix;
+        java.util.List<FileEntry> entries = files.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(dirPrefix))
+                .filter(e -> {
+                    if (recursive) {
+                        return true;
+                    }
+                    // Non-recursive: only direct children
+                    String rest = e.getKey().substring(dirPrefix.length());
+                    return !rest.contains("/");
+                })
+                .map(e -> new FileEntry(
+                        Location.of(e.getKey()),
+                        false,
+                        e.getValue().length,
+                        System.currentTimeMillis()))
+                .collect(Collectors.toList());
+        return FileIterator.fromList(entries);
+    }
+
+    @Override
+    public Set<Location> listDirectories(Location location) {
+        String prefix = normalize(location);
+        if (!prefix.endsWith("/")) {
+            prefix = prefix + "/";
+        }
+        String dirPrefix = prefix;
+        return files.keySet().stream()
+                .filter(key -> key.startsWith(dirPrefix))
+                .map(key -> {
+                    String rest = key.substring(dirPrefix.length());
+                    int slash = rest.indexOf('/');
+                    if (slash > 0) {
+                        return dirPrefix + rest.substring(0, slash);
+                    }
+                    return null;
+                })
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .map(Location::of)
+                .collect(Collectors.toSet());
+    }
+
+    // ====== Test Utilities ======
+
+    /**
+     * Writes data directly to the in-memory store.
+     */
+    public void putFile(Location location, byte[] data) {
+        files.put(normalize(location), data);
+    }
+
+    /**
+     * Reads data directly from the in-memory store.
+     */
+    public byte[] getFileData(Location location) {
+        return files.get(normalize(location));
+    }
+
+    /**
+     * Returns the number of files stored.
+     */
+    public int fileCount() {
+        return files.size();
+    }
+
+    // ====== Internal ======
+
+    private String normalize(Location location) {
+        return location.toString();
+    }
+
+    private boolean isDirectory(String key) {
+        String prefix = key.endsWith("/") ? key : key + "/";
+        return files.keySet().stream().anyMatch(k -> k.startsWith(prefix));
+    }
+
+    // ====== Inner Classes ======
+
+    private class MemoryInputFile implements DorisInputFile {
+        private final Location location;
+        private final long knownLength;
+
+        MemoryInputFile(Location location, long knownLength) {
+            this.location = location;
+            this.knownLength = knownLength;
+        }
+
+        @Override
+        public Location location() {
+            return location;
+        }
+
+        @Override
+        public long length() throws IOException {
+            if (knownLength >= 0) {
+                return knownLength;
+            }
+            byte[] data = files.get(normalize(location));
+            if (data == null) {
+                throw new FileNotFoundException("File not found: " + location);
+            }
+            return data.length;
+        }
+
+        @Override
+        public long lastModifiedTime() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public boolean exists() {
+            return files.containsKey(normalize(location));
+        }
+
+        @Override
+        public DorisInput newInput() throws IOException {
+            byte[] data = files.get(normalize(location));
+            if (data == null) {
+                throw new FileNotFoundException("File not found: " + location);
+            }
+            return new MemoryDorisInput(data);
+        }
+
+        @Override
+        public DorisInputStream newStream() throws IOException {
+            byte[] data = files.get(normalize(location));
+            if (data == null) {
+                throw new FileNotFoundException("File not found: " + location);
+            }
+            return new MemoryDorisInputStream(data);
+        }
+
+        @Override
+        public String toString() {
+            return "MemoryInputFile{" + location + "}";
+        }
+    }
+
+    private class MemoryOutputFile implements DorisOutputFile {
+        private final Location location;
+
+        MemoryOutputFile(Location location) {
+            this.location = location;
+        }
+
+        @Override
+        public OutputStream create() throws IOException {
+            if (files.containsKey(normalize(location))) {
+                throw new IOException("File already exists: " + location);
+            }
+            return new MemoryOutputStream(location);
+        }
+
+        @Override
+        public OutputStream createOrOverwrite() {
+            return new MemoryOutputStream(location);
+        }
+
+        @Override
+        public Location location() {
+            return location;
+        }
+
+        @Override
+        public String toString() {
+            return "MemoryOutputFile{" + location + "}";
+        }
+    }
+
+    private class MemoryOutputStream extends ByteArrayOutputStream {
+        private final Location location;
+
+        MemoryOutputStream(Location location) {
+            this.location = location;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            files.put(normalize(location), toByteArray());
+        }
+    }
+
+    private static class MemoryDorisInput implements DorisInput {
+        private final byte[] data;
+
+        MemoryDorisInput(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+            if (position < 0 || position + length > data.length) {
+                throw new IOException("Read beyond end of data: pos=" + position
+                        + ", len=" + length + ", dataLen=" + data.length);
+            }
+            System.arraycopy(data, (int) position, buffer, offset, length);
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    private static class MemoryDorisInputStream extends DorisInputStream {
+        private final byte[] data;
+        private int pos = 0;
+
+        MemoryDorisInputStream(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public int read() {
+            if (pos >= data.length) {
+                return -1;
+            }
+            return data[pos++] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] buf, int off, int len) {
+            if (pos >= data.length) {
+                return -1;
+            }
+            int toRead = Math.min(len, data.length - pos);
+            System.arraycopy(data, pos, buf, off, toRead);
+            pos += toRead;
+            return toRead;
+        }
+
+        @Override
+        public long getPosition() {
+            return pos;
+        }
+
+        @Override
+        public void seek(long position) {
+            this.pos = (int) position;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/PersistentFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/PersistentFileSystem.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * Use for persistence, Repository will persist properties of file system.
  */
-public abstract class PersistentFileSystem implements FileSystem {
+public abstract class PersistentFileSystem extends LegacyFileSystemAdapter {
     public static final String STORAGE_TYPE = "_DORIS_STORAGE_TYPE_";
     @SerializedName("prop")
     public Map<String, String> properties = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/TransactionScopeCachingDirectoryLister.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/TransactionScopeCachingDirectoryLister.java
@@ -68,12 +68,12 @@ public class TransactionScopeCachingDirectoryLister implements DirectoryLister {
     }
 
     @Override
-    public RemoteIterator<RemoteFile> listFiles(FileSystem fs, boolean recursive, TableIf table, String location)
+    public RemoteIterator<RemoteFile> listFiles(LegacyFileSystem fs, boolean recursive, TableIf table, String location)
             throws FileSystemIOException {
         return listInternal(fs, recursive, table, new TransactionDirectoryListingCacheKey(transactionId, location));
     }
 
-    private RemoteIterator<RemoteFile> listInternal(FileSystem fs, boolean recursive, TableIf table,
+    private RemoteIterator<RemoteFile> listInternal(LegacyFileSystem fs, boolean recursive, TableIf table,
                                                     TransactionDirectoryListingCacheKey cacheKey)
             throws FileSystemIOException {
         FetchingValueHolder cachedValueHolder;
@@ -94,7 +94,7 @@ public class TransactionScopeCachingDirectoryLister implements DirectoryLister {
         return cachingRemoteIterator(cachedValueHolder, cacheKey);
     }
 
-    private RemoteIterator<RemoteFile> createListingRemoteIterator(FileSystem fs, boolean recursive,
+    private RemoteIterator<RemoteFile> createListingRemoteIterator(LegacyFileSystem fs, boolean recursive,
                                                                    TableIf table,
                                                                    TransactionDirectoryListingCacheKey cacheKey)
             throws FileSystemIOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisInputFile.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.fs.io;
 
+import org.apache.doris.fs.Location;
+
 import java.io.IOException;
 
 /**
@@ -26,12 +28,24 @@ import java.io.IOException;
  * Implementations of this interface allow Doris to interact with various file systems in a unified way.
  */
 public interface DorisInputFile {
+
+    /**
+     * Returns the location of this file.
+     *
+     * @return the Location representing the file location
+     */
+    Location location();
+
     /**
      * Returns the path of this file as a ParsedPath object.
      *
      * @return the ParsedPath representing the file location
+     * @deprecated Use {@link #location()} instead
      */
-    ParsedPath path();
+    @Deprecated
+    default ParsedPath path() {
+        return new ParsedPath(location().toString());
+    }
 
     /**
      * Returns the length of the file in bytes.

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisOutputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/DorisOutputFile.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.fs.io;
 
+import org.apache.doris.fs.Location;
+
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -25,7 +27,7 @@ import java.io.OutputStream;
  * <p>
  * This interface provides methods to create output streams for writing file content,
  * either as a new file or by overwriting an existing file.
- * It also provides a method to retrieve the file's path.
+ * It also provides a method to retrieve the file's location.
  * Implementations of this interface allow Doris to interact with various file systems
  * in a unified way for output operations.
  */
@@ -51,9 +53,20 @@ public interface DorisOutputFile {
     OutputStream createOrOverwrite() throws IOException;
 
     /**
+     * Returns the location of this output file.
+     *
+     * @return the Location representing the file location
+     */
+    Location location();
+
+    /**
      * Returns the path of this output file as a ParsedPath object.
      *
      * @return the ParsedPath representing the file location
+     * @deprecated Use {@link #location()} instead
      */
-    ParsedPath path();
+    @Deprecated
+    default ParsedPath path() {
+        return new ParsedPath(location().toString());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/ParsedPath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/ParsedPath.java
@@ -17,12 +17,18 @@
 
 package org.apache.doris.fs.io;
 
+import org.apache.doris.fs.Location;
+
 import org.apache.hadoop.fs.Path;
 
 /**
- * This is temporary class to isolate the path parsing logic from the rest of the codebase.
- * Maybe refactored later
+ * Temporary class to isolate the path parsing logic from the rest of the codebase.
+ *
+ * @deprecated Use {@link Location} instead. This class remains for backward compatibility.
+ *             Use {@link #toLocation()} to convert to the new type,
+ *             or {@link #fromLocation(Location)} to create from Location.
  */
+@Deprecated
 public class ParsedPath {
     private String origPath;
 
@@ -37,5 +43,24 @@ public class ParsedPath {
 
     public Path toHadoopPath() {
         return new Path(origPath);
+    }
+
+    /**
+     * Converts this ParsedPath to a {@link Location}.
+     *
+     * @return a Location representing the same path
+     */
+    public Location toLocation() {
+        return Location.of(origPath);
+    }
+
+    /**
+     * Creates a ParsedPath from a {@link Location}.
+     *
+     * @param location the Location to convert
+     * @return a new ParsedPath
+     */
+    public static ParsedPath fromLocation(Location location) {
+        return new ParsedPath(location.toString());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsInputFile.java
@@ -18,6 +18,7 @@
 package org.apache.doris.fs.io.hdfs;
 
 import org.apache.doris.backup.Status;
+import org.apache.doris.fs.Location;
 import org.apache.doris.fs.io.DorisInput;
 import org.apache.doris.fs.io.DorisInputFile;
 import org.apache.doris.fs.io.DorisInputStream;
@@ -120,11 +121,18 @@ public class HdfsInputFile implements DorisInputFile {
         return status.ok();
     }
 
+    @Override
+    public Location location() {
+        return Location.of(path.toString());
+    }
+
     /**
      * Returns the ParsedPath associated with this input file.
      *
      * @return the ParsedPath
+     * @deprecated Use {@link #location()} instead
      */
+    @Deprecated
     @Override
     public ParsedPath path() {
         return path;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsOutputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/io/hdfs/HdfsOutputFile.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.fs.io.hdfs;
 
+import org.apache.doris.fs.Location;
 import org.apache.doris.fs.io.DorisOutputFile;
 import org.apache.doris.fs.io.ParsedPath;
 import org.apache.doris.fs.remote.dfs.DFSFileSystem;
@@ -73,11 +74,18 @@ public class HdfsOutputFile implements DorisOutputFile {
         return dfs.createFile(hadoopPath, true);
     }
 
+    @Override
+    public Location location() {
+        return Location.of(path.toString());
+    }
+
     /**
      * Returns the ParsedPath associated with this output file.
      *
      * @return the ParsedPath
+     * @deprecated Use {@link #location()} instead
      */
+    @Deprecated
     @Override
     public ParsedPath path() {
         return path;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFile.java
@@ -17,12 +17,28 @@
 
 package org.apache.doris.fs.remote;
 
+import org.apache.doris.fs.FileEntry;
+import org.apache.doris.fs.Location;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.Path;
 
-// represent a file or a dir in remote storage
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a file or directory in remote storage.
+ *
+ * @deprecated Use {@link FileEntry} instead. This class remains for backward compatibility
+ *             during the migration period. Use {@link #toFileEntry()} to convert to the new type,
+ *             or {@link #fromFileEntry(FileEntry)} to convert back.
+ */
+@Deprecated
 public class RemoteFile {
     // Only file name, not full path
     private final String name;
@@ -113,5 +129,75 @@ public class RemoteFile {
         sb.append("]");
 
         return sb.toString();
+    }
+
+    // ====== FileEntry conversion ======
+
+    /**
+     * Converts this RemoteFile to a {@link FileEntry}.
+     *
+     * @return a new FileEntry representing the same file metadata
+     */
+    public FileEntry toFileEntry() {
+        String locationStr;
+        if (path != null) {
+            locationStr = path.toString();
+        } else {
+            locationStr = name;
+        }
+
+        List<FileEntry.BlockInfo> blocks = null;
+        if (blockLocations != null && blockLocations.length > 0) {
+            blocks = new ArrayList<>();
+            for (BlockLocation bl : blockLocations) {
+                try {
+                    blocks.add(new FileEntry.BlockInfo(
+                            Arrays.asList(bl.getHosts()),
+                            bl.getOffset(),
+                            bl.getLength()));
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to get block hosts", e);
+                }
+            }
+        }
+
+        return new FileEntry(
+                Location.of(locationStr),
+                isDirectory,
+                size,
+                modificationTime,
+                blocks);
+    }
+
+    /**
+     * Creates a RemoteFile from a {@link FileEntry}.
+     *
+     * @param entry the FileEntry to convert
+     * @return a new RemoteFile
+     */
+    public static RemoteFile fromFileEntry(FileEntry entry) {
+        BlockLocation[] blockLocs = null;
+        if (entry.blocks().isPresent()) {
+            List<FileEntry.BlockInfo> blocks = entry.blocks().get();
+            blockLocs = new BlockLocation[blocks.size()];
+            for (int i = 0; i < blocks.size(); i++) {
+                FileEntry.BlockInfo bi = blocks.get(i);
+                blockLocs[i] = new BlockLocation(
+                        null,
+                        bi.hosts().toArray(new String[0]),
+                        bi.offset(),
+                        bi.length());
+            }
+        }
+
+        return new RemoteFile(
+                entry.fileName(),
+                new Path(entry.location().toString()),
+                entry.isFile(),
+                entry.isDirectory(),
+                entry.length(),
+                0,
+                entry.lastModified(),
+                blockLocs);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/SwitchingFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/SwitchingFileSystem.java
@@ -21,14 +21,14 @@ import org.apache.doris.backup.Status;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.ExternalMetaCacheMgr;
 import org.apache.doris.datasource.property.storage.StorageProperties;
-import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.LegacyFileSystem;
 import org.apache.doris.fs.FileSystemCache;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class SwitchingFileSystem implements FileSystem {
+public class SwitchingFileSystem extends org.apache.doris.fs.LegacyFileSystemAdapter {
 
     private final ExternalMetaCacheMgr extMetaCacheMgr;
 
@@ -121,11 +121,12 @@ public class SwitchingFileSystem implements FileSystem {
         return fileSystem(remotePath).listDirectories(remotePath, result);
     }
 
-    public FileSystem fileSystem(String location) {
+    public LegacyFileSystem fileSystem(String location) {
         LocationPath path = LocationPath.of(location, storagePropertiesMap);
-        FileSystemCache.FileSystemCacheKey fileSystemCacheKey = new FileSystemCache.FileSystemCacheKey(
-                path.getFsIdentifier(), path.getStorageProperties()
-        );
+        org.apache.doris.fs.FileSystemCache.FileSystemCacheKey fileSystemCacheKey =
+                new org.apache.doris.fs.FileSystemCache.FileSystemCacheKey(
+                        path.getFsIdentifier(), path.getStorageProperties()
+                );
         return extMetaCacheMgr.getFsCache().getRemoteFileSystem(fileSystemCacheKey);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSTransactionPathTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSTransactionPathTest.java
@@ -18,7 +18,7 @@
 package org.apache.doris.datasource.hive;
 
 import org.apache.doris.backup.Status;
-import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.LegacyFileSystem;
 import org.apache.doris.fs.FileSystemProvider;
 import org.apache.doris.fs.LocalDfsFileSystem;
 import org.apache.doris.fs.remote.RemoteFile;
@@ -161,27 +161,27 @@ public class HMSTransactionPathTest {
         Assert.assertFalse(Files.exists(otherFile));
     }
 
-    private static HMSTransaction createTransaction(FileSystem delegate) {
+    private static HMSTransaction createTransaction(LegacyFileSystem delegate) {
         SwitchingFileSystem switchingFs = new TestSwitchingFileSystem(delegate);
         FileSystemProvider provider = ctx -> switchingFs;
         return new HMSTransaction(null, provider, Runnable::run);
     }
 
     private static class TestSwitchingFileSystem extends SwitchingFileSystem {
-        private final FileSystem delegate;
+        private final LegacyFileSystem delegate;
 
-        TestSwitchingFileSystem(FileSystem delegate) {
+        TestSwitchingFileSystem(LegacyFileSystem delegate) {
             super(null, null);
             this.delegate = delegate;
         }
 
         @Override
-        public FileSystem fileSystem(String location) {
+        public LegacyFileSystem fileSystem(String location) {
             return delegate;
         }
     }
 
-    private static class FakeFileSystem implements FileSystem {
+    private static class FakeFileSystem implements LegacyFileSystem {
         private Status listDirectoriesStatus = Status.OK;
         private Status listFilesStatus = Status.OK;
         private Status makeDirStatus = Status.OK;

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
@@ -25,7 +25,7 @@ import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.TestHMSCachedClient;
-import org.apache.doris.fs.FileSystem;
+import org.apache.doris.fs.LegacyFileSystem;
 import org.apache.doris.fs.FileSystemProvider;
 import org.apache.doris.fs.LocalDfsFileSystem;
 import org.apache.doris.fs.remote.SwitchingFileSystem;
@@ -75,7 +75,7 @@ public class HmsCommitTest {
     private static final String dbName = "test_db";
     private static final String tbWithPartition = "test_tb_with_partition";
     private static final String tbWithoutPartition = "test_tb_without_partition";
-    private static FileSystem fs;
+    private static LegacyFileSystem fs;
     private static LocalDfsFileSystem localDFSFileSystem;
     private static Executor fileSystemExecutor;
     static String dbLocation;
@@ -103,7 +103,7 @@ public class HmsCommitTest {
         localDFSFileSystem = new LocalDfsFileSystem();
         new MockUp<SwitchingFileSystem>(SwitchingFileSystem.class) {
             @Mock
-            public FileSystem fileSystem(String location) {
+            public LegacyFileSystem fileSystem(String location) {
                 return localDFSFileSystem;
             }
         };

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/FileEntryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/FileEntryTest.java
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.fs.remote.RemoteFile;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FileEntryTest {
+
+    @Test
+    public void testBasicFileEntry() {
+        Location loc = Location.of("s3://bucket/path/file.parquet");
+        FileEntry entry = new FileEntry(loc, false, 1024, 1000L);
+
+        Assert.assertEquals(loc, entry.location());
+        Assert.assertFalse(entry.isDirectory());
+        Assert.assertTrue(entry.isFile());
+        Assert.assertEquals(1024, entry.length());
+        Assert.assertEquals(1000L, entry.lastModified());
+        Assert.assertEquals("file.parquet", entry.fileName());
+    }
+
+    @Test
+    public void testFileNameExtraction() {
+        FileEntry entry = new FileEntry(
+                Location.of("hdfs://nn/warehouse/table/data.orc"),
+                false, 0, 0);
+        Assert.assertEquals("data.orc", entry.fileName());
+    }
+
+    @Test
+    public void testBlockInfo() {
+        List<FileEntry.BlockInfo> blocks = Arrays.asList(
+                new FileEntry.BlockInfo(Arrays.asList("host1:50010", "host2:50010"), 0, 1024),
+                new FileEntry.BlockInfo(Arrays.asList("host3:50010"), 1024, 2048)
+        );
+
+        FileEntry entry = new FileEntry(
+                Location.of("hdfs://nn/data/file.orc"),
+                false, 3072, 0, blocks);
+
+        Assert.assertTrue(entry.blocks().isPresent());
+        List<FileEntry.BlockInfo> resultBlocks = entry.blocks().get();
+        Assert.assertEquals(2, resultBlocks.size());
+        Assert.assertEquals(0, resultBlocks.get(0).offset());
+        Assert.assertEquals(1024, resultBlocks.get(0).length());
+        Assert.assertEquals(2, resultBlocks.get(0).hosts().size());
+    }
+
+    @Test
+    public void testFromRemoteFile() {
+        RemoteFile rf = new RemoteFile(new Path("hdfs://nn/path/file.dat"), false, 2048L, 512, 999L, null);
+        FileEntry entry = FileEntry.fromRemoteFile(rf, "hdfs://nn/path");
+
+        Assert.assertEquals("hdfs://nn/path/file.dat", entry.location().toString());
+        Assert.assertFalse(entry.isDirectory());
+        Assert.assertEquals(2048, entry.length());
+    }
+
+    @Test
+    public void testToRemoteFile() {
+        FileEntry entry = new FileEntry(
+                Location.of("s3://bucket/prefix/file.csv"),
+                false, 4096, 5000L);
+
+        RemoteFile rf = entry.toRemoteFile();
+        Assert.assertEquals("file.csv", rf.getName());
+        Assert.assertFalse(rf.isDirectory());
+        Assert.assertEquals(4096, rf.getSize());
+    }
+
+    @Test
+    public void testDirectoryEntry() {
+        FileEntry dir = new FileEntry(
+                Location.of("s3://bucket/prefix/subdir"),
+                true, -1, 0);
+
+        Assert.assertTrue(dir.isDirectory());
+        Assert.assertFalse(dir.isFile());
+        Assert.assertEquals("subdir", dir.fileName());
+    }
+
+    @Test
+    public void testNoBlockInfo() {
+        FileEntry entry = new FileEntry(
+                Location.of("s3://bucket/file.dat"),
+                false, 100, 0);
+        Assert.assertFalse(entry.blocks().isPresent());
+    }
+
+    @Test
+    public void testEquality() {
+        FileEntry a = new FileEntry(Location.of("s3://b/k"), false, 100, 200);
+        FileEntry b = new FileEntry(Location.of("s3://b/k"), false, 100, 200);
+        FileEntry c = new FileEntry(Location.of("s3://b/other"), false, 100, 200);
+
+        Assert.assertEquals(a, b);
+        Assert.assertEquals(a.hashCode(), b.hashCode());
+        Assert.assertNotEquals(a, c);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/LocationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/LocationTest.java
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+
+public class LocationTest {
+
+    @Test
+    public void testBasicParsing() {
+        Location loc = Location.of("s3://bucket/path/to/file.parquet");
+        Assert.assertEquals(Optional.of("s3"), loc.scheme());
+        Assert.assertEquals(Optional.of("bucket"), loc.host());
+        Assert.assertEquals("path/to/file.parquet", loc.path());
+        Assert.assertEquals("s3://bucket/path/to/file.parquet", loc.toString());
+    }
+
+    @Test
+    public void testHdfsUri() {
+        Location loc = Location.of("hdfs://namenode:8020/warehouse/data");
+        Assert.assertEquals(Optional.of("hdfs"), loc.scheme());
+        Assert.assertEquals(Optional.of("namenode:8020"), loc.host());
+        Assert.assertEquals("warehouse/data", loc.path());
+    }
+
+    @Test
+    public void testObjectStorageMethods() {
+        Location loc = Location.of("s3://my-bucket/prefix/key/file.dat");
+        Assert.assertEquals("my-bucket", loc.bucket());
+        Assert.assertEquals("prefix/key/file.dat", loc.key());
+    }
+
+    @Test
+    public void testFileName() {
+        Location loc = Location.of("s3://bucket/path/to/file.parquet");
+        Assert.assertEquals("file.parquet", loc.fileName());
+    }
+
+    @Test
+    public void testParentDirectory() {
+        Location loc = Location.of("s3://bucket/path/to/file.parquet");
+        Location parent = loc.parentDirectory();
+        Assert.assertEquals("s3://bucket/path/to", parent.toString());
+    }
+
+    @Test
+    public void testAppendPath() {
+        Location dir = Location.of("s3://bucket/prefix");
+        Location child = dir.appendPath("subdir/file.txt");
+        Assert.assertEquals("s3://bucket/prefix/subdir/file.txt", child.toString());
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        Location a = Location.of("s3://bucket/key");
+        Location b = Location.of("s3://bucket/key");
+        Location c = Location.of("s3://bucket/other");
+
+        Assert.assertEquals(a, b);
+        Assert.assertEquals(a.hashCode(), b.hashCode());
+        Assert.assertNotEquals(a, c);
+    }
+
+    @Test
+    public void testToHadoopPath() {
+        Location loc = Location.of("hdfs://namenode:8020/warehouse/data");
+        org.apache.hadoop.fs.Path hadoopPath = loc.toHadoopPath();
+        Assert.assertEquals("hdfs://namenode:8020/warehouse/data", hadoopPath.toString());
+    }
+
+    @Test
+    public void testPathOnlyLocation() {
+        Location loc = Location.of("/local/path/to/file");
+        Assert.assertEquals(Optional.empty(), loc.scheme());
+        Assert.assertEquals(Optional.empty(), loc.host());
+        Assert.assertEquals("/local/path/to/file", loc.path());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullUri() {
+        Location.of(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyUri() {
+        Location.of("");
+    }
+
+    @Test
+    public void testGcsUri() {
+        Location loc = Location.of("gs://gcs-bucket/data/file.orc");
+        Assert.assertEquals(Optional.of("gs"), loc.scheme());
+        Assert.assertEquals("gcs-bucket", loc.bucket());
+        Assert.assertEquals("data/file.orc", loc.key());
+    }
+
+    @Test
+    public void testSibling() {
+        Location file = Location.of("s3://bucket/prefix/old.txt");
+        Location sibling = file.sibling("new.txt");
+        Assert.assertEquals("s3://bucket/prefix/new.txt", sibling.toString());
+    }
+
+    @Test
+    public void testAppendSuffix() {
+        Location loc = Location.of("s3://bucket/path/file");
+        Location withSuffix = loc.appendSuffix(".parquet");
+        Assert.assertEquals("s3://bucket/path/file.parquet", withSuffix.toString());
+    }
+
+    @Test
+    public void testVerifyValidFileLocation() {
+        Location valid = Location.of("s3://bucket/path/file.txt");
+        valid.verifyValidFileLocation(); // should not throw
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testVerifyInvalidFileLocationTrailingSlash() {
+        Location invalid = Location.of("s3://bucket/path/dir/");
+        invalid.verifyValidFileLocation();
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/MemoryFileSystemTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/MemoryFileSystemTest.java
@@ -1,0 +1,232 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.fs.io.DorisInput;
+import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.fs.io.DorisOutputFile;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+public class MemoryFileSystemTest {
+
+    private MemoryFileSystem fs;
+
+    @Before
+    public void setUp() {
+        fs = new MemoryFileSystem();
+    }
+
+    // ====== Basic IO ======
+
+    @Test
+    public void testWriteAndReadFile() throws IOException {
+        Location loc = Location.of("mem://bucket/test/file.txt");
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+
+        // Write
+        DorisOutputFile outputFile = fs.newOutputFile(loc);
+        try (OutputStream out = outputFile.createOrOverwrite()) {
+            out.write(data);
+        }
+
+        // Read
+        DorisInputFile inputFile = fs.newInputFile(loc);
+        Assert.assertTrue(inputFile.exists());
+        Assert.assertEquals(data.length, inputFile.length());
+
+        // Read via DorisInput
+        DorisInput input = inputFile.newInput();
+        byte[] buf = new byte[data.length];
+        input.readFully(0, buf, 0, buf.length);
+        Assert.assertArrayEquals(data, buf);
+        input.close();
+    }
+
+    @Test
+    public void testCreateFailsIfExists() throws IOException {
+        Location loc = Location.of("mem://bucket/existing.txt");
+        fs.putFile(loc, "existing".getBytes(StandardCharsets.UTF_8));
+
+        DorisOutputFile outputFile = fs.newOutputFile(loc);
+        Assert.assertThrows(IOException.class, outputFile::create);
+    }
+
+    @Test
+    public void testCreateOrOverwrite() throws IOException {
+        Location loc = Location.of("mem://bucket/overwrite.txt");
+        fs.putFile(loc, "old".getBytes(StandardCharsets.UTF_8));
+
+        try (OutputStream out = fs.newOutputFile(loc).createOrOverwrite()) {
+            out.write("new".getBytes(StandardCharsets.UTF_8));
+        }
+
+        byte[] result = fs.getFileData(loc);
+        Assert.assertArrayEquals("new".getBytes(StandardCharsets.UTF_8), result);
+    }
+
+    // ====== Existence ======
+
+    @Test
+    public void testExists() {
+        Location loc = Location.of("mem://bucket/exists.txt");
+        Assert.assertFalse(fs.exists(loc));
+
+        fs.putFile(loc, new byte[0]);
+        Assert.assertTrue(fs.exists(loc));
+    }
+
+    @Test
+    public void testExistsDirectory() {
+        Location dir = Location.of("mem://bucket/dir");
+        Assert.assertFalse(fs.exists(dir));
+
+        fs.putFile(Location.of("mem://bucket/dir/file.txt"), new byte[0]);
+        Assert.assertTrue(fs.exists(dir));
+    }
+
+    // ====== Delete ======
+
+    @Test
+    public void testDeleteFile() throws IOException {
+        Location loc = Location.of("mem://bucket/to_delete.txt");
+        fs.putFile(loc, new byte[0]);
+        Assert.assertTrue(fs.exists(loc));
+
+        fs.deleteFile(loc);
+        Assert.assertFalse(fs.exists(loc));
+    }
+
+    @Test
+    public void testDeleteFileNotFound() {
+        Location loc = Location.of("mem://bucket/not_exist.txt");
+        Assert.assertThrows(FileNotFoundException.class, () -> fs.deleteFile(loc));
+    }
+
+    @Test
+    public void testDeleteDirectory() throws IOException {
+        fs.putFile(Location.of("mem://bucket/dir/a.txt"), "a".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/b.txt"), "b".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/sub/c.txt"), "c".getBytes());
+        fs.putFile(Location.of("mem://bucket/other/d.txt"), "d".getBytes());
+
+        fs.deleteDirectory(Location.of("mem://bucket/dir"));
+
+        Assert.assertEquals(1, fs.fileCount());
+        Assert.assertTrue(fs.exists(Location.of("mem://bucket/other/d.txt")));
+    }
+
+    // ====== Rename ======
+
+    @Test
+    public void testRenameFile() throws IOException {
+        Location src = Location.of("mem://bucket/src.txt");
+        Location dst = Location.of("mem://bucket/dst.txt");
+        fs.putFile(src, "data".getBytes());
+
+        fs.renameFile(src, dst);
+
+        Assert.assertFalse(fs.exists(src));
+        Assert.assertTrue(fs.exists(dst));
+        Assert.assertArrayEquals("data".getBytes(), fs.getFileData(dst));
+    }
+
+    @Test
+    public void testRenameDirectory() throws IOException {
+        fs.putFile(Location.of("mem://bucket/old/a.txt"), "a".getBytes());
+        fs.putFile(Location.of("mem://bucket/old/sub/b.txt"), "b".getBytes());
+
+        fs.renameDirectory(
+                Location.of("mem://bucket/old"),
+                Location.of("mem://bucket/new"));
+
+        Assert.assertFalse(fs.exists(Location.of("mem://bucket/old/a.txt")));
+        Assert.assertTrue(fs.exists(Location.of("mem://bucket/new/a.txt")));
+        Assert.assertTrue(fs.exists(Location.of("mem://bucket/new/sub/b.txt")));
+    }
+
+    // ====== Listing ======
+
+    @Test
+    public void testListFilesNonRecursive() throws IOException {
+        fs.putFile(Location.of("mem://bucket/dir/a.txt"), "a".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/b.txt"), "b".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/sub/c.txt"), "c".getBytes());
+
+        FileIterator iter = fs.listFiles(Location.of("mem://bucket/dir"), false);
+        int count = 0;
+        while (iter.hasNext()) {
+            FileEntry entry = iter.next();
+            Assert.assertFalse(entry.isDirectory());
+            count++;
+        }
+        Assert.assertEquals(2, count);
+    }
+
+    @Test
+    public void testListFilesRecursive() throws IOException {
+        fs.putFile(Location.of("mem://bucket/dir/a.txt"), "a".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/sub/b.txt"), "b".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/sub/deep/c.txt"), "c".getBytes());
+
+        FileIterator iter = fs.listFiles(Location.of("mem://bucket/dir"), true);
+        int count = 0;
+        while (iter.hasNext()) {
+            iter.next();
+            count++;
+        }
+        Assert.assertEquals(3, count);
+    }
+
+    @Test
+    public void testListDirectories() throws IOException {
+        fs.putFile(Location.of("mem://bucket/dir/a.txt"), "a".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/sub1/b.txt"), "b".getBytes());
+        fs.putFile(Location.of("mem://bucket/dir/sub2/c.txt"), "c".getBytes());
+
+        Set<Location> dirs = fs.listDirectories(Location.of("mem://bucket/dir"));
+        Assert.assertEquals(2, dirs.size());
+        Assert.assertTrue(dirs.contains(Location.of("mem://bucket/dir/sub1")));
+        Assert.assertTrue(dirs.contains(Location.of("mem://bucket/dir/sub2")));
+    }
+
+    // ====== Location on InputFile ======
+
+    @Test
+    public void testInputFileLocation() {
+        Location loc = Location.of("mem://bucket/file.dat");
+        DorisInputFile inputFile = fs.newInputFile(loc);
+        Assert.assertEquals(loc, inputFile.location());
+    }
+
+    @Test
+    public void testOutputFileLocation() {
+        Location loc = Location.of("mem://bucket/out.dat");
+        DorisOutputFile outputFile = fs.newOutputFile(loc);
+        Assert.assertEquals(loc, outputFile.location());
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/TransactionScopeCachingDirectoryListerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/TransactionScopeCachingDirectoryListerTest.java
@@ -136,7 +136,7 @@ public class TransactionScopeCachingDirectoryListerTest {
         }
 
         @Override
-        public RemoteIterator<RemoteFile> listFiles(FileSystem fs, boolean recursive, TableIf table, String location)
+        public RemoteIterator<RemoteFile> listFiles(LegacyFileSystem fs, boolean recursive, TableIf table, String location)
                 throws FileSystemIOException {
             // No specific recursive files-only listing implementation
             listCount++;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Phase 1 of the Doris FE remote storage access layer refactoring. This consolidates the `fs` modules into a modern, unified, SPI-based architecture (inspired by Trino FileSystem).

Key changes:
1. Introduced `Location` as a strongly-typed URI value object.
2. Introduced `FileEntry` representing zero-Hadoop file metadata.
3. Introduced `FileIterator` for lazy iteration to prevent OOM on large directories.
4. Cleaned up `FileSystem` interface (IOException-based, Location-typed) and retained the old `LegacyFileSystem` (Status-based) for backward compatibility during migration.
5. Added `LegacyFileSystemAdapter` to bridge old and new interfaces.
6. Upgraded `DorisInputFile` and `DorisOutputFile` with `location()`.
7. Created `MemoryFileSystem` for comprehensive unit testing without real storage.
8. Marked `RemoteFile` and `ParsedPath` as @Deprecated with bidirectional converters.
9. Migrated Iceberg's `DelegateFileIO` to natively use the new `FileSystem` and `Location` API.

### Release note

None

### Check List (For Author)

- Test:
    - Unit Test (Added comprehensive tests for Location, FileEntry, and MemoryFileSystem. Passed all 39 new tests)
- Behavior changed: No
- Does this need documentation: No