### PR TITLE
[fix](editlog) Fix BDBJEJournal.write() burning journal IDs on failure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -131,7 +131,8 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
         List<JournalBatch.Entity> entities = batch.getJournalEntities();
         int entitySize = entities.size();
         long dataSize = 0;
-        long firstId = nextJournalId.getAndAdd(entitySize);
+        // Reserve IDs only after successful commit to avoid burning IDs on write failure.
+        long firstId = nextJournalId.get();
 
         // Write the journals to bdb.
         for (int i = 0; i < RETRY_TIME; i++) {
@@ -155,6 +156,7 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
 
                 txn.commit();
                 txn = null;
+                nextJournalId.addAndGet(entitySize);
 
                 if (MetricRepo.isInit) {
                     MetricRepo.COUNTER_EDIT_LOG_SIZE_BYTES.increase(dataSize);
@@ -237,8 +239,9 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
         entity.setOpCode(op);
         entity.setData(writable);
 
-        // id is the key
-        long id = nextJournalId.getAndIncrement();
+        // id is the key. Reserve ID only after successful write to avoid burning IDs on failure.
+        // This is safe because the method is synchronized.
+        long id = nextJournalId.get();
         DatabaseEntry theKey = idToKey(id);
 
         // entity is the value
@@ -273,6 +276,7 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
                 // Parameter null means auto commit
                 if (currentJournalDB.put(null, theKey, theData) == OperationStatus.SUCCESS) {
                     writeSucceed = true;
+                    nextJournalId.incrementAndGet();
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("master write journal {} finished. db name {}, current time {}",
                                 id, currentJournalDB.getDatabaseName(), System.currentTimeMillis());


### PR DESCRIPTION
## Summary

- Both single-item `write()` and batch `write()` call `nextJournalId.getAndIncrement()` / `getAndAdd()` **before** the actual BDB put/commit
- If the write fails (e.g. `ReplicaWriteException`, `InsufficientAcksException`), the journal IDs are permanently consumed but no journal entry exists
- On retry, the write uses a new ID, creating gaps in the journal ID sequence
- These gaps can confuse the replayer which expects contiguous journal IDs
- Fix: read the current ID with `get()` before writing, advance with `incrementAndGet()` / `addAndGet()` only after successful commit. Both write methods are `synchronized`, so the pattern is safe.

## Test plan
- [ ] Verify journal IDs remain contiguous after transient write failures
- [ ] Verify replayer correctly replays all journals without gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)