### PR TITLE
[refine](expr) Migrate old VExpr execute interface to new execute_column (Part 1)

### DIFF
--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -359,14 +359,12 @@ Status HashJoinBuildSinkLocalState::build_asof_index(Block& block) {
     // Compute build ASOF column by executing build-side expression directly on build block.
     // Expression is prepared against build child's row_desc, matching the build block layout.
     DORIS_CHECK(p._asof_build_side_expr);
-    int result_col_idx = -1;
+    ColumnPtr asof_build_col;
     {
         SCOPED_TIMER(_asof_index_expr_timer);
-        RETURN_IF_ERROR(p._asof_build_side_expr->execute(&block, &result_col_idx));
+        RETURN_IF_ERROR(p._asof_build_side_expr->execute(&block, asof_build_col));
     }
-    DORIS_CHECK(result_col_idx >= 0 && result_col_idx < static_cast<int>(block.columns()));
-    auto asof_build_col =
-            block.get_by_position(result_col_idx).column->convert_to_full_column_if_const();
+    asof_build_col = asof_build_col->convert_to_full_column_if_const();
 
     // Handle nullable: extract nested column for value access, keep nullable for null checks
     const ColumnNullable* nullable_col = nullptr;

--- a/be/src/exec/operator/join/process_hash_table_probe_impl.h
+++ b/be/src/exec/operator/join/process_hash_table_probe_impl.h
@@ -250,15 +250,13 @@ uint32_t ProcessHashTableProbe<JoinOpType>::
     DORIS_CHECK(asof_probe_expr);
 
     auto& probe_block = _parent->_probe_block;
-    int probe_col_idx = -1;
+    ColumnPtr probe_col_ptr;
     {
         SCOPED_TIMER(_asof_probe_expr_timer);
-        auto st = asof_probe_expr->execute(&probe_block, &probe_col_idx);
+        auto st = asof_probe_expr->execute(&probe_block, probe_col_ptr);
         DORIS_CHECK(st.ok());
     }
-    DORIS_CHECK(probe_col_idx >= 0 && probe_col_idx < static_cast<int>(probe_block.columns()));
-    auto probe_col_ptr =
-            probe_block.get_by_position(probe_col_idx).column->convert_to_full_column_if_const();
+    probe_col_ptr = probe_col_ptr->convert_to_full_column_if_const();
 
     // Remove nullable wrapper for comparison - keep original for null check
     ColumnPtr probe_col_for_compare = probe_col_ptr;

--- a/be/src/exec/operator/operator.cpp
+++ b/be/src/exec/operator/operator.cpp
@@ -364,10 +364,8 @@ Status OperatorXBase::do_projections(RuntimeState* state, Block* origin_block,
             VectorizedUtils::build_mutable_mem_reuse_block(output_block, *_output_row_descriptor);
     if (rows != 0) {
         auto& mutable_columns = mutable_block.mutable_columns();
-        const size_t origin_columns_count = input_block.columns();
         DCHECK_EQ(mutable_columns.size(), local_state->_projections.size()) << debug_string();
         for (int i = 0; i < mutable_columns.size(); ++i) {
-            auto result_column_id = -1;
             ColumnPtr column_ptr;
             RETURN_IF_ERROR(local_state->_projections[i]->execute(&input_block, column_ptr));
             if (column_ptr->size() != rows) {
@@ -377,9 +375,7 @@ Status OperatorXBase::do_projections(RuntimeState* state, Block* origin_block,
                         local_state->_projections[i]->root()->debug_string());
             }
             column_ptr = column_ptr->convert_to_full_column_if_const();
-            if (result_column_id >= origin_columns_count) {
-                bytes_usage += column_ptr->allocated_bytes();
-            }
+            bytes_usage += column_ptr->allocated_bytes();
             insert_column_datas(mutable_columns[i], column_ptr, rows);
         }
         DCHECK(mutable_block.rows() == rows);

--- a/be/src/exec/sink/vrow_distribution.cpp
+++ b/be/src/exec/sink/vrow_distribution.cpp
@@ -299,11 +299,8 @@ Status VRowDistribution::_filter_block_by_skip_and_where_clause(
         Block* block, const VExprContextSPtr& where_clause, RowPartTabletIds& row_part_tablet_id) {
     // TODO
     //SCOPED_RAW_TIMER(&_stat.where_clause_ns);
-    int result_index = -1;
-    size_t column_number = block->columns();
-    RETURN_IF_ERROR(where_clause->execute(block, &result_index));
-
-    auto filter_column = block->get_by_position(result_index).column;
+    ColumnPtr filter_column;
+    RETURN_IF_ERROR(where_clause->execute(block, filter_column));
 
     auto& row_ids = row_part_tablet_id.row_ids;
     auto& partition_ids = row_part_tablet_id.partition_ids;
@@ -340,9 +337,7 @@ Status VRowDistribution::_filter_block_by_skip_and_where_clause(
         }
     }
 
-    for (size_t i = block->columns() - 1; i >= column_number; i--) {
-        block->erase(i);
-    }
+
     return Status::OK();
 }
 

--- a/be/src/exec/sink/vrow_distribution.cpp
+++ b/be/src/exec/sink/vrow_distribution.cpp
@@ -337,7 +337,6 @@ Status VRowDistribution::_filter_block_by_skip_and_where_clause(
         }
     }
 
-
     return Status::OK();
 }
 

