### PR TITLE
branch-4.0:[feature](cloud) Support compaction read-write separation for cloud mode #60310

### DIFF
--- a/be/src/cloud/cloud_cluster_info.cpp
+++ b/be/src/cloud/cloud_cluster_info.cpp
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "cloud/cloud_cluster_info.h"
+
+#include <glog/logging.h>
+
+#include "cloud/cloud_meta_mgr.h"
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
+#include "cloud/config.h"
+#include "gen_cpp/cloud.pb.h"
+#include "runtime/exec_env.h"
+#include "util/time.h"
+
+namespace doris {
+
+CloudClusterInfo::~CloudClusterInfo() {
+    stop_bg_worker();
+}
+
+void CloudClusterInfo::start_bg_worker() {
+    bool expected = true;
+    if (!_bg_worker_stopped.compare_exchange_strong(expected, false)) {
+        // Already running
+        return;
+    }
+
+    _bg_worker = std::thread(&CloudClusterInfo::_bg_worker_func, this);
+    LOG(INFO) << "CloudClusterInfo background worker started, "
+              << "refresh_interval=" << config::cluster_status_cache_refresh_interval_sec << "s";
+}
+
+void CloudClusterInfo::stop_bg_worker() {
+    bool expected = false;
+    if (!_bg_worker_stopped.compare_exchange_strong(expected, true)) {
+        // Already stopped
+        return;
+    }
+
+    {
+        std::lock_guard lock(_bg_worker_mutex);
+        _bg_worker_cv.notify_all();
+    }
+
+    if (_bg_worker.joinable()) {
+        _bg_worker.join();
+    }
+
+    LOG(INFO) << "CloudClusterInfo background worker stopped";
+}
+
+void CloudClusterInfo::_bg_worker_func() {
+    LOG(INFO) << "CloudClusterInfo background worker thread running";
+
+    while (!_bg_worker_stopped.load()) {
+        _refresh_cluster_status();
+
+        std::unique_lock lock(_bg_worker_mutex);
+        _bg_worker_cv.wait_for(
+                lock, std::chrono::seconds(config::cluster_status_cache_refresh_interval_sec),
+                [this] { return _bg_worker_stopped.load(); });
+    }
+}
+
+void CloudClusterInfo::_refresh_cluster_status() {
+    if (!config::is_cloud_mode()) {
+        return;
+    }
+    auto* cloud_engine =
+            dynamic_cast<CloudStorageEngine*>(&ExecEnv::GetInstance()->storage_engine());
+    if (!cloud_engine) {
+        return;
+    }
+
+    std::unordered_map<std::string, std::pair<int32_t, int64_t>> cluster_status;
+    std::string resolved_cluster_id;
+    Status st = cloud_engine->meta_mgr().get_cluster_status(
+            &cluster_status, my_cluster_id().empty() ? &resolved_cluster_id : nullptr);
+    if (!st.ok()) {
+        LOG(WARNING) << "Failed to refresh cluster status: " << st;
+        return;
+    }
+
+    // Update cache
+    {
+        std::unique_lock lock(_mutex);
+        _cluster_status_cache.clear();
+        for (const auto& [cluster_id, status_pair] : cluster_status) {
+            _cluster_status_cache[cluster_id] = {status_pair.first, status_pair.second};
+        }
+    }
+
+    VLOG_DEBUG << "Refreshed cluster status cache, " << cluster_status.size() << " clusters";
+
+    // Set our own cluster_id if resolved from the response
+    if (my_cluster_id().empty() && !resolved_cluster_id.empty()) {
+        set_my_cluster_id(resolved_cluster_id);
+        LOG(INFO) << "Resolved my cluster_id: " << resolved_cluster_id;
+    }
+}
+
+bool CloudClusterInfo::should_skip_compaction(CloudTablet* tablet) const {
+    if (!config::enable_compaction_rw_separation) {
+        return false;
+    }
+
+    std::string last_active_cluster = tablet->last_active_cluster_id();
+    std::string my_cluster = my_cluster_id();
+    int64_t tablet_id = tablet->tablet_id();
+
+    // Case 1: No active cluster record, any cluster can compact
+    if (last_active_cluster.empty()) {
+        VLOG_DEBUG << "tablet " << tablet_id << " has no last_active_cluster record, "
+                   << "my_cluster=" << my_cluster << ", allow compaction";
+        return false;
+    }
+
+    // Case 2: This is the active cluster, allow compaction
+    if (last_active_cluster == my_cluster) {
+        VLOG_DEBUG << "tablet " << tablet_id << " last_active_cluster=" << last_active_cluster
+                   << " equals my_cluster=" << my_cluster << ", allow compaction";
+        return false;
+    }
+
+    // Case 3: Check if the last active cluster is available
+    ClusterStatusCache cache;
+    if (!get_cluster_status(last_active_cluster, &cache)) {
+        // Cluster not found in cache, might be deleted, allow takeover
+        LOG(INFO) << "compaction_rw_separation: tablet " << tablet_id
+                  << " last_active_cluster=" << last_active_cluster
+                  << " not found in cache (maybe deleted), my_cluster=" << my_cluster
+                  << ", allow takeover";
+        return false;
+    }
+
+    // Force compaction if tablet has too many rowsets (>80% of max_tablet_version_num),
+    // even on read clusters, to prevent version count from growing unbounded
+    // when the write cluster can't keep up or has compaction disabled.
+    int64_t num_rowsets = tablet->fetch_add_approximate_num_rowsets(0);
+    auto threshold = static_cast<int64_t>(tablet->max_version_config() *
+                                          config::compaction_rw_separation_version_threshold_ratio);
+    if (num_rowsets > threshold) {
+        LOG(INFO) << "compaction_rw_separation: force compaction on tablet " << tablet_id
+                  << ", num_rowsets=" << num_rowsets << " > threshold=" << threshold << " (80% of "
+                  << tablet->max_version_config() << ")"
+                  << ", my_cluster=" << my_cluster;
+        return false;
+    }
+
+    auto status = static_cast<cloud::ClusterStatus>(cache.status);
+    int64_t status_mtime = cache.mtime_ms;
+    int64_t now = UnixMillis();
+    int64_t elapsed = now - status_mtime;
+    int64_t timeout = config::compaction_cluster_takeover_timeout_ms;
+
+    // Case 4: Original cluster is NORMAL (still active), cannot takeover
+    if (status == cloud::ClusterStatus::NORMAL) {
+        LOG_EVERY_N(INFO, 100) << "compaction_rw_separation: skip tablet " << tablet_id
+                               << ", last_active_cluster=" << last_active_cluster
+                               << " is NORMAL (active), my_cluster=" << my_cluster;
+        return true;
+    }
+
+    // Case 5: Original cluster is unavailable (SUSPENDED/MANUAL_SHUTDOWN/deleted)
+    if (elapsed > timeout) {
+        // Takeover successful
+        LOG(INFO) << "compaction_rw_separation: takeover tablet " << tablet_id
+                  << ", last_active_cluster=" << last_active_cluster
+                  << " status=" << cloud::ClusterStatus_Name(status)
+                  << " status_mtime=" << status_mtime << " elapsed=" << elapsed
+                  << "ms > timeout=" << timeout << "ms"
+                  << ", my_cluster=" << my_cluster;
+        return false;
+    } else {
+        // Timeout not reached yet, waiting
+        LOG_EVERY_N(INFO, 100) << "compaction_rw_separation: skip tablet " << tablet_id
+                               << ", last_active_cluster=" << last_active_cluster
+                               << " status=" << cloud::ClusterStatus_Name(status)
+                               << " status_mtime=" << status_mtime << " elapsed=" << elapsed
+                               << "ms <= timeout=" << timeout << "ms"
+                               << ", my_cluster=" << my_cluster << ", waiting for takeover";
+        return true;
+    }
+}
+
+} // namespace doris

