### PR TITLE
[fix](lineage) Propagate connectAttributes through FE forward path for scheduleInfo

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlAuthPacket.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlAuthPacket.java
@@ -106,7 +106,7 @@ public class MysqlAuthPacket extends MysqlPacket {
         if (buffer.remaining() > 0 && capability.isPluginAuth()) {
             pluginName = new String(MysqlProto.readNulTerminateString(buffer));
         }
-        // attribute map, no use now.
+        // connection attributes (e.g. scheduleInfo for lineage tracking)
         if (buffer.remaining() > 0 && capability.isConnectAttrs()) {
             connectAttributes = Maps.newHashMap();
             long attrsLength = MysqlProto.readVInt(buffer);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -663,6 +663,10 @@ public abstract class ConnectProcessor {
             ctx.setUserVars(userVariableFromThrift(request.getUserVariables()));
         }
 
+        if (request.isSetConnectAttributes()) {
+            ctx.setConnectAttributes(request.getConnectAttributes());
+        }
+
         // set compute group
         ctx.setComputeGroup(Env.getCurrentEnv().getAuth().getComputeGroup(ctx.getQualifiedUser()));
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
@@ -195,6 +195,11 @@ public class FEOpExecutor {
         if (null != ctx.queryId()) {
             params.setQueryId(ctx.queryId());
         }
+        // connect attributes (e.g. scheduleInfo for lineage)
+        Map<String, String> connectAttributes = ctx.getConnectAttributes();
+        if (connectAttributes != null && !connectAttributes.isEmpty()) {
+            params.setConnectAttributes(connectAttributes);
+        }
 
         // set transaction load info
         if (ctx.isTxnModel()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectAttributesForwardTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectAttributesForwardTest.java
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.thrift.TMasterOpRequest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests that connectAttributes (e.g. scheduleInfo for Dataworks lineage)
+ * survive the FE-to-FE forward path via TMasterOpRequest.
+ */
+public class ConnectAttributesForwardTest {
+
+    @Test
+    public void testSerializeConnectAttributesToRequest() {
+        ConnectContext ctx = new ConnectContext();
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("scheduleInfo",
+                "{\"SKYNET_TASKID\":\"523987416281\",\"SKYNET_APP_ID\":\"392426\"}");
+        attrs.put("_client_name", "dataworks-connector");
+        ctx.setConnectAttributes(attrs);
+
+        TMasterOpRequest params = new TMasterOpRequest();
+        Map<String, String> connectAttributes = ctx.getConnectAttributes();
+        if (connectAttributes != null && !connectAttributes.isEmpty()) {
+            params.setConnectAttributes(connectAttributes);
+        }
+
+        Assert.assertTrue("connect_attributes should be set on request",
+                params.isSetConnectAttributes());
+        Assert.assertEquals(2, params.getConnectAttributes().size());
+        Assert.assertEquals(
+                "{\"SKYNET_TASKID\":\"523987416281\",\"SKYNET_APP_ID\":\"392426\"}",
+                params.getConnectAttributes().get("scheduleInfo"));
+    }
+
+    @Test
+    public void testRestoreConnectAttributesFromRequest() {
+        TMasterOpRequest request = new TMasterOpRequest();
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("scheduleInfo", "{\"SKYNET_TASKID\":\"523987416281\"}");
+        request.setConnectAttributes(attrs);
+
+        ConnectContext ctx = new ConnectContext();
+        Assert.assertTrue(ctx.getConnectAttributes().isEmpty());
+
+        if (request.isSetConnectAttributes()) {
+            ctx.setConnectAttributes(request.getConnectAttributes());
+        }
+
+        Assert.assertEquals(1, ctx.getConnectAttributes().size());
+        Assert.assertEquals("{\"SKYNET_TASKID\":\"523987416281\"}",
+                ctx.getConnectAttributes().get("scheduleInfo"));
+    }
+
+    @Test
+    public void testScheduleInfoRoundTrip() {
+        String scheduleInfoValue = "{\"SKYNET_ONDUTY\":\"1107550004253538\","
+                + "\"ALISA_TASK_ID\":\"T3_0068646895\","
+                + "\"SKYNET_TASKID\":\"523987416281\"}";
+
+        ConnectContext senderCtx = new ConnectContext();
+        Map<String, String> clientAttrs = new HashMap<>();
+        clientAttrs.put("scheduleInfo", scheduleInfoValue);
+        senderCtx.setConnectAttributes(clientAttrs);
+
+        TMasterOpRequest request = new TMasterOpRequest();
+        Map<String, String> connectAttributes = senderCtx.getConnectAttributes();
+        if (connectAttributes != null && !connectAttributes.isEmpty()) {
+            request.setConnectAttributes(connectAttributes);
+        }
+
+        ConnectContext receiverCtx = new ConnectContext();
+        if (request.isSetConnectAttributes()) {
+            receiverCtx.setConnectAttributes(request.getConnectAttributes());
+        }
+
+        Assert.assertEquals(scheduleInfoValue,
+                receiverCtx.getConnectAttributes().get("scheduleInfo"));
+    }
+
+    @Test
+    public void testEmptyConnectAttributesNotSerialized() {
+        ConnectContext ctx = new ConnectContext();
+
+        TMasterOpRequest params = new TMasterOpRequest();
+        Map<String, String> connectAttributes = ctx.getConnectAttributes();
+        if (connectAttributes != null && !connectAttributes.isEmpty()) {
+            params.setConnectAttributes(connectAttributes);
+        }
+
+        Assert.assertFalse("connect_attributes should NOT be set for empty attributes",
+                params.isSetConnectAttributes());
+    }
+
+    @Test
+    public void testNoConnectAttributesInRequest() {
+        TMasterOpRequest request = new TMasterOpRequest();
+
+        ConnectContext ctx = new ConnectContext();
+        if (request.isSetConnectAttributes()) {
+            ctx.setConnectAttributes(request.getConnectAttributes());
+        }
+
+        Assert.assertNotNull(ctx.getConnectAttributes());
+        Assert.assertTrue(ctx.getConnectAttributes().isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -42,7 +42,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.channels.SocketChannel;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -643,5 +645,46 @@ public class ConnectContextTest {
         } finally {
             Config.cloud_unique_id = originalCloudUniqueId;
         }
+    }
+
+    @Test
+    public void testConnectAttributesDefault() {
+        ConnectContext ctx = new ConnectContext();
+        Map<String, String> attrs = ctx.getConnectAttributes();
+        Assert.assertNotNull("connectAttributes should never be null", attrs);
+        Assert.assertTrue("connectAttributes should default to empty", attrs.isEmpty());
+    }
+
+    @Test
+    public void testConnectAttributesSetAndGet() {
+        ConnectContext ctx = new ConnectContext();
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("scheduleInfo", "{\"SKYNET_TASKID\":\"523987416281\"}");
+        attrs.put("_client_name", "dataworks-connector");
+
+        ctx.setConnectAttributes(attrs);
+        Map<String, String> result = ctx.getConnectAttributes();
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("{\"SKYNET_TASKID\":\"523987416281\"}", result.get("scheduleInfo"));
+        Assert.assertEquals("dataworks-connector", result.get("_client_name"));
+    }
+
+    @Test
+    public void testConnectAttributesDefensiveCopy() {
+        ConnectContext ctx = new ConnectContext();
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put("scheduleInfo", "original");
+        ctx.setConnectAttributes(attrs);
+
+        attrs.put("scheduleInfo", "modified");
+        Assert.assertEquals("original", ctx.getConnectAttributes().get("scheduleInfo"));
+    }
+
+    @Test
+    public void testConnectAttributesSetNull() {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setConnectAttributes(null);
+        Assert.assertNotNull(ctx.getConnectAttributes());
+        Assert.assertTrue(ctx.getConnectAttributes().isEmpty());
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -395,6 +395,7 @@ struct TMasterOpRequest {
     30: optional TGroupCommitInfo groupCommitInfo
     31: optional binary prepareExecuteBuffer
     32: optional bool moreResultExists // Server has more result to send
+    33: optional map<string, string> connect_attributes
 
     // selectdb cloud
     1000: optional string cloud_cluster


### PR DESCRIPTION
### What problem does this PR solve?

When a MySQL client (e.g., DataWorks/SKYNET) connects to a **follower FE**, the `scheduleInfo` connection attribute is lost in the lineage `queryText` output.

In HA mode, DML statements are forwarded from follower FE to master FE via thrift RPC. The `TMasterOpRequest` had no field for `connect_attributes`, causing them to be silently dropped. The master FE creates an empty `ConnectContext`, so `LineageUtils.buildLineageContext()` produces `queryText` without the `/* scheduleInfo={...} */` prefix.

### Fix

1. **Thrift**: Add `connect_attributes` (field 33) to `TMasterOpRequest`
2. **FEOpExecutor**: Serialize `connectAttributes` into forward params (inherited by `MasterOpExecutor`)
3. **ConnectProcessor**: Restore `connectAttributes` in `proxyExecute()` on master FE

### Testing

- `ConnectContextTest`: 4 tests for connectAttributes get/set, defensive copy, null/empty handling
- `ConnectAttributesForwardTest`: 5 tests for forward path round-trip including scheduleInfo

### Files Changed

| File | Change |
|------|--------|
| `gensrc/thrift/FrontendService.thrift` | Add `connect_attributes` to `TMasterOpRequest` |
| `fe/.../qe/FEOpExecutor.java` | Serialize connectAttributes in forward params |
| `fe/.../qe/ConnectProcessor.java` | Restore connectAttributes in `proxyExecute()` |
| `fe/.../mysql/MysqlAuthPacket.java` | Fix stale comment |
| + 2 test files | 9 new test cases |



Issue Number: close #xxx

Related PR: #61004 

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
