### PR TITLE
[fix](arrow-flight) Fix DDL via Flight SQL crashing with getMysqlChannel RuntimeException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1611,7 +1611,9 @@ public class StmtExecutor {
     }
 
     private void sendMetaData(ResultSetMetaData metaData, List<FieldInfo> fieldInfos) throws IOException {
-        Preconditions.checkState(context.getConnectType() == ConnectType.MYSQL);
+        if (context.getConnectType() != ConnectType.MYSQL) {
+            return;
+        }
         // sends how many columns
         serializer.reset();
         serializer.writeVInt(metaData.getColumnCount());
@@ -1644,7 +1646,9 @@ public class StmtExecutor {
     }
 
     public void sendStmtPrepareOK(int stmtId, List<String> labels, List<Slot> output) throws IOException {
-        Preconditions.checkState(context.getConnectType() == ConnectType.MYSQL);
+        if (context.getConnectType() != ConnectType.MYSQL) {
+            return;
+        }
         // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response
         serializer.reset();
         // 0x00 OK
@@ -1725,7 +1729,9 @@ public class StmtExecutor {
 
     private void sendFields(List<String> colNames, List<FieldInfo> fieldInfos, List<Type> types) throws
             IOException {
-        Preconditions.checkState(context.getConnectType() == ConnectType.MYSQL);
+        if (context.getConnectType() != ConnectType.MYSQL) {
+            return;
+        }
         // sends how many columns
         serializer.reset();
         serializer.writeVInt(colNames.size());


### PR DESCRIPTION
## Proposed changes

Fix DDL statements (CREATE DATABASE, CREATE TABLE, etc.) via Arrow Flight SQL crashing with `RuntimeException: getMysqlChannel not in mysql connection`.

## Problem Summary

This is a regression introduced in 4.0.5 by commit `1a8590e0b22` ("[fix](protocol) Support CLIENT_DEPRECATE_EOF to fix empty result with MySQL driver 9.5.0 #61050 (#61062)").

The CLIENT_DEPRECATE_EOF fix added `context.getMysqlChannel().clientDeprecatedEOF()` calls in `StmtExecutor.java` at three locations (`sendFields`, `sendMetaData`, `sendStmtPrepareOK`). These code paths are also traversed during Flight SQL DDL execution, but `FlightSqlConnectContext.getMysqlChannel()` throws `RuntimeException("getMysqlChannel not in mysql connection")` because Flight SQL does not use MySQL channels.

### Stack trace
```
INTERNAL: [FlightSQL] get flight info statement failed, after executeQueryStatement handleQuery,
java.lang.RuntimeException: getMysqlChannel not in mysql connection
  at FlightSqlConnectContext.getMysqlChannel(FlightSqlConnectContext.java:55)
  at StmtExecutor.sendFields(StmtExecutor.java:1537)
```

## Fix

Replace `Preconditions.checkState(context.getConnectType() == ConnectType.MYSQL)` with early return `if (context.getConnectType() != ConnectType.MYSQL) return;` in:
- `sendFields()` (line 1728)
- `sendMetaData()` (line 1614)
- `sendStmtPrepareOK()` (line 1647)

This follows the existing pattern used in:
- `handleQueryStmt()` (line 1259): `if (context.getConnectType() == ConnectType.MYSQL) { context.getMysqlChannel().reset(); }`
- `InsertIntoTableCommand.java` (line 383): `if (ctx.getConnectType() == ConnectType.MYSQL && ctx.getMysqlChannel() != null)`

These three methods only send MySQL wire protocol packets (field definitions, EOF markers, etc.) which are not needed for Flight SQL — the Arrow Flight protocol has its own result schema mechanism via `fetchArrowFlightSchema()`.

Fixes #62017

## Checklist(Required)

- [x] Does it affect the results of decoupled storage and computing mode?  No
- [x] If it has, has it been adapted to the decoupled storage and computing mode?  N/A
- [x] Does it need to update dependencies?  No
- [x] Does it need to be cherry-picked to branch-4.0?  Yes
- [x] Are there any changes that cannot be rolled back?  No
- [x] Does it need to update BE thread names?  No
