### PR TITLE
[fix](editlog) Extract advanceTxIdAndRollIfNeeded() to fix missing roll check in bulk write

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -264,14 +264,7 @@ public class EditLog {
             System.exit(-1);
         }
 
-        txId += batch.size();
-        // update statistics, etc. (optional, can be added as needed)
-        if (txId >= Config.edit_log_roll_num) {
-            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", txId,
-                    Config.edit_log_roll_num);
-            rollEditLog();
-            txId = 0;
-        }
+        advanceTxIdAndRollIfNeeded(batch.size());
         if (MetricRepo.isInit) {
             MetricRepo.COUNTER_EDIT_LOG_WRITE.increase(Long.valueOf(batch.size()));
         }
@@ -1523,6 +1516,16 @@ public class EditLog {
         journal.open();
     }
 
+    private void advanceTxIdAndRollIfNeeded(long delta) {
+        txId += delta;
+        if (txId >= Config.edit_log_roll_num) {
+            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.",
+                    txId, Config.edit_log_roll_num);
+            rollEditLog();
+            txId = 0;
+        }
+    }
+
     /**
      * Close current journal and start a new journal
      */
@@ -1557,7 +1560,7 @@ public class EditLog {
         if (!batch.getJournalEntities().isEmpty()) {
             journal.write(batch);
         }
-        txId += entries.size();
+        advanceTxIdAndRollIfNeeded(entries.size());
     }
 
     /**
@@ -1653,15 +1656,7 @@ public class EditLog {
             System.exit(-1);
         }
 
-        // get a new transactionId
-        txId++;
-
-        if (txId >= Config.edit_log_roll_num) {
-            LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.", txId,
-                    Config.edit_log_roll_num);
-            rollEditLog();
-            txId = 0;
-        }
+        advanceTxIdAndRollIfNeeded(1);
 
         return logId;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1522,7 +1522,7 @@ public class EditLog {
             LOG.info("txId {} is equal to or larger than edit_log_roll_num {}, will roll edit.",
                     txId, Config.edit_log_roll_num);
             rollEditLog();
-            txId = 0;
+            txId %= Config.edit_log_roll_num;
         }
     }
 


### PR DESCRIPTION
## Summary

Three call sites duplicate the txId-increment-and-roll-check pattern:
- `flushEditLog()` — batch queue flush path
- `logEditDirectly()` — direct single-write path
- `logEdit(op, List<T>)` — bulk write path (**was missing the roll check**)

The bulk write path only did `txId += entries.size()` without checking `edit_log_roll_num`, so batch operations (e.g. batch partition writes) never triggered edit log rolling, causing the journal database to grow without bound.

Fix: extract `advanceTxIdAndRollIfNeeded(delta)` and replace all three sites with a single call, fixing the missing check and eliminating duplication.

## Test plan
- [ ] Verify edit log rolls after `edit_log_roll_num` transactions via all write paths
- [ ] Verify batch partition operations trigger roll correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)