### PR TITLE
[opt](memory) Replace tableId/partitionId with tabletId lookup in CloudReplica

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -955,7 +955,7 @@ public class OlapTable extends Table implements MTMVRelatedTableIf, GsonPostProc
                     if (Config.isCloudMode()) {
                         long newReplicaId = Env.getCurrentEnv().getNextId();
                         Replica replica = new CloudReplica(newReplicaId, null, ReplicaState.NORMAL,
-                                visibleVersion, schemaHash, db.getId(), id, entry.getKey(), idx.getId(), i);
+                                visibleVersion, schemaHash, db.getId(), idx.getId(), i);
                         newTablet.addReplica(replica, true /* is restore */);
                         continue;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
@@ -327,7 +327,6 @@ public class CloudRestoreJob extends RestoreJob {
     public Partition resetTabletForRestore(OlapTable localTbl, OlapTable remoteTbl, Partition remotePart,
                                               ReplicaAllocation replicaAlloc) {
         // tablets
-        long partitionId = remotePart.getId();
         long visibleVersion = remotePart.getVisibleVersion();
         for (MaterializedIndex remoteIdx : remotePart.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
             int schemaHash = remoteTbl.getSchemaHashByIndexId(remoteIdx.getId());

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/backup/CloudRestoreJob.java
@@ -342,7 +342,7 @@ public class CloudRestoreJob extends RestoreJob {
                 // replicas
                 long newReplicaId = Env.getCurrentEnv().getNextId();
                 Replica replica = new CloudReplica(newReplicaId, null, Replica.ReplicaState.NORMAL,
-                        visibleVersion, schemaHash, dbId, localTbl.getId(), partitionId, remoteIdx.getId(), i);
+                        visibleVersion, schemaHash, dbId, remoteIdx.getId(), i);
                 newTablet.addReplica(replica, true /* is restore */);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.ColocateTableIndex.GroupId;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
@@ -61,10 +62,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     private ConcurrentHashMap<String, Long> primaryClusterToBackend = new ConcurrentHashMap<>();
     @SerializedName(value = "dbId")
     private long dbId = -1;
-    @SerializedName(value = "tableId")
-    private long tableId = -1;
-    @SerializedName(value = "partitionId")
-    private long partitionId = -1;
+    private transient long tabletId = -1;
     @SerializedName(value = "indexId")
     private long indexId = -1;
     @SerializedName(value = "idx")
@@ -104,23 +102,38 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
 
     public CloudReplica(ReplicaContext context) {
         this(context.replicaId, context.backendId, context.state, context.version,
-                context.schemaHash, context.dbId, context.tableId, context.partitionId,
-                context.indexId,
+                context.schemaHash, context.dbId, context.indexId,
                 context.originReplica != null ? ((CloudReplica) context.originReplica).getIdx() : -1);
     }
 
     public CloudReplica(long replicaId, Long backendId, ReplicaState state, long version, int schemaHash,
-            long dbId, long tableId, long partitionId, long indexId, long idx) {
+            long dbId, long indexId, long idx) {
         super(replicaId, -1, state, version, schemaHash);
         this.dbId = dbId;
-        this.tableId = tableId;
-        this.partitionId = partitionId;
         this.indexId = indexId;
         this.idx = idx;
     }
 
+    public void setTabletId(long tabletId) {
+        this.tabletId = tabletId;
+    }
+
+    private TabletMeta getTabletMeta() {
+        return Env.getCurrentInvertedIndex().getTabletMeta(tabletId);
+    }
+
+    private long getTableIdFromMeta() {
+        TabletMeta meta = getTabletMeta();
+        return meta != null ? meta.getTableId() : -1;
+    }
+
+    private long getPartitionIdFromMeta() {
+        TabletMeta meta = getTabletMeta();
+        return meta != null ? meta.getPartitionId() : -1;
+    }
+
     private boolean isColocated() {
-        return Env.getCurrentColocateIndex().isColocateTableNoLock(tableId);
+        return Env.getCurrentColocateIndex().isColocateTableNoLock(getTableIdFromMeta());
     }
 
     public long getColocatedBeId(String clusterId) throws ComputeGroupException {
@@ -156,7 +169,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
                 ComputeGroupException.FailedTypeEnum.COMPUTE_GROUPS_NO_ALIVE_BE);
         }
 
-        GroupId groupId = Env.getCurrentColocateIndex().getGroupNoLock(tableId);
+        GroupId groupId = Env.getCurrentColocateIndex().getGroupNoLock(getTableIdFromMeta());
         HashCode hashCode = Hashing.murmur3_128().hashLong(groupId.grpId);
         if (availableBes.size() != bes.size()) {
             // some be is dead recently, still hash tablets on all backends.
@@ -468,13 +481,14 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         if (idx == -1) {
             index = getId() % availableBes.size();
         } else {
-            hashCode = Hashing.murmur3_128().hashLong(partitionId);
+            long partId = getPartitionIdFromMeta();
+            hashCode = Hashing.murmur3_128().hashLong(partId);
             index = getIndexByBeNum(hashCode.asLong() + idx, availableBes.size());
         }
         long pickedBeId = availableBes.get((int) index).getId();
         LOG.info("picked clusterName {} beId {}, replicaId {}, partitionId {}, beNum {}, "
                 + "replicaIdx {}, picked Index {}, hashVal {}",
-                clusterName, pickedBeId, getId(), partitionId, availableBes.size(), idx, index,
+                clusterName, pickedBeId, getId(), getPartitionIdFromMeta(), availableBes.size(), idx, index,
                 hashCode == null ? -1 : hashCode.asLong());
 
         return pickedBeId;
@@ -549,13 +563,14 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
             if (idx == -1) {
                 index = getId() % availableBes.size();
             } else {
-                hashCode = Hashing.murmur3_128().hashLong(partitionId + i);
+                long partId = getPartitionIdFromMeta();
+                hashCode = Hashing.murmur3_128().hashLong(partId + i);
                 index = getIndexByBeNum(hashCode.asLong() + idx, availableBes.size());
             }
             long pickedBeId = availableBes.get((int) index).getId();
             availableBes.remove((int) index);
             LOG.info("picked beId {}, replicaId {}, partId {}, beNum {}, replicaIdx {}, picked Index {}, hashVal {}",
-                    pickedBeId, getId(), partitionId, availableBes.size(), idx, index,
+                    pickedBeId, getId(), getPartitionIdFromMeta(), availableBes.size(), idx, index,
                     hashCode == null ? -1 : hashCode.asLong());
             // save to memClusterToBackends map
             bes.add(pickedBeId);
@@ -579,11 +594,11 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     }
 
     public long getTableId() {
-        return tableId;
+        return getTableIdFromMeta();
     }
 
     public long getPartitionId() {
-        return partitionId;
+        return getPartitionIdFromMeta();
     }
 
     public long getIndexId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -62,7 +62,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     private ConcurrentHashMap<String, Long> primaryClusterToBackend = new ConcurrentHashMap<>();
     @SerializedName(value = "dbId")
     private long dbId = -1;
-    private transient long tabletId = -1;
+    private transient volatile long tabletId = -1;
     @SerializedName(value = "indexId")
     private long indexId = -1;
     @SerializedName(value = "idx")

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletInvertedIndex.java
@@ -72,6 +72,9 @@ public class CloudTabletInvertedIndex extends TabletInvertedIndex {
         try {
             Preconditions.checkState(tabletMetaMap.containsKey(tabletId),
                     "tablet " + tabletId + " not exists, replica " + replica.getId());
+            if (replica instanceof CloudReplica) {
+                ((CloudReplica) replica).setTabletId(tabletId);
+            }
             replicaMetaMap.put(tabletId, replica);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("add replica {} of tablet {}", replica.getId(), tabletId);

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -454,8 +454,7 @@ public class CloudInternalCatalog extends InternalCatalog {
 
             long replicaId = Env.getCurrentEnv().getNextId();
             Replica replica = new CloudReplica(replicaId, null, replicaState, version,
-                    tabletMeta.getOldSchemaHash(), tabletMeta.getDbId(), tabletMeta.getTableId(),
-                    tabletMeta.getPartitionId(), tabletMeta.getIndexId(), i);
+                    tabletMeta.getOldSchemaHash(), tabletMeta.getDbId(), tabletMeta.getIndexId(), i);
             tablet.addReplica(replica);
         }
     }
@@ -879,7 +878,11 @@ public class CloudInternalCatalog extends InternalCatalog {
             for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
                 indexIds.add(index.getId());
                 if (tableId == -1) {
-                    tableId = ((CloudTablet) index.getTablets().get(0)).getCloudReplica().getTableId();
+                    long firstTabletId = index.getTablets().get(0).getId();
+                    TabletMeta meta = Env.getCurrentInvertedIndex().getTabletMeta(firstTabletId);
+                    if (meta != null) {
+                        tableId = meta.getTableId();
+                    }
                 }
             }
             partitionIds.add(partition.getId());

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/datasource/CloudInternalCatalog.java
@@ -870,20 +870,14 @@ public class CloudInternalCatalog extends InternalCatalog {
             return;
         }
 
-        long tableId = -1;
+        CloudPartition partition0 = (CloudPartition) partitions.get(0);
+        long tableId = partition0.getTableId();
         List<Long> partitionIds = Lists.newArrayList();
         Set<Long> indexIds = new HashSet<>();
         boolean needUpdateTableVersion = false;
         for (Partition partition : partitions) {
             for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
                 indexIds.add(index.getId());
-                if (tableId == -1) {
-                    long firstTabletId = index.getTablets().get(0).getId();
-                    TabletMeta meta = Env.getCurrentInvertedIndex().getTabletMeta(firstTabletId);
-                    if (meta != null) {
-                        tableId = meta.getTableId();
-                    }
-                }
             }
             partitionIds.add(partition.getId());
             if (partition.hasData()) {
@@ -891,8 +885,6 @@ public class CloudInternalCatalog extends InternalCatalog {
                 needUpdateTableVersion = true;
             }
         }
-
-        CloudPartition partition0 = (CloudPartition) partitions.get(0);
 
         int tryCnt = 0;
         while (true) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CatalogTestUtil.java
@@ -174,11 +174,11 @@ public class CatalogTestUtil {
         if (Config.isCloudMode()) {
             // In cloud mode we must create CloudReplica instances to avoid ClassCastException
             replica1 = new CloudReplica(testReplicaId1, testBackendId1, Replica.ReplicaState.NORMAL, version,
-                    /*schemaHash*/ 0, dbId, tableId, partitionId, indexId, /*idx*/ 0);
+                    /*schemaHash*/ 0, dbId, indexId, /*idx*/ 0);
             replica2 = new CloudReplica(testReplicaId2, testBackendId2, Replica.ReplicaState.NORMAL, version,
-                    0, dbId, tableId, partitionId, indexId, 1);
+                    0, dbId, indexId, 1);
             replica3 = new CloudReplica(testReplicaId3, testBackendId3, Replica.ReplicaState.NORMAL, version,
-                    0, dbId, tableId, partitionId, indexId, 2);
+                    0, dbId, indexId, 2);
         } else {
             replica1 = new LocalReplica(testReplicaId1, testBackendId1, version, 0, 0L, 0L, 0L,
                     Replica.ReplicaState.NORMAL, -1, 0);
@@ -247,7 +247,7 @@ public class CatalogTestUtil {
         Replica replica;
         if (Config.isCloudMode()) {
             replica = new CloudReplica(testReplicaId4, testBackendId1, Replica.ReplicaState.NORMAL, testStartVersion,
-                    0, db.getId(), testTableId2, testPartitionId2, testIndexId2, 0);
+                    0, db.getId(), testIndexId2, 0);
         } else {
             replica = new LocalReplica(testReplicaId4, testBackendId1, testStartVersion, 0, 0L, 0L, 0L,
                     Replica.ReplicaState.NORMAL, -1, 0);


### PR DESCRIPTION
## Summary
- Remove `tableId` and `partitionId` fields from `CloudReplica`, replacing them with a transient `tabletId` field that enables O(1) lookups via `TabletMeta` in the inverted index
- The `tabletId` is populated in `CloudTabletInvertedIndex.addReplica()`, which is called both at tablet creation time and during image load via `recreateTabletInvertIndex()`
- Internal methods (`isColocated()`, `hashReplicaToBe()`, `hashReplicaToBes()`, `getColocatedBeId()`) now look up `tableId`/`partitionId` from `TabletMeta`
- External caller in `CloudInternalCatalog` replaced with direct `TabletMeta` lookup
- Constructor simplified to remove `tableId`/`partitionId` parameters; all callers updated
- `TabletInvertedIndex.getTabletMeta()` uses `StampedLock.readLock()` + `Long2ObjectOpenHashMap.get()` — O(1) with minimal contention

## Memory Impact
Net -8 bytes/replica (remove 2 longs = -16, add 1 transient long = +8). At 10M replicas: ~76 MB saved. At 100M replicas: ~763 MB saved.

## Files Changed
- `CloudReplica.java` — remove fields, add tabletId + helper methods, simplify constructor
- `CloudTabletInvertedIndex.java` — set tabletId on replica in addReplica()
- `CloudInternalCatalog.java` — update constructor call + TabletMeta lookup
- `OlapTable.java` — update constructor call
- `CloudRestoreJob.java` — update constructor call
- `CatalogTestUtil.java` — update constructor calls

## Test plan
- [ ] Existing cloud tests pass (`mvn test -pl fe/fe-core -Dtest="*Cloud*"`)
- [ ] Verify TabletMeta lookup works correctly for colocated and non-colocated tables
- [ ] Gson backward compatibility: old-format JSON with "tableId"/"partitionId" keys deserializes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)