### PR TITLE
[fix](ui) Fix query profile displaying as garbled text with html tags in FE UI

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/QueryProfileController.java
@@ -54,8 +54,6 @@ public class QueryProfileController extends BaseController {
         if (profile == null) {
             return ResponseEntityBuilder.okWithCommonError("ID " + id + " does not exist");
         }
-        profile = profile.replaceAll("\n", "</br>");
-        profile = profile.replaceAll(" ", "&nbsp;&nbsp;");
         return ResponseEntityBuilder.ok(profile);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: 
After the frontend UI was updated to use `innerText` to prevent profile truncation by special characters（https://github.com/apache/doris/pull/58613）, the profile page started showing garbled text full of `</br>` and `&nbsp;` tags.

This is because the backend API `QueryProfileController` was forcibly injecting these HTML formatting tags into the plain text data. Since the modern frontend `<pre>` tag naturally handles line breaks and spaces, we should remove these destructive string replacements from the backend to keep the API data clean.

### Release note

Fix the issue where the Query Profile page in the Web UI displays garbled text with HTML tags.

### Check List (For Author)

- Test: Manual test
- Behavior changed: No
- Does this need documentation: No

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

