### PR TITLE
[fix](mtmv) Fix NPE in show create materialized view after upgrade

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ShowCreateMTMVInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ShowCreateMTMVInfo.java
@@ -36,7 +36,9 @@ import org.apache.doris.qe.ShowResultSetMetaData;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -90,7 +92,9 @@ public class ShowCreateMTMVInfo {
         Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(mvName.getDb());
         MTMV mtmv = (MTMV) db.getTableOrDdlException(mvName.getTbl());
         String mtmvDdl = Env.getMTMVDdl(mtmv);
-        rows.add(Lists.newArrayList(mtmv.getName(), mtmvDdl, mtmv.getSessionVariables().toString()));
+        Map<String, String> sessionVars = mtmv.getSessionVariables();
+        rows.add(Lists.newArrayList(mtmv.getName(), mtmvDdl,
+                sessionVars == null ? Collections.emptyMap().toString() : sessionVars.toString()));
         return new ShowResultSet(META_DATA, rows);
 
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateMTMVCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateMTMVCommandTest.java
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MTMV;
+import org.apache.doris.nereids.trees.plans.commands.info.ShowCreateMTMVInfo;
+import org.apache.doris.info.TableNameInfo;
+import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+public class ShowCreateMTMVCommandTest extends TestWithFeService {
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test_show_create_mtmv_db");
+        useDatabase("test_show_create_mtmv_db");
+        createTables(
+                "CREATE TABLE IF NOT EXISTS t1 (\n"
+                        + "    id INT,\n"
+                        + "    name VARCHAR(50)\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(id)\n"
+                        + "DISTRIBUTED BY HASH(id) BUCKETS 1\n"
+                        + "PROPERTIES (\n"
+                        + "  \"replication_num\" = \"1\"\n"
+                        + ")\n"
+        );
+        createMvByNereids("CREATE MATERIALIZED VIEW mv1 BUILD DEFERRED REFRESH COMPLETE ON MANUAL\n"
+                + "DISTRIBUTED BY RANDOM BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1')\n"
+                + "AS SELECT * FROM t1;");
+    }
+
+    @Test
+    public void testShowCreateMTMVWithSessionVariables() throws Exception {
+        // Verify show create materialized view works normally
+        ShowCreateMTMVInfo info = new ShowCreateMTMVInfo(
+                new TableNameInfo("test_show_create_mtmv_db", "mv1"));
+        info.analyze(connectContext);
+        ShowResultSet resultSet = info.getShowResultSet();
+
+        List<List<String>> rows = resultSet.getResultRows();
+        Assertions.assertEquals(1, rows.size());
+        List<String> row = rows.get(0);
+        // 3 columns: Materialized View, Create Materialized View, Session Variables
+        Assertions.assertEquals(3, row.size());
+        Assertions.assertEquals("mv1", row.get(0));
+        // Session variables should not be null or empty
+        Assertions.assertNotNull(row.get(2));
+        Assertions.assertFalse(row.get(2).isEmpty());
+    }
+
+    @Test
+    public void testShowCreateMTMVWithNullSessionVariables() throws Exception {
+        // Simulate upgrade scenario: MTMVs created before sessionVariables field was introduced
+        // have null sessionVariables after deserialization
+        Database db = Env.getCurrentEnv().getInternalCatalog()
+                .getDbOrAnalysisException("test_show_create_mtmv_db");
+        MTMV mtmv = (MTMV) db.getTableOrAnalysisException("mv1");
+
+        // Use reflection to set sessionVariables to null, simulating pre-upgrade MTMV
+        Field sessionVariablesField = MTMV.class.getDeclaredField("sessionVariables");
+        sessionVariablesField.setAccessible(true);
+        Map<String, String> originalSessionVars = (Map<String, String>) sessionVariablesField.get(mtmv);
+        sessionVariablesField.set(mtmv, null);
+
+        try {
+            // This should NOT throw NPE after the fix
+            ShowCreateMTMVInfo info = new ShowCreateMTMVInfo(
+                    new TableNameInfo("test_show_create_mtmv_db", "mv1"));
+            info.analyze(connectContext);
+            ShowResultSet resultSet = info.getShowResultSet();
+
+            List<List<String>> rows = resultSet.getResultRows();
+            Assertions.assertEquals(1, rows.size());
+            List<String> row = rows.get(0);
+            Assertions.assertEquals(3, row.size());
+            Assertions.assertEquals("mv1", row.get(0));
+            // When sessionVariables is null, should display empty map representation
+            Assertions.assertEquals("{}", row.get(2));
+        } finally {
+            // Restore original sessionVariables to avoid affecting other tests
+            sessionVariablesField.set(mtmv, originalSessionVars);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateMTMVCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateMTMVCommandTest.java
@@ -20,8 +20,8 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MTMV;
-import org.apache.doris.nereids.trees.plans.commands.info.ShowCreateMTMVInfo;
 import org.apache.doris.info.TableNameInfo;
+import org.apache.doris.nereids.trees.plans.commands.info.ShowCreateMTMVInfo;
 import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.utframe.TestWithFeService;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
After upgrading from 4.0.2 to 4.0.4, executing `SHOW CREATE MATERIALIZED VIEW` throws NullPointerException because `MTMV.getSessionVariables()` returns null for materialized views created before the `sessionVariables` field was introduced.

The `sessionVariables` field (annotated with `@SerializedName("sv")`) was added after 4.0.2. MTMVs created in 4.0.2 do not have this field persisted, so after upgrade it deserializes as null. The code in `ShowCreateMTMVInfo.getShowResultSet()` called `mtmv.getSessionVariables().toString()` without null protection.

Fix: Add null check - when sessionVariables is null, display empty map `{}`.

### Release note

Fix NPE when executing SHOW CREATE MATERIALIZED VIEW for materialized views created before the sessionVariables feature was introduced (e.g. upgrade from 4.0.2 to 4.0.4).

### Check List (For Author)

- Test: Unit Test
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: #58031 

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

