### PR TITLE
[Bug](pipeline) do not set shared hash table signaled when task terminated

### DIFF
--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -244,8 +244,8 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
             // enter std::visit on monostate and crash with "Hash table type mismatch".
             //
             // _terminated is reliably true here when the task was woken up early, because
-            // operator terminate() is called in the execute() Defer (pipeline_task.cpp:510-512)
-            // BEFORE close() runs.
+            // operator terminate() is called from the execute() Defer in PipelineTask
+            // before close() is invoked.
             if (!_terminated) {
                 p._signaled = true;
             }

--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -237,7 +237,18 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
 
         if (p._use_shared_hash_table) {
             std::unique_lock lock(p._mutex);
-            p._signaled = true;
+            // Only signal non-builder tasks when the builder actually built the hash table.
+            // When the builder is terminated (woken up early because the probe side finished
+            // first), it never called process_build_block() so the hash table variant is still
+            // monostate. Setting _signaled=true in that case would cause non-builder tasks to
+            // enter std::visit on monostate and crash with "Hash table type mismatch".
+            //
+            // _terminated is reliably true here when the task was woken up early, because
+            // operator terminate() is called in the execute() Defer (pipeline_task.cpp:510-512)
+            // BEFORE close() runs.
+            if (!_terminated) {
+                p._signaled = true;
+            }
             for (auto& dep : _shared_state->sink_deps) {
                 dep->set_ready();
             }
@@ -840,10 +851,18 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, Block* in_block, bo
         RETURN_IF_ERROR(local_state.build_asof_index(*local_state._shared_state->build_block));
         local_state.init_short_circuit_for_probe();
     } else if (!local_state._should_build_hash_table) {
-        // the instance which is not build hash table, it's should wait the signal of hash table build finished.
-        // but if it's running and signaled == false, maybe the source operator have closed caused by some short circuit
-        // return eof will make task marked as wake_up_early
-        // todo: remove signaled after we can guarantee that wake up eraly is always set accurately
+        // The non-builder instance waits for the builder (task 0) to finish building the hash table.
+        // If _signaled is false, either the builder hasn't finished yet, or the builder was
+        // terminated (woken up early) without building the hash table — in both cases, return EOF.
+        //
+        // The close() Defer in the builder conditionally sets _signaled=true ONLY when the builder
+        // was NOT terminated (i.e., the hash table was actually built). When the builder is
+        // terminated, _signaled stays false, so non-builders always hit this guard and return EOF
+        // safely — never reaching the std::visit on an uninitialized (monostate) hash table.
+        //
+        // _terminated is also checked as a secondary guard. Note that _terminated is always false
+        // inside sink() during execute() (it's set in the Defer AFTER execute() returns), so it
+        // provides no protection against the race. The _signaled check is the real guard.
         if (!_signaled || local_state._terminated) {
             return Status::Error<ErrorCode::END_OF_FILE>("source have closed");
         }

--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -860,10 +860,10 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, Block* in_block, bo
         // terminated, _signaled stays false, so non-builders always hit this guard and return EOF
         // safely — never reaching the std::visit on an uninitialized (monostate) hash table.
         //
-        // _terminated is also checked as a secondary guard. Note that _terminated is always false
-        // inside sink() during execute() (it's set in the Defer AFTER execute() returns), so it
-        // provides no protection against the race. The _signaled check is the real guard.
-        if (!_signaled || local_state._terminated) {
+        // At this point, termination is reflected solely through the value of _signaled: a
+        // terminated builder never sets _signaled to true. Checking !_signaled is therefore
+        // sufficient and serves as the real guard against racing with an uninitialized hash table.
+        if (!_signaled) {
             return Status::Error<ErrorCode::END_OF_FILE>("source has closed");
         }
 

--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -864,7 +864,7 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, Block* in_block, bo
         // inside sink() during execute() (it's set in the Defer AFTER execute() returns), so it
         // provides no protection against the race. The _signaled check is the real guard.
         if (!_signaled || local_state._terminated) {
-            return Status::Error<ErrorCode::END_OF_FILE>("source have closed");
+            return Status::Error<ErrorCode::END_OF_FILE>("source has closed");
         }
 
         DCHECK_LE(local_state._task_idx,

--- a/be/test/exec/operator/hashjoin_build_sink_test.cpp
+++ b/be/test/exec/operator/hashjoin_build_sink_test.cpp
@@ -28,16 +28,19 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <variant>
 #include <vector>
 
 #include "common/config.h"
 #include "core/block/block.h"
+#include "core/data_type/data_type_number.h"
 #include "exec/operator/hash_join_test_helper.h"
 #include "exec/operator/operator.h"
 #include "exec/pipeline/pipeline_task.h"
 #include "exprs/vexpr_context.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
+#include "testutil/column_helper.h"
 #include "testutil/mock/mock_runtime_state.h"
 
 namespace doris {
@@ -356,6 +359,265 @@ TEST_F(HashJoinBuildSinkTest, Terminate) {
     };
 
     run_test_block(test_block);
+}
+
+// ============================================================================
+// Tests for shared hash table signaling when builder task is terminated.
+//
+// The problematic timing sequence (before the fix):
+//   Thread A: triggers make_all_runnable
+//   Thread A: make_all_runnable wakes up task0 (the builder)
+//   Thread B: task0 is terminated (wake_up_early) and close() runs ->
+//             unconditionally sets _signaled=true and wakes other tasks
+//   Thread C: task1 (non-builder) wakes up, calls sink() ->
+//             sees _signaled=true, enters std::visit on monostate hash table -> crash
+//   Thread A: make_all_runnable continues
+//
+// The fix: In close(), only set _signaled=true when the builder was NOT terminated
+// (i.e., the hash table was actually built). When terminated, _signaled stays false,
+// so non-builder tasks return EOF safely.
+// ============================================================================
+
+class SharedHashTableSignalTest : public testing::Test {
+public:
+    void SetUp() override { _helper.SetUp(); }
+    void TearDown() override { _helper.TearDown(); }
+
+protected:
+    // Set up a broadcast join with shared hash table containing num_instances tasks.
+    // Returns the sink operator, shared state, and runtime states for all tasks.
+    struct BroadcastJoinSetup {
+        std::shared_ptr<HashJoinBuildSinkOperatorX> sink_op;
+        std::shared_ptr<HashJoinProbeOperatorX> probe_op;
+        std::shared_ptr<BasicSharedState> shared_state;
+        // runtime_state for the builder (task_idx=0)
+        MockRuntimeState* builder_state;
+        // runtime_states for non-builder tasks (task_idx=1..N-1)
+        std::vector<std::shared_ptr<MockRuntimeState>> non_builder_states;
+    };
+
+    BroadcastJoinSetup setup_broadcast_join(int num_instances) {
+        BroadcastJoinSetup result;
+
+        auto tnode = _helper.create_test_plan_node(TJoinOp::INNER_JOIN, {TPrimitiveType::INT},
+                                                   {false}, {false});
+
+        tnode.hash_join_node.__isset.is_broadcast_join = true;
+        tnode.hash_join_node.is_broadcast_join = true;
+
+        auto [probe_op, sink_op] = _helper.create_operators(tnode);
+        EXPECT_TRUE(probe_op);
+        EXPECT_TRUE(sink_op);
+
+        auto st = sink_op->init(tnode, _helper.runtime_state.get());
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        st = sink_op->prepare(_helper.runtime_state.get());
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        st = probe_op->init(tnode, _helper.runtime_state.get());
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        st = probe_op->prepare(_helper.runtime_state.get());
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        // Create shared state for broadcast join with num_instances
+        auto shared_state = HashJoinSharedState::create_shared(num_instances);
+        shared_state->create_source_dependencies(num_instances, sink_op->operator_id(),
+                                                 sink_op->node_id(), "HASH_JOIN_PROBE");
+
+        // Set up non-builder tasks first (task_idx=1..N-1)
+        for (int i = 1; i < num_instances; i++) {
+            auto non_builder_state = std::make_shared<MockRuntimeState>();
+            non_builder_state->_query_ctx = _helper.runtime_state->_query_ctx;
+            non_builder_state->_query_id = _helper.runtime_state->_query_id;
+            non_builder_state->resize_op_id_to_local_state(-100);
+            non_builder_state->set_max_operator_id(-100);
+
+            LocalSinkStateInfo info {
+                    .task_idx = i,
+                    .parent_profile = _helper.runtime_profile.get(),
+                    .sender_id = 0,
+                    .shared_state = shared_state.get(),
+                    .shared_state_map = {},
+                    .tsink = TDataSink(),
+            };
+            st = sink_op->setup_local_state(non_builder_state.get(), info);
+            EXPECT_TRUE(st.ok()) << st.to_string();
+
+            auto* local_state = assert_cast<HashJoinBuildSinkLocalState*>(
+                    non_builder_state->get_sink_local_state());
+            EXPECT_TRUE(local_state);
+            st = local_state->open(non_builder_state.get());
+            EXPECT_TRUE(st.ok()) << st.to_string();
+
+            // Non-builder should have _should_build_hash_table=false
+            EXPECT_FALSE(local_state->_should_build_hash_table);
+
+            result.non_builder_states.push_back(non_builder_state);
+        }
+
+        // Set up builder task (task_idx=0) using _helper.runtime_state
+        LocalSinkStateInfo builder_info {
+                .task_idx = 0,
+                .parent_profile = _helper.runtime_profile.get(),
+                .sender_id = 0,
+                .shared_state = shared_state.get(),
+                .shared_state_map = {},
+                .tsink = TDataSink(),
+        };
+        st = sink_op->setup_local_state(_helper.runtime_state.get(), builder_info);
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        auto* builder_local_state = assert_cast<HashJoinBuildSinkLocalState*>(
+                _helper.runtime_state->get_sink_local_state());
+        EXPECT_TRUE(builder_local_state);
+        st = builder_local_state->open(_helper.runtime_state.get());
+        EXPECT_TRUE(st.ok()) << st.to_string();
+
+        // Builder should have _should_build_hash_table=true
+        EXPECT_TRUE(builder_local_state->_should_build_hash_table);
+
+        result.sink_op = sink_op;
+        result.probe_op = probe_op;
+        result.shared_state = shared_state;
+        result.builder_state = _helper.runtime_state.get();
+
+        return result;
+    }
+
+    HashJoinTestHelper _helper;
+};
+
+// Test the fix: when the builder task is terminated (woken up early because the probe side
+// finished first), close() should NOT set _signaled=true. This prevents non-builder tasks
+// from entering std::visit on an uninitialized (monostate) hash table.
+//
+// Reproduces the problematic timing sequence:
+//   1. Builder task is woken up and gets terminated (wake_up_early)
+//   2. Builder's terminate() sets _terminated=true (like pipeline_task.cpp's Defer)
+//   3. Builder's close() runs — should NOT set _signaled=true
+//   4. Non-builder task calls sink(eos=true) — should see _signaled=false and return EOF
+TEST_F(SharedHashTableSignalTest, BuilderTerminatedDoesNotSignal) {
+    auto setup = setup_broadcast_join(2);
+
+    auto* builder_local_state =
+            assert_cast<HashJoinBuildSinkLocalState*>(setup.builder_state->get_sink_local_state());
+
+    // Verify initial state: _signaled should be false, hash table should be monostate
+    ASSERT_FALSE(setup.sink_op->_signaled);
+    ASSERT_TRUE(
+            std::holds_alternative<std::monostate>(setup.shared_state->cast<HashJoinSharedState>()
+                                                           ->hash_table_variant_vector.front()
+                                                           ->method_variant));
+
+    // Step 1-2: Simulate the builder being terminated (wake_up_early path).
+    // In the real code path, pipeline_task.cpp's execute() Defer calls terminate()
+    // BEFORE close() runs.
+    auto st = builder_local_state->terminate(setup.builder_state);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_TRUE(builder_local_state->_terminated);
+
+    // Step 3: Builder's close() runs. With the fix, _signaled should stay false
+    // because the builder was terminated without building the hash table.
+    st = setup.sink_op->close(setup.builder_state, Status::OK());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Key assertion: _signaled must remain false after terminated builder's close()
+    ASSERT_FALSE(setup.sink_op->_signaled) << "_signaled should NOT be set when builder was "
+                                              "terminated without building hash table";
+
+    // Step 4: Non-builder task calls sink(eos=true).
+    // It should see _signaled=false and return EOF, NOT crash on monostate.
+    auto* non_builder_state = setup.non_builder_states[0].get();
+    Block empty_block;
+    st = setup.sink_op->sink(non_builder_state, &empty_block, true);
+    ASSERT_TRUE(st.is<ErrorCode::END_OF_FILE>())
+            << "Non-builder should return EOF when builder was terminated, got: " << st.to_string();
+
+    // Clean up the non-builder
+    st = setup.sink_op->close(non_builder_state, Status::OK());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+}
+
+// Test the normal path: when the builder completes normally (not terminated),
+// close() should set _signaled=true, and non-builder tasks should proceed
+// to share the hash table successfully.
+TEST_F(SharedHashTableSignalTest, BuilderNormalCompletionSignals) {
+    auto setup = setup_broadcast_join(2);
+
+    auto* builder_local_state =
+            assert_cast<HashJoinBuildSinkLocalState*>(setup.builder_state->get_sink_local_state());
+
+    // Verify initial state
+    ASSERT_FALSE(setup.sink_op->_signaled);
+    ASSERT_FALSE(builder_local_state->_terminated);
+
+    // Builder sinks data normally
+    auto build_block = ColumnHelper::create_block<DataTypeInt32>({1, 2, 3});
+    auto st = setup.sink_op->sink(setup.builder_state, &build_block, false);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Builder receives eos
+    Block empty_block;
+    st = setup.sink_op->sink(setup.builder_state, &empty_block, true);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Hash table should have been built (no longer monostate)
+    ASSERT_FALSE(
+            std::holds_alternative<std::monostate>(setup.shared_state->cast<HashJoinSharedState>()
+                                                           ->hash_table_variant_vector.front()
+                                                           ->method_variant));
+
+    // Builder closes normally (not terminated)
+    ASSERT_FALSE(builder_local_state->_terminated);
+    st = setup.sink_op->close(setup.builder_state, Status::OK());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Key assertion: _signaled should be true after normal builder close
+    ASSERT_TRUE(setup.sink_op->_signaled)
+            << "_signaled should be set when builder completed normally";
+
+    // Non-builder task calls sink(eos=true) — should succeed, sharing the hash table
+    auto* non_builder_state = setup.non_builder_states[0].get();
+    st = setup.sink_op->sink(non_builder_state, &empty_block, true);
+    ASSERT_TRUE(st.ok()) << "Non-builder should succeed when builder signaled, got: "
+                         << st.to_string();
+
+    // Clean up
+    st = setup.sink_op->close(non_builder_state, Status::OK());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+}
+
+// Test with multiple non-builder tasks: when builder is terminated,
+// ALL non-builder tasks should return EOF safely (no crash on monostate).
+TEST_F(SharedHashTableSignalTest, MultipleNonBuildersAllReturnEOFWhenTerminated) {
+    constexpr int num_instances = 4;
+    auto setup = setup_broadcast_join(num_instances);
+
+    auto* builder_local_state =
+            assert_cast<HashJoinBuildSinkLocalState*>(setup.builder_state->get_sink_local_state());
+
+    // Terminate the builder (simulate wake_up_early)
+    auto st = builder_local_state->terminate(setup.builder_state);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Builder close — should NOT set _signaled
+    st = setup.sink_op->close(setup.builder_state, Status::OK());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_FALSE(setup.sink_op->_signaled);
+
+    // All non-builder tasks should return EOF safely
+    for (int i = 0; i < num_instances - 1; i++) {
+        auto* non_builder_state = setup.non_builder_states[i].get();
+        Block empty_block;
+        st = setup.sink_op->sink(non_builder_state, &empty_block, true);
+        ASSERT_TRUE(st.is<ErrorCode::END_OF_FILE>())
+                << "Non-builder task " << (i + 1) << " should return EOF, got: " << st.to_string();
+
+        st = setup.sink_op->close(non_builder_state, Status::OK());
+        ASSERT_TRUE(st.ok()) << st.to_string();
+    }
 }
 
 } // namespace doris


### PR DESCRIPTION
shared hash table + broadcast join有问题的时序：
1. thread A: 触发make all runable
2. thread A: make all runable运行到唤醒task0
3. thread B: task0 terminate and close -> signal other task
3. thread C: task1被唤醒，正常执行sink -> 发现没有hash table -> 类型对不上 ->报错
4. thread A: make all runable 继续运行

https://github.com/apache/doris/pull/61768 在这个pr中，我们调整了先set所有task为wake up early，再set所有task ready的顺序，所以引入了这个问题

This pull request improves the safety and clarity of the hash join build sink operator's handling of early termination and hash table signaling. The changes ensure that non-builder tasks do not attempt to access an uninitialized hash table, preventing potential crashes due to type mismatches.

Hash join build signaling and termination handling:

* In `HashJoinBuildSinkLocalState::close`, the builder task now sets `_signaled = true` only if it was not terminated early, ensuring that non-builder tasks do not attempt to access an uninitialized hash table. Additional comments clarify the logic and the relationship between `_terminated` and `_signaled`.
* In `HashJoinBuildSinkOperatorX::sink`, updated the logic and comments to clarify that non-builder tasks will return EOF if the builder has not finished or was terminated early, relying on the improved `_signaled` guard to prevent unsafe access to the hash table.