### PR TITLE
[fix](compaction) Remove upper limit for vertical_compaction_num_columns_per_group

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -2286,9 +2286,9 @@ public class PropertyAnalyzer {
         properties.remove(PROPERTIES_VERTICAL_COMPACTION_NUM_COLUMNS_PER_GROUP);
         try {
             int num = Integer.parseInt(value);
-            if (num < 1 || num > 50) {
+            if (num < 1) {
                 throw new AnalysisException(PROPERTIES_VERTICAL_COMPACTION_NUM_COLUMNS_PER_GROUP
-                        + " must be between 1 and 50");
+                        + " must be >= 1");
             }
             return num;
         } catch (NumberFormatException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ModifyTablePropertiesOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ModifyTablePropertiesOp.java
@@ -241,9 +241,9 @@ public class ModifyTablePropertiesOp extends AlterTableOp {
                     .get(PropertyAnalyzer.PROPERTIES_VERTICAL_COMPACTION_NUM_COLUMNS_PER_GROUP);
             try {
                 numColumnsPerGroup = Integer.parseInt(numColumnsPerGroupStr);
-                if (numColumnsPerGroup < 1 || numColumnsPerGroup > 50) {
+                if (numColumnsPerGroup < 1) {
                     throw new AnalysisException(
-                            "vertical_compaction_num_columns_per_group must be between 1 and 50: "
+                            "vertical_compaction_num_columns_per_group must be >= 1: "
                                     + numColumnsPerGroupStr);
                 }
             } catch (NumberFormatException e) {


### PR DESCRIPTION

Remove the upper bound check and only validate that the value is >= 1.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

