### PR TITLE
 [refine](be) Refactor DataTypeNumberSerDe hierarchy: split base/final, sink if-constexpr branches

### DIFF
--- a/be/src/core/data_type/data_type_date.h
+++ b/be/src/core/data_type/data_type_date.h
@@ -30,7 +30,7 @@
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_number_base.h"
 #include "core/data_type/define_primitive_type.h"
-#include "core/data_type_serde/data_type_date_or_datetime_serde.h"
+#include "core/data_type_serde/data_type_date_serde.h"
 #include "core/types.h"
 
 namespace doris {
@@ -64,7 +64,7 @@ public:
 
     MutableColumnPtr create_column() const override;
 
-    using SerDeType = DataTypeDateSerDe<TYPE_DATE>;
+    using SerDeType = DataTypeDateSerDe;
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
         return std::make_shared<SerDeType>(nesting_level);
     }

--- a/be/src/core/data_type/data_type_date_time.h
+++ b/be/src/core/data_type/data_type_date_time.h
@@ -31,7 +31,7 @@
 #include "core/data_type/data_type_number_base.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/data_type/primitive_type.h"
-#include "core/data_type_serde/data_type_date_or_datetime_serde.h"
+#include "core/data_type_serde/data_type_datetime_serde.h"
 #include "core/types.h"
 
 namespace doris {

--- a/be/src/core/data_type/data_type_number.h
+++ b/be/src/core/data_type/data_type_number.h
@@ -32,6 +32,10 @@ public:
     using ColumnType = typename PrimitiveTypeTraits<T>::ColumnType;
     using FieldType = typename PrimitiveTypeTraits<T>::CppType;
     bool equals(const IDataType& rhs) const override { return typeid(rhs) == typeid(*this); }
+    using SerDeType = DataTypeNumberSerDe<T>;
+    DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
+        return std::make_shared<SerDeType>(nesting_level);
+    };
 };
 template <typename DataType>
 constexpr bool IsDataTypeBool = false;

--- a/be/src/core/data_type/data_type_number_base.h
+++ b/be/src/core/data_type/data_type_number_base.h
@@ -138,7 +138,7 @@ public:
     }
     bool is_null_literal() const override { return _is_null_literal; }
     void set_null_literal(bool flag) { _is_null_literal = flag; }
-    using SerDeType = DataTypeNumberSerDe<T>;
+    using SerDeType = DataTypeNumberSerDeBase<T>;
     DataTypeSerDeSPtr get_serde(int nesting_level = 1) const override {
         return std::make_shared<SerDeType>(nesting_level);
     };

--- a/be/src/core/data_type_serde/data_type_date_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_date_serde.cpp
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "core/data_type_serde/data_type_date_or_datetime_serde.h"
+#include "core/data_type_serde/data_type_date_serde.h"
 
 #include <arrow/builder.h>
 #include <cctz/time_zone.h>
@@ -28,25 +28,27 @@
 #include "exprs/function/cast/cast_base.h"
 #include "exprs/function/cast/cast_to_date_or_datetime_impl.hpp"
 #include "util/io_helper.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::serialize_column_to_json(
