### PR TITLE
[fix](auto-partition) Register auto-partition tables with retention_count in DynamicPartitionScheduler on restart

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -982,7 +982,9 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             for (Table table : tableList) {
                 table.readLock();
                 try {
-                    if (DynamicPartitionUtil.isDynamicPartitionTable(table)) {
+                    if (table instanceof OlapTable
+                            && (((OlapTable) table).getPartitionRetentionCount() > 0
+                            || DynamicPartitionUtil.isDynamicPartitionTable(table))) {
                         registerDynamicPartitionTable(db.getId(), table.getId());
                     }
                 } finally {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DynamicPartitionTableTest.java
@@ -46,6 +46,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -794,6 +795,36 @@ public class DynamicPartitionTableTest {
         Assert.assertEquals(14, emptyDynamicTable.getAllPartitions().size());
         // never delete the old partitions
         Assert.assertEquals(Integer.parseInt(tableProperties.get("dynamic_partition.start")), Integer.MIN_VALUE);
+    }
+
+    @Test
+    public void testAutoPartitionRetentionCountTableRegisteredAfterSchedulerInit() throws Exception {
+        String createOlapTblStmt = "CREATE TABLE test.`auto_partition_retention_init` (\n"
+                + "  `k1` datetime(6) NOT NULL\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`k1`)\n"
+                + "AUTO PARTITION BY RANGE (date_trunc(k1, 'day')) ()\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\",\n"
+                + "\"partition.retention_count\" = \"3\"\n"
+                + ");";
+        createTable(createOlapTblStmt);
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException("test");
+        OlapTable tbl = (OlapTable) db.getTableOrAnalysisException("auto_partition_retention_init");
+        DynamicPartitionScheduler scheduler = Env.getCurrentEnv().getDynamicPartitionScheduler();
+
+        Assert.assertTrue(scheduler.containsDynamicPartitionTable(db.getId(), tbl.getId()));
+
+        scheduler.removeDynamicPartitionTable(db.getId(), tbl.getId());
+        Assert.assertFalse(scheduler.containsDynamicPartitionTable(db.getId(), tbl.getId()));
+
+        Method initDynamicPartitionTable = DynamicPartitionScheduler.class
+                .getDeclaredMethod("initDynamicPartitionTable");
+        initDynamicPartitionTable.setAccessible(true);
+        initDynamicPartitionTable.invoke(scheduler);
+        Assert.assertTrue(scheduler.containsDynamicPartitionTable(db.getId(), tbl.getId()));
     }
 
     @Test

--- a/regression-test/suites/partition_p0/auto_partition/test_auto_partition_retention_restart.groovy
+++ b/regression-test/suites/partition_p0/auto_partition/test_auto_partition_retention_restart.groovy
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite("test_auto_partition_retention_restart", "docker") {
+    def options = new ClusterOptions()
+    options.feNum = 1
+    options.beNum = 1
+    options.feConfigs += [
+        "dynamic_partition_enable=true",
+        "dynamic_partition_check_interval_seconds=1"
+    ]
+
+    docker(options) {
+        def tableName = "test_auto_partition_retention_restart"
+
+        def waitPartitions = { Closure<Boolean> predicate, long timeoutMs = 30000L ->
+            long start = System.currentTimeMillis()
+            while (System.currentTimeMillis() - start < timeoutMs) {
+                def partitions = sql "show partitions from ${tableName}"
+                if (predicate.call(partitions)) {
+                    return partitions
+                }
+                sleep(1000)
+            }
+            def partitions = sql "show partitions from ${tableName}"
+            assertTrue(predicate.call(partitions))
+            return partitions
+        }
+
+        sql "drop table if exists ${tableName} force"
+        sql """
+            create table ${tableName}(
+                k0 datetime(6) not null
+            )
+            auto partition by range (date_trunc(k0, 'day')) ()
+            distributed by hash(`k0`) buckets 1
+            properties(
+                "replication_num" = "1"
+            )
+        """
+
+        try {
+            sql """
+                insert into ${tableName}
+                select date_add('2020-01-01 00:00:00', interval number day)
+                from numbers("number" = "100")
+            """
+
+            sql "alter table ${tableName} set ('partition.retention_count' = '3')"
+
+            def partitionsBeforeRestart = waitPartitions.call({ partitions -> partitions.size() == 3 })
+            def oldestBeforeRestart = partitionsBeforeRestart[0][1].toString()
+
+            cluster.restartFrontends()
+            sleep(20000)
+            context.reconnectFe()
+
+            sql """
+                insert into ${tableName}
+                values ('2020-04-10 00:00:00')
+            """
+
+            def partitions = waitPartitions.call({ currentPartitions ->
+                currentPartitions.size() == 3 && currentPartitions[0][1].toString() != oldestBeforeRestart
+            })
+            assertEquals(partitions.size(), 3)
+            assertTrue(partitions[0][1].toString().startsWith("p20200408"))
+            assertTrue(partitions[2][1].toString().startsWith("p20200410"))
+
+            def rows = sql "select * from ${tableName} order by k0"
+            assertEquals(rows.size(), 3)
+            assertEquals(rows[0][0].toString().startsWith("2020-04-08"), true)
+            assertEquals(rows[2][0].toString().startsWith("2020-04-10"), true)
+        } finally {
+            sql "drop table if exists ${tableName} force"
+        }
+    }
+}


### PR DESCRIPTION
Related PR: https://github.com/apache/doris/pull/57013

Auto-partition tables with `partition.retention_count` set were not being registered in DynamicPartitionScheduler during FE restart, causing retention policies to stop working until manual re-registration. Modified `initDynamicPartitionTable()` to check for both dynamic partition tables and OlapTables with retention_count > 0, ensuring these tables are properly tracked after restart