### PR TITLE
[fix](jdbc) Preserve query tvf column aliases across JDBC catalogs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchema.java
@@ -99,7 +99,10 @@ public class JdbcFieldSchema {
     }
 
     public JdbcFieldSchema(ResultSetMetaData metaData, int columnIndex) throws SQLException {
-        this.columnName = metaData.getColumnName(columnIndex);
+        String columnLabel = metaData.getColumnLabel(columnIndex);
+        this.columnName = columnLabel == null || columnLabel.isEmpty()
+                ? metaData.getColumnName(columnIndex)
+                : columnLabel;
         this.dataType = metaData.getColumnType(columnIndex);
         this.dataTypeName = Optional.ofNullable(metaData.getColumnTypeName(columnIndex));
         this.columnSize = Optional.of(metaData.getPrecision(columnIndex));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchemaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchemaTest.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.jdbc.util;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+
+public class JdbcFieldSchemaTest {
+
+    @Mocked
+    private ResultSetMetaData metaData;
+
+    @Test
+    public void testUseColumnLabelForQueryAlias() throws Exception {
+        new Expectations() {{
+                metaData.getColumnLabel(1);
+                result = "t1";
+                metaData.getColumnType(1);
+                result = Types.VARCHAR;
+                metaData.getColumnTypeName(1);
+                result = "VARCHAR";
+                metaData.getPrecision(1);
+                result = 64;
+                metaData.getScale(1);
+                result = 0;
+            }};
+
+        JdbcFieldSchema schema = new JdbcFieldSchema(metaData, 1);
+
+        Assert.assertEquals("t1", schema.getColumnName());
+    }
+
+    @Test
+    public void testFallbackToColumnNameWhenLabelMissing() throws Exception {
+        new Expectations() {{
+                metaData.getColumnLabel(1);
+                result = "";
+                metaData.getColumnName(1);
+                result = "username";
+                metaData.getColumnType(1);
+                result = Types.VARCHAR;
+                metaData.getColumnTypeName(1);
+                result = "VARCHAR";
+                metaData.getPrecision(1);
+                result = 64;
+                metaData.getScale(1);
+                result = 0;
+            }};
+
+        JdbcFieldSchema schema = new JdbcFieldSchema(metaData, 1);
+
+        Assert.assertEquals("username", schema.getColumnName());
+    }
+}

--- a/regression-test/data/external_table_p0/jdbc/test_jdbc_query_tvf.out
+++ b/regression-test/data/external_table_p0/jdbc/test_jdbc_query_tvf.out
@@ -42,3 +42,9 @@ year	smallint	Yes	true	\N	NONE
 -- !sql --
 4
 
+-- !sql --
+alias_smallint_u	int	Yes	true	\N	NONE
+alias_tinyint_u	smallint	Yes	true	\N	NONE
+
+-- !sql --
+203	303

--- a/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_tvf.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_jdbc_query_tvf.groovy
@@ -43,8 +43,11 @@ suite("test_jdbc_query_tvf", "p0,external") {
         order_qt_sql """desc function query('catalog' = '${catalog_name}', 'query' = 'select * from doris_test.all_types') """
         order_qt_sql """select * from query('catalog' = '${catalog_name}', 'query' = 'select * from doris_test.all_types') """
         order_qt_sql """select * from query('catalog' = '${catalog_name}', 'query' = 'select count(*) as cnt from doris_test.all_types') """
+        order_qt_sql """desc function query('catalog' = '${catalog_name}',
+                'query' = 'select tinyint_u as alias_tinyint_u, smallint_u as alias_smallint_u from doris_test.all_types where tinyint_u is not null') """
+        order_qt_sql """select * from query('catalog' = '${catalog_name}',
+                'query' = 'select tinyint_u as alias_tinyint_u, smallint_u as alias_smallint_u from doris_test.all_types where tinyint_u is not null') where alias_tinyint_u = 203 """
 
 //         sql """drop catalog if exists ${catalog_name} """
     }
 }
-


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #34516

Problem Summary:

Fix bug:
`query()` passes the SQL through to the JDBC catalog directly, so the returned column names should follow the aliases defined in that SQL.

For example, for:
```sql
select * from query(
  'catalog' = 'jdbc_catalog',
  'query' = 'select a as x from test.t'
);
```
the output column name should be `x`, not the original source column name `a`.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

