### PR TITLE
branch-4.1: [fix](scan) Fix missing predicate filter when Native and JNI readers are mixed in FileScanner (#61929)

### DIFF
--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -357,7 +357,10 @@ Status FileScanner::_process_conjuncts() {
 Status FileScanner::_process_late_arrival_conjuncts() {
     if (_push_down_conjuncts.size() < _conjuncts.size()) {
         _push_down_conjuncts = _conjuncts;
-        _conjuncts.clear();
+        // Do not clear _conjuncts here!
+        // We must keep it for fallback filtering, especially when mixing
+        // Native readers (which use _push_down_conjuncts) and JNI readers (which rely on _conjuncts).
+        // _conjuncts.clear();
         RETURN_IF_ERROR(_process_conjuncts());
     }
     if (_applied_rf_num == _total_rf_num) {

--- a/be/test/exec/scan/vfile_scanner_exception_test.cpp
+++ b/be/test/exec/scan/vfile_scanner_exception_test.cpp
@@ -295,4 +295,45 @@ TEST_F(VfileScannerExceptionTest, failure_case) {
     WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
 }
 
+TEST_F(VfileScannerExceptionTest, process_late_arrival_conjuncts_retain) {
+    std::shared_ptr<FileScanner> scanner = nullptr;
+    generate_scanner(scanner);
+
+    // Simulate some conjuncts in scanner
+    // Let's create a dummy expr context to test the exact function
+    doris::TExprNode expr_node;
+    expr_node.node_type = TExprNodeType::BOOL_LITERAL;
+    expr_node.type = create_type_desc(PrimitiveType::TYPE_BOOLEAN);
+    expr_node.num_children = 0;
+    expr_node.__isset.bool_literal = true;
+    expr_node.bool_literal.value = true;
+
+    doris::TExpr texpr;
+    texpr.nodes.push_back(expr_node);
+
+    VExprContextSPtr ctx;
+    Status st = VExpr::create_expr_tree(texpr, ctx);
+    ASSERT_TRUE(st.ok());
+    st = ctx->prepare(&_runtime_state, RowDescriptor());
+    ASSERT_TRUE(st.ok());
+    st = ctx->open(&_runtime_state);
+    ASSERT_TRUE(st.ok());
+
+    scanner->_conjuncts.push_back(ctx);
+    ASSERT_EQ(scanner->_conjuncts.size(), 1);
+    ASSERT_EQ(scanner->_push_down_conjuncts.size(), 0);
+
+    // Call the function that used to clear conjuncts in branch-4.0
+    st = scanner->_process_late_arrival_conjuncts();
+    ASSERT_TRUE(st.ok());
+
+    // The key assertion: _conjuncts MUST NOT be cleared after this call!
+    // This guarantees that subsequent JNI scanners or other readers will still have fallback filters.
+    ASSERT_EQ(scanner->_conjuncts.size(), 1);
+    // And push_down_conjuncts should be cloned/assigned successfully
+    ASSERT_EQ(scanner->_push_down_conjuncts.size(), 1);
+
+    WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
+}
+
 } // namespace doris


### PR DESCRIPTION
bp: #61929