### PR TITLE
[opt](memory) Remove unused indexId field from CloudReplica

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -65,8 +65,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     private long tableId = -1;
     @SerializedName(value = "partitionId")
     private long partitionId = -1;
-    @SerializedName(value = "indexId")
-    private long indexId = -1;
     @SerializedName(value = "idx")
     private long idx = -1;
     // last time to get tablet stats
@@ -115,7 +113,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
-        this.indexId = indexId;
         this.idx = idx;
     }
 
@@ -584,10 +581,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
 
     public long getPartitionId() {
         return partitionId;
-    }
-
-    public long getIndexId() {
-        return indexId;
     }
 
     public long getIdx() {


### PR DESCRIPTION
## Summary
- Remove the `indexId` field and its `@SerializedName` from `CloudReplica`, saving 8 bytes per replica object
- The only external usage is debug logging in `CloudTabletStatMgr` which already uses `stat.getIdx().getIndexId()` from the proto response — no change needed
- Constructor parameter is kept for source compatibility but the value is no longer stored
- Gson silently ignores unknown keys when deserializing old images, so backward compatibility is maintained

## Memory Impact
-8 bytes/replica. At 10M replicas: ~76 MB saved. At 100M replicas: ~763 MB saved.

## Test plan
- [ ] Existing cloud tests pass (`mvn test -pl fe/fe-core -Dtest="*Cloud*"`)
- [ ] Gson backward compatibility: old-format JSON with "indexId" key deserializes without errors (silently ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)