### PR TITLE
[opt](memory) Remove unused dbId field from CloudReplica

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -59,8 +59,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     private ConcurrentHashMap<String, List<Long>> primaryClusterToBackends = null;
     @SerializedName(value = "be")
     private ConcurrentHashMap<String, Long> primaryClusterToBackend = new ConcurrentHashMap<>();
-    @SerializedName(value = "dbId")
-    private long dbId = -1;
     @SerializedName(value = "tableId")
     private long tableId = -1;
     @SerializedName(value = "partitionId")
@@ -112,7 +110,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     public CloudReplica(long replicaId, Long backendId, ReplicaState state, long version, int schemaHash,
             long dbId, long tableId, long partitionId, long indexId, long idx) {
         super(replicaId, -1, state, version, schemaHash);
-        this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.indexId = indexId;
@@ -572,10 +569,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         // depends this feature to implement snapshot partition version. See comments in
         // OlapScanNode.addScanRangeLocations for details.
         return true;
-    }
-
-    public long getDbId() {
-        return dbId;
     }
 
     public long getTableId() {


### PR DESCRIPTION
## Summary
- Remove the `dbId` field and its `@SerializedName` from `CloudReplica`, saving 8 bytes per replica object
- No external callers read `dbId` from CloudReplica — all callers use `TabletMeta.getDbId()` via the inverted index instead
- Constructor parameter is kept for source compatibility but the value is no longer stored
- Gson silently ignores unknown keys when deserializing old images, so backward compatibility is maintained

## Memory Impact
-8 bytes/replica. At 10M replicas: ~76 MB saved. At 100M replicas: ~763 MB saved.

## Test plan
- [ ] Existing cloud tests pass (`mvn test -pl fe/fe-core -Dtest="*Cloud*"`)
- [ ] Gson backward compatibility: old-format JSON with "dbId" key deserializes without errors (silently ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)