--- a/be/src/cloud/cloud_cluster_info.h
+++ b/be/src/cloud/cloud_cluster_info.h
@@ -15,18 +15,92 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
 #include "runtime/cluster_info.h"
 
 namespace doris {
 
+class CloudTablet;
+
+// Cached cluster status information
+struct ClusterStatusCache {
+    int32_t status {0};   // ClusterStatus enum value
+    int64_t mtime_ms {0}; // Timestamp when status was last changed
+};
+
 class CloudClusterInfo : public ClusterInfo {
 public:
-    bool is_in_standby() const { return _is_in_standby; }
+    ~CloudClusterInfo();
 
+    bool is_in_standby() const { return _is_in_standby; }
     void set_is_in_standby(bool flag) { _is_in_standby = flag; }
 
+    // Get this BE's cluster ID
+    std::string my_cluster_id() const {
+        std::shared_lock lock(_mutex);
+        return _my_cluster_id;
+    }
+    void set_my_cluster_id(const std::string& id) {
+        std::unique_lock lock(_mutex);
+        _my_cluster_id = id;
+    }
+
+    // Get cached cluster status, returns false if not found
+    bool get_cluster_status(const std::string& id, ClusterStatusCache* cache) const {
+        std::shared_lock lock(_mutex);
+        auto it = _cluster_status_cache.find(id);
+        if (it != _cluster_status_cache.end()) {
+            *cache = it->second;
+            return true;
+        }
+        return false;
+    }
+
+    // Update cluster status cache
+    void set_cluster_status(const std::string& id, int32_t status, int64_t mtime_ms) {
+        std::unique_lock lock(_mutex);
+        _cluster_status_cache[id] = {status, mtime_ms};
+    }
+
+    // Clear all cached cluster status
+    void clear_cluster_status_cache() {
+        std::unique_lock lock(_mutex);
+        _cluster_status_cache.clear();
+    }
+
+    // Start background refresh thread
+    void start_bg_worker();
+    // Stop background refresh thread
+    void stop_bg_worker();
+
+    // Check if this cluster should skip compaction for the given tablet
+    // Returns true if should skip (i.e., another cluster should do the compaction)
+    bool should_skip_compaction(CloudTablet* tablet) const;
+
 private:
+    void _bg_worker_func();
+    void _refresh_cluster_status();
+
     bool _is_in_standby = false;
+
+    mutable std::shared_mutex _mutex;
+    std::string _my_cluster_id;
+    std::unordered_map<std::string, ClusterStatusCache> _cluster_status_cache;
+
+    // Background worker
+    std::thread _bg_worker;
+    std::atomic<bool> _bg_worker_stopped {true};
+    std::mutex _bg_worker_mutex;
+    std::condition_variable _bg_worker_cv;
 };
 
 } // namespace doris

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -352,7 +352,7 @@ static std::string debug_info(const Request& req) {
     } else if constexpr (is_any_v<Request, GetTabletRequest>) {
         return fmt::format(" tablet_id={}", req.tablet_id());
     } else if constexpr (is_any_v<Request, GetObjStoreInfoRequest, ListSnapshotRequest,
-                                  GetInstanceRequest>) {
+                                  GetInstanceRequest, GetClusterStatusRequest>) {
         return "";
     } else if constexpr (is_any_v<Request, CreateRowsetRequest>) {
         return fmt::format(" tablet_id={}", req.rowset_meta().tablet_id());
@@ -789,6 +789,12 @@ Status CloudMetaMgr::sync_tablet_rowsets_unlocked(CloudTablet* tablet,
             tablet->set_cumulative_layer_point(stats.cumulative_point());
             tablet->reset_approximate_stats(stats.num_rowsets(), stats.num_segments(),
                                             stats.num_rows(), stats.data_size());
+
+            // Sync last active cluster info for compaction read-write separation
+            if (config::enable_compaction_rw_separation && stats.has_last_active_cluster_id()) {
+                tablet->set_last_active_cluster_info(stats.last_active_cluster_id(),
+                                                     stats.last_active_time_ms());
+            }
         }
         return Status::OK();
     }
@@ -2277,6 +2283,37 @@ Status CloudMetaMgr::update_packed_file_info(const std::string& packed_file_path
     // Make RPC call using retry pattern
     return retry_rpc("update packed file info", req, &resp,
                      &cloud::MetaService_Stub::update_packed_file_info);
+}
+
+Status CloudMetaMgr::get_cluster_status(
+        std::unordered_map<std::string, std::pair<int32_t, int64_t>>* result,
+        std::string* my_cluster_id) {
+    GetClusterStatusRequest req;
+    GetClusterStatusResponse resp;
+    req.add_cloud_unique_ids(config::cloud_unique_id);
+
+    Status s = retry_rpc("get cluster status", req, &resp, &MetaService_Stub::get_cluster_status);
+    if (!s.ok()) {
+        return s;
+    }
+
+    result->clear();
+    for (const auto& detail : resp.details()) {
+        for (const auto& cluster : detail.clusters()) {
+            // Store cluster status and mtime (mtime is in seconds from MS, convert to ms).
+            // If mtime is not set, use current time as a conservative default
+            // to avoid immediate takeover due to elapsed being huge.
+            int64_t mtime_ms = cluster.has_mtime() ? cluster.mtime() * 1000 : UnixMillis();
+            (*result)[cluster.cluster_id()] = {static_cast<int32_t>(cluster.cluster_status()),
+                                               mtime_ms};
+        }
+    }
+
+    if (my_cluster_id && resp.has_requester_cluster_id()) {
+        *my_cluster_id = resp.requester_cluster_id();
+    }
+
+    return Status::OK();
 }
 
 #include "common/compile_check_end.h"

--- a/be/src/cloud/cloud_meta_mgr.h
+++ b/be/src/cloud/cloud_meta_mgr.h
@@ -169,6 +169,12 @@ public:
                                    int64_t& max_reserved_snapshots,
                                    int64_t& snapshot_interval_seconds);
 
