### PR TITLE
[fix](regression) Add external regression stage timing summary

### DIFF
--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -405,3 +405,34 @@ file_changed_meta() {
     done
     echo "Doris meta not changed" && return 1
 }
+
+github_utils__maybe_enable_external_stage_timer() {
+    local timer_script
+    local main_definition
+
+    if [[ -z "${teamcity_build_checkoutDir:-}" ]]; then
+        return 0
+    fi
+    timer_script="${teamcity_build_checkoutDir}/regression-test/pipeline/external/external-stage-timer.sh"
+    if [[ ! -f "${timer_script}" ]]; then
+        return 0
+    fi
+    if ! declare -F main >/dev/null; then
+        return 0
+    fi
+
+    main_definition="$(declare -f main)"
+    if [[ "${main_definition}" != *"START EXTERNAL DOCKER"* ]] ||
+        [[ "${main_definition}" != *"RUN EXTERNAL CASE"* ]] ||
+        ([[ "${main_definition}" != *"collect_docker_logs"* ]] &&
+            [[ "${main_definition}" != *"COLLECT DOCKER LOGS"* ]]) ||
+        [[ "${main_definition}" != *"deploy_cluster.sh"* ]]; then
+        return 0
+    fi
+
+    # shellcheck source=/dev/null
+    source "${timer_script}"
+    external_regression_stage_timer_enable_auto_hooks
+}
+
+github_utils__maybe_enable_external_stage_timer

