### PR TITLE
[Improvement](shuffle) enlarge bucket number to fullBucketNum

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/job/UnassignedScanBucketOlapTableJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/job/UnassignedScanBucketOlapTableJob.java
@@ -254,13 +254,18 @@ public class UnassignedScanBucketOlapTableJob extends AbstractUnassignedScanJob 
             }
         }
 
+        // When instanceNum > numBuckets (physical bucket count), extra instances would get
+        // no data through BUCKET_HASH_SHUFFLE local exchange because hash % numBuckets never
+        // maps to them. Fix: assign virtual bucket indexes (beyond physical range) to extra
+        // instances so the expanded bucket space covers all instances evenly.
         int thisWorkerInstanceNum = instances.size() - existsInstanceNum;
+        int numBuckets = fullBucketNum();
         for (int i = thisWorkerInstanceNum; i < instanceNum; ++i) {
+            int virtualBucketIndex = numBuckets + (i - thisWorkerInstanceNum);
             LocalShuffleBucketJoinAssignedJob instance = new LocalShuffleBucketJoinAssignedJob(
                     instances.size(), shareScanId, context.nextInstanceId(),
                     this, worker, emptyShareScanSource,
-                    // these instance not need to join, because no any bucket assign to it
-                    ImmutableSet.of()
+                    ImmutableSet.of(virtualBucketIndex)
             );
             instances.add(instance);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/ThriftPlansBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/ThriftPlansBuilder.java
@@ -411,11 +411,16 @@ public class ThriftPlansBuilder {
             params.setFileScanParams(fileScanRangeParamsMap);
 
             if (fragmentPlan.getFragmentJob() instanceof UnassignedScanBucketOlapTableJob) {
-                int bucketNum = ((UnassignedScanBucketOlapTableJob) fragmentPlan.getFragmentJob())
+                int physicalBucketNum = ((UnassignedScanBucketOlapTableJob) fragmentPlan.getFragmentJob())
                         .getOlapScanNodes()
                         .get(0)
                         .getBucketNum();
-                params.setNumBuckets(bucketNum);
+                // When local shuffle creates more instances than physical buckets,
+                // virtual bucket indexes are assigned beyond the physical range.
+                // Expand num_buckets to cover all virtual buckets so that
+                // hash % num_buckets can route data to every instance.
+                int workerInstanceNum = instancesPerWorker.get(worker).size();
+                params.setNumBuckets(Math.max(physicalBucketNum, workerInstanceNum));
             }
 
             List<AssignedJob> instances = instancesPerWorker.get(worker);


### PR DESCRIPTION
This pull request addresses the scenario where the number of local shuffle instances exceeds the number of physical buckets in bucketed OLAP table scans. The changes ensure that all instances are properly assigned data by introducing the concept of virtual buckets and expanding the bucket space accordingly. The most important changes are:

**Bucket assignment logic improvements:**

* In `UnassignedScanBucketOlapTableJob.java`, when the number of instances exceeds the number of physical buckets, virtual bucket indexes are assigned to the extra instances. This guarantees that every instance receives data during local shuffle, preventing idle instances.

**Thrift parameter updates:**

* In `ThriftPlansBuilder.java`, the `num_buckets` parameter is set to the maximum of the physical bucket count and the number of worker instances. This ensures that the hash distribution covers both physical and virtual buckets, so data can be routed to every instance.