### PR TITLE
[fix](editlog) Fix BDBEnvironment.removeDatabase() wrong list removal index

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -60,6 +60,7 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -257,7 +258,7 @@ public class BDBEnvironment {
         lock.writeLock().lock();
         try {
             // find if the specified database is already opened. find and return it.
-            for (java.util.Iterator<Database> iter = openedDatabases.iterator(); iter.hasNext();) {
+            for (Iterator<Database> iter = openedDatabases.iterator(); iter.hasNext();) {
                 Database openedDb = iter.next();
                 try {
                     if (openedDb.getDatabaseName() == null) {
@@ -312,21 +313,15 @@ public class BDBEnvironment {
     public void removeDatabase(String dbName) {
         lock.writeLock().lock();
         try {
-            String targetDbName = null;
-            int index = 0;
-            for (Database db : openedDatabases) {
+            for (Iterator<Database> iter = openedDatabases.iterator(); iter.hasNext();) {
+                Database db = iter.next();
                 String name = db.getDatabaseName();
                 if (dbName.equals(name)) {
                     db.close();
                     LOG.info("database {} has been closed", name);
-                    targetDbName = name;
+                    iter.remove();
                     break;
                 }
-                index++;
-            }
-            if (targetDbName != null) {
-                LOG.info("begin to remove database {} from openedDatabases", targetDbName);
-                openedDatabases.remove(index);
             }
             try {
                 LOG.info("begin to remove database {} from replicatedEnvironment", dbName);

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -315,7 +315,23 @@ public class BDBEnvironment {
         try {
             for (Iterator<Database> iter = openedDatabases.iterator(); iter.hasNext();) {
                 Database db = iter.next();
-                String name = db.getDatabaseName();
+                String name;
+                try {
+                    name = db.getDatabaseName();
+                } catch (Exception e) {
+                    // Database handle may have been preempted by a replicated remove
+                    // (DatabasePreemptedException). Mirror the cleanup pattern from
+                    // openDatabase(): close the stale handle, remove it, and continue.
+                    LOG.warn("get exception when getting database name in removeDatabase. "
+                            + "close and remove the stale handle", e);
+                    try {
+                        db.close();
+                    } catch (Exception ce) {
+                        LOG.warn("failed to close stale database handle", ce);
+                    }
+                    iter.remove();
+                    continue;
+                }
                 if (dbName.equals(name)) {
                     db.close();
                     LOG.info("database {} has been closed", name);

--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
@@ -650,6 +650,66 @@ public class BDBEnvironmentTest {
     }
 
     @RepeatedTest(1)
+    public void testRemoveDatabaseWithPreemptedHandle() throws Exception {
+        int port = findValidPort();
+        String selfNodeName = Env.genFeNodeName("127.0.0.1", port, false);
+        String selfNodeHostPort = "127.0.0.1:" + port;
+
+        BDBEnvironment bdbEnvironment = new BDBEnvironment(true, false);
+        bdbEnvironment.setup(new File(createTmpDir()), selfNodeName, selfNodeHostPort, selfNodeHostPort);
+
+        // Open a real database
+        String dbName = "testRemoveWithPreempted";
+        Database db = bdbEnvironment.openDatabase(dbName);
+        Assertions.assertNotNull(db);
+
+        // Inject a mock "preempted" database handle before the real one in openedDatabases.
+        // This simulates a DatabasePreemptedException scenario where getDatabaseName() throws.
+        Database preemptedDb = new MockUp<Database>() {
+            @Mock
+            public String getDatabaseName() {
+                throw new IllegalStateException("Database was forcibly closed (simulated preemption)");
+            }
+
+            @Mock
+            public void close() {
+                // no-op for mock
+            }
+        }.getMockInstance();
+
+        List<Database> openedDatabases = Deencapsulation.getField(bdbEnvironment, "openedDatabases");
+        openedDatabases.add(0, preemptedDb);
+
+        // removeDatabase should skip the preempted handle and still successfully
+        // close and remove the real database
+        bdbEnvironment.removeDatabase(dbName);
+
+        // Verify the preempted handle was removed from the list
+        Assertions.assertFalse(openedDatabases.contains(preemptedDb),
+                "Preempted database handle should have been removed from openedDatabases");
+
+        // Verify the real database was also removed (the database should not be in the list)
+        boolean found = false;
+        for (Database d : openedDatabases) {
+            try {
+                if (dbName.equals(d.getDatabaseName())) {
+                    found = true;
+                }
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        Assertions.assertFalse(found,
+                "The target database should have been removed from openedDatabases");
+
+        // Verify the database was removed from the replicated environment
+        // (calling removeDatabase again should just get DatabaseNotFoundException, not crash)
+        bdbEnvironment.removeDatabase(dbName);
+
+        bdbEnvironment.close();
+    }
+
+    @RepeatedTest(1)
     public void testReadTxnIsNotMatched() throws Exception {
         List<Pair<BDBEnvironment, NodeInfo>> followersInfo = new ArrayList<>();
 


### PR DESCRIPTION
## Summary

- `removeDatabase()` uses a manual `index` counter during iteration, then calls `openedDatabases.remove(index)` after the loop
- If `getDatabaseName()` throws (e.g. `DatabasePreemptedException` for a preempted database), the index counter gets out of sync with actual position, causing removal of the wrong database handle
- Fix: replace manual index tracking with `iterator.remove()`, which is both correct and concise

## Test plan
- [ ] Verify old journal databases are correctly removed during cleanup
- [ ] Verify no wrong database handles are removed from `openedDatabases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)