+    // Get all cluster status for the instance
+    // Returns cluster_id -> (status, mtime_ms)
+    // If my_cluster_id is not null, also returns the requesting node's cluster_id
+    Status get_cluster_status(std::unordered_map<std::string, std::pair<int32_t, int64_t>>* result,
+                              std::string* my_cluster_id = nullptr);
+
 private:
     bool sync_tablet_delete_bitmap_by_cache(CloudTablet* tablet, int64_t old_max_version,
                                             std::ranges::range auto&& rs_metas,

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -251,6 +251,21 @@ public:
     int64_t alter_version() const { return _alter_version; }
     void set_alter_version(int64_t alter_version) { _alter_version = alter_version; }
 
+    // Last active cluster info for compaction read-write separation
+    std::string last_active_cluster_id() const {
+        std::shared_lock lock(_cluster_info_mutex);
+        return _last_active_cluster_id;
+    }
+    int64_t last_active_time_ms() const {
+        std::shared_lock lock(_cluster_info_mutex);
+        return _last_active_time_ms;
+    }
+    void set_last_active_cluster_info(const std::string& cluster_id, int64_t time_ms) {
+        std::unique_lock lock(_cluster_info_mutex);
+        _last_active_cluster_id = cluster_id;
+        _last_active_time_ms = time_ms;
+    }
+
     std::vector<RowsetSharedPtr> pick_candidate_rowsets_to_base_compaction();
 
     inline Version max_version() const {
@@ -471,6 +486,11 @@ private:
 
     mutable std::shared_mutex _warmed_up_rowsets_mutex;
     std::unordered_set<RowsetId> _warmed_up_rowsets;
+
+    // Cluster info for compaction read-write separation
+    mutable std::shared_mutex _cluster_info_mutex;
+    std::string _last_active_cluster_id;
+    int64_t _last_active_time_ms {0};
 };
 
 using CloudTabletSPtr = std::shared_ptr<CloudTablet>;

--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -404,10 +404,17 @@ Status CloudTabletMgr::get_topn_tablets_to_compact(
     auto now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
     auto skip = [now, compaction_type](CloudTablet* t) {
         auto* cloud_cluster_info = static_cast<CloudClusterInfo*>(ExecEnv::GetInstance()->cluster_info());
+
         if (config::enable_standby_passive_compaction && cloud_cluster_info->is_in_standby()) {
             if (t->fetch_add_approximate_num_rowsets(0) < config::max_tablet_version_num * config::standby_compaction_version_ratio) {
                 return true;
             }
+        }
+
+        // Compaction read-write separation: skip tablets that should be compacted by other clusters.
+        // Placed after standby check so standby invariants (version count threshold) are preserved.
+        if (cloud_cluster_info->should_skip_compaction(t)) {
+            return true;
         }
 
         int32_t max_version_config = t->max_version_config();
@@ -419,7 +426,7 @@ Status CloudTabletMgr::get_topn_tablets_to_compact(
             g_base_compaction_not_frozen_tablet_num << !is_frozen;
             return is_recent_failure || is_frozen;
         }
-        
+
         // If tablet has too many rowsets but not be compacted for a long time, compaction should be performed
         // regardless of whether there is a load job recently.
         bool is_recent_failure = now - t->last_cumu_compaction_failure_time() < config::min_compaction_failure_interval_ms;

--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -148,6 +148,17 @@ DEFINE_mBool(enable_standby_passive_compaction, "true");
 
 DEFINE_mDouble(standby_compaction_version_ratio, "0.8");
 
+// Compaction read-write separation: only the "last active" cluster (the one that most recently
+// performed load) is allowed to compact a tablet
+DEFINE_mBool(enable_compaction_rw_separation, "false");
+// Timeout in ms for takeover when last active cluster becomes unavailable (default 5 min)
+DEFINE_mInt64(compaction_cluster_takeover_timeout_ms, "300000");
+// Interval in seconds to refresh cluster status cache (default 1 min)
+DEFINE_mInt64(cluster_status_cache_refresh_interval_sec, "60");
+// When version count exceeds this ratio of max_tablet_version_num, force compaction
+// even on read-only clusters (safety valve)
+DEFINE_mDouble(compaction_rw_separation_version_threshold_ratio, "0.8");
+
 DEFINE_mBool(enable_cache_read_from_peer, "true");
 
 // Rate limit for warmup download in bytes per second, default 100MB/s

--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -191,6 +191,17 @@ DECLARE_mBool(enable_standby_passive_compaction);
 
 DECLARE_mDouble(standby_compaction_version_ratio);
 
+// Compaction read-write separation: only the "last active" cluster (the one that most recently
+// performed load) is allowed to compact a tablet
+DECLARE_mBool(enable_compaction_rw_separation);
+// Timeout in ms for takeover when last active cluster becomes unavailable (default 5 min)
+DECLARE_mInt64(compaction_cluster_takeover_timeout_ms);
+// Interval in seconds to refresh cluster status cache for compaction read-write separation
+DECLARE_mInt64(cluster_status_cache_refresh_interval_sec);
+// When version count exceeds this ratio of max_tablet_version_num, force compaction
+// even on read-only clusters (safety valve to prevent unbounded version growth)
+DECLARE_mDouble(compaction_rw_separation_version_threshold_ratio);
+
 DECLARE_mBool(enable_cache_read_from_peer);
 
 // Rate limit for warmup download in bytes per second, default 100MB/s

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -421,6 +421,9 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
     if (config::is_cloud_mode()) {
         RETURN_IF_ERROR(_packed_file_manager->init());
         _packed_file_manager->start_background_manager();
+
+        // Start cluster info background worker for compaction read-write separation
+        static_cast<CloudClusterInfo*>(_cluster_info)->start_bg_worker();
     }
 
     _index_policy_mgr = new IndexPolicyMgr();
@@ -821,6 +824,11 @@ void ExecEnv::destroy() {
 
     // _id_manager must be destoried before tablet schema cache
     SAFE_DELETE(_id_manager);
+
+    // Stop cluster info background worker before storage engine is destroyed
+    if (config::is_cloud_mode() && _cluster_info) {
+        static_cast<CloudClusterInfo*>(_cluster_info)->stop_bg_worker();
+    }
 
     // StorageEngine must be destoried before _cache_manager destory
     SAFE_STOP(_storage_engine);

--- a/be/test/cloud/cloud_cluster_info_test.cpp
+++ b/be/test/cloud/cloud_cluster_info_test.cpp
@@ -1,0 +1,280 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "cloud/cloud_cluster_info.h"
+
+#include <gtest/gtest.h>
+
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
+#include "cloud/config.h"
+#include "gen_cpp/cloud.pb.h"
+#include "olap/tablet_meta.h"
+#include "util/time.h"
+#include "util/uid_util.h"
+
+namespace doris {
+
+class CloudClusterInfoTest : public testing::Test {
+public:
+    CloudClusterInfoTest() : _engine(CloudStorageEngine(EngineOptions {})) {}
+
+    void SetUp() override {
+        _cluster_info = std::make_unique<CloudClusterInfo>();
+
+        _tablet_meta.reset(new TabletMeta(1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}},
+                                          UniqueId(9, 10), TTabletType::TABLET_TYPE_DISK,
+                                          TCompressionType::LZ4F));
+        _tablet =
+                std::make_shared<CloudTablet>(_engine, std::make_shared<TabletMeta>(*_tablet_meta));
+    }
+
+    void TearDown() override {
+        _cluster_info.reset();
+        _tablet.reset();
+    }
+
+protected:
+    CloudStorageEngine _engine;
+    std::unique_ptr<CloudClusterInfo> _cluster_info;
+    std::shared_ptr<TabletMeta> _tablet_meta;
+    std::shared_ptr<CloudTablet> _tablet;
+};
+
+// Test my_cluster_id get/set
+TEST_F(CloudClusterInfoTest, MyClusterId) {
+    EXPECT_EQ(_cluster_info->my_cluster_id(), "");
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    EXPECT_EQ(_cluster_info->my_cluster_id(), "cluster_a");
+
+    _cluster_info->set_my_cluster_id("cluster_b");
+    EXPECT_EQ(_cluster_info->my_cluster_id(), "cluster_b");
+}
+
+// Test cluster status cache get/set/clear
+TEST_F(CloudClusterInfoTest, ClusterStatusCache) {
+    ClusterStatusCache cache;
+
+    // Not found initially
+    EXPECT_FALSE(_cluster_info->get_cluster_status("cluster_a", &cache));
+
+    // Set and get
+    _cluster_info->set_cluster_status("cluster_a", cloud::ClusterStatus::NORMAL, 1000);
+    EXPECT_TRUE(_cluster_info->get_cluster_status("cluster_a", &cache));
+    EXPECT_EQ(cache.status, cloud::ClusterStatus::NORMAL);
+    EXPECT_EQ(cache.mtime_ms, 1000);
+
+    // Set another cluster
+    _cluster_info->set_cluster_status("cluster_b", cloud::ClusterStatus::SUSPENDED, 2000);
+    EXPECT_TRUE(_cluster_info->get_cluster_status("cluster_b", &cache));
+    EXPECT_EQ(cache.status, cloud::ClusterStatus::SUSPENDED);
+    EXPECT_EQ(cache.mtime_ms, 2000);
+
+    // Clear
+    _cluster_info->clear_cluster_status_cache();
+    EXPECT_FALSE(_cluster_info->get_cluster_status("cluster_a", &cache));
+    EXPECT_FALSE(_cluster_info->get_cluster_status("cluster_b", &cache));
+}
+
+// Test is_in_standby
+TEST_F(CloudClusterInfoTest, IsInStandby) {
+    EXPECT_FALSE(_cluster_info->is_in_standby());
+    _cluster_info->set_is_in_standby(true);
+    EXPECT_TRUE(_cluster_info->is_in_standby());
+    _cluster_info->set_is_in_standby(false);
+    EXPECT_FALSE(_cluster_info->is_in_standby());
+}
+
+// Case 1: Feature disabled, should never skip
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionDisabled) {
+    config::enable_compaction_rw_separation = false;
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_b", UnixMillis());
+
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 2: No last_active_cluster, allow compaction
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionNoActiveCluster) {
+    config::enable_compaction_rw_separation = true;
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    // tablet has no last_active_cluster set (empty)
+
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 3: This is the active cluster, allow compaction
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionSameCluster) {
+    config::enable_compaction_rw_separation = true;
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_a", UnixMillis());
+
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 4: Active cluster not in cache (deleted), allow takeover
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionClusterDeleted) {
+    config::enable_compaction_rw_separation = true;
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_deleted", UnixMillis());
+    // cluster_deleted is not in cache
+
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 5: Active cluster is NORMAL, skip compaction
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionActiveClusterNormal) {
+    config::enable_compaction_rw_separation = true;
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_b", UnixMillis());
+    _cluster_info->set_cluster_status("cluster_b", cloud::ClusterStatus::NORMAL, UnixMillis());
+
+    EXPECT_TRUE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 6: Active cluster SUSPENDED, timeout not reached, skip
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionSuspendedNotTimedOut) {
+    config::enable_compaction_rw_separation = true;
+    config::compaction_cluster_takeover_timeout_ms = 60000; // 60s
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_b", UnixMillis());
+    // Set suspended just now — timeout not reached
+    _cluster_info->set_cluster_status("cluster_b", cloud::ClusterStatus::SUSPENDED, UnixMillis());
+
+    EXPECT_TRUE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 7: Active cluster SUSPENDED, timeout exceeded, allow takeover
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionSuspendedTimedOut) {
+    config::enable_compaction_rw_separation = true;
+    config::compaction_cluster_takeover_timeout_ms = 1000; // 1s
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_b", UnixMillis());
+    // Set suspended long ago
+    _cluster_info->set_cluster_status("cluster_b", cloud::ClusterStatus::SUSPENDED,
+                                      UnixMillis() - 5000);
+
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 8: Active cluster MANUAL_SHUTDOWN, timeout exceeded, allow takeover
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionManualShutdownTimedOut) {
+    config::enable_compaction_rw_separation = true;
+    config::compaction_cluster_takeover_timeout_ms = 1000;
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_b", UnixMillis());
+    _cluster_info->set_cluster_status("cluster_b", cloud::ClusterStatus::MANUAL_SHUTDOWN,
+                                      UnixMillis() - 5000);
+
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Test CloudTablet last_active_cluster_info accessors
+TEST_F(CloudClusterInfoTest, TabletLastActiveClusterInfo) {
+    EXPECT_EQ(_tablet->last_active_cluster_id(), "");
+    EXPECT_EQ(_tablet->last_active_time_ms(), 0);
+
+    int64_t now = UnixMillis();
+    _tablet->set_last_active_cluster_info("cluster_x", now);
+    EXPECT_EQ(_tablet->last_active_cluster_id(), "cluster_x");
+    EXPECT_EQ(_tablet->last_active_time_ms(), now);
+
+    _tablet->set_last_active_cluster_info("cluster_y", now + 1000);
+    EXPECT_EQ(_tablet->last_active_cluster_id(), "cluster_y");
+    EXPECT_EQ(_tablet->last_active_time_ms(), now + 1000);
+}
+
+// Case 9: Active cluster is NORMAL but version count exceeds 80% threshold, force compaction
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionForceOnHighVersionCount) {
+    config::enable_compaction_rw_separation = true;
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_b", UnixMillis());
+    _cluster_info->set_cluster_status("cluster_b", cloud::ClusterStatus::NORMAL, UnixMillis());
+
+    // Default max_tablet_version_num is 2000, 80% threshold = 1600
+    // _approximate_num_rowsets starts at -1, so add (1600 - (-1)) = 1601 to reach 1600
+    int64_t cur = _tablet->fetch_add_approximate_num_rowsets(0);
+    _tablet->fetch_add_approximate_num_rowsets(1600 - cur);
+    EXPECT_TRUE(_cluster_info->should_skip_compaction(_tablet.get()));
+
+    // Now bump to 1601 (above threshold) => should NOT skip (force compaction)
+    _tablet->fetch_add_approximate_num_rowsets(1);
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Case 10: Active cluster SUSPENDED, not timed out, but version count exceeds threshold
+TEST_F(CloudClusterInfoTest, ShouldSkipCompactionForceOnHighVersionCountSuspended) {
+    config::enable_compaction_rw_separation = true;
+    config::compaction_cluster_takeover_timeout_ms = 60000; // 60s
+
+    _cluster_info->set_my_cluster_id("cluster_a");
+    _tablet->set_last_active_cluster_info("cluster_b", UnixMillis());
+    _cluster_info->set_cluster_status("cluster_b", cloud::ClusterStatus::SUSPENDED, UnixMillis());
+
+    // Set approximate_num_rowsets above 80% threshold => force compaction
+    int64_t cur = _tablet->fetch_add_approximate_num_rowsets(0);
+    _tablet->fetch_add_approximate_num_rowsets(1601 - cur);
+    EXPECT_FALSE(_cluster_info->should_skip_compaction(_tablet.get()));
+}
+
+// Test start/stop bg worker lifecycle — covers start_bg_worker, stop_bg_worker,
+// _bg_worker_func, and _refresh_cluster_status (early return branch since no CloudStorageEngine)
+TEST_F(CloudClusterInfoTest, BgWorkerStartStop) {
+    // Use a very short refresh interval so the bg thread loops quickly
+    auto old_interval = config::cluster_status_cache_refresh_interval_sec;
+    config::cluster_status_cache_refresh_interval_sec = 1;
+
+    // Start the bg worker — this spawns a thread that calls _bg_worker_func,
+    // which calls _refresh_cluster_status (returns early since no CloudStorageEngine)
+    _cluster_info->start_bg_worker();
+
+    // Let it run at least one iteration
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    // Double start should be safe (already running)
+    _cluster_info->start_bg_worker();
+
+    // Stop
+    _cluster_info->stop_bg_worker();
+
+    // Double stop should be safe
+    _cluster_info->stop_bg_worker();
+
+    config::cluster_status_cache_refresh_interval_sec = old_interval;
+}
+
+// Test destructor stops bg worker
+TEST_F(CloudClusterInfoTest, DestructorStopsBgWorker) {
+    auto info = std::make_unique<CloudClusterInfo>();
+    config::cluster_status_cache_refresh_interval_sec = 1;
+    info->start_bg_worker();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    // Destructor should call stop_bg_worker
+    info.reset();
+}
+
+} // namespace doris

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -40,6 +40,7 @@
 #include "meta-store/txn_kv.h"
 #include "meta-store/txn_kv_error.h"
 #include "meta-store/versioned_value.h"
+#include "resource-manager/resource_manager.h"
 
 using namespace std::chrono;
 
@@ -1180,6 +1181,48 @@ void scan_tmp_rowset(
     return;
 }
 
+// Update the last active cluster info for a tablet
+void update_tablet_last_active_cluster(const StatsTabletKeyInfo& info,
+                                       const std::string& cluster_id,
+                                       std::unique_ptr<Transaction>& txn, MetaServiceCode& code,
+                                       std::string& msg) {
+    if (cluster_id.empty()) {
+        return;
+    }
+
+    std::string key;
+    stats_tablet_key(info, &key);
+    std::string val;
+    TxnErrorCode err = txn->get(key, &val);
+    if (err != TxnErrorCode::TXN_OK) {
+        // If tablet stats not found, skip (will be created later)
+        if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
+            return;
+        }
+        code = cast_as<ErrCategory::READ>(err);
+        msg = fmt::format("failed to get tablet stats for cluster update, err={} tablet_id={}", err,
+                          std::get<4>(info));
+        return;
+    }
+
+    TabletStatsPB stats_pb;
+    if (!stats_pb.ParseFromString(val)) {
+        code = MetaServiceCode::PROTOBUF_PARSE_ERR;
+        msg = fmt::format("malformed tablet stats value for cluster update, key={}", hex(key));
+        return;
+    }
+
+    stats_pb.set_last_active_cluster_id(cluster_id);
+    stats_pb.set_last_active_time_ms(::time(nullptr) * 1000);
+    // Clear the mtime when updating cluster to allow dynamic filling on next get_rowset
+    stats_pb.clear_last_active_cluster_status_mtime_ms();
+
+    stats_pb.SerializeToString(&val);
+    txn->put(key, val);
+    LOG(INFO) << "update last_active_cluster, key=" << hex(key) << " cluster_id=" << cluster_id
+              << " tablet_id=" << std::get<4>(info);
+}
+
 void update_tablet_stats(const StatsTabletKeyInfo& info, const TabletStats& stats,
                          std::unique_ptr<Transaction>& txn, MetaServiceCode& code,
                          std::string& msg) {
@@ -1817,6 +1860,14 @@ void MetaServiceImpl::commit_txn_immediately(
                       << " versioned tablet stats, txn_id=" << txn_id;
         }
 
+        // Get cluster_id for updating last active cluster.
+        // Use load_cluster_id stored in TxnInfoPB by prepare_rowset (called by BE),
+        // because commit_txn is called by FE whose cloud_unique_id resolves to SQL server cluster.
+        std::string requester_cluster_id;
+        if (txn_info.has_load_cluster_id()) {
+            requester_cluster_id = txn_info.load_cluster_id();
+        }
+
         // Update stats of affected tablet
         for (auto& [tablet_id, stats] : tablet_stats) {
             DCHECK(tablet_ids.count(tablet_id));
@@ -1825,6 +1876,12 @@ void MetaServiceImpl::commit_txn_immediately(
                                      tablet_idx.partition_id(), tablet_id};
             update_tablet_stats(info, stats, txn, code, msg);
             if (code != MetaServiceCode::OK) return;
+
+            // Update last active cluster if load has data
+            if (!requester_cluster_id.empty() && stats.num_segs > 0) {
+                update_tablet_last_active_cluster(info, requester_cluster_id, txn, code, msg);
+                if (code != MetaServiceCode::OK) return;
+            }
 
             if (is_versioned_write) {
                 TabletStatsPB stats_pb = existing_versioned_stats[tablet_id];
@@ -2977,6 +3034,13 @@ void MetaServiceImpl::commit_txn_with_sub_txn(const CommitTxnRequest* request,
                       << " versioned tablet stats, txn_id=" << txn_id;
         }
 
+        // Get cluster_id for updating last active cluster.
+        // Use load_cluster_id stored in TxnInfoPB by prepare_rowset (called by BE).
+        std::string requester_cluster_id_ev;
+        if (txn_info.has_load_cluster_id()) {
+            requester_cluster_id_ev = txn_info.load_cluster_id();
+        }
+
         // Update stats of affected tablet
         for (auto& [tablet_id, stats] : tablet_stats) {
             DCHECK(tablet_ids.count(tablet_id));
@@ -2985,6 +3049,12 @@ void MetaServiceImpl::commit_txn_with_sub_txn(const CommitTxnRequest* request,
                                      tablet_idx.partition_id(), tablet_id};
             update_tablet_stats(info, stats, txn, code, msg);
             if (code != MetaServiceCode::OK) return;
+
+            // Update last active cluster if load has data
+            if (!requester_cluster_id_ev.empty() && stats.num_segs > 0) {
+                update_tablet_last_active_cluster(info, requester_cluster_id_ev, txn, code, msg);
+                if (code != MetaServiceCode::OK) return;
+            }
 
             if (is_versioned_write) {
                 TabletStatsPB stats_pb = existing_versioned_stats[tablet_id];

--- a/cloud/test/CMakeLists.txt
+++ b/cloud/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(meta_service_test
    meta_service_tablet_stats_test.cpp
    meta_service_versioned_read_test.cpp
    schema_kv_test.cpp
+   compaction_rw_separation_test.cpp
 )
 
 add_executable(meta_server_test meta_server_test.cpp)

--- a/cloud/test/compaction_rw_separation_test.cpp
+++ b/cloud/test/compaction_rw_separation_test.cpp
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <brpc/controller.h>
+#include <gen_cpp/cloud.pb.h>
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "meta-service/meta_service.h"
+#include "meta-store/keys.h"
+#include "meta-store/mem_txn_kv.h"
+#include "mock_resource_manager.h"
+#include "rate-limiter/rate_limiter.h"
+
+namespace doris::cloud {
+
+// Test: commit_txn always updates last_active_cluster_id
+// MS always updates this field, BE controls whether to use it for compaction skipping
+TEST(CompactionRWSeparationTest, CommitTxnUpdatesLastActiveCluster) {
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    // Clear data
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    txn->remove("\x00", "\xfe");
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    auto rs = std::make_shared<MockResourceManager>(txn_kv);
+    auto rl = std::make_shared<RateLimiter>();
+    auto snapshot = std::make_shared<SnapshotManager>(txn_kv);
+    MetaServiceImpl meta_service(txn_kv, rs, rl, snapshot);
+
+    int64_t db_id = 1;
+    int64_t table_id = 100;
+    int64_t index_id = 100;
+    int64_t partition_id = 100;
+    int64_t tablet_id = 10001;
+
+    // Create tablet
+    {
+        brpc::Controller cntl;
+        CreateTabletsRequest req;
+        CreateTabletsResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_db_id(db_id);
+
+        auto tablet = req.add_tablet_metas();
+        tablet->set_table_id(table_id);
+        tablet->set_index_id(index_id);
+        tablet->set_partition_id(partition_id);
+        tablet->set_tablet_id(tablet_id);
+        auto schema = tablet->mutable_schema();
+        schema->set_schema_version(0);
+        auto first_rowset = tablet->add_rs_metas();
+        first_rowset->set_rowset_id(0);
+        first_rowset->set_rowset_id_v2("rowset_0");
+        first_rowset->set_start_version(0);
+        first_rowset->set_end_version(1);
+        first_rowset->mutable_tablet_schema()->CopyFrom(*schema);
+
+        meta_service.create_tablets(&cntl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+    }
+
+    // Begin txn
+    int64_t txn_id = -1;
+    {
+        brpc::Controller cntl;
+        BeginTxnRequest req;
+        BeginTxnResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        auto txn_info = req.mutable_txn_info();
+        txn_info->set_db_id(db_id);
+        txn_info->set_label("test_label_1");
+        txn_info->add_table_ids(table_id);
+        txn_info->set_timeout_ms(36000);
+        // FE sets load_cluster_id during begin_txn for compaction RW separation
+        txn_info->set_load_cluster_id(mock_cluster_id);
+
+        meta_service.begin_txn(&cntl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        txn_id = res.txn_id();
+    }
+
+    // Prepare rowset
+    {
+        brpc::Controller cntl;
+        CreateRowsetRequest req;
+        CreateRowsetResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+
+        auto rowset = req.mutable_rowset_meta();
+        rowset->set_rowset_id(0);
+        rowset->set_rowset_id_v2("rowset_txn_1");
+        rowset->set_tablet_id(tablet_id);
+        rowset->set_partition_id(partition_id);
+        rowset->set_txn_id(txn_id);
+        rowset->set_num_segments(1);
+        rowset->set_num_rows(100);
+        rowset->set_data_disk_size(1024);
+        rowset->mutable_tablet_schema()->set_schema_version(0);
+        rowset->set_txn_expiration(::time(nullptr) + 3600);
+
+        meta_service.prepare_rowset(&cntl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+    }
+
+    // Commit rowset
+    {
+        brpc::Controller cntl;
+        CreateRowsetRequest req;
+        CreateRowsetResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+
+        auto rowset = req.mutable_rowset_meta();
+        rowset->set_rowset_id(0);
+        rowset->set_rowset_id_v2("rowset_txn_1");
+        rowset->set_tablet_id(tablet_id);
+        rowset->set_partition_id(partition_id);
+        rowset->set_txn_id(txn_id);
+        rowset->set_num_segments(1);
+        rowset->set_num_rows(100);
+        rowset->set_data_disk_size(1024);
+        rowset->mutable_tablet_schema()->set_schema_version(0);
+        rowset->set_txn_expiration(::time(nullptr) + 3600);
+
+        meta_service.commit_rowset(&cntl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+    }
+
+    // Commit txn
+    {
+        brpc::Controller cntl;
+        CommitTxnRequest req;
+        CommitTxnResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_db_id(db_id);
+        req.set_txn_id(txn_id);
+
+        meta_service.commit_txn(&cntl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+    }
+
+    // Get rowset and check last_active_cluster_id
+    {
+        brpc::Controller cntl;
+        GetRowsetRequest req;
+        GetRowsetResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.mutable_idx()->set_tablet_id(tablet_id);
+        req.set_start_version(0);
+        req.set_end_version(-1);
+        req.set_base_compaction_cnt(0);
+        req.set_cumulative_compaction_cnt(0);
+        req.set_cumulative_point(2);
+
+        meta_service.get_rowset(&cntl, &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+
+        // Check that last_active_cluster_id is always set (MS always updates it)
+        EXPECT_TRUE(res.stats().has_last_active_cluster_id());
+        EXPECT_EQ(res.stats().last_active_cluster_id(), mock_cluster_id);
+    }
+}
+
+} // namespace doris::cloud

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -304,6 +304,22 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
             txnInfoBuilder.setTimeoutMs(timeoutSecond * 1000);
             txnInfoBuilder.setPrecommitTimeoutMs(Config.stream_load_default_precommit_timeout_second * 1000);
 
+            // Set load_cluster_id for compaction read-write separation.
+            // commit_txn uses this to update last_active_cluster_id on tablet stats.
+            if (Config.isCloudMode()) {
+                try {
+                    ConnectContext ctx = ConnectContext.get();
+                    if (ctx != null) {
+                        String clusterId = ctx.getComputeGroup().getId();
+                        if (clusterId != null && !clusterId.isEmpty()) {
+                            txnInfoBuilder.setLoadClusterId(clusterId);
+                        }
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Failed to get compute group id for load_cluster_id, label: {}", label, e);
+                }
+            }
+
             final BeginTxnRequest beginTxnRequest = BeginTxnRequest.newBuilder()
                     .setTxnInfo(txnInfoBuilder.build())
                     .setCloudUniqueId(Config.cloud_unique_id)

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -506,6 +506,9 @@ message TxnInfoPB {
     // TODO: There are more fields TBD
     optional bool versioned_write = 19;  // versioned write, don't need to write RecycleTxnPB again
     optional bool versioned_read = 20;  // whether to read versioned keys
+    // The cluster_id of the compute cluster that performed the load
+    // Set by FE during begin_txn, used by commit_txn for compaction read-write separation
+    optional string load_cluster_id = 22;
 }
 
 // For check txn conflict and txn timeout
@@ -884,6 +887,17 @@ message TabletStatsPB {
     optional int64 last_full_compaction_time_ms = 13;
     optional int64 index_size = 14;
     optional int64 segment_size = 15;
+    // The cluster ID that most recently performed load or compaction on this tablet
+    optional string last_active_cluster_id = 16;
+    // Timestamp (ms) when the last_active_cluster was updated
+    optional int64 last_active_time_ms = 17;
+    // Current status of the last_active_cluster (filled by MS at get_rowset time)
+    // NORMAL means available, other states (SUSPENDED/MANUAL_SHUTDOWN) or UNKNOWN means unavailable
+    optional ClusterStatus last_active_cluster_status = 18;
+    // Timestamp for timeout judgment
+    // - Normal case: dynamically filled with ClusterPB.mtime (not persisted)
+    // - Deleted case: persisted when first detected as deleted, reused thereafter
+    optional int64 last_active_cluster_status_mtime_ms = 19;
 }
 
 message ObjectFilePB {
@@ -1335,6 +1349,8 @@ message GetRowsetResponse {
     optional SchemaCloudDictionary schema_dict = 4;
     // The current max version of the partition
     optional int64 partition_max_version = 5;
+    // The cluster_id of the requester
+    optional string requester_cluster_id = 6;
 }
 
 message GetSchemaDictRequest {
@@ -1523,6 +1539,8 @@ message GetClusterStatusResponse {
     }
     optional MetaServiceResponseStatus status = 1;
     repeated GetClusterStatusResponseDetail details = 2;
+    // The cluster_id of the requesting node (resolved from cloud_unique_id)
+    optional string requester_cluster_id = 3;
 }
 
 message GetClusterResponse {

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_cluster_takeover.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_cluster_takeover.groovy
@@ -1,0 +1,264 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+import groovy.json.JsonOutput
+
+/**
+ * Test compaction cluster takeover when the original write cluster becomes unavailable.
+ *
+ * Scenario:
+ * 1. Write cluster performs load, auto compaction is disabled at BE level initially
+ * 2. Write cluster becomes SUSPENDED via MS API
+ * 3. After timeout, enable auto compaction on read cluster BE via HTTP config update
+ * 4. Read cluster should take over compaction via auto compaction
+ *
+ * This test uses auto compaction (not manual trigger) because manual trigger bypasses
+ * the get_topn_tablets_to_compact logic where should_skip_compaction is checked.
+ * Auto compaction is controlled via BE config (not table property) because ALTER TABLE
+ * disable_auto_compaction has a known bug and may not take effect immediately.
+ */
+suite('test_compaction_cluster_takeover', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'compaction_cluster_takeover_timeout_ms=10000',  // 10 seconds for faster testing
+        'cluster_status_cache_refresh_interval_sec=3',   // 3 seconds for faster testing
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',  // Disable auto compaction initially, enable via HTTP later
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tablet_id ->
+        def url = "http://${ip}:${port}/api/compaction/show?tablet_id=${tablet_id}"
+        def response = new URL(url).text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { cluster_name ->
+        def backends = sql """SHOW BACKENDS"""
+        def cluster_bes = backends.findAll { it[19].contains("""\"compute_group_name\" : \"${cluster_name}\"""") }
+
+        if (cluster_bes.isEmpty()) {
+            throw new RuntimeException("No BE found for cluster: ${cluster_name}")
+        }
+
+        def firstBe = cluster_bes[0]
+        return [ip: firstBe[1], http_port: firstBe[4], brpc_port: firstBe[5], backend_id: firstBe[0]]
+    }
+
+    def getCloudClusterId = { cluster_name ->
+        def backends = sql """SHOW BACKENDS"""
+        def cluster_be = backends.find { it[19].contains("""\"compute_group_name\" : \"${cluster_name}\"""") }
+        if (cluster_be == null) {
+            throw new RuntimeException("No BE found for cluster: ${cluster_name}")
+        }
+        def tag = cluster_be[19]
+        def jsonSlurper = new JsonSlurper()
+        def jsonObject = jsonSlurper.parseText(tag)
+        return [cluster_id: jsonObject.compute_group_id, unique_id: jsonObject.cloud_unique_id]
+    }
+
+    // Helper function to set cluster status via MS HTTP API
+    def setClusterStatus = { String unique_id, String cluster_id, String status, def ms ->
+        def jsonOutput = new JsonOutput()
+        def reqBody = [
+            cloud_unique_id: unique_id,
+            cluster: [
+                cluster_id: cluster_id,
+                cluster_status: status
+            ]
+        ]
+        def js = jsonOutput.toJson(reqBody)
+        logger.info("set_cluster_status request: ${js}")
+
+        httpTest {
+            endpoint ms.host + ':' + ms.httpPort
+            uri "/MetaService/http/set_cluster_status?token=greedisgood9999"
+            body js
+            check { respCode, body ->
+                logger.info("set_cluster_status response: ${body} ${respCode}")
+                def json = parseJson(body)
+                assertTrue(json.code.equalsIgnoreCase("OK"), "Failed to set cluster status: ${body}")
+            }
+        }
+    }
+
+    docker(options) {
+        def writeCluster = "primary_cluster"
+        def readCluster = "secondary_cluster"
+
+        // Add two clusters
+        cluster.addBackend(1, writeCluster)
+        cluster.addBackend(1, readCluster)
+
+        // Get MS instance
+        def ms = cluster.getAllMetaservices().get(0)
+        logger.info("Meta service: ${ms.host}:${ms.httpPort}")
+
+        def writeBe = getBeIpAndPort(writeCluster)
+        def readBe = getBeIpAndPort(readCluster)
+        def writeClusterInfo = getCloudClusterId(writeCluster)
+
+        logger.info("Primary BE: ${writeBe.ip}:${writeBe.http_port}")
+        logger.info("Secondary BE: ${readBe.ip}:${readBe.http_port}")
+        logger.info("Primary cluster ID: ${writeClusterInfo.cluster_id}")
+
+        // Use write cluster to create table and load data
+        // Auto compaction is disabled at BE level, so no compaction will run initially
+        sql """use @${writeCluster}"""
+
+        def tableName = "test_compaction_takeover"
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 INT NOT NULL,
+                v1 STRING NOT NULL
+            ) UNIQUE KEY(`k1`)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            );
+        """
+
+        // Insert data from primary cluster (this sets last_active_cluster_id)
+        for (int i = 0; i < 10; i++) {
+            sql """INSERT INTO ${tableName} VALUES (${i}, 'value_${i}')"""
+        }
+
+        // Get tablet info
+        def tablets = sql_return_maparray """ SHOW TABLETS FROM ${tableName} """
+        assertEquals(1, tablets.size())
+        def tablet = tablets[0]
+        def tablet_id = tablet.TabletId
+        logger.info("Tablet ID: ${tablet_id}")
+
+        sleep(3000)
+
+        // Sync rowsets to read cluster
+        sql """use @${readCluster}"""
+        def result = sql """SELECT COUNT(*) FROM ${tableName}"""
+        assertEquals(10, result[0][0])
+
+        // Now suspend the primary cluster using MS HTTP API
+        logger.info("Suspending primary cluster to simulate unavailability...")
+        setClusterStatus(writeClusterInfo.unique_id, writeClusterInfo.cluster_id, "SUSPENDED", ms)
+
+        // Wait for cluster status cache to refresh + takeover timeout
+        // cluster_status_cache_refresh_interval_sec=3, compaction_cluster_takeover_timeout_ms=10000
+        logger.info("Waiting for cluster status cache refresh and takeover timeout...")
+        sleep(15000)
+
+        // Enable auto compaction on the read cluster BE via HTTP config update
+        // (Using BE config instead of ALTER TABLE because ALTER TABLE disable_auto_compaction
+        // has a known bug and may not take effect immediately)
+        logger.info("Enabling auto compaction on read cluster BE...")
+        def (code, out, err) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                readBe.ip, readBe.http_port))
+        logger.info("Update config response: code=${code}, out=${out}")
+
+        // Wait for auto compaction to run on the read cluster
+        logger.info("Waiting for auto compaction on read cluster after takeover...")
+        sleep(30000)
+
+        // Check that read cluster has compacted
+        def readStatus = getTabletStatus(readBe.ip, readBe.http_port, tablet_id)
+        logger.info("Read cluster tablet status: ${readStatus}")
+        def readLastCumuTime = readStatus["last cumulative success time"]
+        logger.info("Read cluster last cumulative success time: ${readLastCumuTime}")
+
+        assertTrue(readLastCumuTime != "1970-01-01 08:00:00.000",
+            "Read cluster should have taken over compaction after timeout, but last cumulative success time is: ${readLastCumuTime}")
+
+        logger.info("Secondary cluster successfully took over compaction!")
+
+        // ==========================================
+        // Phase 2: Primary resumes, loads data, and takes back compaction control
+        // ==========================================
+        logger.info("=== Phase 2: Testing primary cluster recovery ===")
+
+        // Resume the primary cluster
+        logger.info("Resuming primary cluster...")
+        setClusterStatus(writeClusterInfo.unique_id, writeClusterInfo.cluster_id, "NORMAL", ms)
+
+        // Record secondary's compaction timestamp before primary recovery
+        def readStatusBefore = getTabletStatus(readBe.ip, readBe.http_port, tablet_id)
+        def readCumuTimeBefore = readStatusBefore["last cumulative success time"]
+        logger.info("Secondary last cumulative success time before primary recovery: ${readCumuTimeBefore}")
+
+        // Insert more data from primary cluster — this updates last_active_cluster_id back to primary
+        sql """use @${writeCluster}"""
+        for (int i = 10; i < 20; i++) {
+            sql """INSERT INTO ${tableName} VALUES (${i}, 'value_${i}')"""
+        }
+        logger.info("Inserted more data from primary cluster")
+
+        // Sync to secondary so both clusters have the new rowsets
+        sql """use @${readCluster}"""
+        def result2 = sql """SELECT COUNT(*) FROM ${tableName}"""
+        assertEquals(20, result2[0][0])
+
+        // Wait for cluster status cache to refresh so both clusters see updated last_active_cluster
+        sleep(5000)
+
+        // Enable auto compaction on both clusters
+        logger.info("Enabling auto compaction on both cluster BEs...")
+        def (code3, out3, err3) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                writeBe.ip, writeBe.http_port))
+        logger.info("Enable primary auto compaction response: code=${code3}, out=${out3}")
+        def (code4, out4, err4) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                readBe.ip, readBe.http_port))
+        logger.info("Enable secondary auto compaction response: code=${code4}, out=${out4}")
+
+        // Wait for auto compaction to run
+        logger.info("Waiting for auto compaction after primary recovery...")
+        sleep(30000)
+
+        // Check that primary cluster has compacted after recovery
+        def writeStatus = getTabletStatus(writeBe.ip, writeBe.http_port, tablet_id)
+        logger.info("Primary cluster tablet status after recovery: ${writeStatus}")
+        def writeLastCumuTime = writeStatus["last cumulative success time"]
+        logger.info("Primary cluster last cumulative success time: ${writeLastCumuTime}")
+
+        assertTrue(writeLastCumuTime != "1970-01-01 08:00:00.000",
+            "Primary cluster should have resumed compaction after recovery, but last cumulative success time is: ${writeLastCumuTime}")
+
+        logger.info("Primary cluster successfully took back compaction control!")
+
+        // Check that secondary cluster did NOT do new compaction after primary took back control
+        def readStatusAfter = getTabletStatus(readBe.ip, readBe.http_port, tablet_id)
+        def readCumuTimeAfter = readStatusAfter["last cumulative success time"]
+        logger.info("Secondary last cumulative success time after primary recovery: ${readCumuTimeAfter}")
+
+        assertEquals(readCumuTimeBefore, readCumuTimeAfter,
+            "Secondary cluster should have stopped compaction after primary recovered, " +
+            "but cumulative time changed from ${readCumuTimeBefore} to ${readCumuTimeAfter}")
+
+        // Clean up
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+
+        logger.info("All takeover tests passed!")
+    }
+}

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation.groovy
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+/**
+ * Test compaction read-write separation feature.
+ *
+ * When enable_compaction_rw_separation is enabled:
+ * - Only the cluster that last performed load (write cluster) should execute compaction
+ * - Read-only clusters should skip compaction to avoid file cache invalidation
+ *
+ * This test uses auto compaction (not manual trigger) because manual trigger bypasses
+ * the get_topn_tablets_to_compact logic where should_skip_compaction is checked.
+ */
+suite('test_compaction_rw_separation', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'compaction_cluster_takeover_timeout_ms=600000',  // 10 min, ensure no takeover in test
+        'cluster_status_cache_refresh_interval_sec=5',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',  // Disable initially, enable via HTTP after data load
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tablet_id ->
+        def url = "http://${ip}:${port}/api/compaction/show?tablet_id=${tablet_id}"
+        def response = new URL(url).text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { cluster_name ->
+        def backends = sql """SHOW BACKENDS"""
+        def cluster_bes = backends.findAll { it[19].contains("""\"compute_group_name\" : \"${cluster_name}\"""") }
+
+        if (cluster_bes.isEmpty()) {
+            throw new RuntimeException("No BE found for cluster: ${cluster_name}")
+        }
+
+        def firstBe = cluster_bes[0]
+        return [ip: firstBe[1], http_port: firstBe[4], brpc_port: firstBe[5], backend_id: firstBe[0]]
+    }
+
+    docker(options) {
+        def writeCluster = "write_cluster"
+        def readCluster = "read_cluster"
+
+        // Add two clusters
+        cluster.addBackend(1, writeCluster)
+        cluster.addBackend(1, readCluster)
+
+        logger.info("Created write cluster: ${writeCluster}")
+        logger.info("Created read cluster: ${readCluster}")
+
+        def writeBe = getBeIpAndPort(writeCluster)
+        def readBe = getBeIpAndPort(readCluster)
+
+        logger.info("Write BE: ${writeBe.ip}:${writeBe.http_port}")
+        logger.info("Read BE: ${readBe.ip}:${readBe.http_port}")
+
+        // Use write cluster to create table (auto compaction enabled)
+        sql """use @${writeCluster}"""
+
+        def tableName = "test_compaction_rw_sep"
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL
+            ) UNIQUE KEY(`k1`)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            );
+        """
+
+        // Insert multiple rowsets from write cluster to trigger auto compaction
+        for (int i = 0; i < 10; i++) {
+            sql """INSERT INTO ${tableName} VALUES (${i}, ${i * 10})"""
+        }
+
+        // Get tablet info
+        def tablets = sql_return_maparray """ SHOW TABLETS FROM ${tableName} """
+        assertEquals(1, tablets.size())
+        def tablet = tablets[0]
+        def tablet_id = tablet.TabletId
+        logger.info("Tablet ID: ${tablet_id}")
+
+        // Sync rowsets to read cluster
+        sql """use @${readCluster}"""
+        def result = sql """SELECT COUNT(*) FROM ${tableName}"""
+        assertEquals(10, result[0][0])
+
+        // Enable auto compaction on both BEs via HTTP config update
+        // (Using BE config instead of table property because ALTER TABLE disable_auto_compaction
+        // has a known bug and may not take effect immediately)
+        logger.info("Enabling auto compaction on both BEs...")
+        def (code1, out1, err1) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                writeBe.ip, writeBe.http_port))
+        logger.info("Update write BE config response: code=${code1}, out=${out1}")
+        def (code2, out2, err2) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                readBe.ip, readBe.http_port))
+        logger.info("Update read BE config response: code=${code2}, out=${out2}")
+
+        // Wait for auto compaction to run on both clusters
+        // Write cluster should compact, read cluster should skip
+        logger.info("Waiting for auto compaction to run...")
+        sleep(30000)
+
+        // Check compaction status on write cluster
+        def writeStatus = getTabletStatus(writeBe.ip, writeBe.http_port, tablet_id)
+        logger.info("Write cluster tablet status: ${writeStatus}")
+        def writeLastCumuTime = writeStatus["last cumulative success time"]
+        logger.info("Write cluster last cumulative success time: ${writeLastCumuTime}")
+
+        // Check compaction status on read cluster
+        def readStatus = getTabletStatus(readBe.ip, readBe.http_port, tablet_id)
+        logger.info("Read cluster tablet status: ${readStatus}")
+        def readLastCumuTime = readStatus["last cumulative success time"]
+        logger.info("Read cluster last cumulative success time: ${readLastCumuTime}")
+
+        // Write cluster should have compacted (last success time is not the initial value)
+        assertTrue(writeLastCumuTime != "1970-01-01 08:00:00.000",
+            "Write cluster should have executed compaction, but last cumulative success time is: ${writeLastCumuTime}")
+
+        // Read cluster should NOT have compacted (last success time should still be initial)
+        assertTrue(readLastCumuTime == "1970-01-01 08:00:00.000",
+            "Read cluster should NOT have executed compaction, but last cumulative success time is: ${readLastCumuTime}")
+
+        logger.info("Test passed: Write cluster compacted, read cluster skipped!")
+
+        // Clean up
+        sql """use @${writeCluster}"""
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+    }
+}

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_disabled.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_disabled.groovy
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+/**
+ * Test behavior when compaction read-write separation is DISABLED.
+ *
+ * When enable_compaction_rw_separation is false (default):
+ * - All clusters should be able to execute compaction regardless of which cluster last performed load
+ *
+ * This test uses auto compaction to verify that both clusters can compact.
+ */
+suite('test_compaction_rw_separation_disabled', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=false',  // Feature disabled
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',  // Disable initially, enable via HTTP after data load
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tablet_id ->
+        def url = "http://${ip}:${port}/api/compaction/show?tablet_id=${tablet_id}"
+        def response = new URL(url).text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { cluster_name ->
+        def backends = sql """SHOW BACKENDS"""
+        def cluster_bes = backends.findAll { it[19].contains("""\"compute_group_name\" : \"${cluster_name}\"""") }
+
+        if (cluster_bes.isEmpty()) {
+            throw new RuntimeException("No BE found for cluster: ${cluster_name}")
+        }
+
+        def firstBe = cluster_bes[0]
+        return [ip: firstBe[1], http_port: firstBe[4], brpc_port: firstBe[5], backend_id: firstBe[0]]
+    }
+
+    docker(options) {
+        def clusterA = "cluster_a"
+        def clusterB = "cluster_b"
+
+        // Add two clusters
+        cluster.addBackend(1, clusterA)
+        cluster.addBackend(1, clusterB)
+
+        logger.info("Created cluster A: ${clusterA}")
+        logger.info("Created cluster B: ${clusterB}")
+
+        def beA = getBeIpAndPort(clusterA)
+        def beB = getBeIpAndPort(clusterB)
+
+        logger.info("Cluster A BE: ${beA.ip}:${beA.http_port}")
+        logger.info("Cluster B BE: ${beB.ip}:${beB.http_port}")
+
+        // Use cluster A to create table and load data (auto compaction enabled)
+        sql """use @${clusterA}"""
+
+        def tableName = "test_compaction_disabled"
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL
+            ) UNIQUE KEY(`k1`)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            );
+        """
+
+        // Insert data from cluster A
+        for (int i = 0; i < 10; i++) {
+            sql """INSERT INTO ${tableName} VALUES (${i}, ${i * 100})"""
+        }
+
+        // Get tablet info
+        def tablets = sql_return_maparray """ SHOW TABLETS FROM ${tableName} """
+        assertEquals(1, tablets.size())
+        def tablet = tablets[0]
+        def tablet_id = tablet.TabletId
+        logger.info("Tablet ID: ${tablet_id}")
+
+        // Sync rowsets to cluster B
+        sql """use @${clusterB}"""
+        def result = sql """SELECT COUNT(*) FROM ${tableName}"""
+        assertEquals(10, result[0][0])
+
+        // Enable auto compaction on both BEs via HTTP config update
+        // (Using BE config instead of table property because ALTER TABLE disable_auto_compaction
+        // has a known bug and may not take effect immediately)
+        logger.info("Enabling auto compaction on both BEs...")
+        def (code1, out1, err1) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                beA.ip, beA.http_port))
+        logger.info("Update cluster A BE config response: code=${code1}, out=${out1}")
+        def (code2, out2, err2) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                beB.ip, beB.http_port))
+        logger.info("Update cluster B BE config response: code=${code2}, out=${out2}")
+
+        // Wait for auto compaction to run on both clusters
+        logger.info("Waiting for auto compaction to run on both clusters...")
+        sleep(30000)
+
+        // Check compaction status on both clusters
+        def statusA = getTabletStatus(beA.ip, beA.http_port, tablet_id)
+        logger.info("Cluster A tablet status: ${statusA}")
+        def lastCumuTimeA = statusA["last cumulative success time"]
+        logger.info("Cluster A last cumulative success time: ${lastCumuTimeA}")
+
+        def statusB = getTabletStatus(beB.ip, beB.http_port, tablet_id)
+        logger.info("Cluster B tablet status: ${statusB}")
+        def lastCumuTimeB = statusB["last cumulative success time"]
+        logger.info("Cluster B last cumulative success time: ${lastCumuTimeB}")
+
+        // When feature is disabled, both clusters should be able to compact
+        // At least one of them should have compacted within 30 seconds
+        // (Both may not compact if they contend, but at least cluster A which has the tablet should)
+        assertTrue(lastCumuTimeA != "1970-01-01 08:00:00.000" || lastCumuTimeB != "1970-01-01 08:00:00.000",
+            "At least one cluster should have compacted when feature is disabled. " +
+            "Cluster A time: ${lastCumuTimeA}, Cluster B time: ${lastCumuTimeB}")
+
+        logger.info("Feature disabled test passed - compaction ran successfully!")
+
+        // Clean up
+        sql """use @${clusterA}"""
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+    }
+}

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_force.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_force.groovy
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+/**
+ * Test force compaction on read cluster when version count exceeds 80% of max_tablet_version_num.
+ *
+ * When the write cluster cannot keep up with compaction (disabled, overloaded, etc.),
+ * version count accumulates. If it exceeds 80% of max_tablet_version_num, read clusters
+ * should do compaction anyway despite RW separation being enabled.
+ *
+ * Setup:
+ * - max_tablet_version_num=20 on both BEs (so threshold = 16)
+ * - Disable auto compaction initially
+ * - Load 18 rowsets from write cluster (exceeds threshold)
+ * - Sync to read cluster
+ * - Keep auto compaction disabled on write cluster
+ * - Enable auto compaction only on read cluster
+ * - Verify read cluster performs compaction despite RW separation
+ */
+suite('test_compaction_rw_separation_force', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'compaction_cluster_takeover_timeout_ms=600000',  // 10 min, ensure no takeover in test
+        'cluster_status_cache_refresh_interval_sec=5',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',  // Disable initially
+        'max_tablet_version_num=20',     // Low limit so 80% threshold = 16
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tablet_id ->
+        def url = "http://${ip}:${port}/api/compaction/show?tablet_id=${tablet_id}"
+        def response = new URL(url).text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { cluster_name ->
+        def backends = sql """SHOW BACKENDS"""
+        def cluster_bes = backends.findAll { it[19].contains("""\"compute_group_name\" : \"${cluster_name}\"""") }
+
+        if (cluster_bes.isEmpty()) {
+            throw new RuntimeException("No BE found for cluster: ${cluster_name}")
+        }
+
+        def firstBe = cluster_bes[0]
+        return [ip: firstBe[1], http_port: firstBe[4], brpc_port: firstBe[5], backend_id: firstBe[0]]
+    }
+
+    docker(options) {
+        def writeCluster = "write_cluster"
+        def readCluster = "read_cluster"
+
+        // Add two clusters
+        cluster.addBackend(1, writeCluster)
+        cluster.addBackend(1, readCluster)
+
+        logger.info("Created write cluster: ${writeCluster}")
+        logger.info("Created read cluster: ${readCluster}")
+
+        def writeBe = getBeIpAndPort(writeCluster)
+        def readBe = getBeIpAndPort(readCluster)
+
+        logger.info("Write BE: ${writeBe.ip}:${writeBe.http_port}")
+        logger.info("Read BE: ${readBe.ip}:${readBe.http_port}")
+
+        // Use write cluster to create table
+        sql """use @${writeCluster}"""
+
+        def tableName = "test_compaction_rw_sep_force"
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+        sql """
+            CREATE TABLE ${tableName} (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL
+            ) UNIQUE KEY(`k1`)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            );
+        """
+
+        // Insert 18 rowsets from write cluster to exceed 80% of max_tablet_version_num=20 (threshold=16)
+        for (int i = 0; i < 18; i++) {
+            sql """INSERT INTO ${tableName} VALUES (${i}, ${i * 10})"""
+        }
+
+        // Get tablet info
+        def tablets = sql_return_maparray """ SHOW TABLETS FROM ${tableName} """
+        assertEquals(1, tablets.size())
+        def tablet = tablets[0]
+        def tablet_id = tablet.TabletId
+        logger.info("Tablet ID: ${tablet_id}")
+
+        // Sync rowsets to read cluster
+        sql """use @${readCluster}"""
+        def result = sql """SELECT COUNT(*) FROM ${tableName}"""
+        assertEquals(18, result[0][0])
+
+        // Keep auto compaction DISABLED on write cluster (simulating "can't compact")
+        // Enable auto compaction ONLY on read cluster
+        logger.info("Enabling auto compaction only on read cluster...")
+        def (code2, out2, err2) = curl("POST",
+            String.format("http://%s:%s/api/update_config?disable_auto_compaction=false",
+                readBe.ip, readBe.http_port))
+        logger.info("Update read BE config response: code=${code2}, out=${out2}")
+
+        // Wait for auto compaction to run on read cluster
+        // Since version count (18) > 80% of max_tablet_version_num (20) = 16,
+        // read cluster should force compaction despite RW separation
+        logger.info("Waiting for read cluster to force compaction...")
+        sleep(30000)
+
+        // Check compaction status on write cluster (should NOT have compacted, auto compaction disabled)
+        def writeStatus = getTabletStatus(writeBe.ip, writeBe.http_port, tablet_id)
+        logger.info("Write cluster tablet status: ${writeStatus}")
+        def writeLastCumuTime = writeStatus["last cumulative success time"]
+        logger.info("Write cluster last cumulative success time: ${writeLastCumuTime}")
+
+        // Check compaction status on read cluster (should have compacted due to force)
+        def readStatus = getTabletStatus(readBe.ip, readBe.http_port, tablet_id)
+        logger.info("Read cluster tablet status: ${readStatus}")
+        def readLastCumuTime = readStatus["last cumulative success time"]
+        logger.info("Read cluster last cumulative success time: ${readLastCumuTime}")
+
+        // Write cluster should NOT have compacted (auto compaction is disabled)
+        assertTrue(writeLastCumuTime == "1970-01-01 08:00:00.000",
+            "Write cluster should NOT have executed compaction (disabled), but last cumulative success time is: ${writeLastCumuTime}")
+
+        // Read cluster SHOULD have compacted (forced by high version count)
+        assertTrue(readLastCumuTime != "1970-01-01 08:00:00.000",
+            "Read cluster should have force-compacted due to high version count, but last cumulative success time is: ${readLastCumuTime}")
+
+        logger.info("Test passed: Read cluster force-compacted despite RW separation!")
+
+        // Clean up
+        sql """use @${writeCluster}"""
+        sql """ DROP TABLE IF EXISTS ${tableName} """
+    }
+}


### PR DESCRIPTION
## Summary
Cherry-pick from apache/doris#60310 (commit 5cbe1b4) to branch-4.0

- Implements compaction read-write separation for cloud mode so that only the cluster that last performed data load executes compaction, preventing file cache invalidation on read-only clusters
- **Default is disabled** (`enable_compaction_rw_separation = false`), can be enabled per-cluster via BE config

### Conflict Resolution
- `gensrc/proto/cloud.proto`: `TxnInfoPB` field 21 (`defer_deleting_pending_delete_bitmaps`) does not exist on branch-4.0, only added `load_cluster_id` (field 22) from this PR

### Key changes
- Track "last active cluster" per tablet in `TabletStatsPB` (updated during `commit_txn`)
- FE sets `load_cluster_id` in `TxnInfoPB` during `begin_txn`
- BE background thread caches cluster status via `get_cluster_status` RPC
- Skip compaction in `get_topn_tablets_to_compact` for tablets owned by other clusters
- Safety valve: force compaction when version count exceeds 80% of max
- Configurable takeover timeout when write cluster becomes unavailable

## Test plan
- Unit tests: `cloud_cluster_info_test`, `compaction_rw_separation_test`
- Regression tests: `test_compaction_rw_separation`, `test_compaction_cluster_takeover`, `test_compaction_rw_separation_disabled`, `test_compaction_rw_separation_force`