### PR TITLE
[feature](iceberg) Distributed metadata planning for large Iceberg tables

### DIFF
--- a/be/src/format/table/iceberg_sys_table_jni_reader.cpp
+++ b/be/src/format/table/iceberg_sys_table_jni_reader.cpp
@@ -25,6 +25,10 @@
 namespace doris {
 
 static const std::string HADOOP_OPTION_PREFIX = "hadoop.";
+static const std::string ICEBERG_SYS_TABLE_SCANNER =
+        "org/apache/doris/iceberg/IcebergSysTableJniScanner";
+static const std::string ICEBERG_METADATA_PLANNING_SCANNER =
+        "org/apache/doris/iceberg/IcebergMetadataPlanningJniScanner";
 
 Status IcebergSysTableJniReader::validate_scan_range(const TFileRangeDesc& range) {
     if (!range.__isset.table_format_params) {
@@ -48,8 +52,7 @@ IcebergSysTableJniReader::IcebergSysTableJniReader(
         RuntimeProfile* profile, const TFileRangeDesc& range,
         const TFileScanRangeParams* range_params)
         : JniReader(
-                  file_slot_descs, state, profile,
-                  "org/apache/doris/iceberg/IcebergSysTableJniScanner",
+                  file_slot_descs, state, profile, get_java_scanner_class(range),
                   [&]() {
                       std::vector<std::string> required_fields;
                       std::vector<std::string> required_types;
@@ -81,6 +84,15 @@ IcebergSysTableJniReader::IcebergSysTableJniReader(
                   }(),
                   range.__isset.self_split_weight ? range.self_split_weight : -1),
           _init_status(validate_scan_range(range)) {}
+
+std::string IcebergSysTableJniReader::get_java_scanner_class(const TFileRangeDesc& range) {
+    DCHECK(range.__isset.table_format_params);
+    if (range.table_format_params.__isset.iceberg_params &&
+        range.table_format_params.iceberg_params.is_metadata_planning) {
+        return ICEBERG_METADATA_PLANNING_SCANNER;
+    }
+    return ICEBERG_SYS_TABLE_SCANNER;
+}
 
 Status IcebergSysTableJniReader::init_reader() {
     RETURN_IF_ERROR(_init_status);

--- a/be/src/format/table/iceberg_sys_table_jni_reader.h
+++ b/be/src/format/table/iceberg_sys_table_jni_reader.h
@@ -56,6 +56,7 @@ protected:
     Status _do_init_reader(ReaderInitContext* /*ctx*/) override { return init_reader(); }
 
 private:
+    static std::string get_java_scanner_class(const TFileRangeDesc& range);
     Status _init_status;
 };
 

--- a/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergMetadataPlanningJniScanner.java
+++ b/fe/be-java-extensions/iceberg-metadata-scanner/src/main/java/org/apache/doris/iceberg/IcebergMetadataPlanningJniScanner.java
@@ -1,0 +1,352 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.iceberg;
+
+import org.apache.doris.common.classloader.ThreadClassLoaderContext;
+import org.apache.doris.common.jni.JniScanner;
+import org.apache.doris.common.jni.vec.ColumnType;
+import org.apache.doris.common.jni.vec.ColumnValue;
+import org.apache.doris.common.security.authentication.PreExecutionAuthenticator;
+import org.apache.doris.common.security.authentication.PreExecutionAuthenticatorCache;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.util.SerializationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * JniScanner for Doris internal iceberg metadata planning system table.
+ *
+ * <p>The scanner consumes FE-sharded manifest paths and emits file-level metadata
+ * rows that FE will later convert into scan tasks / splits.
+ */
+public class IcebergMetadataPlanningJniScanner extends JniScanner {
+    private static final Logger LOG = LoggerFactory.getLogger(IcebergMetadataPlanningJniScanner.class);
+    private static final String HADOOP_OPTION_PREFIX = "hadoop.";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private static final String COL_CONTENT = "content";
+    private static final String COL_FILE_PATH = "file_path";
+    private static final String COL_FILE_FORMAT = "file_format";
+    private static final String COL_SPEC_ID = "spec_id";
+    private static final String COL_PARTITION_DATA = "partition_data";
+    private static final String COL_RECORD_COUNT = "record_count";
+    private static final String COL_FILE_SIZE = "file_size_in_bytes";
+    private static final String COL_SPLIT_OFFSETS = "split_offsets";
+    private static final String COL_FIRST_ROW_ID = "first_row_id";
+    private static final String COL_FILE_SEQUENCE_NUMBER = "file_sequence_number";
+    private static final String COL_PREDICATE = "predicate";
+
+    private final ClassLoader classLoader;
+    private final PreExecutionAuthenticator preExecutionAuthenticator;
+    private final String timezone;
+    private final PlanningScanInput scanInput;
+    private final Table table;
+    private final Expression predicate;
+    private Iterator<ContentFile<?>> reader = Collections.emptyIterator();
+    private List<CloseableIterable<? extends ContentFile<?>>> readers = Collections.emptyList();
+    private List<CloseableIterator<? extends ContentFile<?>>> iterators = Collections.emptyList();
+
+    public IcebergMetadataPlanningJniScanner(int batchSize, Map<String, String> params) {
+        this.classLoader = this.getClass().getClassLoader();
+        String serializedSplitParams = params.get("serialized_split");
+        Preconditions.checkArgument(serializedSplitParams != null && !serializedSplitParams.isEmpty(),
+                "serialized_split should not be empty");
+        this.scanInput = parseScanInput(serializedSplitParams);
+        Preconditions.checkArgument(scanInput.snapshotId > 0, "snapshotId should be positive");
+        Preconditions.checkArgument(scanInput.serializedTable != null && !scanInput.serializedTable.isEmpty(),
+                "serializedTable should not be empty");
+        Preconditions.checkArgument(scanInput.serializedPredicate != null
+                        && !scanInput.serializedPredicate.isEmpty(),
+                "serializedPredicate should not be empty");
+        Preconditions.checkArgument(scanInput.serializedManifests != null && !scanInput.serializedManifests.isEmpty(),
+                "serializedManifests should not be empty");
+        this.table = SerializationUtil.deserializeFromBase64(scanInput.serializedTable);
+        this.predicate = SerializationUtil.deserializeFromBase64(scanInput.serializedPredicate);
+        this.timezone = params.getOrDefault("time_zone", TimeZone.getDefault().getID());
+        Map<String, String> hadoopOptionParams = new HashMap<>();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (entry.getKey().startsWith(HADOOP_OPTION_PREFIX)) {
+                hadoopOptionParams.put(entry.getKey().substring(HADOOP_OPTION_PREFIX.length()),
+                        entry.getValue());
+            }
+        }
+        this.preExecutionAuthenticator = PreExecutionAuthenticatorCache.getAuthenticator(hadoopOptionParams);
+        String[] requiredFields = params.get("required_fields").split(",");
+        ColumnType[] requiredTypes = parseRequiredTypes(params.get("required_types").split("#"), requiredFields);
+        initTableInfo(requiredTypes, requiredFields, batchSize);
+    }
+
+    @Override
+    public void open() throws IOException {
+        try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+            preExecutionAuthenticator.execute(() -> {
+                initReader();
+                return null;
+            });
+        } catch (Exception e) {
+            close();
+            throw new IOException("Failed to open Iceberg metadata planning scanner", e);
+        }
+    }
+
+    @Override
+    protected int getNext() throws IOException {
+        try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+            int rows = 0;
+            while (rows < getBatchSize() && reader.hasNext()) {
+                ContentFile<?> file = reader.next();
+                for (int i = 0; i < fields.length; i++) {
+                    Object fieldData = getFieldValue(fields[i], file);
+                    ColumnValue fieldValue = fieldData == null ? null
+                            : new IcebergSysTableColumnValue(fieldData, timezone);
+                    appendData(i, fieldValue);
+                }
+                rows++;
+            }
+            return rows;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+            IOException closeException = null;
+            for (CloseableIterator<? extends ContentFile<?>> iterator : iterators) {
+                try {
+                    iterator.close();
+                } catch (IOException e) {
+                    if (closeException == null) {
+                        closeException = e;
+                    }
+                }
+            }
+            iterators = Collections.emptyList();
+            for (CloseableIterable<? extends ContentFile<?>> closeable : readers) {
+                try {
+                    closeable.close();
+                } catch (IOException e) {
+                    if (closeException == null) {
+                        closeException = e;
+                    }
+                }
+            }
+            readers = Collections.emptyList();
+            reader = Collections.emptyIterator();
+            if (closeException != null) {
+                throw closeException;
+            }
+        }
+    }
+
+    private void initReader() {
+        Snapshot snapshot = table.snapshot(scanInput.snapshotId);
+        Preconditions.checkState(snapshot != null, "Snapshot %s not found for metadata planning",
+                scanInput.snapshotId);
+        Map<Integer, PartitionSpec> specs = table.specs();
+        List<CloseableIterable<? extends ContentFile<?>>> planningReaders = new ArrayList<>();
+        for (String serializedManifest : scanInput.serializedManifests) {
+            // FE already prunes the candidate manifests for this task. We decode those ManifestFile
+            // descriptors directly here so the scanner does not re-scan the entire snapshot manifest list
+            // just to recover path -> ManifestFile for each task.
+            ManifestFile manifest = decodeManifest(serializedManifest);
+            if (manifest.content() == ManifestContent.DATA) {
+                planningReaders.add(ManifestFiles.read(manifest, table.io(), specs)
+                        .filterRows(predicate)
+                        .caseSensitive(false));
+            }
+        }
+        this.readers = planningReaders;
+        this.reader = flatten(planningReaders);
+    }
+
+    private ManifestFile decodeManifest(String serializedManifest) {
+        try {
+            return ManifestFiles.decode(Base64.getDecoder().decode(serializedManifest));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to decode metadata planning manifest payload", e);
+        }
+    }
+
+    private Object getFieldValue(String columnName, ContentFile<?> file) {
+        switch (columnName) {
+            case COL_CONTENT:
+                return file.content().id();
+            case COL_FILE_PATH:
+                return file.path().toString();
+            case COL_FILE_FORMAT:
+                return file.format().toString();
+            case COL_SPEC_ID:
+                return file.specId();
+            case COL_PARTITION_DATA:
+                return getPartitionDataJson(file);
+            case COL_RECORD_COUNT:
+                return file.recordCount();
+            case COL_FILE_SIZE:
+                return file.fileSizeInBytes();
+            case COL_SPLIT_OFFSETS:
+                return file.splitOffsets();
+            case COL_FIRST_ROW_ID:
+                return file.firstRowId();
+            case COL_FILE_SEQUENCE_NUMBER:
+                return file.fileSequenceNumber();
+            case COL_PREDICATE:
+                return scanInput.serializedPredicate;
+            default:
+                throw new IllegalArgumentException("Unsupported metadata planning column: " + columnName);
+        }
+    }
+
+    private String getPartitionDataJson(ContentFile<?> file) {
+        PartitionSpec spec = table.specs().get(file.specId());
+        if (spec == null || spec.fields().isEmpty()) {
+            return null;
+        }
+        org.apache.iceberg.StructLike partition = file.partition();
+        List<NestedField> fields = spec.partitionType().asNestedType().fields();
+        Class<?>[] classes = spec.javaClasses();
+        Preconditions.checkState(fields.size() == spec.fields().size(),
+                "Partition fields size does not match partition spec fields size");
+        List<String> values = new ArrayList<>(fields.size());
+        for (int i = 0; i < fields.size(); i++) {
+            values.add(serializePartitionValue(fields.get(i).type(), partition.get(i, classes[i])));
+        }
+        return serializePartitionData(values);
+    }
+
+    private String serializePartitionData(List<String> values) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(values);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize partition data", e);
+        }
+    }
+
+    private String serializePartitionValue(org.apache.iceberg.types.Type type, Object value) {
+        switch (type.typeId()) {
+            case BOOLEAN:
+            case INTEGER:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+            case STRING:
+            case UUID:
+            case DECIMAL:
+                return value == null ? null : value.toString();
+            case DATE:
+                return value == null ? null : LocalDate.ofEpochDay((Integer) value)
+                        .format(DateTimeFormatter.ISO_LOCAL_DATE);
+            case TIME:
+                return value == null ? null : LocalTime.ofNanoOfDay(((Long) value) * 1000)
+                        .format(DateTimeFormatter.ISO_LOCAL_TIME);
+            case TIMESTAMP:
+                // Store the raw epoch-microseconds value as a plain numeric string to avoid
+                // any timezone-conversion round-trip loss between the BE JNI scanner and the
+                // FE DistributedPlanningSplitProducer. FE restores the Long directly without
+                // interpreting the string as a human-readable datetime.
+                return value == null ? null : value.toString();
+            default:
+                throw new UnsupportedOperationException("Unsupported partition type: " + type);
+        }
+    }
+
+    private Iterator<ContentFile<?>> flatten(List<CloseableIterable<? extends ContentFile<?>>> readers) {
+        List<CloseableIterator<? extends ContentFile<?>>> openedIterators = new ArrayList<>(readers.size());
+        for (CloseableIterable<? extends ContentFile<?>> iterable : readers) {
+            openedIterators.add(iterable.iterator());
+        }
+        this.iterators = openedIterators;
+        return new Iterator<ContentFile<?>>() {
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                while (index < openedIterators.size()) {
+                    if (openedIterators.get(index).hasNext()) {
+                        return true;
+                    }
+                    index++;
+                }
+                return false;
+            }
+
+            @Override
+            public ContentFile<?> next() {
+                if (!hasNext()) {
+                    throw new java.util.NoSuchElementException();
+                }
+                return openedIterators.get(index).next();
+            }
+        };
+    }
+
+    private static PlanningScanInput parseScanInput(String serializedSplitParams) {
+        try {
+            return OBJECT_MAPPER.readValue(serializedSplitParams, PlanningScanInput.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to parse metadata planning split payload", e);
+        }
+    }
+
+    private static ColumnType[] parseRequiredTypes(String[] typeStrings, String[] requiredFields) {
+        ColumnType[] requiredTypes = new ColumnType[typeStrings.length];
+        for (int i = 0; i < typeStrings.length; i++) {
+            String type = typeStrings[i];
+            ColumnType parsedType = ColumnType.parseType(requiredFields[i], type);
+            if (parsedType.isUnsupported()) {
+                throw new IllegalArgumentException("Unsupported type " + type + " for field " + requiredFields[i]);
+            }
+            requiredTypes[i] = parsedType;
+        }
+        return requiredTypes;
+    }
+
+    private static class PlanningScanInput {
+        public long snapshotId;
+        public String serializedTable;
+        public String serializedPredicate;
+        public List<String> serializedManifests = Collections.emptyList();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -21,6 +21,12 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.SafeStringBuilder;
+import org.apache.doris.nereids.trees.plans.distribute.DistributedPlan;
+import org.apache.doris.nereids.trees.plans.distribute.PipelineDistributedPlan;
+import org.apache.doris.nereids.trees.plans.distribute.worker.DistributedPlanWorker;
+import org.apache.doris.nereids.trees.plans.distribute.worker.job.AssignedJob;
+import org.apache.doris.nereids.trees.plans.distribute.worker.job.LocalShuffleAssignedJob;
+import org.apache.doris.nereids.trees.plans.distribute.worker.job.LocalShuffleBucketJoinAssignedJob;
 import org.apache.doris.planner.PlanFragmentId;
 import org.apache.doris.thrift.TDetailedReportParams;
 import org.apache.doris.thrift.TNetworkAddress;
@@ -29,12 +35,14 @@ import org.apache.doris.thrift.TRuntimeProfileTree;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TUniqueId;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -68,6 +76,7 @@ public class ExecutionProfile {
     private Map<Integer, RuntimeProfile> fragmentProfiles;
     // Profile for load channels. Only for load job.
     private RuntimeProfile loadChannelProfile;
+    private RuntimeProfile distributedPlanProfile;
 
     // use to merge profile from multi be
     private Map<Integer, Map<TNetworkAddress, List<RuntimeProfile>>> multiBeProfile = null;
@@ -102,6 +111,100 @@ public class ExecutionProfile {
         }
         loadChannelProfile = new RuntimeProfile("LoadChannels");
         root.addChild(loadChannelProfile, true);
+    }
+
+    public synchronized void setDistributedPlans(Collection<? extends DistributedPlan> distributedPlans) {
+        if (distributedPlans == null || distributedPlans.isEmpty()) {
+            return;
+        }
+        if (distributedPlanProfile != null) {
+            return;
+        }
+
+        Map<Integer, DistributedPlan> fragmentIdToPlan = Maps.newLinkedHashMap();
+        for (DistributedPlan distributedPlan : distributedPlans) {
+            int fragmentId = distributedPlan.getFragmentJob().getFragment().getFragmentId().asInt();
+            fragmentIdToPlan.put(fragmentId, distributedPlan);
+        }
+
+        RuntimeProfile planProfile = new RuntimeProfile("DistributedPlan");
+        for (int i = 0; i < fragmentProfiles.size(); ++i) {
+            int fragmentId = seqNoToFragmentId.get(i);
+            DistributedPlan distributedPlan = fragmentIdToPlan.get(fragmentId);
+            if (distributedPlan == null) {
+                continue;
+            }
+            Preconditions.checkState(distributedPlan instanceof PipelineDistributedPlan,
+                    "Unsupported distributed plan type: %s", distributedPlan.getClass().getName());
+            planProfile.addChild(
+                    buildFragmentDistributedPlanProfile(i, (PipelineDistributedPlan) distributedPlan), true);
+        }
+
+        distributedPlanProfile = planProfile;
+        root.addChild(distributedPlanProfile, true);
+    }
+
+    private RuntimeProfile buildFragmentDistributedPlanProfile(
+            int displayFragmentId, PipelineDistributedPlan distributedPlan) {
+        RuntimeProfile fragmentProfile = new RuntimeProfile("Fragment " + displayFragmentId);
+        fragmentProfile.addInfoString("FragmentId",
+                String.valueOf(distributedPlan.getFragmentJob().getFragment().getFragmentId().asInt()));
+        fragmentProfile.addInfoString("FragmentJob", distributedPlan.getFragmentJob().getClass().getSimpleName());
+        fragmentProfile.addInfoString("Parallel", String.valueOf(distributedPlan.getInstanceJobs().size()));
+
+        if (!distributedPlan.getDestinations().isEmpty()) {
+            RuntimeProfile destinationsProfile = new RuntimeProfile("Destinations");
+            for (Entry<org.apache.doris.planner.DataSink, List<AssignedJob>> destinationEntry
+                    : distributedPlan.getDestinations().entrySet()) {
+                RuntimeProfile destinationProfile = new RuntimeProfile(
+                        "Exchange " + destinationEntry.getKey().getExchNodeId().asInt());
+                StringBuilder destinationInstances = new StringBuilder();
+                List<AssignedJob> destinations = destinationEntry.getValue();
+                for (int i = 0; i < destinations.size(); ++i) {
+                    if (i > 0) {
+                        destinationInstances.append(", ");
+                    }
+                    destinationInstances.append(DebugUtil.printId(destinations.get(i).instanceId()));
+                }
+                destinationProfile.addInfoString("DestinationInstances", destinationInstances.toString());
+                destinationsProfile.addChild(destinationProfile, true);
+            }
+            fragmentProfile.addChild(destinationsProfile, true);
+        }
+
+        RuntimeProfile instancesProfile = new RuntimeProfile("Instances");
+        for (AssignedJob instanceJob : distributedPlan.getInstanceJobs()) {
+            instancesProfile.addChild(buildInstanceDistributedPlanProfile(instanceJob), true);
+        }
+        fragmentProfile.addChild(instancesProfile, true);
+        return fragmentProfile;
+    }
+
+    private RuntimeProfile buildInstanceDistributedPlanProfile(AssignedJob instanceJob) {
+        RuntimeProfile instanceProfile = new RuntimeProfile("Instance " + instanceJob.indexInUnassignedJob());
+        DistributedPlanWorker worker = instanceJob.getAssignedWorker();
+        instanceProfile.addInfoString("InstanceId", DebugUtil.printId(instanceJob.instanceId()));
+        instanceProfile.addInfoString("Worker", worker.id() + "@" + worker.address());
+        instanceProfile.addInfoString("JobType", instanceJob.getClass().getSimpleName());
+        instanceProfile.addInfoString("ScanSource", instanceJob.getScanSource().getClass().getSimpleName());
+        if (instanceJob instanceof LocalShuffleAssignedJob) {
+            instanceProfile.addInfoString("ShareScanIndex",
+                    String.valueOf(((LocalShuffleAssignedJob) instanceJob).shareScanId));
+        }
+        if (instanceJob instanceof LocalShuffleBucketJoinAssignedJob) {
+            StringBuilder bucketIndexes = new StringBuilder();
+            int index = 0;
+            for (Integer bucketIndex
+                    : ((LocalShuffleBucketJoinAssignedJob) instanceJob).getAssignedJoinBucketIndexes()) {
+                if (index++ > 0) {
+                    bucketIndexes.append(", ");
+                }
+                bucketIndexes.append(bucketIndex);
+            }
+            instanceProfile.addInfoString("AssignedJoinBuckets",
+                    bucketIndexes.toString());
+        }
+        return instanceProfile;
     }
 
     private List<List<RuntimeProfile>> getMultiBeProfile(int fragmentId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalTable.java
@@ -328,6 +328,9 @@ public class IcebergExternalTable extends ExternalTable implements MTMVRelatedTa
         if (IcebergSysTable.POSITION_DELETES.equals(sysTableName)) {
             return Optional.of(IcebergSysTable.UNSUPPORTED_POSITION_DELETES_TABLE);
         }
+        if (IcebergSysTable.METADATA_PLANNING.equals(sysTableName)) {
+            return Optional.of(IcebergSysTable.INTERNAL_METADATA_PLANNING_TABLE);
+        }
         return Optional.empty();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataPlanningExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataPlanningExternalTable.java
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg;
+
+import org.apache.doris.catalog.ArrayType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.datasource.SchemaCacheKey;
+import org.apache.doris.datasource.SchemaCacheValue;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.Table;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Internal-only logical Iceberg metadata planning table.
+ *
+ * <p>This table is not backed by an Iceberg native metadata table type. It uses
+ * the system-table framework only as the entry point for Doris internal planning
+ * queries, and exposes a file-level metadata row schema for later BE/JNI planning.
+ */
+public class IcebergMetadataPlanningExternalTable extends IcebergSysExternalTable {
+    public static final String CONTROL_PREDICATE_COLUMN = "predicate";
+    private static final List<Column> RESULT_SCHEMA = ImmutableList.of(
+            new Column("content", Type.INT, true),
+            new Column("file_path", ScalarType.createStringType(), true),
+            new Column("file_format", ScalarType.createStringType(), true),
+            new Column("spec_id", Type.INT, true),
+            new Column("partition_data", ScalarType.createStringType(), true),
+            new Column("record_count", Type.BIGINT, true),
+            new Column("file_size_in_bytes", Type.BIGINT, true),
+            new Column("split_offsets", ArrayType.create(Type.BIGINT, true), true),
+            new Column("first_row_id", Type.BIGINT, true),
+            new Column("file_sequence_number", Type.BIGINT, true)
+    );
+    private static final List<Column> FULL_SCHEMA = ImmutableList.<Column>builder()
+            .addAll(RESULT_SCHEMA)
+            .add(new Column(CONTROL_PREDICATE_COLUMN, ScalarType.createStringType(), true))
+            .build();
+    public static final List<String> OUTPUT_COLUMN_NAMES = RESULT_SCHEMA.stream()
+            .map(Column::getName)
+            .collect(Collectors.toList());
+
+    private final SchemaCacheValue schemaCacheValue = new SchemaCacheValue(FULL_SCHEMA);
+
+    public IcebergMetadataPlanningExternalTable(IcebergExternalTable sourceTable, String sysTableType) {
+        super(sourceTable, sysTableType);
+    }
+
+    @Override
+    public Table getSysIcebergTable() {
+        return getSourceTable().getIcebergTable();
+    }
+
+    @Override
+    public List<Column> getFullSchema() {
+        return FULL_SCHEMA;
+    }
+
+    @Override
+    public Optional<SchemaCacheValue> initSchema(SchemaCacheKey key) {
+        return Optional.of(schemaCacheValue);
+    }
+
+    @Override
+    public Optional<SchemaCacheValue> getSchemaCacheValue() {
+        return Optional.of(schemaCacheValue);
+    }
+
+    @Override
+    public String getComment() {
+        return "Iceberg internal metadata planning table for " + getSourceTable().getName();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -744,6 +744,21 @@ public class IcebergUtils {
         }
     }
 
+    public static PartitionData parsePartitionDataJson(String partitionDataJson, PartitionSpec spec) {
+        PartitionData partitionData = new PartitionData(spec.partitionType());
+        if (StringUtils.isBlank(partitionDataJson)) {
+            return partitionData;
+        }
+        List<String> partitionValues = parsePartitionValuesFromJson(partitionDataJson);
+        List<NestedField> fields = spec.partitionType().asNestedType().fields();
+        Preconditions.checkArgument(partitionValues.size() == fields.size(),
+                "Partition values size does not match partition spec fields size");
+        for (int i = 0; i < partitionValues.size(); i++) {
+            partitionData.set(i, parsePartitionValueFromString(partitionValues.get(i), fields.get(i).type()));
+        }
+        return partitionData;
+    }
+
     private static String serializePartitionValue(org.apache.iceberg.types.Type type, Object value, String timeZone) {
         switch (type.typeId()) {
             case BOOLEAN:
@@ -914,7 +929,15 @@ public class IcebergUtils {
                     // Parse date string (format: yyyy-MM-dd) to epoch day
                     return (int) LocalDate.parse(valueStr, DateTimeFormatter.ISO_LOCAL_DATE).toEpochDay();
                 case TIMESTAMP:
-                    return parseTimestampToMicros(valueStr, (TimestampType) icebergType);
+                    // The distributed metadata planning path serializes TIMESTAMP partition values
+                    // as raw epoch-microseconds strings to avoid cross-node timezone conversion
+                    // loss. Detect and restore such values directly; fall back to human-readable
+                    // datetime parsing for all other callers.
+                    try {
+                        return Long.parseLong(valueStr);
+                    } catch (NumberFormatException ignored) {
+                        return parseTimestampToMicros(valueStr, (TimestampType) icebergType);
+                    }
                 case DECIMAL:
                     return new BigDecimal(valueStr);
                 default:

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/DistributedPlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/DistributedPlanningSplitProducer.java
@@ -1,0 +1,459 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.iceberg.IcebergMetadataPlanningExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergUtils;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.qe.AutoCloseConnectContext;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.OriginStatement;
+import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.statistics.ResultRow;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.gson.reflect.TypeToken;
+import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.util.SerializationUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * FE-side distributed planning producer.
+ *
+ * <p>The producer queries the logical system table {@code tbl$metadata_planning},
+ * reconstructs file scan tasks from the result rows, and then reuses the normal
+ * {@code FileScanTask -> IcebergSplit} path in {@link IcebergScanNode}.
+ */
+public class DistributedPlanningSplitProducer implements PlanningSplitProducer {
+    private static final Logger LOG = LogManager.getLogger(DistributedPlanningSplitProducer.class);
+    private static final Type LONG_LIST_TYPE = new TypeToken<List<Long>>() { }.getType();
+    // Pre-built index map for O(1) column lookup; avoids O(n) linear search per field per row.
+    private static final Map<String, Integer> COL_INDEX;
+
+    static {
+        COL_INDEX = new HashMap<>();
+        List<String> cols = IcebergMetadataPlanningExternalTable.OUTPUT_COLUMN_NAMES;
+        for (int i = 0; i < cols.size(); i++) {
+            COL_INDEX.put(cols.get(i).toLowerCase(), i);
+        }
+    }
+
+    private final PlanningSplitProducer.Context context;
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private final AtomicReference<CompletableFuture<Void>> runningTask = new AtomicReference<>();
+
+    public DistributedPlanningSplitProducer(PlanningSplitProducer.Context context) {
+        this.context = Preconditions.checkNotNull(context, "planning context is null");
+    }
+
+    @Override
+    public void start(int numBackends, SplitSink sink) throws UserException {
+        stopped.set(false);
+        String planningQuerySql;
+        ConnectContext parentContext;
+        try {
+            TableScan scan = context.getExecutionAuthenticator().execute(new Callable<TableScan>() {
+                @Override
+                public TableScan call() throws Exception {
+                    return context.createTableScan();
+                }
+            });
+            planningQuerySql = buildMetadataPlanningQuerySql(scan);
+            parentContext = capturePlanningParentContext();
+        } catch (Exception e) {
+            Optional<NotSupportedException> opt = context.checkNotSupportedException(e);
+            if (opt.isPresent()) {
+                throw new UserException(opt.get().getMessage(), opt.get());
+            } else if (e instanceof UserException) {
+                throw (UserException) e;
+            }
+            throw new UserException(e.getMessage(), e);
+        }
+        final String sql = planningQuerySql;
+        final ConnectContext planningParentContext = parentContext;
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+            try {
+                context.getExecutionAuthenticator().execute(() -> {
+                    ConnectContext queryContext = createPlanningQueryContext(planningParentContext, sql);
+                    try (AutoCloseConnectContext ignored = new AutoCloseConnectContext(queryContext);
+                            StmtExecutor.ResultRowBatchIterator resultBatches =
+                                    createPlanningQueryIterator(queryContext, sql)) {
+                        while (!stopped.get() && sink.needMore()) {
+                            List<ResultRow> batchRows = resultBatches.getNextBatch();
+                            if (batchRows == null) {
+                                break;
+                            }
+                            List<FileScanTask> planningTasks = new ArrayList<>(batchRows.size());
+                            for (ResultRow row : batchRows) {
+                                if (stopped.get() || !sink.needMore()) {
+                                    break;
+                                }
+                                planningTasks.add(createPlanningTask(row));
+                            }
+                            try (CloseableIterable<FileScanTask> splitTasks =
+                                         context.splitPlanningTasks(planningTasks)) {
+                                CloseableIterator<FileScanTask> iterator = splitTasks.iterator();
+                                while (!stopped.get() && sink.needMore() && iterator.hasNext()) {
+                                    sink.addBatch(Lists.newArrayList(context.createPlanningSplit(iterator.next())));
+                                }
+                            }
+                        }
+                    }
+                    return null;
+                });
+                if (!stopped.get()) {
+                    sink.finish();
+                    LOG.info("Iceberg distributed metadata planning executed query [{}] "
+                            + "and converted rows to split tasks", sql);
+                }
+            } catch (Exception e) {
+                if (stopped.get()) {
+                    LOG.debug("Iceberg distributed metadata planning is stopped");
+                    return;
+                }
+                Optional<NotSupportedException> opt = context.checkNotSupportedException(e);
+                if (opt.isPresent()) {
+                    sink.fail(new UserException(opt.get().getMessage(), opt.get()));
+                } else if (e instanceof UserException) {
+                    sink.fail((UserException) e);
+                } else {
+                    LOG.warn("Unexpected error during iceberg distributed metadata planning", e);
+                    sink.fail(new UserException(e.getMessage(), e));
+                }
+            }
+        }, context.getScheduleExecutor());
+        runningTask.set(future);
+    }
+
+    @Override
+    public void stop() {
+        if (!stopped.compareAndSet(false, true)) {
+            return;
+        }
+        CompletableFuture<Void> task = runningTask.get();
+        if (task != null) {
+            task.cancel(true);
+        }
+    }
+
+    private String buildMetadataPlanningQuerySql(TableScan scan) {
+        List<String> qualifier = context.getSourceTableQualifier();
+        String qualifiedTable = quoteIdentifier(qualifier.get(0))
+                + "." + quoteIdentifier(qualifier.get(1))
+                + "." + quoteIdentifier(qualifier.get(2)
+                + "$" + org.apache.doris.datasource.systable.IcebergSysTable.METADATA_PLANNING);
+        String projection = String.join(", ", IcebergMetadataPlanningExternalTable.OUTPUT_COLUMN_NAMES);
+        long snapshotId = Preconditions.checkNotNull(scan.snapshot(),
+                "Iceberg distributed planning snapshot is null").snapshotId();
+        String serializedPredicate = SerializationUtil.serializeToBase64(scan.filter());
+        return "SELECT " + projection + " FROM " + qualifiedTable
+                + " FOR VERSION AS OF " + snapshotId
+                + " WHERE " + quoteIdentifier(IcebergMetadataPlanningExternalTable.CONTROL_PREDICATE_COLUMN)
+                + " = " + quoteStringLiteral(serializedPredicate);
+    }
+
+    private ConnectContext capturePlanningParentContext() {
+        ConnectContext parentContext = Preconditions.checkNotNull(ConnectContext.get(), "ConnectContext is null");
+        ConnectContext contextSnapshot = parentContext.cloneContext();
+        contextSnapshot.setSessionVariable(VariableMgr.cloneSessionVariable(parentContext.getSessionVariable()));
+        contextSnapshot.setRemoteIP(parentContext.getRemoteIP());
+        return contextSnapshot;
+    }
+
+    private ConnectContext createPlanningQueryContext(ConnectContext parentContext, String planningQuerySql) {
+        ConnectContext queryContext = parentContext.cloneContext();
+        queryContext.setSessionVariable(VariableMgr.cloneSessionVariable(parentContext.getSessionVariable()));
+        queryContext.setRemoteIP(parentContext.getRemoteIP());
+        queryContext.resetQueryId();
+        queryContext.setStartTime();
+        StatementContext statementContext = new StatementContext(queryContext,
+                new OriginStatement(planningQuerySql, 0));
+        queryContext.setStatementContext(statementContext);
+        return queryContext;
+    }
+
+    private StmtExecutor.ResultRowBatchIterator createPlanningQueryIterator(
+            ConnectContext queryContext, String planningQuerySql) {
+        LogicalPlan logicalPlan = new NereidsParser().parseSingle(planningQuerySql);
+        LogicalPlanAdapter parsedStmt = new LogicalPlanAdapter(logicalPlan, queryContext.getStatementContext());
+        parsedStmt.setOrigStmt(new OriginStatement(planningQuerySql, 0));
+        StmtExecutor stmtExecutor = new StmtExecutor(queryContext, parsedStmt);
+        return stmtExecutor.executeInternalQueryLazy();
+    }
+
+    private FileScanTask createPlanningTask(ResultRow row) throws UserException {
+        int content = parseRequiredIntField(row, "content");
+        Preconditions.checkState(content == ManifestContent.DATA.id(),
+                "Only data file planning rows are supported, but got content %s", content);
+        int specId = parseRequiredIntField(row, "spec_id");
+        PartitionSpec partitionSpec = context.getPlanningPartitionSpec(specId);
+        Preconditions.checkNotNull(partitionSpec, "Partition spec with specId %s not found", specId);
+        DataFile dataFile = createPlanningDataFile(row, partitionSpec);
+        return new BaseFileScanTask(
+                dataFile,
+                new DeleteFile[0],
+                context.getPlanningTableSchemaJson(),
+                PartitionSpecParser.toJson(partitionSpec),
+                ResidualEvaluator.of(partitionSpec, Expressions.alwaysTrue(), true));
+    }
+
+    private DataFile createPlanningDataFile(ResultRow row, PartitionSpec partitionSpec) {
+        String originalPath = getRequiredStringField(row, "file_path");
+        long fileSizeInBytes = parseRequiredLongField(row, "file_size_in_bytes");
+        long recordCount = parseRequiredLongField(row, "record_count");
+        String fileFormat = getRequiredStringField(row, "file_format");
+        String partitionDataJson = getOptionalStringField(row, "partition_data");
+        List<Long> splitOffsets = parseSplitOffsets(getOptionalStringField(row, "split_offsets"));
+        Long firstRowId = parseOptionalLongField(row, "first_row_id");
+        Long fileSequenceNumber = parseOptionalLongField(row, "file_sequence_number");
+
+        DataFiles.Builder builder = DataFiles.builder(partitionSpec)
+                .withPath(originalPath)
+                .withFileSizeInBytes(fileSizeInBytes)
+                .withRecordCount(recordCount)
+                .withFormat(FileFormat.fromString(fileFormat))
+                .withSplitOffsets(splitOffsets)
+                .withFirstRowId(firstRowId);
+        if (partitionDataJson != null) {
+            builder.withPartition(IcebergUtils.parsePartitionDataJson(partitionDataJson, partitionSpec));
+        }
+        return new PlanningDataFile(builder.build(), fileSequenceNumber);
+    }
+
+    private static int getRequiredColumnIndex(String columnName) {
+        Integer index = COL_INDEX.get(columnName.toLowerCase());
+        if (index == null) {
+            throw new IllegalStateException("Required metadata planning column is missing: " + columnName);
+        }
+        return index;
+    }
+
+    private String getRequiredStringField(ResultRow row, String columnName) {
+        String value = row.get(getRequiredColumnIndex(columnName));
+        Preconditions.checkNotNull(value, "Metadata planning result column %s is null", columnName);
+        return value;
+    }
+
+    private String getOptionalStringField(ResultRow row, String columnName) {
+        return row.get(getRequiredColumnIndex(columnName));
+    }
+
+    private int parseRequiredIntField(ResultRow row, String columnName) {
+        return Integer.parseInt(getRequiredStringField(row, columnName));
+    }
+
+    private long parseRequiredLongField(ResultRow row, String columnName) {
+        return Long.parseLong(getRequiredStringField(row, columnName));
+    }
+
+    private Long parseOptionalLongField(ResultRow row, String columnName) {
+        String value = getOptionalStringField(row, columnName);
+        return value == null ? null : Long.valueOf(value);
+    }
+
+    private List<Long> parseSplitOffsets(String splitOffsets) {
+        if (splitOffsets == null || splitOffsets.isEmpty()) {
+            return Collections.emptyList();
+        }
+        try {
+            List<Long> offsets = org.apache.doris.persist.gson.GsonUtils.GSON.fromJson(splitOffsets, LONG_LIST_TYPE);
+            return offsets == null ? Collections.emptyList() : offsets;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse split offsets: " + splitOffsets, e);
+        }
+    }
+
+    private String quoteIdentifier(String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
+    }
+
+    private String quoteStringLiteral(String value) {
+        return "'" + value.replace("'", "''") + "'";
+    }
+
+    private static class PlanningDataFile implements DataFile {
+        private final DataFile delegate;
+        private final Long fileSequenceNumber;
+
+        private PlanningDataFile(DataFile delegate, Long fileSequenceNumber) {
+            this.delegate = delegate;
+            this.fileSequenceNumber = fileSequenceNumber;
+        }
+
+        @Override
+        public Long pos() {
+            return delegate.pos();
+        }
+
+        @Override
+        public int specId() {
+            return delegate.specId();
+        }
+
+        @Override
+        public FileContent content() {
+            return delegate.content();
+        }
+
+        @Override
+        public CharSequence path() {
+            return delegate.path();
+        }
+
+        @Override
+        public FileFormat format() {
+            return delegate.format();
+        }
+
+        @Override
+        public StructLike partition() {
+            return delegate.partition();
+        }
+
+        @Override
+        public long recordCount() {
+            return delegate.recordCount();
+        }
+
+        @Override
+        public long fileSizeInBytes() {
+            return delegate.fileSizeInBytes();
+        }
+
+        @Override
+        public Map<Integer, Long> columnSizes() {
+            return delegate.columnSizes();
+        }
+
+        @Override
+        public Map<Integer, Long> valueCounts() {
+            return delegate.valueCounts();
+        }
+
+        @Override
+        public Map<Integer, Long> nullValueCounts() {
+            return delegate.nullValueCounts();
+        }
+
+        @Override
+        public Map<Integer, Long> nanValueCounts() {
+            return delegate.nanValueCounts();
+        }
+
+        @Override
+        public Map<Integer, ByteBuffer> lowerBounds() {
+            return delegate.lowerBounds();
+        }
+
+        @Override
+        public Map<Integer, ByteBuffer> upperBounds() {
+            return delegate.upperBounds();
+        }
+
+        @Override
+        public ByteBuffer keyMetadata() {
+            return delegate.keyMetadata();
+        }
+
+        @Override
+        public List<Long> splitOffsets() {
+            return delegate.splitOffsets();
+        }
+
+        @Override
+        public List<Integer> equalityFieldIds() {
+            return delegate.equalityFieldIds();
+        }
+
+        @Override
+        public Integer sortOrderId() {
+            return delegate.sortOrderId();
+        }
+
+        @Override
+        public Long dataSequenceNumber() {
+            return delegate.dataSequenceNumber();
+        }
+
+        @Override
+        public Long fileSequenceNumber() {
+            // DataFiles.Builder can restore first_row_id, split_offsets and partition values, but it does not
+            // expose a setter for file_sequence_number. Keep a thin wrapper here so the distributed path can
+            // feed the same row-lineage metadata into IcebergScanNode#createIcebergSplit(FileScanTask) as the
+            // local planning path.
+            return fileSequenceNumber;
+        }
+
+        @Override
+        public Long firstRowId() {
+            return delegate.firstRowId();
+        }
+
+        @Override
+        public DataFile copy() {
+            return new PlanningDataFile(delegate.copy(), fileSequenceNumber);
+        }
+
+        @Override
+        public DataFile copyWithoutStats() {
+            return new PlanningDataFile(delegate.copyWithoutStats(), fileSequenceNumber);
+        }
+
+        @Override
+        public DataFile copyWithStats(Set<Integer> requestedColumnIds) {
+            return new PlanningDataFile(delegate.copyWithStats(requestedColumnIds), fileSequenceNumber);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergMetadataPlanningMode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergMetadataPlanningMode.java
@@ -1,0 +1,142 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import java.util.Arrays;
+
+/**
+ * FE-side mode switch for Iceberg metadata planning.
+ *
+ * <p>Each mode knows how to resolve itself to a concrete planning decision
+ * given a {@link PlanningInputs} snapshot of the current query context.
+ * The AUTO mode implements a threshold-based algorithm; the thresholds are
+ * internal constants that are not user-tunable.
+ */
+public enum IcebergMetadataPlanningMode {
+    LOCAL("local"),
+    DISTRIBUTED("distributed"),
+    AUTO("auto");
+
+    // ---- AUTO mode decision thresholds (not user-tunable) ----
+    // Minimum ratio of BE available planning slots to FE local parallelism.
+    // When R <= ALPHA * L the distributed path offers no meaningful parallelism advantage.
+    private static final double AUTO_ALPHA = 1.25;
+    // Minimum ratio of matching manifest count to FE local parallelism.
+    // When M <= BETA * L the local thread pool is not the bottleneck.
+    private static final int AUTO_BETA = 2;
+    // Maximum manifest bytes a single FE planning thread can handle without becoming a bottleneck.
+    // When total manifest bytes B <= L * SLOT_BYTES the local path is still efficient.
+    private static final long AUTO_SLOT_BYTES = 8L * 1024 * 1024; // 8 MB
+    // Upper bound on estimated scan tasks to be returned from distributed planning.
+    // When S >= this threshold the result serialization / network cost offsets the BE parallelism gain.
+    private static final long AUTO_RESULT_THRESHOLD = 1_000_000L;
+
+    private final String name;
+
+    IcebergMetadataPlanningMode(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static IcebergMetadataPlanningMode fromName(String name) {
+        return Arrays.stream(values())
+                .filter(mode -> mode.name.equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(LOCAL);
+    }
+
+    /**
+     * Resolves whether this mode should use distributed planning given the collected
+     * query-time inputs.
+     *
+     * <p>Callers should NOT invoke this for {@link #LOCAL}; it always returns {@code false}
+     * and the caller can short-circuit before collecting inputs.
+     *
+     * @param inputs lightweight manifest-list metadata collected without reading manifest files
+     * @return {@code true} if distributed planning should be used, {@code false} for local
+     */
+    public boolean resolveDistributed(PlanningInputs inputs) {
+        switch (this) {
+            case DISTRIBUTED:
+                // Hard gate: delete manifests require extra metadata that the distributed
+                // path does not currently support.
+                return !inputs.needStats;
+            case AUTO:
+                return resolveAuto(inputs);
+            default: // LOCAL
+                return false;
+        }
+    }
+
+    private boolean resolveAuto(PlanningInputs inputs) {
+        // need_stats: delete manifests require extra metadata; keep complexity local.
+        if (inputs.needStats) {
+            return false;
+        }
+        // R <= alpha * L: no meaningful BE parallelism advantage over local threads.
+        if (inputs.beSlots <= AUTO_ALPHA * inputs.feParallelism) {
+            return false;
+        }
+        // M <= beta * L: manifest count does not saturate the local thread pool.
+        if (inputs.manifestCount <= AUTO_BETA * inputs.feParallelism) {
+            return false;
+        }
+        // B <= L * slot_bytes: total manifest volume is within local capacity.
+        if (inputs.manifestBytes <= (long) inputs.feParallelism * AUTO_SLOT_BYTES) {
+            return false;
+        }
+        // S >= result_threshold: result serialization / network cost offsets the BE gain.
+        if (inputs.estimatedFiles >= AUTO_RESULT_THRESHOLD) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Lightweight inputs for the planning mode decision.
+     *
+     * <p>All fields are derived from manifest-list metadata without reading manifest files.
+     */
+    public static class PlanningInputs {
+        /** True when delete manifests are present; signals that extra metadata is needed. */
+        public final boolean needStats;
+        /** M: number of data manifests that pass partition/filter pruning. */
+        public final int manifestCount;
+        /** B: total byte size of matching data manifests. */
+        public final long manifestBytes;
+        /** S: estimated number of data files across all matching manifests. */
+        public final long estimatedFiles;
+        /** L: FE local planning parallelism (Iceberg catalog executor thread count). */
+        public final int feParallelism;
+        /** R: available BE planning slots (alive backend count). */
+        public final int beSlots;
+
+        public PlanningInputs(boolean needStats, int manifestCount, long manifestBytes,
+                long estimatedFiles, int feParallelism, int beSlots) {
+            this.needStats = needStats;
+            this.manifestCount = manifestCount;
+            this.manifestBytes = manifestBytes;
+            this.estimatedFiles = estimatedFiles;
+            this.feParallelism = feParallelism;
+            this.beSlots = beSlots;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergMetadataPlanningScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergMetadataPlanningScanNode.java
@@ -1,0 +1,256 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.analysis.BinaryPredicate;
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.TableFormatType;
+import org.apache.doris.datasource.iceberg.IcebergMetadataPlanningExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergUtils;
+import org.apache.doris.planner.PlanNodeId;
+import org.apache.doris.planner.ScanContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.spi.Split;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TFileRangeDesc;
+import org.apache.doris.thrift.TIcebergFileDesc;
+import org.apache.doris.thrift.TTableFormatFileDesc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.util.SerializationUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+/**
+ * Scan node for the Iceberg metadata planning system table ({@code tbl$metadata_planning}).
+ *
+ * <p>This node is used by the distributed Iceberg metadata planning path. It groups the
+ * matching data manifests from the current snapshot into per-BE shards using a weighted
+ * min-heap assignment, then emits one {@link IcebergSplit} per shard. Each split carries
+ * the serialized table, snapshot ID, predicate, and manifest list so that the BE-side
+ * {@code IcebergMetadataPlanningJniScanner} can scan only the assigned manifests and return
+ * file-level metadata rows back to FE for split construction.
+ */
+public class IcebergMetadataPlanningScanNode extends IcebergSysScanNode {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public IcebergMetadataPlanningScanNode(PlanNodeId id, TupleDescriptor desc, boolean needCheckColumnPriv,
+            SessionVariable sv, ScanContext scanContext) {
+        super(id, desc, needCheckColumnPriv, sv, scanContext);
+    }
+
+    @Override
+    protected void setScanParams(TFileRangeDesc rangeDesc, Split split) {
+        Preconditions.checkState(split instanceof IcebergSplit,
+                "Iceberg metadata planning split must be IcebergSplit, but got %s",
+                split == null ? "null" : split.getClass().getName());
+        IcebergSplit icebergSplit = (IcebergSplit) split;
+        TTableFormatFileDesc tableFormatFileDesc = new TTableFormatFileDesc();
+        tableFormatFileDesc.setTableFormatType(TableFormatType.ICEBERG.value());
+        tableFormatFileDesc.setTableLevelRowCount(-1);
+        TIcebergFileDesc fileDesc = new TIcebergFileDesc();
+        fileDesc.setSerializedSplit(icebergSplit.getSerializedSplit());
+        fileDesc.setIsMetadataPlanning(true);
+        tableFormatFileDesc.setIcebergParams(fileDesc);
+        rangeDesc.setFormatType(TFileFormatType.FORMAT_JNI);
+        rangeDesc.setTableFormatParams(tableFormatFileDesc);
+    }
+
+    @Override
+    public List<Split> getSplits(int numBackends) throws UserException {
+        return executeWithPreExecutionAuthenticator(() -> buildMetadataPlanningSystemTableSplits(numBackends));
+    }
+
+    @VisibleForTesting
+    List<Split> buildMetadataPlanningSystemTableSplits(int numBackends) throws UserException {
+        Snapshot snapshot = Preconditions.checkNotNull(createMetadataPlanningTableScan().snapshot(),
+                "Metadata planning snapshot is null");
+        String serializedPredicate = extractSerializedPredicate();
+        List<List<ManifestFile>> manifestGroups = buildPlanningTaskManifestGroups(snapshot,
+                SerializationUtil.deserializeFromBase64(serializedPredicate), numBackends);
+        List<Split> splits = new ArrayList<>();
+        String serializedTable = SerializationUtil.serializeToBase64(
+                SerializableTable.copyOf(getIcebergTableInstance()));
+        for (List<ManifestFile> manifestGroup : manifestGroups) {
+            splits.add(createMetadataPlanningSysSplit(snapshot.snapshotId(), serializedTable,
+                    serializedPredicate, manifestGroup));
+        }
+        selectedPartitionNum = 0;
+        return splits;
+    }
+
+    private TableScan createMetadataPlanningTableScan() throws UserException {
+        TableScan scan = getIcebergTableInstance().newScan();
+        IcebergTableQueryInfo info = getSpecifiedSnapshot();
+        if (info != null) {
+            if (info.getRef() != null) {
+                scan = scan.useRef(info.getRef());
+            } else {
+                scan = scan.useSnapshot(info.getSnapshotId());
+            }
+        }
+        return scan.planWith(getIcebergSource().getCatalog().getThreadPoolWithPreAuth());
+    }
+
+    private String extractSerializedPredicate() throws UserException {
+        for (Expr conjunct : conjuncts) {
+            if (!(conjunct instanceof BinaryPredicate)) {
+                continue;
+            }
+            BinaryPredicate predicate = (BinaryPredicate) conjunct;
+            if (predicate.getOp() != BinaryPredicate.Operator.EQ) {
+                continue;
+            }
+            String serializedPredicate = extractPredicateLiteral(predicate.getChild(0), predicate.getChild(1));
+            if (serializedPredicate != null) {
+                return serializedPredicate;
+            }
+            serializedPredicate = extractPredicateLiteral(predicate.getChild(1), predicate.getChild(0));
+            if (serializedPredicate != null) {
+                return serializedPredicate;
+            }
+        }
+        throw new UserException("Iceberg metadata planning query requires WHERE predicate = '<serialized_expr>'");
+    }
+
+    private String extractPredicateLiteral(Expr slotExpr, Expr literalExpr) {
+        SlotRef slotRef = slotExpr.unwrapSlotRef();
+        if (slotRef == null || literalExpr == null || !literalExpr.isLiteral()) {
+            return null;
+        }
+        String columnName = slotRef.getColumnName();
+        if (!IcebergMetadataPlanningExternalTable.CONTROL_PREDICATE_COLUMN.equalsIgnoreCase(columnName)) {
+            return null;
+        }
+        Preconditions.checkState(literalExpr instanceof LiteralExpr,
+                "Metadata planning predicate literal must be LiteralExpr");
+        String value = ((LiteralExpr) literalExpr).getStringValue();
+        Preconditions.checkState(value != null && !value.isEmpty(),
+                "Metadata planning predicate literal must not be empty");
+        return value;
+    }
+
+    private List<List<ManifestFile>> buildPlanningTaskManifestGroups(Snapshot snapshot,
+            org.apache.iceberg.expressions.Expression filterExpr, int numBackends) {
+        if (snapshot == null) {
+            return Collections.emptyList();
+        }
+        int shardCount = Math.max(1, numBackends);
+        List<List<ManifestFile>> shardManifests = new ArrayList<>(shardCount);
+        for (int i = 0; i < shardCount; i++) {
+            shardManifests.add(new ArrayList<>());
+        }
+        try (org.apache.iceberg.io.CloseableIterator<ManifestFile> matchingManifests = IcebergUtils.getMatchingManifest(
+                snapshot.dataManifests(getIcebergTableInstance().io()), getIcebergTableInstance().specs(),
+                filterExpr).iterator()) {
+            // Weighted greedy assignment: assign each manifest to the group with the current
+            // lowest estimated file count, so that BEs receive roughly equal scanning work
+            // even when individual manifests differ greatly in size.
+            PriorityQueue<long[]> heap = new PriorityQueue<>(shardCount,
+                    Comparator.comparingLong(a -> a[0])); // [0]=totalFileCount, [1]=groupIndex
+            for (int i = 0; i < shardCount; i++) {
+                heap.offer(new long[]{0L, i});
+            }
+            while (matchingManifests.hasNext()) {
+                ManifestFile manifest = matchingManifests.next();
+                long[] minGroup = heap.poll();
+                shardManifests.get((int) minGroup[1]).add(manifest);
+                long fileCount = (manifest.addedFilesCount() != null ? manifest.addedFilesCount() : 0L)
+                        + (manifest.existingFilesCount() != null ? manifest.existingFilesCount() : 0L);
+                minGroup[0] += Math.max(fileCount, 1L);
+                heap.offer(minGroup);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to build Iceberg metadata planning task groups", e);
+        }
+        List<List<ManifestFile>> manifestGroups = new ArrayList<>();
+        for (List<ManifestFile> manifests : shardManifests) {
+            if (manifests.isEmpty()) {
+                continue;
+            }
+            manifestGroups.add(manifests);
+        }
+        return manifestGroups;
+    }
+
+    private Split createMetadataPlanningSysSplit(long snapshotId, String serializedTable,
+            String serializedPredicate, List<ManifestFile> manifestGroup) {
+        IcebergSplit split = IcebergSplit.newSysTableSplit(
+                serializeSplitInput(new MetadataPlanningSplitInput(snapshotId, serializedTable,
+                        serializedPredicate, serializeManifests(manifestGroup))),
+                manifestGroup.size());
+        return split;
+    }
+
+    private String serializeSplitInput(MetadataPlanningSplitInput input) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(input);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize metadata planning split input", e);
+        }
+    }
+
+    private List<String> serializeManifests(List<ManifestFile> manifests) {
+        List<String> serializedManifests = new ArrayList<>(manifests.size());
+        for (ManifestFile manifest : manifests) {
+            try {
+                // We intentionally pass serialized ManifestFile descriptors instead of only manifest paths.
+                // If we pass only paths, every BE-side planning task must scan the full snapshot manifest list
+                // again to recover path -> ManifestFile, which repeats metadata work for each task.
+                // The descriptor is still lightweight compared with the manifest file contents themselves,
+                // and lets BE read only the FE-selected candidate manifests.
+                serializedManifests.add(Base64.getEncoder().encodeToString(ManifestFiles.encode(manifest)));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to serialize Iceberg manifest " + manifest.path(), e);
+            }
+        }
+        return serializedManifests;
+    }
+
+    private static class MetadataPlanningSplitInput {
+        public long snapshotId;
+        public String serializedTable;
+        public String serializedPredicate;
+        public List<String> serializedManifests;
+
+        private MetadataPlanningSplitInput(long snapshotId, String serializedTable, String serializedPredicate,
+                List<String> serializedManifests) {
+            this.snapshotId = snapshotId;
+            this.serializedTable = serializedTable;
+            this.serializedPredicate = serializedPredicate;
+            this.serializedManifests = serializedManifests;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -98,7 +98,6 @@ import org.apache.iceberg.mapping.MappedFields;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.util.ScanTaskUtil;
-import org.apache.iceberg.util.SerializationUtil;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -113,8 +112,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 
 public class IcebergScanNode extends FileQueryScanNode {
 
@@ -161,7 +160,7 @@ public class IcebergScanNode extends FileQueryScanNode {
     private String cachedFsIdentifier;
 
     private Boolean isBatchMode = null;
-    private boolean isSystemTable = false;
+    private PlanningSplitProducer planningSplitProducer;
 
     // ReferencedDataFile path -> List<DeleteFile> / List<TIcebergDeleteFileDesc> (exclude equal delete)
     public Map<String, List<DeleteFile>> deleteFilesByReferencedDataFile = new HashMap<>();
@@ -187,9 +186,6 @@ public class IcebergScanNode extends FileQueryScanNode {
         if (table instanceof HMSExternalTable) {
             source = new IcebergHMSSource((HMSExternalTable) table, desc);
         } else if (table instanceof IcebergExternalTable || table instanceof IcebergSysExternalTable) {
-            if (table instanceof IcebergSysExternalTable) {
-                isSystemTable = true;
-            }
             String catalogType = table instanceof IcebergExternalTable
                     ? ((IcebergExternalTable) table).getIcebergCatalogType()
                     : ((IcebergSysExternalTable) table).getSourceTable().getIcebergCatalogType();
@@ -216,14 +212,7 @@ public class IcebergScanNode extends FileQueryScanNode {
         icebergTable = source.getIcebergTable();
         partitionMapInfos = new HashMap<>();
         isPartitionedTable = icebergTable.spec().isPartitioned();
-        // Metadata tables (system tables) are not BaseTable instances, so we need to handle this case
-        if (icebergTable instanceof BaseTable) {
-            formatVersion = ((BaseTable) icebergTable).operations().current().formatVersion();
-        } else {
-            // For metadata tables (e.g., snapshots, history), use a default format version
-            // These tables are always readable regardless of format version
-            formatVersion = MIN_DELETE_FILE_SUPPORT_VERSION;
-        }
+        formatVersion = resolveFormatVersion(icebergTable);
         preExecutionAuthenticator = source.getCatalog().getExecutionAuthenticator();
         storagePropertiesMap = VendedCredentialsFactory.getStoragePropertiesMapWithVendedCredentials(
                 source.getCatalog().getCatalogProperty().getMetastoreProperties(),
@@ -232,6 +221,12 @@ public class IcebergScanNode extends FileQueryScanNode {
         );
         backendStorageProperties = CredentialUtils.getBackendPropertiesFromStorageMap(storagePropertiesMap);
         super.doInitialize();
+    }
+
+    protected int resolveFormatVersion(Table table) {
+        Preconditions.checkState(table instanceof BaseTable,
+                "Only base iceberg tables are expected in IcebergScanNode, but got %s", table.getClass().getName());
+        return ((BaseTable) table).operations().current().formatVersion();
     }
 
     /**
@@ -275,18 +270,10 @@ public class IcebergScanNode extends FileQueryScanNode {
         }
     }
 
-    private void setIcebergParams(TFileRangeDesc rangeDesc, IcebergSplit icebergSplit) {
+    protected void setIcebergParams(TFileRangeDesc rangeDesc, IcebergSplit icebergSplit) {
         TTableFormatFileDesc tableFormatFileDesc = new TTableFormatFileDesc();
         tableFormatFileDesc.setTableFormatType(icebergSplit.getTableFormatType().value());
         TIcebergFileDesc fileDesc = new TIcebergFileDesc();
-        if (isSystemTable) {
-            rangeDesc.setFormatType(TFileFormatType.FORMAT_JNI);
-            tableFormatFileDesc.setTableLevelRowCount(-1);
-            fileDesc.setSerializedSplit(icebergSplit.getSerializedSplit());
-            tableFormatFileDesc.setIcebergParams(fileDesc);
-            rangeDesc.setTableFormatParams(tableFormatFileDesc);
-            return;
-        }
         if (tableLevelPushDownCount) {
             tableFormatFileDesc.setTableLevelRowCount(icebergSplit.getTableLevelRowCount());
         } else {
@@ -482,55 +469,7 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public void startSplit(int numBackends) throws UserException {
-        try {
-            preExecutionAuthenticator.execute(() -> {
-                doStartSplit();
-                return null;
-            });
-        } catch (Exception e) {
-            throw new UserException(e.getMessage(), e);
-        }
-    }
-
-    public void doStartSplit() throws UserException {
-        TableScan scan = createTableScan();
-        CompletableFuture.runAsync(() -> {
-            AtomicReference<CloseableIterable<FileScanTask>> taskRef = new AtomicReference<>();
-            try {
-                preExecutionAuthenticator.execute(
-                        () -> {
-                            CloseableIterable<FileScanTask> fileScanTasks = planFileScanTask(scan);
-                            taskRef.set(fileScanTasks);
-
-                            CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
-                            while (splitAssignment.needMoreSplit() && iterator.hasNext()) {
-                                try {
-                                    splitAssignment.addToQueue(Lists.newArrayList(createIcebergSplit(iterator.next())));
-                                } catch (UserException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
-                        }
-                );
-                splitAssignment.finishSchedule();
-                recordManifestCacheProfile();
-            } catch (Exception e) {
-                Optional<NotSupportedException> opt = checkNotSupportedException(e);
-                if (opt.isPresent()) {
-                    splitAssignment.setException(new UserException(opt.get().getMessage(), opt.get()));
-                } else {
-                    splitAssignment.setException(new UserException(e.getMessage(), e));
-                }
-            } finally {
-                if (taskRef.get() != null) {
-                    try {
-                        taskRef.get().close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
-            }
-        }, Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor());
+        getPlanningSplitProducer().start(numBackends, new SplitAssignmentSink(splitAssignment));
     }
 
     @VisibleForTesting
@@ -570,26 +509,29 @@ public class IcebergScanNode extends FileQueryScanNode {
     }
 
     private CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) {
+        boolean batchMode = isBatchMode();
         if (!IcebergUtils.isManifestCacheEnabled(source.getCatalog())) {
-            return splitFiles(scan);
+            return splitFiles(scan, batchMode);
         }
         try {
-            return planFileScanTaskWithManifestCache(scan);
+            return planFileScanTaskWithManifestCache(scan, batchMode);
         } catch (Exception e) {
             manifestCacheFailures++;
             LOG.warn("Plan with manifest cache failed, fallback to original scan: " + e.getMessage(), e);
-            return splitFiles(scan);
+            return splitFiles(scan, batchMode);
         }
     }
 
-    private CloseableIterable<FileScanTask> splitFiles(TableScan scan) {
+    private CloseableIterable<FileScanTask> splitFiles(TableScan scan, boolean batchMode) {
         if (sessionVariable.getFileSplitSize() > 0) {
+            targetSplitSize = sessionVariable.getFileSplitSize();
             return TableScanUtil.splitFiles(scan.planFiles(),
                     sessionVariable.getFileSplitSize());
         }
-        if (isBatchMode()) {
+        if (batchMode) {
             // Currently iceberg batch split mode will use max split size.
             // TODO: dynamic split size in batch split mode need to customize iceberg splitter.
+            targetSplitSize = sessionVariable.getMaxSplitSize();
             return TableScanUtil.splitFiles(scan.planFiles(), sessionVariable.getMaxSplitSize());
         }
 
@@ -605,11 +547,11 @@ public class IcebergScanNode extends FileQueryScanNode {
             throw new RuntimeException("Failed to materialize file scan tasks", e);
         }
 
-        targetSplitSize = determineTargetFileSplitSize(fileScanTaskList);
+        targetSplitSize = determineTargetFileSplitSize(fileScanTaskList, false);
         return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(fileScanTaskList), targetSplitSize);
     }
 
-    private long determineTargetFileSplitSize(Iterable<FileScanTask> tasks) {
+    private long determineTargetFileSplitSize(Iterable<FileScanTask> tasks, boolean batchMode) {
         long result = sessionVariable.getMaxInitialSplitSize();
         long accumulatedTotalFileSize = 0;
         boolean exceedInitialThreshold = false;
@@ -621,13 +563,14 @@ public class IcebergScanNode extends FileQueryScanNode {
             }
         }
         result = exceedInitialThreshold ? sessionVariable.getMaxSplitSize() : result;
-        if (!isBatchMode()) {
+        if (!batchMode) {
             result = applyMaxFileSplitNumLimit(result, accumulatedTotalFileSize);
         }
         return result;
     }
 
-    private CloseableIterable<FileScanTask> planFileScanTaskWithManifestCache(TableScan scan) throws IOException {
+    private CloseableIterable<FileScanTask> planFileScanTaskWithManifestCache(TableScan scan, boolean batchMode)
+            throws IOException {
         // Get the snapshot from the scan; return empty if no snapshot exists
         Snapshot snapshot = scan.snapshot();
         if (snapshot == null) {
@@ -745,7 +688,7 @@ public class IcebergScanNode extends FileQueryScanNode {
         }
 
         // Split tasks into smaller chunks based on target split size for parallel processing
-        targetSplitSize = determineTargetFileSplitSize(tasks);
+        targetSplitSize = determineTargetFileSplitSize(tasks, batchMode);
         return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(tasks), targetSplitSize);
     }
 
@@ -870,14 +813,6 @@ public class IcebergScanNode extends FileQueryScanNode {
         return split;
     }
 
-    private Split createIcebergSysSplit(FileScanTask fileScanTask) {
-        long rowCount = fileScanTask.file() == null ? 1 : fileScanTask.file().recordCount();
-        IcebergSplit split = IcebergSplit.newSysTableSplit(
-                SerializationUtil.serializeToBase64(fileScanTask), rowCount);
-        split.setTableFormatType(TableFormatType.ICEBERG);
-        return split;
-    }
-
     @Override
     protected TColumnCategory classifyColumn(SlotDescriptor slot, List<String> partitionKeys) {
         if (Column.ICEBERG_ROWID_COL.equalsIgnoreCase(slot.getColumn().getName())) {
@@ -892,10 +827,7 @@ public class IcebergScanNode extends FileQueryScanNode {
         return super.classifyColumn(slot, partitionKeys);
     }
 
-    private List<Split> doGetSplits(int numBackends) throws UserException {
-        if (isSystemTable) {
-            return doGetSystemTableSplits();
-        }
+    protected List<Split> doGetSplits(int numBackends) throws UserException {
 
         List<Split> splits = new ArrayList<>();
 
@@ -939,24 +871,8 @@ public class IcebergScanNode extends FileQueryScanNode {
         return splits;
     }
 
-    private List<Split> doGetSystemTableSplits() throws UserException {
-        List<Split> splits = new ArrayList<>();
-        TableScan scan = createTableScan();
-        try (CloseableIterable<FileScanTask> fileScanTasks = scan.planFiles()) {
-            fileScanTasks.forEach(task -> splits.add(createIcebergSysSplit(task)));
-        } catch (IOException e) {
-            throw new UserException(e.getMessage(), e);
-        }
-        selectedPartitionNum = 0;
-        return splits;
-    }
-
     @Override
     public boolean isBatchMode() {
-        if (isSystemTable) {
-            isBatchMode = false;
-            return false;
-        }
         Boolean cached = isBatchMode;
         if (cached != null) {
             return cached;
@@ -1019,6 +935,233 @@ public class IcebergScanNode extends FileQueryScanNode {
         }
     }
 
+    @Override
+    public int numApproximateSplits() {
+        return partitionMapInfos.size() > 0 ? NUM_SPLITS_PER_PARTITION * partitionMapInfos.size() : 1;
+    }
+
+    @Override
+    public void stop() {
+        if (planningSplitProducer != null) {
+            planningSplitProducer.stop();
+        }
+        super.stop();
+    }
+
+    private PlanningSplitProducer getPlanningSplitProducer() {
+        if (planningSplitProducer == null) {
+            planningSplitProducer = createPlanningSplitProducer();
+        }
+        return planningSplitProducer;
+    }
+
+    @VisibleForTesting
+    protected PlanningSplitProducer createPlanningSplitProducer() {
+        PlanningSplitProducer.Context context = new IcebergPlanningSplitProducerContext();
+        if (shouldUseDistributedPlanning()) {
+            return new DistributedPlanningSplitProducer(context);
+        }
+        return new LocalParallelPlanningSplitProducer(context);
+    }
+
+    @VisibleForTesting
+    void setPlanningSplitProducer(PlanningSplitProducer planningSplitProducer) {
+        this.planningSplitProducer = planningSplitProducer;
+    }
+
+    @VisibleForTesting
+    protected boolean shouldUseDistributedPlanning() {
+        if (hasRewriteFileScanTasksInContext()) {
+            return false;
+        }
+        if (getPushDownAggNoGroupingOp() == TPushAggOp.COUNT) {
+            return false;
+        }
+        IcebergMetadataPlanningMode mode =
+                IcebergMetadataPlanningMode.fromName(sessionVariable.getIcebergMetadataPlanningMode());
+        if (mode == IcebergMetadataPlanningMode.LOCAL) {
+            return false;
+        }
+        return mode.resolveDistributed(collectPlanningInputs());
+    }
+
+    /**
+     * Collects lightweight planning inputs from manifest-list metadata without reading
+     * manifest files. All inputs are available from the snapshot's manifest-list headers.
+     */
+    private IcebergMetadataPlanningMode.PlanningInputs collectPlanningInputs() {
+        try {
+            return preExecutionAuthenticator.execute(() -> {
+                TableScan scan = createTableScan();
+                org.apache.iceberg.Snapshot snapshot = scan.snapshot();
+
+                // Check whether delete manifests are present (need_stats signal).
+                boolean needStats = snapshot != null
+                        && !snapshot.deleteManifests(icebergTable.io()).isEmpty();
+
+                if (snapshot == null) {
+                    return new IcebergMetadataPlanningMode.PlanningInputs(
+                            needStats, 0, 0L, 0L,
+                            Runtime.getRuntime().availableProcessors(),
+                            Env.getCurrentSystemInfo().getAllBackendIds(true).size());
+                }
+
+                // Collect M, B, S from data manifest headers (no manifest file reads).
+                int manifestCount = 0;
+                long manifestBytes = 0L;
+                long estimatedFiles = 0L;
+                try (CloseableIterable<ManifestFile> matching = IcebergUtils.getMatchingManifest(
+                        snapshot.dataManifests(icebergTable.io()),
+                        icebergTable.specs(),
+                        scan.filter())) {
+                    for (ManifestFile m : matching) {
+                        manifestCount++;
+                        manifestBytes += m.length();
+                        long added = m.addedFilesCount() != null ? m.addedFilesCount() : 0L;
+                        long existing = m.existingFilesCount() != null ? m.existingFilesCount() : 0L;
+                        estimatedFiles += added + existing;
+                    }
+                } catch (IOException e) {
+                    LOG.warn("Failed to collect manifest metrics for planning mode decision, "
+                            + "falling back to local planning", e);
+                    // Return inputs that will cause the mode to resolve to LOCAL.
+                    return new IcebergMetadataPlanningMode.PlanningInputs(
+                            true, 0, 0L, 0L, 1, 0);
+                }
+
+                int feParallelism = Runtime.getRuntime().availableProcessors();
+                int beSlots = Env.getCurrentSystemInfo().getAllBackendIds(true).size();
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Iceberg planning inputs: M={} B={} S={} L={} R={} needStats={}",
+                            manifestCount, manifestBytes, estimatedFiles,
+                            feParallelism, beSlots, needStats);
+                }
+
+                return new IcebergMetadataPlanningMode.PlanningInputs(
+                        needStats, manifestCount, manifestBytes,
+                        estimatedFiles, feParallelism, beSlots);
+            });
+        } catch (Exception e) {
+            Optional<NotSupportedException> opt = checkNotSupportedException(e);
+            if (opt.isPresent()) {
+                throw opt.get();
+            }
+            LOG.warn("Error collecting planning inputs, falling back to local planning", e);
+            return new IcebergMetadataPlanningMode.PlanningInputs(true, 0, 0L, 0L, 1, 0);
+        }
+    }
+
+    protected boolean hasRewriteFileScanTasksInContext() {
+        ConnectContext ctx = ConnectContext.get();
+        return ctx != null
+                && ctx.getStatementContext() != null
+                && ctx.getStatementContext().hasIcebergRewriteFileScanTasks();
+    }
+
+    protected IcebergSource getIcebergSource() {
+        return source;
+    }
+
+    protected Table getIcebergTableInstance() {
+        return icebergTable;
+    }
+
+    private ExecutionAuthenticator getExecutionAuthenticator() {
+        return preExecutionAuthenticator;
+    }
+
+    private Executor getScheduleExecutor() {
+        return Env.getCurrentEnv().getExtMetaCacheMgr().getScheduleExecutor();
+    }
+
+    private List<String> getSourceTableQualifier() {
+        return Arrays.asList(source.getCatalog().getName(),
+                source.getTargetTable().getDatabase().getFullName(), source.getTargetTable().getName());
+    }
+
+    private String getPlanningTableSchemaJson() {
+        return SchemaParser.toJson(icebergTable.schema());
+    }
+
+    private PartitionSpec getPlanningPartitionSpec(int specId) {
+        return icebergTable.specs().get(specId);
+    }
+
+    private CloseableIterable<FileScanTask> splitPlanningTasks(List<FileScanTask> fileScanTasks) {
+        if (sessionVariable.getFileSplitSize() > 0) {
+            targetSplitSize = sessionVariable.getFileSplitSize();
+            return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(fileScanTasks),
+                    sessionVariable.getFileSplitSize());
+        }
+        // Distributed metadata planning always materializes file-level tasks first and then asks Doris to split
+        // them for execution. Keep the split-size calculation explicit here instead of re-checking the current
+        // producer state through isBatchMode(), so this helper stays independent from producer wiring.
+        targetSplitSize = determineTargetFileSplitSize(fileScanTasks, true);
+        return TableScanUtil.splitFiles(CloseableIterable.withNoopClose(fileScanTasks), targetSplitSize);
+    }
+
+    private Split createPlanningSplit(FileScanTask task) {
+        return createIcebergSplit(task);
+    }
+
+    private class IcebergPlanningSplitProducerContext implements PlanningSplitProducer.Context {
+        @Override
+        public TableScan createTableScan() throws UserException {
+            return IcebergScanNode.this.createTableScan();
+        }
+
+        @Override
+        public CloseableIterable<FileScanTask> planFileScanTask(TableScan scan) {
+            return IcebergScanNode.this.planFileScanTask(scan);
+        }
+
+        @Override
+        public CloseableIterable<FileScanTask> splitPlanningTasks(List<FileScanTask> fileScanTasks) {
+            return IcebergScanNode.this.splitPlanningTasks(fileScanTasks);
+        }
+
+        @Override
+        public Split createPlanningSplit(FileScanTask task) {
+            return IcebergScanNode.this.createPlanningSplit(task);
+        }
+
+        @Override
+        public void recordManifestCacheProfile() {
+            IcebergScanNode.this.recordManifestCacheProfile();
+        }
+
+        @Override
+        public Optional<NotSupportedException> checkNotSupportedException(Exception e) {
+            return IcebergScanNode.this.checkNotSupportedException(e);
+        }
+
+        @Override
+        public ExecutionAuthenticator getExecutionAuthenticator() {
+            return IcebergScanNode.this.getExecutionAuthenticator();
+        }
+
+        @Override
+        public Executor getScheduleExecutor() {
+            return IcebergScanNode.this.getScheduleExecutor();
+        }
+
+        @Override
+        public List<String> getSourceTableQualifier() {
+            return IcebergScanNode.this.getSourceTableQualifier();
+        }
+
+        @Override
+        public String getPlanningTableSchemaJson() {
+            return IcebergScanNode.this.getPlanningTableSchemaJson();
+        }
+
+        @Override
+        public PartitionSpec getPlanningPartitionSpec(int specId) {
+            return IcebergScanNode.this.getPlanningPartitionSpec(specId);
+        }
+    }
+
     public IcebergTableQueryInfo getSpecifiedSnapshot() throws UserException {
         TableSnapshot tableSnapshot = getQueryTableSnapshot();
         TableScanParams scanParams = getScanParams();
@@ -1050,9 +1193,6 @@ public class IcebergScanNode extends FileQueryScanNode {
 
     @Override
     public TFileFormatType getFileFormatType() throws UserException {
-        if (isSystemTable) {
-            return TFileFormatType.FORMAT_JNI;
-        }
         TFileFormatType type;
         String icebergFormat = source.getFileFormat();
         if (icebergFormat.equalsIgnoreCase("parquet")) {
@@ -1184,11 +1324,6 @@ public class IcebergScanNode extends FileQueryScanNode {
         ((IcebergSplit) splits.get(size - 1)).setTableLevelRowCount(countPerSplit + totalCount % size);
     }
 
-    @Override
-    public int numApproximateSplits() {
-        return NUM_SPLITS_PER_PARTITION * partitionMapInfos.size() > 0 ? partitionMapInfos.size() : 1;
-    }
-
     private Optional<NotSupportedException> checkNotSupportedException(Exception e) {
         if (e instanceof NullPointerException) {
             /*
@@ -1224,5 +1359,24 @@ public class IcebergScanNode extends FileQueryScanNode {
                             + Util.getRootCauseMessage(e)));
         }
         return Optional.empty();
+    }
+
+    protected <T> T executeWithPreExecutionAuthenticator(Callable<T> action) throws UserException {
+        try {
+            return preExecutionAuthenticator.execute(new Callable<T>() {
+                @Override
+                public T call() throws Exception {
+                    return action.call();
+                }
+            });
+        } catch (UserException e) {
+            throw e;
+        } catch (Exception e) {
+            Optional<NotSupportedException> opt = checkNotSupportedException(e);
+            if (opt.isPresent()) {
+                throw opt.get();
+            }
+            throw new RuntimeException(ExceptionUtils.getRootCauseMessage(e), e);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSysScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergSysScanNode.java
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.TableFormatType;
+import org.apache.doris.planner.PlanNodeId;
+import org.apache.doris.planner.ScanContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.spi.Split;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TFileRangeDesc;
+import org.apache.doris.thrift.TIcebergFileDesc;
+import org.apache.doris.thrift.TTableFormatFileDesc;
+
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.util.SerializationUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public class IcebergSysScanNode extends IcebergScanNode {
+    public IcebergSysScanNode(PlanNodeId id, TupleDescriptor desc, boolean needCheckColumnPriv, SessionVariable sv,
+            ScanContext scanContext) {
+        super(id, desc, needCheckColumnPriv, sv, scanContext);
+    }
+
+    @Override
+    protected void setScanParams(TFileRangeDesc rangeDesc, org.apache.doris.spi.Split split) {
+        if (split instanceof IcebergSplit) {
+            setIcebergSysParams(rangeDesc, (IcebergSplit) split);
+        }
+    }
+
+    @Override
+    public List<Split> getSplits(int numBackends) throws UserException {
+        return executeWithPreExecutionAuthenticator(new Callable<List<Split>>() {
+            @Override
+            public List<Split> call() throws Exception {
+                return doGetSystemTableSplits();
+            }
+        });
+    }
+
+    @Override
+    public boolean isBatchMode() {
+        return false;
+    }
+
+    @Override
+    public TFileFormatType getFileFormatType() {
+        return TFileFormatType.FORMAT_JNI;
+    }
+
+    protected void setIcebergSysParams(TFileRangeDesc rangeDesc, IcebergSplit icebergSplit) {
+        TTableFormatFileDesc tableFormatFileDesc = new TTableFormatFileDesc();
+        tableFormatFileDesc.setTableFormatType(icebergSplit.getTableFormatType().value());
+        tableFormatFileDesc.setTableLevelRowCount(-1);
+        TIcebergFileDesc fileDesc = new TIcebergFileDesc();
+        fileDesc.setSerializedSplit(icebergSplit.getSerializedSplit());
+        tableFormatFileDesc.setIcebergParams(fileDesc);
+        rangeDesc.setFormatType(TFileFormatType.FORMAT_JNI);
+        rangeDesc.setTableFormatParams(tableFormatFileDesc);
+    }
+
+    @Override
+    protected int resolveFormatVersion(Table table) {
+        if (table instanceof BaseTable) {
+            return ((BaseTable) table).operations().current().formatVersion();
+        }
+        return MIN_DELETE_FILE_SUPPORT_VERSION;
+    }
+
+    protected List<Split> doGetSystemTableSplits() throws UserException {
+        List<Split> splits = new ArrayList<>();
+        TableScan scan = createTableScan();
+        try (org.apache.iceberg.io.CloseableIterable<FileScanTask> fileScanTasks = scan.planFiles()) {
+            for (FileScanTask task : fileScanTasks) {
+                splits.add(createIcebergSysSplit(task));
+            }
+        } catch (IOException e) {
+            throw new UserException(e.getMessage(), e);
+        }
+        selectedPartitionNum = 0;
+        return splits;
+    }
+
+    protected Split createIcebergSysSplit(FileScanTask fileScanTask) {
+        long rowCount = fileScanTask.file() == null ? 1 : fileScanTask.file().recordCount();
+        IcebergSplit split = IcebergSplit.newSysTableSplit(
+                SerializationUtil.serializeToBase64(fileScanTask), rowCount);
+        split.setTableFormatType(TableFormatType.ICEBERG);
+        return split;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/LocalParallelPlanningSplitProducer.java
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Local FE async planning producer that reuses current Iceberg planning flow.
+ */
+public class LocalParallelPlanningSplitProducer implements PlanningSplitProducer {
+    private static final Logger LOG = LogManager.getLogger(LocalParallelPlanningSplitProducer.class);
+    private final PlanningSplitProducer.Context context;
+    private final AtomicBoolean stopped = new AtomicBoolean(false);
+    private final AtomicReference<CompletableFuture<Void>> runningTask = new AtomicReference<>();
+
+    public LocalParallelPlanningSplitProducer(PlanningSplitProducer.Context context) {
+        this.context = Preconditions.checkNotNull(context, "planning context is null");
+    }
+
+    @Override
+    public void start(int numBackends, SplitSink sink) throws UserException {
+        stopped.set(false);
+        final TableScan scan;
+        try {
+            scan = context.getExecutionAuthenticator().execute(context::createTableScan);
+        } catch (Exception e) {
+            throw new UserException(e.getMessage(), e);
+        }
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+            AtomicReference<CloseableIterable<FileScanTask>> taskRef = new AtomicReference<>();
+            try {
+                context.getExecutionAuthenticator().execute(() -> {
+                    CloseableIterable<FileScanTask> fileScanTasks = context.planFileScanTask(scan);
+                    taskRef.set(fileScanTasks);
+                    CloseableIterator<FileScanTask> iterator = fileScanTasks.iterator();
+                    while (!stopped.get() && sink.needMore() && iterator.hasNext()) {
+                        sink.addBatch(Lists.newArrayList(context.createPlanningSplit(iterator.next())));
+                    }
+                    return null;
+                });
+                sink.finish();
+                context.recordManifestCacheProfile();
+            } catch (Exception e) {
+                if (stopped.get()) {
+                    LOG.debug("Iceberg local split planning is stopped");
+                    return;
+                }
+                Optional<NotSupportedException> opt = context.checkNotSupportedException(e);
+                if (opt.isPresent()) {
+                    sink.fail(new UserException(opt.get().getMessage(), opt.get()));
+                } else {
+                    sink.fail(new UserException(e.getMessage(), e));
+                }
+            } finally {
+                closeTaskIterable(taskRef.get());
+            }
+        }, context.getScheduleExecutor());
+        runningTask.set(future);
+    }
+
+    @Override
+    public void stop() {
+        if (!stopped.compareAndSet(false, true)) {
+            return;
+        }
+        CompletableFuture<Void> task = runningTask.get();
+        if (task != null) {
+            task.cancel(true);
+        }
+    }
+
+    private void closeTaskIterable(CloseableIterable<FileScanTask> tasks) {
+        if (tasks == null) {
+            return;
+        }
+        try {
+            tasks.close();
+        } catch (IOException e) {
+            LOG.warn("close file scan task iterable failed: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/PlanningSplitProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/PlanningSplitProducer.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
+import org.apache.doris.spi.Split;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+/**
+ * FE-side split production strategy for Iceberg planning.
+ */
+public interface PlanningSplitProducer {
+
+    interface Context {
+        TableScan createTableScan() throws UserException;
+
+        CloseableIterable<FileScanTask> planFileScanTask(TableScan scan);
+
+        CloseableIterable<FileScanTask> splitPlanningTasks(List<FileScanTask> fileScanTasks);
+
+        Split createPlanningSplit(FileScanTask task);
+
+        void recordManifestCacheProfile();
+
+        Optional<NotSupportedException> checkNotSupportedException(Exception e);
+
+        ExecutionAuthenticator getExecutionAuthenticator();
+
+        Executor getScheduleExecutor();
+
+        List<String> getSourceTableQualifier();
+
+        String getPlanningTableSchemaJson();
+
+        PartitionSpec getPlanningPartitionSpec(int specId);
+    }
+
+    void start(int numBackends, SplitSink sink) throws UserException;
+
+    default void stop() {
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSink.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.SplitAssignment;
+import org.apache.doris.spi.Split;
+
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+/**
+ * Adapter that bridges {@link SplitSink} with existing {@link SplitAssignment}.
+ */
+public class SplitAssignmentSink implements SplitSink {
+    private final SplitAssignment splitAssignment;
+
+    public SplitAssignmentSink(SplitAssignment splitAssignment) {
+        this.splitAssignment = Preconditions.checkNotNull(splitAssignment, "splitAssignment is null");
+    }
+
+    @Override
+    public void addBatch(List<Split> splits) throws UserException {
+        splitAssignment.addToQueue(splits);
+    }
+
+    @Override
+    public boolean needMore() {
+        return splitAssignment.needMoreSplit();
+    }
+
+    @Override
+    public void finish() {
+        splitAssignment.finishSchedule();
+    }
+
+    @Override
+    public void fail(UserException e) {
+        splitAssignment.setException(e);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/SplitSink.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.spi.Split;
+
+import java.util.List;
+
+/**
+ * Sink abstraction consumed by planning split producers.
+ */
+public interface SplitSink {
+    void addBatch(List<Split> splits) throws UserException;
+
+    boolean needMore();
+
+    void finish();
+
+    void fail(UserException e);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/systable/IcebergMetadataPlanningSysTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/systable/IcebergMetadataPlanningSysTable.java
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.systable;
+
+import org.apache.doris.datasource.ExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergExternalTable;
+import org.apache.doris.datasource.iceberg.IcebergMetadataPlanningExternalTable;
+
+/**
+ * Internal-only sys table entry for Iceberg metadata planning.
+ *
+ * <p>This table is intentionally not part of the public supported sys table map
+ * until the dedicated planning scan path is fully implemented.
+ */
+public class IcebergMetadataPlanningSysTable extends NativeSysTable {
+    public IcebergMetadataPlanningSysTable(String sysTableName) {
+        super(sysTableName);
+    }
+
+    @Override
+    public ExternalTable createSysExternalTable(ExternalTable sourceTable) {
+        if (!(sourceTable instanceof IcebergExternalTable)) {
+            throw new IllegalArgumentException(
+                    "Expected IcebergExternalTable but got " + sourceTable.getClass().getSimpleName());
+        }
+        return new IcebergMetadataPlanningExternalTable((IcebergExternalTable) sourceTable, getSysTableName());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/systable/IcebergSysTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/systable/IcebergSysTable.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
  * @see org.apache.iceberg.MetadataTableType for all supported system table types
  */
 public class IcebergSysTable extends NativeSysTable {
+    public static final String METADATA_PLANNING = "metadata_planning";
     public static final String POSITION_DELETES = MetadataTableType.POSITION_DELETES.name().toLowerCase(Locale.ROOT);
 
     /**
@@ -53,6 +54,8 @@ public class IcebergSysTable extends NativeSysTable {
                     .collect(Collectors.toMap(SysTable::getSysTableName, Function.identity())));
     public static final SysTable UNSUPPORTED_POSITION_DELETES_TABLE =
             new IcebergSysTable(POSITION_DELETES, false);
+    public static final SysTable INTERNAL_METADATA_PLANNING_TABLE =
+            new IcebergMetadataPlanningSysTable(METADATA_PLANNING);
 
     private final String tableName;
     private final boolean supported;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -313,6 +313,7 @@ public class StatementContext implements Closeable {
     // IcebergScanNode
     // TODO: better solution?
     private List<org.apache.iceberg.FileScanTask> icebergRewriteFileScanTasks = null;
+    // FE-local context for one internal metadata planning query.
     // For Iceberg rewrite operations: control whether to use GATHER distribution
     // When true, data will be collected to a single node to avoid generating too many small files
     private boolean useGatherForIcebergRewrite = false;
@@ -1179,6 +1180,10 @@ public class StatementContext implements Closeable {
         List<org.apache.iceberg.FileScanTask> tasks = this.icebergRewriteFileScanTasks;
         this.icebergRewriteFileScanTasks = null;
         return tasks;
+    }
+
+    public boolean hasIcebergRewriteFileScanTasks() {
+        return icebergRewriteFileScanTasks != null && !icebergRewriteFileScanTasks.isEmpty();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -65,8 +65,11 @@ import org.apache.doris.datasource.hive.source.HiveScanNode;
 import org.apache.doris.datasource.hudi.source.HudiScanNode;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergMergeOperation;
+import org.apache.doris.datasource.iceberg.IcebergMetadataPlanningExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergSysExternalTable;
+import org.apache.doris.datasource.iceberg.source.IcebergMetadataPlanningScanNode;
 import org.apache.doris.datasource.iceberg.source.IcebergScanNode;
+import org.apache.doris.datasource.iceberg.source.IcebergSysScanNode;
 import org.apache.doris.datasource.lakesoul.LakeSoulExternalTable;
 import org.apache.doris.datasource.lakesoul.source.LakeSoulScanNode;
 import org.apache.doris.datasource.maxcompute.MaxComputeExternalTable;
@@ -777,7 +780,13 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 default:
                     throw new RuntimeException("do not support DLA type " + ((HMSExternalTable) table).getDlaType());
             }
-        } else if (table instanceof IcebergExternalTable || table instanceof IcebergSysExternalTable) {
+        } else if (table instanceof IcebergMetadataPlanningExternalTable) {
+            scanNode = new IcebergMetadataPlanningScanNode(context.nextPlanNodeId(), tupleDescriptor, false, sv,
+                    context.getScanContext());
+        } else if (table instanceof IcebergSysExternalTable) {
+            scanNode = new IcebergSysScanNode(context.nextPlanNodeId(), tupleDescriptor, false, sv,
+                    context.getScanContext());
+        } else if (table instanceof IcebergExternalTable) {
             scanNode = new IcebergScanNode(context.nextPlanNodeId(), tupleDescriptor, false, sv,
                     context.getScanContext());
         } else if (table.getType() == TableIf.TableType.PAIMON_EXTERNAL_TABLE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -373,6 +373,9 @@ public class Coordinator implements CoordInterface {
             fragmentIds.add(fragment.getFragmentId().asInt());
         }
         this.executionProfile = new ExecutionProfile(queryId, fragmentIds);
+        if (distributedPlans != null) {
+            this.executionProfile.setDistributedPlans(distributedPlans.values());
+        }
     }
 
     // Used for broker load task/export task/update coordinator

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -125,6 +125,7 @@ public class NereidsCoordinator extends Coordinator {
             List<ScanNode> scanNodes, String timezone, boolean loadZeroTolerance,
             boolean enableProfile) {
         super(jobId, queryId, descTable, fragments, scanNodes, timezone, loadZeroTolerance, enableProfile);
+        getExecutionProfile().setDistributedPlans(distributedPlans);
         this.coordinatorContext = CoordinatorContext.buildForLoad(
                 this, jobId, queryId, fragments, distributedPlans, scanNodes,
                 descTable, timezone, loadZeroTolerance, enableProfile

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -541,6 +541,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // Target file size in bytes for Iceberg write operations
     public static final String ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES = "iceberg_write_target_file_size_bytes";
+    public static final String ICEBERG_METADATA_PLANNING_MODE = "iceberg_metadata_planning_mode";
     public static final String ENABLE_ICEBERG_MERGE_PARTITIONING = "enable_iceberg_merge_partitioning";
 
     public static final String NUM_PARTITIONS_IN_BATCH_MODE = "num_partitions_in_batch_mode";
@@ -2412,6 +2413,13 @@ public class SessionVariable implements Serializable, Writable {
     // Default 0 means use config::iceberg_sink_max_file_size
     @VarAttrDef.VarAttr(name = ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES, needForward = true)
     public long icebergWriteTargetFileSizeBytes = 0L;
+
+    @VarAttrDef.VarAttr(name = ICEBERG_METADATA_PLANNING_MODE, needForward = true,
+            options = {"local", "distributed", "auto"},
+            description = {"控制 Iceberg metadata planning 的 FE 侧执行模式。",
+                    "Controls FE-side execution mode for Iceberg metadata planning."},
+            affectQueryResultInPlan = true)
+    public String icebergMetadataPlanningMode = "local";
 
     @VarAttrDef.VarAttr(
             name = NUM_PARTITIONS_IN_BATCH_MODE,
@@ -6375,6 +6383,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean getEnableExternalTableBatchMode() {
         return enableExternalTableBatchMode;
+    }
+
+    public String getIcebergMetadataPlanningMode() {
+        return icebergMetadataPlanningMode;
     }
 
     public boolean showSplitProfileInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1993,7 +1993,34 @@ public class StmtExecutor {
         return nereidsPlanner.getCascadesContext().getRewritePlan().getOutput();
     }
 
+    public interface ResultRowBatchIterator extends AutoCloseable {
+        List<ResultRow> getNextBatch();
+
+        @Override
+        void close();
+    }
+
     public List<ResultRow> executeInternalQuery() {
+        List<ResultRow> resultRows = new ArrayList<>();
+        try (ResultRowBatchIterator iterator = executeInternalQueryLazy()) {
+            while (true) {
+                List<ResultRow> batchRows = iterator.getNextBatch();
+                if (batchRows == null) {
+                    return resultRows;
+                }
+                resultRows.addAll(batchRows);
+            }
+        }
+    }
+
+    /**
+     * Executes an internal query and returns a lazy batch iterator.
+     *
+     * <p>The caller controls when to fetch the next batch and can stop early by closing the
+     * iterator. This keeps backpressure outside of {@link StmtExecutor} and avoids forcing
+     * all internal query consumers into a push-based API.
+     */
+    public ResultRowBatchIterator executeInternalQueryLazy() {
         if (LOG.isDebugEnabled()) {
             LOG.debug("INTERNAL QUERY: {}", originStmt.toString());
         }
@@ -2004,78 +2031,114 @@ public class StmtExecutor {
             context.setSqlHash(DigestUtils.md5Hex(originStmt.originStmt));
         }
         try {
-            List<ResultRow> resultRows = new ArrayList<>();
-            try {
-                parseByNereids();
-                Preconditions.checkState(parsedStmt instanceof LogicalPlanAdapter,
-                        "Nereids only process LogicalPlanAdapter,"
-                                + " but parsedStmt is " + parsedStmt.getClass().getName());
-                context.getState().setNereids(true);
-                context.getState().setIsQuery(true);
-                context.getState().setInternal(true);
-                planner = new NereidsPlanner(statementContext);
-                planner.plan(parsedStmt, context.getSessionVariable().toThrift());
-            } catch (Exception e) {
-                LOG.warn("Failed to run internal SQL: {}", originStmt, e);
-                throw new RuntimeException("Failed to execute internal SQL. " + Util.getRootCauseMessage(e), e);
-            }
-            RowBatch batch;
-            if (Config.enable_collect_internal_query_profile) {
-                context.getSessionVariable().enableProfile = true;
-            }
-            coord = EnvFactory.getInstance().createCoordinator(context,
-                    planner, context.getStatsErrorEstimator());
-            profile.addExecutionProfile(coord.getExecutionProfile());
-            try {
-                QeProcessorImpl.INSTANCE.registerQuery(context.queryId(),
-                        new QueryInfo(context, originStmt.originStmt, coord));
-            } catch (UserException e) {
-                throw new RuntimeException("Failed to execute internal SQL. " + Util.getRootCauseMessage(e), e);
-            }
-            updateProfile(false);
-            try {
-                coord.exec();
-            } catch (Exception e) {
-                throw new InternalQueryExecutionException(e.getMessage() + Util.getRootCauseMessage(e), e);
-            }
+            prepareInternalQueryExecution();
+            return new InternalQueryResultBatchIteratorImpl(queryId);
+        } catch (RuntimeException e) {
+            cleanupInternalQueryExecution();
+            throw e;
+        } catch (Exception e) {
+            cleanupInternalQueryExecution();
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
 
+    private void prepareInternalQueryExecution() {
+        try {
+            parseByNereids();
+            Preconditions.checkState(parsedStmt instanceof LogicalPlanAdapter,
+                    "Nereids only process LogicalPlanAdapter,"
+                            + " but parsedStmt is " + parsedStmt.getClass().getName());
+            context.getState().setNereids(true);
+            context.getState().setIsQuery(true);
+            context.getState().setInternal(true);
+            planner = new NereidsPlanner(statementContext);
+            planner.plan(parsedStmt, context.getSessionVariable().toThrift());
+        } catch (Exception e) {
+            LOG.warn("Failed to run internal SQL: {}", originStmt, e);
+            throw new RuntimeException("Failed to execute internal SQL. " + Util.getRootCauseMessage(e), e);
+        }
+        if (Config.enable_collect_internal_query_profile) {
+            context.getSessionVariable().enableProfile = true;
+        }
+        coord = EnvFactory.getInstance().createCoordinator(context,
+                planner, context.getStatsErrorEstimator());
+        profile.addExecutionProfile(coord.getExecutionProfile());
+        try {
+            QeProcessorImpl.INSTANCE.registerQuery(context.queryId(),
+                    new QueryInfo(context, originStmt.originStmt, coord));
+        } catch (UserException e) {
+            throw new RuntimeException("Failed to execute internal SQL. " + Util.getRootCauseMessage(e), e);
+        }
+        updateProfile(false);
+        try {
+            coord.exec();
+        } catch (Exception e) {
+            throw new InternalQueryExecutionException(e.getMessage() + Util.getRootCauseMessage(e), e);
+        }
+    }
+
+    private void cleanupInternalQueryExecution() {
+        if (coord != null) {
+            coord.close();
+            coord = null;
+        }
+        AuditLogHelper.logAuditLog(context, originStmt.originStmt, parsedStmt, getQueryStatisticsForAuditLog(),
+                true);
+        QeProcessorImpl.INSTANCE.unregisterQuery(context.queryId());
+        updateProfile(true);
+    }
+
+    private class InternalQueryResultBatchIteratorImpl implements ResultRowBatchIterator {
+        private final TUniqueId queryId;
+        private boolean closed = false;
+        private long totalRows = 0;
+
+        private InternalQueryResultBatchIteratorImpl(TUniqueId queryId) {
+            this.queryId = queryId;
+        }
+
+        public List<ResultRow> getNextBatch() {
+            Preconditions.checkState(!closed, "Internal query result iterator is closed");
             try {
                 while (true) {
-                    batch = coord.getNext();
+                    RowBatch batch = coord.getNext();
                     Preconditions.checkNotNull(batch, "Batch is Null.");
                     if (batch.isEos()) {
-                        LOG.info("Result rows for query {} is {}", DebugUtil.printId(queryId), resultRows.size());
-                        return resultRows;
-                    } else {
-                        // For null and not EOS batch, continue to get the next batch.
-                        if (batch.getBatch() == null) {
-                            continue;
-                        }
-                        if (batch.getBatch().getRows() != null) {
-                            context.updateReturnRows(batch.getBatch().getRows().size());
-                            if (LOG.isDebugEnabled()) {
-                                LOG.debug("Batch size for query {} is {}",
-                                        DebugUtil.printId(queryId), batch.getBatch().rows.size());
-                            }
-                        }
-                        resultRows.addAll(convertResultBatchToResultRows(batch.getBatch()));
+                        LOG.info("Result rows for query {} is {}", DebugUtil.printId(queryId), totalRows);
+                        close();
+                        return null;
+                    }
+                    if (batch.getBatch() == null) {
+                        continue;
+                    }
+                    if (batch.getBatch().getRows() != null) {
+                        context.updateReturnRows(batch.getBatch().getRows().size());
                         if (LOG.isDebugEnabled()) {
-                            LOG.debug("Result size for query {} is currently {}",
-                                    DebugUtil.printId(queryId), resultRows.size());
+                            LOG.debug("Batch size for query {} is {}",
+                                    DebugUtil.printId(queryId), batch.getBatch().rows.size());
                         }
                     }
+                    List<ResultRow> batchRows = convertResultBatchToResultRows(batch.getBatch());
+                    totalRows += batchRows.size();
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Result size for query {} is currently {}",
+                                DebugUtil.printId(queryId), totalRows);
+                    }
+                    return batchRows;
                 }
             } catch (Exception e) {
+                close();
                 throw new RuntimeException("Failed to fetch internal SQL result. " + Util.getRootCauseMessage(e), e);
             }
-        } finally {
-            if (coord != null) {
-                coord.close();
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
             }
-            AuditLogHelper.logAuditLog(context, originStmt.originStmt, parsedStmt, getQueryStatisticsForAuditLog(),
-                    true);
-            QeProcessorImpl.INSTANCE.unregisterQuery(context.queryId());
-            updateProfile(true);
+            closed = true;
+            cleanupInternalQueryExecution();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileStructureTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileStructureTest.java
@@ -19,13 +19,24 @@ package org.apache.doris.common.profile;
 
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.SafeStringBuilder;
+import org.apache.doris.nereids.trees.plans.distribute.PipelineDistributedPlan;
+import org.apache.doris.nereids.trees.plans.distribute.worker.DistributedPlanWorker;
+import org.apache.doris.nereids.trees.plans.distribute.worker.job.DefaultScanSource;
+import org.apache.doris.nereids.trees.plans.distribute.worker.job.StaticAssignedJob;
+import org.apache.doris.nereids.trees.plans.distribute.worker.job.UnassignedJob;
+import org.apache.doris.planner.DataSink;
+import org.apache.doris.planner.PlanFragment;
+import org.apache.doris.planner.PlanFragmentId;
+import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TUniqueId;
 
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -127,5 +138,40 @@ public class ProfileStructureTest {
                 pipeline0.getName().contains("Pipeline 0(instance_num=4)"));
         Assert.assertTrue("Pipeline 1 should contain instance count",
                 pipeline1.getName().contains("Pipeline 1(instance_num=4)"));
+    }
+
+    @Test
+    public void testSetDistributedPlans() {
+        TUniqueId queryId = new TUniqueId(1L, 2L);
+        ExecutionProfile profile = new ExecutionProfile(queryId, Lists.newArrayList(100));
+
+        PlanFragment fragment = Mockito.mock(PlanFragment.class);
+        Mockito.when(fragment.getFragmentId()).thenReturn(new PlanFragmentId(100));
+
+        UnassignedJob unassignedJob = Mockito.mock(UnassignedJob.class);
+        Mockito.when(unassignedJob.getFragment()).thenReturn(fragment);
+
+        DistributedPlanWorker worker = Mockito.mock(DistributedPlanWorker.class);
+        Mockito.when(worker.id()).thenReturn(7L);
+        Mockito.when(worker.address()).thenReturn("127.0.0.1:9050");
+
+        StaticAssignedJob assignedJob = new StaticAssignedJob(0, new TUniqueId(3L, 4L),
+                unassignedJob, worker, DefaultScanSource.empty());
+        PipelineDistributedPlan distributedPlan = new PipelineDistributedPlan(unassignedJob,
+                Lists.newArrayList(assignedJob), LinkedHashMultimap.create());
+
+        DataSink sink = Mockito.mock(DataSink.class);
+        Mockito.when(sink.getExchNodeId()).thenReturn(new PlanNodeId(9));
+        distributedPlan.addDestinations(sink, Lists.newArrayList(assignedJob));
+
+        profile.setDistributedPlans(Lists.newArrayList(distributedPlan));
+
+        String result = profile.toString();
+        Assert.assertTrue(result.contains("DistributedPlan"));
+        Assert.assertTrue(result.contains("FragmentId: 100"));
+        Assert.assertTrue(result.contains("Destinations:"));
+        Assert.assertTrue(result.contains("Exchange 9:"));
+        Assert.assertTrue(result.contains("Instances:"));
+        Assert.assertTrue(result.contains("Worker: 7@127.0.0.1:9050"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -70,9 +70,10 @@ public class IcebergScanNodeTest {
             mockedScanTaskUtil.when(() -> ScanTaskUtil.contentSizeInBytes(dataFile))
                     .thenReturn(10_000L * MB);
 
-            Method method = IcebergScanNode.class.getDeclaredMethod("determineTargetFileSplitSize", Iterable.class);
+            Method method = IcebergScanNode.class.getDeclaredMethod("determineTargetFileSplitSize",
+                    Iterable.class, boolean.class);
             method.setAccessible(true);
-            long target = (long) method.invoke(node, Collections.singletonList(task));
+            long target = (long) method.invoke(node, Collections.singletonList(task), false);
             Assert.assertEquals(100 * MB, target);
         }
     }
@@ -143,4 +144,5 @@ public class IcebergScanNodeTest {
                 .get(0);
         Assert.assertEquals(org.apache.doris.thrift.TFileFormatType.FORMAT_ORC, deleteFileDesc.getFileFormat());
     }
+
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/SplitAssignmentSinkTest.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.iceberg.source;
+
+import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.SplitAssignment;
+import org.apache.doris.spi.Split;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SplitAssignmentSinkTest {
+    @Test
+    public void testDelegateToSplitAssignment() throws Exception {
+        SplitAssignment splitAssignment = Mockito.mock(SplitAssignment.class);
+        Split split = Mockito.mock(Split.class);
+        List<Split> splits = Collections.singletonList(split);
+        UserException userException = new UserException("test");
+        Mockito.when(splitAssignment.needMoreSplit()).thenReturn(true);
+
+        SplitAssignmentSink sink = new SplitAssignmentSink(splitAssignment);
+        sink.addBatch(splits);
+        sink.finish();
+        sink.fail(userException);
+
+        Assertions.assertTrue(sink.needMore());
+        Mockito.verify(splitAssignment).addToQueue(splits);
+        Mockito.verify(splitAssignment).finishSchedule();
+        Mockito.verify(splitAssignment).setException(userException);
+        Mockito.verify(splitAssignment).needMoreSplit();
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/systable/IcebergSysTableResolverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/systable/IcebergSysTableResolverTest.java
@@ -36,6 +36,7 @@ public class IcebergSysTableResolverTest {
     @Test
     public void testSupportedSysTablesExcludePositionDeletes() {
         Assertions.assertFalse(IcebergSysTable.SUPPORTED_SYS_TABLES.containsKey(IcebergSysTable.POSITION_DELETES));
+        Assertions.assertFalse(IcebergSysTable.SUPPORTED_SYS_TABLES.containsKey(IcebergSysTable.METADATA_PLANNING));
     }
 
     @Test

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -333,6 +333,9 @@ struct TIcebergFileDesc {
     // Only for format_version >= 3, the sequence number which last updated this file.
     11: optional i64 last_updated_sequence_number;
     12: optional string serialized_split;
+    // True when this split is for iceberg metadata planning (distributed manifest scanning).
+    // Selects IcebergMetadataPlanningJniScanner instead of IcebergSysTableJniScanner on BE.
+    13: optional bool is_metadata_planning = false;
 }
 
 struct TPaimonDeletionFileDesc {


### PR DESCRIPTION
### What problem does this PR solve?

**Problem Summary:**

For large Iceberg tables with thousands of manifest files, FE-local manifest scanning becomes
a bottleneck during query planning. All manifest I/O runs on the FE, limiting planning
throughput regardless of how many BE nodes are available.

This PR introduces **distributed metadata planning**: FE partitions the matching manifests
across available BE nodes, each BE scans its assigned manifests in parallel, and FE
reconstructs the scan tasks from the results. This allows planning to scale with cluster size
for large tables.

The planning path is controlled by the session variable `iceberg_metadata_planning_mode`:

- `local` (default) — FE-local planning, existing behavior unchanged
- `distributed` — always use distributed planning
- `auto` — automatically choose based on table size and cluster capacity

In `auto` mode, Doris collects lightweight signals from manifest-list metadata (no manifest
file I/O) and applies a threshold-based algorithm to decide whether distributed planning
provides a meaningful parallelism advantage over the local path.

### Release note

Support distributed Iceberg metadata planning via session variable
`iceberg_metadata_planning_mode` (values: `local` / `distributed` / `auto`, default: `local`).
In `auto` mode, Doris automatically offloads manifest scanning to BE nodes when the table is
large enough to benefit from distributed parallelism.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [ ] No.
    - [x] Yes.
      New session variable `iceberg_metadata_planning_mode` (default `local`) controls whether
      manifest scanning is offloaded to BE. Existing behavior is preserved by default.

- Does this need documentation?
    - [ ] No.
    - [x] Yes. (session variable `iceberg_metadata_planning_mode` should be documented)

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label