### PR TITLE
[fix](backup) Fix UnsupportedOperationException in RestoreCommand by copying properties before modification

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/RestoreCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/RestoreCommand.java
@@ -211,13 +211,15 @@ public class RestoreCommand extends Command implements ForwardWithSync {
      * analyzeProperties
      */
     public void analyzeProperties() throws AnalysisException {
+        Map<String, String> copiedProperties = Maps.newHashMap(properties);
+
         // timeout
-        if (properties.containsKey("timeout")) {
+        if (copiedProperties.containsKey(PROP_TIMEOUT)) {
             try {
-                timeoutMs = Long.valueOf(properties.get(PROP_TIMEOUT));
+                timeoutMs = Long.valueOf(copiedProperties.get(PROP_TIMEOUT));
             } catch (NumberFormatException e) {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
-                        "Invalid timeout format: " + properties.get(PROP_TIMEOUT));
+                        "Invalid timeout format: " + copiedProperties.get(PROP_TIMEOUT));
             }
 
             if (timeoutMs * 1000 < MIN_TIMEOUT_MS) {
@@ -225,12 +227,10 @@ public class RestoreCommand extends Command implements ForwardWithSync {
             }
 
             timeoutMs = timeoutMs * 1000;
-            properties.remove(PROP_TIMEOUT);
+            copiedProperties.remove(PROP_TIMEOUT);
         } else {
             timeoutMs = Config.backup_job_default_timeout_ms;
         }
-
-        Map<String, String> copiedProperties = Maps.newHashMap(properties);
 
         // allow load
         allowLoad = eatBooleanProperty(copiedProperties, PROP_ALLOW_LOAD, allowLoad);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/RestoreCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/RestoreCommandTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.collect.ImmutableMap;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.commons.collections4.map.HashedMap;
@@ -135,5 +136,20 @@ public class RestoreCommandTest {
         String repoName2 = "__keep_on_local__";
         RestoreCommand command5 = new RestoreCommand(labelNameInfo, repoName2, tableRefInfos, properties2, isExclude);
         Assertions.assertThrows(DdlException.class, () -> command5.validate(connectContext));
+    }
+
+    @Test
+    public void testAnalyzePropertiesWithImmutableMap() {
+        LabelNameInfo labelNameInfo = new LabelNameInfo(dbName, "label0");
+        Map<String, String> properties = ImmutableMap.of(
+                "timeout", "86400",
+                "backup_timestamp", "2025-06-12-11-15-20");
+
+        RestoreCommand command = new RestoreCommand(labelNameInfo, "testRepo",
+                new ArrayList<>(), properties, false);
+
+        Assertions.assertDoesNotThrow(command::analyzeProperties);
+        Assertions.assertEquals(86400L * 1000, command.getTimeoutMs());
+        Assertions.assertEquals("2025-06-12-11-15-20", command.getBackupTimestamp());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #50638

Problem Summary:

The properties map could be an ImmutableMap, so calling remove() on it causes UnsupportedOperationException.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

