### PR TITLE
[chore](ci) Remove author association check from opencode-review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -15,12 +15,7 @@ jobs:
     timeout-minutes: 60
     if: >-
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/review') &&
-      (
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
-      )
+      contains(github.event.comment.body, '/review')
     steps:
       - name: Get PR info
         id: pr


### PR DESCRIPTION
Remove the author association restriction (MEMBER/OWNER/COLLABORATOR) from the opencode-review workflow trigger conditions, allowing any user to trigger code review via `/review` comment.