### PR TITLE
[fix](fe) Enable fuzzy for enable_query_cache

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1438,7 +1438,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_HIVE_SQL_CACHE, fuzzy = false)
     public boolean enableHiveSqlCache = false;
 
-    @VariableMgr.VarAttr(name = ENABLE_QUERY_CACHE)
+    @VariableMgr.VarAttr(name = ENABLE_QUERY_CACHE, fuzzy = true)
     public boolean enableQueryCache = false;
 
     @VarAttr(name = QUERY_CACHE_FORCE_REFRESH)


### PR DESCRIPTION
## Summary

Enable fuzzy for `enable_query_cache` session variable to match similar pattern with other cache variables.

## What problem does this PR solve?

Issue Number: N/A

Problem Summary: The `enable_query_cache` variable was missing the `fuzzy = true` attribute, which is inconsistent with other similar cache-related session variables like `enableHiveSqlCache`.

## Release note

None