### PR TITLE
[fix](exec) Fix data race on _queue_deps and _parents in ExchangeSinkBuffer

### DIFF
--- a/be/src/common/thread_safety_annotations.h
+++ b/be/src/common/thread_safety_annotations.h
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Thread safety annotation macros and annotated mutex wrappers for
+// Clang's -Wthread-safety static analysis.
+// Reference: https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
+
+#pragma once
+
+#include <mutex>
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) // no-op
+#endif
+
+#define TSA_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define TSA_SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define TSA_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define TSA_PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define TSA_ACQUIRED_BEFORE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define TSA_ACQUIRED_AFTER(...) THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define TSA_REQUIRES(...) THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define TSA_REQUIRES_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+#define TSA_ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define TSA_ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+#define TSA_RELEASE(...) THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define TSA_RELEASE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+#define TSA_TRY_ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define TSA_TRY_ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+#define TSA_EXCLUDES(...) THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define TSA_ASSERT_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define TSA_ASSERT_SHARED_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+#define TSA_RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define TSA_NO_THREAD_SAFETY_ANALYSIS THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+// Annotated mutex wrapper for use with Clang thread safety analysis.
+// Wraps std::mutex and provides the CAPABILITY annotation so that
+// GUARDED_BY / REQUIRES / etc. annotations can reference it.
+class TSA_CAPABILITY("mutex") AnnotatedMutex {
+public:
+    void lock() TSA_ACQUIRE() { _mutex.lock(); }
+    void unlock() TSA_RELEASE() { _mutex.unlock(); }
+    bool try_lock() TSA_TRY_ACQUIRE(true) { return _mutex.try_lock(); }
+
+    // Access the underlying std::mutex (e.g., for std::condition_variable).
+    // Use with care — this bypasses thread safety annotations.
+    std::mutex& native_handle() { return _mutex; }
+
+private:
+    std::mutex _mutex;
+};
+
+// RAII scoped lock guard annotated for thread safety analysis.
+template <typename MutexType>
+class TSA_SCOPED_CAPABILITY AnnotatedLockGuard {
+public:
+    explicit AnnotatedLockGuard(MutexType& mu) TSA_ACQUIRE(mu) : _mu(mu) { _mu.lock(); }
+    ~AnnotatedLockGuard() TSA_RELEASE() { _mu.unlock(); }
+
+    AnnotatedLockGuard(const AnnotatedLockGuard&) = delete;
+    AnnotatedLockGuard& operator=(const AnnotatedLockGuard&) = delete;
+
+private:
+    MutexType& _mu;
+};

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -32,6 +32,14 @@ if (WITH_LZO)
     )
 endif()
 
+# Enable Clang thread safety analysis for specific files
+if (COMPILER_CLANG)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/operator/exchange_sink_buffer.cpp
+        PROPERTIES COMPILE_FLAGS "-Wthread-safety"
+    )
+endif()
+
 add_library(Exec STATIC
     ${EXEC_FILES}
 )

--- a/be/src/exec/operator/exchange_sink_buffer.cpp
+++ b/be/src/exec/operator/exchange_sink_buffer.cpp
@@ -177,9 +177,12 @@ Status ExchangeSinkBuffer::add_block(Channel* channel, TransmitInfo&& request) {
         }
         instance_data.package_queue[channel].emplace(std::move(request));
         _total_queue_size++;
-        if (_total_queue_size > _queue_capacity) {
-            for (auto& dep : _queue_deps) {
-                dep->block();
+        {
+            AnnotatedLockGuard l(_m);
+            if (_total_queue_size > _queue_capacity) {
+                for (auto& dep : _queue_deps) {
+                    dep->block();
+                }
             }
         }
     }
@@ -377,9 +380,12 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
         }
         DCHECK_GE(_total_queue_size, requests.size());
         _total_queue_size -= (int)requests.size();
