### PR TITLE
[refine](be) Deprecate TYPE_LAMBDA_FUNCTION in PrimitiveType enum

### DIFF
--- a/be/src/core/data_type/data_type_decimal.cpp
+++ b/be/src/core/data_type/data_type_decimal.cpp
@@ -70,8 +70,7 @@ DataTypePtr get_data_type_with_default_argument(DataTypePtr type) {
             DCHECK_EQ(res->get_scale(), BeConsts::MAX_DECIMALV2_SCALE);
 
             return res;
-        } else if (t->get_primitive_type() == PrimitiveType::TYPE_BINARY ||
-                   t->get_primitive_type() == PrimitiveType::TYPE_LAMBDA_FUNCTION) {
+        } else if (t->get_primitive_type() == PrimitiveType::TYPE_BINARY) {
             return DataTypeFactory::instance().create_data_type(TYPE_STRING, t->is_nullable());
         } else {
             return t;

--- a/be/src/core/data_type/data_type_factory.cpp
+++ b/be/src/core/data_type/data_type_factory.cpp
@@ -457,7 +457,6 @@ DataTypePtr DataTypeFactory::create_data_type(const PrimitiveType primitive_type
         nested = std::make_shared<DataTypeString>(len, primitive_type);
         break;
     case TYPE_BINARY:
-    case TYPE_LAMBDA_FUNCTION:
         nested = std::make_shared<DataTypeString>(len, TYPE_STRING);
         break;
     case TYPE_JSONB:

--- a/be/src/core/data_type/define_primitive_type.h
+++ b/be/src/core/data_type/define_primitive_type.h
@@ -50,27 +50,27 @@ enum PrimitiveType : PrimitiveNative {
 
     TYPE_TIME [[deprecated]], /*TYPE_TIMEV2*/
 
-    TYPE_BITMAP,              /* 22, bitmap */
-    TYPE_STRING,              /* 23 */
-    TYPE_QUANTILE_STATE,      /* 24 */
-    TYPE_DATEV2,              /* 25 */
-    TYPE_DATETIMEV2,          /* 26 */
-    TYPE_TIMEV2,              /* 27 */
-    TYPE_DECIMAL32,           /* 28 */
-    TYPE_DECIMAL64,           /* 29 */
-    TYPE_DECIMAL128I,         /* 30, v3 128bit */
-    TYPE_JSONB,               /* 31 */
-    TYPE_VARIANT,                          /* 32 */
-    TYPE_LAMBDA_FUNCTION [[deprecated]],     /* 33 */
-    TYPE_AGG_STATE,                          /* 34 */
-    TYPE_DECIMAL256,          /* 35 */
-    TYPE_IPV4,                /* 36 */
-    TYPE_IPV6,                /* 37 */
-    TYPE_UINT32,              /* 38, used as offset */
-    TYPE_UINT64,              /* 39, used as offset */
-    TYPE_FIXED_LENGTH_OBJECT, /* 40, represent fixed-length object on BE */
-    TYPE_VARBINARY,           /* 41, varbinary */
-    TYPE_TIMESTAMPTZ          /* 42, timestamptz */
+    TYPE_BITMAP,                         /* 22, bitmap */
+    TYPE_STRING,                         /* 23 */
+    TYPE_QUANTILE_STATE,                 /* 24 */
+    TYPE_DATEV2,                         /* 25 */
+    TYPE_DATETIMEV2,                     /* 26 */
+    TYPE_TIMEV2,                         /* 27 */
+    TYPE_DECIMAL32,                      /* 28 */
+    TYPE_DECIMAL64,                      /* 29 */
+    TYPE_DECIMAL128I,                    /* 30, v3 128bit */
+    TYPE_JSONB,                          /* 31 */
+    TYPE_VARIANT,                        /* 32 */
+    TYPE_LAMBDA_FUNCTION [[deprecated]], /* 33 */
+    TYPE_AGG_STATE,                      /* 34 */
+    TYPE_DECIMAL256,                     /* 35 */
+    TYPE_IPV4,                           /* 36 */
+    TYPE_IPV6,                           /* 37 */
+    TYPE_UINT32,                         /* 38, used as offset */
+    TYPE_UINT64,                         /* 39, used as offset */
+    TYPE_FIXED_LENGTH_OBJECT,            /* 40, represent fixed-length object on BE */
+    TYPE_VARBINARY,                      /* 41, varbinary */
+    TYPE_TIMESTAMPTZ                     /* 42, timestamptz */
 };
 
 } // namespace doris

--- a/be/src/core/data_type/define_primitive_type.h
+++ b/be/src/core/data_type/define_primitive_type.h
@@ -60,9 +60,9 @@ enum PrimitiveType : PrimitiveNative {
     TYPE_DECIMAL64,           /* 29 */
     TYPE_DECIMAL128I,         /* 30, v3 128bit */
     TYPE_JSONB,               /* 31 */
-    TYPE_VARIANT,             /* 32 */
-    TYPE_LAMBDA_FUNCTION,     /* 33 */
-    TYPE_AGG_STATE,           /* 34 */
+    TYPE_VARIANT,                          /* 32 */
+    TYPE_LAMBDA_FUNCTION [[deprecated]],     /* 33 */
+    TYPE_AGG_STATE,                          /* 34 */
     TYPE_DECIMAL256,          /* 35 */
     TYPE_IPV4,                /* 36 */
     TYPE_IPV6,                /* 37 */

--- a/be/src/core/data_type/primitive_type.cpp
+++ b/be/src/core/data_type/primitive_type.cpp
@@ -127,7 +127,10 @@ PrimitiveType thrift_to_type(TPrimitiveType::type ttype) {
         return TYPE_STRUCT;
 
     case TPrimitiveType::LAMBDA_FUNCTION:
-        return TYPE_LAMBDA_FUNCTION;
+        // TYPE_LAMBDA_FUNCTION is deprecated. Lambda execution is driven by
+        // TExprNodeType::LAMBDA_FUNCTION_EXPR, not PrimitiveType. Map to TYPE_STRING
+        // since DataTypeFactory always created DataTypeString for it anyway.
+        return TYPE_STRING;
 
     case TPrimitiveType::AGG_STATE:
         return TYPE_AGG_STATE;
@@ -247,8 +250,6 @@ TPrimitiveType::type to_thrift(PrimitiveType ptype) {
 
     case TYPE_STRUCT:
         return TPrimitiveType::STRUCT;
-    case TYPE_LAMBDA_FUNCTION:
-        return TPrimitiveType::LAMBDA_FUNCTION;
     case TYPE_AGG_STATE:
         return TPrimitiveType::AGG_STATE;
     case TYPE_VARBINARY:
@@ -363,8 +364,6 @@ std::string type_to_string(PrimitiveType t) {
 
     case TYPE_STRUCT:
         return "STRUCT";
-    case TYPE_LAMBDA_FUNCTION:
-        return "LAMBDA_FUNCTION TYPE";
 
     case TYPE_VARIANT:
         return "VARIANT";

--- a/be/src/exprs/vlambda_function_expr.h
+++ b/be/src/exprs/vlambda_function_expr.h
@@ -30,6 +30,10 @@ public:
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override {
         RETURN_IF_ERROR_OR_PREPARED(VExpr::prepare(state, desc, context));
+        // Fix _data_type to match the lambda body's actual return type.
+        // The initial _data_type was set to DataTypeString as a placeholder during
+        // VExpr(TExprNode) construction; override it with the body's real type.
+        data_type() = get_child(0)->data_type();
         _prepare_finished = true;
         return Status::OK();
     }

--- a/be/src/storage/tablet/tablet_schema.cpp
+++ b/be/src/storage/tablet/tablet_schema.cpp
@@ -128,8 +128,6 @@ FieldType TabletColumn::get_field_type_by_type(PrimitiveType primitiveType) {
         return FieldType::OLAP_FIELD_TYPE_IPV4;
     case PrimitiveType::TYPE_IPV6:
         return FieldType::OLAP_FIELD_TYPE_IPV6;
-    case PrimitiveType::TYPE_LAMBDA_FUNCTION:
-        return FieldType::OLAP_FIELD_TYPE_UNKNOWN; // Not implemented
     case PrimitiveType::TYPE_AGG_STATE:
         return FieldType::OLAP_FIELD_TYPE_AGG_STATE;
     default:

--- a/be/test/exprs/function/cast/cast_test.h
+++ b/be/test/exprs/function/cast/cast_test.h
@@ -182,9 +182,6 @@ struct FunctionCastTest : public testing::Test {
             return "jsonb";
         case TYPE_VARIANT: /* 32 */
             return "variant";
-        case TYPE_LAMBDA_FUNCTION: /* 33 */
-            __builtin_unreachable();
-            break;
         case TYPE_AGG_STATE: /* 34 */
             __builtin_unreachable();
             break;


### PR DESCRIPTION
### What problem does this PR solve?

`TYPE_LAMBDA_FUNCTION` (enum value 33) is not a real column data type — it is a semantic tag for lambda expressions. Lambda execution is entirely driven by `TExprNodeType::LAMBDA_FUNCTION_EXPR`, not `PrimitiveType`. Having it in the `PrimitiveType` enum pollutes the enum semantics and causes a structural inconsistency in `VLambdaFunctionExpr._data_type`.

### Changes

1. **Mark `TYPE_LAMBDA_FUNCTION` as `[[deprecated]]`** in `define_primitive_type.h` (enum value 33 is preserved for ABI compatibility).

2. **`from_thrift()`**: Map `TPrimitiveType::LAMBDA_FUNCTION` → `TYPE_STRING` instead of `TYPE_LAMBDA_FUNCTION`. This is semantically equivalent since `DataTypeFactory` always created `DataTypeString` for it anyway. Thrift protocol compatibility is maintained (old FE → new BE still works).

3. **Remove all BE references** to `TYPE_LAMBDA_FUNCTION`:
   - `to_thrift()` / `type_to_string()` — removed switch cases (all have `default:` branches)
   - `data_type_factory.cpp` — removed case (falls through to `default:`)
   - `data_type_decimal.cpp` — removed dead code branch (unreachable since `create_data_type(TYPE_LAMBDA_FUNCTION)` returns `DataTypeString` whose `get_primitive_type()` is `TYPE_STRING`)
   - `tablet_schema.cpp` — removed case (identical to `default:` behavior)
   - `cast_test.h` — removed case (identical to `default:` behavior)

4. **Fix `VLambdaFunctionExpr._data_type` inconsistency**: In `prepare()`, override `_data_type` with `get_child(0)->data_type()` (the lambda body's actual return type) instead of keeping the placeholder `DataTypeString`.

### Release note

None

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

