### PR TITLE
[fix](serde) fix split_by_delimiter missing backslash escape handling

### DIFF
--- a/be/src/core/data_type_serde/complex_type_deserialize_util.h
+++ b/be/src/core/data_type_serde/complex_type_deserialize_util.h
@@ -42,7 +42,9 @@ struct ComplexTypeDeserializeUtil {
         std::vector<SplitResult> elements;
         for (int pos = 0; pos < str.size; ++pos) {
             char c = str.data[pos];
-            if (c == '"' || c == '\'') {
+            if (c == '\\' && pos + 1 < static_cast<int>(str.size)) {
+                ++pos; // skip escaped character
+            } else if (c == '"' || c == '\'') {
                 if (!has_quote) {
                     quote_char = c;
                     has_quote = !has_quote;

--- a/be/test/core/data_type_serde/data_type_serde_map_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_map_test.cpp
@@ -41,6 +41,7 @@
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/define_primitive_type.h"
+#include "core/data_type_serde/complex_type_deserialize_util.h"
 #include "core/field.h"
 #include "core/types.h"
 #include "storage/olap_common.h"
@@ -176,6 +177,62 @@ TEST_F(DataTypeMapSerDeTest, ArrowMemNotAligned) {
     auto serde_map = std::make_shared<DataTypeMapSerDe>(serde_str_key, serde_str_value);
     auto st = serde_map->read_column_from_arrow(*ser_col, arr.get(), 0, 1, tz);
     EXPECT_TRUE(st.ok());
+}
+
+// Stream Load JSON stores Map as String via to_json_string, then converts back
+// via from_string → split_by_delimiter. The splitter must handle '\' escapes
+// so that '\"' inside a value doesn't flip quote state and expose inner ':'/','.
+TEST_F(DataTypeMapSerDeTest, SplitByDelimiterHandlesBackslashEscape) {
+    DataTypeSerDe::FormatOptions opts;
+    opts.map_key_delim = ':';
+    opts.collection_delim = ',';
+
+    auto make_map_type = []() {
+        auto str = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
+        return std::make_shared<DataTypeMap>(str, str);
+    };
+
+    // split_by_delimiter: '\"' must not toggle quote state
+    // Input (after stripping outer {}): "k":"[{\"a\":\"b\\nc:"
+    // Expected: 2 elements — key "k" and value "[{\"a\":\"b\\nc:"
+    {
+        std::string inner = "\"k\":\"[{\\\"a\\\":\\\"b\\\\nc:\"";
+        StringRef str(inner.data(), inner.size());
+        auto result = ComplexTypeDeserializeUtil::split_by_delimiter(
+                str, [&](char c) { return c == opts.map_key_delim || c == opts.collection_delim; });
+        EXPECT_EQ(result.size(), 2u);
+    }
+
+    // from_string: value ending with ':' (map_key_delim) must not cause split error
+    // Simulates to_json_string output: {"k":"[{\"a\":\"b\\nc:"}
+    {
+        auto map_type = make_map_type();
+        auto col = map_type->create_column();
+        std::string map_str = "{\"k\":\"[{\\\"a\\\":\\\"b\\\\nc:\"}";
+        StringRef ref(map_str.data(), map_str.size());
+        EXPECT_TRUE(map_type->get_serde()->from_string(ref, *col, opts).ok());
+        EXPECT_EQ(col->size(), 1u);
+    }
+
+    // from_string: value ending with ',' (collection_delim) — same class of bug
+    {
+        auto map_type = make_map_type();
+        auto col = map_type->create_column();
+        std::string map_str = "{\"k\":\"[{\\\"a\\\":\\\"b\\\\nc,\"}";
+        StringRef ref(map_str.data(), map_str.size());
+        EXPECT_TRUE(map_type->get_serde()->from_string(ref, *col, opts).ok());
+        EXPECT_EQ(col->size(), 1u);
+    }
+
+    // Control: value ending with ')' (not a delimiter) — always worked
+    {
+        auto map_type = make_map_type();
+        auto col = map_type->create_column();
+        std::string map_str = "{\"k\":\"[{\\\"a\\\":\\\"b\\\\nc)\"}";
+        StringRef ref(map_str.data(), map_str.size());
+        EXPECT_TRUE(map_type->get_serde()->from_string(ref, *col, opts).ok());
+        EXPECT_EQ(col->size(), 1u);
+    }
 }
 
 } // namespace doris

--- a/regression-test/data/jsonb_p0/test_jsonb_cast.csv
+++ b/regression-test/data/jsonb_p0/test_jsonb_cast.csv
@@ -1,4 +1,4 @@
 1	\N
 2	['{\'x\':\'{"y":1}\', \'t\':\'{"y":2}\'}', '{"x":1}']
-3	['foo\'bar', 'foo"bar', 'foo\\'bar', 'foo\'\'bar']
+3	['foo\'bar', 'foo"bar', 'foo\'bar', 'foo\'\'bar']
 4	['\/some\/cool\/url', '/some/cool/url', 'a\\_\\c\\l\\i\\c\\k\\h\\o\\u\\s\\e']

--- a/regression-test/data/jsonb_p0/test_jsonb_cast.out
+++ b/regression-test/data/jsonb_p0/test_jsonb_cast.out
@@ -2,13 +2,13 @@
 -- !select_1 --
 1	\N
 2	["{'x':'{"y":1}', 't':'{"y":2}'}", "{"x":1}"]
-3	["foo'bar', 'foo"bar', 'foo\\'bar', 'foo''bar"]
+3	["foo'bar", "foo"bar", "foo'bar", "foo''bar"]
 4	["/some/cool/url", "/some/cool/url", "a\\_\\c\\l\\i\\c\\k\\h\\o\\u\\s\\e"]
 
 -- !select_2 --
 1	\N
 2	["{'x':'{"y":1}', 't':'{"y":2}'}", "{"x":1}"]
-3	["foo'bar', 'foo"bar', 'foo\\'bar', 'foo''bar"]
+3	["foo'bar", "foo"bar", "foo'bar", "foo''bar"]
 4	["/some/cool/url", "/some/cool/url", "a\\_\\c\\l\\i\\c\\k\\h\\o\\u\\s\\e"]
 27	["{"k1":"v1", "k2":200}"]
 28	["{"a.b.c":{"k1.a1":"v31", "k2":300},"a":"niu"}"]
@@ -18,7 +18,7 @@
 -- !select_json --
 1	\N
 2	["{'x':'{\\"y\\":1}', 't':'{\\"y\\":2}'}","{\\"x\\":1}"]
-3	["foo'bar', 'foo\\"bar', 'foo\\\\'bar', 'foo''bar"]
+3	["foo'bar","foo\\"bar","foo'bar","foo''bar"]
 4	["/some/cool/url","/some/cool/url","a\\\\_\\\\c\\\\l\\\\i\\\\c\\\\k\\\\h\\\\o\\\\u\\\\s\\\\e"]
 27	["{\\"k1\\":\\"v1\\", \\"k2\\":200}"]
 28	["{\\"a.b.c\\":{\\"k1.a1\\":\\"v31\\", \\"k2\\":300},\\"a\\":\\"niu\\"}"]

--- a/regression-test/data/jsonb_p0/test_jsonb_unescaped.csv
+++ b/regression-test/data/jsonb_p0/test_jsonb_unescaped.csv
@@ -1,5 +1,5 @@
 1	\N
 2	['{\'x\' : \'{"y" : 1}\', \'t\' : \'{"y" : 2}\'}', '{"x" : 1}']
-3	['foo\'bar', 'foo"bar', 'foo\\'bar', 'foo\'\'bar']
+3	['foo\'bar', 'foo"bar', 'foo\'bar', 'foo\'\'bar']
 4	['\/some\/cool\/url', '/some/cool/url', 'a\\_\\c\\l\\i\\c\\k\\h\\o\\u\\s\\e']
 5	["\"双引号\"", "反斜\\线"]

--- a/regression-test/data/jsonb_p0/test_jsonb_with_unescaped_string.out
+++ b/regression-test/data/jsonb_p0/test_jsonb_with_unescaped_string.out
@@ -2,14 +2,14 @@
 -- !select_csv --
 1	\N
 2	["{'x' : '{"y" : 1}', 't' : '{"y" : 2}'}", "{"x" : 1}"]
-3	["foo'bar', 'foo"bar', 'foo\\'bar', 'foo''bar"]
+3	["foo'bar", "foo"bar", "foo'bar", "foo''bar"]
 4	["/some/cool/url", "/some/cool/url", "a\\_\\c\\l\\i\\c\\k\\h\\o\\u\\s\\e"]
 5	[""双引号"", "反斜\\线"]
 
 -- !select_json --
 1	\N
 2	["{'x' : '{"y" : 1}', 't' : '{"y" : 2}'}", "'{"x" : 1}'"]
-3	["foo'bar', 'foo"bar', 'foo\\'bar', 'foo''bar"]
+3	["foo'bar", "foo"bar", "foo\\'bar", "foo''bar"]
 4	["/some/cool/url", "/some/cool/url", "a\\_\\c\\l\\i\\c\\k\\h\\o\\u\\s\\e"]
 5	[""双引号"", "反斜\\线"]
 


### PR DESCRIPTION
### Bug

Stream Load (JSON format) writing to `Map<String, String>` columns silently sets the column to NULL when the map value contains both `\"` (escaped quotes) and `:` or `,`. Stream Load returns Success with FilteredRows=0 — data loss with no error indication.

### Fix

Added `\` escape skip in `split_by_delimiter`'s character loop, before quote detection — consistent with the existing escape handling in `deserialize_one_cell_from_json`.



### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

