### PR TITLE
[fix](sink) Mark cancelled node channels as failed in close_wait timeout

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -365,12 +365,20 @@ Status IndexChannel::close_wait(
                 for (auto& it : unfinished_node_channel_ids) {
                     unfinished_node_channel_host_str << _node_channels[it]->host() << ",";
                     _node_channels[it]->cancel("timeout");
+                    mark_as_failed(_node_channels[it].get(),
+                                   "cancelled due to close_wait timeout", -1);
                 }
                 LOG(WARNING) << "reach max wait time, max_wait_time_ms: " << max_wait_time_ms
                              << ", cancel unfinished node channel and finish close"
                              << ", load id: " << print_id(_parent->_load_id)
                              << ", txn_id: " << _parent->_txn_id << ", unfinished node channel: "
                              << unfinished_node_channel_host_str.str();
+                Status intolerable_st = check_intolerable_failure();
+                if (!intolerable_st.ok()) {
+                    status = std::move(intolerable_st);
+                } else {
+                    set_error_tablet_in_state(_parent->_state);
+                }
                 break;
             }
             bthread_usleep(1000 * 10);


### PR DESCRIPTION
What problem does this PR solve?
Issue Number: close https://github.com/apache/doris/issues/61916

Problem Summary:

When close_wait times out waiting for unfinished node channels after quorum success, the cancelled channels were not marked as failed. FE was unaware of the failure, causing publish to send tasks to the cancelled node and fail, making data invisible for a long time (30+ minutes until publish retry).

Reproduction scenario (3-replica table):

Quorum success achieved (2 of 3 replicas finish writing)
close_wait times out after max_wait_time_ms, cancels the slow 3rd replica
Only cancel("timeout") was called — no failure reported to FE
FE commit succeeds with error replicas num: 0, publishes to all 3 backends
Publish to the cancelled backend fails, data invisible until retry
BE log before fix:

W... reach max wait time, max_wait_time_ms: 180000, cancel unfinished node channel and finish close
BE log after fix:

I... mark node_id:VNodeChannel[...-1748408277298] ... tablet_id: -1 as failed, err: cancelled due to close_wait timeout
W... reach max wait time, max_wait_time_ms: 180000, cancel unfinished node channel and finish close, ... unfinished node channel: 10.244.19.226
Fix: In IndexChannel::close_wait(), after cancelling unfinished node channels:

Call mark_as_failed() to record failed tablets in _failed_channels
Call check_intolerable_failure() to check if failures exceed tolerance threshold
Call set_error_tablet_in_state() to propagate TErrorTabletInfo to FE so publish skips the failed replica

Release note
When close_wait times out after quorum success, cancelled node channels are now properly marked as failed and reported to FE. Previously this caused publish to fail on the cancelled node, delaying data visibility by 30+ minutes.

Check List (For Author)
Test

Regression test
Unit Test
Manual test (add detailed scripts or steps below)
Deployed fix to production environment, observed mark_as_failed log triggered correctly when close_wait timeout occurred on node 226 (txn_id=2767312). FE received error tablet info and data became visible immediately via quorum publish.
No need to test or manual test. Explain why:
Behavior changed:

No.
Yes. Cancelled node channels due to close_wait timeout are now marked as failed and reported to FE. In edge cases where failures are intolerable (too many replicas failed), the load will fail entirely instead of succeeding with delayed visibility.
Does this need documentation?

No.
Yes.
Check List (For Reviewer who merge this PR)
Confirm the release note
Confirm test cases
Confirm document
Add branch pick label