-        if (_total_queue_size <= _queue_capacity) {
-            for (auto& dep : _queue_deps) {
-                dep->set_ready();
+        {
+            AnnotatedLockGuard l(_m);
+            if (_total_queue_size <= _queue_capacity) {
+                for (auto& dep : _queue_deps) {
+                    dep->set_ready();
+                }
             }
         }
     } else if (broadcast_q_ptr && !broadcast_q_ptr->empty()) {
@@ -557,9 +563,12 @@ void ExchangeSinkBuffer::_set_receiver_eof(RpcInstance& ins) {
     }
 
     // Try to wake up pipeline after clearing the queue
-    if (_total_queue_size <= _queue_capacity) {
-        for (auto& dep : _queue_deps) {
-            dep->set_ready();
+    {
+        AnnotatedLockGuard l(_m);
+        if (_total_queue_size <= _queue_capacity) {
+            for (auto& dep : _queue_deps) {
+                dep->set_ready();
+            }
         }
     }
 
@@ -579,6 +588,7 @@ void ExchangeSinkBuffer::_turn_off_channel(RpcInstance& ins,
     ins.rpc_channel_is_turn_off = true;
     auto weak_task_ctx = weak_task_exec_ctx();
     if (auto pip_ctx = weak_task_ctx.lock()) {
+        AnnotatedLockGuard l(_m);
         for (auto& parent : _parents) {
             parent->on_channel_finished(ins.id);
         }

--- a/be/src/exec/operator/exchange_sink_buffer.h
+++ b/be/src/exec/operator/exchange_sink_buffer.h
@@ -34,6 +34,7 @@
 
 #include "common/global_types.h"
 #include "common/status.h"
+#include "common/thread_safety_annotations.h"
 #include "runtime/runtime_state.h"
 #include "service/backend_options.h"
 #include "util/brpc_closure.h"
@@ -277,7 +278,7 @@ public:
 
     void set_dependency(InstanceLoId sender_ins_id, std::shared_ptr<Dependency> queue_dependency,
                         ExchangeSinkLocalState* local_state) {
-        std::lock_guard l(_m);
+        AnnotatedLockGuard l(_m);
         _queue_deps.push_back(queue_dependency);
         _parents.push_back(local_state);
     }
@@ -330,11 +331,11 @@ private:
     std::atomic<int> _total_queue_size = 0;
 
     // protected the `_queue_deps` and `_parents`
-    std::mutex _m;
+    AnnotatedMutex _m;
     // _queue_deps is used for memory control.
-    std::vector<std::shared_ptr<Dependency>> _queue_deps;
+    std::vector<std::shared_ptr<Dependency>> _queue_deps TSA_GUARDED_BY(_m);
     // The ExchangeSinkLocalState in _parents is only used in _turn_off_channel.
-    std::vector<ExchangeSinkLocalState*> _parents;
+    std::vector<ExchangeSinkLocalState*> _parents TSA_GUARDED_BY(_m);
     const int64_t _exchange_sink_num;
     bool _send_multi_blocks = false;
     int _send_multi_blocks_byte_size = 256 * 1024;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

```
exchange_sink_buffer.cpp:569:24: error: reading variable '_queue_deps' requires holding mutex '_m'
[-Werror,-Wthread-safety-analysis]
  569 |         for (auto& dep : _queue_deps) {
      |                        ^
```



`ExchangeSinkBuffer` has two member fields `_queue_deps` and `_parents` that are protected by mutex `_m`. However, multiple code paths access these fields without holding `_m`, leading to data races.

Specifically, `add_block()`, `_send_rpc()`, and `_set_receiver_eof()` iterate `_queue_deps` while only holding the per-`RpcInstance` mutex (`instance_data.mutex`), and `_turn_off_channel()` iterates `_parents` also without holding `_m`. Concurrently, `set_dependency()` acquires `_m` and pushes to both `_queue_deps` and `_parents`. Since the two lock domains are disjoint, if a new sink registers via `set_dependency()` while another thread is iterating `_queue_deps`, the `std::vector` may be reallocated underneath the iterator, causing use-after-free or corrupted iteration. This is undefined behavior.

Beyond the data race on the vector itself, there is also a **missed-wakeup** problem: the check-then-act pattern on `_total_queue_size` (an `std::atomic<int>`) versus the `_queue_deps` block/unblock iteration is not atomic. Two threads holding different instance mutexes can interleave such that one thread blocks all dependencies right after another thread has already checked and decided to unblock, resulting in a permanently blocked pipeline (deadlock).

### Approach

This PR introduces Clang's `-Wthread-safety` static analysis on `exchange_sink_buffer.cpp` to mechanically detect all unprotected accesses, then fixes all reported violations.

#### 1. Thread Safety Annotation Infrastructure

Added `be/src/common/thread_safety_annotations.h` which provides:
- `TSA_GUARDED_BY`, `TSA_REQUIRES`, `TSA_ACQUIRE`, `TSA_RELEASE`, etc. — standard Clang thread safety annotation macros
- `AnnotatedMutex` — a `std::mutex` wrapper annotated with `TSA_CAPABILITY("mutex")`
- `AnnotatedLockGuard<MutexType>` — an RAII lock guard annotated with `TSA_SCOPED_CAPABILITY`

These are no-ops when compiling with non-Clang compilers.

#### 2. Annotations Applied to ExchangeSinkBuffer

In `exchange_sink_buffer.h`:
- `std::mutex _m` → `AnnotatedMutex _m`
- `_queue_deps` marked with `TSA_GUARDED_BY(_m)`
- `_parents` marked with `TSA_GUARDED_BY(_m)`
- `set_dependency()` uses `AnnotatedLockGuard` instead of `std::lock_guard`

In `be/src/exec/CMakeLists.txt`:
- Added `set_source_files_properties(... PROPERTIES COMPILE_FLAGS "-Wthread-safety")` for `exchange_sink_buffer.cpp`, so the analysis is enabled per-file without affecting the rest of the build.

#### 3. Compilation Errors Detected

With `-Wthread-safety` enabled, Clang reported **8 errors at 4 locations**:

| Location | Line | Field | Access Pattern |
|---|---|---|---|
| `add_block()` | ~189 | `_queue_deps` | Iterates to call `dep->block()` — only holds `instance_data.mutex`, not `_m` |
| `_send_rpc()` | ~389 | `_queue_deps` | Iterates to call `dep->set_ready()` — only holds `instance_data.mutex`, not `_m` |
| `_set_receiver_eof()` | ~569 | `_queue_deps` | Iterates to call `dep->set_ready()` — holds no lock at all |
| `_turn_off_channel()` | ~590 | `_parents` | Iterates to call `parent->on_channel_finished()` — holds `instance_data.mutex`, not `_m` |

#### 4. Fixes Applied

All four sites now acquire `_m` (via `AnnotatedLockGuard l(_m)`) before iterating the guarded fields:

- **`add_block()`**: Wrapped the `_total_queue_size > _queue_capacity` check and `_queue_deps` iteration in `AnnotatedLockGuard l(_m)`.
- **`_send_rpc()`**: Wrapped the `_total_queue_size <= _queue_capacity` check and `_queue_deps` iteration in `AnnotatedLockGuard l(_m)`.
- **`_set_receiver_eof()`**: Wrapped the `_total_queue_size <= _queue_capacity` check and `_queue_deps` iteration in `AnnotatedLockGuard l(_m)`.
- **`_turn_off_channel()`**: Wrapped the `_parents` iteration in `AnnotatedLockGuard l(_m)`.

Lock ordering is always `instance_data.mutex` → `_m` (the inner lock), so there is no deadlock risk.

After applying the fixes, the file compiles cleanly with zero thread-safety violations.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

