### PR TITLE
[fix](editlog) Fix BDBEnvironment.close() ConcurrentModificationException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -479,31 +479,52 @@ public class BDBEnvironment {
         return ret;
     }
 
-    // Close the store and environment
+    // Close the store and environment.
+    // Two-phase close: detach resources under the write lock, then close them outside the lock
+    // to avoid blocking openDatabase() callers during potentially slow close() calls.
     public void close() {
-        for (Database db : openedDatabases) {
+        List<Database> databasesToClose;
+        Database epochDBToClose = null;
+        ReplicatedEnvironment envToClose = null;
+
+        lock.writeLock().lock();
+        try {
+            databasesToClose = new ArrayList<>(openedDatabases);
+            openedDatabases.clear();
+
+            if (epochDB != null) {
+                epochDBToClose = epochDB;
+                epochDB = null;
+            }
+
+            if (replicatedEnvironment != null) {
+                envToClose = replicatedEnvironment;
+                replicatedEnvironment = null;
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+
+        // Close resources outside the lock
+        for (Database db : databasesToClose) {
             try {
                 db.close();
             } catch (DatabaseException exception) {
-                LOG.error("Error closing db {} will exit", db.getDatabaseName(), exception);
+                LOG.error("Error closing db {}", db.getDatabaseName(), exception);
             }
         }
-        openedDatabases.clear();
 
-        if (epochDB != null) {
+        if (epochDBToClose != null) {
             try {
-                epochDB.close();
-                epochDB = null;
+                epochDBToClose.close();
             } catch (DatabaseException exception) {
-                LOG.error("Error closing db {} will exit", epochDB.getDatabaseName(), exception);
+                LOG.error("Error closing epoch db {}", epochDBToClose.getDatabaseName(), exception);
             }
         }
 
-        if (replicatedEnvironment != null) {
+        if (envToClose != null) {
             try {
-                // Finally, close the store and environment.
-                replicatedEnvironment.close();
-                replicatedEnvironment = null;
+                envToClose.close();
             } catch (DatabaseException exception) {
                 LOG.error("Error closing replicatedEnvironment", exception);
             }


### PR DESCRIPTION
## Summary

- `BDBEnvironment.close()` iterates `openedDatabases` without acquiring `lock.writeLock()`
- `openDatabase()` concurrently modifies the same `ArrayList` under the write lock
- When the replayer thread catches `RollbackException` and calls `close()`, while HTTP/heartbeat/RPC handler threads call `openDatabase()` via `getMaxJournalId()`, `ConcurrentModificationException` is thrown
- This kills the replayer thread, causing the follower FE to fall permanently behind the master

**Fix: two-phase close pattern**
- Phase 1 (under writeLock): atomically detach resources — copy `openedDatabases` to local list, clear original, null out `epochDB` and `replicatedEnvironment`
- Phase 2 (outside lock): perform actual `db.close()` / `env.close()` without holding the lock, avoiding blocking unrelated threads during potentially slow close operations

Also fixes misleading "will exit" in log messages — `close()` does not exit the process.

## Test plan
- [ ] Verify follower FE handles RollbackException recovery correctly
- [ ] Verify `SHOW FRONTENDS` works concurrently with journal operations
- [ ] Verify no ConcurrentModificationException in FE logs during role transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)