### PR TITLE
[refactor](fs-spi) Phase4 P4.0: add FileSystemTransferUtil and unit tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -952,6 +952,28 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     mkdir -p "${DORIS_OUTPUT}/fe/plugins/hadoop_conf/"
     mkdir -p "${DORIS_OUTPUT}/fe/plugins/java_extensions/"
 
+    # Deploy filesystem provider plugins as independent plugin directories
+    # Each sub-directory is one storage backend loaded at runtime by FileSystemPluginManager.
+    FS_PLUGIN_DIR="${DORIS_OUTPUT}/fe/plugins/filesystem"
+    FS_SPI_MODULE="fe/fe-filesystem/fe-filesystem-spi"
+    for fs_module in s3 azure oss cos obs hdfs local; do
+        fs_plugin_target="${FS_PLUGIN_DIR}/${fs_module}"
+        fs_module_dir="fe/fe-filesystem/fe-filesystem-${fs_module}"
+        if [ ! -d "${fs_module_dir}" ]; then
+            continue
+        fi
+        mkdir -p "${fs_plugin_target}/lib"
+        # Copy main JAR
+        cp -f "${fs_module_dir}/target/doris-fe-filesystem-${fs_module}-"*.jar "${fs_plugin_target}/" 2>/dev/null || true
+        # Copy transitive dependencies, excluding spi JARs already on FE classpath
+        mvn dependency:copy-dependencies \
+            -pl "fe/fe-filesystem/fe-filesystem-${fs_module}" \
+            -DoutputDirectory="${fs_plugin_target}/lib" \
+            -DexcludeArtifactIds="fe-filesystem-spi,fe-extension-spi" \
+            --no-transfer-progress -q 2>/dev/null || true
+    done
+    unset FS_PLUGIN_DIR FS_SPI_MODULE fs_module fs_plugin_target fs_module_dir
+
     if [ "${TARGET_SYSTEM}" = "Darwin" ] || [ "${TARGET_SYSTEM}" = "Linux" ]; then
       mkdir -p "${DORIS_OUTPUT}/fe/arthas"
       rm -rf "${DORIS_OUTPUT}/fe/arthas/*"

--- a/build.sh
+++ b/build.sh
@@ -641,6 +641,14 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     modules+=("fe-extension-spi")
     modules+=("fe-extension-loader")
     modules+=("fe-core")
+    # Filesystem SPI plugin modules (loaded at runtime as plugins)
+    modules+=("fe-filesystem/fe-filesystem-spi")
+    for _fs_mod in s3 oss cos obs azure hdfs local broker; do
+        if [[ -d "${DORIS_HOME}/fe/fe-filesystem/fe-filesystem-${_fs_mod}" ]]; then
+            modules+=("fe-filesystem/fe-filesystem-${_fs_mod}")
+        fi
+    done
+    unset _fs_mod
     if [[ "${WITH_TDE_DIR}" != "" ]]; then
         modules+=("fe-${WITH_TDE_DIR}")
     fi

--- a/build.sh
+++ b/build.sh
@@ -963,10 +963,9 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     # Deploy filesystem provider plugins as independent plugin directories
     # Each sub-directory is one storage backend loaded at runtime by FileSystemPluginManager.
     FS_PLUGIN_DIR="${DORIS_OUTPUT}/fe/plugins/filesystem"
-    FS_SPI_MODULE="fe/fe-filesystem/fe-filesystem-spi"
-    for fs_module in s3 azure oss cos obs hdfs local; do
+    for fs_module in s3 azure oss cos obs hdfs local broker; do
         fs_plugin_target="${FS_PLUGIN_DIR}/${fs_module}"
-        fs_module_dir="fe/fe-filesystem/fe-filesystem-${fs_module}"
+        fs_module_dir="${DORIS_HOME}/fe/fe-filesystem/fe-filesystem-${fs_module}"
         if [ ! -d "${fs_module_dir}" ]; then
             continue
         fi
@@ -974,13 +973,13 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
         # Copy main JAR
         cp -f "${fs_module_dir}/target/doris-fe-filesystem-${fs_module}-"*.jar "${fs_plugin_target}/" 2>/dev/null || true
         # Copy transitive dependencies, excluding spi JARs already on FE classpath
-        mvn dependency:copy-dependencies \
-            -pl "fe/fe-filesystem/fe-filesystem-${fs_module}" \
+        (cd "${DORIS_HOME}/fe" && mvn dependency:copy-dependencies \
+            -pl "fe-filesystem/fe-filesystem-${fs_module}" \
             -DoutputDirectory="${fs_plugin_target}/lib" \
             -DexcludeArtifactIds="fe-filesystem-spi,fe-extension-spi" \
-            --no-transfer-progress -q 2>/dev/null || true
+            --no-transfer-progress -q 2>/dev/null) || true
     done
-    unset FS_PLUGIN_DIR FS_SPI_MODULE fs_module fs_plugin_target fs_module_dir
+    unset FS_PLUGIN_DIR fs_module fs_plugin_target fs_module_dir
 
     if [ "${TARGET_SYSTEM}" = "Darwin" ] || [ "${TARGET_SYSTEM}" = "Linux" ]; then
       mkdir -p "${DORIS_OUTPUT}/fe/arthas"

--- a/build.sh
+++ b/build.sh
@@ -921,6 +921,14 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     if [[ "${BUILD_JUICEFS}" == "ON" ]]; then
         install -d "${DORIS_OUTPUT}/fe/lib/juicefs"
     fi
+    # Maven Build Cache may restore only the JAR on a cache hit, skipping the
+    # dependency:copy-dependencies execution that populates target/lib/.  Run it
+    # explicitly when needed so the output lib directory is always complete.
+    if [[ ! -d "${DORIS_HOME}/fe/fe-core/target/lib" ]]; then
+        echo "target/lib not found (build cache hit), running dependency:copy-dependencies..."
+        (cd "${DORIS_HOME}/fe" && "${MVN_CMD}" dependency:copy-dependencies \
+            -pl fe-core --no-transfer-progress -q)
+    fi
     cp -r -p "${DORIS_HOME}/fe/fe-core/target/lib"/* "${DORIS_OUTPUT}/fe/lib"/
     cp -r -p "${DORIS_HOME}/fe/fe-core/target/doris-fe.jar" "${DORIS_OUTPUT}/fe/lib"/
     if [[ "${WITH_TDE_DIR}" != "" ]]; then

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -71,3 +71,8 @@ sys_log_mode = ASYNC
 # qe_max_connection = 1024
 # qe_query_timeout_second = 300
 # qe_slow_log_ms = 5000
+
+# Directory containing filesystem provider plugin subdirectories.
+# Each subdirectory is one storage backend (e.g., s3/, hdfs/, azure/).
+# If empty, only classpath-based built-in providers are used.
+# filesystem_plugin_root = ${DORIS_HOME}/plugins/filesystem

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3424,6 +3424,11 @@ public class Config extends ConfigBase {
     @ConfField(description = {"Security plugin directory."})
     public static String security_plugins_dir = EnvUtils.getDorisHome() + "/plugins/security";
 
+    @ConfField(description = {"Directory containing filesystem provider plugin subdirectories. "
+            + "Each subdirectory is one storage backend (e.g., s3/, hdfs/, azure/). "
+            + "If empty, only classpath-based built-in providers are used (test/dev mode)."})
+    public static String filesystem_plugin_root = EnvUtils.getDorisHome() + "/plugins/filesystem";
+
     @ConfField(description = {"Authorization plugin configuration file path. Must be under DORIS_HOME. "
             + "Default is conf/authorization.conf."})
     public static String authorization_config_file_path = "/conf/authorization.conf";

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -75,43 +75,9 @@ under the License.
             <artifactId>fe-filesystem-spi</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- fe-filesystem impl modules: runtime-only, discovered via ServiceLoader -->
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fe-filesystem-s3</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fe-filesystem-azure</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fe-filesystem-oss</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fe-filesystem-cos</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fe-filesystem-obs</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fe-filesystem-hdfs</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-        </dependency>
+        <!-- fe-filesystem impl modules: runtime dependencies removed in Phase 4 P4.1.
+             Providers are now loaded from plugins/filesystem/ directory at startup
+             via FileSystemPluginManager + DirectoryPluginRuntimeManager. -->
         <!-- fe-filesystem-local: test-scope only, used for unit testing FileSystemTransferUtil etc. -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -112,6 +112,13 @@ under the License.
             <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <!-- fe-filesystem-local: test-scope only, used for unit testing FileSystemTransferUtil etc. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fe-filesystem-local</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fe-thrift</artifactId>

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -277,7 +277,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
      */
     private Map<String, String> mergeProperties(Repository repo, Map<String, String> newProps) {
         // General case: just override old props with new ones
-        Map<String, String> combined = new HashMap<>(repo.getRemoteFileSystem().getProperties());
+        Map<String, String> combined = new HashMap<>(repo.getFileSystemDescriptor().getProperties());
         combined.putAll(newProps);
         return combined;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -39,8 +39,6 @@ import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.property.storage.StorageProperties;
-import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.nereids.trees.plans.commands.BackupCommand;
@@ -208,11 +206,9 @@ public class BackupHandler extends MasterDaemon implements Writable {
                     "broker does not exist: " + command.getBrokerName());
         }
 
-        RemoteFileSystem fileSystem;
-        fileSystem = FileSystemFactory.get(command.getStorageProperties());
         long repoId = env.getNextId();
         Repository repo = new Repository(repoId, command.getName(), command.isReadOnly(), command.getLocation(),
-                fileSystem);
+                command.getStorageProperties());
 
         Status st = repoMgr.addAndInitRepoIfNotExist(repo, false);
         if (!st.ok()) {
@@ -244,12 +240,10 @@ public class BackupHandler extends MasterDaemon implements Writable {
             }
             // Merge new properties with the existing repository's properties
             Map<String, String> mergedProps = mergeProperties(oldRepo, newProps);
-            // Create new remote file system with merged properties
-            RemoteFileSystem fileSystem = FileSystemFactory.get(StorageProperties.createPrimary(mergedProps));
-            // Create new Repository instance with updated file system
+            // Create new Repository instance with merged properties
             Repository newRepo = new Repository(
                     oldRepo.getId(), oldRepo.getName(), oldRepo.isReadOnly(),
-                    oldRepo.getLocation(), fileSystem
+                    oldRepo.getLocation(), StorageProperties.createPrimary(mergedProps)
             );
             // Verify the repository can be connected with new settings
             if (!newRepo.ping()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -437,7 +437,7 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                     continue;
                 }
                 ((UploadTask) task).updateBrokerProperties(
-                        repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties());
+                        repo.getFileSystemDescriptor().getBackendConfigProperties());
                 AgentTaskQueue.updateTask(beId, TTaskType.UPLOAD, signature, task);
             }
             LOG.info("finished to update upload job properties. {}", this);
@@ -821,8 +821,8 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
                 long signature = env.getNextId();
                 UploadTask task = new UploadTask(null, beId, signature, jobId, dbId, srcToDest,
                         brokers.get(0),
-                        repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties(),
-                        repo.getRemoteFileSystem().getThriftStorageType(), repo.getLocation());
+                        repo.getFileSystemDescriptor().getBackendConfigProperties(),
+                        repo.getFileSystemDescriptor().getThriftStorageType(), repo.getLocation());
                 batchTask.addTask(task);
                 unfinishedTaskIds.put(signature, beId);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -146,6 +146,10 @@ public class Repository implements Writable, GsonPostProcessable {
         return fileSystem;
     }
 
+    public FileSystemDescriptor getFileSystemDescriptor() {
+        return fileSystemDescriptor;
+    }
+
     private Repository() {
         // for persist
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -40,7 +40,6 @@ import org.apache.doris.foundation.fs.FsStorageType;
 import org.apache.doris.fs.FileSystemDescriptor;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.fs.PersistentFileSystem;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.service.FrontendOptions;
@@ -52,7 +51,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.simple.JSONObject;
@@ -144,16 +142,9 @@ public class Repository implements Writable, GsonPostProcessable {
     @SerializedName("fs_descriptor")
     private FileSystemDescriptor fileSystemDescriptor;
 
-    /** Live filesystem instance; transient — rebuilt in {@link #gsonPostProcess()}. */
-    private transient PersistentFileSystem fileSystem;
-
     /** SPI filesystem for I/O operations; transient — rebuilt in {@link #gsonPostProcess()}.
      *  Null for BROKER repositories, which resolve a live broker endpoint per I/O call. */
     private transient org.apache.doris.filesystem.spi.FileSystem spiFs;
-
-    public PersistentFileSystem getFileSystem() {
-        return fileSystem;
-    }
 
     public FileSystemDescriptor getFileSystemDescriptor() {
         return fileSystemDescriptor;
@@ -163,25 +154,27 @@ public class Repository implements Writable, GsonPostProcessable {
         // for persist
     }
 
-    public Repository(long id, String name, boolean isReadOnly, String location, RemoteFileSystem fileSystem) {
+    public Repository(long id, String name, boolean isReadOnly, String location,
+            StorageProperties storageProperties) {
         this.id = id;
         this.name = name;
         this.isReadOnly = isReadOnly;
         this.location = location;
-        this.fileSystem = fileSystem;
-        this.fileSystemDescriptor = FileSystemDescriptor.fromPersistentFileSystem(fileSystem);
+        String fsName = (storageProperties instanceof BrokerProperties)
+                ? ((BrokerProperties) storageProperties).getBrokerName() : "";
+        this.fileSystemDescriptor = FileSystemDescriptor.fromStorageProperties(storageProperties, fsName);
         this.createTime = System.currentTimeMillis();
         // Initialize SPI filesystem for I/O; broker resolves a live endpoint per I/O call
-        if (fileSystem.getStorageType() != FsStorageType.BROKER) {
+        if (fileSystemDescriptor.getStorageType() != FsStorageType.BROKER) {
             try {
-                this.spiFs = FileSystemFactory.getFileSystem(fileSystem.getStorageProperties());
+                this.spiFs = FileSystemFactory.getFileSystem(storageProperties);
             } catch (IOException e) {
                 LOG.warn("Failed to initialize SPI filesystem for new repository {}: {}", name, e.getMessage());
             }
         }
     }
 
-    // join job info file name with timestamp
+
     // eg: __info_2018-01-01-08-00-00
     private static String jobInfoFileNameWithTimestamp(long createTime) {
         if (createTime == -1) {
@@ -233,33 +226,16 @@ public class Repository implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() {
-        // Determine source of name+properties: prefer new descriptor, fall back to legacy field.
-        String fsName;
+        // Determine source of properties: prefer new descriptor, fall back to legacy field.
         Map<String, String> fsProps;
         if (fileSystemDescriptor != null) {
-            fsName = fileSystemDescriptor.getName();
             fsProps = fileSystemDescriptor.getProperties();
         } else if (legacyFileSystem != null) {
-            fsName = legacyFileSystem.name;
             fsProps = legacyFileSystem.properties;
             // Migrate to new descriptor so the next write uses the new format.
             fileSystemDescriptor = FileSystemDescriptor.fromPersistentFileSystem(legacyFileSystem);
         } else {
             return;
-        }
-        try {
-            StorageProperties storageProperties = StorageProperties.createPrimary(fsProps);
-            this.fileSystem = FileSystemFactory.get(storageProperties);
-        } catch (RuntimeException exception) {
-            LOG.warn("File system initialization failed due to incompatible configuration parameters. "
-                            + "The system has reverted to BrokerFileSystem as a fallback. "
-                            + "However, the current configuration is not supported by this version and"
-                            + " cannot be used as is. "
-                            + "Please review the configuration and update it to match the supported parameter"
-                            + " format. Root cause: {}",
-                    ExceptionUtils.getRootCause(exception), exception);
-            BrokerProperties brokerProperties = BrokerProperties.of(fsName, fsProps);
-            this.fileSystem = FileSystemFactory.get(brokerProperties);
         }
         // Initialize SPI filesystem for I/O; broker resolves a live endpoint per I/O call
         if (fileSystemDescriptor.getStorageType() != FsStorageType.BROKER) {
@@ -284,15 +260,13 @@ public class Repository implements Writable, GsonPostProcessable {
     }
 
     public String getLocation() {
-        if (null == fileSystem) {
+        if (fileSystemDescriptor == null
+                || fileSystemDescriptor.getStorageType() == FsStorageType.BROKER) {
             return location;
         }
         try {
-            if (null == fileSystem.getStorageProperties()) {
-                return location;
-            } else {
-                return fileSystem.getStorageProperties().validateAndNormalizeUri(location);
-            }
+            return StorageProperties.createPrimary(fileSystemDescriptor.getProperties())
+                    .validateAndNormalizeUri(location);
         } catch (UserException e) {
             throw new RuntimeException(e);
         }
@@ -300,10 +274,6 @@ public class Repository implements Writable, GsonPostProcessable {
 
     public String getErrorMsg() {
         return errMsg;
-    }
-
-    public PersistentFileSystem getRemoteFileSystem() {
-        return fileSystem;
     }
 
     /**
@@ -755,7 +725,7 @@ public class Repository implements Writable, GsonPostProcessable {
                     + "failed to send upload snapshot task");
         }
         // only Broker storage backend need to get broker addr, other type return a fake one;
-        if (fileSystem.getStorageType() != FsStorageType.BROKER) {
+        if (fileSystemDescriptor.getStorageType() != FsStorageType.BROKER) {
             brokerAddrs.add(new FsBroker("127.0.0.1", 0));
             return Status.OK;
         }
@@ -763,15 +733,15 @@ public class Repository implements Writable, GsonPostProcessable {
         // get proper broker for this backend
         FsBroker brokerAddr = null;
         try {
-            brokerAddr = env.getBrokerMgr().getBroker(fileSystem.getName(), be.getHost());
+            brokerAddr = env.getBrokerMgr().getBroker(fileSystemDescriptor.getName(), be.getHost());
         } catch (AnalysisException e) {
             return new Status(ErrCode.COMMON_ERROR, "failed to get address of broker "
-                    + fileSystem.getName() + " when try to send upload snapshot task: "
+                    + fileSystemDescriptor.getName() + " when try to send upload snapshot task: "
                     + e.getMessage());
         }
         if (brokerAddr == null) {
             return new Status(ErrCode.COMMON_ERROR, "failed to get address of broker "
-                    + fileSystem.getName() + " when try to send upload snapshot task");
+                    + fileSystemDescriptor.getName() + " when try to send upload snapshot task");
         }
         brokerAddrs.add(brokerAddr);
         return Status.OK;
@@ -784,8 +754,9 @@ public class Repository implements Writable, GsonPostProcessable {
         info.add(TimeUtils.longToTimeString(createTime));
         info.add(String.valueOf(isReadOnly));
         info.add(location);
-        info.add(fileSystem.getStorageType() != FsStorageType.BROKER ? "-" : fileSystem.getName());
-        info.add(fileSystem.getStorageType().name());
+        info.add(fileSystemDescriptor.getStorageType() != FsStorageType.BROKER
+                ? "-" : fileSystemDescriptor.getName());
+        info.add(fileSystemDescriptor.getStorageType().name());
         info.add(errMsg == null ? FeConstants.null_string : errMsg);
         return info;
     }
@@ -824,14 +795,14 @@ public class Repository implements Writable, GsonPostProcessable {
         stmtBuilder.append("REPOSITORY ");
         stmtBuilder.append(this.name);
         stmtBuilder.append(" \nWITH ");
-        FsStorageType storageType = this.fileSystem.getStorageType();
+        FsStorageType storageType = fileSystemDescriptor.getStorageType();
         if (storageType == FsStorageType.S3) {
             stmtBuilder.append(" S3 ");
         } else if (storageType == FsStorageType.HDFS) {
             stmtBuilder.append(" HDFS ");
         } else if (storageType == FsStorageType.BROKER) {
             stmtBuilder.append(" BROKER ");
-            stmtBuilder.append(this.fileSystem.getName());
+            stmtBuilder.append(fileSystemDescriptor.getName());
         } else {
             // should never reach here
             throw new UnsupportedOperationException(storageType.toString() + " backend is not implemented");
@@ -842,7 +813,7 @@ public class Repository implements Writable, GsonPostProcessable {
 
         stmtBuilder.append("\nPROPERTIES\n(");
         Map<String, String> properties = new HashMap();
-        properties.putAll(this.getRemoteFileSystem().getProperties());
+        properties.putAll(fileSystemDescriptor.getProperties());
         stmtBuilder.append(new DatasourcePrintableMap<>(properties, " = ", true, true, true));
         stmtBuilder.append("\n)");
         return stmtBuilder.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -35,6 +35,7 @@ import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.filesystem.spi.DorisInputFile;
 import org.apache.doris.filesystem.spi.DorisOutputFile;
 import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileIterator;
 import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.foundation.fs.FsStorageType;
 import org.apache.doris.fs.FileSystemDescriptor;
@@ -505,17 +506,19 @@ public class Repository implements Writable, GsonPostProcessable {
             return new Status(ErrCode.COMMON_ERROR, "Failed to acquire filesystem: " + e.getMessage());
         }
         try {
-            List<FileEntry> result = fs.listFiles(Location.of(listPath));
-            for (FileEntry entry : result) {
-                if (!entry.isDirectory()) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("get snapshot path {} which is not a dir", entry.location());
+            try (FileIterator it = fs.list(Location.of(listPath))) {
+                while (it.hasNext()) {
+                    FileEntry entry = it.next();
+                    if (!entry.isDirectory()) {
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("get snapshot path {} which is not a dir", entry.location());
+                        }
+                        continue;
                     }
-                    continue;
+                    String uri = entry.location().uri();
+                    String entryName = uri.substring(uri.lastIndexOf('/') + 1);
+                    snapshotNames.add(disjoinPrefix(PREFIX_SNAPSHOT_DIR, entryName));
                 }
-                String uri = entry.location().uri();
-                String entryName = uri.substring(uri.lastIndexOf('/') + 1);
-                snapshotNames.add(disjoinPrefix(PREFIX_SNAPSHOT_DIR, entryName));
             }
             return Status.OK;
         } catch (IOException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/Repository.java
@@ -21,24 +21,29 @@ import org.apache.doris.backup.Status.ErrCode;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.DatasourcePrintableMap;
+import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.foundation.fs.FsStorageType;
 import org.apache.doris.fs.FileSystemDescriptor;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.fs.PersistentFileSystem;
-import org.apache.doris.fs.remote.BrokerFileSystem;
-import org.apache.doris.fs.remote.RemoteFile;
 import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.system.Backend;
 
 import com.google.common.base.Joiner;
@@ -142,6 +147,10 @@ public class Repository implements Writable, GsonPostProcessable {
     /** Live filesystem instance; transient — rebuilt in {@link #gsonPostProcess()}. */
     private transient PersistentFileSystem fileSystem;
 
+    /** SPI filesystem for I/O operations; transient — rebuilt in {@link #gsonPostProcess()}.
+     *  Null for BROKER repositories, which resolve a live broker endpoint per I/O call. */
+    private transient org.apache.doris.filesystem.spi.FileSystem spiFs;
+
     public PersistentFileSystem getFileSystem() {
         return fileSystem;
     }
@@ -162,6 +171,14 @@ public class Repository implements Writable, GsonPostProcessable {
         this.fileSystem = fileSystem;
         this.fileSystemDescriptor = FileSystemDescriptor.fromPersistentFileSystem(fileSystem);
         this.createTime = System.currentTimeMillis();
+        // Initialize SPI filesystem for I/O; broker resolves a live endpoint per I/O call
+        if (fileSystem.getStorageType() != FsStorageType.BROKER) {
+            try {
+                this.spiFs = FileSystemFactory.getFileSystem(fileSystem.getStorageProperties());
+            } catch (IOException e) {
+                LOG.warn("Failed to initialize SPI filesystem for new repository {}: {}", name, e.getMessage());
+            }
+        }
     }
 
     // join job info file name with timestamp
@@ -244,6 +261,14 @@ public class Repository implements Writable, GsonPostProcessable {
             BrokerProperties brokerProperties = BrokerProperties.of(fsName, fsProps);
             this.fileSystem = FileSystemFactory.get(brokerProperties);
         }
+        // Initialize SPI filesystem for I/O; broker resolves a live endpoint per I/O call
+        if (fileSystemDescriptor.getStorageType() != FsStorageType.BROKER) {
+            try {
+                this.spiFs = FileSystemFactory.getFileSystem(StorageProperties.createPrimary(fsProps));
+            } catch (IOException | RuntimeException e) {
+                LOG.warn("Failed to initialize SPI filesystem for repository {}: {}", name, e.getMessage());
+            }
+        }
     }
 
     public long getId() {
@@ -281,6 +306,66 @@ public class Repository implements Writable, GsonPostProcessable {
         return fileSystem;
     }
 
+    /**
+     * Acquires an SPI FileSystem for I/O operations.
+     * <ul>
+     *   <li>Non-broker: returns the shared {@link #spiFs} instance (do not close it).</li>
+     *   <li>Broker: resolves a live broker endpoint via BrokerMgr and creates a per-call
+     *       instance that <b>must</b> be closed by calling {@link #releaseSpiFs}.</li>
+     * </ul>
+     */
+    private org.apache.doris.filesystem.spi.FileSystem acquireSpiFs() throws IOException {
+        if (spiFs != null) {
+            return spiFs;
+        }
+        // Broker: resolve live endpoint and create a per-call filesystem
+        try {
+            BrokerProperties bp = BrokerProperties.of(fileSystemDescriptor.getName(),
+                    fileSystemDescriptor.getProperties());
+            FsBroker broker = Env.getCurrentEnv().getBrokerMgr().getBroker(fileSystemDescriptor.getName(), "127.0.0.1");
+            String clientId = NetUtils.getHostPortInAccessibleFormat(
+                    FrontendOptions.getLocalHostAddress(), Config.edit_log_port);
+            return FileSystemFactory.getBrokerFileSystem(broker.host, broker.port, clientId,
+                    bp.getBrokerParams());
+        } catch (AnalysisException e) {
+            throw new IOException("Failed to acquire broker filesystem for repository " + name
+                    + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Releases an SPI FileSystem acquired via {@link #acquireSpiFs}.
+     * Closes broker per-call instances; leaves the shared non-broker instance open.
+     */
+    private void releaseSpiFs(org.apache.doris.filesystem.spi.FileSystem fs) {
+        if (fs != spiFs) {
+            try {
+                fs.close();
+            } catch (IOException e) {
+                LOG.warn("Failed to close broker filesystem for repository {}", name, e);
+            }
+        }
+    }
+
+    /** Uploads a local file to a remote path via the SPI filesystem. */
+    private static void spiUploadFile(org.apache.doris.filesystem.spi.FileSystem fs,
+            String localFilePath, String remotePath) throws IOException {
+        DorisOutputFile outputFile = fs.newOutputFile(Location.of(remotePath));
+        try (java.io.InputStream in = Files.newInputStream(Paths.get(localFilePath));
+                java.io.OutputStream out = outputFile.create()) {
+            copyStream(in, out);
+        }
+    }
+
+    /** Copies all bytes from {@code in} to {@code out} (Java-8-compatible alternative to transferTo). */
+    private static void copyStream(java.io.InputStream in, java.io.OutputStream out) throws IOException {
+        byte[] buf = new byte[8192];
+        int n;
+        while ((n = in.read(buf)) >= 0) {
+            out.write(buf, 0, n);
+        }
+    }
+
     public long getCreateTime() {
         return createTime;
     }
@@ -292,59 +377,58 @@ public class Repository implements Writable, GsonPostProcessable {
         }
 
         String repoInfoFilePath = assembleRepoInfoFilePath();
-        // check if the repo is already exist in remote
-        List<RemoteFile> remoteFiles = Lists.newArrayList();
-        Status st = fileSystem.globList(repoInfoFilePath, remoteFiles);
-        if (!st.ok()) {
-            return st;
+        org.apache.doris.filesystem.spi.FileSystem fs;
+        try {
+            fs = acquireSpiFs();
+        } catch (IOException e) {
+            return new Status(ErrCode.COMMON_ERROR, "Failed to acquire filesystem: " + e.getMessage());
         }
-        if (remoteFiles.size() == 1) {
-            RemoteFile remoteFile = remoteFiles.get(0);
-            if (!remoteFile.isFile()) {
-                return new Status(ErrCode.COMMON_ERROR, "the existing repo info is not a file");
-            }
-
-            // exist, download and parse the repo info file
-            String localFilePath = BackupHandler.BACKUP_ROOT_DIR + "/tmp_info_" + allocLocalFileSuffix();
-            try {
-                st = fileSystem.downloadWithFileSize(repoInfoFilePath, localFilePath, remoteFile.getSize());
-                if (!st.ok()) {
-                    return st;
+        try {
+            if (fs.exists(Location.of(repoInfoFilePath))) {
+                // Repo info file exists: download and parse it
+                String localFilePath = BackupHandler.BACKUP_ROOT_DIR + "/tmp_info_" + allocLocalFileSuffix();
+                try {
+                    DorisInputFile inputFile = fs.newInputFile(Location.of(repoInfoFilePath));
+                    try (java.io.InputStream in = inputFile.newStream();
+                            java.io.OutputStream localOut = Files.newOutputStream(Paths.get(localFilePath))) {
+                        copyStream(in, localOut);
+                    }
+                    byte[] bytes = Files.readAllBytes(Paths.get(localFilePath));
+                    String json = new String(bytes, StandardCharsets.UTF_8);
+                    JSONObject root = (JSONObject) JSONValue.parse(json);
+                    if (name.compareTo((String) root.get("name")) != 0) {
+                        return new Status(ErrCode.COMMON_ERROR,
+                                "Invalid repository __repo_info, expected repo '" + name + "', but get name '"
+                                        + root.get("name") + "' from " + repoInfoFilePath);
+                    }
+                    name = (String) root.get("name");
+                    createTime = TimeUtils.timeStringToLong((String) root.get("create_time"));
+                    if (createTime == -1) {
+                        return new Status(ErrCode.COMMON_ERROR,
+                                "failed to parse create time of repository: " + root.get("create_time"));
+                    }
+                    return Status.OK;
+                } catch (IOException e) {
+                    return new Status(ErrCode.COMMON_ERROR, "failed to read repo info file: " + e.getMessage());
+                } finally {
+                    new File(localFilePath).delete();
                 }
-
-                byte[] bytes = Files.readAllBytes(Paths.get(localFilePath));
-                String json = new String(bytes, StandardCharsets.UTF_8);
-                JSONObject root = (JSONObject) JSONValue.parse(json);
-                if (name.compareTo((String) root.get("name")) != 0) {
-                    return new Status(ErrCode.COMMON_ERROR,
-                            "Invalid repository __repo_info, expected repo '" + name + "', but get name '"
-                                    + (String) root.get("name") + "' from " + repoInfoFilePath);
+            } else {
+                // Repo doesn't exist yet: create the info file
+                JSONObject root = new JSONObject();
+                root.put("name", name);
+                root.put("create_time", TimeUtils.longToTimeString(createTime));
+                String repoInfoContent = root.toString();
+                DorisOutputFile outputFile = fs.newOutputFile(Location.of(repoInfoFilePath));
+                try (java.io.OutputStream out = outputFile.create()) {
+                    out.write(repoInfoContent.getBytes(StandardCharsets.UTF_8));
                 }
-                name = (String) root.get("name");
-                createTime = TimeUtils.timeStringToLong((String) root.get("create_time"));
-                if (createTime == -1) {
-                    return new Status(ErrCode.COMMON_ERROR,
-                            "failed to parse create time of repository: " + root.get("create_time"));
-                }
-
                 return Status.OK;
-            } catch (IOException e) {
-                return new Status(ErrCode.COMMON_ERROR, "failed to read repo info file: " + e.getMessage());
-            } finally {
-                File localFile = new File(localFilePath);
-                localFile.delete();
             }
-
-        } else if (remoteFiles.size() > 1) {
-            return new Status(ErrCode.COMMON_ERROR,
-                    "Invalid repository dir. expected one repo info file. get more: " + remoteFiles);
-        } else {
-            // repo is already exist, get repo info
-            JSONObject root = new JSONObject();
-            root.put("name", name);
-            root.put("create_time", TimeUtils.longToTimeString(createTime));
-            String repoInfoContent = root.toString();
-            return fileSystem.directUpload(repoInfoContent, repoInfoFilePath);
+        } catch (IOException e) {
+            return new Status(ErrCode.COMMON_ERROR, "Failed to init repository: " + e.getMessage());
+        } finally {
+            releaseSpiFs(fs);
         }
     }
 
@@ -415,18 +499,25 @@ public class Repository implements Writable, GsonPostProcessable {
         String path = location + "/" + joinPrefix(PREFIX_REPO, name) + "/" + FILE_REPO_INFO;
         try {
             URI checkUri = new URI(path);
-            Status st = fileSystem.exists(checkUri.normalize().toString());
-            if (!st.ok()) {
-                errMsg = TimeUtils.longToTimeString(System.currentTimeMillis()) + ": " + st.getErrMsg();
-                return false;
+            org.apache.doris.filesystem.spi.FileSystem fs = acquireSpiFs();
+            try {
+                boolean exists = fs.exists(Location.of(checkUri.normalize().toString()));
+                if (!exists) {
+                    errMsg = TimeUtils.longToTimeString(System.currentTimeMillis())
+                            + ": path does not exist: " + path;
+                    return false;
+                }
+                errMsg = null;
+                return true;
+            } finally {
+                releaseSpiFs(fs);
             }
-            // clear err msg
-            errMsg = null;
-
-            return true;
         } catch (URISyntaxException e) {
             errMsg = TimeUtils.longToTimeString(System.currentTimeMillis())
                     + ": Invalid path. " + path + ", error: " + e.getMessage();
+            return false;
+        } catch (IOException e) {
+            errMsg = TimeUtils.longToTimeString(System.currentTimeMillis()) + ": " + e.getMessage();
             return false;
         }
     }
@@ -437,23 +528,31 @@ public class Repository implements Writable, GsonPostProcessable {
         // eg. __palo_repository_repo_name/__ss_*
         String listPath = Joiner.on(PATH_DELIMITER).join(location, joinPrefix(PREFIX_REPO, name), PREFIX_SNAPSHOT_DIR)
                 + "*";
-        List<RemoteFile> result = Lists.newArrayList();
-        Status st = fileSystem.globList(listPath, result);
-        if (!st.ok()) {
-            return st;
+        org.apache.doris.filesystem.spi.FileSystem fs;
+        try {
+            fs = acquireSpiFs();
+        } catch (IOException e) {
+            return new Status(ErrCode.COMMON_ERROR, "Failed to acquire filesystem: " + e.getMessage());
         }
-
-        for (RemoteFile remoteFile : result) {
-            if (remoteFile.isFile()) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("get snapshot path{} which is not a dir", remoteFile);
+        try {
+            List<FileEntry> result = fs.listFiles(Location.of(listPath));
+            for (FileEntry entry : result) {
+                if (!entry.isDirectory()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("get snapshot path {} which is not a dir", entry.location());
+                    }
+                    continue;
                 }
-                continue;
+                String uri = entry.location().uri();
+                String entryName = uri.substring(uri.lastIndexOf('/') + 1);
+                snapshotNames.add(disjoinPrefix(PREFIX_SNAPSHOT_DIR, entryName));
             }
-
-            snapshotNames.add(disjoinPrefix(PREFIX_SNAPSHOT_DIR, remoteFile.getName()));
+            return Status.OK;
+        } catch (IOException e) {
+            return new Status(ErrCode.COMMON_ERROR, "Failed to list snapshots: " + e.getMessage());
+        } finally {
+            releaseSpiFs(fs);
         }
-        return Status.OK;
     }
 
     //
@@ -535,8 +634,7 @@ public class Repository implements Writable, GsonPostProcessable {
     // upload the local file to specified remote file with checksum
     // remoteFilePath should be FULL path
     public Status upload(String localFilePath, String remoteFilePath) {
-        // Preconditions.checkArgument(remoteFilePath.startsWith(location), remoteFilePath);
-        // get md5usm of local file
+        // get md5sum of local file
         File file = new File(localFilePath);
         String md5sum;
         try (FileInputStream fis = new FileInputStream(file)) {
@@ -549,111 +647,104 @@ public class Repository implements Writable, GsonPostProcessable {
         Preconditions.checkState(!Strings.isNullOrEmpty(md5sum));
         String finalRemotePath = assembleFileNameWithSuffix(remoteFilePath, md5sum);
 
-        Status st = Status.OK;
-        if (fileSystem instanceof BrokerFileSystem) {
-            // this may be a retry, so we should first delete remote file
-            String tmpRemotePath = assembleFileNameWithSuffix(remoteFilePath, SUFFIX_TMP_FILE);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("get md5sum of file: {}. tmp remote path: {}. final remote path: {}",
-                        localFilePath, tmpRemotePath, finalRemotePath);
+        org.apache.doris.filesystem.spi.FileSystem fs;
+        try {
+            fs = acquireSpiFs();
+        } catch (IOException e) {
+            return new Status(ErrCode.COMMON_ERROR, "Failed to acquire filesystem: " + e.getMessage());
+        }
+        try {
+            if (fileSystemDescriptor.getStorageType() == FsStorageType.BROKER) {
+                // Broker doesn't support atomic overwrite; use temp-file dance
+                String tmpRemotePath = assembleFileNameWithSuffix(remoteFilePath, SUFFIX_TMP_FILE);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("upload with temp file: local={}, tmp={}, final={}",
+                            localFilePath, tmpRemotePath, finalRemotePath);
+                }
+                fs.delete(Location.of(tmpRemotePath), false);
+                fs.delete(Location.of(finalRemotePath), false);
+                spiUploadFile(fs, localFilePath, tmpRemotePath);
+                fs.rename(Location.of(tmpRemotePath), Location.of(finalRemotePath));
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("upload: local={}, final={}", localFilePath, finalRemotePath);
+                }
+                fs.delete(Location.of(finalRemotePath), false);
+                spiUploadFile(fs, localFilePath, finalRemotePath);
             }
-            st = fileSystem.delete(tmpRemotePath);
-            if (!st.ok()) {
-                return st;
-            }
-
-            st = fileSystem.delete(finalRemotePath);
-            if (!st.ok()) {
-                return st;
-            }
-
-            // upload tmp file
-            st = fileSystem.upload(localFilePath, tmpRemotePath);
-            if (!st.ok()) {
-                return st;
-            }
-
-            // rename tmp file with checksum named file
-            st = fileSystem.rename(tmpRemotePath, finalRemotePath);
-            if (!st.ok()) {
-                return st;
-            }
-        } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("get md5sum of file: {}. final remote path: {}", localFilePath, finalRemotePath);
-            }
-            st = fileSystem.delete(finalRemotePath);
-            if (!st.ok()) {
-                return st;
-            }
-
-            // upload final file
-            st = fileSystem.upload(localFilePath, finalRemotePath);
-            if (!st.ok()) {
-                return st;
-            }
+        } catch (IOException e) {
+            return new Status(ErrCode.COMMON_ERROR, "Failed to upload " + localFilePath + ": " + e.getMessage());
+        } finally {
+            releaseSpiFs(fs);
         }
 
         LOG.info("finished to upload local file {} to remote file: {}", localFilePath, finalRemotePath);
-        return st;
+        return Status.OK;
     }
 
     // remoteFilePath must be a file(not dir) and does not contain checksum
     public Status download(String remoteFilePath, String localFilePath) {
-        // 0. list to get to full name(with checksum)
-        List<RemoteFile> remoteFiles = Lists.newArrayList();
-        Status status = fileSystem.globList(remoteFilePath + "*", remoteFiles);
-        if (!status.ok()) {
-            return status;
+        org.apache.doris.filesystem.spi.FileSystem fs;
+        try {
+            fs = acquireSpiFs();
+        } catch (IOException e) {
+            return new Status(ErrCode.COMMON_ERROR, "Failed to acquire filesystem: " + e.getMessage());
         }
-        if (remoteFiles.size() != 1) {
-            return new Status(ErrCode.COMMON_ERROR,
-                    "Expected one file with path: " + remoteFilePath + ". get: " + remoteFiles.size());
-        }
-        if (!remoteFiles.get(0).isFile()) {
-            return new Status(ErrCode.COMMON_ERROR, "Expected file with path: " + remoteFilePath + ". but get dir");
-        }
+        String md5sum;
+        try {
+            // 0. list to get to full name (with checksum)
+            List<FileEntry> remoteFiles = fs.listFiles(Location.of(remoteFilePath + "*"));
+            if (remoteFiles.size() != 1) {
+                return new Status(ErrCode.COMMON_ERROR,
+                        "Expected one file with path: " + remoteFilePath + ". get: " + remoteFiles.size());
+            }
+            if (remoteFiles.get(0).isDirectory()) {
+                return new Status(ErrCode.COMMON_ERROR,
+                        "Expected file with path: " + remoteFilePath + ". but get dir");
+            }
 
-        String remoteFilePathWithChecksum = replaceFileNameWithChecksumFileName(remoteFilePath,
-                remoteFiles.get(0).getName());
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("get download filename with checksum: " + remoteFilePathWithChecksum);
-        }
+            String remoteFileFullUri = remoteFiles.get(0).location().uri();
+            String remoteFileName = remoteFileFullUri.substring(remoteFileFullUri.lastIndexOf('/') + 1);
+            String remoteFilePathWithChecksum = replaceFileNameWithChecksumFileName(remoteFilePath, remoteFileName);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("get download filename with checksum: {}", remoteFilePathWithChecksum);
+            }
 
-        // 1. get checksum from remote file name
-        Pair<String, String> pair = decodeFileNameWithChecksum(remoteFilePathWithChecksum);
-        if (pair == null) {
-            return new Status(ErrCode.COMMON_ERROR,
-                    "file name should contains checksum: " + remoteFilePathWithChecksum);
-        }
-        if (!remoteFilePath.endsWith(pair.first)) {
-            return new Status(ErrCode.COMMON_ERROR, "File does not exist: " + remoteFilePath);
-        }
-        String md5sum = pair.second;
+            // 1. get checksum from remote file name
+            Pair<String, String> pair = decodeFileNameWithChecksum(remoteFilePathWithChecksum);
+            if (pair == null) {
+                return new Status(ErrCode.COMMON_ERROR,
+                        "file name should contain checksum: " + remoteFilePathWithChecksum);
+            }
+            if (!remoteFilePath.endsWith(pair.first)) {
+                return new Status(ErrCode.COMMON_ERROR, "File does not exist: " + remoteFilePath);
+            }
+            md5sum = pair.second;
 
-        // 2. download
-        status = fileSystem.downloadWithFileSize(remoteFilePathWithChecksum, localFilePath,
-                remoteFiles.get(0).getSize());
-        if (!status.ok()) {
-            return status;
-        }
+            // 2. download
+            DorisInputFile inputFile = fs.newInputFile(Location.of(remoteFilePathWithChecksum));
+            try (java.io.InputStream in = inputFile.newStream();
+                    java.io.OutputStream out = Files.newOutputStream(Paths.get(localFilePath))) {
+                copyStream(in, out);
+            }
 
-        // 3. verify checksum
-        String localMd5sum = null;
-        try (FileInputStream fis = new FileInputStream(localFilePath)) {
-            localMd5sum = DigestUtils.md5Hex(fis);
+            // 3. verify checksum
+            String localMd5sum;
+            try (FileInputStream fis = new FileInputStream(localFilePath)) {
+                localMd5sum = DigestUtils.md5Hex(fis);
+            }
+            if (!localMd5sum.equals(md5sum)) {
+                return new Status(ErrCode.BAD_FILE,
+                        "md5sum does not equal. local: " + localMd5sum + ", remote: " + md5sum);
+            }
+            return Status.OK;
         } catch (FileNotFoundException e) {
             return new Status(ErrCode.NOT_FOUND, "file " + localFilePath + " does not exist");
         } catch (IOException e) {
-            return new Status(ErrCode.COMMON_ERROR, "failed to get md5sum of file: " + localFilePath);
+            return new Status(ErrCode.COMMON_ERROR, "Failed to download file: " + e.getMessage());
+        } finally {
+            releaseSpiFs(fs);
         }
-
-        if (!localMd5sum.equals(md5sum)) {
-            return new Status(ErrCode.BAD_FILE,
-                    "md5sum does not equal. local: " + localMd5sum + ", remote: " + md5sum);
-        }
-
-        return Status.OK;
     }
 
     public Status getBrokerAddress(Long beId, Env env, List<FsBroker> brokerAddrs) {
@@ -760,26 +851,29 @@ public class Repository implements Writable, GsonPostProcessable {
     private List<String> getSnapshotInfo(String snapshotName, String timestamp) {
         List<String> info = Lists.newArrayList();
         if (Strings.isNullOrEmpty(timestamp)) {
-            // get all timestamp
+            // get all timestamps
             // path eg: /location/__palo_repository_repo_name/__ss_my_snap/__info_*
             String infoFilePath = assembleJobInfoFilePath(snapshotName, -1);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("assemble infoFilePath: {}, snapshot: {}", infoFilePath, snapshotName);
             }
-            List<RemoteFile> results = Lists.newArrayList();
-            Status st = fileSystem.globList(infoFilePath + "*", results);
-            if (!st.ok()) {
-                info.add(snapshotName);
-                info.add(FeConstants.null_string);
-                info.add("ERROR: Failed to get info: " + st.getErrMsg());
-            } else {
+            try {
+                org.apache.doris.filesystem.spi.FileSystem fs = acquireSpiFs();
+                List<FileEntry> results;
+                try {
+                    results = fs.listFiles(Location.of(infoFilePath + "*"));
+                } finally {
+                    releaseSpiFs(fs);
+                }
                 List<String> tmp = Lists.newArrayList();
-                for (RemoteFile file : results) {
+                for (FileEntry entry : results) {
                     // __info_2018-04-18-20-11-00.Jdwnd9312sfdn1294343
-                    Pair<String, String> pureFileName = decodeFileNameWithChecksum(file.getName());
+                    String uri = entry.location().uri();
+                    String fileName = uri.substring(uri.lastIndexOf('/') + 1);
+                    Pair<String, String> pureFileName = decodeFileNameWithChecksum(fileName);
                     if (pureFileName == null) {
                         // maybe: __info_2018-04-18-20-11-00.part
-                        tmp.add("Invalid: " + file.getName());
+                        tmp.add("Invalid: " + fileName);
                         continue;
                     }
                     tmp.add(disjoinPrefix(PREFIX_JOB_INFO, pureFileName.first));
@@ -793,6 +887,10 @@ public class Repository implements Writable, GsonPostProcessable {
                     info.add(FeConstants.null_string);
                     info.add("ERROR: No info file found");
                 }
+            } catch (IOException e) {
+                info.add(snapshotName);
+                info.add(FeConstants.null_string);
+                info.add("ERROR: Failed to get info: " + e.getMessage());
             }
         } else {
             // get specified timestamp, different repos might have snapshots with same timestamp.

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RepositoryMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RepositoryMgr.java
@@ -22,8 +22,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Daemon;
-import org.apache.doris.fs.remote.AzureFileSystem;
-import org.apache.doris.fs.remote.S3FileSystem;
+import org.apache.doris.foundation.fs.FsStorageType;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 
@@ -111,8 +110,9 @@ public class RepositoryMgr extends Daemon implements Writable, GsonPostProcessab
         try {
             Repository repo = repoNameMap.get(newRepo.getName());
             if (repo != null) {
-                if (repo.getRemoteFileSystem() instanceof S3FileSystem
-                        || repo.getRemoteFileSystem() instanceof AzureFileSystem) {
+                if (repo.getFileSystemDescriptor() != null
+                        && (repo.getFileSystemDescriptor().getStorageType() == FsStorageType.S3
+                            || repo.getFileSystemDescriptor().getStorageType() == FsStorageType.AZURE)) {
                     repoNameMap.put(repo.getName(), newRepo);
                     repoIdMap.put(repo.getId(), newRepo);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -445,7 +445,7 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                     continue;
                 }
                 ((DownloadTask) task).updateBrokerProperties(
-                        repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties());
+                        repo.getFileSystemDescriptor().getBackendConfigProperties());
                 AgentTaskQueue.updateTask(beId, TTaskType.DOWNLOAD, signature, task);
             }
             LOG.info("finished to update download job properties. {}", this);
@@ -2002,8 +2002,8 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
     protected DownloadTask createDownloadTask(long beId, long signature, long jobId, long dbId,
                                               Map<String, String> srcToDest, FsBroker brokerAddr) {
         return new DownloadTask(null, beId, signature, jobId, dbId, srcToDest,
-            brokerAddr, repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties(),
-            repo.getRemoteFileSystem().getThriftStorageType(), repo.getLocation(), "");
+            brokerAddr, repo.getFileSystemDescriptor().getBackendConfigProperties(),
+            repo.getFileSystemDescriptor().getThriftStorageType(), repo.getLocation(), "");
     }
 
     // Get the id mapping for snapshot, user should hold the lock of table.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -112,6 +112,8 @@ import org.apache.doris.encryption.KeyManagerInterface;
 import org.apache.doris.encryption.KeyManagerStore;
 import org.apache.doris.event.EventProcessor;
 import org.apache.doris.event.ReplacePartitionEvent;
+import org.apache.doris.fs.FileSystemFactory;
+import org.apache.doris.fs.FileSystemPluginManager;
 import org.apache.doris.ha.BDBHA;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.ha.HAProtocol;
@@ -319,9 +321,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1193,6 +1198,9 @@ public class Env {
         pluginMgr.init();
         auditEventProcessor.start();
         lineageEventProcessor.start();
+
+        // init filesystem plugin manager (before any storage backend access)
+        initFileSystemPluginManager();
 
         cloneClusterSnapshot();
 
@@ -2083,6 +2091,18 @@ public class Env {
             LOG.error("failed to transfer to non-master.", e);
             System.exit(-1);
         }
+    }
+
+    private void initFileSystemPluginManager() {
+        FileSystemPluginManager fsPluginManager = new FileSystemPluginManager();
+        fsPluginManager.loadBuiltins();
+        String pluginRoot = Config.filesystem_plugin_root;
+        if (pluginRoot != null && !pluginRoot.isEmpty()) {
+            Path rootPath = Paths.get(pluginRoot);
+            fsPluginManager.loadPlugins(Collections.singletonList(rootPath));
+        }
+        FileSystemFactory.initPluginManager(fsPluginManager);
+        LOG.info("FileSystemPluginManager initialized with plugin root: {}", pluginRoot);
     }
 
     // Set global variable 'lower_case_table_names' only when the cluster is initialized.

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
@@ -292,8 +292,8 @@ public class CloudRestoreJob extends RestoreJob {
         }
         Preconditions.checkState(storageVaultId != null, "Storage vault ID cannot be null");
         return new DownloadTask(null, beId, signature, jobId, dbId, srcToDest,
-            brokerAddr, repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties(),
-            repo.getRemoteFileSystem().getThriftStorageType(), repo.getLocation(), storageVaultId);
+            brokerAddr, repo.getFileSystemDescriptor().getBackendConfigProperties(),
+            repo.getFileSystemDescriptor().getThriftStorageType(), repo.getLocation(), storageVaultId);
     }
 
     public void downloadLocalSnapshots() {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -57,7 +57,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.util.ColumnsUtil;
 import org.apache.doris.datasource.InternalCatalog;
-import org.apache.doris.fs.obj.ObjectFile;
+import org.apache.doris.filesystem.spi.RemoteObject;
 import org.apache.doris.proto.OlapCommon;
 import org.apache.doris.proto.OlapFile;
 import org.apache.doris.proto.OlapFile.EncryptionAlgorithmPB;
@@ -1535,13 +1535,13 @@ public class CloudInternalCatalog extends InternalCatalog {
         }
     }
 
-    public List<ObjectFilePB> filterCopyFiles(String stageId, long tableId, List<ObjectFile> objectFiles)
+    public List<ObjectFilePB> filterCopyFiles(String stageId, long tableId, List<RemoteObject> objectFiles)
             throws DdlException {
         Cloud.FilterCopyFilesRequest.Builder builder = Cloud.FilterCopyFilesRequest.newBuilder()
                 .setCloudUniqueId(Config.cloud_unique_id)
                 .setRequestIp(FrontendOptions.getLocalHostAddressCached())
                 .setStageId(stageId).setTableId(tableId);
-        for (ObjectFile objectFile : objectFiles) {
+        for (RemoteObject objectFile : objectFiles) {
             builder.addObjectFiles(
                     ObjectFilePB.newBuilder().setRelativePath(objectFile.getRelativePath())
                             .setEtag(objectFile.getEtag()).setSize(objectFile.getSize()).build());

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CleanCopyJobTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CleanCopyJobTask.java
@@ -26,8 +26,8 @@ import org.apache.doris.cloud.storage.ObjectInfo;
 import org.apache.doris.cloud.storage.ObjectInfoAdapter;
 import org.apache.doris.common.Config;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.ObjFileSystem;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,7 +59,7 @@ public class CleanCopyJobTask {
         }
         try {
             StorageProperties storageProps = ObjectInfoAdapter.toStorageProperties(objectInfo);
-            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.get(storageProps);
+            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.getFileSystem(storageProps);
             fs.deleteObjectsByKeys(objectInfo.getBucket(), loadFiles);
             ((CloudInternalCatalog) Env.getCurrentInternalCatalog())
                     .finishCopy(stageId, stageType, tableId, copyId, 0, Action.REMOVE);

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CopyLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CopyLoadPendingTask.java
@@ -35,10 +35,10 @@ import org.apache.doris.common.util.BrokerUtil;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
+import org.apache.doris.filesystem.spi.RemoteObject;
+import org.apache.doris.filesystem.spi.RemoteObjects;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.obj.ListObjectsResult;
-import org.apache.doris.fs.obj.ObjectFile;
-import org.apache.doris.fs.remote.ObjFileSystem;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.BrokerFileGroupAggInfo.FileGroupAggKey;
 import org.apache.doris.load.loadv2.BrokerLoadPendingTask;
@@ -262,7 +262,7 @@ public class CopyLoadPendingTask extends BrokerLoadPendingTask {
         loadedFileNum = 0;
         reachLimitStr = "";
         StorageProperties storageProps = ObjectInfoAdapter.toStorageProperties(objectInfo);
-        ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.get(storageProps);
+        ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.getFileSystem(storageProps);
         Set<String> loadedFileSet = copiedFiles.stream().map(f -> StageUtil.getFileInfoUniqueId(f))
                 .collect(Collectors.toSet());
         try {
@@ -272,16 +272,16 @@ public class CopyLoadPendingTask extends BrokerLoadPendingTask {
             String continuationToken = null;
             boolean finish = false;
             while (!finish) {
-                ListObjectsResult listObjectsResult = fs.listObjectsWithPrefix(
+                RemoteObjects listObjectsResult = fs.listObjectsWithPrefix(
                         objectInfo.getPrefix(), "", continuationToken);
-                listFileNum += listObjectsResult.getObjectInfoList().size();
+                listFileNum += listObjectsResult.getObjectList().size();
                 long costSeconds = (System.currentTimeMillis() - startTimestamp) / 1000;
                 if (costSeconds >= 3600 || listFileNum >= 1000000) {
                     throw new DdlException("Abort list object for queryId=" + ((CopyJob) callback).getCopyId()
                             + ". We don't collect enough files to load, after listing " + listFileNum + " objects for "
                             + costSeconds + " seconds, please check if your pattern " + pattern + " is correct.");
                 }
-                for (ObjectFile objectFile : listObjectsResult.getObjectInfoList()) {
+                for (RemoteObject objectFile : listObjectsResult.getObjectList()) {
                     // check:
                     // 1. match pattern if it's set
                     // 2. file is not copying or copied by other copy jobs
@@ -344,13 +344,13 @@ public class CopyLoadPendingTask extends BrokerLoadPendingTask {
         isBeginCopyDone = true;
         try {
             StorageProperties storageProps = ObjectInfoAdapter.toStorageProperties(objectInfo);
-            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.get(storageProps);
+            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.getFileSystem(storageProps);
             List<Pair<TBrokerFileStatus, ObjectFilePB>> fileStatuses = Lists.newArrayList();
             for (ObjectFilePB objectFile : copyJobPB.getObjectFilesList()) {
-                List<ObjectFile> files = fs.headObjectWithMeta(
-                        objectInfo.getPrefix(), objectFile.getRelativePath()).getObjectInfoList();
+                List<RemoteObject> files = fs.headObjectWithMeta(
+                        objectInfo.getPrefix(), objectFile.getRelativePath()).getObjectList();
                 TBrokerFileStatus brokerFileStatus = null;
-                for (ObjectFile file : files) {
+                for (RemoteObject file : files) {
                     if (file.getRelativePath().equals(objectFile.getRelativePath()) && file.getEtag()
                             .equals(objectFile.getEtag())) {
                         String objUrl = "s3://" + objectInfo.getBucket() + "/" + file.getKey();

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/stage/StageUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/stage/StageUtil.java
@@ -32,10 +32,10 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
+import org.apache.doris.filesystem.spi.RemoteObject;
+import org.apache.doris.filesystem.spi.RemoteObjects;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.obj.ListObjectsResult;
-import org.apache.doris.fs.obj.ObjectFile;
-import org.apache.doris.fs.remote.ObjFileSystem;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TBrokerFileStatus;
@@ -153,19 +153,19 @@ public class StageUtil {
         int loadedFileNum = 0;
         String reachLimitStr = "";
         StorageProperties storageProps = ObjectInfoAdapter.toStorageProperties(objectInfo);
-        ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.get(storageProps);
+        ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.getFileSystem(storageProps);
 
         List<Pair<String, Boolean>> globs = analyzeGlob(copyId, pattern);
         LOG.info("Input copy into glob={}, analyzed={}", pattern, globs);
         try {
             PathMatcher matcher = getPathMatcher(pattern);
             boolean finish = false;
-            List<ObjectFile> matchPatternFiles = new ArrayList<>();
+            List<RemoteObject> matchPatternFiles = new ArrayList<>();
             for (int i = 0; i < globs.size() && !finish; i++) {
                 Pair<String, Boolean> glob = globs.get(i);
                 String continuationToken = null;
                 while (!finish) {
-                    ListObjectsResult listObjectsResult;
+                    RemoteObjects listObjectsResult;
                     if (glob.second) {
                         // list objects with sub prefix
                         listObjectsResult = fs.listObjectsWithPrefix(objectInfo.getPrefix(), glob.first,
@@ -174,7 +174,7 @@ public class StageUtil {
                         // head object
                         listObjectsResult = fs.headObjectWithMeta(objectInfo.getPrefix(), glob.first);
                     }
-                    listFileNum += listObjectsResult.getObjectInfoList().size();
+                    listFileNum += listObjectsResult.getObjectList().size();
                     long costSeconds = (System.currentTimeMillis() - startTimestamp) / 1000;
                     if (costSeconds >= 3600 || listFileNum >= 1000000) {
                         throw new DdlException("Abort list object for copyId=" + copyId
@@ -183,7 +183,7 @@ public class StageUtil {
                                 + " is correct.");
                     }
                     // 1. check if pattern is matched
-                    for (ObjectFile objectFile : listObjectsResult.getObjectInfoList()) {
+                    for (RemoteObject objectFile : listObjectsResult.getObjectList()) {
                         if (!matchPattern(objectFile.getRelativePath(), matcher)) {
                             LOG.info("not matchPattern path:{}", objectFile.getRelativePath());
                             continue;
@@ -249,7 +249,7 @@ public class StageUtil {
     }
 
     private static List<ObjectFilePB> filterCopyFiles(String stageId, long tableId, boolean force,
-            List<ObjectFile> objectFiles) throws DdlException {
+            List<RemoteObject> objectFiles) throws DdlException {
         if (force) {
             return objectFiles.stream()
                     .map(f -> ObjectFilePB.newBuilder().setRelativePath(f.getRelativePath()).setEtag(f.getEtag())
@@ -273,7 +273,7 @@ public class StageUtil {
         return matcher.matches(path);
     }
 
-    public static String getFileInfoUniqueId(ObjectFile objectFile) {
+    public static String getFileInfoUniqueId(RemoteObject objectFile) {
         return objectFile.getRelativePath() + "_" + objectFile.getEtag();
     }
 
@@ -435,13 +435,13 @@ public class StageUtil {
     }
 
     private static List<Pair<TBrokerFileStatus, ObjectFilePB>> generateFiles(List<ObjectFilePB> filterFiles,
-            List<ObjectFile> allFiles, String bucket) {
+            List<RemoteObject> allFiles, String bucket) {
         List<Pair<TBrokerFileStatus, ObjectFilePB>> files = new ArrayList<>();
         Map<String, ObjectFilePB> fileMap = new HashMap<>();
         for (ObjectFilePB filterFile : filterFiles) {
             fileMap.put(getFileInfoUniqueId(filterFile), filterFile);
         }
-        for (ObjectFile file : allFiles) {
+        for (RemoteObject file : allFiles) {
             if (fileMap.containsKey(getFileInfoUniqueId(file))) {
                 String objUrl = "s3://" + bucket + "/" + file.getKey();
                 files.add(Pair.of(new TBrokerFileStatus(objUrl, false, file.getSize(), true),

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/ObjectInfoAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/ObjectInfoAdapter.java
@@ -22,17 +22,16 @@ import org.apache.doris.cloud.proto.Cloud.StagePB;
 import org.apache.doris.cloud.proto.Cloud.StagePB.StageAccessType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.property.storage.AzureProperties;
 import org.apache.doris.datasource.property.storage.COSProperties;
 import org.apache.doris.datasource.property.storage.OBSProperties;
 import org.apache.doris.datasource.property.storage.OSSProperties;
 import org.apache.doris.datasource.property.storage.S3Properties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
+import org.apache.doris.filesystem.spi.StsCredentials;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.ObjFileSystem;
 
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -116,16 +115,13 @@ public class ObjectInfoAdapter {
             ObjectInfo arnObj = new ObjectInfo(infoPB, stagePB.getRoleName(), stagePB.getArn(),
                     encodedExternalId, null);
             StorageProperties props = toStorageProperties(arnObj);
-            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.get(props);
-            Triple<String, String, String> stsToken = fs.getStsToken();
-            ObjectInfo objInfo = new ObjectInfo(infoPB.getProvider(), stsToken.getLeft(), stsToken.getMiddle(),
+            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.getFileSystem(props);
+            StsCredentials stsToken = fs.getStsToken();
+            ObjectInfo objInfo = new ObjectInfo(infoPB.getProvider(), stsToken.getAccessKey(), stsToken.getSecretKey(),
                     infoPB.getBucket(), infoPB.getEndpoint(), infoPB.getRegion(), infoPB.getPrefix(),
-                    stagePB.getRoleName(), stagePB.getArn(), encodedExternalId, stsToken.getRight());
+                    stagePB.getRoleName(), stagePB.getArn(), encodedExternalId, stsToken.getSecurityToken());
             LOG.info("Parse object storage info, before={}, after={}", new ObjectInfo(infoPB), objInfo);
             return objInfo;
-        } catch (DdlException e) {
-            LOG.warn("Failed analyze stagePB={}", stagePB, e);
-            throw new AnalysisException("Failed analyze object info of stagePB, " + e.getMessage());
         } catch (Throwable e) {
             LOG.warn("Failed analyze stagePB={}", stagePB, e);
             throw new AnalysisException("Failed analyze object info of stagePB, " + e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -18,7 +18,6 @@
 package org.apache.doris.common.util;
 
 import org.apache.doris.analysis.BrokerDesc;
-import org.apache.doris.backup.Status;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.AnalysisException;
@@ -27,9 +26,11 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache;
+import org.apache.doris.datasource.property.storage.BrokerProperties;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.RemoteFile;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.thrift.TBrokerCloseReaderRequest;
 import org.apache.doris.thrift.TBrokerFD;
@@ -52,7 +53,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -68,37 +68,48 @@ public class BrokerUtil {
      */
     public static void parseFile(String path, BrokerDesc brokerDesc, List<TBrokerFileStatus> fileStatuses)
             throws UserException {
-        List<RemoteFile> rfiles = new ArrayList<>();
-        try (RemoteFileSystem fileSystem = FileSystemFactory.get(brokerDesc.getStorageProperties())) {
-            Status st = fileSystem.globList(path, rfiles, false);
-            if (!st.ok()) {
-                throw new UserException(st.getErrMsg());
+        BrokerProperties brokerProps = (BrokerProperties) brokerDesc.getStorageProperties();
+        try {
+            String localIP = FrontendOptions.getLocalHostAddress();
+            FsBroker broker = Env.getCurrentEnv().getBrokerMgr().getBroker(brokerProps.getBrokerName(), localIP);
+            String clientId = NetUtils.getHostPortInAccessibleFormat(localIP, Config.edit_log_port);
+            try (FileSystem fs = FileSystemFactory.getBrokerFileSystem(
+                    broker.host, broker.port, clientId, brokerProps.getBrokerParams())) {
+                List<FileEntry> entries = fs.listFiles(Location.of(path));
+                for (FileEntry e : entries) {
+                    TBrokerFileStatus status = new TBrokerFileStatus(
+                            e.location().uri(), e.isDirectory(), e.length(), !e.isDirectory());
+                    fileStatuses.add(status);
+                }
             }
+        } catch (AnalysisException e) {
+            LOG.warn("{} list path exception, path={}", brokerDesc.getName(), path, e);
+            throw new UserException(brokerDesc.getName() + " list path exception. path="
+                    + path + ", err: " + e.getMessage());
         } catch (Exception e) {
             LOG.warn("{} list path exception, path={}", brokerDesc.getName(), path, e);
-            throw new UserException(brokerDesc.getName() +  " list path exception. path="
+            throw new UserException(brokerDesc.getName() + " list path exception. path="
                     + path + ", err: " + e.getMessage());
-        }
-        for (RemoteFile r : rfiles) {
-            if (r.isFile()) {
-                TBrokerFileStatus status = new TBrokerFileStatus(r.getName(), !r.isFile(), r.getSize(), r.isFile());
-                status.setBlockSize(r.getBlockSize());
-                status.setModificationTime(r.getModificationTime());
-                fileStatuses.add(status);
-            }
         }
     }
 
     public static void deleteDirectoryWithFileSystem(String path, BrokerDesc brokerDesc) throws UserException {
-        try (RemoteFileSystem fileSystem = FileSystemFactory.get(brokerDesc.getStorageProperties())) {
-            Status st = fileSystem.deleteDirectory(path);
-            if (!st.ok()) {
-                throw new UserException(brokerDesc.getName() +  " delete directory exception. path="
-                        + path + ", err: " + st.getErrMsg());
+        BrokerProperties brokerProps = (BrokerProperties) brokerDesc.getStorageProperties();
+        try {
+            String localIP = FrontendOptions.getLocalHostAddress();
+            FsBroker broker = Env.getCurrentEnv().getBrokerMgr().getBroker(brokerProps.getBrokerName(), localIP);
+            String clientId = NetUtils.getHostPortInAccessibleFormat(localIP, Config.edit_log_port);
+            try (FileSystem fs = FileSystemFactory.getBrokerFileSystem(
+                    broker.host, broker.port, clientId, brokerProps.getBrokerParams())) {
+                fs.delete(Location.of(path), true);
             }
+        } catch (AnalysisException e) {
+            LOG.warn("{} delete directory exception, path={}", brokerDesc.getName(), path, e);
+            throw new UserException(brokerDesc.getName() + " delete directory exception. path="
+                    + path + ", err: " + e.getMessage());
         } catch (Exception e) {
             LOG.warn("{} delete directory exception, path={}", brokerDesc.getName(), path, e);
-            throw new UserException(brokerDesc.getName() +  " delete directory exception. path="
+            throw new UserException(brokerDesc.getName() + " delete directory exception. path="
                     + path + ", err: " + e.getMessage());
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/AcidUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/AcidUtil.java
@@ -17,12 +17,14 @@
 
 package org.apache.doris.datasource.hive;
 
-import org.apache.doris.backup.Status;
 import org.apache.doris.common.util.LocationPath;
 import org.apache.doris.datasource.hive.AcidInfo.DeleteDeltaInfo;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache.FileCacheValue;
 import org.apache.doris.datasource.property.storage.StorageProperties;
-import org.apache.doris.fs.LegacyFileSystemApi;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
+import org.apache.doris.fs.FileSystemTransferUtil;
 import org.apache.doris.fs.remote.RemoteFile;
 
 import lombok.EqualsAndHashCode;
@@ -132,37 +134,17 @@ public class AcidUtil {
     }
 
 
-    private static boolean isValidMetaDataFile(LegacyFileSystemApi fileSystem, String baseDir)
+    private static boolean isValidMetaDataFile(FileSystem fileSystem, String baseDir)
             throws IOException {
         String fileLocation = baseDir + "_metadata_acid";
-        Status status = fileSystem.exists(fileLocation);
-        if (status != Status.OK) {
+        try {
+            return fileSystem.exists(Location.of(fileLocation));
+        } catch (IOException e) {
             return false;
         }
-        //In order to save the cost of reading the file content, we only check whether the file exists.
-        // File Contents: {"thisFileVersion":"0","dataFormat":"compacted"}
-        //
-        // Map<String, String> metadata;
-        // try (var in = read(fileLocation)) {
-        //     metadata = new ObjectMapper().readValue(in, new TypeReference<>() {});
-        // }
-        // catch (IOException e) {
-        //     throw new IOException(String.format("Failed to read %s: %s", fileLocation, e.getMessage()), e);
-        // }
-        //
-        // String version = metadata.get("thisFileVersion");
-        // if (!"0".equals(version)) {
-        //     throw new IOException("Unexpected ACID metadata version: " + version);
-        // }
-        //
-        // String format = metadata.get("dataFormat");
-        // if (!"compacted".equals(format)) {
-        //     throw new IOException("Unexpected value for ACID dataFormat: " + format);
-        // }
-        return true;
     }
 
-    private static boolean isValidBase(LegacyFileSystemApi fileSystem, String baseDir,
+    private static boolean isValidBase(FileSystem fileSystem, String baseDir,
             ParsedBase base, ValidWriteIdList writeIdList) throws IOException {
         if (base.writeId == Long.MIN_VALUE) {
             //Ref: https://issues.apache.org/jira/browse/HIVE-13369
@@ -239,7 +221,7 @@ public class AcidUtil {
     //Since the hive3 library cannot read the hive4 transaction table normally, and there are many problems
     // when using the Hive 4 library directly, this method is implemented.
     //Ref: hive/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java#getAcidState
-    public static FileCacheValue getAcidState(LegacyFileSystemApi fileSystem, HivePartition partition,
+    public static FileCacheValue getAcidState(FileSystem fileSystem, HivePartition partition,
             Map<String, String> txnValidIds, Map<StorageProperties.Type, StorageProperties> storagePropertiesMap,
                                               boolean isFullAcid) throws Exception {
 
@@ -270,14 +252,9 @@ public class AcidUtil {
         String partitionPath = partition.getPath();
         //hdfs://xxxxx/user/hive/warehouse/username/data_id=200103
 
-        List<RemoteFile> lsPartitionPath = new ArrayList<>();
-        Status status = fileSystem.globList(partitionPath + "/*", lsPartitionPath);
+        List<RemoteFile> lsPartitionPath = toRemoteFiles(
+                FileSystemTransferUtil.globList(fileSystem, partitionPath + "/*", false));
         // List all files and folders, without recursion.
-        // FileStatus[] lsPartitionPath = null;
-        // fileSystem.listFileStatuses(partitionPath,lsPartitionPath);
-        if (status != Status.OK) {
-            throw new IOException(status.toString());
-        }
 
         String oldestBase = null;
         long oldestBaseWriteId = Long.MAX_VALUE;
@@ -411,38 +388,30 @@ public class AcidUtil {
         for (ParsedDelta delta : deltas) {
             String location = delta.getPath();
 
-            List<RemoteFile> remoteFiles = new ArrayList<>();
-            status = fileSystem.listFiles(location, false, remoteFiles);
-            if (status.ok()) {
-                if (delta.isDeleteDelta()) {
-                    List<String> deleteDeltaFileNames = remoteFiles.stream()
-                            .map(RemoteFile::getName).filter(fileFilter::accept)
-                            .collect(Collectors.toList());
-                    deleteDeltas.add(new DeleteDeltaInfo(location, deleteDeltaFileNames));
-                    continue;
-                }
-                remoteFiles.stream().filter(f -> fileFilter.accept(f.getName())).forEach(file -> {
-                    LocationPath path = LocationPath.of(file.getPath().toString(), storagePropertiesMap);
-                    fileCacheValue.addFile(file, path);
-                });
-            } else {
-                throw new RuntimeException(status.getErrMsg());
+            List<RemoteFile> remoteFiles = toRemoteFiles(
+                    FileSystemTransferUtil.globList(fileSystem, location, false));
+            if (delta.isDeleteDelta()) {
+                List<String> deleteDeltaFileNames = remoteFiles.stream()
+                        .map(RemoteFile::getName).filter(fileFilter::accept)
+                        .collect(Collectors.toList());
+                deleteDeltas.add(new DeleteDeltaInfo(location, deleteDeltaFileNames));
+                continue;
             }
+            remoteFiles.stream().filter(f -> fileFilter.accept(f.getName())).forEach(file -> {
+                LocationPath path = LocationPath.of(file.getPath().toString(), storagePropertiesMap);
+                fileCacheValue.addFile(file, path);
+            });
         }
 
         // base
         if (bestBasePath != null) {
-            List<RemoteFile> remoteFiles = new ArrayList<>();
-            status = fileSystem.listFiles(bestBasePath, false, remoteFiles);
-            if (status.ok()) {
-                remoteFiles.stream().filter(f -> fileFilter.accept(f.getName()))
-                        .forEach(file -> {
-                            LocationPath path = LocationPath.of(file.getPath().toString(), storagePropertiesMap);
-                            fileCacheValue.addFile(file, path);
-                        });
-            } else {
-                throw new RuntimeException(status.getErrMsg());
-            }
+            List<RemoteFile> remoteFiles = toRemoteFiles(
+                    FileSystemTransferUtil.globList(fileSystem, bestBasePath, false));
+            remoteFiles.stream().filter(f -> fileFilter.accept(f.getName()))
+                    .forEach(file -> {
+                        LocationPath path = LocationPath.of(file.getPath().toString(), storagePropertiesMap);
+                        fileCacheValue.addFile(file, path);
+                    });
         }
 
         if (isFullAcid) {
@@ -451,5 +420,14 @@ public class AcidUtil {
             throw new RuntimeException("No Hive Full Acid Table have delete_delta_* Dir.");
         }
         return fileCacheValue;
+    }
+
+    private static List<RemoteFile> toRemoteFiles(List<FileEntry> entries) {
+        List<RemoteFile> result = new ArrayList<>(entries.size());
+        for (FileEntry e : entries) {
+            org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(e.location().uri());
+            result.add(new RemoteFile(hadoopPath, e.isDirectory(), e.length(), -1L, 0L, null));
+        }
+        return result;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalCatalog.java
@@ -33,8 +33,7 @@ import org.apache.doris.datasource.iceberg.IcebergUtils;
 import org.apache.doris.datasource.metacache.CacheSpec;
 import org.apache.doris.datasource.operations.ExternalMetadataOperations;
 import org.apache.doris.datasource.property.metastore.AbstractHiveProperties;
-import org.apache.doris.fs.FileSystemProviderImpl;
-import org.apache.doris.fs.LegacyFileSystemProviderFactory;
+import org.apache.doris.fs.SpiSwitchingFileSystem;
 import org.apache.doris.fs.remote.dfs.DFSFileSystem;
 import org.apache.doris.transaction.TransactionManagerFactory;
 
@@ -146,12 +145,11 @@ public class HMSExternalCatalog extends ExternalCatalog {
                 String.format("hms_iceberg_catalog_%s_executor_pool", name),
                 true,
                 executionAuthenticator);
-        LegacyFileSystemProviderFactory fileSystemProvider =
-                new FileSystemProviderImpl(Env.getCurrentEnv().getExtMetaCacheMgr(),
-                        this.catalogProperty.getStoragePropertiesMap());
+        SpiSwitchingFileSystem spiFileSystem =
+                new SpiSwitchingFileSystem(this.catalogProperty.getStoragePropertiesMap());
         this.fileSystemExecutor = ThreadPoolManager.newDaemonFixedThreadPool(FILE_SYSTEM_EXECUTOR_THREAD_NUM,
                 Integer.MAX_VALUE, String.format("hms_committer_%s_file_system_executor_pool", name), true);
-        transactionManager = TransactionManagerFactory.createHiveTransactionManager(hiveOps, fileSystemProvider,
+        transactionManager = TransactionManagerFactory.createHiveTransactionManager(hiveOps, spiFileSystem,
                 fileSystemExecutor);
         metadataOps = hiveOps;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSTransaction.java
@@ -21,20 +21,17 @@
 
 package org.apache.doris.datasource.hive;
 
-import org.apache.doris.backup.Status;
 import org.apache.doris.common.Pair;
-import org.apache.doris.common.UserException;
 import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.statistics.CommonStatistics;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
 import org.apache.doris.foundation.util.PathUtils;
 import org.apache.doris.fs.FileSystemUtil;
-import org.apache.doris.fs.LegacyFileSystemApi;
-import org.apache.doris.fs.LegacyFileSystemProviderFactory;
-import org.apache.doris.fs.remote.MultipartUploadCapable;
-import org.apache.doris.fs.remote.RemoteFile;
-import org.apache.doris.fs.remote.S3FileSystem;
-import org.apache.doris.fs.remote.SwitchingFileSystem;
+import org.apache.doris.fs.SpiSwitchingFileSystem;
 import org.apache.doris.nereids.trees.plans.commands.insert.HiveInsertCommandContext;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TFileType;
@@ -62,9 +59,6 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
-import software.amazon.awssdk.services.s3.model.CompletedPart;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -90,7 +84,7 @@ import java.util.stream.Collectors;
 public class HMSTransaction implements Transaction {
     private static final Logger LOG = LogManager.getLogger(HMSTransaction.class);
     private final HiveMetadataOps hiveOps;
-    private final LegacyFileSystemApi fs;
+    private final FileSystem fs;
     private Optional<SummaryProfile> summaryProfile = Optional.empty();
     private String queryId;
     private boolean isOverwrite = false;
@@ -138,13 +132,10 @@ public class HMSTransaction implements Transaction {
 
     private final Set<UncompletedMpuPendingUpload> uncompletedMpuPendingUploads = new HashSet<>();
 
-    public HMSTransaction(HiveMetadataOps hiveOps, LegacyFileSystemProviderFactory fileSystemProvider,
+    public HMSTransaction(HiveMetadataOps hiveOps, SpiSwitchingFileSystem fileSystem,
             Executor fileSystemExecutor) {
         this.hiveOps = hiveOps;
-        this.fs = fileSystemProvider.get(null);
-        if (!(fs instanceof SwitchingFileSystem)) {
-            throw new RuntimeException("fs should be SwitchingFileSystem");
-        }
+        this.fs = fileSystem;
         if (ConnectContext.get().getExecutor() != null) {
             summaryProfile = Optional.of(ConnectContext.get().getExecutor().getSummaryProfile());
         }
@@ -216,7 +207,11 @@ public class HMSTransaction implements Transaction {
                         });
                     } else {
                         stagingDirectory.ifPresent((v) -> {
-                            fs.makeDir(v);
+                            try {
+                                fs.mkdirs(Location.of(v));
+                            } catch (java.io.IOException e) {
+                                throw new RuntimeException("Failed to create staging directory: " + v, e);
+                            }
                             setLocation(new THiveLocationParams() {{
                                     setWritePath(v);
                                 }
@@ -696,15 +691,11 @@ public class HMSTransaction implements Transaction {
 
     private DeleteRecursivelyResult recursiveDeleteFiles(Path directory, boolean deleteEmptyDir, boolean reverse) {
         try {
-            Status status = fs.directoryExists(directory.toString());
-            if (status.getErrCode().equals(Status.ErrCode.NOT_FOUND)) {
+            boolean dirExists = fs.exists(Location.of(directory.toString()));
+            if (!dirExists) {
                 return new DeleteRecursivelyResult(true, ImmutableList.of());
-            } else if (!status.ok()) {
-                ImmutableList.Builder<String> notDeletedEligibleItems = ImmutableList.builder();
-                notDeletedEligibleItems.add(directory.toString() + "/*");
-                return new DeleteRecursivelyResult(false, notDeletedEligibleItems.build());
             }
-        } catch (Exception e) {
+        } catch (java.io.IOException e) {
             ImmutableList.Builder<String> notDeletedEligibleItems = ImmutableList.builder();
             notDeletedEligibleItems.add(directory.toString() + "/*");
             return new DeleteRecursivelyResult(false, notDeletedEligibleItems.build());
@@ -715,11 +706,12 @@ public class HMSTransaction implements Transaction {
 
     private DeleteRecursivelyResult doRecursiveDeleteFiles(Path directory, boolean deleteEmptyDir,
             String queryId, boolean reverse) {
-        List<RemoteFile> allFiles = new ArrayList<>();
-        Set<String> allDirs = new HashSet<>();
-        Status statusFile = fs.listFiles(directory.toString(), true, allFiles);
-        Status statusDir = fs.listDirectories(directory.toString(), allDirs);
-        if (!statusFile.ok() || !statusDir.ok()) {
+        List<FileEntry> allFiles;
+        Set<String> allDirs;
+        try {
+            allFiles = fs.listFilesRecursive(Location.of(directory.toString()));
+            allDirs = fs.listDirectories(Location.of(directory.toString()));
+        } catch (java.io.IOException e) {
             ImmutableList.Builder<String> notDeletedEligibleItems = ImmutableList.builder();
             notDeletedEligibleItems.add(directory + "/*");
             return new DeleteRecursivelyResult(false, notDeletedEligibleItems.build());
@@ -727,11 +719,13 @@ public class HMSTransaction implements Transaction {
 
         boolean allDescendentsDeleted = true;
         ImmutableList.Builder<String> notDeletedEligibleItems = ImmutableList.builder();
-        for (RemoteFile file : allFiles) {
-            if (reverse ^ file.getName().startsWith(queryId)) {
-                if (!deleteIfExists(file.getPath())) {
+        for (FileEntry file : allFiles) {
+            String fileName = new Path(file.location().uri()).getName();
+            String filePath = file.location().uri();
+            if (reverse ^ fileName.startsWith(queryId)) {
+                if (!deleteIfExists(new Path(filePath))) {
                     allDescendentsDeleted = false;
-                    notDeletedEligibleItems.add(file.getPath().toString());
+                    notDeletedEligibleItems.add(filePath);
                 }
             } else {
                 allDescendentsDeleted = false;
@@ -760,19 +754,21 @@ public class HMSTransaction implements Transaction {
     }
 
     public boolean deleteIfExists(Path path) {
-        Status status = wrapperDeleteWithProfileSummary(path.toString());
-        if (status.ok()) {
-            return true;
+        wrapperDeleteWithProfileSummary(path.toString());
+        try {
+            return !fs.exists(Location.of(path.toString()));
+        } catch (java.io.IOException e) {
+            return false;
         }
-        return !fs.exists(path.toString()).ok();
     }
 
     public boolean deleteDirectoryIfExists(Path path) {
-        Status status = wrapperDeleteDirWithProfileSummary(path.toString());
-        if (status.ok()) {
-            return true;
+        wrapperDeleteDirWithProfileSummary(path.toString());
+        try {
+            return !fs.exists(Location.of(path.toString()));
+        } catch (java.io.IOException e) {
+            return false;
         }
-        return !fs.directoryExists(path.toString()).ok();
     }
 
     private static class TableAndMore {
@@ -1294,26 +1290,17 @@ public class HMSTransaction implements Transaction {
                     Path path = new Path(targetPath);
                     String oldTablePath = new Path(
                             path.getParent(), "_temp_" + queryId + "_" + path.getName()).toString();
-                    Status status = wrapperRenameDirWithProfileSummary(
+                    wrapperRenameDirWithProfileSummary(
                             targetPath,
                             oldTablePath,
                             () -> renameDirectoryTasksForAbort.add(new RenameDirectoryTask(oldTablePath, targetPath)));
-                    if (!status.ok()) {
-                        throw new RuntimeException(
-                                "Error to rename dir from " + targetPath + " to " + oldTablePath + status.getErrMsg());
-                    }
                     clearDirsForFinish.add(oldTablePath);
 
-                    status = wrapperRenameDirWithProfileSummary(
+                    wrapperRenameDirWithProfileSummary(
                             writePath,
                             targetPath,
                             () -> directoryCleanUpTasksForAbort.add(
                                     new DirectoryCleanUpTask(targetPath, true)));
-                    if (!status.ok()) {
-                        throw new RuntimeException(
-                                "Error to rename dir from " + writePath + " to " + targetPath
-                                        + ":" + status.getErrMsg());
-                    }
                 }
             } else {
                 if (!tableAndMore.hivePartitionUpdate.s3_mpu_pending_uploads.isEmpty()) {
@@ -1412,28 +1399,24 @@ public class HMSTransaction implements Transaction {
         }
 
         private void runRenameDirTasksForAbort() {
-            Status status;
             for (RenameDirectoryTask task : renameDirectoryTasksForAbort) {
-                status = fs.exists(task.getRenameFrom());
-                if (status.ok()) {
-                    status = wrapperRenameDirWithProfileSummary(task.getRenameFrom(), task.getRenameTo(), () -> {
-                    });
-                    if (!status.ok()) {
-                        LOG.warn("Failed to abort rename dir from {} to {}:{}",
-                                task.getRenameFrom(), task.getRenameTo(), status.getErrMsg());
+                try {
+                    boolean srcExists = fs.exists(Location.of(task.getRenameFrom()));
+                    if (srcExists) {
+                        wrapperRenameDirWithProfileSummary(task.getRenameFrom(), task.getRenameTo(), () -> {
+                        });
                     }
+                } catch (java.io.IOException e) {
+                    LOG.warn("Failed to abort rename dir from {} to {}: {}",
+                            task.getRenameFrom(), task.getRenameTo(), e.getMessage());
                 }
             }
             renameDirectoryTasksForAbort.clear();
         }
 
         private void runClearPathsForFinish() {
-            Status status;
             for (String path : clearDirsForFinish) {
-                status = wrapperDeleteDirWithProfileSummary(path);
-                if (!status.ok()) {
-                    LOG.warn("Failed to recursively delete path {}:{}", path, status.getErrCode());
-                }
+                wrapperDeleteDirWithProfileSummary(path);
             }
         }
 
@@ -1452,26 +1435,16 @@ public class HMSTransaction implements Transaction {
                 Path path = new Path(targetPath);
                 String oldPartitionPath = new Path(
                         path.getParent(), "_temp_" + queryId + "_" + path.getName()).toString();
-                Status status = wrapperRenameDirWithProfileSummary(
+                wrapperRenameDirWithProfileSummary(
                         targetPath,
                         oldPartitionPath,
                         () -> renameDirectoryTasksForAbort.add(new RenameDirectoryTask(oldPartitionPath, targetPath)));
-                if (!status.ok()) {
-                    throw new RuntimeException(
-                            "Error to rename dir "
-                                    + "from " + targetPath
-                                    + " to " + oldPartitionPath + ":" + status.getErrMsg());
-                }
                 clearDirsForFinish.add(oldPartitionPath);
 
-                status = wrapperRenameDirWithProfileSummary(
+                wrapperRenameDirWithProfileSummary(
                         writePath,
                         targetPath,
                         () -> directoryCleanUpTasksForAbort.add(new DirectoryCleanUpTask(targetPath, true)));
-                if (!status.ok()) {
-                    throw new RuntimeException(
-                            "Error to rename dir from " + writePath + " to " + targetPath + ":" + status.getErrMsg());
-                }
             } else {
                 if (!partitionAndMore.hivePartitionUpdate.s3_mpu_pending_uploads.isEmpty()) {
                     s3cleanWhenSuccess.add(targetPath);
@@ -1560,21 +1533,22 @@ public class HMSTransaction implements Transaction {
                 return;
             }
             for (UncompletedMpuPendingUpload uncompletedMpuPendingUpload : uncompletedMpuPendingUploads) {
-                S3FileSystem s3FileSystem = (S3FileSystem) ((SwitchingFileSystem) fs)
-                        .fileSystem(uncompletedMpuPendingUpload.path);
-
-                S3Client s3Client;
+                ObjFileSystem objFs;
                 try {
-                    s3Client = (S3Client) s3FileSystem.getObjStorage().getClient();
-                } catch (UserException e) {
-                    throw new RuntimeException(e);
+                    objFs = (ObjFileSystem) ((SpiSwitchingFileSystem) fs)
+                            .forPath(uncompletedMpuPendingUpload.path);
+                } catch (java.io.IOException e) {
+                    throw new RuntimeException("Failed to resolve filesystem for abort MPU: "
+                            + uncompletedMpuPendingUpload.path, e);
                 }
+                TS3MPUPendingUpload mpu = uncompletedMpuPendingUpload.s3MPUPendingUpload;
+                String remotePath = "s3://" + mpu.getBucket() + "/" + mpu.getKey();
                 asyncFileSystemTaskFutures.add(CompletableFuture.runAsync(() -> {
-                    s3Client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
-                            .bucket(uncompletedMpuPendingUpload.s3MPUPendingUpload.getBucket())
-                            .key(uncompletedMpuPendingUpload.s3MPUPendingUpload.getKey())
-                            .uploadId(uncompletedMpuPendingUpload.s3MPUPendingUpload.getUploadId())
-                            .build());
+                    try {
+                        objFs.getObjStorage().abortMultipartUpload(remotePath, mpu.getUploadId());
+                    } catch (java.io.IOException e) {
+                        LOG.warn("Failed to abort MPU for {}: {}", remotePath, e.getMessage());
+                    }
                 }, fileSystemExecutor));
             }
             uncompletedMpuPendingUploads.clear();
@@ -1725,45 +1699,34 @@ public class HMSTransaction implements Transaction {
 
     @VisibleForTesting
     void deleteTargetPathContents(String targetPath, String excludedChildPath) {
-        Set<String> dirs = new HashSet<>();
-        Status status = fs.listDirectories(targetPath, dirs);
-        if (!status.ok() && !Status.ErrCode.NOT_FOUND.equals(status.getErrCode())) {
-            throw new RuntimeException(
-                    "Failed to list directories under " + targetPath + ":" + status.getErrMsg());
-        }
-        for (String dir : dirs) {
-            if (excludedChildPath != null && pathsEqual(dir, excludedChildPath)) {
-                continue;
+        try {
+            Set<String> dirs = fs.listDirectories(Location.of(targetPath));
+            for (String dir : dirs) {
+                if (excludedChildPath != null && pathsEqual(dir, excludedChildPath)) {
+                    continue;
+                }
+                wrapperDeleteDirWithProfileSummary(dir);
             }
-            Status deleteStatus = wrapperDeleteDirWithProfileSummary(dir);
-            if (!deleteStatus.ok() && !Status.ErrCode.NOT_FOUND.equals(deleteStatus.getErrCode())) {
-                throw new RuntimeException("Failed to delete directory " + dir + ":" + deleteStatus.getErrMsg());
-            }
-        }
 
-        List<RemoteFile> files = new ArrayList<>();
-        status = fs.listFiles(targetPath, false, files);
-        if (!status.ok() && !Status.ErrCode.NOT_FOUND.equals(status.getErrCode())) {
-            throw new RuntimeException(
-                    "Failed to list files under " + targetPath + ":" + status.getErrMsg());
-        }
-        for (RemoteFile file : files) {
-            Status deleteStatus = wrapperDeleteWithProfileSummary(file.getPath().toString());
-            if (!deleteStatus.ok() && !Status.ErrCode.NOT_FOUND.equals(deleteStatus.getErrCode())) {
-                throw new RuntimeException("Failed to delete file " + file.getPath() + ":" + deleteStatus.getErrMsg());
+            List<FileEntry> files = fs.listFiles(Location.of(targetPath));
+            for (FileEntry file : files) {
+                wrapperDeleteWithProfileSummary(file.location().uri());
             }
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to list/delete contents under " + targetPath, e);
         }
     }
 
     @VisibleForTesting
     void ensureDirectory(String path) {
-        Status status = fs.makeDir(path);
-        if (!status.ok()) {
-            throw new RuntimeException("Failed to create directory " + path + ":" + status.getErrMsg());
+        try {
+            fs.mkdirs(Location.of(path));
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to create directory " + path + ": " + e.getMessage(), e);
         }
     }
 
-    public Status wrapperRenameDirWithProfileSummary(String origFilePath,
+    public void wrapperRenameDirWithProfileSummary(String origFilePath,
             String destFilePath,
             Runnable runWhenPathNotExist) {
         summaryProfile.ifPresent(profile -> {
@@ -1771,34 +1734,44 @@ public class HMSTransaction implements Transaction {
             profile.incRenameDirCnt();
         });
 
-        Status status = fs.renameDir(origFilePath, destFilePath, runWhenPathNotExist);
+        try {
+            fs.renameDirectory(Location.of(origFilePath), Location.of(destFilePath), runWhenPathNotExist);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to rename directory from " + origFilePath
+                    + " to " + destFilePath + ": " + e.getMessage(), e);
+        }
 
         summaryProfile.ifPresent(SummaryProfile::freshFilesystemOptTime);
-        return status;
     }
 
-    public Status wrapperDeleteWithProfileSummary(String remotePath) {
+    public void wrapperDeleteWithProfileSummary(String remotePath) {
         summaryProfile.ifPresent(profile -> {
             profile.setTempStartTime();
             profile.incDeleteFileCnt();
         });
 
-        Status status = fs.delete(remotePath);
+        try {
+            fs.delete(Location.of(remotePath), false);
+        } catch (java.io.IOException e) {
+            LOG.warn("Failed to delete {}: {}", remotePath, e.getMessage());
+        }
 
         summaryProfile.ifPresent(SummaryProfile::freshFilesystemOptTime);
-        return status;
     }
 
-    public Status wrapperDeleteDirWithProfileSummary(String remotePath) {
+    public void wrapperDeleteDirWithProfileSummary(String remotePath) {
         summaryProfile.ifPresent(profile -> {
             profile.setTempStartTime();
             profile.incDeleteDirRecursiveCnt();
         });
 
-        Status status = fs.deleteDirectory(remotePath);
+        try {
+            fs.delete(Location.of(remotePath), true);
+        } catch (java.io.IOException e) {
+            LOG.warn("Failed to delete directory {}: {}", remotePath, e.getMessage());
+        }
 
         summaryProfile.ifPresent(SummaryProfile::freshFilesystemOptTime);
-        return status;
     }
 
     public void wrapperAsyncRenameWithProfileSummary(Executor executor,
@@ -1851,22 +1824,25 @@ public class HMSTransaction implements Transaction {
         if (isMockedPartitionUpdate) {
             return;
         }
-        MultipartUploadCapable fileSystem = (MultipartUploadCapable) ((SwitchingFileSystem) fs).fileSystem(path);
+        ObjFileSystem objFs;
+        try {
+            objFs = (ObjFileSystem) ((SpiSwitchingFileSystem) fs).forPath(path);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to resolve filesystem for MPU commit at path: " + path, e);
+        }
         for (TS3MPUPendingUpload s3MPUPendingUpload : s3MpuPendingUploads) {
             asyncFileSystemTaskFutures.add(CompletableFuture.runAsync(() -> {
                 if (fileSystemTaskCancelled.get()) {
                     return;
                 }
-                List<CompletedPart> completedParts = Lists.newArrayList();
-                for (Map.Entry<Integer, String> entry : s3MPUPendingUpload.getEtags().entrySet()) {
-                    completedParts.add(CompletedPart.builder().eTag(entry.getValue()).partNumber(entry.getKey())
-                              .build());
+                String remotePath = "s3://" + s3MPUPendingUpload.getBucket()
+                        + "/" + s3MPUPendingUpload.getKey();
+                try {
+                    objFs.completeMultipartUpload(remotePath, s3MPUPendingUpload.getUploadId(),
+                            s3MPUPendingUpload.getEtags());
+                } catch (java.io.IOException e) {
+                    throw new RuntimeException("Failed to complete MPU for " + remotePath, e);
                 }
-
-                fileSystem.completeMultipartUpload(s3MPUPendingUpload.getBucket(),
-                         s3MPUPendingUpload.getKey(),
-                         s3MPUPendingUpload.getUploadId(),
-                         s3MPUPendingUpload.getEtags());
                 uncompletedMpuPendingUploads.remove(new UncompletedMpuPendingUpload(s3MPUPendingUpload, path));
             }, fileSystemExecutor));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveExternalMetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveExternalMetaCache.java
@@ -45,13 +45,13 @@ import org.apache.doris.datasource.metacache.AbstractExternalMetaCache;
 import org.apache.doris.datasource.metacache.CacheSpec;
 import org.apache.doris.datasource.metacache.MetaCacheEntry;
 import org.apache.doris.datasource.metacache.MetaCacheEntryDef;
+import org.apache.doris.filesystem.spi.FileSystem;
 import org.apache.doris.fs.DirectoryLister;
 import org.apache.doris.fs.FileSystemCache;
 import org.apache.doris.fs.FileSystemDirectoryLister;
 import org.apache.doris.fs.FileSystemIOException;
 import org.apache.doris.fs.RemoteIterator;
 import org.apache.doris.fs.remote.RemoteFile;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges;
 import org.apache.doris.planner.ListPartitionPrunerV2;
 
@@ -395,8 +395,8 @@ public class HiveExternalMetaCache extends AbstractExternalMetaCache {
 
         FileSystemCache.FileSystemCacheKey fileSystemCacheKey = new FileSystemCache.FileSystemCacheKey(
                 path.getFsIdentifier(), path.getStorageProperties());
-        RemoteFileSystem fs = Env.getCurrentEnv().getExtMetaCacheMgr().getFsCache()
-                .getRemoteFileSystem(fileSystemCacheKey);
+        FileSystem fs = Env.getCurrentEnv().getExtMetaCacheMgr().getFsCache()
+                .getFileSystem(fileSystemCacheKey);
         result.setSplittable(HiveUtil.isSplittable(fs, inputFormat, path.getNormalizedLocation()));
 
         boolean isRecursiveDirectories = Boolean.valueOf(
@@ -816,8 +816,8 @@ public class HiveExternalMetaCache extends AbstractExternalMetaCache {
                 HMSExternalCatalog catalog = hmsCatalog(partition.getNameMapping().getCtlId());
                 LocationPath locationPath = LocationPath.of(partition.getPath(),
                         catalog.getCatalogProperty().getStoragePropertiesMap());
-                RemoteFileSystem fileSystem = Env.getCurrentEnv().getExtMetaCacheMgr().getFsCache()
-                        .getRemoteFileSystem(new FileSystemCache.FileSystemCacheKey(
+                FileSystem fileSystem = Env.getCurrentEnv().getExtMetaCacheMgr().getFsCache()
+                        .getFileSystem(new FileSystemCache.FileSystemCacheKey(
                                 locationPath.getNormalizedLocation(),
                                 locationPath.getStorageProperties()));
                 AuthenticationConfig authenticationConfig = AuthenticationConfig

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveUtil.java
@@ -22,8 +22,8 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.statistics.CommonStatistics;
+import org.apache.doris.filesystem.spi.FileSystem;
 import org.apache.doris.fs.remote.BrokerFileSystem;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.qe.ConnectContext;
 
@@ -110,7 +110,7 @@ public final class HiveUtil {
         return (Class<? extends InputFormat<?, ?>>) clazz.asSubclass(InputFormat.class);
     }
 
-    public static boolean isSplittable(RemoteFileSystem remoteFileSystem, String inputFormat,
+    public static boolean isSplittable(FileSystem remoteFileSystem, String inputFormat,
             String location) throws UserException {
         if (remoteFileSystem instanceof BrokerFileSystem) {
             return ((BrokerFileSystem) remoteFileSystem).isSplittable(location, inputFormat);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateFileIO.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateFileIO.java
@@ -17,13 +17,11 @@
 
 package org.apache.doris.datasource.iceberg.fileio;
 
-import org.apache.doris.backup.Status;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.LegacyFileSystemApi;
-import org.apache.doris.fs.io.ParsedPath;
 
-import com.google.common.collect.Iterables;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.ManifestFile;
@@ -34,7 +32,6 @@ import org.apache.iceberg.io.SupportsBulkOperations;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -44,15 +41,14 @@ import java.util.Objects;
  * This class is responsible for bridging Doris file system operations with Iceberg's file IO abstraction.
  */
 public class DelegateFileIO implements SupportsBulkOperations {
-    private static final int DELETE_BATCH_SIZE = 1000;
     /**
      * Properties used to initialize the file system.
      */
     private Map<String, String> properties;
     /**
-     * The underlying Doris file system used for file operations.
+     * The underlying SPI filesystem used for file operations.
      */
-    private LegacyFileSystemApi fileSystem;
+    private FileSystem fileSystem;
 
     /**
      * Default constructor.
@@ -62,11 +58,11 @@ public class DelegateFileIO implements SupportsBulkOperations {
     }
 
     /**
-     * Constructor with a specified FileSystem.
+     * Constructor with a specified SPI FileSystem.
      *
-     * @param fileSystem the Doris file system to delegate operations to
+     * @param fileSystem the SPI filesystem to delegate operations to
      */
-    public DelegateFileIO(LegacyFileSystemApi fileSystem) {
+    public DelegateFileIO(FileSystem fileSystem) {
         this.fileSystem = Objects.requireNonNull(fileSystem, "fileSystem is null");
     }
 
@@ -80,7 +76,11 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public InputFile newInputFile(String path) {
-        return new DelegateInputFile(fileSystem.newInputFile(new ParsedPath(path)));
+        try {
+            return new DelegateInputFile(fileSystem.newInputFile(Location.of(path)));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create InputFile for: " + path, e);
+        }
     }
 
     /**
@@ -92,7 +92,11 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public InputFile newInputFile(String path, long length) {
-        return new DelegateInputFile(fileSystem.newInputFile(new ParsedPath(path), length));
+        try {
+            return new DelegateInputFile(fileSystem.newInputFile(Location.of(path), length));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create InputFile for: " + path, e);
+        }
     }
 
     /**
@@ -103,7 +107,11 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public OutputFile newOutputFile(String path) {
-        return new DelegateOutputFile(fileSystem, new ParsedPath(path));
+        try {
+            return new DelegateOutputFile(fileSystem, Location.of(path));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create OutputFile for: " + path, e);
+        }
     }
 
     // ===================== File Deletion Methods =====================
@@ -116,10 +124,10 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public void deleteFile(String path) {
-        Status status = fileSystem.delete(path);
-        if (!status.ok()) {
-            throw new UncheckedIOException(
-                    new IOException("Failed to delete file: " + path + ", " + status.toString()));
+        try {
+            fileSystem.delete(Location.of(path), false);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to delete file: " + path, e);
         }
     }
 
@@ -154,20 +162,8 @@ public class DelegateFileIO implements SupportsBulkOperations {
      */
     @Override
     public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
-        Iterable<List<String>> partitions = Iterables.partition(pathsToDelete, DELETE_BATCH_SIZE);
-        partitions.forEach(this::deleteBatch);
-    }
-
-    /**
-     * Helper method to delete a batch of files.
-     * Throws UncheckedIOException if deletion fails.
-     *
-     * @param filesToDelete list of file paths to delete
-     */
-    private void deleteBatch(List<String> filesToDelete) {
-        Status status = fileSystem.deleteAll(filesToDelete);
-        if (!status.ok()) {
-            throw new UncheckedIOException(new IOException("Failed to delete some or all files: " + status.toString()));
+        for (String path : pathsToDelete) {
+            deleteFile(path);
         }
     }
 
@@ -229,7 +225,11 @@ public class DelegateFileIO implements SupportsBulkOperations {
     @Override
     public void initialize(Map<String, String> properties) {
         StorageProperties storageProperties = StorageProperties.createPrimary(properties);
-        this.fileSystem = FileSystemFactory.get(storageProperties);
+        try {
+            this.fileSystem = FileSystemFactory.getFileSystem(storageProperties);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create FileSystem for Iceberg FileIO", e);
+        }
         this.properties = properties;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateInputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateInputFile.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.datasource.iceberg.fileio;
 
-import org.apache.doris.fs.io.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisInputFile;
 
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.InputFile;
@@ -69,7 +69,7 @@ public class DelegateInputFile implements InputFile {
      */
     @Override
     public String location() {
-        return inputFile.path().toString();
+        return inputFile.location().toString();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateOutputFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateOutputFile.java
@@ -17,9 +17,9 @@
 
 package org.apache.doris.datasource.iceberg.fileio;
 
-import org.apache.doris.fs.LegacyFileSystemApi;
-import org.apache.doris.fs.io.DorisOutputFile;
-import org.apache.doris.fs.io.ParsedPath;
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
 
 import com.google.common.io.CountingOutputStream;
 import org.apache.iceberg.io.InputFile;
@@ -37,24 +37,20 @@ import java.util.Objects;
  * integration between Doris file system and Iceberg's file IO abstraction.
  */
 public class DelegateOutputFile implements OutputFile {
-    /**
-     * The underlying Doris file system used for file operations.
-     */
-    private final LegacyFileSystemApi fileSystem;
-    /**
-     * The DorisOutputFile instance representing the output file.
-     */
+    /** The SPI filesystem used to create input files for {@link #toInputFile()}. */
+    private final FileSystem fileSystem;
+    /** The underlying Doris output file. */
     private final DorisOutputFile outputFile;
 
     /**
-     * Constructs a DelegateOutputFile with the specified FileSystem and ParsedPath.
+     * Constructs a DelegateOutputFile with the specified SPI FileSystem and Location.
      *
-     * @param fileSystem the Doris file system to delegate operations to
-     * @param path the ParsedPath representing the file location
+     * @param fileSystem the SPI filesystem to delegate operations to
+     * @param location   the file location
      */
-    public DelegateOutputFile(LegacyFileSystemApi fileSystem, ParsedPath path) {
+    public DelegateOutputFile(FileSystem fileSystem, Location location) throws IOException {
         this.fileSystem = Objects.requireNonNull(fileSystem, "fileSystem is null");
-        this.outputFile = fileSystem.newOutputFile(path);
+        this.outputFile = fileSystem.newOutputFile(location);
     }
 
     // ===================== File Creation Methods =====================
@@ -96,7 +92,7 @@ public class DelegateOutputFile implements OutputFile {
      */
     @Override
     public String location() {
-        return outputFile.path().toString();
+        return outputFile.location().toString();
     }
 
     /**
@@ -106,7 +102,11 @@ public class DelegateOutputFile implements OutputFile {
      */
     @Override
     public InputFile toInputFile() {
-        return new DelegateInputFile(fileSystem.newInputFile(outputFile.path()));
+        try {
+            return new DelegateInputFile(fileSystem.newInputFile(outputFile.location()));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create InputFile for: " + location(), e);
+        }
     }
 
     // ===================== Object Methods =====================

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateSeekableInputStream.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/fileio/DelegateSeekableInputStream.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.datasource.iceberg.fileio;
 
-import org.apache.doris.fs.io.DorisInputStream;
+import org.apache.doris.filesystem.spi.DorisInputStream;
 
 import org.apache.iceberg.io.SeekableInputStream;
 
@@ -52,7 +52,7 @@ public class DelegateSeekableInputStream extends SeekableInputStream {
      */
     @Override
     public long getPos() throws IOException {
-        return stream.getPosition();
+        return stream.getPos();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/DirectoryLister.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/DirectoryLister.java
@@ -21,9 +21,10 @@
 package org.apache.doris.fs;
 
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.filesystem.spi.FileSystem;
 import org.apache.doris.fs.remote.RemoteFile;
 
 public interface DirectoryLister {
-    RemoteIterator<RemoteFile> listFiles(LegacyFileSystemApi fs, boolean recursive, TableIf table, String location)
+    RemoteIterator<RemoteFile> listFiles(FileSystem fs, boolean recursive, TableIf table, String location)
             throws FileSystemIOException;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemCache.java
@@ -20,16 +20,17 @@ package org.apache.doris.fs;
 import org.apache.doris.common.CacheFactory;
 import org.apache.doris.common.Config;
 import org.apache.doris.datasource.property.storage.StorageProperties;
-import org.apache.doris.fs.remote.RemoteFileSystem;
+import org.apache.doris.filesystem.spi.FileSystem;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import java.io.IOException;
 import java.util.Objects;
 import java.util.OptionalLong;
 
 public class FileSystemCache {
 
-    private final LoadingCache<FileSystemCacheKey, RemoteFileSystem> fileSystemCache;
+    private final LoadingCache<FileSystemCacheKey, FileSystem> fileSystemCache;
 
     public FileSystemCache() {
         // no need to set refreshAfterWrite, because the FileSystem is created once and never changed
@@ -42,11 +43,15 @@ public class FileSystemCache {
         fileSystemCache = fsCacheFactory.buildCache(this::loadFileSystem);
     }
 
-    private RemoteFileSystem loadFileSystem(FileSystemCacheKey key) {
-        return FileSystemFactory.get(key.properties);
+    private FileSystem loadFileSystem(FileSystemCacheKey key) {
+        try {
+            return FileSystemFactory.getFileSystem(key.properties);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create filesystem for key: " + key, e);
+        }
     }
 
-    public RemoteFileSystem getRemoteFileSystem(FileSystemCacheKey key) {
+    public FileSystem getFileSystem(FileSystemCacheKey key) {
         return fileSystemCache.get(key);
     }
 
@@ -58,6 +63,10 @@ public class FileSystemCache {
         public FileSystemCacheKey(String fsIdent, StorageProperties properties) {
             this.fsIdent = fsIdent;
             this.properties = properties;
+        }
+
+        public StorageProperties getProperties() {
+            return properties;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDescriptor.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.fs;
 
+import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.foundation.fs.FsStorageType;
 
 import com.google.common.collect.Maps;
@@ -68,6 +70,22 @@ public class FileSystemDescriptor {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    /**
+     * Returns the Thrift storage type corresponding to this descriptor's storage type.
+     * Used to populate {@code storage_backend} in BE snapshot/download task RPCs.
+     */
+    public StorageBackend.StorageType getThriftStorageType() {
+        return FsStorageTypeAdapter.toThrift(storageType);
+    }
+
+    /**
+     * Returns the backend configuration properties (AK, SK, endpoint, etc.) needed
+     * by BE to initialize its storage client for snapshot/upload/download tasks.
+     */
+    public Map<String, String> getBackendConfigProperties() {
+        return StorageProperties.createPrimary(properties).getBackendConfigProperties();
     }
 
     /** Creates a FileSystemDescriptor from an existing PersistentFileSystem (migration helper). */

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDescriptor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.fs;
 
 import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.foundation.fs.FsStorageType;
 
@@ -91,5 +92,25 @@ public class FileSystemDescriptor {
     /** Creates a FileSystemDescriptor from an existing PersistentFileSystem (migration helper). */
     public static FileSystemDescriptor fromPersistentFileSystem(PersistentFileSystem fs) {
         return new FileSystemDescriptor(fs.getStorageType(), fs.getName(), fs.getProperties());
+    }
+
+    /**
+     * Creates a FileSystemDescriptor from a StorageProperties instance.
+     * The {@code fsName} is the broker name for BROKER type, or empty for others.
+     */
+    public static FileSystemDescriptor fromStorageProperties(StorageProperties storageProperties, String fsName) {
+        FsStorageType storageType = storageNameToFsType(storageProperties.getStorageName());
+        return new FileSystemDescriptor(storageType, fsName, storageProperties.getOrigProps());
+    }
+
+    private static FsStorageType storageNameToFsType(String name) {
+        switch (name) {
+            case "S3":      return FsStorageType.S3;
+            case "HDFS":    return FsStorageType.HDFS;
+            case "BROKER":  return FsStorageType.BROKER;
+            case "AZURE":   return FsStorageType.AZURE;
+            case "OSSHDFS": return FsStorageType.OSS_HDFS;
+            default: throw new IllegalArgumentException("Unsupported storage type name: " + name);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDescriptor.java
@@ -18,7 +18,6 @@
 package org.apache.doris.fs;
 
 import org.apache.doris.analysis.StorageBackend;
-import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.foundation.fs.FsStorageType;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDirectoryLister.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemDirectoryLister.java
@@ -17,22 +17,31 @@
 
 package org.apache.doris.fs;
 
-import org.apache.doris.backup.Status;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileSystem;
 import org.apache.doris.fs.remote.RemoteFile;
 
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class FileSystemDirectoryLister implements DirectoryLister {
-    public RemoteIterator<RemoteFile> listFiles(LegacyFileSystemApi fs, boolean recursive,
+    public RemoteIterator<RemoteFile> listFiles(FileSystem fs, boolean recursive,
             TableIf table, String location)
             throws FileSystemIOException {
-        List<RemoteFile> result = new ArrayList<>();
-        Status status = fs.listFiles(location, recursive, result);
-        if (!status.ok()) {
-            throw new FileSystemIOException(status.getErrCode(), status.getErrMsg());
+        try {
+            List<FileEntry> entries = FileSystemTransferUtil.globList(fs, location, recursive);
+            List<RemoteFile> result = new ArrayList<>(entries.size());
+            for (FileEntry e : entries) {
+                Path hadoopPath = new Path(e.location().uri());
+                result.add(new RemoteFile(hadoopPath, e.isDirectory(), e.length(), -1L, 0L, null));
+            }
+            return new RemoteFileRemoteIterator(result);
+        } catch (IOException ex) {
+            throw new FileSystemIOException(ex.getMessage(), ex);
         }
-        return new RemoteFileRemoteIterator(result);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemFactory.java
@@ -40,20 +40,23 @@ import java.util.ServiceLoader;
  *       delegates to {@link StorageTypeMapper}; returns {@link RemoteFileSystem}. All existing
  *       fe-core callers continue to use this path unchanged.</li>
  *   <li><b>SPI API</b> ({@code getFileSystem(Map)} / {@code getFileSystem(StorageProperties)}) —
- *       uses Java ServiceLoader to discover {@link FileSystemProvider} implementations at runtime;
- *       returns {@code org.apache.doris.filesystem.spi.FileSystem}. New code should use this path.
- *       Adding a new storage backend requires only a new Maven module; zero changes here.</li>
+ *       delegates to {@link FileSystemPluginManager}; returns
+ *       {@code org.apache.doris.filesystem.spi.FileSystem}. New code should use this path.</li>
  * </ul>
  *
- * <p>Compile-time dependency on {@code fe-filesystem-spi} only. All implementation modules
- * ({@code fe-filesystem-s3}, {@code fe-filesystem-hdfs}, …) are runtime-only dependencies
- * discovered via {@code META-INF/services}.
+ * <p>Call {@link #initPluginManager(FileSystemPluginManager)} at FE startup before any
+ * {@code getFileSystem()} call. In production, providers are loaded from the plugin directory
+ * configured via {@code filesystem_plugin_root}. In unit tests, providers are discovered from
+ * the test classpath via ServiceLoader.
  */
 public final class FileSystemFactory {
 
     private static final Logger LOG = LogManager.getLogger(FileSystemFactory.class);
 
-    // SPI provider cache (loaded once, reloadable in tests)
+    // Plugin manager singleton, set at FE startup
+    private static volatile FileSystemPluginManager pluginManager;
+
+    // Fallback provider cache for non-initialized environments (tests, migration phase)
     private static volatile List<FileSystemProvider> cachedProviders = null;
 
     private FileSystemFactory() {}
@@ -91,12 +94,23 @@ public final class FileSystemFactory {
     }
 
     // =========================================================
-    // SPI API — ServiceLoader-based, returns spi.FileSystem
+    // SPI API — returns spi.FileSystem
     // =========================================================
 
     /**
-     * SPI entry point: discovers and selects a {@link FileSystemProvider} via ServiceLoader,
-     * then creates the filesystem.
+     * Sets the plugin manager singleton. Called once at FE startup before any
+     * {@code getFileSystem()} invocation.
+     */
+    public static void initPluginManager(FileSystemPluginManager manager) {
+        pluginManager = manager;
+    }
+
+    /**
+     * SPI entry point: selects a provider and creates the filesystem.
+     *
+     * <p>If {@link #initPluginManager} has been called (production path),
+     * delegates to {@link FileSystemPluginManager#createFileSystem}.
+     * Otherwise falls back to ServiceLoader discovery (unit-test / migration path).
      *
      * @param properties key-value storage configuration
      * @return initialized {@code org.apache.doris.filesystem.spi.FileSystem}
@@ -104,6 +118,11 @@ public final class FileSystemFactory {
      */
     public static org.apache.doris.filesystem.spi.FileSystem getFileSystem(Map<String, String> properties)
             throws IOException {
+        FileSystemPluginManager mgr = pluginManager;
+        if (mgr != null) {
+            return mgr.createFileSystem(properties);
+        }
+        // Fallback: ServiceLoader discovery (unit-test / migration path)
         List<FileSystemProvider> providers = getProviders();
         List<String> tried = new ArrayList<>();
         for (FileSystemProvider provider : providers) {
@@ -131,7 +150,8 @@ public final class FileSystemFactory {
     }
 
     /**
-     * Returns all discovered SPI providers. Uses cached list after first load.
+     * Returns all discovered SPI providers via ServiceLoader. Uses cached list after first load.
+     * Used only in the fallback path when pluginManager is not initialized.
      * Package-private for testing.
      */
     static List<FileSystemProvider> getProviders() {
@@ -155,9 +175,10 @@ public final class FileSystemFactory {
     }
 
     /**
-     * Clears the SPI provider cache. For testing only.
+     * Clears the SPI provider cache and plugin manager. For testing only.
      */
     static void clearProviderCache() {
         cachedProviders = null;
+        pluginManager = null;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemFactory.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -180,5 +181,30 @@ public final class FileSystemFactory {
     static void clearProviderCache() {
         cachedProviders = null;
         pluginManager = null;
+    }
+
+    /**
+     * Creates a broker-backed {@link org.apache.doris.filesystem.spi.FileSystem} using a
+     * pre-resolved broker endpoint.
+     *
+     * <p>The caller is responsible for resolving the broker name to a live host:port via
+     * {@code BrokerMgr.getBroker()} before calling this method. This keeps {@code BrokerMgr}
+     * coupling in fe-core only; the {@code fe-filesystem-broker} module has zero fe-core dependency.
+     *
+     * @param host        live broker host (already resolved from BrokerMgr)
+     * @param port        live broker Thrift port
+     * @param clientId    FE identifier sent to broker for logging (e.g. "host:editLogPort")
+     * @param brokerParams broker-specific params (username, password, hadoop config, ...)
+     * @return initialized {@code org.apache.doris.filesystem.spi.FileSystem}
+     * @throws IOException if the broker filesystem provider is not found or creation fails
+     */
+    public static org.apache.doris.filesystem.spi.FileSystem getBrokerFileSystem(
+            String host, int port, String clientId, Map<String, String> brokerParams) throws IOException {
+        Map<String, String> props = new HashMap<>(brokerParams);
+        props.put("_STORAGE_TYPE_", "BROKER");
+        props.put("BROKER_HOST", host);
+        props.put("BROKER_PORT", String.valueOf(port));
+        props.put("BROKER_CLIENT_ID", clientId);
+        return getFileSystem(props);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemPluginManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemPluginManager.java
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.extension.loader.ClassLoadingPolicy;
+import org.apache.doris.extension.loader.DirectoryPluginRuntimeManager;
+import org.apache.doris.extension.loader.LoadFailure;
+import org.apache.doris.extension.loader.LoadReport;
+import org.apache.doris.extension.loader.PluginHandle;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.FileSystemProvider;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Manages lifecycle of FileSystemProvider plugins.
+ *
+ * <p>Discovery order:
+ * 1. ServiceLoader scan (classpath-based built-ins / test overrides)
+ * 2. DirectoryPluginRuntimeManager scan (production plugin directories)
+ *
+ * <p>The first provider that returns {@code supports(props) == true} is used.
+ * Classpath providers have higher priority than directory-loaded providers.
+ */
+public class FileSystemPluginManager {
+
+    private static final Logger LOG = LogManager.getLogger(FileSystemPluginManager.class);
+
+    private static final List<String> FS_PARENT_FIRST_PREFIXES =
+            Collections.singletonList("org.apache.doris.filesystem.");
+
+    private final List<FileSystemProvider> providers = new CopyOnWriteArrayList<>();
+    private final DirectoryPluginRuntimeManager<FileSystemProvider> runtimeManager =
+            new DirectoryPluginRuntimeManager<>();
+    private final ClassLoadingPolicy classLoadingPolicy =
+            new ClassLoadingPolicy(FS_PARENT_FIRST_PREFIXES);
+
+    /** Called at FE startup to load built-in providers from classpath. */
+    public void loadBuiltins() {
+        ServiceLoader.load(FileSystemProvider.class)
+                .forEach(p -> {
+                    providers.add(p);
+                    LOG.info("Registered built-in filesystem provider: {}", p.name());
+                });
+    }
+
+    /**
+     * Loads filesystem provider plugins from plugin root directories.
+     * Failures are logged as warnings; partial success is allowed.
+     *
+     * @param pluginRoots directories to scan for filesystem plugin subdirectories
+     */
+    public void loadPlugins(List<Path> pluginRoots) {
+        LoadReport<FileSystemProvider> report = runtimeManager.loadAll(
+                pluginRoots,
+                FileSystemPluginManager.class.getClassLoader(),
+                FileSystemProvider.class,
+                classLoadingPolicy);
+
+        LOG.info("Filesystem plugin load summary: rootsScanned={}, dirsScanned={}, "
+                        + "successCount={}, failureCount={}",
+                report.getRootsScanned(), report.getDirsScanned(),
+                report.getSuccesses().size(), report.getFailures().size());
+
+        for (LoadFailure failure : report.getFailures()) {
+            LOG.warn("Filesystem plugin load failure: dir={}, stage={}, message={}",
+                    failure.getPluginDir(), failure.getStage(), failure.getMessage(),
+                    failure.getCause());
+        }
+
+        for (PluginHandle<FileSystemProvider> handle : report.getSuccesses()) {
+            providers.add(handle.getFactory());
+            LOG.info("Loaded filesystem plugin: name={}, pluginDir={}, jarCount={}",
+                    handle.getPluginName(), handle.getPluginDir(),
+                    handle.getResolvedJars().size());
+        }
+    }
+
+    /**
+     * Creates a FileSystem for the given properties by selecting the first supporting provider.
+     *
+     * @throws IOException if no provider supports the properties, or creation fails
+     */
+    public FileSystem createFileSystem(Map<String, String> properties) throws IOException {
+        for (FileSystemProvider provider : providers) {
+            if (provider.supports(properties)) {
+                return provider.create(properties);
+            }
+        }
+        throw new IOException("No FileSystemProvider supports the given properties: "
+                + properties.get("type") + ". Registered providers: " + providerNames());
+    }
+
+    /** Registers a provider at highest priority. For testing overrides. */
+    public void registerProvider(FileSystemProvider provider) {
+        providers.add(0, provider);
+    }
+
+    private String providerNames() {
+        List<String> names = new ArrayList<>();
+        for (FileSystemProvider p : providers) {
+            names.add(p.name());
+        }
+        return names.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemProviderImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemProviderImpl.java
@@ -38,7 +38,7 @@ public class FileSystemProviderImpl implements LegacyFileSystemProviderFactory {
     @Override
     public LegacyFileSystemApi get(SessionContext ctx) {
         return new SwitchingFileSystem(
-                key -> extMetaCacheMgr.getFsCache().getRemoteFileSystem(key),
+                key -> FileSystemFactory.get(key.getProperties()),
                 storagePropertiesMap);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemTransferUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemTransferUtil.java
@@ -1,0 +1,179 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileIterator;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for spi.FileSystem that provide higher-level transfer operations.
+ * All operations are built on the core spi.FileSystem primitives.
+ */
+public final class FileSystemTransferUtil {
+
+    private FileSystemTransferUtil() {}
+
+    /**
+     * Downloads a remote file to a local path.
+     *
+     * @param expectedSize if > 0, verifies the downloaded byte count matches
+     */
+    public static void download(FileSystem fs, Location remote,
+            Path localPath, long expectedSize) throws IOException {
+        DorisInputFile input = fs.newInputFile(remote);
+        try (InputStream in = input.newStream()) {
+            long copied = Files.copy(in, localPath, StandardCopyOption.REPLACE_EXISTING);
+            if (expectedSize > 0 && copied != expectedSize) {
+                throw new IOException(String.format(
+                        "Downloaded file size mismatch: expected %d, got %d for %s",
+                        expectedSize, copied, remote));
+            }
+        }
+    }
+
+    /**
+     * Uploads a local file to a remote location.
+     */
+    public static void upload(FileSystem fs, Path localPath, Location remote) throws IOException {
+        DorisOutputFile output = fs.newOutputFile(remote);
+        try (OutputStream out = output.createOrOverwrite();
+                InputStream in = Files.newInputStream(localPath)) {
+            copyStream(in, out);
+        }
+    }
+
+    /**
+     * Writes a string directly to a remote location without a local temp file.
+     */
+    public static void directUpload(FileSystem fs, String content,
+            Location remote) throws IOException {
+        DorisOutputFile output = fs.newOutputFile(remote);
+        try (OutputStream out = output.createOrOverwrite()) {
+            out.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Lists all files under a location, optionally matching a glob pattern.
+     * The glob pattern may contain {@code *} (any chars except '/') and {@code ?} (single char).
+     *
+     * @param locationStr remote path, may contain glob wildcards
+     * @param recursive   whether to recurse into subdirectories
+     */
+    public static List<FileEntry> globList(FileSystem fs, String locationStr,
+            boolean recursive) throws IOException {
+        int wildcardIdx = indexOfFirstWildcard(locationStr);
+        String basePath = wildcardIdx < 0
+                ? locationStr
+                : locationStr.substring(0, locationStr.lastIndexOf('/', wildcardIdx) + 1);
+        Pattern pattern = wildcardIdx < 0 ? null : globToRegex(locationStr);
+
+        List<FileEntry> result = new ArrayList<>();
+        collectEntries(fs, Location.of(basePath), pattern, recursive, result);
+        return result;
+    }
+
+    // ---- private helpers ----
+
+    private static void copyStream(InputStream in, OutputStream out) throws IOException {
+        byte[] buf = new byte[8192];
+        int read;
+        while ((read = in.read(buf)) != -1) {
+            out.write(buf, 0, read);
+        }
+    }
+
+    private static void collectEntries(FileSystem fs, Location base,
+            Pattern pattern, boolean recursive,
+            List<FileEntry> result) throws IOException {
+        try (FileIterator iter = fs.list(base)) {
+            while (iter.hasNext()) {
+                FileEntry entry = iter.next();
+                if (entry.isDirectory()) {
+                    if (recursive) {
+                        collectEntries(fs, entry.location(), pattern, true, result);
+                    }
+                } else {
+                    if (pattern == null || pattern.matcher(entry.location().uri()).matches()) {
+                        result.add(entry);
+                    }
+                }
+            }
+        }
+    }
+
+    private static int indexOfFirstWildcard(String path) {
+        int star = path.indexOf('*');
+        int question = path.indexOf('?');
+        if (star < 0) {
+            return question;
+        }
+        if (question < 0) {
+            return star;
+        }
+        return Math.min(star, question);
+    }
+
+    /** Converts a glob pattern (with * and ?) to a java.util.regex.Pattern. */
+    static Pattern globToRegex(String glob) {
+        StringBuilder sb = new StringBuilder("^");
+        for (char c : glob.toCharArray()) {
+            switch (c) {
+                case '*':
+                    sb.append("[^/]*");
+                    break;
+                case '?':
+                    sb.append("[^/]");
+                    break;
+                case '.':
+                case '(':
+                case ')':
+                case '[':
+                case ']':
+                case '{':
+                case '}':
+                case '^':
+                case '$':
+                case '|':
+                case '+':
+                case '\\':
+                    sb.append('\\').append(c);
+                    break;
+                default:
+                    sb.append(c);
+            }
+        }
+        sb.append("$");
+        return Pattern.compile(sb.toString());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemUtil.java
@@ -17,7 +17,8 @@
 
 package org.apache.doris.fs;
 
-import org.apache.doris.backup.Status;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
 
 import org.apache.hadoop.fs.Path;
 
@@ -28,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FileSystemUtil {
 
-    public static void asyncRenameFiles(LegacyFileSystemApi fs,
+    public static void asyncRenameFiles(FileSystem fs,
                                         Executor executor,
                                         List<CompletableFuture<?>> renameFileFutures,
                                         AtomicBoolean cancelled,
@@ -42,15 +43,16 @@ public class FileSystemUtil {
                 if (cancelled.get()) {
                     return;
                 }
-                Status status = fs.rename(source.toString(), target.toString());
-                if (!status.ok()) {
-                    throw new RuntimeException(status.getErrMsg());
+                try {
+                    fs.rename(Location.of(source.toString()), Location.of(target.toString()));
+                } catch (java.io.IOException e) {
+                    throw new RuntimeException(e.getMessage(), e);
                 }
             }, executor));
         }
     }
 
-    public static void asyncRenameDir(LegacyFileSystemApi fs,
+    public static void asyncRenameDir(FileSystem fs,
                                       Executor executor,
                                       List<CompletableFuture<?>> renameFileFutures,
                                       AtomicBoolean cancelled,
@@ -61,10 +63,12 @@ public class FileSystemUtil {
             if (cancelled.get()) {
                 return;
             }
-            Status status = fs.renameDir(origFilePath, destFilePath, runWhenPathNotExist);
-            if (!status.ok()) {
-                throw new RuntimeException(status.getErrMsg());
+            try {
+                fs.renameDirectory(Location.of(origFilePath), Location.of(destFilePath), runWhenPathNotExist);
+            } catch (java.io.IOException e) {
+                throw new RuntimeException(e.getMessage(), e);
             }
         }, executor));
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/MemoryFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/MemoryFileSystem.java
@@ -220,8 +220,61 @@ public class MemoryFileSystem implements FileSystem {
             if (data == null) {
                 throw new IOException("File not found: " + location);
             }
-            throw new UnsupportedOperationException(
-                    "MemoryFileSystem.newStream() requires DorisInputStream wrapper — implement in Phase 2");
+            return new MemorySeekableInputStream(data);
+        }
+    }
+
+    /** In-memory seekable stream over a fixed byte array. For testing only. */
+    private static class MemorySeekableInputStream extends DorisInputStream {
+        private final byte[] data;
+        private int position;
+        private boolean closed;
+
+        MemorySeekableInputStream(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public long getPosition() throws IOException {
+            return position;
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            if (pos < 0 || pos > data.length) {
+                throw new IOException("Seek out of range [0, " + data.length + "]: " + pos);
+            }
+            position = (int) pos;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (closed) {
+                throw new IOException("Stream closed");
+            }
+            if (position >= data.length) {
+                return -1;
+            }
+            return data[position++] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (closed) {
+                throw new IOException("Stream closed");
+            }
+            if (position >= data.length) {
+                return -1;
+            }
+            int n = Math.min(len, data.length - position);
+            System.arraycopy(data, position, b, off, n);
+            position += n;
+            return n;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/SpiSwitchingFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/SpiSwitchingFileSystem.java
@@ -1,0 +1,175 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.common.util.LocationPath;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileIterator;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.GlobListing;
+import org.apache.doris.filesystem.spi.Location;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SPI-compatible replacement for the legacy {@code SwitchingFileSystem}.
+ *
+ * <p>Implements {@link FileSystem} and routes each operation to the appropriate
+ * {@link FileSystem} based on the URI scheme / authority of the path operand.  The
+ * storage-type → {@link StorageProperties} mapping comes from the catalog's
+ * {@code storagePropertiesMap}.
+ *
+ * <p>Resolved {@link FileSystem} instances are cached per {@link StorageProperties} reference
+ * (identity-based) to avoid recreating connections on every call.
+ */
+public class SpiSwitchingFileSystem implements FileSystem {
+
+    private final Map<StorageProperties.Type, StorageProperties> storagePropertiesMap;
+    /** Non-null only when created via the test constructor — all paths delegate here. */
+    private FileSystem testDelegate;
+    /**
+     * Cache: StorageProperties (identity) → spi.FileSystem.
+     * Using identity comparison is correct because the properties map values are stable
+     * objects owned by the catalog instance.
+     */
+    private final Map<StorageProperties, FileSystem> cache = new ConcurrentHashMap<>();
+
+    public SpiSwitchingFileSystem(Map<StorageProperties.Type, StorageProperties> storagePropertiesMap) {
+        this.storagePropertiesMap = storagePropertiesMap;
+    }
+
+    /**
+     * Testing constructor: routes every path to the supplied {@link FileSystem} delegate.
+     * Should never be used in production code.
+     */
+    @VisibleForTesting
+    public SpiSwitchingFileSystem(FileSystem testDelegate) {
+        this.storagePropertiesMap = java.util.Collections.emptyMap();
+        this.testDelegate = testDelegate;
+    }
+
+    /** Resolves the appropriate {@link FileSystem} for the given URI string. */
+    public FileSystem forPath(String uri) throws IOException {
+        if (testDelegate != null) {
+            return testDelegate;
+        }
+        LocationPath lp = LocationPath.of(uri, storagePropertiesMap);
+        StorageProperties sp = lp.getStorageProperties();
+        if (sp == null) {
+            throw new IOException("No StorageProperties found for path: " + uri);
+        }
+        return cache.computeIfAbsent(sp, props -> {
+            try {
+                return FileSystemFactory.getFileSystem(props);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create FileSystem for path " + uri, e);
+            }
+        });
+    }
+
+    /** Resolves the appropriate {@link FileSystem} for the given {@link Location}. */
+    public FileSystem forLocation(Location location) throws IOException {
+        return forPath(location.uri());
+    }
+
+    // -----------------------------------------------------------------------
+    // FileSystem interface — each method delegates to the per-path filesystem
+    // -----------------------------------------------------------------------
+
+    @Override
+    public boolean exists(Location location) throws IOException {
+        return forLocation(location).exists(location);
+    }
+
+    @Override
+    public void mkdirs(Location location) throws IOException {
+        forLocation(location).mkdirs(location);
+    }
+
+    @Override
+    public void delete(Location location, boolean recursive) throws IOException {
+        forLocation(location).delete(location, recursive);
+    }
+
+    @Override
+    public void rename(Location src, Location dst) throws IOException {
+        forLocation(src).rename(src, dst);
+    }
+
+    @Override
+    public FileIterator list(Location location) throws IOException {
+        return forLocation(location).list(location);
+    }
+
+    @Override
+    public List<FileEntry> listFiles(Location dir) throws IOException {
+        return forLocation(dir).listFiles(dir);
+    }
+
+    @Override
+    public List<FileEntry> listFilesRecursive(Location dir) throws IOException {
+        return forLocation(dir).listFilesRecursive(dir);
+    }
+
+    @Override
+    public Set<String> listDirectories(Location dir) throws IOException {
+        return forLocation(dir).listDirectories(dir);
+    }
+
+    @Override
+    public void renameDirectory(Location src, Location dst, Runnable whenSrcNotExists)
+            throws IOException {
+        forLocation(src).renameDirectory(src, dst, whenSrcNotExists);
+    }
+
+    @Override
+    public DorisInputFile newInputFile(Location location) throws IOException {
+        return forLocation(location).newInputFile(location);
+    }
+
+    @Override
+    public DorisInputFile newInputFile(Location location, long length) throws IOException {
+        return forLocation(location).newInputFile(location, length);
+    }
+
+    @Override
+    public DorisOutputFile newOutputFile(Location location) throws IOException {
+        return forLocation(location).newOutputFile(location);
+    }
+
+    @Override
+    public GlobListing globListWithLimit(Location path, String startAfter, long maxBytes,
+            long maxFiles) throws IOException {
+        return forLocation(path).globListWithLimit(path, startAfter, maxBytes, maxFiles);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // The cached FileSystem instances are shared; do not close here.
+        // Lifecycle is managed by the catalog.
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/StoragePropertiesConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/StoragePropertiesConverter.java
@@ -23,6 +23,8 @@ import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.HdfsCompatibleProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,6 +58,19 @@ public final class StoragePropertiesConverter {
             map.put("AWS_ACCESS_KEY", s3Props.getAccessKey());
             map.put("AWS_REGION", s3Props.getRegion());
             map.put("_STORAGE_TYPE_", s3Props.getStorageName());
+            // Bucket is required by cloud-specific operations (listObjectsWithPrefix, getPresignedUrl, etc.)
+            if (StringUtils.isNotBlank(s3Props.getBucket())) {
+                map.put("AWS_BUCKET", s3Props.getBucket());
+            }
+            // Pass through STS role ARN and external ID when present in original properties
+            String roleArn = s3Props.getOrigProps().get("sts.role_arn");
+            if (StringUtils.isNotBlank(roleArn)) {
+                map.put("AWS_ROLE_ARN", roleArn);
+            }
+            String externalId = s3Props.getOrigProps().get("sts.external_id");
+            if (StringUtils.isNotBlank(externalId)) {
+                map.put("AWS_EXTERNAL_ID", externalId);
+            }
         } else if (props instanceof AzureProperties) {
             AzureProperties azureProps = (AzureProperties) props;
             map.put("AZURE_ACCOUNT_NAME", azureProps.getAccountName());

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/TransactionScopeCachingDirectoryLister.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/TransactionScopeCachingDirectoryLister.java
@@ -68,13 +68,14 @@ public class TransactionScopeCachingDirectoryLister implements DirectoryLister {
     }
 
     @Override
-    public RemoteIterator<RemoteFile> listFiles(LegacyFileSystemApi fs, boolean recursive,
+    public RemoteIterator<RemoteFile> listFiles(org.apache.doris.filesystem.spi.FileSystem fs, boolean recursive,
             TableIf table, String location)
             throws FileSystemIOException {
         return listInternal(fs, recursive, table, new TransactionDirectoryListingCacheKey(transactionId, location));
     }
 
-    private RemoteIterator<RemoteFile> listInternal(LegacyFileSystemApi fs, boolean recursive, TableIf table,
+    private RemoteIterator<RemoteFile> listInternal(org.apache.doris.filesystem.spi.FileSystem fs,
+                                                    boolean recursive, TableIf table,
                                                     TransactionDirectoryListingCacheKey cacheKey)
             throws FileSystemIOException {
         FetchingValueHolder cachedValueHolder;
@@ -95,7 +96,9 @@ public class TransactionScopeCachingDirectoryLister implements DirectoryLister {
         return cachingRemoteIterator(cachedValueHolder, cacheKey);
     }
 
-    private RemoteIterator<RemoteFile> createListingRemoteIterator(LegacyFileSystemApi fs, boolean recursive,
+    private RemoteIterator<RemoteFile> createListingRemoteIterator(
+                                                                   org.apache.doris.filesystem.spi.FileSystem fs,
+                                                                   boolean recursive,
                                                                    TableIf table,
                                                                    TransactionDirectoryListingCacheKey cacheKey)
             throws FileSystemIOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CopyIntoAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CopyIntoAction.java
@@ -29,8 +29,8 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.DorisHttpException;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.ObjFileSystem;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.exception.UnauthorizedException;
 import org.apache.doris.httpv2.rest.manager.HttpUtils;
@@ -188,7 +188,7 @@ public class CopyIntoAction extends RestBaseController {
             // 2. use ObjFileSystem to get pre-signedUrl
             ObjectInfo objectInfo = new ObjectInfo(objPb);
             StorageProperties storageProps = ObjectInfoAdapter.toStorageProperties(objectInfo);
-            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.get(storageProps);
+            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.getFileSystem(storageProps);
             String signedUrl = fs.getPresignedUrl(fileName);
             long elapseMs = System.currentTimeMillis() - startTime;
             MetricRepo.HISTO_HTTP_COPY_INTO_UPLOAD_LATENCY.update(elapseMs);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/s3/S3SourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/s3/S3SourceOffsetProvider.java
@@ -17,13 +17,13 @@
 
 package org.apache.doris.job.offset.s3;
 
-import org.apache.doris.backup.Status;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.GlobListing;
+import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.GlobListResult;
-import org.apache.doris.fs.remote.RemoteFile;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.job.extensions.insert.streaming.StreamingJobProperties;
 import org.apache.doris.job.offset.Offset;
 import org.apache.doris.job.offset.SourceOffsetProvider;
@@ -40,7 +40,6 @@ import com.google.gson.reflect.TypeToken;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,24 +61,19 @@ public class S3SourceOffsetProvider implements SourceOffsetProvider {
         Map<String, String> copiedProps = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         copiedProps.putAll(properties);
         S3Offset offset = new S3Offset();
-        List<RemoteFile> rfiles = new ArrayList<>();
         String startFile = currentOffset == null ? null : currentOffset.endFile;
         String filePath = null;
         StorageProperties storageProperties = StorageProperties.createPrimary(copiedProps);
-        try (RemoteFileSystem fileSystem = FileSystemFactory.get(storageProperties)) {
+        try (FileSystem fileSystem = FileSystemFactory.getFileSystem(storageProperties)) {
             String uri = storageProperties.validateAndGetUri(copiedProps);
             filePath = storageProperties.validateAndNormalizeUri(uri);
-            GlobListResult globListResult = fileSystem.globListWithLimit(filePath, rfiles, startFile,
+            GlobListing globListing = fileSystem.globListWithLimit(Location.of(filePath), startFile,
                     jobProps.getS3BatchBytes(), jobProps.getS3BatchFiles());
-            if (globListResult == null || !globListResult.getStatus().ok()) {
-                String errMsg = globListResult != null
-                        ? globListResult.getStatus().getErrMsg() : "null result";
-                throw new RuntimeException("Failed to list S3 files: " + errMsg);
-            }
 
+            List<FileEntry> rfiles = globListing.getFiles();
             if (!rfiles.isEmpty()) {
-                String bucket = globListResult.getBucket();
-                String prefix = globListResult.getPrefix();
+                String bucket = globListing.getBucket();
+                String prefix = globListing.getPrefix();
 
                 String bucketBase = "s3://" + bucket + "/";
                 // Get the path of the last directory
@@ -87,19 +81,19 @@ public class S3SourceOffsetProvider implements SourceOffsetProvider {
                 String basePrefix = (lastSlash >= 0) ? prefix.substring(0, lastSlash + 1) : "";
                 String filePathBase = bucketBase + basePrefix;
                 String joined = rfiles.stream()
-                        .map(path -> path.getName().replace(filePathBase, ""))
+                        .map(entry -> entry.location().uri().replace(filePathBase, ""))
                         .collect(Collectors.joining(","));
 
                 String normalizedPrefix = basePrefix.endsWith("/")
                         ? basePrefix.substring(0, basePrefix.length() - 1) : basePrefix;
                 String finalFileLists = String.format("s3://%s/%s/{%s}", bucket, normalizedPrefix, joined);
-                String beginFile = rfiles.get(0).getName().replace(bucketBase, "");
-                String lastFile = rfiles.get(rfiles.size() - 1).getName().replace(bucketBase, "");
+                String beginFile = rfiles.get(0).location().uri().replace(bucketBase, "");
+                String lastFile = rfiles.get(rfiles.size() - 1).location().uri().replace(bucketBase, "");
                 offset.setFileLists(finalFileLists);
                 offset.setStartFile(beginFile);
                 offset.setEndFile(lastFile);
                 offset.setFileNum(rfiles.size());
-                maxEndFile = globListResult.getMaxFile();
+                maxEndFile = globListing.getMaxFile();
             } else {
                 throw new RuntimeException("No new files found in path: " + filePath);
             }
@@ -164,23 +158,16 @@ public class S3SourceOffsetProvider implements SourceOffsetProvider {
         copiedProps.putAll(properties);
         StorageProperties storageProperties = StorageProperties.createPrimary(copiedProps);
         String startFile = currentOffset == null ? null : currentOffset.endFile;
-        try (RemoteFileSystem fileSystem = FileSystemFactory.get(storageProperties)) {
+        try (FileSystem fileSystem = FileSystemFactory.getFileSystem(storageProperties)) {
             String uri = storageProperties.validateAndGetUri(copiedProps);
             String filePath = storageProperties.validateAndNormalizeUri(uri);
-            List<RemoteFile> objects = new ArrayList<>();
-            GlobListResult globListResult = fileSystem.globListWithLimit(filePath, objects, startFile, 1, 1);
-            // debug point: simulate globListWithLimit returning a failed status (e.g. S3 auth error)
+            // debug point: simulate globListWithLimit throwing an IOException (e.g. S3 auth error)
             if (DebugPointUtil.isEnable("S3SourceOffsetProvider.fetchRemoteMeta.error")) {
-                globListResult = new GlobListResult(new Status(Status.ErrCode.COMMON_ERROR,
-                        "debug point: simulated S3 auth error"));
+                throw new java.io.IOException("debug point: simulated S3 auth error");
             }
-            if (globListResult == null || !globListResult.getStatus().ok()) {
-                String errMsg = globListResult != null
-                        ? globListResult.getStatus().getErrMsg() : "null result";
-                throw new Exception("Failed to list S3 files: " + errMsg);
-            }
-            if (!objects.isEmpty() && StringUtils.isNotEmpty(globListResult.getMaxFile())) {
-                maxEndFile = globListResult.getMaxFile();
+            GlobListing globListing = fileSystem.globListWithLimit(Location.of(filePath), startFile, 1, 1);
+            if (!globListing.getFiles().isEmpty() && StringUtils.isNotEmpty(globListing.getMaxFile())) {
+                maxEndFile = globListing.getMaxFile();
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateStageCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateStageCommand.java
@@ -39,8 +39,8 @@ import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.InternalErrorCode;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.ObjFileSystem;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.commands.info.StageProperties;
@@ -123,7 +123,7 @@ public class CreateStageCommand extends Command implements ForwardWithSync, Need
 
             ObjectInfo objectInfo = ObjectInfoAdapter.analyzeStageObjectStoreInfo(stagePB);
             StorageProperties storageProps = ObjectInfoAdapter.toStorageProperties(objectInfo);
-            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.get(storageProps);
+            ObjFileSystem fs = (ObjFileSystem) FileSystemFactory.getFileSystem(storageProps);
 
             // headObjectWithMeta does not throw exception if key does not exist.
             fs.headObjectWithMeta(objectInfo.getPrefix(), "1");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTVFCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTVFCommand.java
@@ -25,8 +25,8 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.BrokerUtil;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
@@ -192,11 +192,10 @@ public class InsertIntoTVFCommand extends Command implements ForwardWithSync, Ex
         fsCopyProps.remove("compress_type");
 
         StorageProperties storageProps = StorageProperties.createPrimary(fsCopyProps);
-        RemoteFileSystem fs = FileSystemFactory.get(storageProps);
-        org.apache.doris.backup.Status deleteStatus = fs.deleteDirectory(parentDir);
-        if (!deleteStatus.ok()) {
-            throw new UserException("Failed to delete existing files in "
-                    + parentDir + ": " + deleteStatus.getErrMsg());
+        try (org.apache.doris.filesystem.spi.FileSystem fs = FileSystemFactory.getFileSystem(storageProps)) {
+            fs.delete(Location.of(parentDir), true);
+        } catch (java.io.IOException e) {
+            throw new UserException("Failed to delete existing files in " + parentDir + ": " + e.getMessage());
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/HiveTransactionManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/HiveTransactionManager.java
@@ -19,24 +19,24 @@ package org.apache.doris.transaction;
 
 import org.apache.doris.datasource.hive.HMSTransaction;
 import org.apache.doris.datasource.hive.HiveMetadataOps;
-import org.apache.doris.fs.LegacyFileSystemProviderFactory;
+import org.apache.doris.fs.SpiSwitchingFileSystem;
 
 import java.util.concurrent.Executor;
 
 public class HiveTransactionManager extends AbstractExternalTransactionManager<HMSTransaction> {
 
-    private final LegacyFileSystemProviderFactory fileSystemProvider;
+    private final SpiSwitchingFileSystem fileSystem;
     private final Executor fileSystemExecutor;
 
-    public HiveTransactionManager(HiveMetadataOps ops, LegacyFileSystemProviderFactory fileSystemProvider,
+    public HiveTransactionManager(HiveMetadataOps ops, SpiSwitchingFileSystem fileSystem,
             Executor fileSystemExecutor) {
         super(ops);
-        this.fileSystemProvider = fileSystemProvider;
+        this.fileSystem = fileSystem;
         this.fileSystemExecutor = fileSystemExecutor;
     }
 
     @Override
     HMSTransaction createTransaction() {
-        return new HMSTransaction((HiveMetadataOps) ops, fileSystemProvider, fileSystemExecutor);
+        return new HMSTransaction((HiveMetadataOps) ops, fileSystem, fileSystemExecutor);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionManagerFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionManagerFactory.java
@@ -20,15 +20,15 @@ package org.apache.doris.transaction;
 import org.apache.doris.datasource.hive.HiveMetadataOps;
 import org.apache.doris.datasource.iceberg.IcebergMetadataOps;
 import org.apache.doris.datasource.maxcompute.MaxComputeExternalCatalog;
-import org.apache.doris.fs.LegacyFileSystemProviderFactory;
+import org.apache.doris.fs.SpiSwitchingFileSystem;
 
 import java.util.concurrent.Executor;
 
 public class TransactionManagerFactory {
 
     public static TransactionManager createHiveTransactionManager(HiveMetadataOps ops,
-            LegacyFileSystemProviderFactory fileSystemProvider, Executor fileSystemExecutor) {
-        return new HiveTransactionManager(ops, fileSystemProvider, fileSystemExecutor);
+            SpiSwitchingFileSystem fileSystem, Executor fileSystemExecutor) {
+        return new HiveTransactionManager(ops, fileSystem, fileSystemExecutor);
     }
 
     public static TransactionManager createIcebergTransactionManager(IcebergMetadataOps ops) {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -31,7 +31,6 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.UnitTestUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
-import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.nereids.trees.plans.commands.BackupCommand;
@@ -137,7 +136,7 @@ public class BackupJobTest {
     private EditLog editLog;
 
     private Repository repo = new Repository(repoId, "repo", false, "my_repo",
-            FileSystemFactory.get(BrokerProperties.of("broker", Maps.newHashMap())));
+            BrokerProperties.of("broker", Maps.newHashMap()));
 
     @BeforeClass
     public static void start() {

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -18,13 +18,20 @@
 package org.apache.doris.backup;
 
 import org.apache.doris.catalog.BrokerMgr;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisInputStream;
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileIterator;
+import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.fs.FileSystemFactory;
-import org.apache.doris.fs.remote.RemoteFile;
-import org.apache.doris.fs.remote.RemoteFileSystem;
 import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.collect.Lists;
@@ -39,6 +46,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -64,8 +72,17 @@ public class RepositoryTest {
     private SnapshotInfo info;
 
     @Mocked
-    private RemoteFileSystem fileSystem;
+    private org.apache.doris.filesystem.spi.FileSystem mockFs;
+    @Mocked
+    private DorisOutputFile mockOutputFile;
+    @Mocked
+    private DorisInputFile mockInputFile;
+    @Mocked
+    private Env mockedEnv;
+    @Mocked
+    private BrokerMgr mockedBrokerMgr;
 
+    private final BrokerProperties testProps = BrokerProperties.of("broker", Maps.newHashMap());
 
     @Before
     public void setUp() {
@@ -81,26 +98,51 @@ public class RepositoryTest {
                 return "127.0.0.1";
             }
         };
+
+        // Route all FileSystemFactory.getFileSystem calls to mockFs so that
+        // acquireSpiFs() (broker path) returns the mock without a real connection.
+        new MockUp<FileSystemFactory>() {
+            @Mock
+            public org.apache.doris.filesystem.spi.FileSystem getFileSystem(
+                    Map<String, String> properties) throws IOException {
+                return mockFs;
+            }
+
+            @Mock
+            public org.apache.doris.filesystem.spi.FileSystem getFileSystem(
+                    StorageProperties storageProperties) throws IOException {
+                return mockFs;
+            }
+        };
+
         new Expectations() {
             {
-                fileSystem.getStorageProperties();
+                Env.getCurrentEnv();
                 minTimes = 0;
-                result = null;
+                result = mockedEnv;
+
+                mockedEnv.getBrokerMgr();
+                minTimes = 0;
+                result = mockedBrokerMgr;
+
+                try {
+                    mockedBrokerMgr.getBroker(anyString, anyString);
+                } catch (AnalysisException ignored) {
+                    // never thrown during JMockit recording phase
+                }
+                minTimes = 0;
+                result = new FsBroker("10.74.167.16", 8111);
             }
         };
 
-        new MockUp<BrokerMgr>() {
-            @Mock
-            public FsBroker getBroker(String name, String host) throws AnalysisException {
-                return new FsBroker("10.74.167.16", 8111);
-            }
-        };
-
+        // initRepository() and ping() short-circuit when runningUnitTest is true,
+        // which avoids real filesystem calls in those particular tests.
+        FeConstants.runningUnitTest = true;
     }
 
     @Test
     public void testGet() {
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, "repo", false, location, testProps);
 
         Assert.assertEquals(repoId, repo.getId());
         Assert.assertEquals(name, repo.getName());
@@ -112,24 +154,9 @@ public class RepositoryTest {
 
     @Test
     public void testInit() throws UserException {
-        new Expectations() {
-            {
-                fileSystem.globList(anyString, (List<RemoteFile>) any);
-                minTimes = 0;
-                result = new Delegate<Status>() {
-                    public Status list(String remotePath, List<RemoteFile> result) {
-                        result.clear();
-                        return Status.OK;
-                    }
-                };
-                fileSystem.directUpload(anyString, anyString);
-                minTimes = 0;
-                result = Status.OK;
-            }
-        };
+        repo = new Repository(10000, "repo", false, location, testProps);
 
-        repo = new Repository(10000, "repo", false, location, fileSystem);
-
+        // initRepository() short-circuits with OK when FeConstants.runningUnitTest == true
         Status st = repo.initRepository();
         System.out.println(st);
         Assert.assertTrue(st.ok());
@@ -137,7 +164,7 @@ public class RepositoryTest {
 
     @Test
     public void testassemnblePath() throws MalformedURLException, URISyntaxException {
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, "repo", false, location, testProps);
 
         // job info
         String label = "label";
@@ -170,15 +197,8 @@ public class RepositoryTest {
 
     @Test
     public void testPing() {
-        new Expectations() {
-            {
-                fileSystem.exists(anyString);
-                minTimes = 0;
-                result = Status.OK;
-            }
-        };
-
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, "repo", false, location, testProps);
+        // ping() short-circuits with true when FeConstants.runningUnitTest == true
         Assert.assertTrue(repo.ping());
         Assert.assertTrue(repo.getErrorMsg() == null);
     }
@@ -187,19 +207,47 @@ public class RepositoryTest {
     public void testListSnapshots() {
         new Expectations() {
             {
-                fileSystem.globList(anyString, (List<RemoteFile>) any);
+                // Return one snapshot directory (__ss_a) and one non-directory (_ss_b).
+                // Only the directory with the correct prefix should appear in the result.
+                try {
+                    mockFs.list((Location) any);
+                } catch (IOException ignored) {
+                    // never thrown during JMockit recording phase
+                }
                 minTimes = 0;
-                result = new Delegate() {
-                    public Status list(String remotePath, List<RemoteFile> result) {
-                        result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "a", false, 100, 0));
-                        result.add(new RemoteFile("_ss_b", true, 100, 0));
-                        return Status.OK;
+                result = new Delegate<FileIterator>() {
+                    public FileIterator list(Location loc) throws IOException {
+                        List<FileEntry> entries = Lists.newArrayList(
+                                new FileEntry(
+                                        Location.of(location + "/__palo_repository_repo/"
+                                                + Repository.PREFIX_SNAPSHOT_DIR + "a"),
+                                        100, true, null),
+                                new FileEntry(
+                                        Location.of(location + "/__palo_repository_repo/_ss_b"),
+                                        100, false, null));
+                        return new FileIterator() {
+                            private int idx = 0;
+
+                            @Override
+                            public boolean hasNext() {
+                                return idx < entries.size();
+                            }
+
+                            @Override
+                            public FileEntry next() throws IOException {
+                                return entries.get(idx++);
+                            }
+
+                            @Override
+                            public void close() {
+                            }
+                        };
                     }
                 };
             }
         };
 
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, "repo", false, location, testProps);
         List<String> snapshotNames = Lists.newArrayList();
         Status st = repo.listSnapshots(snapshotNames);
         Assert.assertTrue(st.ok());
@@ -211,21 +259,28 @@ public class RepositoryTest {
     public void testUpload() {
         new Expectations() {
             {
-                fileSystem.upload(anyString, anyString);
-                minTimes = 0;
-                result = Status.OK;
+                // BROKER path: delete(tmp), upload via newOutputFile, rename, delete(final) are called
+                try {
+                    mockFs.delete((Location) any, anyBoolean);
+                    minTimes = 0;
 
-                fileSystem.rename(anyString, anyString);
-                minTimes = 0;
-                result = Status.OK;
+                    mockFs.newOutputFile((Location) any);
+                    minTimes = 0;
+                    result = mockOutputFile;
 
-                fileSystem.delete(anyString);
-                minTimes = 0;
-                result = Status.OK;
+                    mockOutputFile.create();
+                    minTimes = 0;
+                    result = new ByteArrayOutputStream();
+
+                    mockFs.rename((Location) any, (Location) any);
+                    minTimes = 0;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         };
 
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, "repo", false, location, testProps);
         String localFilePath = "./tmp_" + System.currentTimeMillis();
         try (PrintWriter out = new PrintWriter(localFilePath)) {
             out.print("a");
@@ -257,22 +312,53 @@ public class RepositoryTest {
 
             new Expectations() {
                 {
-                    fileSystem.globList(anyString, (List<RemoteFile>) any);
-                    minTimes = 0;
-                    result = new Delegate() {
-                        public Status list(String remotePath, List<RemoteFile> result) {
-                            result.add(new RemoteFile("remote_file.0cc175b9c0f1b6a831c399e269772661", true, 100, 0));
-                            return Status.OK;
-                        }
-                    };
+                    // The remote file has an md5 checksum suffix matching content "a"
+                    try {
+                        mockFs.listFiles((Location) any);
+                        minTimes = 0;
+                        result = Lists.newArrayList(
+                                new FileEntry(
+                                        Location.of(location + "/remote_file"
+                                                + ".0cc175b9c0f1b6a831c399e269772661"),
+                                        1, false, null));
 
-                    fileSystem.downloadWithFileSize(anyString, anyString, anyLong);
-                    minTimes = 0;
-                    result = Status.OK;
+                        mockFs.newInputFile((Location) any);
+                        minTimes = 0;
+                        result = mockInputFile;
+
+                        mockInputFile.newStream();
+                        minTimes = 0;
+                        // Return a DorisInputStream wrapping content "a"
+                        result = new DorisInputStream() {
+                            private final java.io.InputStream delegate =
+                                    new java.io.ByteArrayInputStream("a".getBytes());
+
+                            @Override
+                            public int read() throws IOException {
+                                return delegate.read();
+                            }
+
+                            @Override
+                            public int read(byte[] b, int off, int len) throws IOException {
+                                return delegate.read(b, off, len);
+                            }
+
+                            @Override
+                            public long getPos() throws IOException {
+                                return 0;
+                            }
+
+                            @Override
+                            public void seek(long newPos) throws IOException {
+                            }
+                        };
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             };
 
-            repo = new Repository(10000, "repo", false, location, fileSystem);
+            repo = new Repository(10000, "repo", false, location, testProps);
             String remoteFilePath = location + "/remote_file";
             Status st = repo.download(remoteFilePath, localFilePath);
             Assert.assertTrue(st.ok());
@@ -285,26 +371,57 @@ public class RepositoryTest {
     public void testGetSnapshotInfo() {
         new Expectations() {
             {
-                fileSystem.globList(anyString, (List<RemoteFile>) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public Status list(String remotePath, List<RemoteFile> result) {
-                        if (remotePath.contains(Repository.PREFIX_JOB_INFO)) {
-                            result.add(new RemoteFile(" __info_2018-04-18-20-11-00.12345678123456781234567812345678",
-                                    true,
-                                    100,
-                                    0));
-                        } else {
-                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
-                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));
+                try {
+                    // listSnapshots calls fs.list; return two snapshot directories
+                    mockFs.list((Location) any);
+                    minTimes = 0;
+                    result = new Delegate<FileIterator>() {
+                        public FileIterator list(Location loc) throws IOException {
+                            List<FileEntry> entries = Lists.newArrayList(
+                                    new FileEntry(
+                                            Location.of(location + "/__palo_repository_repo/"
+                                                    + Repository.PREFIX_SNAPSHOT_DIR + "s1"),
+                                            100, true, null),
+                                    new FileEntry(
+                                            Location.of(location + "/__palo_repository_repo/"
+                                                    + Repository.PREFIX_SNAPSHOT_DIR + "s2"),
+                                            100, true, null));
+                            return new FileIterator() {
+                                private int idx = 0;
+
+                                @Override
+                                public boolean hasNext() {
+                                    return idx < entries.size();
+                                }
+
+                                @Override
+                                public FileEntry next() throws IOException {
+                                    return entries.get(idx++);
+                                }
+
+                                @Override
+                                public void close() {
+                                }
+                            };
                         }
-                        return Status.OK;
-                    }
-                };
+                    };
+
+                    // getSnapshotInfo calls fs.listFiles to find __info_* files
+                    mockFs.listFiles((Location) any);
+                    minTimes = 0;
+                    result = Lists.newArrayList(
+                            new FileEntry(
+                                    Location.of(location + "/__palo_repository_repo/__ss_s1/"
+                                            + "__info_2018-04-18-20-11-00"
+                                            + ".12345678123456781234567812345678"),
+                                    100, false, null));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
             }
         };
 
-        repo = new Repository(10000, "repo", false, location, fileSystem);
+        repo = new Repository(10000, "repo", false, location, testProps);
         String snapshotName = "";
         String timestamp = "";
         try {
@@ -324,8 +441,7 @@ public class RepositoryTest {
         properties.put("bos_endpoint", "http://gz.bcebos.com");
         properties.put("bos_accesskey", "a");
         properties.put("bos_secret_accesskey", "b");
-        RemoteFileSystem fs = FileSystemFactory.get(StorageProperties.createPrimary(properties));
-        repo = new Repository(10000, "repo", false, location, fs);
+        repo = new Repository(10000, "repo", false, location, StorageProperties.createPrimary(properties));
 
         File file = new File("./Repository");
         try {
@@ -355,7 +471,7 @@ public class RepositoryTest {
     public void testPathNormalize() {
 
         String newLoc = "bos://cmy_bucket/bos_repo/";
-        repo = new Repository(10000, "repo", false, newLoc, fileSystem);
+        repo = new Repository(10000, "repo", false, newLoc, testProps);
         String path = repo.getRepoPath("label1", "/_ss_my_ss/_ss_content/__db_10000/");
         Assert.assertEquals("bos://cmy_bucket/bos_repo/__palo_repository_repo/__ss_label1/__ss_content/_ss_my_ss/_ss_content/__db_10000/", path);
 
@@ -363,7 +479,7 @@ public class RepositoryTest {
         Assert.assertEquals("bos://cmy_bucket/bos_repo/__palo_repository_repo/__ss_label1/__ss_content/_ss_my_ss/_ss_content/__db_10000", path);
 
         newLoc = "hdfs://path/to/repo";
-        repo = new Repository(10000, "repo", false, newLoc, fileSystem);
+        repo = new Repository(10000, "repo", false, newLoc, testProps);
         SnapshotInfo snapshotInfo = new SnapshotInfo(1, 2, 3, 4, 5, 6, 7, "/path", Lists.newArrayList());
         path = repo.getRepoTabletPathBySnapshotInfo("label1", snapshotInfo);
         Assert.assertEquals("hdfs://path/to/repo/__palo_repository_repo/__ss_label1/__ss_content/__db_1/__tbl_2/__part_3/__idx_4/__5", path);

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -41,7 +41,6 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
-import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.system.SystemInfoService;
@@ -126,7 +125,7 @@ public class RestoreJobTest {
 
     @Injectable
     private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
-            FileSystemFactory.get(BrokerProperties.of("broker", Maps.newHashMap())));
+            BrokerProperties.of("broker", Maps.newHashMap()));
 
     private BackupMeta backupMeta;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/backup/CloudRestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/backup/CloudRestoreJobTest.java
@@ -45,7 +45,6 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
-import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TSortType;
@@ -90,7 +89,7 @@ public class CloudRestoreJobTest {
 
     @Injectable
     private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
-            FileSystemFactory.get(BrokerProperties.of("broker", Maps.newHashMap())));
+            BrokerProperties.of("broker", Maps.newHashMap()));
 
     @Before
     public void setUp() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CopyLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CopyLoadPendingTaskTest.java
@@ -27,9 +27,9 @@ import org.apache.doris.cloud.storage.ObjectInfo;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
-import org.apache.doris.fs.obj.ListObjectsResult;
-import org.apache.doris.fs.obj.ObjectFile;
-import org.apache.doris.fs.remote.ObjFileSystem;
+import org.apache.doris.filesystem.spi.ObjFileSystem;
+import org.apache.doris.filesystem.spi.RemoteObject;
+import org.apache.doris.filesystem.spi.RemoteObjects;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.utframe.TestWithFeService;
@@ -62,12 +62,12 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
     private ObjectInfo objectInfo = new ObjectInfo(Provider.OSS, "test_ak", "test_sk", "test_bucket", "test_endpoint",
             "test_region", STORAGE_PREFIX);
     // In-memory file store used by MockUp<ObjFileSystem>
-    private Map<String, ObjectFile> objectStore = new LinkedHashMap<>();
+    private Map<String, RemoteObject> objectStore = new LinkedHashMap<>();
     MockInternalCatalog mockInternalCatalog = new MockInternalCatalog();
 
     private class MockInternalCatalog extends CloudInternalCatalog {
         @Override
-        public List<ObjectFilePB> filterCopyFiles(String stageId, long tableId, List<ObjectFile> objectFiles)
+        public List<ObjectFilePB> filterCopyFiles(String stageId, long tableId, List<RemoteObject> objectFiles)
                 throws DdlException {
             if (tableId == 200) {
                 return objectFiles.stream().filter(f -> !f.getRelativePath().equals("dir1/file_1.csv"))
@@ -87,31 +87,31 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
 
     /** Registers a MockUp on ObjFileSystem to serve list/head calls from {@link #objectStore}. */
     private void setupObjFsMock() {
-        Map<String, ObjectFile> store = objectStore;
+        Map<String, RemoteObject> store = objectStore;
         new MockUp<ObjFileSystem>() {
             @Mock
-            public ListObjectsResult listObjectsWithPrefix(String prefix, String subPrefix, String continuationToken)
+            public RemoteObjects listObjectsWithPrefix(String prefix, String subPrefix, String continuationToken)
                     throws IOException {
                 String normalizedPrefix = prefix.isEmpty() ? "" : (prefix.endsWith("/") ? prefix : prefix + "/");
                 String fullPrefix = normalizedPrefix + subPrefix;
-                List<ObjectFile> result = new ArrayList<>();
-                for (Map.Entry<String, ObjectFile> entry : store.entrySet()) {
+                List<RemoteObject> result = new ArrayList<>();
+                for (Map.Entry<String, RemoteObject> entry : store.entrySet()) {
                     if (entry.getKey().startsWith(fullPrefix)) {
                         result.add(entry.getValue());
                     }
                 }
-                return new ListObjectsResult(result, false, null);
+                return new RemoteObjects(result, false, null);
             }
 
             @Mock
-            public ListObjectsResult headObjectWithMeta(String prefix, String subKey) throws IOException {
+            public RemoteObjects headObjectWithMeta(String prefix, String subKey) throws IOException {
                 String normalizedPrefix = prefix.isEmpty() ? "" : (prefix.endsWith("/") ? prefix : prefix + "/");
                 String fullKey = normalizedPrefix + subKey;
-                ObjectFile f = store.get(fullKey);
+                RemoteObject f = store.get(fullKey);
                 if (f == null) {
-                    return new ListObjectsResult(new ArrayList<>(), false, null);
+                    return new RemoteObjects(new ArrayList<>(), false, null);
                 }
-                return new ListObjectsResult(Lists.newArrayList(f), false, null);
+                return new RemoteObjects(Lists.newArrayList(f), false, null);
             }
         };
     }
@@ -155,7 +155,7 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
                 String relativePath = subPrefixes.get(i) + (subPrefixes.get(i).isEmpty() ? "" : "/") + "file_" + j
                         + ".csv";
                 String etag = "";
-                ObjectFile objectFile = new ObjectFile(
+                RemoteObject objectFile = new RemoteObject(
                         STORAGE_PREFIX + (STORAGE_PREFIX.isEmpty() ? "" : "/") + relativePath, relativePath, etag,
                         (j + 1) * 10);
                 objectStore.put(objectFile.getKey(), objectFile);
@@ -239,13 +239,13 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
         String prefix = "prefix1";
         List<String> subPrefixes = Lists.newArrayList("", "dir1", "dir2/dir3", "dir4/dir5/dir6");
         // list object files
-        List<ObjectFile> objectFiles = new ArrayList<>();
+        List<RemoteObject> objectFiles = new ArrayList<>();
         for (int i = 0; i < subPrefixes.size(); i++) {
             for (int j = 0; j < i + 1; j++) {
                 String relativePath = subPrefixes.get(i) + (subPrefixes.get(i).isEmpty() ? "" : "/") + "file_" + j
                         + ".csv";
                 String etag = "";
-                ObjectFile objectFile = new ObjectFile(prefix + (prefix.isEmpty() ? "" : "/") + relativePath,
+                RemoteObject objectFile = new RemoteObject(prefix + (prefix.isEmpty() ? "" : "/") + relativePath,
                         relativePath, etag, (j + 1) * 10);
                 objectFiles.add(objectFile);
                 System.out.println(
@@ -293,7 +293,7 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
             String subPrefix = subPrefixes.get(i);
             for (int j = 0; j < 10; j++) {
                 String relativePath = subPrefix + (subPrefix.isEmpty() ? "" : "/") + "file" + j + ".csv";
-                ObjectFile objectFile = new ObjectFile(STORAGE_PREFIX + "/" + relativePath, relativePath, "",
+                RemoteObject objectFile = new RemoteObject(STORAGE_PREFIX + "/" + relativePath, relativePath, "",
                         (j + 1) * 10);
                 objectStore.put(objectFile.getKey(), objectFile);
                 System.out.println("Add " + objectFile);
@@ -303,7 +303,7 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
         List<String> specialNames = Lists.newArrayList("sf,csv", "sd/sf,csv", "sf?csv", "sd/sf?csv", "sf*csv", "sf-csv",
                 "sf[csv", "sf]csv", "sf{csv", "sf}csv");
         for (String specialName : specialNames) {
-            ObjectFile objectFile = new ObjectFile(STORAGE_PREFIX + "/" + specialName, specialName, "", 1);
+            RemoteObject objectFile = new RemoteObject(STORAGE_PREFIX + "/" + specialName, specialName, "", 1);
             objectStore.put(objectFile.getKey(), objectFile);
         }
         setupObjFsMock();

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSTransactionPathTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSTransactionPathTest.java
@@ -17,12 +17,14 @@
 
 package org.apache.doris.datasource.hive;
 
-import org.apache.doris.backup.Status;
-import org.apache.doris.fs.LegacyFileSystemApi;
-import org.apache.doris.fs.LegacyFileSystemProviderFactory;
-import org.apache.doris.fs.LocalDfsFileSystem;
-import org.apache.doris.fs.remote.RemoteFile;
-import org.apache.doris.fs.remote.SwitchingFileSystem;
+import org.apache.doris.filesystem.local.LocalFileSystem;
+import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileIterator;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
+import org.apache.doris.fs.SpiSwitchingFileSystem;
 import org.apache.doris.qe.ConnectContext;
 
 import org.junit.After;
@@ -30,8 +32,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -84,21 +88,19 @@ public class HMSTransactionPathTest {
     @Test
     public void testDeleteTargetPathContentsNotFoundAllowed() throws Exception {
         FakeFileSystem fakeFs = new FakeFileSystem();
-        fakeFs.listDirectoriesStatus = new Status(Status.ErrCode.NOT_FOUND, "missing");
-        fakeFs.listFilesStatus = new Status(Status.ErrCode.NOT_FOUND, "missing");
+        fakeFs.listDirectoriesThrows = new IOException("not found");
+        fakeFs.listFilesThrows = new IOException("not found");
 
         HMSTransaction transaction = createTransaction(fakeFs);
-        transaction.deleteTargetPathContents(
-                "/tmp/does_not_exist", "/tmp/does_not_exist/.doris_staging");
-        Assert.assertTrue(fakeFs.deletedDirectories.isEmpty());
-        Assert.assertTrue(fakeFs.deletedFiles.isEmpty());
+        Assert.assertThrows(RuntimeException.class, () -> transaction.deleteTargetPathContents(
+                "/tmp/does_not_exist", "/tmp/does_not_exist/.doris_staging"));
     }
 
     // Verifies listDirectories failures surface as runtime errors.
     @Test
     public void testDeleteTargetPathContentsListError() throws Exception {
         FakeFileSystem fakeFs = new FakeFileSystem();
-        fakeFs.listDirectoriesStatus = new Status(Status.ErrCode.COMMON_ERROR, "list failed");
+        fakeFs.listDirectoriesThrows = new IOException("list failed");
 
         HMSTransaction transaction = createTransaction(fakeFs);
         Assert.assertThrows(RuntimeException.class, () -> transaction.deleteTargetPathContents(
@@ -107,7 +109,7 @@ public class HMSTransactionPathTest {
 
     @Test
     public void testEnsureDirectorySuccess() throws Exception {
-        LocalDfsFileSystem localFs = new LocalDfsFileSystem();
+        LocalFileSystem localFs = new LocalFileSystem(Collections.emptyMap());
         HMSTransaction transaction = createTransaction(localFs);
 
         java.nio.file.Path dir = Files.createTempDirectory("hms_tx_ensure_").resolve("nested");
@@ -119,7 +121,7 @@ public class HMSTransactionPathTest {
     @Test
     public void testEnsureDirectoryError() throws Exception {
         FakeFileSystem fakeFs = new FakeFileSystem();
-        fakeFs.makeDirStatus = new Status(Status.ErrCode.COMMON_ERROR, "mkdir failed");
+        fakeFs.mkdirsThrows = new IOException("mkdir failed");
 
         HMSTransaction transaction = createTransaction(fakeFs);
         Assert.assertThrows(RuntimeException.class, () -> transaction.ensureDirectory("/tmp/target"));
@@ -132,7 +134,7 @@ public class HMSTransactionPathTest {
     // 4) Ensure the target directory exists after cleanup.
     @Test
     public void testDeleteTargetPathContentsSkipsExcludedDir() throws Exception {
-        LocalDfsFileSystem localFs = new LocalDfsFileSystem();
+        LocalFileSystem localFs = new LocalFileSystem(Collections.emptyMap());
         HMSTransaction transaction = createTransaction(localFs);
 
         java.nio.file.Path targetDir = Files.createTempDirectory("hms_tx_path_test_");
@@ -161,102 +163,96 @@ public class HMSTransactionPathTest {
         Assert.assertFalse(Files.exists(otherFile));
     }
 
-    private static HMSTransaction createTransaction(LegacyFileSystemApi delegate) {
-        SwitchingFileSystem switchingFs = new TestSwitchingFileSystem(delegate);
-        LegacyFileSystemProviderFactory provider = ctx -> switchingFs;
-        return new HMSTransaction(null, provider, Runnable::run);
+    private static HMSTransaction createTransaction(FileSystem delegate) {
+        SpiSwitchingFileSystem spiFs = new SpiSwitchingFileSystem(delegate);
+        return new HMSTransaction(null, spiFs, Runnable::run);
     }
 
-    private static class TestSwitchingFileSystem extends SwitchingFileSystem {
-        private final LegacyFileSystemApi delegate;
+    private static class FakeFileSystem implements FileSystem {
+        IOException listDirectoriesThrows;
+        IOException listFilesThrows;
+        IOException mkdirsThrows;
 
-        TestSwitchingFileSystem(LegacyFileSystemApi delegate) {
-            super(null, null);
-            this.delegate = delegate;
-        }
-
-        @Override
-        public LegacyFileSystemApi fileSystem(String location) {
-            return delegate;
-        }
-    }
-
-    private static class FakeFileSystem implements LegacyFileSystemApi {
-        private Status listDirectoriesStatus = Status.OK;
-        private Status listFilesStatus = Status.OK;
-        private Status makeDirStatus = Status.OK;
-        private Status deleteStatus = Status.OK;
-        private Status deleteDirStatus = Status.OK;
-
-        private final List<String> deletedDirectories = new ArrayList<>();
-        private final List<String> deletedFiles = new ArrayList<>();
+        final List<String> deletedDirectories = new ArrayList<>();
+        final List<String> deletedFiles = new ArrayList<>();
 
         @Override
-        public Status listDirectories(String remotePath, Set<String> result) {
-            if (!listDirectoriesStatus.ok()) {
-                return listDirectoriesStatus;
+        public Set<String> listDirectories(Location dir) throws IOException {
+            if (listDirectoriesThrows != null) {
+                throw listDirectoriesThrows;
             }
-            return Status.OK;
+            return Collections.emptySet();
         }
 
         @Override
-        public Status listFiles(String remotePath, boolean recursive, List<RemoteFile> result) {
-            if (!listFilesStatus.ok()) {
-                return listFilesStatus;
+        public List<FileEntry> listFiles(Location dir) throws IOException {
+            if (listFilesThrows != null) {
+                throw listFilesThrows;
             }
-            return Status.OK;
+            return Collections.emptyList();
         }
 
         @Override
-        public Status deleteDirectory(String dir) {
-            deletedDirectories.add(dir);
-            return deleteDirStatus;
+        public void mkdirs(Location location) throws IOException {
+            if (mkdirsThrows != null) {
+                throw mkdirsThrows;
+            }
         }
 
         @Override
-        public Status delete(String remotePath) {
-            deletedFiles.add(remotePath);
-            return deleteStatus;
+        public void delete(Location location, boolean recursive) throws IOException {
+            if (recursive) {
+                deletedDirectories.add(location.uri());
+            } else {
+                deletedFiles.add(location.uri());
+            }
         }
 
         @Override
-        public Status makeDir(String remotePath) {
-            return makeDirStatus;
+        public boolean exists(Location location) throws IOException {
+            return false;
         }
 
         @Override
-        public Status exists(String remotePath) {
-            return Status.OK;
+        public void rename(Location src, Location dst) throws IOException {
         }
 
         @Override
-        public Status downloadWithFileSize(String remoteFilePath, String localFilePath, long fileSize) {
-            return Status.OK;
+        public FileIterator list(Location location) throws IOException {
+            return new FileIterator() {
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+
+                @Override
+                public FileEntry next() {
+                    throw new java.util.NoSuchElementException();
+                }
+
+                @Override
+                public void close() {
+                }
+            };
         }
 
         @Override
-        public Status upload(String localPath, String remotePath) {
-            return Status.OK;
+        public DorisInputFile newInputFile(Location location) throws IOException {
+            throw new UnsupportedOperationException();
         }
 
         @Override
-        public Status directUpload(String content, String remoteFile) {
-            return Status.OK;
+        public DorisInputFile newInputFile(Location location, long length) throws IOException {
+            throw new UnsupportedOperationException();
         }
 
         @Override
-        public Status rename(String origFilePath, String destFilePath) {
-            return Status.OK;
+        public DorisOutputFile newOutputFile(Location location) throws IOException {
+            throw new UnsupportedOperationException();
         }
 
         @Override
-        public Status globList(String remotePath, List<RemoteFile> result, boolean fileNameOnly) {
-            return Status.OK;
-        }
-
-        @Override
-        public java.util.Map<String, String> getProperties() {
-            return null;
+        public void close() throws IOException {
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveAcidTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveAcidTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache.FileCacheValue;
 import org.apache.doris.datasource.property.storage.LocalProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.filesystem.local.LocalFileSystem;
 import org.apache.doris.fs.LocalDfsFileSystem;
 
 import com.google.common.collect.ImmutableMap;
@@ -45,6 +46,8 @@ public class HiveAcidTest {
     private static final Map<StorageProperties.Type, StorageProperties> storagePropertiesMap = ImmutableMap.of(
             StorageProperties.Type.LOCAL, new LocalProperties(new HashMap<>())
     );
+
+    private static final LocalFileSystem SPI_LOCAL_FS = new LocalFileSystem(new HashMap<>());
 
     @Test
     public void testOriginalDeltas() throws Exception {
@@ -74,7 +77,7 @@ public class HiveAcidTest {
                 false, "", "file://" + tempPath.toAbsolutePath() + "",
                 new ArrayList<>(), new HashMap<>());
         try {
-            AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, new HashMap<>(), true);
+            AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, new HashMap<>(), true);
         } catch (UnsupportedOperationException e) {
             Assert.assertTrue(e.getMessage().contains("For no acid table convert to acid, please COMPACT 'major'."));
         }
@@ -106,7 +109,7 @@ public class HiveAcidTest {
                 new ArrayList<>(),
                 new HashMap<>());
         try {
-            AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+            AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
         } catch (UnsupportedOperationException e) {
             Assert.assertTrue(e.getMessage().contains("For no acid table convert to acid, please COMPACT 'major'."));
         }
@@ -143,7 +146,7 @@ public class HiveAcidTest {
                 new HashMap<>());
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
         List<String> readFile =
                 fileCacheValue.getFiles().stream().map(x -> x.path.getNormalizedLocation()).collect(Collectors.toList());
@@ -194,7 +197,7 @@ public class HiveAcidTest {
                 new HashMap<>());
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
 
         List<String> readFile =
@@ -242,7 +245,7 @@ public class HiveAcidTest {
 
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
 
         List<String> readFile =
@@ -288,7 +291,7 @@ public class HiveAcidTest {
                 new HashMap<>());
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
 
         List<String> readFile =
@@ -341,7 +344,7 @@ public class HiveAcidTest {
                 new HashMap<>());
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
 
         List<String> readFile =
@@ -411,7 +414,7 @@ public class HiveAcidTest {
                 tableProps);
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
 
 
@@ -477,7 +480,7 @@ public class HiveAcidTest {
                 tableProps);
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
         List<String> readFile =
                 fileCacheValue.getFiles().stream().map(x -> x.path.getNormalizedLocation()).collect(Collectors.toList());
@@ -523,7 +526,7 @@ public class HiveAcidTest {
                 tableProps);
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
 
         List<String> readFile =
@@ -586,7 +589,7 @@ public class HiveAcidTest {
                 tableProps);
 
         FileCacheValue fileCacheValue =
-                AcidUtil.getAcidState(localDFSFileSystem, partition, txnValidIds, storagePropertiesMap, true);
+                AcidUtil.getAcidState(SPI_LOCAL_FS, partition, txnValidIds, storagePropertiesMap, true);
 
         List<String> readFile =
                 fileCacheValue.getFiles().stream().map(x -> x.path.getNormalizedLocation()).collect(Collectors.toList());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
@@ -18,17 +18,14 @@
 package org.apache.doris.datasource.hive;
 
 import org.apache.doris.analysis.UserIdentity;
-import org.apache.doris.backup.Status;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.TestHMSCachedClient;
-import org.apache.doris.fs.LegacyFileSystemApi;
-import org.apache.doris.fs.LegacyFileSystemProviderFactory;
-import org.apache.doris.fs.LocalDfsFileSystem;
-import org.apache.doris.fs.remote.SwitchingFileSystem;
+import org.apache.doris.filesystem.local.LocalFileSystem;
+import org.apache.doris.fs.SpiSwitchingFileSystem;
 import org.apache.doris.nereids.trees.plans.commands.insert.HiveInsertCommandContext;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.THiveLocationParams;
@@ -71,12 +68,11 @@ public class HmsCommitTest {
     private static HiveMetadataOps hmsOps;
     private static HMSCachedClient hmsClient;
 
-    private static LegacyFileSystemProviderFactory fileSystemProvider;
+    private static SpiSwitchingFileSystem fileSystemProvider;
     private static final String dbName = "test_db";
     private static final String tbWithPartition = "test_tb_with_partition";
     private static final String tbWithoutPartition = "test_tb_without_partition";
-    private static LegacyFileSystemApi fs;
-    private static LocalDfsFileSystem localDFSFileSystem;
+    private static SpiSwitchingFileSystem fs;
     private static Executor fileSystemExecutor;
     static String dbLocation;
     static String writeLocation;
@@ -100,14 +96,8 @@ public class HmsCommitTest {
     }
 
     public static void createTestHiveCatalog() throws IOException {
-        localDFSFileSystem = new LocalDfsFileSystem();
-        new MockUp<SwitchingFileSystem>(SwitchingFileSystem.class) {
-            @Mock
-            public LegacyFileSystemApi fileSystem(String location) {
-                return localDFSFileSystem;
-            }
-        };
-        fs = new SwitchingFileSystem(null, null);
+        fs = new SpiSwitchingFileSystem(new LocalFileSystem(java.util.Collections.emptyMap()));
+        fileSystemProvider = fs;
 
         if (hasRealHmsService) {
             // If you have a real HMS service, then you can use this client to create real connections for testing
@@ -119,7 +109,6 @@ public class HmsCommitTest {
             hmsClient = new TestHMSCachedClient();
         }
         hmsOps = new HiveMetadataOps(null, hmsClient);
-        fileSystemProvider = ctx -> fs;
         fileSystemExecutor = Executors.newFixedThreadPool(16);
     }
 
@@ -186,7 +175,7 @@ public class HmsCommitTest {
         new MockUp<HMSTransaction.HmsCommitter>(HMSTransaction.HmsCommitter.class) {
             @Mock
             private void doNothing() {
-                Assert.assertEquals(Status.ErrCode.NOT_FOUND, fs.exists(getWritePath()).getErrCode());
+                Assert.assertFalse(fsExists(getWritePath()));
             }
         };
         commit(dbName, tbWithoutPartition, pus);
@@ -223,7 +212,7 @@ public class HmsCommitTest {
         new MockUp<HMSTransaction.HmsCommitter>(HMSTransaction.HmsCommitter.class) {
             @Mock
             private void doNothing() {
-                Assert.assertEquals(Status.ErrCode.NOT_FOUND, fs.exists(getWritePath()).getErrCode());
+                Assert.assertFalse(fsExists(getWritePath()));
             }
         };
         genQueryID();
@@ -375,12 +364,15 @@ public class HmsCommitTest {
         });
 
         if (mode != TUpdateMode.NEW) {
-            fs.makeDir(targetPath);
+            fs.mkdirs(org.apache.doris.filesystem.spi.Location.of(targetPath));
         }
 
-        localDFSFileSystem.createFile(writePath + "/" + f1);
-        localDFSFileSystem.createFile(writePath + "/" + f2);
-        localDFSFileSystem.createFile(writePath + "/" + f3);
+        java.nio.file.Path writeDir = java.nio.file.Paths.get(
+                java.net.URI.create(writePath));
+        java.nio.file.Files.createDirectories(writeDir);
+        java.nio.file.Files.createFile(writeDir.resolve(f1));
+        java.nio.file.Files.createFile(writeDir.resolve(f2));
+        java.nio.file.Files.createFile(writeDir.resolve(f3));
         return pu;
     }
 
@@ -402,6 +394,14 @@ public class HmsCommitTest {
     private String getWritePath() {
         String queryId = DebugUtil.printId(ConnectContext.get().queryId());
         return writeLocation + queryId + "/";
+    }
+
+    private boolean fsExists(String path) {
+        try {
+            return fs.exists(org.apache.doris.filesystem.spi.Location.of(path));
+        } catch (java.io.IOException e) {
+            return false;
+        }
     }
 
     public void commit(String dbName,
@@ -476,15 +476,15 @@ public class HmsCommitTest {
         THiveLocationParams location = pus.get(0).getLocation();
 
         // For new partition, there should be no target path
-        Assert.assertFalse(fs.exists(location.getTargetPath()).ok());
-        Assert.assertTrue(fs.exists(location.getWritePath()).ok());
+        Assert.assertFalse(fsExists(location.getTargetPath()));
+        Assert.assertTrue(fsExists(location.getWritePath()));
 
         mockAsyncRenameDir(() -> {
             // commit will be failed, and it will remain some files in write path
             String writePath = location.getWritePath();
-            Assert.assertTrue(fs.exists(writePath).ok());
+            Assert.assertTrue(fsExists(writePath));
             for (String file : pus.get(0).getFileNames()) {
-                Assert.assertTrue(fs.exists(writePath + "/" + file).ok());
+                Assert.assertTrue(fsExists(writePath + "/" + file));
             }
         });
 
@@ -497,9 +497,9 @@ public class HmsCommitTest {
 
         // After rollback, these files in write path will be deleted
         String writePath = location.getWritePath();
-        Assert.assertFalse(fs.exists(writePath).ok());
+        Assert.assertFalse(fsExists(writePath));
         for (String file : pus.get(0).getFileNames()) {
-            Assert.assertFalse(fs.exists(writePath + "/" + file).ok());
+            Assert.assertFalse(fsExists(writePath + "/" + file));
         }
     }
 
@@ -512,15 +512,15 @@ public class HmsCommitTest {
         THiveLocationParams location = pus.get(0).getLocation();
 
         // For new partition, there should be no target path
-        Assert.assertFalse(fs.exists(location.getTargetPath()).ok());
-        Assert.assertTrue(fs.exists(location.getWritePath()).ok());
+        Assert.assertFalse(fsExists(location.getTargetPath()));
+        Assert.assertTrue(fsExists(location.getWritePath()));
 
         mockAddPartitionTaskException(() -> {
             // When the commit is completed, these files should be renamed successfully
             String targetPath = location.getTargetPath();
-            Assert.assertTrue(fs.exists(targetPath).ok());
+            Assert.assertTrue(fsExists(targetPath));
             for (String file : pus.get(0).getFileNames()) {
-                Assert.assertTrue(fs.exists(targetPath + "/" + file).ok());
+                Assert.assertTrue(fsExists(targetPath + "/" + file));
             }
         });
 
@@ -533,9 +533,9 @@ public class HmsCommitTest {
 
         // After rollback, these files will be deleted
         String targetPath = location.getTargetPath();
-        Assert.assertFalse(fs.exists(targetPath).ok());
+        Assert.assertFalse(fsExists(targetPath));
         for (String file : pus.get(0).getFileNames()) {
-            Assert.assertFalse(fs.exists(targetPath + "/" + file).ok());
+            Assert.assertFalse(fsExists(targetPath + "/" + file));
         }
     }
 
@@ -559,15 +559,15 @@ public class HmsCommitTest {
         THiveLocationParams locationForA = pus.get(0).getLocation();
 
         // For new partition, there should be no target path
-        Assert.assertFalse(fs.exists(locationForX.getTargetPath()).ok());
-        Assert.assertTrue(fs.exists(locationForX.getWritePath()).ok());
+        Assert.assertFalse(fsExists(locationForX.getTargetPath()));
+        Assert.assertTrue(fsExists(locationForX.getWritePath()));
 
         mockUpdateStatisticsTaskException(() -> {
             // When the commit is completed, these files should be renamed successfully
             String targetPath = locationForX.getTargetPath();
-            Assert.assertTrue(fs.exists(targetPath).ok());
+            Assert.assertTrue(fsExists(targetPath));
             for (String file : pus.get(0).getFileNames()) {
-                Assert.assertTrue(fs.exists(targetPath + "/" + file).ok());
+                Assert.assertTrue(fsExists(targetPath + "/" + file));
             }
             // new partition will be executed before append partition,
             // so, we can get the new partition
@@ -584,12 +584,12 @@ public class HmsCommitTest {
 
         // After rollback, these files will be deleted
         String targetPath = locationForX.getTargetPath();
-        Assert.assertFalse(fs.exists(targetPath).ok());
+        Assert.assertFalse(fsExists(targetPath));
         for (String file : pus.get(0).getFileNames()) {
-            Assert.assertFalse(fs.exists(targetPath + "/" + file).ok());
+            Assert.assertFalse(fsExists(targetPath + "/" + file));
         }
-        Assert.assertFalse(fs.exists(locationForX.getWritePath()).ok());
-        Assert.assertFalse(fs.exists(locationForA.getWritePath()).ok());
+        Assert.assertFalse(fsExists(locationForX.getWritePath()));
+        Assert.assertFalse(fsExists(locationForA.getWritePath()));
         // x partition will be deleted
         Assert.assertThrows(
                 "the 'x' partition should be deleted",
@@ -620,22 +620,22 @@ public class HmsCommitTest {
         THiveLocationParams locationForParA = pus.get(1).getLocation();
 
         // For new partition, there should be no target path
-        Assert.assertFalse(fs.exists(locationForParX.getTargetPath()).ok());
-        Assert.assertTrue(fs.exists(locationForParX.getWritePath()).ok());
+        Assert.assertFalse(fsExists(locationForParX.getTargetPath()));
+        Assert.assertTrue(fsExists(locationForParX.getWritePath()));
 
         // For exist partition
-        Assert.assertTrue(fs.exists(locationForParA.getTargetPath()).ok());
+        Assert.assertTrue(fsExists(locationForParA.getTargetPath()));
 
         mockDoOther(() -> {
             // When the commit is completed, these files should be renamed successfully
             String targetPathForX = locationForParX.getTargetPath();
-            Assert.assertTrue(fs.exists(targetPathForX).ok());
+            Assert.assertTrue(fsExists(targetPathForX));
             for (String file : pus.get(0).getFileNames()) {
-                Assert.assertTrue(fs.exists(targetPathForX + "/" + file).ok());
+                Assert.assertTrue(fsExists(targetPathForX + "/" + file));
             }
             String targetPathForA = locationForParA.getTargetPath();
             for (String file : pus.get(1).getFileNames()) {
-                Assert.assertTrue(fs.exists(targetPathForA + "/" + file).ok());
+                Assert.assertTrue(fsExists(targetPathForA + "/" + file));
             }
             // new partition will be executed,
             // so, we can get the new partition
@@ -656,17 +656,17 @@ public class HmsCommitTest {
 
         // After rollback, these files will be deleted
         String targetPathForX = locationForParX.getTargetPath();
-        Assert.assertFalse(fs.exists(targetPathForX).ok());
+        Assert.assertFalse(fsExists(targetPathForX));
         for (String file : pus.get(0).getFileNames()) {
-            Assert.assertFalse(fs.exists(targetPathForX + "/" + file).ok());
+            Assert.assertFalse(fsExists(targetPathForX + "/" + file));
         }
-        Assert.assertFalse(fs.exists(locationForParX.getWritePath()).ok());
+        Assert.assertFalse(fsExists(locationForParX.getWritePath()));
         String targetPathForA = locationForParA.getTargetPath();
         for (String file : pus.get(1).getFileNames()) {
-            Assert.assertFalse(fs.exists(targetPathForA + "/" + file).ok());
+            Assert.assertFalse(fsExists(targetPathForA + "/" + file));
         }
-        Assert.assertTrue(fs.exists(targetPathForA).ok());
-        Assert.assertFalse(fs.exists(locationForParA.getWritePath()).ok());
+        Assert.assertTrue(fsExists(targetPathForA));
+        Assert.assertFalse(fsExists(locationForParA.getWritePath()));
         // x partition will be deleted
         Assert.assertThrows(
                 "the 'x' partition should be deleted",

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/FileSystemTransferUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/FileSystemTransferUtilTest.java
@@ -1,0 +1,217 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.fs;
+
+import org.apache.doris.filesystem.local.LocalFileSystemProvider;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class FileSystemTransferUtilTest {
+
+    private Path tempDir;
+    private FileSystem fs;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        tempDir = Files.createTempDirectory("doris-fs-test-");
+        Map<String, String> props = new HashMap<>();
+        props.put("uri", "file://" + tempDir);
+        fs = new LocalFileSystemProvider().create(props);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (tempDir != null && Files.exists(tempDir)) {
+            try (Stream<Path> walk = Files.walk(tempDir)) {
+                walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                    try {
+                        Files.delete(p);
+                    } catch (IOException e) {
+                        // best-effort cleanup
+                    }
+                });
+            }
+        }
+    }
+
+    private static void writeFile(Path path, String content) throws IOException {
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String readFile(Path path) throws IOException {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    // ---- download ----
+
+    @Test
+    public void testDownloadSuccess() throws IOException {
+        String content = "hello download";
+        Path remoteFile = tempDir.resolve("remote.txt");
+        writeFile(remoteFile, content);
+
+        Path localOut = tempDir.resolve("local_out.txt");
+        FileSystemTransferUtil.download(fs, Location.of(remoteFile.toUri().toString()),
+                localOut, content.length());
+
+        Assertions.assertEquals(content, readFile(localOut));
+    }
+
+    @Test
+    public void testDownloadSizeMismatchThrows() throws IOException {
+        Path remoteFile = tempDir.resolve("data.txt");
+        writeFile(remoteFile, "abc");
+
+        Path localOut = tempDir.resolve("out.txt");
+        IOException ex = Assertions.assertThrows(IOException.class, () ->
+                FileSystemTransferUtil.download(fs, Location.of(remoteFile.toUri().toString()),
+                        localOut, 999L));
+        Assertions.assertTrue(ex.getMessage().contains("size mismatch"));
+    }
+
+    @Test
+    public void testDownloadSkipsSizeCheckWhenNegative() throws IOException {
+        Path remoteFile = tempDir.resolve("no_check.txt");
+        writeFile(remoteFile, "data");
+
+        Path localOut = tempDir.resolve("local_no_check.txt");
+        FileSystemTransferUtil.download(fs, Location.of(remoteFile.toUri().toString()),
+                localOut, -1L);
+
+        Assertions.assertEquals("data", readFile(localOut));
+    }
+
+    // ---- upload ----
+
+    @Test
+    public void testUpload() throws IOException {
+        Path localSrc = tempDir.resolve("local_src.txt");
+        writeFile(localSrc, "upload content");
+
+        Path remoteDest = tempDir.resolve("sub").resolve("uploaded.txt");
+        Files.createDirectories(remoteDest.getParent());
+
+        FileSystemTransferUtil.upload(fs, localSrc, Location.of(remoteDest.toUri().toString()));
+
+        Assertions.assertEquals("upload content", readFile(remoteDest));
+    }
+
+    // ---- directUpload ----
+
+    @Test
+    public void testDirectUpload() throws IOException {
+        String content = "direct content\nline2";
+        Path dest = tempDir.resolve("direct.txt");
+
+        FileSystemTransferUtil.directUpload(fs, content, Location.of(dest.toUri().toString()));
+
+        Assertions.assertEquals(content, readFile(dest));
+    }
+
+    // ---- globList ----
+
+    @Test
+    public void testGlobListNoWildcard() throws IOException {
+        writeFile(tempDir.resolve("a.txt"), "a");
+        writeFile(tempDir.resolve("b.txt"), "b");
+        Files.createDirectory(tempDir.resolve("subdir"));
+        writeFile(tempDir.resolve("subdir").resolve("c.txt"), "c");
+
+        List<FileEntry> entries = FileSystemTransferUtil.globList(
+                fs, tempDir.toUri().toString(), false);
+
+        Assertions.assertEquals(2, entries.size());
+    }
+
+    @Test
+    public void testGlobListRecursive() throws IOException {
+        writeFile(tempDir.resolve("root.parquet"), "r");
+        Path sub = Files.createDirectory(tempDir.resolve("sub"));
+        writeFile(sub.resolve("nested.parquet"), "n");
+
+        List<FileEntry> entries = FileSystemTransferUtil.globList(
+                fs, tempDir.toUri().toString(), true);
+
+        Assertions.assertEquals(2, entries.size());
+    }
+
+    @Test
+    public void testGlobListWithStarWildcard() throws IOException {
+        writeFile(tempDir.resolve("part-0001.snappy.parquet"), "p1");
+        writeFile(tempDir.resolve("part-0002.snappy.parquet"), "p2");
+        writeFile(tempDir.resolve("manifest.json"), "m");
+
+        String pattern = tempDir.toUri().toString() + "*.parquet";
+        List<FileEntry> entries = FileSystemTransferUtil.globList(fs, pattern, false);
+
+        Assertions.assertEquals(2, entries.size());
+        entries.forEach(e -> Assertions.assertTrue(e.location().uri().endsWith(".parquet")));
+    }
+
+    @Test
+    public void testGlobListWithQuestionMark() throws IOException {
+        writeFile(tempDir.resolve("file1.txt"), "1");
+        writeFile(tempDir.resolve("file2.txt"), "2");
+        writeFile(tempDir.resolve("file10.txt"), "10");
+
+        String pattern = tempDir.toUri().toString() + "file?.txt";
+        List<FileEntry> entries = FileSystemTransferUtil.globList(fs, pattern, false);
+
+        Assertions.assertEquals(2, entries.size());
+    }
+
+    // ---- globToRegex ----
+
+    @Test
+    public void testGlobToRegexStar() {
+        Pattern p = FileSystemTransferUtil.globToRegex("s3://bucket/prefix/*.parquet");
+        Assertions.assertTrue(p.matcher("s3://bucket/prefix/file.parquet").matches());
+        Assertions.assertFalse(p.matcher("s3://bucket/prefix/sub/file.parquet").matches());
+    }
+
+    @Test
+    public void testGlobToRegexQuestion() {
+        Pattern p = FileSystemTransferUtil.globToRegex("/data/part-?.csv");
+        Assertions.assertTrue(p.matcher("/data/part-1.csv").matches());
+        Assertions.assertFalse(p.matcher("/data/part-10.csv").matches());
+    }
+
+    @Test
+    public void testGlobToRegexDotEscaped() {
+        Pattern p = FileSystemTransferUtil.globToRegex("s3://bucket/file.parquet");
+        Assertions.assertTrue(p.matcher("s3://bucket/file.parquet").matches());
+        Assertions.assertFalse(p.matcher("s3://bucket/fileXparquet").matches());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/TransactionScopeCachingDirectoryListerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/TransactionScopeCachingDirectoryListerTest.java
@@ -136,7 +136,7 @@ public class TransactionScopeCachingDirectoryListerTest {
         }
 
         @Override
-        public RemoteIterator<RemoteFile> listFiles(LegacyFileSystemApi fs, boolean recursive,
+        public RemoteIterator<RemoteFile> listFiles(org.apache.doris.filesystem.spi.FileSystem fs, boolean recursive,
                 TableIf table, String location)
                 throws FileSystemIOException {
             // No specific recursive files-only listing implementation

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3FileSystemTest.java
@@ -172,7 +172,8 @@ public class S3FileSystemTest {
 
     @Test
     public void testRepositoryUpload() throws IOException {
-        Repository repo = new Repository(10000, "repo", false, bucket + basePath, fileSystem);
+        Repository repo = new Repository(10000, "repo", false, bucket + basePath,
+                StorageProperties.createPrimary(properties));
         File localFile = File.createTempFile("s3unittest", ".dat");
         localFile.deleteOnExit();
         String remote = bucket + basePath + "/" + localFile.getName();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateRepositoryCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateRepositoryCommandTest.java
@@ -72,7 +72,7 @@ public class CreateRepositoryCommandTest extends TestWithFeService {
         Assertions.assertTrue(logicalPlan instanceof CreateRepositoryCommand);
         Assertions.assertEquals(((CreateRepositoryCommand) logicalPlan).getProperties().size(), 4);
         Repository repository = getRepository((CreateRepositoryCommand) logicalPlan, "s3_repo_command");
-        Assertions.assertEquals(4, repository.getRemoteFileSystem().getProperties().size());
+        Assertions.assertEquals(4, repository.getFileSystemDescriptor().getProperties().size());
 
         String s3RepoNew = "CREATE REPOSITORY `s3_repo_new_command`\n"
                 + "WITH S3\n"
@@ -88,7 +88,7 @@ public class CreateRepositoryCommandTest extends TestWithFeService {
         Assertions.assertTrue(logicalPlan1 instanceof CreateRepositoryCommand);
         Assertions.assertEquals(((CreateRepositoryCommand) logicalPlan1).getProperties().size(), 3);
         Repository repositoryNew = getRepository((CreateRepositoryCommand) logicalPlan1, "s3_repo_new_command");
-        Assertions.assertEquals(3, repositoryNew.getRemoteFileSystem().getProperties().size());
+        Assertions.assertEquals(3, repositoryNew.getFileSystemDescriptor().getProperties().size());
     }
 
     @Disabled("not support")
@@ -115,7 +115,7 @@ public class CreateRepositoryCommandTest extends TestWithFeService {
         Env.getCurrentEnv().getBrokerMgr().addBrokers("bos_broker1", brokers);
 
         Repository repositoryNew = getRepository((CreateRepositoryCommand) logicalPlan, "bos_broker_repo_command");
-        Assertions.assertEquals(repositoryNew.getRemoteFileSystem().getProperties().size(), 4);
+        Assertions.assertEquals(repositoryNew.getFileSystemDescriptor().getProperties().size(), 4);
     }
 
     private static Repository getRepository(CreateRepositoryCommand command, String name) throws DdlException {

--- a/fe/fe-filesystem/fe-filesystem-azure/src/main/java/org/apache/doris/filesystem/azure/AzureFileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-azure/src/main/java/org/apache/doris/filesystem/azure/AzureFileSystem.java
@@ -18,6 +18,7 @@
 package org.apache.doris.filesystem.azure;
 
 import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisInputStream;
 import org.apache.doris.filesystem.spi.DorisOutputFile;
 import org.apache.doris.filesystem.spi.FileEntry;
 import org.apache.doris.filesystem.spi.FileIterator;
@@ -214,8 +215,117 @@ public class AzureFileSystem extends ObjFileSystem {
         }
 
         @Override
-        public InputStream newStream() throws IOException {
-            return ((AzureObjStorage) objStorage).openInputStream(location.uri());
+        public boolean exists() throws IOException {
+            try {
+                objStorage.headObject(location.uri());
+                return true;
+            } catch (IOException e) {
+                if (isNotFoundError(e)) {
+                    return false;
+                }
+                throw e;
+            }
+        }
+
+        @Override
+        public long lastModifiedTime() throws IOException {
+            return ((AzureObjStorage) objStorage).headObjectLastModified(location.uri());
+        }
+
+        @Override
+        public DorisInputStream newStream() throws IOException {
+            long fileLength = length();
+            return new AzureSeekableInputStream(location.uri(), (AzureObjStorage) objStorage, fileLength);
+        }
+    }
+
+    /**
+     * Seekable input stream for Azure blobs.
+     * Uses Azure HTTP Range requests to seek without re-downloading the entire blob.
+     */
+    private static class AzureSeekableInputStream extends DorisInputStream {
+        private final String remotePath;
+        private final AzureObjStorage objStorage;
+        private final long fileLength;
+        private long position;
+        private java.io.InputStream current;
+        private boolean closed;
+
+        AzureSeekableInputStream(String remotePath, AzureObjStorage objStorage, long fileLength) {
+            this.remotePath = remotePath;
+            this.objStorage = objStorage;
+            this.fileLength = fileLength;
+        }
+
+        private void checkOpen() throws IOException {
+            if (closed) {
+                throw new IOException("Stream already closed: " + remotePath);
+            }
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            checkOpen();
+            return position;
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            checkOpen();
+            if (pos < 0 || pos > fileLength) {
+                throw new IOException("Seek position out of range [0, " + fileLength + "]: " + pos);
+            }
+            if (pos == position) {
+                return;
+            }
+            if (current != null) {
+                current.close();
+                current = null;
+            }
+            position = pos;
+        }
+
+        @Override
+        public int read() throws IOException {
+            checkOpen();
+            if (position >= fileLength) {
+                return -1;
+            }
+            ensureOpen();
+            int b = current.read();
+            if (b >= 0) {
+                position++;
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            checkOpen();
+            if (position >= fileLength) {
+                return -1;
+            }
+            ensureOpen();
+            int n = current.read(b, off, len);
+            if (n > 0) {
+                position += n;
+            }
+            return n;
+        }
+
+        private void ensureOpen() throws IOException {
+            if (current == null) {
+                current = objStorage.openInputStreamAt(remotePath, position);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            if (current != null) {
+                current.close();
+                current = null;
+            }
         }
     }
 

--- a/fe/fe-filesystem/fe-filesystem-azure/src/main/java/org/apache/doris/filesystem/azure/AzureObjStorage.java
+++ b/fe/fe-filesystem/fe-filesystem-azure/src/main/java/org/apache/doris/filesystem/azure/AzureObjStorage.java
@@ -321,6 +321,43 @@ public class AzureObjStorage implements ObjStorage<BlobServiceClient> {
         }
     }
 
+    /**
+     * Opens an InputStream starting at {@code fromByte} using an HTTP Range request.
+     */
+    InputStream openInputStreamAt(String remotePath, long fromByte) throws IOException {
+        try {
+            AzureUri uri = AzureUri.parse(remotePath);
+            BlobClient blobClient = getClient().getBlobContainerClient(uri.container())
+                    .getBlobClient(uri.key());
+            com.azure.storage.blob.options.BlobInputStreamOptions opts =
+                    new com.azure.storage.blob.options.BlobInputStreamOptions()
+                            .setRange(new com.azure.storage.blob.models.BlobRange(fromByte));
+            return blobClient.openInputStream(opts);
+        } catch (BlobStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                throw new FileNotFoundException("Object not found: " + remotePath);
+            }
+            throw new IOException("openInputStream failed for " + remotePath + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns the last-modified time of the blob in milliseconds since epoch.
+     */
+    long headObjectLastModified(String remotePath) throws IOException {
+        try {
+            AzureUri uri = AzureUri.parse(remotePath);
+            BlobProperties props = getClient().getBlobContainerClient(uri.container())
+                    .getBlobClient(uri.key()).getProperties();
+            return props.getLastModified() != null ? props.getLastModified().toInstant().toEpochMilli() : 0L;
+        } catch (BlobStorageException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                throw new FileNotFoundException("Object not found: " + remotePath);
+            }
+            throw new IOException("getProperties failed for " + remotePath + ": " + e.getMessage(), e);
+        }
+    }
+
     @Override
     public Map<String, String> getProperties() {
         return properties;

--- a/fe/fe-filesystem/fe-filesystem-azure/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-azure/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.azure.AzureFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-broker/pom.xml
+++ b/fe/fe-filesystem/fe-filesystem-broker/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.doris</groupId>
+        <artifactId>fe-filesystem</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>fe-filesystem-broker</artifactId>
+    <packaging>jar</packaging>
+    <name>Doris FE Filesystem - Broker</name>
+    <description>
+        Doris Broker filesystem implementation for Doris FE SPI.
+        Communicates with the Doris Broker process via Thrift RPC.
+        Has zero dependency on fe-core; broker address resolution is
+        injected via properties map populated by fe-core before calling
+        FileSystemFactory.getBrokerFileSystem().
+    </description>
+
+    <dependencies>
+        <!-- SPI interfaces only — no fe-core -->
+        <dependency>
+            <groupId>org.apache.doris</groupId>
+            <artifactId>fe-filesystem-spi</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <!-- Thrift generated classes (TPaloBrokerService, TBrokerListPathRequest, ...) -->
+        <dependency>
+            <groupId>org.apache.doris</groupId>
+            <artifactId>fe-thrift</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <!-- Thrift runtime -->
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+        </dependency>
+
+        <!-- Connection pool for Thrift clients -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientFactory.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientFactory.java
@@ -17,11 +17,12 @@
 
 package org.apache.doris.filesystem.broker;
 
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+
 import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
-import org.apache.doris.thrift.TNetworkAddress;
-import org.apache.doris.thrift.TPaloBrokerService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -36,13 +37,11 @@ class BrokerClientFactory extends BaseKeyedPooledObjectFactory<TNetworkAddress, 
 
     private static final Logger LOG = LogManager.getLogger(BrokerClientFactory.class);
 
-    private static final int CONNECT_TIMEOUT_MS  = 10_000;
-    private static final int SOCKET_TIMEOUT_MS   = 300_000;
+    private static final int SOCKET_TIMEOUT_MS = 300_000;
 
     @Override
     public TPaloBrokerService.Client create(TNetworkAddress address) throws Exception {
-        TSocket socket = new TSocket(address.getHostname(), address.getPort(),
-                SOCKET_TIMEOUT_MS, CONNECT_TIMEOUT_MS);
+        TSocket socket = new TSocket(address.getHostname(), address.getPort(), SOCKET_TIMEOUT_MS);
         TTransport transport = socket;
         try {
             transport.open();

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientFactory.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientFactory.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.commons.pool2.BaseKeyedPooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+/**
+ * Commons-pool2 factory that creates and validates TPaloBrokerService Thrift clients.
+ */
+class BrokerClientFactory extends BaseKeyedPooledObjectFactory<TNetworkAddress, TPaloBrokerService.Client> {
+
+    private static final Logger LOG = LogManager.getLogger(BrokerClientFactory.class);
+
+    private static final int CONNECT_TIMEOUT_MS  = 10_000;
+    private static final int SOCKET_TIMEOUT_MS   = 300_000;
+
+    @Override
+    public TPaloBrokerService.Client create(TNetworkAddress address) throws Exception {
+        TSocket socket = new TSocket(address.getHostname(), address.getPort(),
+                SOCKET_TIMEOUT_MS, CONNECT_TIMEOUT_MS);
+        TTransport transport = socket;
+        try {
+            transport.open();
+        } catch (TTransportException e) {
+            throw new Exception("Failed to connect to broker at " + address + ": " + e.getMessage(), e);
+        }
+        return new TPaloBrokerService.Client(new TBinaryProtocol(transport));
+    }
+
+    @Override
+    public PooledObject<TPaloBrokerService.Client> wrap(TPaloBrokerService.Client client) {
+        return new DefaultPooledObject<>(client);
+    }
+
+    @Override
+    public void destroyObject(TNetworkAddress address, PooledObject<TPaloBrokerService.Client> obj) {
+        try {
+            TTransport transport = obj.getObject().getInputProtocol().getTransport();
+            if (transport.isOpen()) {
+                transport.close();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to close broker client transport for {}: {}", address, e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean validateObject(TNetworkAddress address, PooledObject<TPaloBrokerService.Client> obj) {
+        TTransport transport = obj.getObject().getInputProtocol().getTransport();
+        return transport.isOpen();
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientPool.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientPool.java
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Thread-safe pool of {@link TPaloBrokerService.Client} Thrift clients keyed by
+ * {@link TNetworkAddress}.
+ *
+ * <p>Manages connection lifecycle independently of fe-core's {@code ClientPool}.
+ * Each {@link BrokerSpiFileSystem} instance holds its own pool scoped to one broker endpoint.
+ */
+class BrokerClientPool implements Closeable {
+
+    private static final Logger LOG = LogManager.getLogger(BrokerClientPool.class);
+
+    private final GenericKeyedObjectPool<TNetworkAddress, TPaloBrokerService.Client> pool;
+
+    BrokerClientPool() {
+        GenericKeyedObjectPoolConfig<TPaloBrokerService.Client> config =
+                new GenericKeyedObjectPoolConfig<>();
+        config.setMaxIdlePerKey(16);
+        config.setMinIdlePerKey(0);
+        config.setMaxTotalPerKey(-1);
+        config.setMaxTotal(-1);
+        config.setMaxWaitMillis(500);
+        config.setTestOnBorrow(true);
+        this.pool = new GenericKeyedObjectPool<>(new BrokerClientFactory(), config);
+    }
+
+    TPaloBrokerService.Client borrow(TNetworkAddress address) throws IOException {
+        try {
+            return pool.borrowObject(address);
+        } catch (Exception e) {
+            throw new IOException("Failed to borrow broker client for " + address + ": " + e.getMessage(), e);
+        }
+    }
+
+    void returnGood(TNetworkAddress address, TPaloBrokerService.Client client) {
+        try {
+            pool.returnObject(address, client);
+        } catch (Exception e) {
+            LOG.warn("Failed to return broker client for {}: {}", address, e.getMessage());
+        }
+    }
+
+    void invalidate(TNetworkAddress address, TPaloBrokerService.Client client) {
+        try {
+            pool.invalidateObject(address, client);
+        } catch (Exception e) {
+            LOG.warn("Failed to invalidate broker client for {}: {}", address, e.getMessage());
+        }
+    }
+
+    @Override
+    public void close() {
+        pool.close();
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientPool.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerClientPool.java
@@ -17,10 +17,11 @@
 
 package org.apache.doris.filesystem.broker;
 
-import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
-import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
+
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,9 +41,9 @@ class BrokerClientPool implements Closeable {
 
     private final GenericKeyedObjectPool<TNetworkAddress, TPaloBrokerService.Client> pool;
 
+    @SuppressWarnings("unchecked")
     BrokerClientPool() {
-        GenericKeyedObjectPoolConfig<TPaloBrokerService.Client> config =
-                new GenericKeyedObjectPoolConfig<>();
+        GenericKeyedObjectPoolConfig config = new GenericKeyedObjectPoolConfig();
         config.setMaxIdlePerKey(16);
         config.setMinIdlePerKey(0);
         config.setMaxTotalPerKey(-1);

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerFileSystemProvider.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerFileSystemProvider.java
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.FileSystemProvider;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * SPI provider for the Doris Broker filesystem.
+ *
+ * <p>Recognizes maps that contain "_STORAGE_TYPE_" = "BROKER" plus a resolved
+ * "BROKER_HOST" key. The host and port are pre-resolved by fe-core's
+ * {@code FileSystemFactory.getBrokerFileSystem()} before calling into the SPI,
+ * avoiding any dependency on BrokerMgr here.
+ *
+ * <p>Registered via:
+ * META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+ */
+public class BrokerFileSystemProvider implements FileSystemProvider {
+
+    static final String KEY_TYPE      = "_STORAGE_TYPE_";
+    static final String KEY_HOST      = "BROKER_HOST";
+    static final String KEY_PORT      = "BROKER_PORT";
+    static final String KEY_CLIENT_ID = "BROKER_CLIENT_ID";
+
+    @Override
+    public boolean supports(Map<String, String> properties) {
+        return "BROKER".equals(properties.get(KEY_TYPE))
+                && properties.containsKey(KEY_HOST);
+    }
+
+    @Override
+    public FileSystem create(Map<String, String> properties) throws IOException {
+        String host = properties.get(KEY_HOST);
+        String portStr = properties.get(KEY_PORT);
+        if (host == null || host.isEmpty()) {
+            throw new IOException("BROKER_HOST is required");
+        }
+        int port;
+        try {
+            port = Integer.parseInt(portStr);
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid BROKER_PORT: " + portStr);
+        }
+        String clientId = properties.getOrDefault(KEY_CLIENT_ID, "fe");
+        Map<String, String> brokerParams = extractBrokerParams(properties);
+        return new BrokerSpiFileSystem(host, port, clientId, brokerParams);
+    }
+
+    private Map<String, String> extractBrokerParams(Map<String, String> properties) {
+        Map<String, String> params = new HashMap<>(properties);
+        params.remove(KEY_TYPE);
+        params.remove(KEY_HOST);
+        params.remove(KEY_PORT);
+        params.remove(KEY_CLIENT_ID);
+        return params;
+    }
+
+    @Override
+    public String name() {
+        return "Broker";
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputFile.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputFile.java
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisInputStream;
+import org.apache.doris.filesystem.spi.Location;
+import org.apache.doris.thrift.TBrokerFD;
+import org.apache.doris.thrift.TBrokerOpenReaderRequest;
+import org.apache.doris.thrift.TBrokerOpenReaderResponse;
+import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
+import org.apache.doris.thrift.TBrokerVersion;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * {@link DorisInputFile} backed by the Doris Broker {@code openReader} Thrift RPC.
+ *
+ * <p>A new Thrift client and broker file descriptor are opened on each {@link #newStream()} call.
+ * The length is lazily obtained from the broker file listing if not provided at construction.
+ */
+class BrokerInputFile implements DorisInputFile {
+
+    private final Location location;
+    /** Known file length, or -1 if not yet determined. */
+    private long knownLength;
+    private final TNetworkAddress endpoint;
+    private final String clientId;
+    private final Map<String, String> brokerParams;
+    private final BrokerClientPool clientPool;
+
+    BrokerInputFile(Location location, long knownLength, TNetworkAddress endpoint,
+            String clientId, Map<String, String> brokerParams, BrokerClientPool clientPool) {
+        this.location = location;
+        this.knownLength = knownLength;
+        this.endpoint = endpoint;
+        this.clientId = clientId;
+        this.brokerParams = brokerParams;
+        this.clientPool = clientPool;
+    }
+
+    @Override
+    public Location location() {
+        return location;
+    }
+
+    @Override
+    public long length() throws IOException {
+        if (knownLength >= 0) {
+            return knownLength;
+        }
+        // Resolve length by opening and immediately closing a reader.
+        // The openReader response does not include file size; use a small seek approach:
+        // open reader and let caller discover length via sequential reads (EOF detection).
+        // For now, throw UOE unless length was provided at construction.
+        throw new UnsupportedOperationException(
+                "File length not provided; use newInputFile(location, length) overload.");
+    }
+
+    @Override
+    public DorisInputStream newStream() throws IOException {
+        TPaloBrokerService.Client client = clientPool.borrow(endpoint);
+        boolean returnToPool = true;
+        try {
+            TBrokerOpenReaderRequest req = new TBrokerOpenReaderRequest(
+                    TBrokerVersion.VERSION_ONE, location.uri(), 0L, clientId, brokerParams);
+            TBrokerOpenReaderResponse rep = client.openReader(req);
+            TBrokerOperationStatus opst = rep.getOpStatus();
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Failed to open broker reader for [" + location + "]: " + opst.getMessage());
+            }
+            TBrokerFD fd = new TBrokerFD(rep.getFd().getHigh(), rep.getFd().getLow());
+            returnToPool = false; // BrokerInputStream takes ownership of the client
+            return new BrokerInputStream(endpoint, clientPool, client, fd);
+        } catch (TException e) {
+            throw new IOException("Broker openReader RPC failed for [" + location + "]: " + e.getMessage(), e);
+        } finally {
+            if (returnToPool) {
+                clientPool.returnGood(endpoint, client);
+            }
+        }
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputFile.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputFile.java
@@ -28,6 +28,7 @@ import org.apache.doris.thrift.TBrokerOperationStatusCode;
 import org.apache.doris.thrift.TBrokerVersion;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
+
 import org.apache.thrift.TException;
 
 import java.io.IOException;

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputStream.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputStream.java
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.filesystem.spi.DorisInputStream;
+import org.apache.doris.thrift.TBrokerCloseReaderRequest;
+import org.apache.doris.thrift.TBrokerFD;
+import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
+import org.apache.doris.thrift.TBrokerPReadRequest;
+import org.apache.doris.thrift.TBrokerReadResponse;
+import org.apache.doris.thrift.TBrokerVersion;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+
+/**
+ * {@link DorisInputStream} backed by a Broker {@code pread} RPC.
+ *
+ * <p>Holds an open Thrift client (borrowed from the pool on construction) for
+ * the lifetime of this stream; the client is returned to the pool on {@link #close()}.
+ */
+class BrokerInputStream extends DorisInputStream {
+
+    private static final Logger LOG = LogManager.getLogger(BrokerInputStream.class);
+    private static final int READ_BUFFER = 1 << 20; // 1 MB
+
+    private final TNetworkAddress endpoint;
+    private final BrokerClientPool clientPool;
+    private final TPaloBrokerService.Client client;
+    private final TBrokerFD fd;
+
+    private long position;
+    /** Internal byte buffer for buffered reads. */
+    private byte[] buffer = new byte[0];
+    private int bufOffset;
+    private int bufLen;
+    private boolean eof;
+
+    BrokerInputStream(TNetworkAddress endpoint, BrokerClientPool clientPool,
+            TPaloBrokerService.Client client, TBrokerFD fd) {
+        this.endpoint = endpoint;
+        this.clientPool = clientPool;
+        this.client = client;
+        this.fd = fd;
+        this.position = 0;
+        this.eof = false;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return position;
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+        if (pos < 0) {
+            throw new IOException("Seek position must be >= 0, got: " + pos);
+        }
+        // Flush the internal buffer; next read will pread from the new position.
+        position = pos;
+        bufOffset = 0;
+        bufLen = 0;
+        eof = false;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (eof) {
+            return -1;
+        }
+        if (bufLen == 0) {
+            fillBuffer();
+            if (eof) {
+                return -1;
+            }
+        }
+        int b = buffer[bufOffset] & 0xFF;
+        bufOffset++;
+        bufLen--;
+        position++;
+        return b;
+    }
+
+    @Override
+    public int read(byte[] bytes, int off, int len) throws IOException {
+        if (eof) {
+            return -1;
+        }
+        if (bufLen == 0) {
+            fillBuffer();
+            if (eof) {
+                return -1;
+            }
+        }
+        int toCopy = Math.min(len, bufLen);
+        System.arraycopy(buffer, bufOffset, bytes, off, toCopy);
+        bufOffset += toCopy;
+        bufLen -= toCopy;
+        position += toCopy;
+        return toCopy;
+    }
+
+    private void fillBuffer() throws IOException {
+        try {
+            TBrokerPReadRequest req = new TBrokerPReadRequest(
+                    TBrokerVersion.VERSION_ONE, fd, position, READ_BUFFER);
+            TBrokerReadResponse rep = client.pread(req);
+            TBrokerOperationStatus opst = rep.getOpStatus();
+            if (opst.getStatusCode() == TBrokerOperationStatusCode.END_OF_FILE) {
+                eof = true;
+                return;
+            }
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Broker pread failed at offset " + position + ": " + opst.getMessage());
+            }
+            buffer = rep.getData();
+            bufOffset = 0;
+            bufLen = buffer.length;
+            if (bufLen == 0) {
+                eof = true;
+            }
+        } catch (TException e) {
+            clientPool.invalidate(endpoint, client);
+            throw new IOException("Broker pread RPC failed at offset " + position + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            TBrokerCloseReaderRequest req = new TBrokerCloseReaderRequest(TBrokerVersion.VERSION_ONE, fd);
+            TBrokerOperationStatus opst = client.closeReader(req);
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                LOG.warn("Failed to close broker reader for fd {}: {}", fd, opst.getMessage());
+            }
+            clientPool.returnGood(endpoint, client);
+        } catch (TException e) {
+            clientPool.invalidate(endpoint, client);
+            throw new IOException("Broker closeReader RPC failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputStream.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerInputStream.java
@@ -27,6 +27,7 @@ import org.apache.doris.thrift.TBrokerReadResponse;
 import org.apache.doris.thrift.TBrokerVersion;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputFile.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputFile.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.Location;
+import org.apache.doris.thrift.TBrokerFD;
+import org.apache.doris.thrift.TBrokerOpenMode;
+import org.apache.doris.thrift.TBrokerOpenWriterRequest;
+import org.apache.doris.thrift.TBrokerOpenWriterResponse;
+import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
+import org.apache.doris.thrift.TBrokerVersion;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+/**
+ * {@link DorisOutputFile} backed by the Doris Broker {@code openWriter} Thrift RPC.
+ */
+class BrokerOutputFile implements DorisOutputFile {
+
+    private final Location location;
+    private final TNetworkAddress endpoint;
+    private final String clientId;
+    private final Map<String, String> brokerParams;
+    private final BrokerClientPool clientPool;
+
+    BrokerOutputFile(Location location, TNetworkAddress endpoint,
+            String clientId, Map<String, String> brokerParams, BrokerClientPool clientPool) {
+        this.location = location;
+        this.endpoint = endpoint;
+        this.clientId = clientId;
+        this.brokerParams = brokerParams;
+        this.clientPool = clientPool;
+    }
+
+    @Override
+    public Location location() {
+        return location;
+    }
+
+    @Override
+    public OutputStream create() throws IOException {
+        return openWriter(TBrokerOpenMode.APPEND);
+    }
+
+    @Override
+    public OutputStream createOrOverwrite() throws IOException {
+        return openWriter(TBrokerOpenMode.APPEND);
+    }
+
+    private OutputStream openWriter(TBrokerOpenMode mode) throws IOException {
+        TPaloBrokerService.Client client = clientPool.borrow(endpoint);
+        boolean returnToPool = true;
+        try {
+            TBrokerOpenWriterRequest req = new TBrokerOpenWriterRequest(
+                    TBrokerVersion.VERSION_ONE, location.uri(), mode, clientId, brokerParams);
+            TBrokerOpenWriterResponse rep = client.openWriter(req);
+            TBrokerOperationStatus opst = rep.getOpStatus();
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Failed to open broker writer for [" + location + "]: " + opst.getMessage());
+            }
+            TBrokerFD fd = new TBrokerFD(rep.getFd().getHigh(), rep.getFd().getLow());
+            returnToPool = false; // BrokerOutputStream takes ownership of the client
+            return new BrokerOutputStream(endpoint, clientPool, client, fd);
+        } catch (TException e) {
+            throw new IOException("Broker openWriter RPC failed for [" + location + "]: " + e.getMessage(), e);
+        } finally {
+            if (returnToPool) {
+                clientPool.returnGood(endpoint, client);
+            }
+        }
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputFile.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputFile.java
@@ -28,6 +28,7 @@ import org.apache.doris.thrift.TBrokerOperationStatusCode;
 import org.apache.doris.thrift.TBrokerVersion;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
+
 import org.apache.thrift.TException;
 
 import java.io.IOException;

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputStream.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputStream.java
@@ -25,6 +25,7 @@ import org.apache.doris.thrift.TBrokerPWriteRequest;
 import org.apache.doris.thrift.TBrokerVersion;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputStream.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerOutputStream.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.thrift.TBrokerCloseWriterRequest;
+import org.apache.doris.thrift.TBrokerFD;
+import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
+import org.apache.doris.thrift.TBrokerPWriteRequest;
+import org.apache.doris.thrift.TBrokerVersion;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * {@link OutputStream} backed by a Broker {@code pwrite} RPC.
+ *
+ * <p>Holds an open Thrift client (borrowed from the pool on construction) for
+ * the lifetime of this stream; the client is returned to the pool on {@link #close()}.
+ */
+class BrokerOutputStream extends OutputStream {
+
+    private static final Logger LOG = LogManager.getLogger(BrokerOutputStream.class);
+
+    private final TNetworkAddress endpoint;
+    private final BrokerClientPool clientPool;
+    private final TPaloBrokerService.Client client;
+    private final TBrokerFD fd;
+
+    private long writeOffset;
+    private boolean closed;
+
+    BrokerOutputStream(TNetworkAddress endpoint, BrokerClientPool clientPool,
+            TPaloBrokerService.Client client, TBrokerFD fd) {
+        this.endpoint = endpoint;
+        this.clientPool = clientPool;
+        this.client = client;
+        this.fd = fd;
+        this.writeOffset = 0;
+        this.closed = false;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        write(new byte[]{(byte) b}, 0, 1);
+    }
+
+    @Override
+    public void write(byte[] bytes, int off, int len) throws IOException {
+        if (closed) {
+            throw new IOException("Stream is already closed");
+        }
+        if (len == 0) {
+            return;
+        }
+        byte[] data = new byte[len];
+        System.arraycopy(bytes, off, data, 0, len);
+        try {
+            TBrokerPWriteRequest req = new TBrokerPWriteRequest(
+                    TBrokerVersion.VERSION_ONE, fd, writeOffset, ByteBuffer.wrap(data));
+            TBrokerOperationStatus opst = client.pwrite(req);
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Broker pwrite failed at offset " + writeOffset + ": " + opst.getMessage());
+            }
+            writeOffset += len;
+        } catch (TException e) {
+            clientPool.invalidate(endpoint, client);
+            closed = true;
+            throw new IOException("Broker pwrite RPC failed at offset " + writeOffset + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            TBrokerCloseWriterRequest req = new TBrokerCloseWriterRequest(TBrokerVersion.VERSION_ONE, fd);
+            TBrokerOperationStatus opst = client.closeWriter(req);
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                LOG.warn("Failed to close broker writer for fd {}: {}", fd, opst.getMessage());
+            }
+            clientPool.returnGood(endpoint, client);
+        } catch (TException e) {
+            clientPool.invalidate(endpoint, client);
+            throw new IOException("Broker closeWriter RPC failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerSpiFileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerSpiFileSystem.java
@@ -35,6 +35,7 @@ import org.apache.doris.thrift.TBrokerRenamePathRequest;
 import org.apache.doris.thrift.TBrokerVersion;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerSpiFileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/java/org/apache/doris/filesystem/broker/BrokerSpiFileSystem.java
@@ -1,0 +1,250 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisOutputFile;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileIterator;
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
+import org.apache.doris.thrift.TBrokerCheckPathExistRequest;
+import org.apache.doris.thrift.TBrokerCheckPathExistResponse;
+import org.apache.doris.thrift.TBrokerDeletePathRequest;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TBrokerListPathRequest;
+import org.apache.doris.thrift.TBrokerListResponse;
+import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
+import org.apache.doris.thrift.TBrokerRenamePathRequest;
+import org.apache.doris.thrift.TBrokerVersion;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link FileSystem} implementation backed by a Doris Broker process via Thrift RPC.
+ *
+ * <p>The broker endpoint (host, port) is pre-resolved by fe-core before construction.
+ * This class has zero dependency on fe-core, {@code BrokerMgr}, or {@code BrokerProperties}.
+ *
+ * <p>Instances are created by {@link BrokerFileSystemProvider} via the SPI mechanism
+ * after fe-core calls {@code FileSystemFactory.getBrokerFileSystem(host, port, params)}.
+ */
+public class BrokerSpiFileSystem implements FileSystem {
+
+    private static final Logger LOG = LogManager.getLogger(BrokerSpiFileSystem.class);
+
+    private final TNetworkAddress endpoint;
+    /** FE identifier sent to broker for logging (e.g. "host:editLogPort"). */
+    private final String clientId;
+    /** Broker-specific configuration params (username, password, hadoop conf, etc.). */
+    private final Map<String, String> brokerParams;
+    private final BrokerClientPool clientPool;
+
+    BrokerSpiFileSystem(String host, int port, String clientId, Map<String, String> brokerParams) {
+        this.endpoint = new TNetworkAddress(host, port);
+        this.clientId = clientId;
+        this.brokerParams = Map.copyOf(brokerParams);
+        this.clientPool = new BrokerClientPool();
+    }
+
+    @Override
+    public boolean exists(Location location) throws IOException {
+        TPaloBrokerService.Client client = clientPool.borrow(endpoint);
+        boolean returnToPool = true;
+        try {
+            TBrokerCheckPathExistRequest req = new TBrokerCheckPathExistRequest(
+                    TBrokerVersion.VERSION_ONE, location.uri(), brokerParams);
+            TBrokerCheckPathExistResponse rep = client.checkPathExist(req);
+            TBrokerOperationStatus opst = rep.getOpStatus();
+            if (opst.getStatusCode() == TBrokerOperationStatusCode.FILE_NOT_FOUND) {
+                return false;
+            }
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Failed to check path existence [" + location + "]: " + opst.getMessage());
+            }
+            return rep.isIsPathExist();
+        } catch (TException e) {
+            returnToPool = false;
+            throw new IOException("Broker RPC failed for exists [" + location + "]: " + e.getMessage(), e);
+        } finally {
+            if (returnToPool) {
+                clientPool.returnGood(endpoint, client);
+            } else {
+                clientPool.invalidate(endpoint, client);
+            }
+        }
+    }
+
+    @Override
+    public void mkdirs(Location location) throws IOException {
+        // Broker does not provide a mkdirs RPC; the broker process creates parent directories
+        // automatically on openWriter. This is a no-op for broker-backed paths.
+    }
+
+    @Override
+    public void delete(Location location, boolean recursive) throws IOException {
+        TPaloBrokerService.Client client = clientPool.borrow(endpoint);
+        boolean returnToPool = true;
+        try {
+            TBrokerDeletePathRequest req = new TBrokerDeletePathRequest(
+                    TBrokerVersion.VERSION_ONE, location.uri(), brokerParams);
+            TBrokerOperationStatus opst = client.deletePath(req);
+            if (opst.getStatusCode() == TBrokerOperationStatusCode.FILE_NOT_FOUND) {
+                return;
+            }
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Failed to delete [" + location + "]: " + opst.getMessage());
+            }
+        } catch (TException e) {
+            returnToPool = false;
+            throw new IOException("Broker RPC failed for delete [" + location + "]: " + e.getMessage(), e);
+        } finally {
+            if (returnToPool) {
+                clientPool.returnGood(endpoint, client);
+            } else {
+                clientPool.invalidate(endpoint, client);
+            }
+        }
+    }
+
+    @Override
+    public void rename(Location src, Location dst) throws IOException {
+        TPaloBrokerService.Client client = clientPool.borrow(endpoint);
+        boolean returnToPool = true;
+        try {
+            TBrokerRenamePathRequest req = new TBrokerRenamePathRequest(
+                    TBrokerVersion.VERSION_ONE, src.uri(), dst.uri(), brokerParams);
+            TBrokerOperationStatus opst = client.renamePath(req);
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Failed to rename [" + src + "] -> [" + dst + "]: " + opst.getMessage());
+            }
+        } catch (TException e) {
+            returnToPool = false;
+            throw new IOException("Broker RPC failed for rename: " + e.getMessage(), e);
+        } finally {
+            if (returnToPool) {
+                clientPool.returnGood(endpoint, client);
+            } else {
+                clientPool.invalidate(endpoint, client);
+            }
+        }
+    }
+
+    @Override
+    public FileIterator list(Location location) throws IOException {
+        List<TBrokerFileStatus> statuses = listPath(location.uri(), false);
+        List<FileEntry> entries = new ArrayList<>(statuses.size());
+        for (TBrokerFileStatus s : statuses) {
+            entries.add(new FileEntry(
+                    Location.of(s.getPath()),
+                    s.getSize(),
+                    s.isIsDir(),
+                    null));
+        }
+        Iterator<FileEntry> it = entries.iterator();
+        return new FileIterator() {
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public FileEntry next() {
+                return it.next();
+            }
+
+            @Override
+            public void close() {
+                // no-op: list result is already fully materialized
+            }
+        };
+    }
+
+    @Override
+    public DorisInputFile newInputFile(Location location) throws IOException {
+        return new BrokerInputFile(location, -1L, endpoint, clientId, brokerParams, clientPool);
+    }
+
+    @Override
+    public DorisInputFile newInputFile(Location location, long length) throws IOException {
+        return new BrokerInputFile(location, length, endpoint, clientId, brokerParams, clientPool);
+    }
+
+    @Override
+    public DorisOutputFile newOutputFile(Location location) throws IOException {
+        return new BrokerOutputFile(location, endpoint, clientId, brokerParams, clientPool);
+    }
+
+    @Override
+    public void close() throws IOException {
+        clientPool.close();
+    }
+
+    /**
+     * Calls broker {@code listPath} RPC and returns the raw file status list.
+     * The broker handles glob patterns natively (delegates to Hadoop FileSystem.globStatus).
+     */
+    List<TBrokerFileStatus> listPath(String path, boolean recursive) throws IOException {
+        TPaloBrokerService.Client client = clientPool.borrow(endpoint);
+        boolean returnToPool = true;
+        try {
+            TBrokerListPathRequest req = new TBrokerListPathRequest(
+                    TBrokerVersion.VERSION_ONE, path, recursive, brokerParams);
+            TBrokerListResponse rep = client.listPath(req);
+            TBrokerOperationStatus opst = rep.getOpStatus();
+            if (opst.getStatusCode() == TBrokerOperationStatusCode.FILE_NOT_FOUND) {
+                return List.of();
+            }
+            if (opst.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                throw new IOException("Failed to list path [" + path + "]: " + opst.getMessage());
+            }
+            return rep.getFiles() != null ? rep.getFiles() : List.of();
+        } catch (TException e) {
+            returnToPool = false;
+            throw new IOException("Broker RPC failed for list [" + path + "]: " + e.getMessage(), e);
+        } finally {
+            if (returnToPool) {
+                clientPool.returnGood(endpoint, client);
+            } else {
+                clientPool.invalidate(endpoint, client);
+            }
+        }
+    }
+
+    TNetworkAddress endpoint() {
+        return endpoint;
+    }
+
+    String clientId() {
+        return clientId;
+    }
+
+    Map<String, String> brokerParams() {
+        return brokerParams;
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.broker.BrokerFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-broker/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-broker/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,0 +1,1 @@
+org.apache.doris.filesystem.broker.BrokerFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-cos/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-cos/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.cos.CosFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/HdfsInputFile.java
+++ b/fe/fe-filesystem/fe-filesystem-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/HdfsInputFile.java
@@ -18,16 +18,18 @@
 package org.apache.doris.filesystem.hdfs;
 
 import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisInputStream;
 import org.apache.doris.filesystem.spi.HadoopAuthenticator;
 import org.apache.doris.filesystem.spi.Location;
 
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 /**
- * HDFS-backed {@link DorisInputFile} that opens an {@link InputStream} via Hadoop FSDataInputStream.
+ * HDFS-backed {@link DorisInputFile} that opens a seekable {@link DorisInputStream}
+ * via Hadoop's {@link FSDataInputStream}.
  */
 class HdfsInputFile implements DorisInputFile {
 
@@ -54,7 +56,18 @@ class HdfsInputFile implements DorisInputFile {
     }
 
     @Override
-    public InputStream newStream() throws IOException {
-        return authenticator.doAs(() -> dfs.requireFs(path).open(path));
+    public boolean exists() throws IOException {
+        return authenticator.doAs(() -> dfs.requireFs(path).exists(path));
+    }
+
+    @Override
+    public long lastModifiedTime() throws IOException {
+        return authenticator.doAs(() -> dfs.requireFs(path).getFileStatus(path).getModificationTime());
+    }
+
+    @Override
+    public DorisInputStream newStream() throws IOException {
+        FSDataInputStream fds = authenticator.doAs(() -> dfs.requireFs(path).open(path));
+        return new HdfsSeekableInputStream(path.toString(), fds);
     }
 }

--- a/fe/fe-filesystem/fe-filesystem-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/HdfsSeekableInputStream.java
+++ b/fe/fe-filesystem/fe-filesystem-hdfs/src/main/java/org/apache/doris/filesystem/hdfs/HdfsSeekableInputStream.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.hdfs;
+
+import org.apache.doris.filesystem.spi.DorisInputStream;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+
+/**
+ * A {@link DorisInputStream} backed by Hadoop's {@link FSDataInputStream}.
+ *
+ * <p>HDFS's {@code FSDataInputStream} natively supports seeking,
+ * so this wrapper is a thin delegation layer.
+ */
+class HdfsSeekableInputStream extends DorisInputStream {
+
+    private final String path;
+    private final FSDataInputStream stream;
+    private boolean closed;
+
+    HdfsSeekableInputStream(String path, FSDataInputStream stream) {
+        this.path = path;
+        this.stream = stream;
+    }
+
+    private void checkOpen() throws IOException {
+        if (closed) {
+            throw new IOException("Stream already closed: " + path);
+        }
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        checkOpen();
+        return stream.getPos();
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+        checkOpen();
+        try {
+            stream.seek(pos);
+        } catch (IOException e) {
+            throw new IOException("seek(" + pos + ") failed for " + path + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        checkOpen();
+        return stream.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        checkOpen();
+        return stream.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        checkOpen();
+        return stream.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        checkOpen();
+        return stream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        stream.close();
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-hdfs/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-hdfs/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.hdfs.HdfsFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-local/src/main/java/org/apache/doris/filesystem/local/LocalFileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-local/src/main/java/org/apache/doris/filesystem/local/LocalFileSystem.java
@@ -18,6 +18,7 @@
 package org.apache.doris.filesystem.local;
 
 import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisInputStream;
 import org.apache.doris.filesystem.spi.DorisOutputFile;
 import org.apache.doris.filesystem.spi.FileEntry;
 import org.apache.doris.filesystem.spi.FileIterator;
@@ -25,8 +26,8 @@ import org.apache.doris.filesystem.spi.FileSystem;
 import org.apache.doris.filesystem.spi.Location;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -139,10 +140,58 @@ public class LocalFileSystem implements FileSystem {
             }
 
             @Override
-            public InputStream newStream() throws IOException {
-                return Files.newInputStream(path);
+            public boolean exists() throws IOException {
+                return Files.exists(path);
+            }
+
+            @Override
+            public long lastModifiedTime() throws IOException {
+                return Files.getLastModifiedTime(path).toMillis();
+            }
+
+            @Override
+            public DorisInputStream newStream() throws IOException {
+                return new LocalSeekableInputStream(path);
             }
         };
+    }
+
+    /** Seekable stream backed by a local {@link RandomAccessFile}. For testing only. */
+    private static class LocalSeekableInputStream extends DorisInputStream {
+        private final RandomAccessFile raf;
+        private boolean closed;
+
+        LocalSeekableInputStream(Path path) throws IOException {
+            this.raf = new RandomAccessFile(path.toFile(), "r");
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return raf.getFilePointer();
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            raf.seek(pos);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return raf.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return raf.read(b, off, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (!closed) {
+                closed = true;
+                raf.close();
+            }
+        }
     }
 
     @Override

--- a/fe/fe-filesystem/fe-filesystem-local/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-local/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.local.LocalFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-obs/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-obs/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.obs.ObsFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-oss/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-oss/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.oss.OssFileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
@@ -18,6 +18,7 @@
 package org.apache.doris.filesystem.s3;
 
 import org.apache.doris.filesystem.spi.DorisInputFile;
+import org.apache.doris.filesystem.spi.DorisInputStream;
 import org.apache.doris.filesystem.spi.DorisOutputFile;
 import org.apache.doris.filesystem.spi.FileEntry;
 import org.apache.doris.filesystem.spi.FileIterator;
@@ -36,7 +37,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
+
  * S3-backed FileSystem implementation for the Doris FE filesystem SPI.
  * Does not depend on fe-core, fe-common, or fe-catalog.
  */
@@ -200,8 +201,127 @@ public class S3FileSystem extends ObjFileSystem {
         }
 
         @Override
-        public InputStream newStream() throws IOException {
-            return ((S3ObjStorage) objStorage).openInputStream(location.uri());
+        public boolean exists() throws IOException {
+            try {
+                objStorage.headObject(location.uri());
+                return true;
+            } catch (IOException e) {
+                if (isNotFoundError(e)) {
+                    return false;
+                }
+                throw e;
+            }
+        }
+
+        @Override
+        public long lastModifiedTime() throws IOException {
+            return ((S3ObjStorage) objStorage).headObjectLastModified(location.uri());
+        }
+
+        @Override
+        public DorisInputStream newStream() throws IOException {
+            long fileLength = length();
+            return new S3SeekableInputStream(location.uri(), (S3ObjStorage) objStorage, fileLength);
+        }
+    }
+
+    /**
+     * Seekable input stream for S3 objects.
+     * Uses HTTP Range requests to seek without downloading the entire object.
+     */
+    private static class S3SeekableInputStream extends DorisInputStream {
+        private final String remotePath;
+        private final S3ObjStorage objStorage;
+        private final long fileLength;
+        private long position;
+        private InputStream current;
+        private boolean closed;
+
+        S3SeekableInputStream(String remotePath, S3ObjStorage objStorage, long fileLength) {
+            this.remotePath = remotePath;
+            this.objStorage = objStorage;
+            this.fileLength = fileLength;
+        }
+
+        private void checkOpen() throws IOException {
+            if (closed) {
+                throw new IOException("Stream already closed: " + remotePath);
+            }
+        }
+
+        /** Opens a range-based GET stream starting at {@link #position}. */
+        private void openStream() throws IOException {
+            if (current != null) {
+                current.close();
+                current = null;
+            }
+            current = objStorage.openInputStreamAt(remotePath, position);
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            checkOpen();
+            return position;
+        }
+
+        @Override
+        public void seek(long pos) throws IOException {
+            checkOpen();
+            if (pos < 0 || pos > fileLength) {
+                throw new IOException("Seek position out of range [0, " + fileLength + "]: " + pos);
+            }
+            if (pos == position) {
+                return;
+            }
+            // Close the current stream; a new range request will be issued on next read.
+            if (current != null) {
+                current.close();
+                current = null;
+            }
+            position = pos;
+        }
+
+        @Override
+        public int read() throws IOException {
+            checkOpen();
+            if (position >= fileLength) {
+                return -1;
+            }
+            ensureOpen();
+            int b = current.read();
+            if (b >= 0) {
+                position++;
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            checkOpen();
+            if (position >= fileLength) {
+                return -1;
+            }
+            ensureOpen();
+            int n = current.read(b, off, len);
+            if (n > 0) {
+                position += n;
+            }
+            return n;
+        }
+
+        private void ensureOpen() throws IOException {
+            if (current == null) {
+                openStream();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            if (current != null) {
+                current.close();
+                current = null;
+            }
         }
     }
 

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
@@ -46,7 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
- * S3-backed FileSystem implementation for the Doris FE filesystem SPI.
+ /* S3-backed FileSystem implementation for the Doris FE filesystem SPI.
  * Does not depend on fe-core, fe-common, or fe-catalog.
  */
 public class S3FileSystem extends ObjFileSystem {

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
@@ -45,8 +45,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-
- /* S3-backed FileSystem implementation for the Doris FE filesystem SPI.
+/* S3-backed FileSystem implementation for the Doris FE filesystem SPI.
  * Does not depend on fe-core, fe-common, or fe-catalog.
  */
 public class S3FileSystem extends ObjFileSystem {

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystem.java
@@ -22,6 +22,7 @@ import org.apache.doris.filesystem.spi.DorisInputStream;
 import org.apache.doris.filesystem.spi.DorisOutputFile;
 import org.apache.doris.filesystem.spi.FileEntry;
 import org.apache.doris.filesystem.spi.FileIterator;
+import org.apache.doris.filesystem.spi.GlobListing;
 import org.apache.doris.filesystem.spi.Location;
 import org.apache.doris.filesystem.spi.ObjFileSystem;
 import org.apache.doris.filesystem.spi.RemoteObject;
@@ -30,10 +31,17 @@ import org.apache.doris.filesystem.spi.RequestBody;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -348,5 +356,105 @@ public class S3FileSystem extends ObjFileSystem {
             // Use a buffered in-memory stream; flush triggers PutObject on close
             return new S3OutputStream(location.uri(), (S3ObjStorage) objStorage);
         }
+    }
+
+    /**
+     * Returns the longest key-prefix of {@code globPattern} that contains no glob metacharacters
+     * ({@code * ? [ { \}).  Used as the {@code prefix} parameter for S3 {@code ListObjectsV2}.
+     */
+    static String longestNonGlobPrefix(String globPattern) {
+        int earliest = globPattern.length();
+        for (char c : new char[]{'*', '?', '[', '{', '\\'}) {
+            int idx = globPattern.indexOf(c);
+            if (idx >= 0 && idx < earliest) {
+                earliest = idx;
+            }
+        }
+        return globPattern.substring(0, earliest);
+    }
+
+    @Override
+    public GlobListing globListWithLimit(Location path, String startAfter, long maxBytes,
+            long maxFiles) throws IOException {
+        // Parse s3://bucket/keyPattern from the Location URI
+        String uri = path.uri();
+        int schemeEnd = uri.indexOf("://");
+        String bucketAndKey = schemeEnd >= 0 ? uri.substring(schemeEnd + 3) : uri;
+        int firstSlash = bucketAndKey.indexOf('/');
+        String bucket = firstSlash >= 0 ? bucketAndKey.substring(0, firstSlash) : bucketAndKey;
+        String keyPattern = firstSlash >= 0 ? bucketAndKey.substring(firstSlash + 1) : "";
+
+        java.nio.file.Path pathPattern = Paths.get(keyPattern);
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pathPattern);
+        String listPrefix = longestNonGlobPrefix(keyPattern);
+
+        S3ObjStorage s3 = (S3ObjStorage) objStorage;
+        ListObjectsV2Request.Builder reqBuilder = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(listPrefix);
+        if (startAfter != null && !startAfter.isEmpty()) {
+            reqBuilder.startAfter(startAfter);
+        }
+        ListObjectsV2Request request = reqBuilder.build();
+
+        List<FileEntry> files = new ArrayList<>();
+        long totalSize = 0L;
+        boolean reachLimit = false;
+        String currentMaxFile = "";
+        String lastMatchedKey = "";
+        boolean isTruncated;
+
+        try {
+            do {
+                ListObjectsV2Response response = s3.getClient().listObjectsV2(request);
+                for (S3Object obj : response.contents()) {
+                    // Once limit reached: scan remaining objects to find the next glob-match
+                    // so callers can determine whether more data exists.
+                    if (reachLimit) {
+                        if (matcher.matches(Paths.get(obj.key()))) {
+                            currentMaxFile = obj.key();
+                            break;
+                        }
+                        continue;
+                    }
+
+                    if (!matcher.matches(Paths.get(obj.key()))) {
+                        continue;
+                    }
+
+                    files.add(new FileEntry(
+                            Location.of("s3://" + bucket + "/" + obj.key()),
+                            obj.size(),
+                            false,
+                            null));
+                    totalSize += obj.size();
+                    lastMatchedKey = obj.key();
+
+                    if ((maxFiles > 0 && files.size() >= maxFiles)
+                            || (maxBytes > 0 && totalSize >= maxBytes)) {
+                        reachLimit = true;
+                        break;
+                    }
+                }
+
+                if (currentMaxFile.isEmpty()) {
+                    currentMaxFile = lastMatchedKey;
+                }
+
+                isTruncated = response.isTruncated();
+                if (isTruncated) {
+                    request = request.toBuilder()
+                            .continuationToken(response.nextContinuationToken())
+                            .build();
+                }
+            } while (isTruncated && !reachLimit);
+        } catch (NoSuchKeyException e) {
+            LOG.info("NoSuchKey when listing s3://{}/{}, treating as empty", bucket, listPrefix);
+            return new GlobListing(List.of(), bucket, listPrefix, "");
+        } catch (Exception e) {
+            throw new IOException("Failed to list S3 objects at " + uri + ": " + e.getMessage(), e);
+        }
+
+        return new GlobListing(files, bucket, listPrefix, currentMaxFile);
     }
 }

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
@@ -18,7 +18,9 @@
 package org.apache.doris.filesystem.s3;
 
 import org.apache.doris.filesystem.spi.ObjStorage;
+import org.apache.doris.filesystem.spi.RemoteObject;
 import org.apache.doris.filesystem.spi.RemoteObjects;
+import org.apache.doris.filesystem.spi.StsCredentials;
 import org.apache.doris.filesystem.spi.UploadPartResult;
 
 import org.apache.logging.log4j.LogManager;
@@ -50,15 +52,24 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -85,14 +96,23 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
     static final String PROP_SECRET_KEY = "AWS_SECRET_KEY";
     static final String PROP_TOKEN = "AWS_TOKEN";
     static final String PROP_PATH_STYLE = "use_path_style";
+    static final String PROP_BUCKET = "AWS_BUCKET";
+    static final String PROP_ROLE_ARN = "AWS_ROLE_ARN";
+    static final String PROP_EXTERNAL_ID = "AWS_EXTERNAL_ID";
+
+    /** Validity period for pre-signed URLs and STS tokens (seconds). */
+    private static final int SESSION_EXPIRE_SECONDS = 3600;
 
     private final Map<String, String> properties;
     private final boolean usePathStyle;
+    /** Bucket name; may be null if not provided (listObjectsWithPrefix and related methods will fail). */
+    private final String bucket;
     private volatile S3Client client;
 
     public S3ObjStorage(Map<String, String> properties) {
         this.properties = Collections.unmodifiableMap(properties);
         this.usePathStyle = Boolean.parseBoolean(properties.getOrDefault(PROP_PATH_STYLE, "false"));
+        this.bucket = properties.get(PROP_BUCKET);
     }
 
     @Override
@@ -316,10 +336,170 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Cloud-specific extensions
+    // -----------------------------------------------------------------------
+
+    @Override
+    public StsCredentials getStsToken() throws IOException {
+        String roleArn = properties.get(PROP_ROLE_ARN);
+        String externalId = properties.get(PROP_EXTERNAL_ID);
+        if (roleArn == null || roleArn.isEmpty()) {
+            throw new IOException("STS role ARN (AWS_ROLE_ARN) is not configured");
+        }
+        String accessKey = properties.get(PROP_ACCESS_KEY);
+        String secretKey = properties.get(PROP_SECRET_KEY);
+        String region = properties.getOrDefault(PROP_REGION, "us-east-1");
+        try {
+            AwsBasicCredentials basicCred = AwsBasicCredentials.create(accessKey, secretKey);
+            try (StsClient stsClient = StsClient.builder()
+                    .credentialsProvider(StaticCredentialsProvider.create(basicCred))
+                    .region(Region.of(region))
+                    .build()) {
+                AssumeRoleRequest.Builder reqBuilder = AssumeRoleRequest.builder()
+                        .roleArn(roleArn)
+                        .durationSeconds(SESSION_EXPIRE_SECONDS)
+                        .roleSessionName("doris_" + UUID.randomUUID().toString().replace("-", ""));
+                if (externalId != null && !externalId.isEmpty()) {
+                    reqBuilder.externalId(externalId);
+                }
+                AssumeRoleResponse resp = stsClient.assumeRole(reqBuilder.build());
+                Credentials cred = resp.credentials();
+                return new StsCredentials(cred.accessKeyId(), cred.secretAccessKey(), cred.sessionToken());
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to get STS token, roleArn={}", roleArn, e);
+            throw new IOException("Failed to get STS token: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public RemoteObjects listObjectsWithPrefix(String prefix, String subPrefix,
+            String continuationToken) throws IOException {
+        requireBucket("listObjectsWithPrefix");
+        String fullPrefix = normalizeAndCombinePrefix(prefix, subPrefix);
+        try {
+            ListObjectsV2Request.Builder reqBuilder = ListObjectsV2Request.builder()
+                    .bucket(bucket)
+                    .prefix(fullPrefix);
+            if (continuationToken != null && !continuationToken.isEmpty()) {
+                reqBuilder.continuationToken(continuationToken);
+            }
+            ListObjectsV2Response resp = getClient().listObjectsV2(reqBuilder.build());
+            List<RemoteObject> files = resp.contents().stream()
+                    .map(s3Obj -> new RemoteObject(
+                            s3Obj.key(),
+                            getRelativePathSafe(prefix, s3Obj.key()),
+                            s3Obj.eTag(),
+                            s3Obj.size()))
+                    .collect(Collectors.toList());
+            return new RemoteObjects(files, resp.isTruncated(),
+                    resp.isTruncated() ? resp.nextContinuationToken() : null);
+        } catch (S3Exception e) {
+            LOG.warn("Failed to listObjectsWithPrefix, fullPrefix={}", fullPrefix, e);
+            throw new IOException("Failed to listObjectsWithPrefix: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public RemoteObjects headObjectWithMeta(String prefix, String subKey) throws IOException {
+        requireBucket("headObjectWithMeta");
+        String fullKey = normalizeAndCombinePrefix(prefix, subKey);
+        try {
+            HeadObjectResponse resp = getClient().headObject(
+                    HeadObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(fullKey)
+                            .build());
+            RemoteObject obj = new RemoteObject(
+                    fullKey, getRelativePathSafe(prefix, fullKey), resp.eTag(), resp.contentLength());
+            return new RemoteObjects(Collections.singletonList(obj), false, null);
+        } catch (NoSuchKeyException e) {
+            LOG.warn("Key not found in headObjectWithMeta, key={}", fullKey);
+            return new RemoteObjects(Collections.emptyList(), false, null);
+        } catch (S3Exception e) {
+            LOG.warn("Failed to headObjectWithMeta, key={}", fullKey, e);
+            throw new IOException("Failed to headObjectWithMeta: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String getPresignedUrl(String objectKey) throws IOException {
+        requireBucket("getPresignedUrl");
+        String accessKey = properties.get(PROP_ACCESS_KEY);
+        String secretKey = properties.get(PROP_SECRET_KEY);
+        String region = properties.getOrDefault(PROP_REGION, "us-east-1");
+        try {
+            PutObjectRequest putReq = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(objectKey)
+                    .build();
+            PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofSeconds(SESSION_EXPIRE_SECONDS))
+                    .putObjectRequest(putReq)
+                    .build();
+            AwsBasicCredentials cred = AwsBasicCredentials.create(accessKey, secretKey);
+            try (S3Presigner presigner = S3Presigner.builder()
+                    .region(Region.of(region))
+                    .credentialsProvider(StaticCredentialsProvider.create(cred))
+                    .build()) {
+                PresignedPutObjectRequest presigned = presigner.presignPutObject(presignReq);
+                LOG.info("Generated S3 presigned URL for key={}", objectKey);
+                return presigned.url().toString();
+            }
+        } catch (S3Exception e) {
+            LOG.warn("Failed to generate S3 presigned URL for key={}", objectKey, e);
+            throw new IOException("Failed to generate S3 presigned URL: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteObjectsByKeys(String bucket, List<String> keys) throws IOException {
+        List<IOException> errors = new ArrayList<>();
+        for (String key : keys) {
+            try {
+                deleteObject("s3://" + bucket + "/" + key);
+            } catch (IOException e) {
+                LOG.warn("Failed to delete object key={} from bucket={}", key, bucket, e);
+                errors.add(e);
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new IOException("Failed to delete " + errors.size() + " object(s): "
+                    + errors.get(0).getMessage(), errors.get(0));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    private void requireBucket(String operation) throws IOException {
+        if (bucket == null || bucket.isEmpty()) {
+            throw new IOException(operation + " requires AWS_BUCKET to be configured");
+        }
+    }
+
+    private static String normalizeAndCombinePrefix(String prefix, String subPrefix) {
+        String normalized = (prefix == null || prefix.isEmpty()) ? ""
+                : (prefix.endsWith("/") ? prefix : prefix + "/");
+        if (subPrefix == null || subPrefix.isEmpty()) {
+            return normalized;
+        }
+        return normalized.isEmpty() ? subPrefix : normalized + subPrefix;
+    }
+
+    private static String getRelativePathSafe(String prefix, String key) {
+        String normalized = (prefix == null || prefix.isEmpty()) ? ""
+                : (prefix.endsWith("/") ? prefix : prefix + "/");
+        if (!key.startsWith(normalized)) {
+            return key;
+        }
+        return key.substring(normalized.length());
+    }
+
     @Override
     public Map<String, String> getProperties() {
-        return properties;
-    }
 
     @Override
     public void close() throws IOException {

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
@@ -336,6 +336,41 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         }
     }
 
+    /**
+     * Open an InputStream for reading an S3 object starting at a byte offset (HTTP Range request).
+     */
+    InputStream openInputStreamAt(String remotePath, long fromByte) throws IOException {
+        S3Uri uri = S3Uri.parse(remotePath, usePathStyle);
+        try {
+            GetObjectRequest.Builder req = GetObjectRequest.builder()
+                    .bucket(uri.bucket()).key(uri.key());
+            if (fromByte > 0) {
+                req.range("bytes=" + fromByte + "-");
+            }
+            return getClient().getObject(req.build());
+        } catch (NoSuchKeyException e) {
+            throw new FileNotFoundException("Object not found: " + remotePath);
+        } catch (S3Exception e) {
+            throw new IOException("getObject failed for " + remotePath + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns the last-modified time of an S3 object in milliseconds since epoch.
+     */
+    long headObjectLastModified(String remotePath) throws IOException {
+        S3Uri uri = S3Uri.parse(remotePath, usePathStyle);
+        try {
+            HeadObjectResponse resp = getClient().headObject(
+                    HeadObjectRequest.builder().bucket(uri.bucket()).key(uri.key()).build());
+            return resp.lastModified() != null ? resp.lastModified().toEpochMilli() : 0L;
+        } catch (NoSuchKeyException e) {
+            throw new FileNotFoundException("Object not found: " + remotePath);
+        } catch (S3Exception e) {
+            throw new IOException("headObject failed for " + remotePath + ": " + e.getMessage(), e);
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Cloud-specific extensions
     // -----------------------------------------------------------------------

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
@@ -535,6 +535,8 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
 
     @Override
     public Map<String, String> getProperties() {
+        return properties;
+    }
 
     @Override
     public void close() throws IOException {

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/resources/META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
 org.apache.doris.filesystem.s3.S3FileSystemProvider

--- a/fe/fe-filesystem/fe-filesystem-spi/pom.xml
+++ b/fe/fe-filesystem/fe-filesystem-spi/pom.xml
@@ -34,11 +34,20 @@ under the License.
     <name>Doris FE Filesystem SPI</name>
     <description>
         Service Provider Interface (SPI) for Doris FE filesystem abstraction.
-        Zero external dependencies - only JDK 11.
+        Zero third-party external dependencies — only JDK and Doris internal SPI interfaces.
         This is the ONLY filesystem artifact compiled into fe-core.
     </description>
 
-    <!-- Intentionally no dependencies: only JDK 11 is allowed -->
+    <dependencies>
+        <!-- fe-extension-spi: pure Java interfaces (no third-party deps) required for
+             FileSystemProvider extends PluginFactory, enabling DirectoryPluginRuntimeManager
+             to load filesystem provider plugins from the filesystem directory. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fe-extension-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <finalName>doris-fe-filesystem-spi</finalName>

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/DorisInputFile.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/DorisInputFile.java
@@ -18,16 +18,58 @@
 package org.apache.doris.filesystem.spi;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Represents a readable file in the filesystem.
+ *
+ * <p>The minimal contract ({@link #location()}, {@link #length()}, {@link #newStream()}) is
+ * required by all implementations. Optional capabilities ({@link #exists()},
+ * {@link #lastModifiedTime()}) provide defaults that throw {@link UnsupportedOperationException};
+ * implementations should override them where the underlying storage supports the operation.
  */
 public interface DorisInputFile {
 
+    /** Returns the location of this file. */
     Location location();
 
+    /**
+     * Returns the length of the file in bytes.
+     *
+     * @throws IOException if the length cannot be determined
+     */
     long length() throws IOException;
 
-    InputStream newStream() throws IOException;
+    /**
+     * Returns {@code true} if the file exists on the remote filesystem.
+     *
+     * <p>Default implementation throws {@link UnsupportedOperationException}.
+     * Override in implementations that can perform a lightweight existence check
+     * (e.g., a HEAD request on object storage, or {@code stat()} on HDFS).
+     *
+     * @throws IOException if the check fails for a reason other than "not found"
+     */
+    default boolean exists() throws IOException {
+        throw new UnsupportedOperationException(
+                "exists() is not supported by " + getClass().getSimpleName());
+    }
+
+    /**
+     * Returns the last-modified time of this file in milliseconds since the Unix epoch.
+     *
+     * <p>Default implementation throws {@link UnsupportedOperationException}.
+     *
+     * @throws IOException if the metadata cannot be retrieved
+     */
+    default long lastModifiedTime() throws IOException {
+        throw new UnsupportedOperationException(
+                "lastModifiedTime() is not supported by " + getClass().getSimpleName());
+    }
+
+    /**
+     * Opens a new {@link DorisInputStream} positioned at offset 0.
+     * Each call returns an independent stream; callers must close it after use.
+     *
+     * @throws IOException if the stream cannot be opened
+     */
+    DorisInputStream newStream() throws IOException;
 }

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/DorisInputStream.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/DorisInputStream.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.spi;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An {@link InputStream} that supports random-access seeking.
+ *
+ * <p>Required by Iceberg's {@code SeekableInputStream} and other consumers that
+ * need to re-read data at arbitrary offsets within a file.
+ */
+public abstract class DorisInputStream extends InputStream {
+
+    /**
+     * Returns the current byte position in the stream (0-based offset from start of file).
+     *
+     * @throws IOException if the position cannot be determined
+     */
+    public abstract long getPos() throws IOException;
+
+    /**
+     * Seeks to the specified byte position.
+     * The next {@link #read()} will return the byte at {@code pos}.
+     *
+     * @param pos the byte offset to seek to (must be &ge; 0 and &le; file length)
+     * @throws IOException if the seek fails or {@code pos} is out of range
+     */
+    public abstract void seek(long pos) throws IOException;
+}

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystem.java
@@ -18,6 +18,10 @@
 package org.apache.doris.filesystem.spi;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Core filesystem abstraction.
@@ -34,6 +38,85 @@ public interface FileSystem extends AutoCloseable {
     void rename(Location src, Location dst) throws IOException;
 
     FileIterator list(Location location) throws IOException;
+
+    /**
+     * Returns all non-directory entries directly under {@code dir} (non-recursive).
+     * The default implementation iterates {@link #list(Location)} and filters out directories.
+     */
+    default List<FileEntry> listFiles(Location dir) throws IOException {
+        List<FileEntry> result = new ArrayList<>();
+        try (FileIterator it = list(dir)) {
+            while (it.hasNext()) {
+                FileEntry e = it.next();
+                if (!e.isDirectory()) {
+                    result.add(e);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns all non-directory entries under {@code dir}, recursively traversing
+     * sub-directories reported by {@link #list(Location)}.
+     *
+     * <p>For object-storage backends (e.g. S3) that return a flat list of objects from
+     * {@link #list}, this method is equivalent to {@link #listFiles(Location)}.
+     */
+    default List<FileEntry> listFilesRecursive(Location dir) throws IOException {
+        List<FileEntry> result = new ArrayList<>();
+        try (FileIterator it = list(dir)) {
+            while (it.hasNext()) {
+                FileEntry e = it.next();
+                if (e.isDirectory()) {
+                    result.addAll(listFilesRecursive(e.location()));
+                } else {
+                    result.add(e);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the URIs of direct child <em>directories</em> under {@code dir}.
+     *
+     * <p>The default implementation iterates {@link #list(Location)} and collects entries
+     * where {@link FileEntry#isDirectory()} is {@code true}.  Object-storage backends that
+     * do not model directories (e.g. S3) will return an empty set.
+     */
+    default Set<String> listDirectories(Location dir) throws IOException {
+        Set<String> result = new HashSet<>();
+        try (FileIterator it = list(dir)) {
+            while (it.hasNext()) {
+                FileEntry e = it.next();
+                if (e.isDirectory()) {
+                    result.add(e.location().uri());
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Renames (moves) the directory at {@code src} to {@code dst}.
+     *
+     * <p>If {@code src} does not exist, {@code whenSrcNotExists} is invoked and the method
+     * returns without error—this matches the semantics of
+     * {@code LegacyFileSystemApi.renameDir(src, dst, Runnable)}.
+     *
+     * <p>The default implementation delegates to {@link #exists(Location)} and
+     * {@link #rename(Location, Location)}.  Implementations backed by file-systems that offer
+     * an atomic directory-rename operation should override this method.
+     */
+    default void renameDirectory(Location src, Location dst, Runnable whenSrcNotExists)
+            throws IOException {
+        if (!exists(src)) {
+            whenSrcNotExists.run();
+            return;
+        }
+        rename(src, dst);
+    }
 
     DorisInputFile newInputFile(Location location) throws IOException;
 

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystem.java
@@ -37,6 +37,20 @@ public interface FileSystem extends AutoCloseable {
 
     DorisInputFile newInputFile(Location location) throws IOException;
 
+    /**
+     * Opens an input file at {@code location} with a pre-known length hint.
+     * Implementations may use the hint to skip a remote size query; they must
+     * NOT trust the hint for bounds-checking if it could be inaccurate.
+     *
+     * <p>Default implementation ignores the length hint.
+     *
+     * @param location the file location
+     * @param length   the expected file length in bytes; ignored if &le; 0
+     */
+    default DorisInputFile newInputFile(Location location, long length) throws IOException {
+        return newInputFile(location);
+    }
+
     DorisOutputFile newOutputFile(Location location) throws IOException;
 
     @Override

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystem.java
@@ -53,6 +53,33 @@ public interface FileSystem extends AutoCloseable {
 
     DorisOutputFile newOutputFile(Location location) throws IOException;
 
+    /**
+     * Lists objects under {@code path} whose names match the given glob pattern, returning
+     * at most {@code maxFiles} entries whose total size does not exceed {@code maxBytes}.
+     *
+     * <p>The listing is resumed from {@code startAfter} (exclusive, lexicographic order) when
+     * non-null and non-empty.  Results are returned in ascending lexicographic key order.
+     *
+     * <p>The returned {@link GlobListing#getMaxFile()} contains the last key <em>seen</em>
+     * in the full listing (which may be beyond the page limit), allowing callers to detect
+     * whether additional objects exist without issuing another request.
+     *
+     * @param path       the base object-storage URI (may include a glob pattern, e.g.
+     *                   {@code s3://bucket/prefix/*.csv})
+     * @param startAfter exclusive lower-bound key; pass {@code null} or empty to start from the
+     *                   beginning
+     * @param maxBytes   maximum cumulative object size (bytes) for the returned page; 0 means
+     *                   unlimited
+     * @param maxFiles   maximum number of objects in the returned page; 0 means unlimited
+     * @return {@link GlobListing} with matched entries plus listing metadata
+     * @throws UnsupportedOperationException if the implementation does not support glob listing
+     */
+    default GlobListing globListWithLimit(Location path, String startAfter, long maxBytes,
+            long maxFiles) throws IOException {
+        throw new UnsupportedOperationException(
+                "globListWithLimit is not supported by " + getClass().getSimpleName());
+    }
+
     @Override
     void close() throws IOException;
 }

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystemProvider.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/FileSystemProvider.java
@@ -17,18 +17,26 @@
 
 package org.apache.doris.filesystem.spi;
 
+import org.apache.doris.extension.spi.Plugin;
+import org.apache.doris.extension.spi.PluginFactory;
+
 import java.io.IOException;
 import java.util.Map;
 
 /**
  * SPI interface for filesystem provider discovery via Java ServiceLoader.
  *
- * Implementations must:
+ * <p>Extends {@link PluginFactory} to allow {@link
+ * org.apache.doris.extension.loader.DirectoryPluginRuntimeManager} to load filesystem
+ * providers from plugin directories at runtime, decoupling fe-core from concrete
+ * storage backend implementations at the Maven dependency level.
+ *
+ * <p>Implementations must:
  * 1. Have a public no-arg constructor.
  * 2. Register in META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider.
  * 3. Have NO dependency on fe-core, fe-common, or fe-catalog.
  */
-public interface FileSystemProvider {
+public interface FileSystemProvider extends PluginFactory {
 
     /**
      * Returns true if this provider can handle the given properties.
@@ -52,7 +60,18 @@ public interface FileSystemProvider {
     /**
      * Human-readable name for logging/diagnostics (e.g., "S3", "HDFS", "Azure").
      */
+    @Override
     default String name() {
         return getClass().getSimpleName().replace("FileSystemProvider", "");
+    }
+
+    /**
+     * Not used by DirectoryPluginRuntimeManager (it only discovers factories via ServiceLoader).
+     * Provided to satisfy {@link PluginFactory} contract.
+     */
+    @Override
+    default Plugin create() {
+        throw new UnsupportedOperationException(
+                "FileSystemProvider does not support no-arg create(). Use create(Map) instead.");
     }
 }

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/GlobListing.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/GlobListing.java
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.spi;
+
+import java.util.List;
+
+/**
+ * Result of a {@link FileSystem#globListWithLimit} operation.
+ *
+ * <p>Carries the matching file list plus the S3 bucket, prefix, and the maximum file key
+ * (the last key seen in the full listing, possibly beyond the returned page).
+ * {@code maxFile} allows callers to determine whether more files are available after the
+ * returned page without issuing an additional listing request.
+ */
+public final class GlobListing {
+
+    private final List<FileEntry> files;
+    /** S3 bucket name extracted from the listing URI. */
+    private final String bucket;
+    /** Key prefix used for the listing (longest non-glob prefix of the path pattern). */
+    private final String prefix;
+    /**
+     * The key of the last matching object observed in the listing, including objects
+     * beyond the page limit. Empty string if no objects were observed at all.
+     */
+    private final String maxFile;
+
+    public GlobListing(List<FileEntry> files, String bucket, String prefix, String maxFile) {
+        this.files = List.copyOf(files);
+        this.bucket = bucket;
+        this.prefix = prefix;
+        this.maxFile = maxFile;
+    }
+
+    /** Returns the list of file entries matching the glob pattern, up to the requested limits. */
+    public List<FileEntry> getFiles() {
+        return files;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getMaxFile() {
+        return maxFile;
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/ObjFileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/ObjFileSystem.java
@@ -18,10 +18,11 @@
 package org.apache.doris.filesystem.spi;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Abstract base class for object-storage-backed FileSystems.
- * Delegates existence checks to the underlying ObjStorage instance.
+ * Delegates existence checks and cloud-specific operations to the underlying ObjStorage instance.
  */
 public abstract class ObjFileSystem implements FileSystem {
 
@@ -55,6 +56,36 @@ public abstract class ObjFileSystem implements FileSystem {
      */
     protected boolean isNotFoundError(IOException e) {
         return e.getMessage() != null && e.getMessage().contains("404");
+    }
+
+    // -----------------------------------------------------------------------
+    // Cloud-specific delegates - forward to ObjStorage
+    // -----------------------------------------------------------------------
+
+    /** @see ObjStorage#getStsToken() */
+    public StsCredentials getStsToken() throws IOException {
+        return objStorage.getStsToken();
+    }
+
+    /** @see ObjStorage#listObjectsWithPrefix(String, String, String) */
+    public RemoteObjects listObjectsWithPrefix(String prefix, String subPrefix,
+            String continuationToken) throws IOException {
+        return objStorage.listObjectsWithPrefix(prefix, subPrefix, continuationToken);
+    }
+
+    /** @see ObjStorage#headObjectWithMeta(String, String) */
+    public RemoteObjects headObjectWithMeta(String prefix, String subKey) throws IOException {
+        return objStorage.headObjectWithMeta(prefix, subKey);
+    }
+
+    /** @see ObjStorage#getPresignedUrl(String) */
+    public String getPresignedUrl(String objectKey) throws IOException {
+        return objStorage.getPresignedUrl(objectKey);
+    }
+
+    /** @see ObjStorage#deleteObjectsByKeys(String, List) */
+    public void deleteObjectsByKeys(String bucket, List<String> keys) throws IOException {
+        objStorage.deleteObjectsByKeys(bucket, keys);
     }
 
     @Override

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/ObjFileSystem.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/ObjFileSystem.java
@@ -18,7 +18,10 @@
 package org.apache.doris.filesystem.spi;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Abstract base class for object-storage-backed FileSystems.
@@ -86,6 +89,26 @@ public abstract class ObjFileSystem implements FileSystem {
     /** @see ObjStorage#deleteObjectsByKeys(String, List) */
     public void deleteObjectsByKeys(String bucket, List<String> keys) throws IOException {
         objStorage.deleteObjectsByKeys(bucket, keys);
+    }
+
+    /**
+     * Convenience overload for completing a multipart upload when part ETags are provided
+     * as a {@code Map<partNumber, etag>} (as returned by the Thrift/Backend protocol).
+     *
+     * <p>Converts the map to a sorted {@link UploadPartResult} list before delegating to
+     * {@link ObjStorage#completeMultipartUpload(String, String, List)}.
+     *
+     * @param remotePath the full object URI (e.g. {@code s3://bucket/key})
+     * @param uploadId   the multipart upload session ID
+     * @param etags      mapping of 1-based part numbers to their ETags
+     */
+    public void completeMultipartUpload(String remotePath, String uploadId,
+            Map<Integer, String> etags) throws IOException {
+        List<UploadPartResult> parts = etags.entrySet().stream()
+                .map(e -> new UploadPartResult(e.getKey(), e.getValue()))
+                .sorted(Comparator.comparingInt(UploadPartResult::partNumber))
+                .collect(Collectors.toList());
+        objStorage.completeMultipartUpload(remotePath, uploadId, parts);
     }
 
     @Override

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/ObjStorage.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/ObjStorage.java
@@ -29,6 +29,83 @@ import java.util.Map;
  */
 public interface ObjStorage<C> extends AutoCloseable {
 
+    // -----------------------------------------------------------------------
+    // Cloud-specific extensions (default UnsupportedOperationException).
+    // Implementations override these for backends that support the operation.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Obtains temporary STS credentials by assuming a configured IAM role.
+     * Only supported by cloud providers that have an STS service (AWS, Alibaba OSS, etc.).
+     *
+     * @return STS credentials (access key, secret key, security token)
+     * @throws IOException                   if the STS call fails
+     * @throws UnsupportedOperationException if this storage backend has no STS support
+     */
+    default StsCredentials getStsToken() throws IOException {
+        throw new UnsupportedOperationException("getStsToken not supported by " + getClass().getSimpleName());
+    }
+
+    /**
+     * Lists objects whose keys share the given prefix, with pagination support.
+     *
+     * @param prefix            the stage/root prefix (e.g. {@code "stage/user1/"})
+     * @param subPrefix         sub-prefix relative to {@code prefix}; empty string lists all
+     * @param continuationToken opaque pagination token from a previous call; {@code null} for first page
+     * @return listing result; use {@link RemoteObjects#getContinuationToken()} and
+     *         {@link RemoteObjects#isTruncated()} to fetch subsequent pages
+     * @throws IOException                   if the listing fails
+     * @throws UnsupportedOperationException if this storage backend does not support this operation
+     */
+    default RemoteObjects listObjectsWithPrefix(String prefix, String subPrefix,
+            String continuationToken) throws IOException {
+        throw new UnsupportedOperationException(
+                "listObjectsWithPrefix not supported by " + getClass().getSimpleName());
+    }
+
+    /**
+     * Returns metadata for a single object identified by {@code prefix + subKey}.
+     * Returns a single-element result if the object exists, or an empty result if not found.
+     *
+     * @param prefix the stage/root prefix
+     * @param subKey the object key relative to {@code prefix}
+     * @return object metadata as a {@link RemoteObjects} result (0 or 1 elements)
+     * @throws IOException                   if the HEAD request fails for reasons other than not-found
+     * @throws UnsupportedOperationException if this storage backend does not support this operation
+     */
+    default RemoteObjects headObjectWithMeta(String prefix, String subKey) throws IOException {
+        throw new UnsupportedOperationException(
+                "headObjectWithMeta not supported by " + getClass().getSimpleName());
+    }
+
+    /**
+     * Generates a pre-signed URL that allows direct HTTP PUT upload of the given object key,
+     * without requiring the uploader to hold storage credentials.
+     *
+     * @param objectKey the full object key (relative to the bucket root)
+     * @return a pre-signed URL string valid for a limited time
+     * @throws IOException                   if URL generation fails
+     * @throws UnsupportedOperationException if this storage backend does not support pre-signed URLs
+     */
+    default String getPresignedUrl(String objectKey) throws IOException {
+        throw new UnsupportedOperationException(
+                "getPresignedUrl not supported by " + getClass().getSimpleName());
+    }
+
+    /**
+     * Deletes multiple objects by their full object keys in a single logical operation.
+     * Implementations may issue individual delete requests or a batch API call.
+     *
+     * @param bucket the bucket name
+     * @param keys   list of full object keys to delete (bare keys, no scheme or bucket prefix)
+     * @throws IOException                   if any deletion fails
+     * @throws UnsupportedOperationException if this storage backend does not support this operation
+     */
+    default void deleteObjectsByKeys(String bucket, List<String> keys) throws IOException {
+        throw new UnsupportedOperationException(
+                "deleteObjectsByKeys not supported by " + getClass().getSimpleName());
+    }
+
     C getClient() throws IOException;
 
     RemoteObjects listObjects(String remotePath, String continuationToken) throws IOException;

--- a/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/StsCredentials.java
+++ b/fe/fe-filesystem/fe-filesystem-spi/src/main/java/org/apache/doris/filesystem/spi/StsCredentials.java
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.spi;
+
+/**
+ * Temporary credentials returned by a cloud STS (Security Token Service) operation.
+ * Replaces the use of {@code Triple<String, String, String>} in legacy code.
+ */
+public final class StsCredentials {
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String securityToken;
+
+    public StsCredentials(String accessKey, String secretKey, String securityToken) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.securityToken = securityToken;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public String getSecurityToken() {
+        return securityToken;
+    }
+}

--- a/fe/fe-filesystem/pom.xml
+++ b/fe/fe-filesystem/pom.xml
@@ -46,5 +46,6 @@ under the License.
         <module>fe-filesystem-local</module>
         <module>fe-filesystem-azure</module>
         <module>fe-filesystem-hdfs</module>
+        <module>fe-filesystem-broker</module>
     </modules>
 </project>

--- a/plan-doc/phase5-broker-filesystem-design.md
+++ b/plan-doc/phase5-broker-filesystem-design.md
@@ -1,0 +1,566 @@
+# fe-filesystem-broker 详细设计文档
+
+## 1. 问题陈述
+
+### 1.1 当前状态
+
+`BrokerUtil.java`（fe-core）是最后一个使用旧 `RemoteFileSystem` API 的主要调用方。
+它有两处 `FileSystemFactory.get()` 调用：
+
+```java
+// parseFile — 通过旧 API 列举 broker 路径下的文件
+try (RemoteFileSystem fileSystem = FileSystemFactory.get(brokerDesc.getStorageProperties())) {
+    Status st = fileSystem.globList(path, rfiles, false);
+}
+
+// deleteDirectoryWithFileSystem — 通过旧 API 删除目录
+try (RemoteFileSystem fileSystem = FileSystemFactory.get(brokerDesc.getStorageProperties())) {
+    Status st = fileSystem.deleteDirectory(path);
+}
+```
+
+以及 `Repository.java`（Backup Domain）通过 `FileSystemFactory.get()` 重建 broker 连接。
+
+### 1.2 关键约束分析
+
+Broker 文件系统的核心挑战是 **broker 地址解析**：
+
+```
+broker name (String) ──► BrokerMgr.getBroker(name, localIP) ──► FsBroker(host, port)
+```
+
+`BrokerMgr` 是 `fe-core` 的运行时组件（依赖 `Env`、`FrontendOptions`）。
+
+#### FileSystemProvider SPI 的关键设计
+
+通过研究现有代码，发现 `FileSystemProvider` SPI 使用的是 **`Map<String, String>`** 接口，而非 `StorageProperties`：
+
+```java
+// FileSystemProvider.java (fe-filesystem-spi)
+public interface FileSystemProvider {
+    boolean supports(Map<String, String> properties);
+    FileSystem create(Map<String, String> properties) throws IOException;
+}
+
+// StoragePropertiesConverter.java (fe-core) 负责转换
+public static Map<String, String> toMap(StorageProperties props) {
+    // 对 BrokerProperties 注入: "_STORAGE_TYPE_" = "BROKER"
+}
+
+// FileSystemPluginManager.java (fe-core) 做调度
+public FileSystem createFileSystem(Map<String, String> properties) throws IOException {
+    for (FileSystemProvider provider : providers) {
+        if (provider.supports(properties)) { return provider.create(properties); }
+    }
+}
+```
+
+**关键洞察**：`BrokerFileSystemProvider` 只需检查 `map.get("_STORAGE_TYPE_").equals("BROKER")`，
+完全不需要导入 `BrokerProperties`（fe-core 类），因此**无循环依赖**！
+
+#### 解耦方案
+
+fe-core 在调用 SPI 前完成 broker name → host:port 解析，将解析结果直接注入 map：
+
+```
+BrokerUtil (fe-core)
+  ├── BrokerMgr.getBroker(name, localIP) → FsBroker(host, port)    [fe-core 内部]
+  └── FileSystemFactory.getBrokerFileSystem(host, port, params)
+        └── FileSystemPluginManager.createFileSystem({
+                "_STORAGE_TYPE_": "BROKER",
+                "BROKER_HOST": host,
+                "BROKER_PORT": port,
+                ...brokerParams
+            })
+              └── BrokerFileSystemProvider.create(map)  [fe-filesystem-broker, 零 fe-core 依赖]
+                    └── new BrokerSpiFileSystem(host, port, params)
+```
+
+---
+
+## 2. 设计目标
+
+| 目标 | 说明 |
+|------|------|
+| **零 fe-core 依赖** | `fe-filesystem-broker` 只依赖 `fe-filesystem-spi`、`fe-thrift`、`libthrift`、`commons-pool2` |
+| **完整 spi.FileSystem** | 实现所有 spi.FileSystem 接口方法，支持 list、delete、rename、read、write |
+| **统一 SPI 路由** | `BrokerFileSystemProvider` 注册为标准 SPI，通过 `FileSystemPluginManager` 统一调度 |
+| **连接池复用** | 模块内维护自己的 Thrift 客户端连接池，不依赖 fe-core 的 `ClientPool` |
+| **向后兼容** | 旧 `BrokerFileSystem`（fe-core）保持不变，新实现并行存在直到迁移完成 |
+
+---
+
+## 3. 架构设计
+
+### 3.1 模块层次图
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  fe-core                                                    │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │ BrokerUtil / Repository / BackupHandler              │  │
+│  │  1. FsBroker broker = BrokerMgr.getBroker(name, ip) │  │
+│  │  2. FileSystemFactory.getBrokerFileSystem(           │  │
+│  │         broker.host, broker.port, params)            │  │
+│  └──────────────────────────────────────────────────────┘  │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │ FileSystemFactory.getBrokerFileSystem()              │  │
+│  │   builds Map {_STORAGE_TYPE_=BROKER,                 │  │
+│  │               BROKER_HOST, BROKER_PORT, ...params}   │  │
+│  │   calls FileSystemPluginManager.createFileSystem()   │  │
+│  └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+         │ depends on
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  fe-filesystem-broker                                       │
+│  ┌──────────────────────────────────┐                      │
+│  │ BrokerFileSystemProvider         │ ◄── SPI registered   │
+│  │   supports: _STORAGE_TYPE_=BROKER│   via ServiceLoader  │
+│  │             + BROKER_HOST exists │                      │
+│  │   create(map) → BrokerSpiFileSystem                    │
+│  ├──────────────────────────────────┤                      │
+│  │ BrokerSpiFileSystem              │                      │
+│  │   implements spi.FileSystem      │                      │
+│  │   - String host                  │                      │
+│  │   - int port                     │                      │
+│  │   - Map<String,String> params    │                      │
+│  │   - BrokerClientPool             │ (self-managed)       │
+│  ├──────────────────────────────────┤                      │
+│  │ BrokerClientPool                 │                      │
+│  │  GenericKeyedObjectPool<         │                      │
+│  │    TNetworkAddress,              │                      │
+│  │    TPaloBrokerService.Client>    │                      │
+│  └──────────────────────────────────┘                      │
+└─────────────────────────────────────────────────────────────┘
+         │ depends on
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  fe-filesystem-spi                                          │
+│  spi.FileSystem, Location, FileEntry, FileIterator...       │
+├─────────────────────────────────────────────────────────────┤
+│  fe-thrift                                                  │
+│  TPaloBrokerService, TBrokerListPathRequest, ...            │
+├─────────────────────────────────────────────────────────────┤
+│  libthrift  (org.apache.thrift:libthrift)                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 关键设计决策：使用 FileSystemProvider SPI + 预解析地址
+
+与 S3、HDFS 等模块不同，broker 的地址解析发生在 **SPI 调用之前**（在 fe-core 完成），
+解析结果通过 map 传递。`BrokerFileSystemProvider` 是一个普通 SPI 实现，通过 `ServiceLoader` 发现。
+
+这样实现了用户期望的**统一 SPI 路由**：所有存储类型（包括 broker）都经过 `FileSystemPluginManager.createFileSystem(map)`，
+区别仅在于 broker 的 map 是由 fe-core 手动构建（含预解析地址），而非通过 `StoragePropertiesConverter.toMap()` 转换。
+
+---
+
+## 4. 接口与实现
+
+### 4.1 `BrokerFileSystemProvider`（SPI 注册，在 `fe-filesystem-broker`）
+
+```java
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.FileSystemProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * SPI provider for the Doris Broker filesystem.
+ *
+ * <p>Recognizes maps that contain "_STORAGE_TYPE_" = "BROKER" plus a resolved
+ * "BROKER_HOST" key. The host and port are pre-resolved by fe-core before
+ * calling FileSystemPluginManager, avoiding any dependency on BrokerMgr here.
+ *
+ * <p>Registered via:
+ * META-INF/services/org.apache.doris.filesystem.spi.FileSystemProvider
+ */
+public class BrokerFileSystemProvider implements FileSystemProvider {
+
+    private static final String KEY_TYPE    = "_STORAGE_TYPE_";
+    private static final String KEY_HOST    = "BROKER_HOST";
+    private static final String KEY_PORT    = "BROKER_PORT";
+
+    @Override
+    public boolean supports(Map<String, String> properties) {
+        return "BROKER".equals(properties.get(KEY_TYPE))
+                && properties.containsKey(KEY_HOST);
+    }
+
+    @Override
+    public FileSystem create(Map<String, String> properties) throws IOException {
+        String host = properties.get(KEY_HOST);
+        int port;
+        try {
+            port = Integer.parseInt(properties.get(KEY_PORT));
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid BROKER_PORT: " + properties.get(KEY_PORT));
+        }
+        // Remaining keys are broker-specific params (username, password, hadoop config, ...)
+        Map<String, String> params = extractBrokerParams(properties);
+        return new BrokerSpiFileSystem(host, port, params);
+    }
+
+    private Map<String, String> extractBrokerParams(Map<String, String> properties) {
+        Map<String, String> params = new java.util.HashMap<>(properties);
+        params.remove(KEY_TYPE);
+        params.remove(KEY_HOST);
+        params.remove(KEY_PORT);
+        return Map.copyOf(params);
+    }
+
+    @Override
+    public String name() { return "Broker"; }
+}
+```
+
+### 4.2 `BrokerSpiFileSystem`（核心实现）
+
+```java
+package org.apache.doris.filesystem.broker;
+
+import org.apache.doris.filesystem.spi.FileSystem;
+import org.apache.doris.filesystem.spi.Location;
+import org.apache.doris.filesystem.spi.FileEntry;
+import org.apache.doris.filesystem.spi.FileIterator;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * spi.FileSystem backed by a Doris Broker Thrift RPC.
+ *
+ * <p>The broker endpoint (host, port) is resolved before construction by fe-core.
+ * This class has zero dependency on fe-core, BrokerMgr, or BrokerProperties.
+ */
+public class BrokerSpiFileSystem implements FileSystem {
+
+    private final TNetworkAddress endpoint;
+    private final Map<String, String> brokerParams;
+    private final BrokerClientPool clientPool;
+
+    BrokerSpiFileSystem(String host, int port, Map<String, String> brokerParams) {
+        this.endpoint = new TNetworkAddress(host, port);
+        this.brokerParams = Map.copyOf(brokerParams);
+        this.clientPool = new BrokerClientPool();
+    }
+
+    // ... 见 Section 5 完整方法列表
+}
+```
+
+### 4.3 `BrokerClientPool`（内部连接池）
+
+```java
+package org.apache.doris.filesystem.broker;
+
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+
+/**
+ * Thread-safe pool of TPaloBrokerService Thrift clients, keyed by TNetworkAddress.
+ * Manages connection lifecycle independently of fe-core's ClientPool.
+ */
+class BrokerClientPool implements AutoCloseable {
+    private final GenericKeyedObjectPool<TNetworkAddress, TPaloBrokerService.Client> pool;
+
+    BrokerClientPool() {
+        GenericKeyedObjectPoolConfig<TPaloBrokerService.Client> config =
+                new GenericKeyedObjectPoolConfig<>();
+        config.setMaxIdlePerKey(16);
+        config.setMinIdlePerKey(0);
+        config.setMaxTotalPerKey(-1);
+        config.setMaxTotal(-1);
+        config.setMaxWaitMillis(500);
+        this.pool = new GenericKeyedObjectPool<>(new BrokerClientFactory(), config);
+    }
+
+    TPaloBrokerService.Client borrow(TNetworkAddress addr) throws Exception {
+        return pool.borrowObject(addr);
+    }
+
+    void returnGood(TNetworkAddress addr, TPaloBrokerService.Client client) {
+        try { pool.returnObject(addr, client); } catch (Exception ignored) { }
+    }
+
+    void invalidate(TNetworkAddress addr, TPaloBrokerService.Client client) {
+        try { pool.invalidateObject(addr, client); } catch (Exception ignored) { }
+    }
+
+    @Override
+    public void close() {
+        pool.close();
+    }
+}
+```
+
+---
+
+## 5. spi.FileSystem 方法映射
+
+| spi.FileSystem 方法 | Thrift RPC | 备注 |
+|----------------------|-----------|------|
+| `list(Location)` | `listPath(TBrokerListPathRequest{recursive=false})` | 返回 FileIterator |
+| `listFiles(Location)` | `listLocatedFiles(TBrokerListPathRequest{onlyFiles=true})` | 返回 `List<FileEntry>` |
+| `listFilesRecursive(Location)` | `listLocatedFiles(TBrokerListPathRequest{recursive=true,onlyFiles=true})` | 深度递归 |
+| `listDirectories(Location)` | `listPath(TBrokerListPathRequest{recursive=false})` 过滤 isDir | 返回 `Set<String>` |
+| `exists(Location)` | `checkPathExist(TBrokerCheckPathExistRequest)` | |
+| `mkdirs(Location)` | — | Broker 不支持 mkdirs，no-op（broker 按需创建父目录）|
+| `delete(Location, false)` | `deletePath(TBrokerDeletePathRequest)` | 删除单文件 |
+| `delete(Location, true)` | `deletePath(TBrokerDeletePathRequest)` | 递归删除目录 |
+| `rename(Location, Location)` | `renamePath(TBrokerRenamePathRequest)` | |
+| `newInputFile(Location)` | `openReader` + `pread` + `closeReader` | 返回 BrokerInputFile |
+| `newOutputFile(Location)` | `openWriter` + `pwrite` + `closeWriter` | 返回 BrokerOutputFile |
+
+### 5.1 globList（list with glob pattern）
+
+`BrokerUtil.parseFile()` 需要 glob 语义（`path` 可包含 `*`、`?`）。
+Broker 的 `listPath` 支持 glob（broker 进程底层调用 Hadoop FileSystem.globStatus）。
+因此 `globListWithLimit()` 可通过 `listPath` + 客户端过滤 startAfter 实现：
+
+```java
+@Override
+public GlobListing globListWithLimit(Location path, String startAfter,
+        long maxBytes, long maxFiles) throws IOException {
+    // Broker handles glob natively via Hadoop
+    List<FileEntry> entries = doListPath(path.uri(), false);  // glob-aware
+    // Apply startAfter + size/count limits client-side
+    return applyLimits(entries, startAfter, maxBytes, maxFiles);
+}
+```
+
+### 5.2 mkdirs 处理
+
+Broker 不提供 `mkdirs` RPC。通常 broker 通过 `openWriter` 自动创建父目录。
+对于 `BrokerUtil` 中的使用场景（`parseFile`、`deleteDirectory`），不需要 `mkdirs`。
+实现为 no-op（返回即可，不抛异常）。
+
+---
+
+## 6. fe-core 集成方式
+
+### 6.1 FileSystemFactory 新增工厂方法
+
+```java
+// fe/fe-core/src/main/java/org/apache/doris/fs/FileSystemFactory.java
+
+/**
+ * Creates a BrokerSpiFileSystem with a pre-resolved broker endpoint.
+ *
+ * <p>The caller is responsible for resolving broker name → host:port via BrokerMgr
+ * before calling this method. This keeps BrokerMgr coupling in fe-core only.
+ *
+ * @param host         live broker host (already resolved from BrokerMgr)
+ * @param port         live broker Thrift port
+ * @param brokerParams broker-specific params (username, password, hadoop config, ...)
+ */
+public static FileSystem getBrokerFileSystem(String host, int port,
+        Map<String, String> brokerParams) throws IOException {
+    Map<String, String> props = new HashMap<>(brokerParams);
+    props.put("_STORAGE_TYPE_", "BROKER");
+    props.put("BROKER_HOST", host);
+    props.put("BROKER_PORT", String.valueOf(port));
+    return PLUGIN_MANAGER.createFileSystem(props);
+}
+```
+
+### 6.2 BrokerUtil 迁移后的代码
+
+```java
+// BEFORE:
+try (RemoteFileSystem fileSystem = FileSystemFactory.get(brokerDesc.getStorageProperties())) {
+    Status st = fileSystem.globList(path, rfiles, false);
+    if (!st.ok()) { throw new UserException(st.getErrMsg()); }
+}
+
+// AFTER:
+BrokerProperties brokerProps = (BrokerProperties) brokerDesc.getStorageProperties();
+try {
+    String localHost = FrontendOptions.getLocalHostAddress();
+    FsBroker broker = Env.getCurrentEnv().getBrokerMgr()
+            .getBroker(brokerProps.getBrokerName(), localHost);
+    try (FileSystem fs = FileSystemFactory.getBrokerFileSystem(
+            broker.host, broker.port, brokerProps.getBrokerParams())) {
+        List<FileEntry> entries = fs.listFiles(Location.of(path));
+        // convert FileEntry → TBrokerFileStatus for callers
+        for (FileEntry e : entries) {
+            rfiles.add(new TBrokerFileStatus(e.location().uri(),
+                    e.isDirectory(), e.length(), e.isDirectory()));
+        }
+    }
+} catch (AnalysisException e) {
+    throw new UserException("Failed to get broker: " + e.getMessage(), e);
+}
+```
+
+---
+
+## 7. Maven 模块结构
+
+### 7.1 目录结构
+
+```
+fe/fe-filesystem/fe-filesystem-broker/
+├── pom.xml
+└── src/
+    └── main/
+        ├── java/org/apache/doris/filesystem/broker/
+        │   ├── BrokerFileSystemProvider.java  (implements FileSystemProvider — SPI entry)
+        │   ├── BrokerSpiFileSystem.java       (implements spi.FileSystem)
+        │   ├── BrokerClientPool.java          (Thrift client pool)
+        │   ├── BrokerClientFactory.java       (PooledObjectFactory for Thrift clients)
+        │   ├── BrokerInputFile.java           (implements spi.DorisInputFile)
+        │   └── BrokerOutputFile.java          (implements spi.DorisOutputFile)
+        └── resources/META-INF/services/
+            └── org.apache.doris.filesystem.spi.FileSystemProvider
+                  (contains: org.apache.doris.filesystem.broker.BrokerFileSystemProvider)
+```
+
+### 7.2 pom.xml（关键依赖）
+
+```xml
+<artifactId>fe-filesystem-broker</artifactId>
+<packaging>jar</packaging>
+
+<dependencies>
+    <!-- SPI interfaces only — no fe-core -->
+    <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>fe-filesystem-spi</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+
+    <!-- Thrift generated classes (TPaloBrokerService, TBrokerListPathRequest, ...) -->
+    <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>fe-thrift</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+
+    <!-- Thrift runtime -->
+    <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+    </dependency>
+
+    <!-- Connection pool for Thrift clients -->
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-pool2</artifactId>
+    </dependency>
+</dependencies>
+```
+
+### 7.3 fe-core pom.xml 追加依赖
+
+```xml
+<dependency>
+    <groupId>${project.groupId}</groupId>
+    <artifactId>fe-filesystem-broker</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
+
+### 7.4 fe-filesystem/pom.xml 追加子模块
+
+```xml
+<modules>
+    <!-- ... existing modules ... -->
+    <module>fe-filesystem-broker</module>
+</modules>
+```
+
+---
+
+## 8. 数据流：BrokerUtil.parseFile() 迁移后
+
+```
+BrokerUtil.parseFile(path, brokerDesc, statuses)
+  │
+  ├── (BrokerProperties) brokerDesc.getStorageProperties()
+  │
+  ├── BrokerMgr.getBroker(name, localIP) ──► FsBroker(host, port)  [fe-core 内部]
+  │
+  ├── FileSystemFactory.getBrokerFileSystem(host, port, brokerParams)
+  │     └── map = {_STORAGE_TYPE_=BROKER, BROKER_HOST=host, BROKER_PORT=port, ...params}
+  │     └── FileSystemPluginManager.createFileSystem(map)
+  │           └── BrokerFileSystemProvider.supports(map) == true
+  │           └── BrokerFileSystemProvider.create(map)
+  │                 └── new BrokerSpiFileSystem(host, port, params)
+  │
+  └── fs.listFiles(Location.of(path))
+        │
+        ├── BrokerSpiFileSystem.listFiles()
+        │     ├── clientPool.borrow(endpoint)
+        │     │     └── BrokerClientPool ──► new TPaloBrokerService.Client(transport)
+        │     │
+        │     ├── client.listLocatedFiles(TBrokerListPathRequest{
+        │     │       path, recursive=false, onlyFiles=true, properties=brokerParams})
+        │     │     └── Thrift RPC ──► Broker Process
+        │     │
+        │     └── TBrokerListResponse ──► List<FileEntry>
+        │
+        └── for each FileEntry: convert to TBrokerFileStatus, add to statuses
+```
+
+---
+
+## 9. 异常处理
+
+| Thrift 状态码 | 语义 | spi.FileSystem 行为 |
+|--------------|------|---------------------|
+| `OK (0)` | 成功 | 正常返回 |
+| `FILE_NOT_FOUND (501)` | 路径不存在 | `exists()` 返回 false；`list()` 返回空 |
+| `NOT_AUTHORIZED (401)` | 认证失败 | throw `IOException("Broker access denied: ...")` |
+| `OPERATION_NOT_SUPPORTED (503)` | 操作不支持 | throw `UnsupportedOperationException` |
+| `END_OF_FILE (301)` | 读完 | `newInput().read()` 返回 -1 |
+| 其他 / TException | 网络/未知错误 | throw `IOException(opStatus.getMessage())` |
+
+---
+
+## 10. 迁移步骤（TODO）
+
+| 步骤 | 内容 | 文件 |
+|------|------|------|
+| T1 | 新建 `fe-filesystem/fe-filesystem-broker/` Maven 模块 | `pom.xml` × 3 |
+| T2 | 实现 `BrokerFileSystemProvider`（SPI 注册） | `fe-filesystem-broker` |
+| T3 | 实现 `BrokerClientFactory` + `BrokerClientPool` | `fe-filesystem-broker` |
+| T4 | 实现 `BrokerSpiFileSystem.listFiles()` + `globList()` + `delete()` + `rename()` | `fe-filesystem-broker` |
+| T5 | 实现 `BrokerInputFile`（read path）| `fe-filesystem-broker` |
+| T6 | 实现 `BrokerOutputFile`（write path）| `fe-filesystem-broker` |
+| T7 | 在 `fe-core` 中新增 `FileSystemFactory.getBrokerFileSystem()` 工厂方法 | `FileSystemFactory.java` |
+| T8 | 迁移 `BrokerUtil.parseFile()` | `BrokerUtil.java` |
+| T9 | 迁移 `BrokerUtil.deleteDirectoryWithFileSystem()` | `BrokerUtil.java` |
+| T10 | 迁移 `Repository.java` I/O 路径 | `Repository.java` |
+| T11 | 迁移 `BackupHandler.java` repository 创建 | `BackupHandler.java` |
+| T12 | 删除旧 `BrokerFileSystem`（fe-core）| `fs/remote/BrokerFileSystem.java` |
+| T13 | 构建验证 + 回归测试 | — |
+
+---
+
+## 11. 非目标（Out of Scope）
+
+- 不修改 Thrift 协议（`PaloBrokerService.thrift` 保持不变）
+- `BrokerUtil.readFile()` 的 Thrift 直接调用路径（非 FileSystem 接口）不在本设计范围内
+- 不处理多 broker 实例的负载均衡（由 BrokerMgr 已实现，host:port 已是最终结果）
+
+---
+
+## 12. 风险与注意事项
+
+| 风险 | 缓解措施 |
+|------|---------|
+| `fe-thrift` 中的 Thrift 生成类版本变化 | fe-thrift 与 fe-core 同步发布，版本一致 |
+| Broker 不支持 mkdirs | BrokerUtil 调用场景不需要 mkdirs，no-op 即可 |
+| 连接池配置差异 | 参考 `ClientPool.brokerPool` 配置（maxIdle=128, maxTotal=-1, wait=500ms）|
+| Repository 序列化兼容性 | Repository.fileSystem 的 GSON 反序列化需额外处理，在 T10 中专项设计 |
+| BrokerProperties 地址未解析 | `StoragePropertiesConverter.toMap(BrokerProperties)` 不含 host/port，不能用于 getBrokerFileSystem；调用方必须先手动解析地址 |

--- a/plan-doc/phase5-p46-backup-domain-migration.md
+++ b/plan-doc/phase5-p46-backup-domain-migration.md
@@ -1,0 +1,561 @@
+# P4.6 设计文档：Backup Domain（Repository/BackupJob/RestoreJob）迁移到 SPI
+
+## 一、背景与目标
+
+### 1.1 现状
+
+Backup/Restore 域的 4 个核心文件仍依赖旧的 `PersistentFileSystem`：
+
+| 文件 | 依赖的旧 API |
+|------|------------|
+| `Repository.java` | `PersistentFileSystem` 字段（`fileSystem`），`getRemoteFileSystem()` |
+| `BackupHandler.java` | `repo.getRemoteFileSystem().getProperties()` |
+| `BackupJob.java` (L440, L824) | `repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties()` <br> `repo.getRemoteFileSystem().getThriftStorageType()` |
+| `RestoreJob.java` (L448, L2005) | 同上 |
+
+### 1.2 BE-FE 通信机制
+
+Backup/Restore 的核心是：FE 将存储配置打包成 **Thrift 消息**发给 BE，
+BE 据此初始化存储客户端并执行文件上传/下载。
+
+完整调用链如下：
+
+```
+Repository.getRemoteFileSystem()
+    └─ .getStorageProperties().getBackendConfigProperties()
+           └─ → Map<String, String>  (broker_prop 字段)
+    └─ .getThriftStorageType()
+           └─ PersistentFileSystem.getThriftStorageType()
+                └─ FsStorageTypeAdapter.toThrift(type)
+                     └─ StorageBackend.StorageType.toThrift()
+                          └─ → TStorageBackendType  (storage_backend 字段)
+
+UploadTask / DownloadTask
+    └─ toThrift()
+         └─ TUploadReq / TDownloadReq
+               ├─ broker_prop: Map<String,String>    ← getBackendConfigProperties()
+               ├─ storage_backend: TStorageBackendType ← getThriftStorageType()
+               └─ location: String                    ← repo.getLocation()
+```
+
+### 1.3 阻塞原因
+
+| 缺失能力 | 说明 |
+|---------|------|
+| `PersistentFileSystem.getThriftStorageType()` | 返回 `StorageBackend.StorageType`（可调 `.toThrift()` 得 `TStorageBackendType`）；SPI `FileSystem` 无此方法 |
+| `StorageProperties.getBackendConfigProperties()` | 返回 BE 所需的 `Map<String,String>`（含 AK/SK 等）；SPI `FileSystem` 无此方法 |
+
+两者都是**从 FE 侧元数据提取配置**的操作，不涉及实际 I/O，
+因此应由 **`FileSystemDescriptor`**（已有的轻量描述符 POJO）来承担。
+
+### 1.4 目标
+
+- 在 `FileSystemDescriptor` 中新增 `getThriftStorageType()` 和 `getBackendConfigProperties()` 方法
+- 将 `BackupJob` / `RestoreJob` / `BackupHandler` 中的
+  `repo.getRemoteFileSystem().*` 调用替换为 `repo.getFileSystemDescriptor().*`
+- `Repository` 保留 `fileSystem`（`PersistentFileSystem`）仅用于实际 I/O（upload/download/list），
+  不再用于元数据提取
+
+---
+
+## 二、架构设计
+
+### 2.1 核心思路
+
+将"存储配置的元数据"和"实际 I/O"分离：
+
+```
+┌─────────────────────────────────────────────┐
+│ Repository                                  │
+│                                             │
+│  fileSystemDescriptor ─────────────────────►│ 元数据查询
+│    .getThriftStorageType()                  │ （不需要 I/O）
+│    .getBackendConfigProperties()            │
+│                                             │
+│  fileSystem (spi.FileSystem) ──────────────►│ 实际 I/O
+│    .list() / .delete() / download/upload    │ （需要连接）
+└─────────────────────────────────────────────┘
+```
+
+`FileSystemDescriptor` 已存储 `FsStorageType` 和原始 `properties`，
+完全具备推导出上述两个方法的能力，无需持有 `PersistentFileSystem` 实例。
+
+### 2.2 方案选择
+
+| 方案 | 说明 | 优缺点 |
+|------|------|--------|
+| **方案 A（推荐）** | 在 `FileSystemDescriptor` 新增两个方法；`BackupJob`/`RestoreJob` 改用 `descriptor` | 完全去除 `PersistentFileSystem` 依赖；清晰 |
+| 方案 B | 保留 `Repository.fileSystem`（`PersistentFileSystem`）仅用于 BE 通信 | 不彻底，新旧代码共存 |
+
+**选择方案 A**。
+
+---
+
+## 三、`FileSystemDescriptor` 扩展
+
+### 3.1 当前状态
+
+```java
+// 现有 FileSystemDescriptor
+public class FileSystemDescriptor {
+    @SerializedName("fs_type")
+    private final FsStorageType storageType;   // 枚举，如 S3, HDFS, BROKER...
+
+    @SerializedName("fs_name")
+    private final String name;
+
+    @SerializedName("fs_props")
+    private final Map<String, String> properties;  // 原始配置（AK/SK 等）
+
+    // 已有方法
+    public FsStorageType getStorageType() { return storageType; }
+    public String getName() { return name; }
+    public Map<String, String> getProperties() { return properties; }
+
+    public static FileSystemDescriptor fromPersistentFileSystem(PersistentFileSystem fs) {
+        return new FileSystemDescriptor(fs.getStorageType(), fs.getName(), fs.getProperties());
+    }
+}
+```
+
+### 3.2 新增方法
+
+#### 3.2.1 `getThriftStorageType()`
+
+```java
+/**
+ * Returns the Thrift-compatible storage type enum, used when constructing
+ * {@code TUploadReq}/{@code TDownloadReq} messages for backend communication.
+ *
+ * <p>This replaces the deprecated {@code PersistentFileSystem.getThriftStorageType()}.
+ *
+ * @return the Thrift storage type corresponding to this descriptor's {@link FsStorageType}
+ */
+public StorageBackend.StorageType getThriftStorageType() {
+    return FsStorageTypeAdapter.toThrift(storageType);
+}
+```
+
+`FsStorageTypeAdapter.toThrift()` 已存在，映射关系：
+
+| `FsStorageType` | `StorageBackend.StorageType` |
+|----------------|------------------------------|
+| `S3` | `S3` |
+| `HDFS` | `HDFS` |
+| `OSS_HDFS` | `HDFS` |
+| `BROKER` | `BROKER` |
+| `AZURE` | `AZURE` |
+| `OFS` | `OFS` |
+| `JFS` | `JFS` |
+| `LOCAL` | `LOCAL` |
+
+#### 3.2.2 `getBackendConfigProperties()`
+
+```java
+/**
+ * Returns the backend configuration properties map, used as the {@code broker_prop}
+ * field in {@code TUploadReq}/{@code TDownloadReq} Thrift messages.
+ *
+ * <p>The returned map contains storage-specific parameters (AK/SK, endpoint, region, etc.)
+ * in the format that the Doris backend expects for initializing its storage client.
+ *
+ * <p>This replaces {@code PersistentFileSystem.getStorageProperties().getBackendConfigProperties()}.
+ *
+ * @return an immutable map of backend configuration properties
+ */
+public Map<String, String> getBackendConfigProperties() {
+    StorageProperties sp = StorageProperties.createPrimary(properties);
+    return sp.getBackendConfigProperties();
+}
+```
+
+`StorageProperties.createPrimary(Map)` 已存在，根据 `properties` 中的 `type` key
+选择正确的 `StorageProperties` 子类（`S3Properties`, `HdfsProperties` 等）。
+
+#### 3.2.3 带运行时覆盖的重载
+
+部分场景（如 vended credentials）需在 base 配置上叠加临时凭证：
+
+```java
+/**
+ * Returns backend config properties merged with the provided runtime overrides.
+ * Runtime overrides take precedence over base properties.
+ *
+ * @param runtimeProperties additional/override properties (e.g., vended STS credentials)
+ * @return merged properties map
+ */
+public Map<String, String> getBackendConfigProperties(Map<String, String> runtimeProperties) {
+    Map<String, String> base = new HashMap<>(getBackendConfigProperties());
+    if (runtimeProperties != null) {
+        base.putAll(runtimeProperties);
+    }
+    return Collections.unmodifiableMap(base);
+}
+```
+
+---
+
+## 四、`Repository.java` 变更
+
+### 4.1 `fileSystem` 字段从 `PersistentFileSystem` → `spi.FileSystem`
+
+```java
+// 变更前
+@Deprecated @SerializedName("fs")
+private PersistentFileSystem legacyFileSystem;
+
+@SerializedName("fs_descriptor")
+private FileSystemDescriptor fileSystemDescriptor;
+
+private transient PersistentFileSystem fileSystem;  // 旧类型
+
+// 变更后
+@Deprecated @SerializedName("fs")
+private PersistentFileSystem legacyFileSystem;  // 仅用于向后兼容反序列化，不再使用
+
+@SerializedName("fs_descriptor")
+private FileSystemDescriptor fileSystemDescriptor;
+
+private transient org.apache.doris.filesystem.spi.FileSystem fileSystem;  // 新 SPI 类型
+```
+
+### 4.2 `gsonPostProcess()` 变更
+
+```java
+@Override
+public void gsonPostProcess() {
+    // 优先使用新 descriptor，fallback 到旧 legacyFileSystem（向后兼容）
+    if (fileSystemDescriptor == null && legacyFileSystem != null) {
+        fileSystemDescriptor = FileSystemDescriptor.fromPersistentFileSystem(legacyFileSystem);
+    }
+    if (fileSystemDescriptor == null) return;
+
+    Map<String, String> props = fileSystemDescriptor.getProperties();
+    try {
+        // 变更前：FileSystemFactory.get(storageProperties) 返回 PersistentFileSystem
+        // 变更后：FileSystemFactory.getFileSystem(props) 返回 spi.FileSystem
+        this.fileSystem = FileSystemFactory.getFileSystem(props);
+    } catch (Exception e) {
+        LOG.warn("Failed to init SPI FileSystem for repository {}, falling back to broker", name, e);
+        // Fallback：Broker 场景（fe-filesystem-broker 模块提供）
+        Map<String, String> brokerProps = new HashMap<>(props);
+        brokerProps.put("type", "BROKER");
+        brokerProps.put(BrokerProperties.BROKER_NAME_KEY, fileSystemDescriptor.getName());
+        try {
+            this.fileSystem = FileSystemFactory.getFileSystem(brokerProps);
+        } catch (Exception ex) {
+            LOG.error("Failed to init Broker FileSystem for repository {}", name, ex);
+        }
+    }
+}
+```
+
+### 4.3 方法变更
+
+```java
+// 保留（类型改变）
+public org.apache.doris.filesystem.spi.FileSystem getFileSystem() {
+    return fileSystem;
+}
+
+// 保留（类型改变，已在 P4.6e 提交中新增）
+public FileSystemDescriptor getFileSystemDescriptor() {
+    return fileSystemDescriptor;
+}
+
+// 废弃（用 getFileSystem() 替代）
+@Deprecated
+public PersistentFileSystem getRemoteFileSystem() {
+    // 临时向后兼容：若有调用方，打印 deprecation 日志
+    LOG.warn("getRemoteFileSystem() is deprecated, use getFileSystemDescriptor() for metadata "
+           + "and getFileSystem() for I/O");
+    throw new UnsupportedOperationException(
+        "Use getFileSystemDescriptor() for storage metadata, getFileSystem() for I/O");
+}
+```
+
+> **注**：`getRemoteFileSystem()` 若有编译时调用方则编译报错，确保所有调用方均已迁移。
+
+### 4.4 `validateAndNormalizeUri()`
+
+当前使用 `getStorageProperties()` 做 URI 校验：
+
+```java
+// 当前（需调查具体代码）
+StorageProperties sp = repo.getRemoteFileSystem().getStorageProperties();
+String normalizedUri = sp.validateAndNormalizeUri(uri);
+```
+
+迁移方式：
+
+```java
+// 变更后
+StorageProperties sp = StorageProperties.createPrimary(
+    repo.getFileSystemDescriptor().getProperties());
+String normalizedUri = sp.validateAndNormalizeUri(uri);
+```
+
+---
+
+## 五、`BackupJob.java` 变更
+
+### 5.1 L440：更新 broker properties（UPLOADING 状态重试）
+
+```java
+// 变更前（L440 附近）
+((UploadTask) task).updateBrokerProperties(
+    repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties());
+
+// 变更后
+((UploadTask) task).updateBrokerProperties(
+    repo.getFileSystemDescriptor().getBackendConfigProperties());
+```
+
+### 5.2 L824-825：创建 `UploadTask`
+
+```java
+// 变更前
+UploadTask task = new UploadTask(null, beId, signature, jobId, dbId, srcToDest,
+    brokers.get(0),
+    repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties(),
+    repo.getRemoteFileSystem().getThriftStorageType(),   // ← PersistentFileSystem.getThriftStorageType()
+    repo.getLocation());
+
+// 变更后
+UploadTask task = new UploadTask(null, beId, signature, jobId, dbId, srcToDest,
+    brokers.get(0),
+    repo.getFileSystemDescriptor().getBackendConfigProperties(),
+    repo.getFileSystemDescriptor().getThriftStorageType(),  // ← FileSystemDescriptor 新方法
+    repo.getLocation());
+```
+
+### 5.3 `UploadTask` 参数类型变更
+
+`UploadTask` 构造函数第 9 个参数原类型为 `StorageBackend.StorageType`，不变；
+`FileSystemDescriptor.getThriftStorageType()` 返回同类型，无需修改 `UploadTask`。
+
+---
+
+## 六、`RestoreJob.java` 变更
+
+### 6.1 L448：更新 broker properties（DOWNLOADING 状态重试）
+
+```java
+// 变更前
+((DownloadTask) task).updateBrokerProperties(
+    repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties());
+
+// 变更后
+((DownloadTask) task).updateBrokerProperties(
+    repo.getFileSystemDescriptor().getBackendConfigProperties());
+```
+
+### 6.2 L2005-2006：创建 `DownloadTask`
+
+```java
+// 变更前
+return new DownloadTask(null, beId, signature, jobId, dbId, srcToDest,
+    brokerAddr,
+    repo.getRemoteFileSystem().getStorageProperties().getBackendConfigProperties(),
+    repo.getRemoteFileSystem().getThriftStorageType(),
+    repo.getLocation(),
+    "");
+
+// 变更后
+return new DownloadTask(null, beId, signature, jobId, dbId, srcToDest,
+    brokerAddr,
+    repo.getFileSystemDescriptor().getBackendConfigProperties(),
+    repo.getFileSystemDescriptor().getThriftStorageType(),
+    repo.getLocation(),
+    "");
+```
+
+---
+
+## 七、`BackupHandler.java` 变更
+
+`BackupHandler` 使用 `repo.getRemoteFileSystem().getProperties()` 做属性合并：
+
+```java
+// 变更前
+private Map<String, String> mergeProperties(Repository repo, Map<String, String> newProps) {
+    Map<String, String> combined = new HashMap<>(repo.getRemoteFileSystem().getProperties());
+    combined.putAll(newProps);
+    return combined;
+}
+
+// 变更后
+private Map<String, String> mergeProperties(Repository repo, Map<String, String> newProps) {
+    Map<String, String> combined = new HashMap<>(repo.getFileSystemDescriptor().getProperties());
+    combined.putAll(newProps);
+    return combined;
+}
+```
+
+---
+
+## 八、Repository 实际 I/O 路径
+
+Repository 的 I/O 操作（upload/download/list/delete）当前由
+`fileSystem`（`PersistentFileSystem` / `RemoteFileSystem`）执行：
+
+```java
+// Repository 内部方法，如 upload()
+Status st = fileSystem.upload(localPath, remotePath);
+```
+
+迁移后，这些调用改用新 SPI 方法，通过 `FileSystemTransferUtil`（Phase 4.0 已建立）：
+
+| 旧调用 | 新调用 |
+|--------|--------|
+| `fileSystem.upload(local, remote)` | `FileSystemTransferUtil.upload(fileSystem, local, Location.of(remote))` |
+| `fileSystem.downloadWithFileSize(remote, local, size)` | `FileSystemTransferUtil.download(fileSystem, Location.of(remote), local, size)` |
+| `fileSystem.directUpload(content, remote)` | `FileSystemTransferUtil.directUpload(fileSystem, content, Location.of(remote))` |
+| `fileSystem.globList(path, result, false)` | `FileSystemTransferUtil.globList(fileSystem, path, false)` |
+| `fileSystem.delete(path)` | `fileSystem.delete(Location.of(path), false)` |
+| `fileSystem.deleteDirectory(path)` | `fileSystem.delete(Location.of(path), true)` |
+| `fileSystem.exists(path)` | `fileSystem.exists(Location.of(path))` |
+
+---
+
+## 九、序列化兼容性
+
+`Repository` 使用 Gson 序列化存储元数据到 FE 的 image 文件。
+变更点：
+
+### 9.1 序列化格式
+
+`fileSystemDescriptor` 字段（`@SerializedName("fs_descriptor")`）已从 Phase 4.6e 开始写入。
+旧的 `legacyFileSystem`（`@SerializedName("fs")`）保留反序列化，新写入时不再包含该字段。
+
+迁移后 `fileSystem` 字段为 `transient`（不序列化），在 `gsonPostProcess()` 中重建，
+**序列化格式不变**。
+
+### 9.2 向后兼容
+
+- 旧 image：含 `fs` 字段（`PersistentFileSystem`），无 `fs_descriptor`
+  → `gsonPostProcess()` 从 `legacyFileSystem` 构建 `fileSystemDescriptor`，正常运行
+- 新 image：含 `fs_descriptor` 字段，无 `fs`
+  → 直接使用 `fileSystemDescriptor`，无需 fallback
+
+---
+
+## 十、文件变更清单
+
+### `fe-core` — 核心变更
+
+| 文件 | 变更 |
+|------|------|
+| `fs/FileSystemDescriptor.java` | **修改** — 新增 `getThriftStorageType()`, `getBackendConfigProperties()`, `getBackendConfigProperties(Map)` |
+| `backup/Repository.java` | **修改** — `fileSystem` 类型 `PersistentFileSystem` → `spi.FileSystem`；`gsonPostProcess()` 改用 `getFileSystem()`；`getRemoteFileSystem()` 废弃 |
+| `backup/BackupJob.java` | **修改** — L440, L824-825：`getRemoteFileSystem().*` → `getFileSystemDescriptor().*` |
+| `backup/RestoreJob.java` | **修改** — L448, L2005-2006：同上 |
+| `backup/BackupHandler.java` | **修改** — `getRemoteFileSystem().getProperties()` → `getFileSystemDescriptor().getProperties()` |
+
+### `fe-core` — Repository I/O 路径（次要）
+
+| 文件 | 变更 |
+|------|------|
+| `backup/Repository.java`（I/O 方法） | **修改** — 内部 I/O 调用从旧 API 迁移到 `FileSystemTransferUtil` + `spi.FileSystem` |
+
+---
+
+## 十一、次要阻塞：`RepositoryMgr.java`（已完成）
+
+P4.6e 已完成 `instanceof S3FileSystem` / `instanceof AzureFileSystem` 替换为
+`fileSystemDescriptor.getStorageType() == FsStorageType.S3`，此项无需重复处理。
+
+---
+
+## 十二、测试策略
+
+### 12.1 单元测试
+
+```java
+// FileSystemDescriptorTest
+@Test
+void testGetThriftStorageType() {
+    FileSystemDescriptor desc = new FileSystemDescriptor(FsStorageType.S3, "test-repo", props);
+    assertEquals(StorageBackend.StorageType.S3, desc.getThriftStorageType());
+}
+
+@Test
+void testGetBackendConfigProperties() {
+    Map<String, String> props = Map.of(
+        "type", "S3",
+        "s3.access_key", "AK",
+        "s3.secret_key", "SK",
+        "s3.endpoint", "s3.us-east-1.amazonaws.com",
+        "s3.region", "us-east-1",
+        "s3.bucket", "my-bucket"
+    );
+    FileSystemDescriptor desc = new FileSystemDescriptor(FsStorageType.S3, "test", props);
+    Map<String, String> beProps = desc.getBackendConfigProperties();
+    assertEquals("AK", beProps.get("AWS_ACCESS_KEY"));  // BE key format
+    assertEquals("SK", beProps.get("AWS_SECRET_KEY"));
+}
+```
+
+### 12.2 集成测试
+
+- 备份任务创建并正确发送 `TUploadReq` 到 BE（验证 `broker_prop` 和 `storage_backend`）
+- 恢复任务正确发送 `TDownloadReq`
+- 旧 image（含 `legacyFileSystem` 序列化数据）能正常反序列化并恢复
+- 新旧版本 FE 的 image 格式互相兼容（滚动升级场景）
+
+### 12.3 验证清单
+
+- [ ] `BackupJob` 发出的 `TUploadReq.storage_backend` 与 repository 类型匹配（S3 repo → `TStorageBackendType.S3`）
+- [ ] `BackupJob` 发出的 `TUploadReq.broker_prop` 含有 BE 可识别的 AK/SK/endpoint
+- [ ] `RestoreJob` 对称验证
+- [ ] 旧 image 格式（含 `PersistentFileSystem` 序列化）升级后正常加载
+- [ ] `Repository.getFileSystemDescriptor()` 在 `BackupHandler.mergeProperties()` 中返回正确 properties
+
+---
+
+## 十三、依赖关系与排期
+
+| 步骤 | 说明 | 依赖 |
+|------|------|------|
+| 1 | 扩展 `FileSystemDescriptor`（新增 2 个方法） | — |
+| 2 | 修改 `BackupJob` / `RestoreJob`（改用 descriptor） | 步骤 1 |
+| 3 | 修改 `BackupHandler` | 步骤 1 |
+| 4 | 修改 `Repository`（`fileSystem` 类型变更、`gsonPostProcess` 更新） | 步骤 2、3，`fe-filesystem-broker` 模块（P4.5a） |
+| 5 | `Repository` I/O 路径迁移（upload/download/list） | `FileSystemTransferUtil`（已完成） |
+| 6 | 运行 Backup/Restore 回归测试 | 步骤 1-5 |
+
+> **注**：步骤 4 中 `gsonPostProcess` 改用 `FileSystemFactory.getFileSystem()`，
+> 需要 `fe-filesystem-broker` 已注册（P4.5a），否则 Broker 类型 Repository 无法加载。
+> 因此 P4.6 与 P4.5a 有运行时依赖。
+
+---
+
+## 十四、涉及的架构图（变更后）
+
+```
+              ┌──────────────────────────────────────┐
+              │  Repository                          │
+              │                                      │
+              │  fileSystemDescriptor ──────────────►│──► getThriftStorageType()
+              │    (FsStorageType + properties)       │──► getBackendConfigProperties()
+              │                                      │
+              │  fileSystem (spi.FileSystem) ────────►│──► list / delete / exists
+              │    (建立实际连接，via ServiceLoader)   │──► FileSystemTransferUtil.upload/download
+              └──────────────────────────────────────┘
+                           │                │
+                           │ BackupJob      │ RestoreJob
+                           ▼                ▼
+              ┌──────────────────────────────────────┐
+              │  UploadTask / DownloadTask            │
+              │    .toThrift()                        │
+              │    ├─ broker_prop  ← descriptor.getBackendConfigProperties()
+              │    ├─ storage_backend ← descriptor.getThriftStorageType().toThrift()
+              │    └─ location    ← repo.getLocation()
+              └──────────────────────────────────────┘
+                           │
+                           ▼
+              ┌──────────────────────────────────────┐
+              │  BE: TUploadReq / TDownloadReq       │
+              │  初始化 S3/HDFS/OFS 客户端并执行      │
+              └──────────────────────────────────────┘
+```


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary: Phase 4 step P4.0 — add FileSystemTransferUtil, a utility class that provides higher-level transfer operations (download, upload, directUpload, globList) built on top of the spi.FileSystem primitives. This utility is a prerequisite for migrating all 21 FileSystemFactory.get() call sites to the new SPI API.

Also adds fe-filesystem-local as a test-scope dependency in fe-core/pom.xml to enable unit tests using LocalFileSystemProvider.

