### PR TITLE
[opt](memory) Change CloudReplica idx field from long to int

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -68,7 +68,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     @SerializedName(value = "indexId")
     private long indexId = -1;
     @SerializedName(value = "idx")
-    private long idx = -1;
+    private int idx = -1;
     // last time to get tablet stats
     @Getter
     @Setter
@@ -116,7 +116,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.indexId = indexId;
-        this.idx = idx;
+        this.idx = (int) idx;
     }
 
     private boolean isColocated() {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -116,7 +116,7 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.indexId = indexId;
-        this.idx = (int) idx;
+        this.idx = Math.toIntExact(idx);
     }
 
     private boolean isColocated() {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaIdxTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaIdxTest.java
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cloud.catalog;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.JsonObject;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CloudReplicaIdxTest {
+
+    @Mocked
+    Env env;
+
+    @Test
+    public void testGsonDeserializeLegacyLongIdx() {
+        // Simulate a legacy JSON payload where idx was serialized as a long value.
+        // Before this PR, idx was declared as `long`. Gson must coerce long -> int
+        // on deserialization for backward compatibility with existing images.
+        JsonObject json = new JsonObject();
+        json.addProperty("clazz", "CloudReplica");
+        json.addProperty("idx", 42L);
+        json.addProperty("dbId", 10001L);
+        json.addProperty("tableId", 20001L);
+        json.addProperty("partitionId", 30001L);
+        json.addProperty("indexId", 40001L);
+
+        Replica replica = GsonUtils.GSON.fromJson(json.toString(), Replica.class);
+        Assert.assertTrue(replica instanceof CloudReplica);
+        Assert.assertEquals(42L, ((CloudReplica) replica).getIdx());
+    }
+
+    @Test
+    public void testGsonDeserializeNegativeOneIdx() {
+        // The default sentinel value for idx is -1.
+        JsonObject json = new JsonObject();
+        json.addProperty("clazz", "CloudReplica");
+        json.addProperty("idx", -1L);
+
+        Replica replica = GsonUtils.GSON.fromJson(json.toString(), Replica.class);
+        Assert.assertTrue(replica instanceof CloudReplica);
+        Assert.assertEquals(-1L, ((CloudReplica) replica).getIdx());
+    }
+
+    @Test
+    public void testGsonDeserializeMaxIntIdx() {
+        // Verify that Integer.MAX_VALUE (a valid int) deserializes correctly.
+        JsonObject json = new JsonObject();
+        json.addProperty("clazz", "CloudReplica");
+        json.addProperty("idx", (long) Integer.MAX_VALUE);
+
+        Replica replica = GsonUtils.GSON.fromJson(json.toString(), Replica.class);
+        Assert.assertTrue(replica instanceof CloudReplica);
+        Assert.assertEquals((long) Integer.MAX_VALUE, ((CloudReplica) replica).getIdx());
+    }
+
+    @Test
+    public void testConstructorOverflowThrows() {
+        // Math.toIntExact must throw ArithmeticException for out-of-range values.
+        Assert.assertThrows(ArithmeticException.class, () -> {
+            new CloudReplica(1L, 1L, Replica.ReplicaState.NORMAL, 1L, 0,
+                    1L, 1L, 1L, 1L, (long) Integer.MAX_VALUE + 1);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Change the `idx` field type from `long` to `int` in `CloudReplica`
- The `idx` value represents tablet index within a partition — always a small value that fits in int
- Constructor casts `long` parameter to `int` for source compatibility
- `getIdx()` still returns `long` via auto-widening for API compatibility
- Gson handles `long` → `int` coercion for backward compatibility with old images

## Memory Impact
-4 bytes/replica (plus potential padding savings). At 10M replicas: ~38 MB saved. At 100M replicas: ~381 MB saved.

## Test plan
- [ ] Existing cloud tests pass (`mvn test -pl fe/fe-core -Dtest="*Cloud*"`)
- [ ] Gson backward compatibility: old-format JSON with long idx value deserializes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)