--- a/be/src/exprs/table_function/vexplode_map.cpp
+++ b/be/src/exprs/table_function/vexplode_map.cpp
@@ -58,16 +58,15 @@ Status VExplodeMapTableFunction::process_init(Block* block, RuntimeState* state)
             << "VExplodeMapTableFunction only support 1 child but has "
             << _expr_context->root()->children().size();
 
-    int value_column_idx = -1;
-    RETURN_IF_ERROR(_expr_context->root()->children()[0]->execute(_expr_context.get(), block,
-                                                                  &value_column_idx));
+    ColumnPtr value_column;
+    RETURN_IF_ERROR(_expr_context->root()->children()[0]->execute_column(
+            _expr_context.get(), block, nullptr, block->rows(), value_column));
 
-    _collection_column =
-            block->get_by_position(value_column_idx).column->convert_to_full_column_if_const();
+    _collection_column = value_column->convert_to_full_column_if_const();
 
     if (!extract_column_map_info(*_collection_column, _map_detail)) {
         return Status::NotSupported("column type {} not supported now, only support array or map",
-                                    block->get_by_position(value_column_idx).column->get_name());
+                                    _collection_column->get_name());
     }
 
     return Status::OK();

--- a/be/src/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/exprs/table_function/vexplode_numbers.cpp
@@ -45,10 +45,8 @@ Status VExplodeNumbersTableFunction::process_init(Block* block, RuntimeState* st
             << "VExplodeNumbersTableFunction must be have 1 children but have "
             << _expr_context->root()->children().size();
 
-    int value_column_idx = -1;
-    RETURN_IF_ERROR(_expr_context->root()->children()[0]->execute(_expr_context.get(), block,
-                                                                  &value_column_idx));
-    _value_column = block->get_by_position(value_column_idx).column;
+    RETURN_IF_ERROR(_expr_context->root()->children()[0]->execute_column(
+            _expr_context.get(), block, nullptr, block->rows(), _value_column));
     if (is_column_const(*_value_column)) {
         _cur_size = 0;
 

--- a/be/src/exprs/table_function/vjson_each.cpp
+++ b/be/src/exprs/table_function/vjson_each.cpp
@@ -46,10 +46,10 @@ VJsonEachTableFunction<TEXT_MODE>::VJsonEachTableFunction() {
 
 template <bool TEXT_MODE>
 Status VJsonEachTableFunction<TEXT_MODE>::process_init(Block* block, RuntimeState* /*state*/) {
-    int value_column_idx = -1;
-    RETURN_IF_ERROR(_expr_context->root()->children()[0]->execute(_expr_context.get(), block,
-                                                                  &value_column_idx));
-    auto [col, is_const] = unpack_if_const(block->get_by_position(value_column_idx).column);
+    ColumnPtr value_column;
+    RETURN_IF_ERROR(_expr_context->root()->children()[0]->execute_column(
+            _expr_context.get(), block, nullptr, block->rows(), value_column));
+    auto [col, is_const] = unpack_if_const(value_column);
     _json_column = col;
     _is_const = is_const;
     return Status::OK();

--- a/be/src/format/transformer/iceberg_partition_function.cpp
+++ b/be/src/format/transformer/iceberg_partition_function.cpp
@@ -229,21 +229,20 @@ Status IcebergInsertPartitionFunction::_compute_hashes_with_exprs(
         return Status::InternalError("Merge partitioning insert exprs are empty");
     }
 
-    std::vector<int> results(_partition_expr_ctxs.size());
+    std::vector<ColumnWithTypeAndName> results(_partition_expr_ctxs.size());
     for (size_t i = 0; i < _partition_expr_ctxs.size(); ++i) {
-        RETURN_IF_ERROR(_partition_expr_ctxs[i]->execute(block, &results[i]));
+        RETURN_IF_ERROR(_partition_expr_ctxs[i]->execute(block, results[i]));
     }
 
     initialize_shuffle_hashes(partitions, rows, _hash_method);
     auto* __restrict hash_values = partitions.data();
     for (size_t i = 0; i < results.size(); ++i) {
-        const auto& col_info = block->get_by_position(results[i]);
-        const auto& [column, is_const] = unpack_if_const(col_info.column);
+        const auto& [column, is_const] = unpack_if_const(results[i].column);
         if (is_const) {
             // Same value for all rows — no effect on inter-row partitioning.
             continue;
         }
-        update_shuffle_hashes(column, col_info.type, hash_values, _hash_method);
+        update_shuffle_hashes(column, results[i].type, hash_values, _hash_method);
     }
     return Status::OK();
 }
@@ -312,23 +311,22 @@ Status IcebergDeletePartitionFunction::_compute_hashes(Block* block,
         return Status::InternalError("Merge partitioning delete exprs are empty");
     }
 
-    std::vector<int> results(_delete_partition_expr_ctxs.size());
+    std::vector<ColumnWithTypeAndName> results(_delete_partition_expr_ctxs.size());
     for (size_t i = 0; i < _delete_partition_expr_ctxs.size(); ++i) {
-        RETURN_IF_ERROR(_delete_partition_expr_ctxs[i]->execute(block, &results[i]));
+        RETURN_IF_ERROR(_delete_partition_expr_ctxs[i]->execute(block, results[i]));
     }
 
     initialize_shuffle_hashes(partitions, rows, _hash_method);
     auto* __restrict hash_values = partitions.data();
     for (size_t i = 0; i < results.size(); ++i) {
-        const auto& col_info = block->get_by_position(results[i]);
-        const auto& [column, is_const] = unpack_if_const(col_info.column);
+        const auto& [column, is_const] = unpack_if_const(results[i].column);
         if (is_const) {
             // Same value for all rows — no effect on inter-row partitioning.
             continue;
         }
         ColumnPtr hash_col = column;
-        DataTypePtr hash_type = col_info.type;
-        RETURN_IF_ERROR(_get_delete_hash_column(col_info, &hash_col, &hash_type));
+        DataTypePtr hash_type = results[i].type;
+        RETURN_IF_ERROR(_get_delete_hash_column(results[i], &hash_col, &hash_type));
         update_shuffle_hashes(hash_col, hash_type, hash_values, _hash_method);
     }
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -3206,7 +3206,6 @@ void SegmentIterator::_init_virtual_columns(Block* block) {
 }
 
 Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
-    size_t prev_block_columns = block->columns();
     // Some expr can not process empty block, such as function `element_at`.
     // So materialize virtual column in advance to avoid errors.
     if (block->rows() == 0) {
@@ -3240,21 +3239,17 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
                     block->get_by_position(idx_in_block).column.get())) {
             VLOG_DEBUG << fmt::format("Virtual column is doing materialization, cid {}, col idx {}",
                                       cid, idx_in_block);
-            int result_cid = -1;
-            RETURN_IF_ERROR(column_expr->execute(block, &result_cid));
+            ColumnPtr result_column;
+            RETURN_IF_ERROR(column_expr->execute(block, result_column));
 
-            block->replace_by_position(idx_in_block,
-                                       std::move(block->get_by_position(result_cid).column));
+            block->replace_by_position(idx_in_block, std::move(result_column));
             if (block->get_by_position(idx_in_block).column->size() == 0) {
                 LOG_WARNING(
-                        "Result of expr column {} is empty. cid {}, idx_in_block {}, result_cid",
-                        column_expr->root()->debug_string(), cid, idx_in_block, result_cid);
+                        "Result of expr column {} is empty. cid {}, idx_in_block {}",
+                        column_expr->root()->debug_string(), cid, idx_in_block);
             }
         }
     }
