### PR TITLE
[fix](editlog) Remove dead editStream field and guaranteed-NPE getEditLogSize()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -167,8 +167,6 @@ public class EditLog {
     private final BlockingQueue<EditLogItem> logEditQueue = new LinkedBlockingQueue<>();
     private final Thread flushThread;
 
-    private EditLogOutputStream editStream = null;
-
     private long txId = 0;
 
 
@@ -1713,13 +1711,6 @@ public class EditLog {
         }
 
         return logId;
-    }
-
-    /**
-     * Return the size of the current EditLog
-     */
-    public synchronized long getEditLogSize() throws IOException {
-        return editStream.length();
     }
 
     /**


### PR DESCRIPTION
## Summary

- The \`editStream\` field (\`EditLogOutputStream\`) is declared but never assigned anywhere — it is always \`null\`
- \`getEditLogSize()\` calls \`editStream.length()\`, which will always throw \`NullPointerException\`
- Remove both the unused field and the dead method

## Test plan
- [ ] Verify FE compiles and starts normally
- [ ] Verify no code references \`getEditLogSize()\` (confirmed by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)