### PR TITLE
[fix](editlog) Fix EditLog.txId data race by converting to AtomicLong

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -169,7 +169,7 @@ public class EditLog {
 
     private EditLogOutputStream editStream = null;
 
-    private long txId = 0;
+    private final AtomicLong txId = new AtomicLong(0);
 
 
     private AtomicLong numTransactions = new AtomicLong(0);
@@ -264,13 +264,13 @@ public class EditLog {
             System.exit(-1);
         }
 
-        txId += batch.size();
+        txId.addAndGet(batch.size());
         // update statistics, etc. (optional, can be added as needed)
-        if (txId >= Config.edit_log_roll_num) {
-            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", txId,
+        if (txId.get() >= Config.edit_log_roll_num) {
+            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", txId.get(),
                     Config.edit_log_roll_num);
             rollEditLog();
-            txId = 0;
+            txId.set(0);
         }
         if (MetricRepo.isInit) {
             MetricRepo.COUNTER_EDIT_LOG_WRITE.increase(Long.valueOf(batch.size()));
@@ -1557,7 +1557,7 @@ public class EditLog {
         if (!batch.getJournalEntities().isEmpty()) {
             journal.write(batch);
         }
-        txId += entries.size();
+        txId.addAndGet(entries.size());
     }
 
     /**
@@ -1654,13 +1654,13 @@ public class EditLog {
         }
 
         // get a new transactionId
-        txId++;
+        long newTxId = txId.incrementAndGet();
 
-        if (txId >= Config.edit_log_roll_num) {
-            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", txId,
+        if (newTxId >= Config.edit_log_roll_num) {
+            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", newTxId,
                     Config.edit_log_roll_num);
             rollEditLog();
-            txId = 0;
+            txId.set(0);
         }
 
         return logId;
@@ -1709,7 +1709,7 @@ public class EditLog {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("nextId = {}, numTransactions = {}, totalTimeTransactions = {}, op = {} delta = {}",
-                    txId, numTransactions, totalTimeTransactions, op, end - start);
+                    txId.get(), numTransactions, totalTimeTransactions, op, end - start);
         }
 
         return logId;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -264,13 +264,14 @@ public class EditLog {
             System.exit(-1);
         }
 
-        txId.addAndGet(batch.size());
+        long newTxId = txId.addAndGet(batch.size());
         // update statistics, etc. (optional, can be added as needed)
-        if (txId.get() >= Config.edit_log_roll_num) {
-            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", txId.get(),
+        if (newTxId >= Config.edit_log_roll_num) {
+            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", newTxId,
                     Config.edit_log_roll_num);
             rollEditLog();
-            txId.set(0);
+            // Atomically apply modulo to preserve increments from concurrent threads
+            txId.updateAndGet(v -> v % Config.edit_log_roll_num);
         }
         if (MetricRepo.isInit) {
             MetricRepo.COUNTER_EDIT_LOG_WRITE.increase(Long.valueOf(batch.size()));
@@ -1660,7 +1661,8 @@ public class EditLog {
             LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", newTxId,
                     Config.edit_log_roll_num);
             rollEditLog();
-            txId.set(0);
+            // Atomically apply modulo to preserve increments from concurrent threads
+            txId.updateAndGet(v -> v % Config.edit_log_roll_num);
         }
 
         return logId;


### PR DESCRIPTION
## Summary

- The `txId` field is a plain `long` read/written by multiple threads (flusher, DDL callers, bulk writers) without synchronization
- Long writes are not guaranteed atomic (JLS §17.7), and even on platforms with atomic 64-bit writes, there is no happens-before ordering between threads
- Convert `txId` to `AtomicLong` and update all 6 read/write sites

## Test plan
- [ ] Verify FE master starts and writes edit logs normally
- [ ] Verify edit log rolls correctly after `edit_log_roll_num` transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)