--- a/regression-test/pipeline/common/stage-timer.sh
+++ b/regression-test/pipeline/common/stage-timer.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+stage_timer__now() {
+    date +%s
+}
+
+stage_timer__format_seconds() {
+    local total_seconds="${1:-0}"
+    local hours=$((total_seconds / 3600))
+    local minutes=$(((total_seconds % 3600) / 60))
+    local seconds=$((total_seconds % 60))
+    printf '%02d:%02d:%02d' "${hours}" "${minutes}" "${seconds}"
+}
+
+stage_timer__extract_exit_trap() {
+    local trap_desc
+    trap_desc="$(trap -p EXIT)"
+    if [[ "${trap_desc}" =~ ^trap\ --\ \'(.*)\'\ EXIT$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    fi
+}
+
+stage_timer__record_current_stage() {
+    local end_at="$1"
+    if [[ -z "${STAGE_TIMER_CURRENT_STAGE:-}" ]]; then
+        return 0
+    fi
+    STAGE_TIMER_STAGE_NAMES+=("${STAGE_TIMER_CURRENT_STAGE}")
+    STAGE_TIMER_STAGE_SECONDS+=("$((end_at - STAGE_TIMER_CURRENT_STAGE_STARTED_AT))")
+    STAGE_TIMER_CURRENT_STAGE=''
+    STAGE_TIMER_CURRENT_STAGE_STARTED_AT=''
+}
+
+stage_timer__print_summary() {
+    local exit_code="$1"
+    local finished_at="$2"
+    local total_seconds="$((finished_at - STAGE_TIMER_STARTED_AT))"
+    local index
+
+    echo "========== ${STAGE_TIMER_PIPELINE_NAME} 阶段耗时汇总 =========="
+    for index in "${!STAGE_TIMER_STAGE_NAMES[@]}"; do
+        printf '[stage-timer] %s: %s (%ss)\n' \
+            "${STAGE_TIMER_STAGE_NAMES[$index]}" \
+            "$(stage_timer__format_seconds "${STAGE_TIMER_STAGE_SECONDS[$index]}")" \
+            "${STAGE_TIMER_STAGE_SECONDS[$index]}"
+    done
+    printf '[stage-timer] 总耗时: %s (%ss)\n' \
+        "$(stage_timer__format_seconds "${total_seconds}")" \
+        "${total_seconds}"
+    printf '[stage-timer] 退出码: %s\n' "${exit_code}"
+    echo "=================================================="
+}
+
+stage_timer_finish() {
+    local exit_code="${1:-$?}"
+    local finished_at
+    if [[ "${STAGE_TIMER_INITIALIZED:-false}" != "true" ]]; then
+        return 0
+    fi
+    if [[ "${STAGE_TIMER_SUMMARY_PRINTED:-false}" == "true" ]]; then
+        return 0
+    fi
+    finished_at="$(stage_timer__now)"
+    stage_timer__record_current_stage "${finished_at}"
+    stage_timer__print_summary "${exit_code}" "${finished_at}"
+    STAGE_TIMER_SUMMARY_PRINTED=true
+}
+
+stage_timer__handle_exit() {
+    local exit_code="${1:-0}"
+    stage_timer_finish "${exit_code}"
+    if [[ -n "${STAGE_TIMER_PREVIOUS_EXIT_TRAP:-}" ]] &&
+        [[ "${STAGE_TIMER_PREVIOUS_EXIT_TRAP}" != *"stage_timer__handle_exit"* ]]; then
+        eval "${STAGE_TIMER_PREVIOUS_EXIT_TRAP}"
+    fi
+}
+
+stage_timer_init() {
+    local pipeline_name="${1:-}"
+    if [[ -z "${pipeline_name}" ]]; then
+        echo "ERROR: stage_timer_init need pipeline name"
+        return 1
+    fi
+
+    STAGE_TIMER_PIPELINE_NAME="${pipeline_name}"
+    STAGE_TIMER_STARTED_AT="$(stage_timer__now)"
+    STAGE_TIMER_CURRENT_STAGE=''
+    STAGE_TIMER_CURRENT_STAGE_STARTED_AT=''
+    STAGE_TIMER_SUMMARY_PRINTED=false
+    STAGE_TIMER_INITIALIZED=true
+    STAGE_TIMER_STAGE_NAMES=()
+    STAGE_TIMER_STAGE_SECONDS=()
+    STAGE_TIMER_PREVIOUS_EXIT_TRAP="$(stage_timer__extract_exit_trap)"
+    trap 'stage_timer__handle_exit "$?"' EXIT
+}
+
+stage_timer_enter() {
+    local stage_name="${1:-}"
+    local now
+    if [[ "${STAGE_TIMER_INITIALIZED:-false}" != "true" ]]; then
+        echo "ERROR: stage_timer_enter called before stage_timer_init"
+        return 1
+    fi
+    if [[ -z "${stage_name}" ]]; then
+        echo "ERROR: stage_timer_enter need stage name"
+        return 1
+    fi
+
+    now="$(stage_timer__now)"
+    stage_timer__record_current_stage "${now}"
+    STAGE_TIMER_CURRENT_STAGE="${stage_name}"
+    STAGE_TIMER_CURRENT_STAGE_STARTED_AT="${now}"
+}

--- a/regression-test/pipeline/common/test_stage_timer.py
+++ b/regression-test/pipeline/common/test_stage_timer.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import os
+import stat
 import subprocess
 import tempfile
 import unittest
@@ -24,15 +25,15 @@ import unittest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 HELPER = os.path.join(ROOT, "regression-test", "pipeline", "common", "stage-timer.sh")
+GITHUB_HELPER = os.path.join(ROOT, "regression-test", "pipeline", "common", "github-utils.sh")
 
 
 class StageTimerTest(unittest.TestCase):
-    def _run(self, body):
+    def _run_raw(self, body):
         with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as script:
             script.write("#!/usr/bin/env bash\n")
             script.write("set -euo pipefail\n")
             script.write("export LC_ALL=C.UTF-8\n")
-            script.write("source \"{}\"\n".format(HELPER))
             script.write(body)
             script_path = script.name
         try:
@@ -45,6 +46,9 @@ class StageTimerTest(unittest.TestCase):
             )
         finally:
             os.unlink(script_path)
+
+    def _run(self, body):
+        return self._run_raw('source "{}"\n{}'.format(HELPER, body))
 
     def test_prints_stage_summary_on_success(self):
         result = self._run(
@@ -79,6 +83,66 @@ false
         self.assertIn("external regression 阶段耗时汇总", result.stdout)
         self.assertIn("前置准备", result.stdout)
         self.assertIn("退出码", result.stdout)
+
+    def test_external_pipeline_auto_hooks_print_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ("deploy_cluster.sh", "run-thirdparties-docker.sh", "run-regression-test.sh"):
+                script_path = os.path.join(tmpdir, name)
+                with open(script_path, "w") as script:
+                    script.write("#!/usr/bin/env bash\n")
+                    script.write("exit 0\n")
+                os.chmod(script_path, stat.S_IRWXU)
+
+            result = self._run_raw(
+                """
+export teamcity_build_checkoutDir="{root}"
+
+main() {{
+    source "{github_helper}"
+    echo "PREPARE"
+    cd "{tmpdir}" && bash deploy_cluster.sh test_cluster
+    echo "START EXTERNAL DOCKER"
+    cd "{tmpdir}" && bash run-thirdparties-docker.sh --start
+    echo "RUN EXTERNAL CASE"
+    cd "{tmpdir}" && ./run-regression-test.sh --teamcity --clean --run
+    echo "COLLECT DOCKER LOGS"
+}}
+
+main
+""".format(
+                    root=ROOT,
+                    github_helper=GITHUB_HELPER,
+                    tmpdir=tmpdir,
+                )
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("external regression 阶段耗时汇总", result.stdout)
+        self.assertIn("前置准备", result.stdout)
+        self.assertIn("启动 Doris", result.stdout)
+        self.assertIn("启动依赖", result.stdout)
+        self.assertIn("执行 Case", result.stdout)
+        self.assertIn("收尾归档", result.stdout)
+
+    def test_non_external_pipeline_does_not_enable_auto_hooks(self):
+        result = self._run_raw(
+            """
+export teamcity_build_checkoutDir="{root}"
+
+main() {{
+    source "{github_helper}"
+    echo "regular pipeline"
+}}
+
+main
+""".format(
+                root=ROOT,
+                github_helper=GITHUB_HELPER,
+            )
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertNotIn("external regression 阶段耗时汇总", result.stdout)
 
 
 if __name__ == "__main__":

--- a/regression-test/pipeline/common/test_stage_timer.py
+++ b/regression-test/pipeline/common/test_stage_timer.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+HELPER = os.path.join(ROOT, "regression-test", "pipeline", "common", "stage-timer.sh")
+
+
+class StageTimerTest(unittest.TestCase):
+    def _run(self, body):
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as script:
+            script.write("#!/usr/bin/env bash\n")
+            script.write("set -euo pipefail\n")
+            script.write("export LC_ALL=C.UTF-8\n")
+            script.write("source \"{}\"\n".format(HELPER))
+            script.write(body)
+            script_path = script.name
+        try:
+            return subprocess.run(
+                ["bash", script_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                check=False,
+            )
+        finally:
+            os.unlink(script_path)
+
+    def test_prints_stage_summary_on_success(self):
+        result = self._run(
+            """
+stage_timer_init "external regression"
+stage_timer_enter "前置准备"
+sleep 1
+stage_timer_enter "启动 Doris"
+stage_timer_enter "启动依赖"
+stage_timer_enter "执行 Case"
+stage_timer_enter "收尾归档"
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("external regression 阶段耗时汇总", result.stdout)
+        self.assertIn("前置准备", result.stdout)
+        self.assertIn("启动 Doris", result.stdout)
+        self.assertIn("启动依赖", result.stdout)
+        self.assertIn("执行 Case", result.stdout)
+        self.assertIn("收尾归档", result.stdout)
+        self.assertIn("总耗时", result.stdout)
+
+    def test_prints_stage_summary_on_failure(self):
+        result = self._run(
+            """
+stage_timer_init "external regression"
+stage_timer_enter "前置准备"
+false
+"""
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("external regression 阶段耗时汇总", result.stdout)
+        self.assertIn("前置准备", result.stdout)
+        self.assertIn("退出码", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/regression-test/pipeline/external/external-stage-timer.sh
+++ b/regression-test/pipeline/external/external-stage-timer.sh
@@ -24,31 +24,67 @@ fi
 # shellcheck source=/dev/null
 source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/stage-timer.sh
 
-# Current TeamCity external regression still uses an inline command-line script.
-# Add the calls below into that script at the same anchor points:
-#
-# 1. After env check / variable initialization:
-#    source "${teamcity_build_checkoutDir}"/regression-test/pipeline/external/external-stage-timer.sh
-#    external_regression_stage_timer_init
-#
-# 2. Right before:
-#    cd $work_path && bash deploy_cluster.sh $cluster_name
-#    external_regression_stage_timer_enter_start_doris
-#
-# 3. Right before:
-#    echo "START EXTERNAL DOCKER"
-#    external_regression_stage_timer_enter_start_dependencies
-#
-# 4. Right before:
-#    echo "RUN EXTERNAL CASE"
-#    external_regression_stage_timer_enter_run_cases
-#
-# 5. Right before:
-#    echo "COLLECT DOCKER LOGS"
-#    external_regression_stage_timer_enter_cleanup
-#
-# stage-timer.sh installs an EXIT trap, so the summary is printed automatically
-# when the whole TeamCity shell finishes, even on failure.
+external_regression_stage_timer__extract_debug_trap() {
+    local trap_desc
+    trap_desc="$(trap -p DEBUG)"
+    if [[ "${trap_desc}" =~ ^trap\ --\ \'(.*)\'\ DEBUG$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+    fi
+}
+
+external_regression_stage_timer__enter_if_needed() {
+    local stage_name="${1:-}"
+    if [[ -z "${stage_name}" ]]; then
+        return 1
+    fi
+    if [[ "${STAGE_TIMER_CURRENT_STAGE:-}" == "${stage_name}" ]]; then
+        return 0
+    fi
+    stage_timer_enter "${stage_name}"
+}
+
+external_regression_stage_timer__handle_command() {
+    local current_command="${1:-}"
+    if [[ -z "${current_command}" ]]; then
+        return 0
+    fi
+
+    case "${current_command}" in
+        *"bash deploy_cluster.sh "*)
+            external_regression_stage_timer__enter_if_needed "启动 Doris"
+            ;;
+        *"START EXTERNAL DOCKER"* | *"run-thirdparties-docker.sh "*)
+            if [[ "${current_command}" != *"--stop"* ]]; then
+                external_regression_stage_timer__enter_if_needed "启动依赖"
+            fi
+            ;;
+        *"./run-regression-test.sh --teamcity --clean --run"*)
+            external_regression_stage_timer__enter_if_needed "执行 Case"
+            ;;
+        *"COLLECT DOCKER LOGS"* | *"collect_docker_logs "*)
+            external_regression_stage_timer__enter_if_needed "收尾归档"
+            ;;
+    esac
+}
+
+external_regression_stage_timer__run_previous_debug_trap() {
+    if [[ -n "${EXTERNAL_REGRESSION_STAGE_TIMER_PREVIOUS_DEBUG_TRAP:-}" ]] &&
+        [[ "${EXTERNAL_REGRESSION_STAGE_TIMER_PREVIOUS_DEBUG_TRAP}" != *"external_regression_stage_timer__debug_hook"* ]]; then
+        eval "${EXTERNAL_REGRESSION_STAGE_TIMER_PREVIOUS_DEBUG_TRAP}"
+    fi
+}
+
+external_regression_stage_timer__debug_hook() {
+    local current_command="${1:-$BASH_COMMAND}"
+    if [[ "${EXTERNAL_REGRESSION_STAGE_TIMER_IN_DEBUG_HOOK:-false}" == "true" ]]; then
+        return 0
+    fi
+
+    EXTERNAL_REGRESSION_STAGE_TIMER_IN_DEBUG_HOOK=true
+    external_regression_stage_timer__handle_command "${current_command}"
+    external_regression_stage_timer__run_previous_debug_trap
+    EXTERNAL_REGRESSION_STAGE_TIMER_IN_DEBUG_HOOK=false
+}
 
 external_regression_stage_timer_init() {
     stage_timer_init "external regression"
@@ -69,4 +105,15 @@ external_regression_stage_timer_enter_run_cases() {
 
 external_regression_stage_timer_enter_cleanup() {
     stage_timer_enter "收尾归档"
+}
+
+external_regression_stage_timer_enable_auto_hooks() {
+    if [[ "${EXTERNAL_REGRESSION_STAGE_TIMER_AUTO_HOOK_ENABLED:-false}" == "true" ]]; then
+        return 0
+    fi
+
+    external_regression_stage_timer_init
+    EXTERNAL_REGRESSION_STAGE_TIMER_PREVIOUS_DEBUG_TRAP="$(external_regression_stage_timer__extract_debug_trap)"
+    EXTERNAL_REGRESSION_STAGE_TIMER_AUTO_HOOK_ENABLED=true
+    trap 'external_regression_stage_timer__debug_hook "$BASH_COMMAND"' DEBUG
 }

--- a/regression-test/pipeline/external/external-stage-timer.sh
+++ b/regression-test/pipeline/external/external-stage-timer.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+if [[ -z "${teamcity_build_checkoutDir:-}" ]]; then
+    echo "ERROR: env teamcity_build_checkoutDir not set"
+    return 1 2>/dev/null || exit 1
+fi
+
+# shellcheck source=/dev/null
+source "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/stage-timer.sh
+
+# Current TeamCity external regression still uses an inline command-line script.
+# Add the calls below into that script at the same anchor points:
+#
+# 1. After env check / variable initialization:
+#    source "${teamcity_build_checkoutDir}"/regression-test/pipeline/external/external-stage-timer.sh
+#    external_regression_stage_timer_init
+#
+# 2. Right before:
+#    cd $work_path && bash deploy_cluster.sh $cluster_name
+#    external_regression_stage_timer_enter_start_doris
+#
+# 3. Right before:
+#    echo "START EXTERNAL DOCKER"
+#    external_regression_stage_timer_enter_start_dependencies
+#
+# 4. Right before:
+#    echo "RUN EXTERNAL CASE"
+#    external_regression_stage_timer_enter_run_cases
+#
+# 5. Right before:
+#    echo "COLLECT DOCKER LOGS"
+#    external_regression_stage_timer_enter_cleanup
+#
+# stage-timer.sh installs an EXIT trap, so the summary is printed automatically
+# when the whole TeamCity shell finishes, even on failure.
+
+external_regression_stage_timer_init() {
+    stage_timer_init "external regression"
+    stage_timer_enter "前置准备"
+}
+
+external_regression_stage_timer_enter_start_doris() {
+    stage_timer_enter "启动 Doris"
+}
+
+external_regression_stage_timer_enter_start_dependencies() {
+    stage_timer_enter "启动依赖"
+}
+
+external_regression_stage_timer_enter_run_cases() {
+    stage_timer_enter "执行 Case"
+}
+
+external_regression_stage_timer_enter_cleanup() {
+    stage_timer_enter "收尾归档"
+}


### PR DESCRIPTION
## What changed
- add `regression-test/pipeline/common/stage-timer.sh` to record named stages in bash and print a timing summary on shell exit
- add `regression-test/pipeline/external/external-stage-timer.sh` to map the external regression pipeline into five stages: 前置准备, 启动 Doris, 启动依赖, 执行 Case, 收尾归档
- update `regression-test/pipeline/common/github-utils.sh` to detect the live TeamCity external inline shell and auto-enable the stage timer without editing the TeamCity build step itself
- add `regression-test/pipeline/common/test_stage_timer.py` to verify normal exit, failure exit, auto-hook enablement, and non-external no-op behavior

## Problem
The external regression pipeline usually takes more than one hour, but the final log does not show how much time was spent in startup, case execution, and cleanup. That makes it hard to see whether the bottleneck is Doris startup, external dependency startup, or the case run itself.

## Root cause
The timer helper could live in the repository, but the real external regression job is executed by a TeamCity inline shell. Without an automatic hook on that live shell path, repository-only helper code would not actually print stage timings in the real pipeline.

## How it is fixed
The change uses the existing `github-utils.sh` source point that is already loaded by the live external regression shell. When the shell matches the external pipeline markers, it automatically sources `external-stage-timer.sh`, starts the timer in the prepare stage, switches stages from existing command/log anchors through a `DEBUG` trap, and prints the timing summary from an `EXIT` trap.

## Behavior change
Before this change, external regression only printed the normal build log.
After this change, successful and failed external regression runs print a five-stage timing summary and the total duration before the shell exits.
This change only adds timing output to the pipeline log. It does not change regression case selection or execution order.

## Validation
- `python regression-test/pipeline/common/test_stage_timer.py`
- `bash -n regression-test/pipeline/common/stage-timer.sh regression-test/pipeline/external/external-stage-timer.sh regression-test/pipeline/common/github-utils.sh`