-    // During execution of expr, some columns may be added to the end of the block.
-    // Remove them to keep consistent with current block.
-    block->erase_tail(prev_block_columns);
     return Status::OK();
 }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -3244,9 +3244,8 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
 
             block->replace_by_position(idx_in_block, std::move(result_column));
             if (block->get_by_position(idx_in_block).column->size() == 0) {
-                LOG_WARNING(
-                        "Result of expr column {} is empty. cid {}, idx_in_block {}",
-                        column_expr->root()->debug_string(), cid, idx_in_block);
+                LOG_WARNING("Result of expr column {} is empty. cid {}, idx_in_block {}",
+                            column_expr->root()->debug_string(), cid, idx_in_block);
             }
         }
     }

--- a/be/test/exprs/function/table_function_test.cpp
+++ b/be/test/exprs/function/table_function_test.cpp
@@ -40,6 +40,7 @@ namespace doris {
 
 using ::testing::_;
 using ::testing::DoAll;
+using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::SetArgPointee;
 
@@ -64,6 +65,13 @@ protected:
             _children.push_back(std::make_shared<MockVExpr>());
             EXPECT_CALL(*_children[i], execute(_, _, _))
                     .WillRepeatedly(DoAll(SetArgPointee<2>(_column_ids[i]), Return(Status::OK())));
+            const int col_id = _column_ids[i];
+            EXPECT_CALL(*_children[i], execute_column(_, _, _, _, _))
+                    .WillRepeatedly(Invoke([col_id](VExprContext*, const Block* block, Selector*,
+                                                    size_t, ColumnPtr& result) {
+                        result = block->get_by_position(col_id).column;
+                        return Status::OK();
+                    }));
             _root->add_child(_children[i]);
         }
         _ctx = std::make_shared<VExprContext>(_root);


