### PR TITLE
[refine](expr) Replace manual type switch-case with dispatch_switch helpers

### DIFF
--- a/be/src/exprs/aggregate/aggregate_function_group_array_set_op_impl.h
+++ b/be/src/exprs/aggregate/aggregate_function_group_array_set_op_impl.h
@@ -36,80 +36,25 @@ inline AggregateFunctionPtr create_aggregate_function_group_array_impl(
     const auto& nested_type = remove_nullable(
             assert_cast<const DataTypeArray&>(*(argument_types[0])).get_nested_type());
 
-    switch (nested_type->get_primitive_type()) {
-    case doris::PrimitiveType::TYPE_BOOLEAN:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_BOOLEAN>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_TINYINT:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_TINYINT>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_SMALLINT:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_SMALLINT>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_INT:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_INT>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_BIGINT:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_BIGINT>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_LARGEINT:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_LARGEINT>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_DATEV2:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_DATEV2>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_DATETIMEV2:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_DATETIMEV2>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_DOUBLE:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_DOUBLE>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_FLOAT:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_FLOAT>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_DECIMAL32:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_DECIMAL32>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_DECIMAL64:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_DECIMAL64>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_DECIMAL128I:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_DECIMAL128I>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_DECIMAL256:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_DECIMAL256>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_IPV4:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_IPV4>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_IPV6:
-        return creator_without_type::create<
-                AggregateFunctionGroupArraySetOp<ImplNumericData<TYPE_IPV6>>>(
-                argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_STRING:
-    case PrimitiveType::TYPE_VARCHAR:
-    case PrimitiveType::TYPE_CHAR:
+    auto pt = nested_type->get_primitive_type();
+    if (pt == PrimitiveType::TYPE_STRING || pt == PrimitiveType::TYPE_VARCHAR ||
+        pt == PrimitiveType::TYPE_CHAR) {
         return creator_without_type::create<AggregateFunctionGroupArraySetOp<ImplStringData>>(
                 argument_types, result_is_nullable, attr);
-    default:
-        LOG(WARNING) << " got invalid of nested type: " << nested_type->get_name();
-        return nullptr;
     }
+
+    AggregateFunctionPtr result;
+    dispatch_switch_scalar(pt, [&](auto type_holder) {
+        using DT = std::decay_t<decltype(type_holder)>;
+        result = creator_without_type::create<
+                AggregateFunctionGroupArraySetOp<ImplNumericData<DT::PType>>>(
+                argument_types, result_is_nullable, attr);
+        return true;
+    });
+    if (!result) {
+        LOG(WARNING) << " got invalid of nested type: " << nested_type->get_name();
+    }
+    return result;
 }
 
 } // namespace doris

--- a/be/src/exprs/function/array/function_array_cum_sum.cpp
+++ b/be/src/exprs/function/array/function_array_cum_sum.cpp
@@ -159,62 +159,28 @@ private:
                           const ColumnArray::Offsets64& src_offsets,
                           const NullMapType& src_null_map, ColumnPtr& res_nested_ptr) const {
         bool res = false;
-        switch (src_nested_type->get_primitive_type()) {
-        case TYPE_BOOLEAN:
-            res = _execute_number<TYPE_BOOLEAN, TYPE_BIGINT>(src_column, src_offsets, src_null_map,
+        dispatch_switch_number(src_nested_type->get_primitive_type(), [&](auto type_holder) {
+            using SrcDT = std::decay_t<decltype(type_holder)>;
+            constexpr auto SrcPType = SrcDT::PType;
+            if constexpr (SrcPType == TYPE_LARGEINT) {
+                res = _execute_number<SrcPType, TYPE_LARGEINT>(src_column, src_offsets,
+                                                               src_null_map, res_nested_ptr);
+            } else if constexpr (SrcPType == TYPE_FLOAT || SrcPType == TYPE_DOUBLE) {
+                res = _execute_number<SrcPType, TYPE_DOUBLE>(src_column, src_offsets, src_null_map,
                                                              res_nested_ptr);
-            break;
-        case TYPE_TINYINT:
-            res = _execute_number<TYPE_TINYINT, TYPE_BIGINT>(src_column, src_offsets, src_null_map,
-                                                             res_nested_ptr);
-            break;
-        case TYPE_SMALLINT:
-            res = _execute_number<TYPE_SMALLINT, TYPE_BIGINT>(src_column, src_offsets, src_null_map,
-                                                              res_nested_ptr);
-            break;
-        case TYPE_INT:
-            res = _execute_number<TYPE_INT, TYPE_BIGINT>(src_column, src_offsets, src_null_map,
-                                                         res_nested_ptr);
-            break;
-        case TYPE_BIGINT:
-            res = _execute_number<TYPE_BIGINT, TYPE_BIGINT>(src_column, src_offsets, src_null_map,
-                                                            res_nested_ptr);
-            break;
-        case TYPE_LARGEINT:
-            res = _execute_number<TYPE_LARGEINT, TYPE_LARGEINT>(src_column, src_offsets,
+            } else if constexpr (SrcPType == TYPE_DECIMALV2) {
+                res = _execute_number<SrcPType, TYPE_DECIMALV2>(src_column, src_offsets,
                                                                 src_null_map, res_nested_ptr);
-            break;
-        case TYPE_FLOAT:
-            res = _execute_number<TYPE_FLOAT, TYPE_DOUBLE>(src_column, src_offsets, src_null_map,
-                                                           res_nested_ptr);
-            break;
-        case TYPE_DOUBLE:
-            res = _execute_number<TYPE_DOUBLE, TYPE_DOUBLE>(src_column, src_offsets, src_null_map,
-                                                            res_nested_ptr);
-            break;
-        case TYPE_DECIMAL32:
-            res = _execute_number<TYPE_DECIMAL32, PType>(src_column, src_offsets, src_null_map,
-                                                         res_nested_ptr);
-            break;
-        case TYPE_DECIMAL64:
-            res = _execute_number<TYPE_DECIMAL64, PType>(src_column, src_offsets, src_null_map,
-                                                         res_nested_ptr);
-            break;
-        case TYPE_DECIMAL128I:
-            res = _execute_number<TYPE_DECIMAL128I, PType>(src_column, src_offsets, src_null_map,
-                                                           res_nested_ptr);
-            break;
-        case TYPE_DECIMAL256:
-            res = _execute_number<TYPE_DECIMAL256, PType>(src_column, src_offsets, src_null_map,
-                                                          res_nested_ptr);
-            break;
-        case TYPE_DECIMALV2:
-            res = _execute_number<TYPE_DECIMALV2, TYPE_DECIMALV2>(src_column, src_offsets,
-                                                                  src_null_map, res_nested_ptr);
-            break;
-        default:
-            break;
-        }
+            } else if constexpr (is_decimalv3(SrcPType)) {
+                res = _execute_number<SrcPType, PType>(src_column, src_offsets, src_null_map,
+                                                       res_nested_ptr);
+            } else {
+                // int types: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT
+                res = _execute_number<SrcPType, TYPE_BIGINT>(src_column, src_offsets, src_null_map,
+                                                             res_nested_ptr);
+            }
+            return true;
+        });
         return res;
     }
 

--- a/be/src/exprs/function/least_greast.cpp
+++ b/be/src/exprs/function/least_greast.cpp
@@ -25,6 +25,7 @@
 
 #include "core/accurate_comparison.h"
 #include "core/assert_cast.h"
+#include "core/call_on_type_index.h"
 #include "core/block/block.h"
 #include "core/block/column_numbers.h"
 #include "core/block/column_with_type_and_name.h"
@@ -187,10 +188,9 @@ struct FunctionFieldImpl {
         DCHECK_EQ(arg_const, false);
 
         //TODO: maybe could use hashmap to save column data, not use for loop ervey time to test equals.
-        switch (data_type->get_primitive_type()) {
-        case PrimitiveType::TYPE_STRING:
-        case PrimitiveType::TYPE_CHAR:
-        case PrimitiveType::TYPE_VARCHAR: {
+        if (data_type->get_primitive_type() == PrimitiveType::TYPE_STRING ||
+            data_type->get_primitive_type() == PrimitiveType::TYPE_CHAR ||
+            data_type->get_primitive_type() == PrimitiveType::TYPE_VARCHAR) {
             const auto& column_string = assert_cast<const ColumnString&>(*argument_columns[0]);
             for (int row = 0; row < input_rows_count; ++row) {
                 const auto& str_data = column_string.get_data_at(row);
@@ -204,115 +204,18 @@ struct FunctionFieldImpl {
                     }
                 }
             }
-            break;
-        }
-        case PrimitiveType::TYPE_TINYINT: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_TINYINT>(res_data, argument_columns[0],
-                                                 argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_SMALLINT: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_SMALLINT>(res_data, argument_columns[0],
-                                                  argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_INT: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_INT>(res_data, argument_columns[0], argument_columns[col],
-                                             input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_BIGINT: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_BIGINT>(res_data, argument_columns[0],
-                                                argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_LARGEINT: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_LARGEINT>(res_data, argument_columns[0],
-                                                  argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_FLOAT: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_FLOAT>(res_data, argument_columns[0], argument_columns[col],
-                                               input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DOUBLE: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DOUBLE>(res_data, argument_columns[0],
-                                                argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DECIMAL32: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DECIMAL32>(res_data, argument_columns[0],
-                                                   argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DECIMAL64: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DECIMAL64>(res_data, argument_columns[0],
-                                                   argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DECIMALV2: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DECIMALV2>(res_data, argument_columns[0],
-                                                   argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DECIMAL128I: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DECIMAL128I>(res_data, argument_columns[0],
-                                                     argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DECIMAL256: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DECIMAL256>(res_data, argument_columns[0],
-                                                    argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DATEV2: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DATEV2>(res_data, argument_columns[0],
-                                                argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_DATETIMEV2: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_DATETIMEV2>(res_data, argument_columns[0],
-                                                    argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        case PrimitiveType::TYPE_TIMESTAMPTZ: {
-            for (int col = 1; col < arguments.size(); ++col) {
-                insert_result_data<TYPE_TIMESTAMPTZ>(res_data, argument_columns[0],
-                                                     argument_columns[col], input_rows_count, col);
-            }
-            break;
-        }
-        default:
-            break;
+        } else {
+            bool dispatched = dispatch_switch_scalar(data_type->get_primitive_type(),
+                    [&](auto type_holder) {
+                        using DT = std::decay_t<decltype(type_holder)>;
+                        for (int col = 1; col < column_size; ++col) {
+                            insert_result_data<DT::PType>(res_data, argument_columns[0],
+                                                          argument_columns[col], input_rows_count,
+                                                          col);
+                        }
+                        return true;
+                    });
+            DCHECK(dispatched) << "unsupported type: " << data_type->get_name();
         }
 
         return result_column;

--- a/be/src/exprs/function/least_greast.cpp
+++ b/be/src/exprs/function/least_greast.cpp
@@ -25,10 +25,10 @@
 
 #include "core/accurate_comparison.h"
 #include "core/assert_cast.h"
-#include "core/call_on_type_index.h"
 #include "core/block/block.h"
 #include "core/block/column_numbers.h"
 #include "core/block/column_with_type_and_name.h"
+#include "core/call_on_type_index.h"
 #include "core/column/column.h"
 #include "core/column/column_const.h"
 #include "core/column/column_decimal.h"
@@ -205,8 +205,8 @@ struct FunctionFieldImpl {
                 }
             }
         } else {
-            bool dispatched = dispatch_switch_scalar(data_type->get_primitive_type(),
-                    [&](auto type_holder) {
+            bool dispatched =
+                    dispatch_switch_scalar(data_type->get_primitive_type(), [&](auto type_holder) {
                         using DT = std::decay_t<decltype(type_holder)>;
                         for (int col = 1; col < column_size; ++col) {
                             insert_result_data<DT::PType>(res_data, argument_columns[0],


### PR DESCRIPTION
### What problem does this PR solve?

Several aggregate/scalar functions in `be/src/exprs/` use large hand-written switch-case blocks to dispatch on `PrimitiveType`. These are verbose, error-prone, and generate repetitive boilerplate.

This PR replaces them with the existing `dispatch_switch_scalar` / `dispatch_switch_number` utilities from `call_on_type_index.h`:

- **`least_greast.cpp`** (`FunctionFieldImpl::execute`): ~15 manual cases → `dispatch_switch_scalar`
- **`aggregate_function_group_array_set_op_impl.h`**: ~16 manual cases → `dispatch_switch_scalar` + string branch
- **`function_array_cum_sum.cpp`** (`_execute_by_type`): ~13 manual cases → `dispatch_switch_number` with `constexpr if` type promotion

### Release note

None

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

