### PR TITLE
[fix](editlog) Notify pending producers before System.exit in flushEditLog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -255,6 +255,14 @@ public class EditLog {
                 }
             }
         } catch (Throwable t) {
+            // Notify all pending items so producer threads don't hang if System.exit is delayed
+            for (EditLogItem req : batch) {
+                synchronized (req.lock) {
+                    req.finished = true;
+                    req.logId = -1;
+                    req.lock.notifyAll();
+                }
+            }
             // Throwable contains all Exception and Error, such as IOException and
             // OutOfMemoryError
             if (journal instanceof BDBJEJournal) {


### PR DESCRIPTION
## Summary

- When `flushEditLog()` catches a Throwable and calls `System.exit(-1)`, producer threads blocked on `req.lock.wait()` inside `logEditWithQueue()` are never notified
- If `System.exit` is delayed by shutdown hooks or finalizers, these producer threads hang indefinitely, potentially holding DDL locks and blocking all metadata operations
- Fix: notify all pending `EditLogItem` requests with `finished=true` and `logId=-1` before calling `System.exit`

## Test plan
- [ ] Verify DDL threads don't hang when edit log write fails fatally
- [ ] Verify clean shutdown behavior on write failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)