### PR DESCRIPTION
### What problem does this PR solve?

### Changes

| File | Description |
|------|-------------|
| `exec/operator/hashjoin_build_sink.cpp` | ASOF join build-side expr: use `ColumnPtr` directly, remove `result_col_idx` and the subsequent `block->get_by_position` indirection |
| `exec/operator/join/process_hash_table_probe_impl.h` | ASOF join probe-side expr: same pattern as above |
| `exec/sink/vrow_distribution.cpp` | Where-clause filter: remove `result_index` tracking and the `block->erase` cleanup loop (no longer needed with new interface) |
| `storage/segment/segment_iterator.cpp` | Virtual column materialization: remove `prev_block_columns` tracking and `erase_tail` call; fix stale `result_cid` reference in log message |
| `format/transformer/iceberg_partition_function.cpp` | Iceberg insert/delete partition hash: change `vector<int> results` to `vector<ColumnWithTypeAndName> results`, use `ColumnWithTypeAndName` overload |
| `exprs/table_function/vjson_each.cpp` | `VExpr::execute` (3-arg) → `execute_column` |
| `exprs/table_function/vexplode_numbers.cpp` | Same as above |
| `exprs/table_function/vexplode_map.cpp` | Same as above; also fix error message to use `_collection_column->get_name()` instead of stale block position lookup |
| `exec/operator/operator.cpp` | **Bug fix**: Remove dead `result_column_id = -1` that was never updated after migration to new interface; `bytes_usage` was never accumulated due to `if (result_column_id >= origin_columns_count)` always being false |

### Release note

None
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

