### PR TITLE
[fix](scan) Fix missing predicate filter when Native and JNI readers are mixed in FileScanner

### DIFF
--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -351,7 +351,10 @@ Status FileScanner::_process_conjuncts() {
 Status FileScanner::_process_late_arrival_conjuncts() {
     if (_push_down_conjuncts.size() < _conjuncts.size()) {
         _push_down_conjuncts = _conjuncts;
-        _conjuncts.clear();
+        // Do not clear _conjuncts here!
+        // We must keep it for fallback filtering, especially when mixing
+        // Native readers (which use _push_down_conjuncts) and JNI readers (which rely on _conjuncts).
+        // _conjuncts.clear();
         RETURN_IF_ERROR(_process_conjuncts());
     }
     if (_applied_rf_num == _total_rf_num) {

--- a/be/test/exec/scan/vfile_scanner_exception_test.cpp
+++ b/be/test/exec/scan/vfile_scanner_exception_test.cpp
@@ -311,8 +311,8 @@ TEST_F(VfileScannerExceptionTest, process_late_arrival_conjuncts_retain) {
     doris::TExpr texpr;
     texpr.nodes.push_back(expr_node);
 
-    vectorized::VExprContextSPtr ctx;
-    Status st = vectorized::VExpr::create_expr_tree(texpr, ctx);
+    VExprContextSPtr ctx;
+    Status st = VExpr::create_expr_tree(texpr, ctx);
     ASSERT_TRUE(st.ok());
     st = ctx->prepare(&_runtime_state, RowDescriptor());
     ASSERT_TRUE(st.ok());

--- a/be/test/exec/scan/vfile_scanner_exception_test.cpp
+++ b/be/test/exec/scan/vfile_scanner_exception_test.cpp
@@ -295,4 +295,45 @@ TEST_F(VfileScannerExceptionTest, failure_case) {
     WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
 }
 
+TEST_F(VfileScannerExceptionTest, process_late_arrival_conjuncts_retain) {
+    std::shared_ptr<FileScanner> scanner = nullptr;
+    generate_scanner(scanner);
+
+    // Simulate some conjuncts in scanner
+    // Let's create a dummy expr context to test the exact function
+    doris::TExprNode expr_node;
+    expr_node.node_type = TExprNodeType::BOOL_LITERAL;
+    expr_node.type = create_type_desc(PrimitiveType::TYPE_BOOLEAN);
+    expr_node.num_children = 0;
+    expr_node.__isset.bool_literal = true;
+    expr_node.bool_literal.value = true;
+
+    doris::TExpr texpr;
+    texpr.nodes.push_back(expr_node);
+
+    vectorized::VExprContextSPtr ctx;
+    Status st = vectorized::VExpr::create_expr_tree(texpr, ctx);
+    ASSERT_TRUE(st.ok());
+    st = ctx->prepare(&_runtime_state, RowDescriptor());
+    ASSERT_TRUE(st.ok());
+    st = ctx->open(&_runtime_state);
+    ASSERT_TRUE(st.ok());
+
+    scanner->_conjuncts.push_back(ctx);
+    ASSERT_EQ(scanner->_conjuncts.size(), 1);
+    ASSERT_EQ(scanner->_push_down_conjuncts.size(), 0);
+
+    // Call the function that used to clear conjuncts in branch-4.0
+    st = scanner->_process_late_arrival_conjuncts();
+    ASSERT_TRUE(st.ok());
+
+    // The key assertion: _conjuncts MUST NOT be cleared after this call!
+    // This guarantees that subsequent JNI scanners or other readers will still have fallback filters.
+    ASSERT_EQ(scanner->_conjuncts.size(), 1);
+    // And push_down_conjuncts should be cloned/assigned successfully
+    ASSERT_EQ(scanner->_push_down_conjuncts.size(), 1);
+
+    WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
When querying a Paimon table (or other external tables) with a condition that cannot be pushed down (e.g., `LIKE '%*%'`), if a single `FileScanner` instance processes both Native splits (Parquet/ORC) and JNI splits consecutively, the data returned by the JNI reader will skip the fallback filtering at the `Scanner` layer, resulting in dirty data leaking into the final result.

Root Cause:
1. When `FileScanner` prepares to read a Native split, it calls `_process_late_arrival_conjuncts()` to assign `_conjuncts` into `_push_down_conjuncts`.
2. However, it mistakenly called `_conjuncts.clear()` at the end of this logic, wiping out the shared fallback `_conjuncts` at the scanner level.
3. When the scanner subsequently processes a JNI split (which does not trigger the push-down logic), `Scanner::_filter_output_block()` finds `_conjuncts` is empty, causing predicates like `LIKE` to be completely bypassed.

Solution:
Remove the `_conjuncts.clear()` call in `_process_late_arrival_conjuncts()`. This ensures that `_conjuncts` is always retained as the final fallback filter at the `Scanner` level, regardless of how underlying readers execute their own push-down predicates.

Added a BE unit test `process_late_arrival_conjuncts_retain` to prevent regression.

### Release note

Fix a correctness issue where complex string predicates (like `LIKE`) might fail to filter dirty data when querying external tables with mixed native and JNI splits.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

