### PR TITLE
[fix](editlog) Fix JournalObservable.upperBound() off-by-one in binary search

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/JournalObservable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/JournalObservable.java
@@ -63,23 +63,20 @@ public class JournalObservable {
         }
     }
 
-    // return min pos which is bigger than value
+    // Return the number of elements whose targetJournalVersion <= value.
+    // This is the standard upper_bound pattern: returns the index of the first element > value.
     public static int upperBound(Object[] array, int size, Long value) {
         int left = 0;
-        int right = size - 1;
+        int right = size;
         while (left < right) {
             int middle = left + ((right - left) >> 1);
-            if (value >= ((JournalObserver) array[middle]).getTargetJournalVersion()) {
+            if (((JournalObserver) array[middle]).getTargetJournalVersion() <= value) {
                 left = middle + 1;
             } else {
-                right = middle - 1;
+                right = middle;
             }
         }
-        if (right == -1) {
-            return 0;
-        }
-        Long rightValue = ((JournalObserver) array[right]).getTargetJournalVersion();
-        return value >= rightValue ? right + 1  : right;
+        return left;
     }
 
     public void notifyObservers(Long journalId) {


### PR DESCRIPTION
## Summary

- The binary search uses \`right = size - 1\` and \`right = middle - 1\`, a lower_bound variant that can miss notifying observers at boundaries
- When \`size > 1\` and the matching element is at the boundary, \`right = middle - 1\` can skip past it, returning an index that excludes observers that should have been notified
- The post-loop fixup (\`if (right == -1) return 0\` and \`value >= rightValue ? right + 1 : right\`) is fragile and doesn't cover all edge cases
- Fix: use the standard upper_bound pattern with \`right = size\` and \`right = middle\` (no \`-1\`), which correctly returns the count of elements whose \`targetJournalVersion <= value\`

## Test plan
- [ ] Verify followers waiting on specific journal versions are notified correctly
- [ ] Verify \`waitOn()\` completes when the expected journal version is replayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)