+Status DataTypeDateLikeV1SerDe<T>::serialize_column_to_json(
         const IColumn& column, int64_t start_idx, int64_t end_idx, BufferWritable& bw,
-        typename DataTypeNumberSerDe<T>::FormatOptions& options) const {
+        typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const {
     SERIALIZE_COLUMN_TO_JSON();
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::serialize_one_cell_to_json(
+Status DataTypeDateLikeV1SerDe<T>::serialize_one_cell_to_json(
         const IColumn& column, int64_t row_num, BufferWritable& bw,
-        typename DataTypeNumberSerDe<T>::FormatOptions& options) const {
+        typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;
     row_num = result.second;
-    if (DataTypeNumberSerDe<T>::_nesting_level > 1) {
+    if (DataTypeNumberSerDeBase<T>::_nesting_level > 1) {
         bw.write('"');
     }
     doris::VecDateTimeValue value = assert_cast<const ColumnVector<T>&>(*ptr).get_element(row_num);
@@ -54,26 +56,26 @@ Status DataTypeDateSerDe<T>::serialize_one_cell_to_json(
     char buf[64];
     char* pos = value.to_string(buf);
     bw.write(buf, pos - buf - 1);
-    if (DataTypeNumberSerDe<T>::_nesting_level > 1) {
+    if (DataTypeNumberSerDeBase<T>::_nesting_level > 1) {
         bw.write('"');
     }
     return Status::OK();
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::deserialize_column_from_json_vector(
+Status DataTypeDateLikeV1SerDe<T>::deserialize_column_from_json_vector(
         IColumn& column, std::vector<Slice>& slices, uint64_t* num_deserialized,
-        const typename DataTypeNumberSerDe<T>::FormatOptions& options) const {
+        const typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const {
     DESERIALIZE_COLUMN_FROM_JSON_VECTOR();
     return Status::OK();
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::deserialize_one_cell_from_json(
+Status DataTypeDateLikeV1SerDe<T>::deserialize_one_cell_from_json(
         IColumn& column, Slice& slice,
-        const typename DataTypeNumberSerDe<T>::FormatOptions& options) const {
+        const typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const {
     auto& column_data = assert_cast<ColumnVector<T>&>(column);
-    if (DataTypeNumberSerDe<T>::_nesting_level > 1) {
+    if (DataTypeNumberSerDeBase<T>::_nesting_level > 1) {
         slice.trim_quote();
     }
     VecDateTimeValue val;
@@ -84,65 +86,12 @@ Status DataTypeDateSerDe<T>::deserialize_one_cell_from_json(
     return Status::OK();
 }
 
-Status DataTypeDateTimeSerDe::serialize_column_to_json(const IColumn& column, int64_t start_idx,
-                                                       int64_t end_idx, BufferWritable& bw,
-                                                       FormatOptions& options) const {
-        SERIALIZE_COLUMN_TO_JSON()}
-
-Status DataTypeDateTimeSerDe::serialize_one_cell_to_json(const IColumn& column, int64_t row_num,
-                                                         BufferWritable& bw,
-                                                         FormatOptions& options) const {
-    auto result = check_column_const_set_readability(column, row_num);
-    ColumnPtr ptr = result.first;
-    row_num = result.second;
-
-    auto value = assert_cast<const ColumnDateTime&>(*ptr).get_element(row_num);
-    if (_nesting_level > 1) {
-        bw.write('"');
-    }
-
-    char buf[64];
-    char* pos = value.to_string(buf);
-    bw.write(buf, pos - buf - 1);
-    if (_nesting_level > 1) {
-        bw.write('"');
-    }
-    return Status::OK();
-}
-
-Status DataTypeDateTimeSerDe::deserialize_column_from_json_vector(
-        IColumn& column, std::vector<Slice>& slices, uint64_t* num_deserialized,
-        const FormatOptions& options) const {
-    DESERIALIZE_COLUMN_FROM_JSON_VECTOR()
-    return Status::OK();
-}
-
-Status DataTypeDateTimeSerDe::deserialize_one_cell_from_json(IColumn& column, Slice& slice,
-                                                             const FormatOptions& options) const {
-    auto& column_data = assert_cast<ColumnDateTime&>(column);
-    if (_nesting_level > 1) {
-        slice.trim_quote();
-    }
-    VecDateTimeValue val;
-    if (StringRef str(slice.data, slice.size); !read_datetime_text_impl(val, str)) {
-        return Status::InvalidArgument("parse datetime fail, string: '{}'", str.to_string());
-    }
-    column_data.insert_value(val);
-    return Status::OK();
-}
-
-Status DataTypeDateTimeSerDe::read_column_from_arrow(IColumn& column,
-                                                     const arrow::Array* arrow_array, int64_t start,
-                                                     int64_t end,
-                                                     const cctz::time_zone& ctz) const {
-    return _read_column_from_arrow<false>(column, arrow_array, start, end, ctz);
-}
-
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::write_column_to_arrow(const IColumn& column, const NullMap* null_map,
-                                                   arrow::ArrayBuilder* array_builder,
-                                                   int64_t start, int64_t end,
-                                                   const cctz::time_zone& ctz) const {
+Status DataTypeDateLikeV1SerDe<T>::write_column_to_arrow(const IColumn& column,
+                                                         const NullMap* null_map,
+                                                         arrow::ArrayBuilder* array_builder,
+                                                         int64_t start, int64_t end,
+                                                         const cctz::time_zone& ctz) const {
     auto& col_data = static_cast<const ColumnVector<T>&>(column).get_data();
     auto& string_builder = assert_cast<arrow::StringBuilder&>(*array_builder);
     for (size_t i = start; i < end; ++i) {
@@ -182,10 +131,10 @@ static int64_t time_unit_divisor(arrow::TimeUnit::type unit) {
 
 template <PrimitiveType T>
 template <bool is_date>
-Status DataTypeDateSerDe<T>::_read_column_from_arrow(IColumn& column,
-                                                     const arrow::Array* arrow_array, int64_t start,
-                                                     int64_t end,
-                                                     const cctz::time_zone& ctz) const {
+Status DataTypeDateLikeV1SerDe<T>::_read_column_from_arrow(IColumn& column,
+                                                           const arrow::Array* arrow_array,
+                                                           int64_t start, int64_t end,
+                                                           const cctz::time_zone& ctz) const {
     auto& col_data = static_cast<ColumnVector<T>&>(column).get_data();
     int64_t divisor = 1;
     int64_t multiplier = 1;
@@ -244,17 +193,17 @@ Status DataTypeDateSerDe<T>::_read_column_from_arrow(IColumn& column,
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::read_column_from_arrow(IColumn& column,
-                                                    const arrow::Array* arrow_array, int64_t start,
-                                                    int64_t end, const cctz::time_zone& ctz) const {
+Status DataTypeDateLikeV1SerDe<T>::read_column_from_arrow(IColumn& column,
+                                                          const arrow::Array* arrow_array,
+                                                          int64_t start, int64_t end,
+                                                          const cctz::time_zone& ctz) const {
     return _read_column_from_arrow<true>(column, arrow_array, start, end, ctz);
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::write_column_to_mysql_binary(const IColumn& column,
-                                                          MysqlRowBinaryBuffer& result,
-                                                          int64_t row_idx, bool col_const,
-                                                          const FormatOptions& options) const {
+Status DataTypeDateLikeV1SerDe<T>::write_column_to_mysql_binary(
+        const IColumn& column, MysqlRowBinaryBuffer& result, int64_t row_idx, bool col_const,
+        const FormatOptions& options) const {
     const auto& data = assert_cast<const ColumnVector<T>&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
     VecDateTimeValue time_val = data[col_index];
@@ -265,11 +214,12 @@ Status DataTypeDateSerDe<T>::write_column_to_mysql_binary(const IColumn& column,
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::write_column_to_orc(const std::string& timezone, const IColumn& column,
-                                                 const NullMap* null_map,
-                                                 orc::ColumnVectorBatch* orc_col_batch,
-                                                 int64_t start, int64_t end, Arena& arena,
-                                                 const FormatOptions& options) const {
+Status DataTypeDateLikeV1SerDe<T>::write_column_to_orc(const std::string& timezone,
+                                                       const IColumn& column,
+                                                       const NullMap* null_map,
+                                                       orc::ColumnVectorBatch* orc_col_batch,
+                                                       int64_t start, int64_t end, Arena& arena,
+                                                       const FormatOptions& options) const {
     const auto& col_data = assert_cast<const ColumnVector<T>&>(column).get_data();
     auto* cur_batch = dynamic_cast<orc::StringVectorBatch*>(orc_col_batch);
 
@@ -317,14 +267,15 @@ Status DataTypeDateSerDe<T>::write_column_to_orc(const std::string& timezone, co
 // NOLINTBEGIN(readability-function-size)
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::from_string_batch(
+Status DataTypeDateLikeV1SerDe<T>::from_string_batch(
         const ColumnString& col_str, ColumnNullable& col_res,
-        const typename DataTypeNumberSerDe<T>::FormatOptions& options) const {
+        const typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnType&>(col_res.get_nested_column());
     auto& col_nullmap = assert_cast<ColumnBool&>(col_res.get_null_map_column());
     size_t row = col_str.size();
     col_res.resize(row);
 
+    constexpr auto kTarget = IsDatetime ? DatelikeTargetType::DATE_TIME : DatelikeTargetType::DATE;
     CastParameters params {.status = Status::OK(), .is_strict = false};
     for (size_t i = 0; i < row; ++i) {
         auto str = col_str.get_data_at(i);
@@ -333,10 +284,8 @@ Status DataTypeDateSerDe<T>::from_string_batch(
         // then we rely on return value to check success.
         // return value only represent OK or InvalidArgument for other error(like InternalError) in parser, MUST throw
         // Exception!
-        if (!CastToDateOrDatetime::from_string_non_strict_mode < IsDatetime
-                    ? DatelikeTargetType::DATE_TIME
-                    : DatelikeTargetType::DATE > (str, res, options.timezone, params))
-                [[unlikely]] {
+        if (!CastToDateOrDatetime::from_string_non_strict_mode<kTarget>(str, res, options.timezone,
+                                                                        params)) [[unlikely]] {
             col_nullmap.get_data()[i] = true;
             //TODO: we should set `for` functions who need it then skip to set default value for null rows.
             col_data.get_data()[i] = VecDateTimeValue::FIRST_DAY;
@@ -349,9 +298,9 @@ Status DataTypeDateSerDe<T>::from_string_batch(
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::from_string_strict_mode_batch(
+Status DataTypeDateLikeV1SerDe<T>::from_string_strict_mode_batch(
         const ColumnString& col_str, IColumn& col_res,
-        const typename DataTypeNumberSerDe<T>::FormatOptions& options,
+        const typename DataTypeNumberSerDeBase<T>::FormatOptions& options,
         const NullMap::value_type* null_map) const {
     size_t row = col_str.size();
     col_res.resize(row);
@@ -381,10 +330,11 @@ Status DataTypeDateSerDe<T>::from_string_strict_mode_batch(
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::from_string(StringRef& str, IColumn& column,
-                                         const FormatOptions& options) const {
+Status DataTypeDateLikeV1SerDe<T>::from_string(StringRef& str, IColumn& column,
+                                               const FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnType&>(column);
 
+    constexpr auto kTarget = IsDatetime ? DatelikeTargetType::DATE_TIME : DatelikeTargetType::DATE;
     CastParameters params {.status = Status::OK(), .is_strict = false};
 
     CppType res;
@@ -392,9 +342,8 @@ Status DataTypeDateSerDe<T>::from_string(StringRef& str, IColumn& column,
     // then we rely on return value to check success.
     // return value only represent OK or InvalidArgument for other error(like InternalError) in parser, MUST throw
     // Exception!
-    if (!CastToDateOrDatetime::from_string_non_strict_mode < IsDatetime
-                ? DatelikeTargetType::DATE_TIME
-                : DatelikeTargetType::DATE > (str, res, options.timezone, params)) [[unlikely]] {
+    if (!CastToDateOrDatetime::from_string_non_strict_mode<kTarget>(str, res, options.timezone,
+                                                                    params)) [[unlikely]] {
         return Status::InvalidArgument("parse date or datetime fail, string: '{}'",
                                        str.to_string());
     }
@@ -415,8 +364,9 @@ Status DataTypeDateSerDe<T>::from_string(StringRef& str, IColumn& column,
 //   DateV1:     "YYYY-MM-DD"              e.g. "2023-10-15"
 //   DateTimeV1: "YYYY-MM-DD HH:MM:SS"    e.g. "2023-10-15 14:30:00"
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::from_olap_string(const std::string& str, Field& field,
-                                              const FormatOptions& options) const {
+Status DataTypeDateLikeV1SerDe<T>::from_olap_string(const std::string& str, Field& field,
+                                                    const FormatOptions& options) const {
+    constexpr auto kTarget = IsDatetime ? DatelikeTargetType::DATE_TIME : DatelikeTargetType::DATE;
     CastParameters params {.status = Status::OK(), .is_strict = false};
 
     CppType res;
@@ -424,10 +374,8 @@ Status DataTypeDateSerDe<T>::from_olap_string(const std::string& str, Field& fie
     // then we rely on return value to check success.
     // return value only represent OK or InvalidArgument for other error(like InternalError) in parser, MUST throw
     // Exception!
-    if (!CastToDateOrDatetime::from_string_non_strict_mode < IsDatetime
-                ? DatelikeTargetType::DATE_TIME
-                : DatelikeTargetType::DATE > (StringRef(str), res, options.timezone, params))
-            [[unlikely]] {
+    if (!CastToDateOrDatetime::from_string_non_strict_mode<kTarget>(
+                StringRef(str), res, options.timezone, params)) [[unlikely]] {
         return Status::InvalidArgument("parse date or datetime fail, string: '{}'", str);
     }
     field = Field::create_field<T>(std::move(res));
@@ -435,8 +383,8 @@ Status DataTypeDateSerDe<T>::from_olap_string(const std::string& str, Field& fie
 }
 
 template <PrimitiveType T>
-Status DataTypeDateSerDe<T>::from_string_strict_mode(StringRef& str, IColumn& column,
-                                                     const FormatOptions& options) const {
+Status DataTypeDateLikeV1SerDe<T>::from_string_strict_mode(StringRef& str, IColumn& column,
+                                                           const FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnType&>(column);
 
     CastParameters params {.status = Status::OK(), .is_strict = true};
@@ -458,20 +406,19 @@ Status DataTypeDateSerDe<T>::from_string_strict_mode(StringRef& str, IColumn& co
 
 template <PrimitiveType T>
 template <typename IntDataType>
-Status DataTypeDateSerDe<T>::from_int_batch(const typename IntDataType::ColumnType& int_col,
-                                            ColumnNullable& target_col) const {
+Status DataTypeDateLikeV1SerDe<T>::from_int_batch(const typename IntDataType::ColumnType& int_col,
+                                                  ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col.get_nested_column());
     auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
     col_data.resize(int_col.size());
     col_nullmap.resize(int_col.size());
 
+    constexpr auto kTarget = IsDatetime ? DatelikeTargetType::DATE_TIME : DatelikeTargetType::DATE;
     CastParameters params {.status = Status::OK(), .is_strict = false};
     for (size_t i = 0; i < int_col.size(); ++i) {
         CppType val;
-        if (CastToDateOrDatetime::from_integer < DatelikeParseMode::NON_STRICT,
-            IsDatetime ? DatelikeTargetType::DATE_TIME
-                       : DatelikeTargetType::DATE > (int_col.get_element(i), val, params))
-                [[likely]] {
+        if (CastToDateOrDatetime::from_integer<DatelikeParseMode::NON_STRICT, kTarget>(
+                    int_col.get_element(i), val, params)) [[likely]] {
             // did cast_to_type in `from_integer`
             col_data.get_data()[i] = val;
             col_nullmap.get_data()[i] = false;
@@ -485,7 +432,7 @@ Status DataTypeDateSerDe<T>::from_int_batch(const typename IntDataType::ColumnTy
 
 template <PrimitiveType T>
 template <typename IntDataType>
-Status DataTypeDateSerDe<T>::from_int_strict_mode_batch(
+Status DataTypeDateLikeV1SerDe<T>::from_int_strict_mode_batch(
         const typename IntDataType::ColumnType& int_col, IColumn& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col);
     col_data.resize(int_col.size());
@@ -510,20 +457,19 @@ Status DataTypeDateSerDe<T>::from_int_strict_mode_batch(
 
 template <PrimitiveType T>
 template <typename FloatDataType>
-Status DataTypeDateSerDe<T>::from_float_batch(const typename FloatDataType::ColumnType& float_col,
-                                              ColumnNullable& target_col) const {
+Status DataTypeDateLikeV1SerDe<T>::from_float_batch(
+        const typename FloatDataType::ColumnType& float_col, ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col.get_nested_column());
     auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
     col_data.resize(float_col.size());
     col_nullmap.resize(float_col.size());
 
+    constexpr auto kTarget = IsDatetime ? DatelikeTargetType::DATE_TIME : DatelikeTargetType::DATE;
     CastParameters params {.status = Status::OK(), .is_strict = false};
     for (size_t i = 0; i < float_col.size(); ++i) {
         CppType val;
-        if (CastToDateOrDatetime::from_float < DatelikeParseMode::NON_STRICT,
-            IsDatetime ? DatelikeTargetType::DATE_TIME
-                       : DatelikeTargetType::DATE > (float_col.get_data()[i], val, 0, params))
-                [[likely]] {
+        if (CastToDateOrDatetime::from_float<DatelikeParseMode::NON_STRICT, kTarget>(
+                    float_col.get_data()[i], val, 0, params)) [[likely]] {
             col_data.get_data()[i] = val;
             col_nullmap.get_data()[i] = false;
         } else {
@@ -536,7 +482,7 @@ Status DataTypeDateSerDe<T>::from_float_batch(const typename FloatDataType::Colu
 
 template <PrimitiveType T>
 template <typename FloatDataType>
-Status DataTypeDateSerDe<T>::from_float_strict_mode_batch(
+Status DataTypeDateLikeV1SerDe<T>::from_float_strict_mode_batch(
         const typename FloatDataType::ColumnType& float_col, IColumn& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col);
     col_data.resize(float_col.size());
@@ -561,22 +507,20 @@ Status DataTypeDateSerDe<T>::from_float_strict_mode_batch(
 
 template <PrimitiveType T>
 template <typename DecimalDataType>
-Status DataTypeDateSerDe<T>::from_decimal_batch(
+Status DataTypeDateLikeV1SerDe<T>::from_decimal_batch(
         const typename DecimalDataType::ColumnType& decimal_col, ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col.get_nested_column());
     auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
     col_data.resize(decimal_col.size());
     col_nullmap.resize(decimal_col.size());
 
+    constexpr auto kTarget = IsDatetime ? DatelikeTargetType::DATE_TIME : DatelikeTargetType::DATE;
     CastParameters params {.status = Status::OK(), .is_strict = false};
     for (size_t i = 0; i < decimal_col.size(); ++i) {
         CppType val;
-        if (CastToDateOrDatetime::from_decimal < DatelikeParseMode::NON_STRICT,
-            IsDatetime ? DatelikeTargetType::DATE_TIME
-                       : DatelikeTargetType::DATE > (decimal_col.get_intergral_part(i),
-                                                     decimal_col.get_fractional_part(i),
-                                                     decimal_col.get_scale(), val, params))
-                [[likely]] {
+        if (CastToDateOrDatetime::from_decimal<DatelikeParseMode::NON_STRICT, kTarget>(
+                    decimal_col.get_intergral_part(i), decimal_col.get_fractional_part(i),
+                    decimal_col.get_scale(), val, params)) [[likely]] {
             col_data.get_data()[i] = val;
             col_nullmap.get_data()[i] = false;
         } else {
@@ -589,7 +533,7 @@ Status DataTypeDateSerDe<T>::from_decimal_batch(
 
 template <PrimitiveType T>
 template <typename DecimalDataType>
-Status DataTypeDateSerDe<T>::from_decimal_strict_mode_batch(
+Status DataTypeDateLikeV1SerDe<T>::from_decimal_strict_mode_batch(
         const typename DecimalDataType::ColumnType& decimal_col, IColumn& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col);
     col_data.resize(decimal_col.size());
@@ -623,7 +567,7 @@ Status DataTypeDateSerDe<T>::from_decimal_strict_mode_batch(
 //
 // Note: DateTimeV1 never includes microseconds (VecDateTimeValue::microsecond() always returns 0).
 template <PrimitiveType T>
-std::string DataTypeDateSerDe<T>::to_olap_string(const Field& field) const {
+std::string DataTypeDateLikeV1SerDe<T>::to_olap_string(const Field& field) const {
     char buf[64];
     char* pos = field.get<T>().to_string(buf);
     return std::string(buf, pos - buf - 1);
@@ -631,107 +575,166 @@ std::string DataTypeDateSerDe<T>::to_olap_string(const Field& field) const {
 // NOLINTEND(readability-function-cognitive-complexity)
 // NOLINTEND(readability-function-size)
 
-// instantiation of template functions
-template class DataTypeDateSerDe<TYPE_DATE>;
-template class DataTypeDateSerDe<TYPE_DATETIME>;
+template <PrimitiveType T>
+Status DataTypeDateLikeV1SerDe<T>::write_column_to_pb(const IColumn& column, PValues& result,
+                                                      int64_t start, int64_t end) const {
+    auto row_count = cast_set<int>(end - start);
+    auto* ptype = result.mutable_type();
+    const auto* col = check_and_get_column<ColumnType>(column);
+    auto& data = col->get_data();
+    ptype->set_id(PGenericType::INT64);
+    auto* values = result.mutable_int64_value();
+    values->Reserve(row_count);
+    for (int64_t i = start; i < end; ++i) {
+        values->Add(binary_cast<CppType, Int64>(data[i]));
+    }
+    return Status::OK();
+}
 
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_batch<DataTypeInt8>(
+template <PrimitiveType T>
+Status DataTypeDateLikeV1SerDe<T>::read_column_from_pb(IColumn& column, const PValues& arg) const {
+    auto old_column_size = column.size();
+    column.resize(old_column_size + arg.int64_value_size());
+    auto& data = reinterpret_cast<ColumnType&>(column).get_data();
+    for (int i = 0; i < arg.int64_value_size(); ++i) {
+        data[old_column_size + i] = binary_cast<Int64, VecDateTimeValue>(arg.int64_value(i));
+    }
+    return Status::OK();
+}
+
+template <PrimitiveType T>
+void DataTypeDateLikeV1SerDe<T>::write_one_cell_to_jsonb(const IColumn& column,
+                                                         JsonbWriterT<JsonbOutStream>& result,
+                                                         Arena& mem_pool, int32_t col_id,
+                                                         int64_t row_num,
+                                                         const FormatOptions& options) const {
+    result.writeKey(cast_set<JsonbKeyValue::keyid_type>(col_id));
+    StringRef data_ref = column.get_data_at(row_num);
+    int64_t val = *reinterpret_cast<const int64_t*>(data_ref.data);
+    result.writeInt64(val);
+}
+
+template <PrimitiveType T>
+void DataTypeDateLikeV1SerDe<T>::read_one_cell_from_jsonb(IColumn& column,
+                                                          const JsonbValue* arg) const {
+    auto& col = reinterpret_cast<ColumnType&>(column);
+    col.insert_value(binary_cast<Int64, VecDateTimeValue>(arg->unpack<JsonbInt64Val>()->val()));
+}
+
+// instantiation of template functions
+template class DataTypeDateLikeV1SerDe<TYPE_DATE>;
+template class DataTypeDateLikeV1SerDe<TYPE_DATETIME>;
+
+// Explicit instantiation for _read_column_from_arrow<false> used by DataTypeDateTimeSerDe
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::_read_column_from_arrow<false>(
+        IColumn& column, const arrow::Array* arrow_array, int64_t start, int64_t end,
+        const cctz::time_zone& ctz) const;
+
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_batch<DataTypeInt8>(
         const DataTypeInt8::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_batch<DataTypeInt16>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_batch<DataTypeInt16>(
         const DataTypeInt16::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_batch<DataTypeInt32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_batch<DataTypeInt32>(
         const DataTypeInt32::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_batch<DataTypeInt64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_batch<DataTypeInt64>(
         const DataTypeInt64::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_batch<DataTypeInt128>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_batch<DataTypeInt128>(
         const DataTypeInt128::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt8>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt8>(
         const DataTypeInt8::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt16>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt16>(
         const DataTypeInt16::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt32>(
         const DataTypeInt32::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt64>(
         const DataTypeInt64::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt128>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_int_strict_mode_batch<DataTypeInt128>(
         const DataTypeInt128::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_float_batch<DataTypeFloat32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_float_batch<DataTypeFloat32>(
         const DataTypeFloat32::ColumnType& float_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_float_batch<DataTypeFloat64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_float_batch<DataTypeFloat64>(
         const DataTypeFloat64::ColumnType& float_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_float_strict_mode_batch<DataTypeFloat32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_float_strict_mode_batch<DataTypeFloat32>(
         const DataTypeFloat32::ColumnType& float_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_float_strict_mode_batch<DataTypeFloat64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_float_strict_mode_batch<DataTypeFloat64>(
         const DataTypeFloat64::ColumnType& float_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal32>(
         const DataTypeDecimal32::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal64>(
         const DataTypeDecimal64::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimalV2>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimalV2>(
         const DataTypeDecimalV2::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal128>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal128>(
         const DataTypeDecimal128::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal256>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_batch<DataTypeDecimal256>(
         const DataTypeDecimal256::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal32>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal32>(
         const DataTypeDecimal32::ColumnType& decimal_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal64>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal64>(
         const DataTypeDecimal64::ColumnType& decimal_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimalV2>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimalV2>(
         const DataTypeDecimalV2::ColumnType& decimal_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal128>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal128>(
         const DataTypeDecimal128::ColumnType& decimal_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal256>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATE>::from_decimal_strict_mode_batch<DataTypeDecimal256>(
         const DataTypeDecimal256::ColumnType& decimal_col, IColumn& target_col) const;
 
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt8>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt8>(
         const DataTypeInt8::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt16>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt16>(
         const DataTypeInt16::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt32>(
         const DataTypeInt32::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt64>(
         const DataTypeInt64::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt128>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_batch<DataTypeInt128>(
         const DataTypeInt128::ColumnType& int_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt8>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt8>(
         const DataTypeInt8::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt16>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt16>(
         const DataTypeInt16::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt32>(
         const DataTypeInt32::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt64>(
         const DataTypeInt64::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt128>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_int_strict_mode_batch<DataTypeInt128>(
         const DataTypeInt128::ColumnType& int_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_float_batch<DataTypeFloat32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_float_batch<DataTypeFloat32>(
         const DataTypeFloat32::ColumnType& float_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_float_batch<DataTypeFloat64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_float_batch<DataTypeFloat64>(
         const DataTypeFloat64::ColumnType& float_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_float_strict_mode_batch<DataTypeFloat32>(
-        const DataTypeFloat32::ColumnType& float_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_float_strict_mode_batch<DataTypeFloat64>(
-        const DataTypeFloat64::ColumnType& float_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal32>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_float_strict_mode_batch<
+        DataTypeFloat32>(const DataTypeFloat32::ColumnType& float_col, IColumn& target_col) const;
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_float_strict_mode_batch<
+        DataTypeFloat64>(const DataTypeFloat64::ColumnType& float_col, IColumn& target_col) const;
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal32>(
         const DataTypeDecimal32::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal64>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal64>(
         const DataTypeDecimal64::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimalV2>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimalV2>(
         const DataTypeDecimalV2::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal128>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal128>(
         const DataTypeDecimal128::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal256>(
+template Status DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_batch<DataTypeDecimal256>(
         const DataTypeDecimal256::ColumnType& decimal_col, ColumnNullable& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal32>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal32>(
         const DataTypeDecimal32::ColumnType& decimal_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal64>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal64>(
         const DataTypeDecimal64::ColumnType& decimal_col, IColumn& target_col) const;
-template Status DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimalV2>(
+template Status
+DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimalV2>(
         const DataTypeDecimalV2::ColumnType& decimal_col, IColumn& target_col) const;
 template Status
-DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal128>(
+DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal128>(
         const DataTypeDecimal128::ColumnType& decimal_col, IColumn& target_col) const;
 template Status
-DataTypeDateSerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal256>(
+DataTypeDateLikeV1SerDe<TYPE_DATETIME>::from_decimal_strict_mode_batch<DataTypeDecimal256>(
         const DataTypeDecimal256::ColumnType& decimal_col, IColumn& target_col) const;
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_date_serde.h
+++ b/be/src/core/data_type_serde/data_type_date_serde.h
@@ -35,18 +35,20 @@
 namespace doris {
 class Arena;
 
+/// Shared template implementation for Date v1 and DateTime v1 SerDe.
+/// Both DataTypeDateSerDe and DataTypeDateTimeSerDe inherit from this to share code.
 template <PrimitiveType T = PrimitiveType::TYPE_DATE>
-class DataTypeDateSerDe : public DataTypeNumberSerDe<T> {
+class DataTypeDateLikeV1SerDe : public DataTypeNumberSerDeBase<T> {
 public:
     constexpr static bool IsDatetime = (T == PrimitiveType::TYPE_DATETIME);
     static_assert(IsDatetime || T == PrimitiveType::TYPE_DATE,
-                  "DataTypeDateSerDe can only be used for TYPE_DATE or TYPE_DATETIME");
+                  "DataTypeDateLikeV1SerDe can only be used for TYPE_DATE or TYPE_DATETIME");
     using ColumnType = typename PrimitiveTypeTraits<T>::ColumnType;
     using CppType = typename PrimitiveTypeTraits<T>::CppType; // VecDateTimeValue
     constexpr static std::string_view name() { return IsDatetime ? "DateTime" : "Date"; }
 
-    using typename DataTypeNumberSerDe<T>::FormatOptions;
-    DataTypeDateSerDe(int nesting_level = 1) : DataTypeNumberSerDe<T>(nesting_level) {};
+    using typename DataTypeNumberSerDeBase<T>::FormatOptions;
+    DataTypeDateLikeV1SerDe(int nesting_level = 1) : DataTypeNumberSerDeBase<T>(nesting_level) {};
 
     Status from_string(StringRef& str, IColumn& column,
                        const FormatOptions& options) const override;
@@ -54,14 +56,13 @@ public:
     Status from_string_strict_mode(StringRef& str, IColumn& column,
                                    const FormatOptions& options) const override;
 
-    /// these functions are for both TYPE_DATE and TYPE_DATETIME. we set field according to T.
     Status from_string_batch(
             const ColumnString& str, ColumnNullable& column,
-            const typename DataTypeNumberSerDe<T>::FormatOptions& options) const final;
+            const typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const final;
 
     Status from_string_strict_mode_batch(
             const ColumnString& str, IColumn& column,
-            const typename DataTypeNumberSerDe<T>::FormatOptions& options,
+            const typename DataTypeNumberSerDeBase<T>::FormatOptions& options,
             const NullMap::value_type* null_map = nullptr) const final;
 
     template <typename IntDataType>
@@ -87,17 +88,17 @@ public:
 
     Status serialize_one_cell_to_json(
             const IColumn& column, int64_t row_num, BufferWritable& bw,
-            typename DataTypeNumberSerDe<T>::FormatOptions& options) const override;
+            typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const override;
     Status serialize_column_to_json(
             const IColumn& column, int64_t start_idx, int64_t end_idx, BufferWritable& bw,
-            typename DataTypeNumberSerDe<T>::FormatOptions& options) const override;
+            typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const override;
     Status deserialize_one_cell_from_json(
             IColumn& column, Slice& slice,
-            const typename DataTypeNumberSerDe<T>::FormatOptions& options) const override;
+            const typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const override;
 
     Status deserialize_column_from_json_vector(
             IColumn& column, std::vector<Slice>& slices, uint64_t* num_deserialized,
-            const typename DataTypeNumberSerDe<T>::FormatOptions& options) const override;
+            const typename DataTypeNumberSerDeBase<T>::FormatOptions& options) const override;
 
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
@@ -115,6 +116,15 @@ public:
 
     std::string to_olap_string(const Field& field) const override;
 
+    Status write_column_to_pb(const IColumn& column, PValues& result, int64_t start,
+                              int64_t end) const override;
+    Status read_column_from_pb(IColumn& column, const PValues& arg) const override;
+
+    void write_one_cell_to_jsonb(const IColumn& column, JsonbWriterT<JsonbOutStream>& result,
+                                 Arena& mem_pool, int32_t col_id, int64_t row_num,
+                                 const FormatOptions& options) const override;
+    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override;
+
 protected:
     Status from_olap_string(const std::string& str, Field& field,
                             const FormatOptions& options) const override;
@@ -124,25 +134,11 @@ protected:
                                    int64_t end, const cctz::time_zone& ctz) const;
 };
 
-class DataTypeDateTimeSerDe : public DataTypeDateSerDe<PrimitiveType::TYPE_DATETIME> {
+/// Concrete SerDe for TYPE_DATE (Date v1). Corresponds to DataTypeDate on the DataType side.
+class DataTypeDateSerDe final : public DataTypeDateLikeV1SerDe<PrimitiveType::TYPE_DATE> {
 public:
-    DataTypeDateTimeSerDe(int nesting_level = 1)
-            : DataTypeDateSerDe<PrimitiveType::TYPE_DATETIME>(nesting_level) {};
-
-    // all from_{XXX} use DateTypeDateSerDe's with template check of PrimitiveType T
-
-    Status serialize_column_to_json(const IColumn& column, int64_t start_idx, int64_t end_idx,
-                                    BufferWritable& bw, FormatOptions& options) const override;
-
-    Status serialize_one_cell_to_json(const IColumn& column, int64_t row_num, BufferWritable& bw,
-                                      FormatOptions& options) const override;
-
-    Status deserialize_one_cell_from_json(IColumn& column, Slice& slice,
-                                          const FormatOptions& options) const override;
-    Status deserialize_column_from_json_vector(IColumn& column, std::vector<Slice>& slices,
-                                               uint64_t* num_deserialized,
-                                               const FormatOptions& options) const override;
-    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
-                                  int64_t end, const cctz::time_zone& ctz) const override;
+    DataTypeDateSerDe(int nesting_level = 1)
+            : DataTypeDateLikeV1SerDe<PrimitiveType::TYPE_DATE>(nesting_level) {};
 };
+
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_datetime_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datetime_serde.cpp
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "core/data_type_serde/data_type_datetime_serde.h"
+
+#include "common/status.h"
+#include "core/column/column_const.h"
+#include "core/value/vdatetime_value.h"
+#include "util/io_helper.h"
+
+namespace doris {
+#include "common/compile_check_begin.h"
+
+Status DataTypeDateTimeSerDe::serialize_column_to_json(const IColumn& column, int64_t start_idx,
+                                                       int64_t end_idx, BufferWritable& bw,
+                                                       FormatOptions& options) const {
+    SERIALIZE_COLUMN_TO_JSON();
+}
+
+Status DataTypeDateTimeSerDe::serialize_one_cell_to_json(const IColumn& column, int64_t row_num,
+                                                         BufferWritable& bw,
+                                                         FormatOptions& options) const {
+    auto result = check_column_const_set_readability(column, row_num);
+    ColumnPtr ptr = result.first;
+    row_num = result.second;
+
+    auto value = assert_cast<const ColumnDateTime&>(*ptr).get_element(row_num);
+    if (_nesting_level > 1) {
+        bw.write('"');
+    }
+
+    char buf[64];
+    char* pos = value.to_string(buf);
+    bw.write(buf, pos - buf - 1);
+    if (_nesting_level > 1) {
+        bw.write('"');
+    }
+    return Status::OK();
+}
+
+Status DataTypeDateTimeSerDe::deserialize_column_from_json_vector(
+        IColumn& column, std::vector<Slice>& slices, uint64_t* num_deserialized,
+        const FormatOptions& options) const {
+    DESERIALIZE_COLUMN_FROM_JSON_VECTOR()
+    return Status::OK();
+}
+
+Status DataTypeDateTimeSerDe::deserialize_one_cell_from_json(IColumn& column, Slice& slice,
+                                                             const FormatOptions& options) const {
+    auto& column_data = assert_cast<ColumnDateTime&>(column);
+    if (_nesting_level > 1) {
+        slice.trim_quote();
+    }
+    VecDateTimeValue val;
+    if (StringRef str(slice.data, slice.size); !read_datetime_text_impl(val, str)) {
+        return Status::InvalidArgument("parse datetime fail, string: '{}'", str.to_string());
+    }
+    column_data.insert_value(val);
+    return Status::OK();
+}
+
+Status DataTypeDateTimeSerDe::read_column_from_arrow(IColumn& column,
+                                                     const arrow::Array* arrow_array, int64_t start,
+                                                     int64_t end,
+                                                     const cctz::time_zone& ctz) const {
+    return _read_column_from_arrow<false>(column, arrow_array, start, end, ctz);
+}
+
+} // namespace doris

--- a/be/src/core/data_type_serde/data_type_datetime_serde.h
+++ b/be/src/core/data_type_serde/data_type_datetime_serde.h
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "core/data_type_serde/data_type_date_serde.h"
+
+namespace doris {
+
+/// Concrete SerDe for TYPE_DATETIME (DateTime v1). Corresponds to DataTypeDateTime on the DataType side.
+/// Inherits from shared DataTypeDateLikeV1SerDe<TYPE_DATETIME> (sibling to DataTypeDateSerDe).
+class DataTypeDateTimeSerDe final : public DataTypeDateLikeV1SerDe<PrimitiveType::TYPE_DATETIME> {
+public:
+    DataTypeDateTimeSerDe(int nesting_level = 1)
+            : DataTypeDateLikeV1SerDe<PrimitiveType::TYPE_DATETIME>(nesting_level) {};
+
+    // all from_{XXX} use DataTypeDateLikeV1SerDe's with template check of PrimitiveType T
+
+    Status serialize_column_to_json(const IColumn& column, int64_t start_idx, int64_t end_idx,
+                                    BufferWritable& bw, FormatOptions& options) const override;
+
+    Status serialize_one_cell_to_json(const IColumn& column, int64_t row_num, BufferWritable& bw,
+                                      FormatOptions& options) const override;
+
+    Status deserialize_one_cell_from_json(IColumn& column, Slice& slice,
+                                          const FormatOptions& options) const override;
+    Status deserialize_column_from_json_vector(IColumn& column, std::vector<Slice>& slices,
+                                               uint64_t* num_deserialized,
+                                               const FormatOptions& options) const override;
+    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
+                                  int64_t end, const cctz::time_zone& ctz) const override;
+};
+
+} // namespace doris

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
@@ -33,6 +33,8 @@
 #include "exprs/function/cast/cast_to_datetimev2_impl.hpp"
 #include "exprs/function/cast/cast_to_string.h"
 #include "util/io_helper.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
 
 enum {
     DIVISOR_FOR_SECOND = 1,
@@ -597,4 +599,47 @@ template Status DataTypeDateTimeV2SerDe::from_decimal_strict_mode_batch<DataType
         const DataTypeDecimal128::ColumnType& decimal_col, IColumn& target_col) const;
 template Status DataTypeDateTimeV2SerDe::from_decimal_strict_mode_batch<DataTypeDecimal256>(
         const DataTypeDecimal256::ColumnType& decimal_col, IColumn& target_col) const;
+
+Status DataTypeDateTimeV2SerDe::write_column_to_pb(const IColumn& column, PValues& result,
+                                                   int64_t start, int64_t end) const {
+    auto row_count = cast_set<int>(end - start);
+    auto* ptype = result.mutable_type();
+    const auto* col = check_and_get_column<ColumnType>(column);
+    auto& data = col->get_data();
+    ptype->set_id(PGenericType::UINT64);
+    auto* values = result.mutable_uint64_value();
+    values->Reserve(row_count);
+    values->Add((uint64_t*)data.begin() + start, (uint64_t*)data.begin() + end);
+    return Status::OK();
+}
+
+Status DataTypeDateTimeV2SerDe::read_column_from_pb(IColumn& column, const PValues& arg) const {
+    auto old_column_size = column.size();
+    column.resize(old_column_size + arg.uint64_value_size());
+    auto& data = reinterpret_cast<ColumnType&>(column).get_data();
+    for (int i = 0; i < arg.uint64_value_size(); ++i) {
+        data[old_column_size + i] =
+                binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(arg.uint64_value(i));
+    }
+    return Status::OK();
+}
+
+void DataTypeDateTimeV2SerDe::write_one_cell_to_jsonb(const IColumn& column,
+                                                      JsonbWriterT<JsonbOutStream>& result,
+                                                      Arena& mem_pool, int32_t col_id,
+                                                      int64_t row_num,
+                                                      const FormatOptions& options) const {
+    result.writeKey(cast_set<JsonbKeyValue::keyid_type>(col_id));
+    StringRef data_ref = column.get_data_at(row_num);
+    int64_t val = *reinterpret_cast<const int64_t*>(data_ref.data);
+    result.writeInt64(val);
+}
+
+void DataTypeDateTimeV2SerDe::read_one_cell_from_jsonb(IColumn& column,
+                                                       const JsonbValue* arg) const {
+    auto& col = reinterpret_cast<ColumnType&>(column);
+    col.insert_value(binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(
+            (UInt64)arg->unpack<JsonbInt64Val>()->val()));
+}
+
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.h
@@ -33,10 +33,11 @@
 namespace doris {
 class Arena;
 
-class DataTypeDateTimeV2SerDe : public DataTypeNumberSerDe<PrimitiveType::TYPE_DATETIMEV2> {
+class DataTypeDateTimeV2SerDe : public DataTypeNumberSerDeBase<PrimitiveType::TYPE_DATETIMEV2> {
 public:
     DataTypeDateTimeV2SerDe(int scale, int nesting_level = 1)
-            : DataTypeNumberSerDe<PrimitiveType::TYPE_DATETIMEV2>(nesting_level), _scale(scale) {};
+            : DataTypeNumberSerDeBase<PrimitiveType::TYPE_DATETIMEV2>(nesting_level),
+              _scale(scale) {};
 
     Status from_string_batch(const ColumnString& str, ColumnNullable& column,
                              const FormatOptions& options) const final;
@@ -108,6 +109,15 @@ public:
     int get_scale() const override { return _scale; }
 
     std::string to_olap_string(const Field& field) const override;
+
+    Status write_column_to_pb(const IColumn& column, PValues& result, int64_t start,
+                              int64_t end) const override;
+    Status read_column_from_pb(IColumn& column, const PValues& arg) const override;
+
+    void write_one_cell_to_jsonb(const IColumn& column, JsonbWriterT<JsonbOutStream>& result,
+                                 Arena& mem_pool, int32_t col_id, int64_t row_num,
+                                 const FormatOptions& options) const override;
+    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override;
 
 protected:
     Status from_olap_string(const std::string& str, Field& field,

--- a/be/src/core/data_type_serde/data_type_datev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.cpp
@@ -32,6 +32,8 @@
 #include "exprs/function/cast/cast_to_datev2_impl.hpp"
 #include "exprs/function/cast/cast_to_string.h"
 #include "util/io_helper.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 
@@ -514,5 +516,44 @@ template Status DataTypeDateV2SerDe::from_decimal_strict_mode_batch<DataTypeDeci
         const DataTypeDecimal128::ColumnType& decimal_col, IColumn& target_col) const;
 template Status DataTypeDateV2SerDe::from_decimal_strict_mode_batch<DataTypeDecimal256>(
         const DataTypeDecimal256::ColumnType& decimal_col, IColumn& target_col) const;
+
+Status DataTypeDateV2SerDe::write_column_to_pb(const IColumn& column, PValues& result,
+                                               int64_t start, int64_t end) const {
+    auto row_count = cast_set<int>(end - start);
+    auto* ptype = result.mutable_type();
+    const auto* col = check_and_get_column<ColumnType>(column);
+    auto& data = col->get_data();
+    ptype->set_id(PGenericType::UINT32);
+    auto* values = result.mutable_uint32_value();
+    values->Reserve(row_count);
+    values->Add((uint32_t*)data.begin() + start, (uint32_t*)data.begin() + end);
+    return Status::OK();
+}
+
+Status DataTypeDateV2SerDe::read_column_from_pb(IColumn& column, const PValues& arg) const {
+    auto old_column_size = column.size();
+    column.resize(old_column_size + arg.uint32_value_size());
+    auto& data = assert_cast<ColumnType&>(column).get_data();
+    for (int i = 0; i < arg.uint32_value_size(); ++i) {
+        data[old_column_size + i] = arg.uint32_value(i);
+    }
+    return Status::OK();
+}
+
+void DataTypeDateV2SerDe::write_one_cell_to_jsonb(const IColumn& column,
+                                                  JsonbWriterT<JsonbOutStream>& result,
+                                                  Arena& mem_pool, int32_t col_id, int64_t row_num,
+                                                  const FormatOptions& options) const {
+    result.writeKey(cast_set<JsonbKeyValue::keyid_type>(col_id));
+    StringRef data_ref = column.get_data_at(row_num);
+    int32_t val = *reinterpret_cast<const int32_t*>(data_ref.data);
+    result.writeInt32(val);
+}
+
+void DataTypeDateV2SerDe::read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const {
+    auto& col = reinterpret_cast<ColumnType&>(column);
+    col.insert_value(binary_cast<UInt32, DateV2Value<DateV2ValueType>>(
+            (UInt32)arg->unpack<JsonbInt32Val>()->val()));
+}
 
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_datev2_serde.h
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.h
@@ -32,10 +32,10 @@
 namespace doris {
 class Arena;
 
-class DataTypeDateV2SerDe : public DataTypeNumberSerDe<PrimitiveType::TYPE_DATEV2> {
+class DataTypeDateV2SerDe : public DataTypeNumberSerDeBase<PrimitiveType::TYPE_DATEV2> {
 public:
     DataTypeDateV2SerDe(int nesting_level = 1)
-            : DataTypeNumberSerDe<PrimitiveType::TYPE_DATEV2>(nesting_level) {};
+            : DataTypeNumberSerDeBase<PrimitiveType::TYPE_DATEV2>(nesting_level) {};
 
     Status from_string_batch(const ColumnString& str, ColumnNullable& column,
                              const FormatOptions& options) const final;
@@ -105,6 +105,15 @@ public:
                                   int64_t row_num) const override;
 
     std::string to_olap_string(const Field& field) const override;
+
+    Status write_column_to_pb(const IColumn& column, PValues& result, int64_t start,
+                              int64_t end) const override;
+    Status read_column_from_pb(IColumn& column, const PValues& arg) const override;
+
+    void write_one_cell_to_jsonb(const IColumn& column, JsonbWriterT<JsonbOutStream>& result,
+                                 Arena& mem_pool, int32_t col_id, int64_t row_num,
+                                 const FormatOptions& options) const override;
+    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override;
 
 protected:
     Status from_olap_string(const std::string& str, Field& field,

--- a/be/src/core/data_type_serde/data_type_ipv4_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_ipv4_serde.cpp
@@ -24,6 +24,8 @@
 #include "exprs/function/cast/cast_to_ip.h"
 #include "exprs/function/cast/cast_to_string.h"
 #include "util/io_helper.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
@@ -233,6 +235,21 @@ void DataTypeIPv4SerDe::write_one_cell_to_binary(const IColumn& src_column,
 // Output format: "A.B.C.D", e.g. "192.168.1.1"
 std::string DataTypeIPv4SerDe::to_olap_string(const Field& field) const {
     return CastToString::from_ip(field.get<TYPE_IPV4>());
+}
+
+void DataTypeIPv4SerDe::write_one_cell_to_jsonb(const IColumn& column,
+                                                JsonbWriterT<JsonbOutStream>& result,
+                                                Arena& mem_pool, int32_t col_id, int64_t row_num,
+                                                const FormatOptions& options) const {
+    result.writeKey(cast_set<JsonbKeyValue::keyid_type>(col_id));
+    StringRef data_ref = column.get_data_at(row_num);
+    int32_t val = *reinterpret_cast<const int32_t*>(data_ref.data);
+    result.writeInt32(val);
+}
+
+void DataTypeIPv4SerDe::read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const {
+    auto& col = reinterpret_cast<ColumnType&>(column);
+    col.insert_value(arg->unpack<JsonbInt32Val>()->val());
 }
 
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_ipv4_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv4_serde.h
@@ -35,10 +35,10 @@
 
 namespace doris {
 
-class DataTypeIPv4SerDe : public DataTypeNumberSerDe<PrimitiveType::TYPE_IPV4> {
+class DataTypeIPv4SerDe : public DataTypeNumberSerDeBase<PrimitiveType::TYPE_IPV4> {
 public:
     DataTypeIPv4SerDe(int nesting_level = 1)
-            : DataTypeNumberSerDe<PrimitiveType::TYPE_IPV4>(nesting_level) {};
+            : DataTypeNumberSerDeBase<PrimitiveType::TYPE_IPV4>(nesting_level) {};
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,
@@ -71,6 +71,11 @@ public:
 
     void write_one_cell_to_binary(const IColumn& src_column, ColumnString::Chars& chars,
                                   int64_t row_num) const override;
+
+    void write_one_cell_to_jsonb(const IColumn& column, JsonbWriterT<JsonbOutStream>& result,
+                                 Arena& mem_pool, int32_t col_id, int64_t row_num,
+                                 const FormatOptions& options) const override;
+    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override;
 
     std::string to_olap_string(const Field& field) const override;
 

--- a/be/src/core/data_type_serde/data_type_ipv6_serde.h
+++ b/be/src/core/data_type_serde/data_type_ipv6_serde.h
@@ -37,10 +37,10 @@ namespace doris {
 
 class Arena;
 
-class DataTypeIPv6SerDe : public DataTypeNumberSerDe<PrimitiveType::TYPE_IPV6> {
+class DataTypeIPv6SerDe : public DataTypeNumberSerDeBase<PrimitiveType::TYPE_IPV6> {
 public:
     DataTypeIPv6SerDe(int nesting_level = 1)
-            : DataTypeNumberSerDe<PrimitiveType::TYPE_IPV6>(nesting_level) {};
+            : DataTypeNumberSerDeBase<PrimitiveType::TYPE_IPV6>(nesting_level) {};
 
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -83,10 +83,11 @@ using DORIS_NUMERIC_ARROW_BUILDER =
                 >;
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::write_column_to_arrow(const IColumn& column, const NullMap* null_map,
-                                                     arrow::ArrayBuilder* array_builder,
-                                                     int64_t start, int64_t end,
-                                                     const cctz::time_zone& ctz) const {
+Status DataTypeNumberSerDeBase<T>::write_column_to_arrow(const IColumn& column,
+                                                         const NullMap* null_map,
+                                                         arrow::ArrayBuilder* array_builder,
+                                                         int64_t start, int64_t end,
+                                                         const cctz::time_zone& ctz) const {
     auto& col_data = assert_cast<const ColumnType&>(column).get_data();
     using ARROW_BUILDER_TYPE = typename TypeMapLookup<
             std::conditional_t<
@@ -159,8 +160,8 @@ Status DataTypeNumberSerDe<T>::write_column_to_arrow(const IColumn& column, cons
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::deserialize_one_cell_from_json(IColumn& column, Slice& slice,
-                                                              const FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::deserialize_one_cell_from_json(
+        IColumn& column, Slice& slice, const FormatOptions& options) const {
     auto& column_data = reinterpret_cast<ColumnType&>(column);
     StringRef str_ref {slice.data, slice.size};
     if constexpr (T == TYPE_IPV6) {
@@ -192,16 +193,17 @@ Status DataTypeNumberSerDe<T>::deserialize_one_cell_from_json(IColumn& column, S
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::serialize_column_to_json(const IColumn& column, int64_t start_idx,
-                                                        int64_t end_idx, BufferWritable& bw,
-                                                        FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::serialize_column_to_json(const IColumn& column,
+                                                            int64_t start_idx, int64_t end_idx,
+                                                            BufferWritable& bw,
+                                                            FormatOptions& options) const {
     SERIALIZE_COLUMN_TO_JSON();
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::serialize_one_cell_to_json(const IColumn& column, int64_t row_num,
-                                                          BufferWritable& bw,
-                                                          FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::serialize_one_cell_to_json(const IColumn& column,
+                                                              int64_t row_num, BufferWritable& bw,
+                                                              FormatOptions& options) const {
     auto result = check_column_const_set_readability(column, row_num);
     ColumnPtr ptr = result.first;
     row_num = result.second;
@@ -220,7 +222,7 @@ Status DataTypeNumberSerDe<T>::serialize_one_cell_to_json(const IColumn& column,
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::deserialize_column_from_json_vector(
+Status DataTypeNumberSerDeBase<T>::deserialize_column_from_json_vector(
         IColumn& column, std::vector<Slice>& slices, uint64_t* num_deserialized,
         const FormatOptions& options) const {
     DESERIALIZE_COLUMN_FROM_JSON_VECTOR();
@@ -228,10 +230,10 @@ Status DataTypeNumberSerDe<T>::deserialize_column_from_json_vector(
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::read_column_from_arrow(IColumn& column,
-                                                      const arrow::Array* arrow_array,
-                                                      int64_t start, int64_t end,
-                                                      const cctz::time_zone& ctz) const {
+Status DataTypeNumberSerDeBase<T>::read_column_from_arrow(IColumn& column,
+                                                          const arrow::Array* arrow_array,
+                                                          int64_t start, int64_t end,
+                                                          const cctz::time_zone& ctz) const {
     auto row_count = end - start;
     auto& col_data = static_cast<ColumnType&>(column).get_data();
 
@@ -330,7 +332,7 @@ Status DataTypeNumberSerDe<T>::read_column_from_arrow(IColumn& column,
     return Status::OK();
 }
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::deserialize_column_from_fixed_json(
+Status DataTypeNumberSerDeBase<T>::deserialize_column_from_fixed_json(
         IColumn& column, Slice& slice, uint64_t rows, uint64_t* num_deserialized,
         const FormatOptions& options) const {
     if (rows < 1) [[unlikely]] {
@@ -341,7 +343,7 @@ Status DataTypeNumberSerDe<T>::deserialize_column_from_fixed_json(
         return st;
     }
 
-    DataTypeNumberSerDe::insert_column_last_value_multiple_times(column, rows - 1);
+    DataTypeNumberSerDeBase::insert_column_last_value_multiple_times(column, rows - 1);
     *num_deserialized = rows;
     return Status::OK();
 }
@@ -403,23 +405,24 @@ bool write_to_jsonb_from_number(auto& data, JsonbWriter& writer, int scale) {
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::serialize_column_to_jsonb(const IColumn& from_column,
-                                                         int64_t row_num,
-                                                         JsonbWriter& writer) const {
+Status DataTypeNumberSerDeBase<T>::serialize_column_to_jsonb(const IColumn& from_column,
+                                                             int64_t row_num,
+                                                             JsonbWriter& writer) const {
     if constexpr (!can_write_to_jsonb_from_number<T>()) {
         return Status::NotSupported("{} does not support serialize_column_to_jsonb", get_name());
     }
     const auto& data = assert_cast<const ColumnType&>(from_column).get_element(row_num);
     if (!write_to_jsonb_from_number<T>(data, writer, get_scale())) {
-        return Status::InvalidArgument("DataTypeNumberSerDe<T>::serialize_column_to_jsonb failed");
+        return Status::InvalidArgument(
+                "DataTypeNumberSerDeBase<T>::serialize_column_to_jsonb failed");
     }
 
     return Status::OK();
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::serialize_column_to_jsonb_vector(const IColumn& from_column,
-                                                                ColumnString& to_column) const {
+Status DataTypeNumberSerDeBase<T>::serialize_column_to_jsonb_vector(const IColumn& from_column,
+                                                                    ColumnString& to_column) const {
     if constexpr (!can_write_to_jsonb_from_number<T>()) {
         return Status::NotSupported("{} does not support serialize_column_to_jsonb", get_name());
     }
@@ -431,7 +434,7 @@ Status DataTypeNumberSerDe<T>::serialize_column_to_jsonb_vector(const IColumn& f
         writer.reset();
         if (!write_to_jsonb_from_number<T>(data[i], writer, scale)) {
             return Status::InvalidArgument(
-                    "DataTypeNumberSerDe<T>::serialize_column_to_jsonb failed for row {}", i);
+                    "DataTypeNumberSerDeBase<T>::serialize_column_to_jsonb failed for row {}", i);
         }
         to_column.insert_data(writer.getOutput()->getBuffer(), writer.getOutput()->getSize());
     }
@@ -439,9 +442,9 @@ Status DataTypeNumberSerDe<T>::serialize_column_to_jsonb_vector(const IColumn& f
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::deserialize_column_from_jsonb(IColumn& column,
-                                                             const JsonbValue* jsonb_value,
-                                                             CastParameters& castParms) const {
+Status DataTypeNumberSerDeBase<T>::deserialize_column_from_jsonb(IColumn& column,
+                                                                 const JsonbValue* jsonb_value,
+                                                                 CastParameters& castParms) const {
     if constexpr (!can_write_to_jsonb_from_number<T>()) {
         return Status::NotSupported("{} does not support serialize_column_to_jsonb", get_name());
     } else {
@@ -467,7 +470,7 @@ Status DataTypeNumberSerDe<T>::deserialize_column_from_jsonb(IColumn& column,
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::deserialize_column_from_jsonb_vector(
+Status DataTypeNumberSerDeBase<T>::deserialize_column_from_jsonb_vector(
         ColumnNullable& column_to, const ColumnString& col_from_json,
         CastParameters& castParms) const {
     if constexpr (!can_write_to_jsonb_from_number<T>()) {
@@ -517,8 +520,8 @@ Status DataTypeNumberSerDe<T>::deserialize_column_from_jsonb_vector(
 }
 
 template <PrimitiveType T>
-void DataTypeNumberSerDe<T>::insert_column_last_value_multiple_times(IColumn& column,
-                                                                     uint64_t times) const {
+void DataTypeNumberSerDeBase<T>::insert_column_last_value_multiple_times(IColumn& column,
+                                                                         uint64_t times) const {
     if (times < 1) [[unlikely]] {
         return;
     }
@@ -529,10 +532,9 @@ void DataTypeNumberSerDe<T>::insert_column_last_value_multiple_times(IColumn& co
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::write_column_to_mysql_binary(const IColumn& column,
-                                                            MysqlRowBinaryBuffer& result,
-                                                            int64_t row_idx, bool col_const,
-                                                            const FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::write_column_to_mysql_binary(
+        const IColumn& column, MysqlRowBinaryBuffer& result, int64_t row_idx, bool col_const,
+        const FormatOptions& options) const {
     int buf_ret = 0;
     auto& data = assert_cast<const ColumnType&>(column).get_data();
     const auto col_index = index_check_const(row_idx, col_const);
@@ -583,11 +585,12 @@ Status DataTypeNumberSerDe<T>::write_column_to_mysql_binary(const IColumn& colum
     cur_batch->numElements = end - start;
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::write_column_to_orc(const std::string& timezone,
-                                                   const IColumn& column, const NullMap* null_map,
-                                                   orc::ColumnVectorBatch* orc_col_batch,
-                                                   int64_t start, int64_t end, Arena& arena,
-                                                   const FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::write_column_to_orc(const std::string& timezone,
+                                                       const IColumn& column,
+                                                       const NullMap* null_map,
+                                                       orc::ColumnVectorBatch* orc_col_batch,
+                                                       int64_t start, int64_t end, Arena& arena,
+                                                       const FormatOptions& options) const {
     auto& col_data = assert_cast<const ColumnType&>(column).get_data();
 
     if constexpr (T == TYPE_LARGEINT) { // largeint
@@ -648,26 +651,15 @@ Status DataTypeNumberSerDe<T>::write_column_to_orc(const std::string& timezone,
 }
 
 template <PrimitiveType T>
-void DataTypeNumberSerDe<T>::read_one_cell_from_jsonb(IColumn& column,
-                                                      const JsonbValue* arg) const {
+void DataTypeNumberSerDeBase<T>::read_one_cell_from_jsonb(IColumn& column,
+                                                          const JsonbValue* arg) const {
     auto& col = reinterpret_cast<ColumnType&>(column);
     if constexpr (T == TYPE_TINYINT || T == TYPE_BOOLEAN) {
         col.insert_value(arg->unpack<JsonbInt8Val>()->val());
     } else if constexpr (T == TYPE_SMALLINT) {
         col.insert_value(arg->unpack<JsonbInt16Val>()->val());
-    } else if constexpr (T == TYPE_INT || T == TYPE_IPV4) {
+    } else if constexpr (T == TYPE_INT) {
         col.insert_value(arg->unpack<JsonbInt32Val>()->val());
-    } else if constexpr (T == TYPE_DATEV2) {
-        col.insert_value(binary_cast<UInt32, DateV2Value<DateV2ValueType>>(
-                (UInt32)arg->unpack<JsonbInt32Val>()->val()));
-    } else if constexpr (T == TYPE_DATETIMEV2) {
-        col.insert_value(binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(
-                (UInt64)arg->unpack<JsonbInt64Val>()->val()));
-    } else if constexpr (T == TYPE_TIMESTAMPTZ) {
-        col.insert_value(
-                binary_cast<UInt64, TimestampTzValue>((UInt64)arg->unpack<JsonbInt64Val>()->val()));
-    } else if constexpr (T == TYPE_DATE || T == TYPE_DATETIME) {
-        col.insert_value(binary_cast<Int64, VecDateTimeValue>(arg->unpack<JsonbInt64Val>()->val()));
     } else if constexpr (T == TYPE_BIGINT) {
         col.insert_value(arg->unpack<JsonbInt64Val>()->val());
     } else if constexpr (T == TYPE_LARGEINT) {
@@ -682,11 +674,11 @@ void DataTypeNumberSerDe<T>::read_one_cell_from_jsonb(IColumn& column,
     }
 }
 template <PrimitiveType T>
-void DataTypeNumberSerDe<T>::write_one_cell_to_jsonb(const IColumn& column,
-                                                     JsonbWriterT<JsonbOutStream>& result,
-                                                     Arena& mem_pool, int32_t col_id,
-                                                     int64_t row_num,
-                                                     const FormatOptions& options) const {
+void DataTypeNumberSerDeBase<T>::write_one_cell_to_jsonb(const IColumn& column,
+                                                         JsonbWriterT<JsonbOutStream>& result,
+                                                         Arena& mem_pool, int32_t col_id,
+                                                         int64_t row_num,
+                                                         const FormatOptions& options) const {
     result.writeKey(cast_set<JsonbKeyValue::keyid_type>(col_id));
     StringRef data_ref = column.get_data_at(row_num);
     // TODO: Casting unsigned integers to signed integers may result in loss of data precision.
@@ -699,11 +691,10 @@ void DataTypeNumberSerDe<T>::write_one_cell_to_jsonb(const IColumn& column,
     } else if constexpr (T == TYPE_SMALLINT) {
         int16_t val = *reinterpret_cast<const int16_t*>(data_ref.data);
         result.writeInt16(val);
-    } else if constexpr (T == TYPE_INT || T == TYPE_DATEV2 || T == TYPE_IPV4) {
+    } else if constexpr (T == TYPE_INT) {
         int32_t val = *reinterpret_cast<const int32_t*>(data_ref.data);
         result.writeInt32(val);
-    } else if constexpr (T == TYPE_BIGINT || T == TYPE_DATE || T == TYPE_DATETIME ||
-                         T == TYPE_DATETIMEV2 || T == TYPE_TIMESTAMPTZ) {
+    } else if constexpr (T == TYPE_BIGINT) {
         int64_t val = *reinterpret_cast<const int64_t*>(data_ref.data);
         result.writeInt64(val);
     } else if constexpr (T == TYPE_LARGEINT) {
@@ -737,8 +728,8 @@ bool try_parse_impl(typename PrimitiveTypeTraits<PT>::CppType& x, const StringRe
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::from_string(StringRef& str, IColumn& column,
-                                           const FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::from_string(StringRef& str, IColumn& column,
+                                               const FormatOptions& options) const {
     auto& column_data = assert_cast<ColumnType&, TypeCheckOnRelease::DISABLE>(column);
     typename PrimitiveTypeTraits<T>::CppType val;
     CastParameters params;
@@ -765,7 +756,7 @@ Status DataTypeNumberSerDe<T>::from_string(StringRef& str, IColumn& column,
 //   to_olap_string(Field(Float32(3.14f)))  => "3.14"
 //   to_olap_string(Field(Float64(1e300)))  => "1e+300"
 template <PrimitiveType T>
-std::string DataTypeNumberSerDe<T>::to_olap_string(const Field& field) const {
+std::string DataTypeNumberSerDeBase<T>::to_olap_string(const Field& field) const {
     if constexpr (T == TYPE_BOOLEAN) {
         char buf[8] = {'\0'};
         snprintf(buf, sizeof(buf), "%d", field.get<T>());
@@ -794,8 +785,8 @@ std::string DataTypeNumberSerDe<T>::to_olap_string(const Field& field) const {
 //   from_olap_string("3.14", field, ...)   => field = Float32(3.14)
 //   from_olap_string("NaN", field, ...)     => returns InvalidArgument (NaN/Inf are rejected)
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::from_olap_string(const std::string& str, Field& field,
-                                                const FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::from_olap_string(const std::string& str, Field& field,
+                                                    const FormatOptions& options) const {
     typename PrimitiveTypeTraits<T>::CppType val;
     CastParameters params;
     params.is_strict = false;
@@ -815,8 +806,8 @@ Status DataTypeNumberSerDe<T>::from_olap_string(const std::string& str, Field& f
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::from_string_strict_mode(StringRef& str, IColumn& column,
-                                                       const FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::from_string_strict_mode(StringRef& str, IColumn& column,
+                                                           const FormatOptions& options) const {
     auto& column_data = assert_cast<ColumnType&, TypeCheckOnRelease::DISABLE>(column);
     typename PrimitiveTypeTraits<T>::CppType val;
     CastParameters params;
@@ -829,8 +820,9 @@ Status DataTypeNumberSerDe<T>::from_string_strict_mode(StringRef& str, IColumn& 
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::from_string_batch(const ColumnString& str, ColumnNullable& column,
-                                                 const FormatOptions& options) const {
+Status DataTypeNumberSerDeBase<T>::from_string_batch(const ColumnString& str,
+                                                     ColumnNullable& column,
+                                                     const FormatOptions& options) const {
     const auto size = str.size();
     column.resize(size);
 
@@ -856,7 +848,7 @@ Status DataTypeNumberSerDe<T>::from_string_batch(const ColumnString& str, Column
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::from_string_strict_mode_batch(
+Status DataTypeNumberSerDeBase<T>::from_string_strict_mode_batch(
         const ColumnString& str, IColumn& column, const FormatOptions& options,
         const NullMap::value_type* null_map) const {
     const auto size = str.size();
@@ -889,9 +881,9 @@ Status DataTypeNumberSerDe<T>::from_string_strict_mode_batch(
 }
 
 template <PrimitiveType T>
-void DataTypeNumberSerDe<T>::write_one_cell_to_binary(const IColumn& src_column,
-                                                      ColumnString::Chars& chars,
-                                                      int64_t row_num) const {
+void DataTypeNumberSerDeBase<T>::write_one_cell_to_binary(const IColumn& src_column,
+                                                          ColumnString::Chars& chars,
+                                                          int64_t row_num) const {
     const uint8_t type = (const uint8_t)TabletColumn::get_field_type_by_type(T);
     const auto& data_ref = assert_cast<const ColumnType&>(src_column).get_data_at(row_num);
 
@@ -904,8 +896,8 @@ void DataTypeNumberSerDe<T>::write_one_cell_to_binary(const IColumn& src_column,
 }
 
 template <PrimitiveType T>
-const uint8_t* DataTypeNumberSerDe<T>::deserialize_binary_to_column(const uint8_t* data,
-                                                                    IColumn& column) {
+const uint8_t* DataTypeNumberSerDeBase<T>::deserialize_binary_to_column(const uint8_t* data,
+                                                                        IColumn& column) {
     auto& col = assert_cast<ColumnType&, TypeCheckOnRelease::DISABLE>(column);
     if constexpr (T == TYPE_BOOLEAN) {
         col.insert_value(unaligned_load<UInt8>(data));
@@ -957,8 +949,9 @@ const uint8_t* DataTypeNumberSerDe<T>::deserialize_binary_to_column(const uint8_
 }
 
 template <PrimitiveType T>
-const uint8_t* DataTypeNumberSerDe<T>::deserialize_binary_to_field(const uint8_t* data,
-                                                                   Field& field, FieldInfo& info) {
+const uint8_t* DataTypeNumberSerDeBase<T>::deserialize_binary_to_field(const uint8_t* data,
+                                                                       Field& field,
+                                                                       FieldInfo& info) {
     if constexpr (T == TYPE_BOOLEAN) {
         field = Field::create_field<TYPE_BOOLEAN>(unaligned_load<UInt8>(data));
         data += sizeof(UInt8);
@@ -1044,8 +1037,8 @@ void value_to_string(const typename PrimitiveTypeTraits<T>::CppType value, Buffe
 }
 
 template <PrimitiveType T>
-void DataTypeNumberSerDe<T>::to_string(const IColumn& column, size_t row_num, BufferWritable& bw,
-                                       const FormatOptions& options) const {
+void DataTypeNumberSerDeBase<T>::to_string(const IColumn& column, size_t row_num,
+                                           BufferWritable& bw, const FormatOptions& options) const {
     auto& data = assert_cast<const ColumnType&, TypeCheckOnRelease::DISABLE>(column).get_data();
     if constexpr (is_timestamptz_type(T) || is_date_type(T) || is_time_type(T) || is_ip(T)) {
         if (_nesting_level > 1) {
@@ -1061,18 +1054,18 @@ void DataTypeNumberSerDe<T>::to_string(const IColumn& column, size_t row_num, Bu
 }
 
 template <PrimitiveType T>
-bool DataTypeNumberSerDe<T>::write_column_to_presto_text(const IColumn& column, BufferWritable& bw,
-                                                         int64_t row_idx,
-                                                         const FormatOptions& options) const {
+bool DataTypeNumberSerDeBase<T>::write_column_to_presto_text(const IColumn& column,
+                                                             BufferWritable& bw, int64_t row_idx,
+                                                             const FormatOptions& options) const {
     auto& data = assert_cast<const ColumnType&, TypeCheckOnRelease::DISABLE>(column).get_data();
     value_to_string<T>(data[row_idx], bw, get_scale(), options);
     return true;
 }
 
 template <PrimitiveType T>
-bool DataTypeNumberSerDe<T>::write_column_to_hive_text(const IColumn& column, BufferWritable& bw,
-                                                       int64_t row_idx,
-                                                       const FormatOptions& options) const {
+bool DataTypeNumberSerDeBase<T>::write_column_to_hive_text(const IColumn& column,
+                                                           BufferWritable& bw, int64_t row_idx,
+                                                           const FormatOptions& options) const {
     auto& data = assert_cast<const ColumnType&, TypeCheckOnRelease::DISABLE>(column).get_data();
     if constexpr (is_date_type(T) || is_timestamptz_type(T) || is_time_type(T) || is_ip(T)) {
         if (_nesting_level > 1) {
@@ -1093,8 +1086,8 @@ bool DataTypeNumberSerDe<T>::write_column_to_hive_text(const IColumn& column, Bu
 }
 
 template <PrimitiveType T>
-void DataTypeNumberSerDe<T>::to_string_batch(const IColumn& column, ColumnString& column_to,
-                                             const FormatOptions& options) const {
+void DataTypeNumberSerDeBase<T>::to_string_batch(const IColumn& column, ColumnString& column_to,
+                                                 const FormatOptions& options) const {
     auto& data = assert_cast<const ColumnType&>(column).get_data();
     const size_t size = column.size();
     const auto maybe_reserve_size = CastToString::string_length<T>;
@@ -1109,6 +1102,25 @@ void DataTypeNumberSerDe<T>::to_string_batch(const IColumn& column, ColumnString
 }
 
 /// Explicit template instantiations - to avoid code bloat in headers.
+template class DataTypeNumberSerDeBase<TYPE_BOOLEAN>;
+template class DataTypeNumberSerDeBase<TYPE_TINYINT>;
+template class DataTypeNumberSerDeBase<TYPE_SMALLINT>;
+template class DataTypeNumberSerDeBase<TYPE_INT>;
+template class DataTypeNumberSerDeBase<TYPE_BIGINT>;
+template class DataTypeNumberSerDeBase<TYPE_LARGEINT>;
+template class DataTypeNumberSerDeBase<TYPE_FLOAT>;
+template class DataTypeNumberSerDeBase<TYPE_DOUBLE>;
+template class DataTypeNumberSerDeBase<TYPE_DATE>;
+template class DataTypeNumberSerDeBase<TYPE_DATEV2>;
+template class DataTypeNumberSerDeBase<TYPE_DATETIME>;
+template class DataTypeNumberSerDeBase<TYPE_DATETIMEV2>;
+template class DataTypeNumberSerDeBase<TYPE_IPV4>;
+template class DataTypeNumberSerDeBase<TYPE_IPV6>;
+template class DataTypeNumberSerDeBase<TYPE_TIME>;
+template class DataTypeNumberSerDeBase<TYPE_TIMEV2>;
+template class DataTypeNumberSerDeBase<TYPE_TIMESTAMPTZ>;
+
+// Explicit instantiations for the thin DataTypeNumberSerDe (pure numeric types only)
 template class DataTypeNumberSerDe<TYPE_BOOLEAN>;
 template class DataTypeNumberSerDe<TYPE_TINYINT>;
 template class DataTypeNumberSerDe<TYPE_SMALLINT>;
@@ -1117,13 +1129,5 @@ template class DataTypeNumberSerDe<TYPE_BIGINT>;
 template class DataTypeNumberSerDe<TYPE_LARGEINT>;
 template class DataTypeNumberSerDe<TYPE_FLOAT>;
 template class DataTypeNumberSerDe<TYPE_DOUBLE>;
-template class DataTypeNumberSerDe<TYPE_DATE>;
-template class DataTypeNumberSerDe<TYPE_DATEV2>;
-template class DataTypeNumberSerDe<TYPE_DATETIME>;
-template class DataTypeNumberSerDe<TYPE_DATETIMEV2>;
-template class DataTypeNumberSerDe<TYPE_IPV4>;
-template class DataTypeNumberSerDe<TYPE_IPV6>;
 template class DataTypeNumberSerDe<TYPE_TIME>;
-template class DataTypeNumberSerDe<TYPE_TIMEV2>;
-template class DataTypeNumberSerDe<TYPE_TIMESTAMPTZ>;
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_number_serde.h
+++ b/be/src/core/data_type_serde/data_type_number_serde.h
@@ -48,14 +48,14 @@ class Arena;
 //  IPv4 => T:UInt32
 //  IPv6 => T:uint128_t
 template <PrimitiveType T>
-class DataTypeNumberSerDe : public DataTypeSerDe {
+class DataTypeNumberSerDeBase : public DataTypeSerDe {
     static_assert(is_int_or_bool(T) || is_ip(T) || is_date_type(T) || is_float_or_double(T) ||
                   T == TYPE_TIME || T == TYPE_TIMEV2 || T == TYPE_TIMESTAMPTZ);
 
 public:
     using ColumnType = typename PrimitiveTypeTraits<T>::ColumnType;
 
-    DataTypeNumberSerDe(int nesting_level = 1) : DataTypeSerDe(nesting_level) {};
+    DataTypeNumberSerDeBase(int nesting_level = 1) : DataTypeSerDe(nesting_level) {};
 
     std::string get_name() const override { return type_to_string(T); }
 
@@ -142,9 +142,6 @@ public:
 
     std::string to_olap_string(const Field& field) const override;
 
-    // will override in DateTime and Time
-    virtual int get_scale() const { return 0; }
-
     static const uint8_t* deserialize_binary_to_column(const uint8_t* data, IColumn& column);
 
     static const uint8_t* deserialize_binary_to_field(const uint8_t* data, Field& field,
@@ -155,8 +152,18 @@ protected:
                             const FormatOptions& options) const override;
 };
 
+/// Thin final class for pure numeric types (Bool, Int8-128, Float32-64).
+/// Corresponds to DataTypeNumber<T> on the DataType side.
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::read_column_from_pb(IColumn& column, const PValues& arg) const {
+class DataTypeNumberSerDe final : public DataTypeNumberSerDeBase<T> {
+    static_assert(is_int_or_bool(T) || is_float_or_double(T) || T == TYPE_TIME);
+
+public:
+    using DataTypeNumberSerDeBase<T>::DataTypeNumberSerDeBase;
+};
+
+template <PrimitiveType T>
+Status DataTypeNumberSerDeBase<T>::read_column_from_pb(IColumn& column, const PValues& arg) const {
     auto old_column_size = column.size();
     if constexpr (T == TYPE_BOOLEAN) {
         column.resize(old_column_size + arg.uint32_value_size());
@@ -165,12 +172,6 @@ Status DataTypeNumberSerDe<T>::read_column_from_pb(IColumn& column, const PValue
             data[old_column_size + i] =
                     cast_set<typename PrimitiveTypeTraits<T>::CppType, uint32_t, false>(
                             arg.uint32_value(i));
-        }
-    } else if constexpr (T == TYPE_DATEV2 || T == TYPE_IPV4) {
-        column.resize(old_column_size + arg.uint32_value_size());
-        auto& data = assert_cast<ColumnType&>(column).get_data();
-        for (int i = 0; i < arg.uint32_value_size(); ++i) {
-            data[old_column_size + i] = arg.uint32_value(i);
         }
     } else if constexpr (T == TYPE_TINYINT || T == TYPE_SMALLINT) {
         column.resize(old_column_size + arg.int32_value_size());
@@ -185,25 +186,6 @@ Status DataTypeNumberSerDe<T>::read_column_from_pb(IColumn& column, const PValue
         auto& data = reinterpret_cast<ColumnType&>(column).get_data();
         for (int i = 0; i < arg.int32_value_size(); ++i) {
             data[old_column_size + i] = arg.int32_value(i);
-        }
-    } else if constexpr (T == TYPE_DATETIMEV2) {
-        column.resize(old_column_size + arg.uint64_value_size());
-        auto& data = reinterpret_cast<ColumnType&>(column).get_data();
-        for (int i = 0; i < arg.uint64_value_size(); ++i) {
-            data[old_column_size + i] =
-                    binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(arg.uint64_value(i));
-        }
-    } else if constexpr (T == TYPE_TIMESTAMPTZ) {
-        column.resize(old_column_size + arg.uint64_value_size());
-        auto& data = reinterpret_cast<ColumnType&>(column).get_data();
-        for (int i = 0; i < arg.uint64_value_size(); ++i) {
-            data[old_column_size + i] = binary_cast<UInt64, TimestampTzValue>(arg.uint64_value(i));
-        }
-    } else if constexpr (T == TYPE_DATE || T == TYPE_DATETIME) {
-        column.resize(old_column_size + arg.int64_value_size());
-        auto& data = reinterpret_cast<ColumnType&>(column).get_data();
-        for (int i = 0; i < arg.int64_value_size(); ++i) {
-            data[old_column_size + i] = binary_cast<Int64, VecDateTimeValue>(arg.int64_value(i));
         }
     } else if constexpr (T == TYPE_BIGINT) {
         column.resize(old_column_size + arg.int64_value_size());
@@ -236,8 +218,8 @@ Status DataTypeNumberSerDe<T>::read_column_from_pb(IColumn& column, const PValue
 }
 
 template <PrimitiveType T>
-Status DataTypeNumberSerDe<T>::write_column_to_pb(const IColumn& column, PValues& result,
-                                                  int64_t start, int64_t end) const {
+Status DataTypeNumberSerDeBase<T>::write_column_to_pb(const IColumn& column, PValues& result,
+                                                      int64_t start, int64_t end) const {
     auto row_count = cast_set<int>(end - start);
     auto* ptype = result.mutable_type();
     const auto* col = check_and_get_column<ColumnType>(column);
@@ -256,21 +238,6 @@ Status DataTypeNumberSerDe<T>::write_column_to_pb(const IColumn& column, PValues
         auto* values = result.mutable_uint32_value();
         values->Reserve(row_count);
         values->Add(data.begin() + start, data.begin() + end);
-    } else if constexpr (T == TYPE_DATEV2) {
-        ptype->set_id(PGenericType::UINT32);
-        auto* values = result.mutable_uint32_value();
-        values->Reserve(row_count);
-        values->Add((uint32_t*)data.begin() + start, (uint32_t*)data.begin() + end);
-    } else if constexpr (T == TYPE_IPV4) {
-        ptype->set_id(PGenericType::UINT32);
-        auto* values = result.mutable_uint32_value();
-        values->Reserve(row_count);
-        values->Add(data.begin() + start, data.begin() + end);
-    } else if constexpr (T == TYPE_DATETIMEV2 || T == TYPE_TIMESTAMPTZ) {
-        ptype->set_id(PGenericType::UINT64);
-        auto* values = result.mutable_uint64_value();
-        values->Reserve(row_count);
-        values->Add((uint64_t*)data.begin() + start, (uint64_t*)data.begin() + end);
     } else if constexpr (T == TYPE_TINYINT) {
         ptype->set_id(PGenericType::INT8);
         auto* values = result.mutable_int32_value();
@@ -286,11 +253,6 @@ Status DataTypeNumberSerDe<T>::write_column_to_pb(const IColumn& column, PValues
         auto* values = result.mutable_int32_value();
         values->Reserve(row_count);
         values->Add(data.begin() + start, data.begin() + end);
-    } else if constexpr (T == TYPE_DATE || T == TYPE_DATETIME) {
-        ptype->set_id(PGenericType::INT64);
-        auto* values = result.mutable_int64_value();
-        values->Reserve(row_count);
-        values->Add((int64_t*)data.begin() + start, (int64_t*)data.begin() + end);
     } else if constexpr (T == TYPE_BIGINT) {
         ptype->set_id(PGenericType::INT64);
         auto* values = result.mutable_int64_value();

--- a/be/src/core/data_type_serde/data_type_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_serde.cpp
@@ -177,12 +177,12 @@ const uint8_t* DataTypeSerDe::deserialize_binary_to_column(const uint8_t* data, 
         break;                                                                                \
     }
 
-#define HANDLE_T_NUM_SERDE(FT, TYPEID)                                   \
-    case FieldType::FT: {                                                \
-        end = DataTypeNumberSerDe<TYPEID>::deserialize_binary_to_column( \
-                data, nullable_column.get_nested_column());              \
-        nullable_column.push_false_to_nullmap(1);                        \
-        break;                                                           \
+#define HANDLE_T_NUM_SERDE(FT, TYPEID)                                       \
+    case FieldType::FT: {                                                    \
+        end = DataTypeNumberSerDeBase<TYPEID>::deserialize_binary_to_column( \
+                data, nullable_column.get_nested_column());                  \
+        nullable_column.push_false_to_nullmap(1);                            \
+        break;                                                               \
     }
 
 #define HANDLE_T_DEC_SERDE(FT, TYPEID)                                    \
@@ -243,10 +243,10 @@ const uint8_t* DataTypeSerDe::deserialize_binary_to_field(const uint8_t* data, F
         break;                                                       \
     }
 
-#define HANDLE_T_NUM_SERDE(FT, TYPEID)                                                     \
-    case FieldType::FT: {                                                                  \
-        end = DataTypeNumberSerDe<TYPEID>::deserialize_binary_to_field(data, field, info); \
-        break;                                                                             \
+#define HANDLE_T_NUM_SERDE(FT, TYPEID)                                                         \
+    case FieldType::FT: {                                                                      \
+        end = DataTypeNumberSerDeBase<TYPEID>::deserialize_binary_to_field(data, field, info); \
+        break;                                                                                 \
     }
 
 #define HANDLE_T_DEC_SERDE(FT, TYPEID)                                                      \

--- a/be/src/core/data_type_serde/data_type_serde.h
+++ b/be/src/core/data_type_serde/data_type_serde.h
@@ -496,6 +496,8 @@ public:
 
     virtual void set_return_object_as_string(bool value) { _return_object_as_string = value; }
 
+    virtual int get_scale() const { return 0; }
+
     virtual DataTypeSerDeSPtrs get_nested_serdes() const {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
                                "Method get_nested_serdes is not supported for this serde");

--- a/be/src/core/data_type_serde/data_type_time_serde.h
+++ b/be/src/core/data_type_serde/data_type_time_serde.h
@@ -27,10 +27,10 @@
 namespace doris {
 class JsonbOutStream;
 #include "common/compile_check_begin.h"
-class DataTypeTimeV2SerDe : public DataTypeNumberSerDe<PrimitiveType::TYPE_TIMEV2> {
+class DataTypeTimeV2SerDe : public DataTypeNumberSerDeBase<PrimitiveType::TYPE_TIMEV2> {
 public:
     DataTypeTimeV2SerDe(int scale = 0, int nesting_level = 1)
-            : DataTypeNumberSerDe<PrimitiveType::TYPE_TIMEV2>(nesting_level), _scale(scale) {};
+            : DataTypeNumberSerDeBase<PrimitiveType::TYPE_TIMEV2>(nesting_level), _scale(scale) {};
     Status write_column_to_mysql_binary(const IColumn& column, MysqlRowBinaryBuffer& row_buffer,
                                         int64_t row_idx, bool col_const,
                                         const FormatOptions& options) const override;

--- a/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
@@ -17,6 +17,7 @@
 
 #include "core/data_type_serde/data_type_timestamptz_serde.h"
 
+#include <arrow/array.h>
 #include <arrow/builder.h>
 
 #include "core/data_type/primitive_type.h"
@@ -24,6 +25,8 @@
 #include "exprs/function/cast/cast_parameters.h"
 #include "exprs/function/cast/cast_to_string.h"
 #include "exprs/function/cast/cast_to_timestamptz.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
 namespace doris {
 
 // The implementation of these functions mainly refers to data_type_datetimev2_serde.cpp
@@ -248,6 +251,99 @@ Status DataTypeTimeStampTzSerDe::write_column_to_orc(const std::string& timezone
 
 std::string DataTypeTimeStampTzSerDe::to_olap_string(const Field& field) const {
     return CastToString::from_timestamptz(field.get<TYPE_TIMESTAMPTZ>(), 6);
+}
+
+Status DataTypeTimeStampTzSerDe::write_column_to_pb(const IColumn& column, PValues& result,
+                                                    int64_t start, int64_t end) const {
+    auto row_count = cast_set<int>(end - start);
+    auto* ptype = result.mutable_type();
+    const auto* col = check_and_get_column<ColumnType>(column);
+    auto& data = col->get_data();
+    ptype->set_id(PGenericType::UINT64);
+    auto* values = result.mutable_uint64_value();
+    values->Reserve(row_count);
+    values->Add((uint64_t*)data.begin() + start, (uint64_t*)data.begin() + end);
+    return Status::OK();
+}
+
+Status DataTypeTimeStampTzSerDe::read_column_from_pb(IColumn& column, const PValues& arg) const {
+    auto old_column_size = column.size();
+    column.resize(old_column_size + arg.uint64_value_size());
+    auto& data = reinterpret_cast<ColumnType&>(column).get_data();
+    for (int i = 0; i < arg.uint64_value_size(); ++i) {
+        data[old_column_size + i] = binary_cast<UInt64, TimestampTzValue>(arg.uint64_value(i));
+    }
+    return Status::OK();
+}
+
+void DataTypeTimeStampTzSerDe::write_one_cell_to_jsonb(const IColumn& column,
+                                                       JsonbWriterT<JsonbOutStream>& result,
+                                                       Arena& mem_pool, int32_t col_id,
+                                                       int64_t row_num,
+                                                       const FormatOptions& options) const {
+    result.writeKey(cast_set<JsonbKeyValue::keyid_type>(col_id));
+    StringRef data_ref = column.get_data_at(row_num);
+    int64_t val = *reinterpret_cast<const int64_t*>(data_ref.data);
+    result.writeInt64(val);
+}
+
+void DataTypeTimeStampTzSerDe::read_one_cell_from_jsonb(IColumn& column,
+                                                        const JsonbValue* arg) const {
+    auto& col = reinterpret_cast<ColumnType&>(column);
+    col.insert_value(
+            binary_cast<UInt64, TimestampTzValue>((UInt64)arg->unpack<JsonbInt64Val>()->val()));
+}
+
+Status DataTypeTimeStampTzSerDe::read_column_from_arrow(IColumn& column,
+                                                        const arrow::Array* arrow_array,
+                                                        int64_t start, int64_t end,
+                                                        const cctz::time_zone& ctz) const {
+    auto row_count = end - start;
+    auto& col_data = static_cast<ColumnType&>(column).get_data();
+
+    if (arrow_array->type_id() == arrow::Type::STRING) {
+        const auto* concrete_array = dynamic_cast<const arrow::StringArray*>(arrow_array);
+        std::shared_ptr<arrow::Buffer> buffer = concrete_array->value_data();
+        const auto* offsets_data = concrete_array->value_offsets()->data();
+        const size_t offset_size = sizeof(int32_t);
+        for (size_t offset_i = start; offset_i < end; ++offset_i) {
+            if (!concrete_array->IsNull(offset_i)) {
+                int32_t start_offset = 0;
+                int32_t end_offset = 0;
+                memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
+                memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
+                const auto* raw_data = buffer->data() + start_offset;
+                const auto raw_data_len = end_offset - start_offset;
+                if (raw_data_len == 0) {
+                    col_data.emplace_back(TimestampTzValue());
+                } else {
+                    StringRef str_ref(raw_data, raw_data_len);
+                    UInt64 val = 0;
+                    if (!try_read_int_text(val, str_ref)) {
+                        return Status::Error(ErrorCode::INVALID_ARGUMENT,
+                                             "parse number fail, string: '{}'",
+                                             std::string(str_ref.data, str_ref.size).c_str());
+                    }
+                    col_data.emplace_back(binary_cast<UInt64, TimestampTzValue>(val));
+                }
+            } else {
+                col_data.emplace_back(TimestampTzValue());
+            }
+        }
+        return Status::OK();
+    }
+
+    // Buffer path
+    if (row_count == 0 || arrow_array->data()->buffers[1] == nullptr) {
+        return Status::OK();
+    }
+    std::shared_ptr<arrow::Buffer> buffer = arrow_array->data()->buffers[1];
+    const auto* raw_data =
+            reinterpret_cast<const typename PrimitiveTypeTraits<TYPE_TIMESTAMPTZ>::CppType*>(
+                    buffer->data()) +
+            start;
+    col_data.insert(raw_data, raw_data + row_count);
+    return Status::OK();
 }
 
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_timestamptz_serde.h
+++ b/be/src/core/data_type_serde/data_type_timestamptz_serde.h
@@ -26,13 +26,14 @@
 #include "core/value/time_value.h"
 
 namespace doris {
-class DataTypeTimeStampTzSerDe : public DataTypeNumberSerDe<PrimitiveType::TYPE_TIMESTAMPTZ> {
+class DataTypeTimeStampTzSerDe : public DataTypeNumberSerDeBase<PrimitiveType::TYPE_TIMESTAMPTZ> {
 public:
     DataTypeTimeStampTzSerDe(const UInt32 scale, int nesting_level = 1)
-            : DataTypeNumberSerDe<PrimitiveType::TYPE_TIMESTAMPTZ>(nesting_level), _scale(scale) {};
+            : DataTypeNumberSerDeBase<PrimitiveType::TYPE_TIMESTAMPTZ>(nesting_level),
+              _scale(scale) {};
 
     // Currently DataTypeTimeStampTzSerDe only supports from_string interface and MySQL output interface
-    // Other interfaces are in DataTypeNumberSerDe, and an error will be reported when called.
+    // Other interfaces are in DataTypeNumberSerDeBase, and an error will be reported when called.
     Status from_string(StringRef& str, IColumn& column,
                        const FormatOptions& options) const override;
 
@@ -66,6 +67,8 @@ public:
     Status write_column_to_arrow(const IColumn& column, const NullMap* null_map,
                                  arrow::ArrayBuilder* array_builder, int64_t start, int64_t end,
                                  const cctz::time_zone& ctz) const override;
+    Status read_column_from_arrow(IColumn& column, const arrow::Array* arrow_array, int64_t start,
+                                  int64_t end, const cctz::time_zone& ctz) const override;
 
     Status write_column_to_orc(const std::string& timezone, const IColumn& column,
                                const NullMap* null_map, orc::ColumnVectorBatch* orc_col_batch,
@@ -73,6 +76,15 @@ public:
                                const FormatOptions& options) const override;
 
     std::string to_olap_string(const Field& field) const override;
+
+    Status write_column_to_pb(const IColumn& column, PValues& result, int64_t start,
+                              int64_t end) const override;
+    Status read_column_from_pb(IColumn& column, const PValues& arg) const override;
+
+    void write_one_cell_to_jsonb(const IColumn& column, JsonbWriterT<JsonbOutStream>& result,
+                                 Arena& mem_pool, int32_t col_id, int64_t row_num,
+                                 const FormatOptions& options) const override;
+    void read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const override;
 
 protected:
     Status from_olap_string(const std::string& str, Field& field,

--- a/be/test/core/data_type_serde/data_type_serde_datelike_batch_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_datelike_batch_test.cpp
@@ -34,7 +34,8 @@
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_decimal.h"
 #include "core/data_type/data_type_number.h"
-#include "core/data_type_serde/data_type_date_or_datetime_serde.h"
+#include "core/data_type_serde/data_type_date_serde.h"
+#include "core/data_type_serde/data_type_datetime_serde.h"
 #include "core/data_type_serde/data_type_datetimev2_serde.h"
 #include "core/data_type_serde/data_type_datev2_serde.h"
 #include "core/data_type_serde/data_type_time_serde.h"
@@ -77,14 +78,14 @@ static ColumnFloat64::MutablePtr build_float64_column(const std::vector<double>&
 }
 
 // ============================================================================
-// DateV1 / DateTimeV1 (DataTypeDateSerDe<TYPE_DATE / TYPE_DATETIME>)
+// DateV1 / DateTimeV1 (DataTypeDateSerDe / DataTypeDateTimeSerDe)
 // ============================================================================
 
 // --- from_decimal_batch (non-strict) ---
 // Valid: 20230115 (8 digits → 2023-01-15)
 // Invalid: -1 (negative, always rejected)
 TEST_F(DatelikeSerDeBatchTest, datev1_from_decimal_batch) {
-    DataTypeDateSerDe<TYPE_DATE> serde;
+    DataTypeDateSerDe serde;
     auto dec_col = build_decimal64_column({20230115, -1}, /*scale=*/0);
 
     auto data_col = ColumnDate::create();
@@ -100,7 +101,7 @@ TEST_F(DatelikeSerDeBatchTest, datev1_from_decimal_batch) {
 
 // --- from_decimal_strict_mode_batch (strict) ---
 TEST_F(DatelikeSerDeBatchTest, datev1_from_decimal_strict_mode_batch) {
-    DataTypeDateSerDe<TYPE_DATE> serde;
+    DataTypeDateSerDe serde;
     auto dec_col = build_decimal64_column({-1}, /*scale=*/0);
 
     auto target = ColumnDate::create();
@@ -109,7 +110,7 @@ TEST_F(DatelikeSerDeBatchTest, datev1_from_decimal_strict_mode_batch) {
 }
 
 TEST_F(DatelikeSerDeBatchTest, datetimev1_from_decimal_batch) {
-    DataTypeDateSerDe<TYPE_DATETIME> serde;
+    DataTypeDateTimeSerDe serde;
     auto dec_col = build_decimal64_column({20230115143059, -1}, /*scale=*/0);
 
     auto data_col = ColumnDateTime::create();
@@ -124,7 +125,7 @@ TEST_F(DatelikeSerDeBatchTest, datetimev1_from_decimal_batch) {
 }
 
 TEST_F(DatelikeSerDeBatchTest, datetimev1_from_decimal_strict_mode_batch) {
-    DataTypeDateSerDe<TYPE_DATETIME> serde;
+    DataTypeDateTimeSerDe serde;
     auto dec_col = build_decimal64_column({-1}, /*scale=*/0);
 
     auto target = ColumnDateTime::create();
@@ -134,7 +135,7 @@ TEST_F(DatelikeSerDeBatchTest, datetimev1_from_decimal_strict_mode_batch) {
 
 // --- from_int_batch / from_int_strict_mode_batch ---
 TEST_F(DatelikeSerDeBatchTest, datev1_from_int_batch) {
-    DataTypeDateSerDe<TYPE_DATE> serde;
+    DataTypeDateSerDe serde;
     auto int_col = build_int64_column({20230115, -1});
 
     auto data_col = ColumnDate::create();
@@ -149,7 +150,7 @@ TEST_F(DatelikeSerDeBatchTest, datev1_from_int_batch) {
 }
 
 TEST_F(DatelikeSerDeBatchTest, datev1_from_int_strict_mode_batch) {
-    DataTypeDateSerDe<TYPE_DATE> serde;
+    DataTypeDateSerDe serde;
     auto int_col = build_int64_column({-1});
 
     auto target = ColumnDate::create();
@@ -159,7 +160,7 @@ TEST_F(DatelikeSerDeBatchTest, datev1_from_int_strict_mode_batch) {
 
 // --- from_float_batch / from_float_strict_mode_batch ---
 TEST_F(DatelikeSerDeBatchTest, datev1_from_float_batch) {
-    DataTypeDateSerDe<TYPE_DATE> serde;
+    DataTypeDateSerDe serde;
     auto float_col = build_float64_column({20230115.0, -1.0});
 
     auto data_col = ColumnDate::create();
@@ -174,7 +175,7 @@ TEST_F(DatelikeSerDeBatchTest, datev1_from_float_batch) {
 }
 
 TEST_F(DatelikeSerDeBatchTest, datev1_from_float_strict_mode_batch) {
-    DataTypeDateSerDe<TYPE_DATE> serde;
+    DataTypeDateSerDe serde;
     auto float_col = build_float64_column({-1.0});
 
     auto target = ColumnDate::create();
@@ -417,7 +418,7 @@ TEST_F(DatelikeSerDeBatchTest, timev2_from_float_strict_mode_batch) {
 // accidentally used in from_decimal_batch for DateV1/DateTimeV1.
 // ============================================================================
 TEST_F(DatelikeSerDeBatchTest, datev1_from_decimal_batch_mixed) {
-    DataTypeDateSerDe<TYPE_DATE> serde;
+    DataTypeDateSerDe serde;
     // valid, invalid, valid, invalid
     auto dec_col = build_decimal64_column({20230115, -1, 20001231, 0}, /*scale=*/0);
 
@@ -435,7 +436,7 @@ TEST_F(DatelikeSerDeBatchTest, datev1_from_decimal_batch_mixed) {
 }
 
 TEST_F(DatelikeSerDeBatchTest, datetimev1_from_decimal_batch_mixed) {
-    DataTypeDateSerDe<TYPE_DATETIME> serde;
+    DataTypeDateTimeSerDe serde;
     auto dec_col = build_decimal64_column({20230115143059, -1, 20001231235959, 0}, /*scale=*/0);
 
     auto data_col = ColumnDateTime::create();

--- a/be/test/core/data_type_serde/data_type_serde_datetime_v1_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_datetime_v1_test.cpp
@@ -29,7 +29,8 @@
 #include "core/data_type/common_data_type_serder_test.h"
 #include "core/data_type/common_data_type_test.h"
 #include "core/data_type/data_type.h"
-#include "core/data_type_serde/data_type_date_or_datetime_serde.h"
+#include "core/data_type_serde/data_type_date_serde.h"
+#include "core/data_type_serde/data_type_datetime_serde.h"
 #include "core/types.h"
 #include "testutil/test_util.h"
 #include "util/slice.h"
@@ -38,7 +39,7 @@
 namespace doris {
 static std::string test_data_dir;
 
-static auto serde_date_v1 = std::make_shared<DataTypeDateSerDe<>>();
+static auto serde_date_v1 = std::make_shared<DataTypeDateSerDe>();
 static auto serde_datetime_v1 = std::make_shared<DataTypeDateTimeSerDe>(0);
 
 static ColumnDateTime::MutablePtr column_datetime_v1_0;


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

`DataTypeNumberSerDe<T>` was a monolithic template class serving as both the base class for all number-like SerDe types and the concrete implementation for pure numeric types. It handled 17+ types via extensive `if constexpr` branches, making the code hard to read and maintain. The inheritance structure was also asymmetric with the DataType side.

#### DataType hierarchy (for reference)

The DataType side already has a clean two-level design:

```
IDataType
  └── DataTypeNumberBase<T>                  // shared base (non-final)
        ├── DataTypeNumber<T>  final         // pure numerics (Bool/Int8~Int128/Float/Double)
        ├── DataTypeDate  final
        ├── DataTypeDateTime  final
        ├── DataTypeDateV2  final
        ├── DataTypeDateTimeV2  final
        ├── DataTypeIPv4  final
        ├── DataTypeIPv6  final
        ├── DataTypeTimeV2  final
        └── DataTypeTimeStampTz  final
```

#### SerDe hierarchy — BEFORE

The old SerDe side was flat and asymmetric — `DataTypeNumberSerDe<T>` served as both the base and the final class, with massive `if constexpr` branches to dispatch type-specific logic:

```
DataTypeSerDe
  └── DataTypeNumberSerDe<T>        // monolithic: base + concrete all in one
        ├── DataTypeDateV2SerDe
        ├── DataTypeDateTimeV2SerDe
        ├── DataTypeDateSerDe        // DateTime v1 inherits from DateSerDe (!)
        │     └── DataTypeDateTimeSerDe
        ├── DataTypeIPv4SerDe
        ├── DataTypeIPv6SerDe
        ├── DataTypeTimeV2SerDe
        └── DataTypeTimeStampTzSerDe
```

Problems: (1) no separation between base and pure-numeric final class, (2) `if constexpr` branches for 10+ types scattered in base methods, (3) DateTime inheriting from Date (wrong relationship).

#### SerDe hierarchy — AFTER

```
DataTypeSerDe
  └── DataTypeNumberSerDeBase<T>              // shared base (non-final)
        ├── DataTypeNumberSerDe<T>  final     // pure numerics only (Bool/Int/Float/Time)
        ├── DataTypeDateLikeV1SerDe<T>        // shared Date/DateTime v1 template
        │     ├── DataTypeDateSerDe  final
        │     └── DataTypeDateTimeSerDe  final
        ├── DataTypeDateV2SerDe
        ├── DataTypeDateTimeV2SerDe
        ├── DataTypeIPv4SerDe
        ├── DataTypeIPv6SerDe
        ├── DataTypeTimeV2SerDe
        └── DataTypeTimeStampTzSerDe
```

Now the SerDe hierarchy mirrors the DataType hierarchy: `DataTypeNumberSerDeBase<T>` ↔ `DataTypeNumberBase<T>`, `DataTypeNumberSerDe<T> final` ↔ `DataTypeNumber<T> final`, and Date/DateTime are siblings via a shared intermediate template.

---

This PR performs a multi-phase refactoring:

**Phase 1 — Split base class and add thin final wrapper**
- Rename `DataTypeNumberSerDe<T>` → `DataTypeNumberSerDeBase<T>` (base class)
- Add `DataTypeNumberSerDe<T> final` for pure numeric types (Bool/Int/Float/Double/Time), mirroring `DataTypeNumber<T>` on the DataType side

**Phase 3 — Lift `get_scale()` to `DataTypeSerDe` base**
- Move `get_scale()` from `DataTypeNumberSerDeBase<T>` to `DataTypeSerDe`, making it available to all SerDe types (e.g. Decimal)

**Phase 4 — Split Date/DateTime v1 SerDe into separate files**
- Create `DataTypeDateLikeV1SerDe<T>` shared template for Date/DateTime v1 common logic
- Split into `data_type_date_serde.h/.cpp` and `data_type_datetime_serde.h/.cpp`
- `DataTypeDateSerDe` and `DataTypeDateTimeSerDe` are now siblings (not parent-child)

**Phase 2 — Sink `if constexpr` branches to subclasses**
- Move type-specific PB/Jsonb serialization logic from `DataTypeNumberSerDeBase<T>` into subclass overrides:
  - `DataTypeDateLikeV1SerDe<T>`: write/read PB (INT64), write/read Jsonb
  - `DataTypeDateV2SerDe`: write/read PB (UINT32), write/read Jsonb
  - `DataTypeDateTimeV2SerDe`: write/read PB (UINT64), write/read Jsonb
  - `DataTypeTimeStampTzSerDe`: write/read PB (UINT64), write/read Jsonb, read_column_from_arrow
  - `DataTypeIPv4SerDe`: write/read Jsonb
- Remove corresponding dead branches from the base class

After refactoring, the base class `DataTypeNumberSerDeBase<T>` PB methods only handle pure numeric types (Bool, TinyInt–BigInt, LargeInt, Float, Double, Time/TimeV2).

### Release note

None
### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

