### PR TITLE
[fix](variant) preserve subcolumns after row-store partial update

### DIFF
--- a/be/src/storage/segment/segment_writer.cpp
+++ b/be/src/storage/segment/segment_writer.cpp
@@ -628,6 +628,11 @@ Status SegmentWriter::append_block_with_partial_content(const Block* block, size
             use_default_or_null_flag, has_default_or_nullable,
             cast_set<uint32_t>(segment_start_pos), block));
 
+    if (_tablet_schema->num_variant_columns() > 0) {
+        RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
+                full_block, *_tablet_schema, missing_cids));
+    }
+
     // convert block to row store format
     _serialize_block_to_row_column(full_block);
 

--- a/be/src/storage/segment/vertical_segment_writer.cpp
+++ b/be/src/storage/segment/vertical_segment_writer.cpp
@@ -636,6 +636,11 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
             _opts.rowset_ctx, _rsid_to_rowset, *_tablet_schema, full_block,
             use_default_or_null_flag, has_default_or_nullable, segment_start_pos, data.block));
 
+    if (_tablet_schema->num_variant_columns() > 0) {
+        RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
+                full_block, *_tablet_schema, _opts.rowset_ctx->partial_update_info->missing_cids));
+    }
+
     // row column should be filled here
     // convert block to row store format
     _serialize_block_to_row_column(full_block);

--- a/regression-test/suites/variant_p0/delete_update.groovy
+++ b/regression-test/suites/variant_p0/delete_update.groovy
@@ -73,6 +73,46 @@ suite("regression_test_variant_delete_and_update", "variant_type"){
     sql """delete from ${table_name} where vs = 'xxx' or vs = 'yyy'"""
     qt_sql "select * from ${table_name} order by k"
 
+    def partialUpdateVariantTable = "var_partial_update_keep_subcolumn"
+    sql "DROP TABLE IF EXISTS ${partialUpdateVariantTable}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${partialUpdateVariantTable} (
+            event_id bigint,
+            oneid string,
+            event_property_variant variant
+        )
+        UNIQUE KEY(`event_id`)
+        DISTRIBUTED BY HASH(event_id) BUCKETS 1
+        properties(
+            "replication_num" = "1",
+            "enable_unique_key_merge_on_write" = "true",
+            "store_row_column" = "true"
+        );
+    """
+    sql """insert into ${partialUpdateVariantTable} values
+            (1, 'old-oneid', '{"base_id":"100000000009523363","other_key":"abc"}')"""
+    sql "sync"
+
+    def beforeUpdate = sql """select cast(event_property_variant['base_id'] as string)
+                              from ${partialUpdateVariantTable}
+                              where event_id = 1"""
+    assertEquals("100000000009523363", beforeUpdate[0][0])
+
+    sql """update ${partialUpdateVariantTable}
+           set oneid = 'new-oneid'
+           where event_id = 1"""
+    sql "sync"
+
+    def afterUpdate = sql """select cast(event_property_variant['base_id'] as string)
+                             from ${partialUpdateVariantTable}
+                             where event_id = 1"""
+    assertEquals("100000000009523363", afterUpdate[0][0])
+
+    def wholeVariant = sql """select cast(event_property_variant as string)
+                              from ${partialUpdateVariantTable}
+                              where event_id = 1"""
+    assertEquals('{"base_id":"100000000009523363","other_key":"abc"}', wholeVariant[0][0])
+
     // delete & insert concurrently
     sql "set enable_unique_key_partial_update=true;"
     sql "sync"


### PR DESCRIPTION
need to materialize variant after reading from row store when partial update