### PR TITLE
[emhancement](compaction) disable compaction pause on high memory by default

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1647,7 +1647,7 @@ DEFINE_mBool(enable_mow_verbose_log, "false");
 DEFINE_mInt32(tablet_sched_delay_time_ms, "5000");
 DEFINE_mInt32(load_trigger_compaction_version_percent, "66");
 DEFINE_mInt64(base_compaction_interval_seconds_since_last_operation, "86400");
-DEFINE_mBool(enable_compaction_pause_on_high_memory, "true");
+DEFINE_mBool(enable_compaction_pause_on_high_memory, "false");
 
 DEFINE_mBool(enable_quorum_success_write, "true");
 DEFINE_mDouble(quorum_success_max_wait_multiplier, "0.2");


### PR DESCRIPTION
pick master #61288 

High compaction score keeps more rowset metadata,
delete bitmaps, and version graph state in
memory.

Pausing compaction on high memory makes those
high-score tablets harder to merge, so
metadata backlog and memory pressure become
harder to bring down.

Disable this pause by default to avoid
reinforcing that feedback loop.
