### PR TITLE
[refine](be) remove -Wno-deprecated-declarations and fix all deprecated usages

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -317,7 +317,6 @@ add_compile_options(-g
                     $<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>)
 
 add_compile_options(-Wno-unused-parameter
-                    -Wno-deprecated-declarations
                     -Wno-sign-compare)
 
 if (COMPILER_GCC)

--- a/be/src/common/multi_version.h
+++ b/be/src/common/multi_version.h
@@ -51,16 +51,13 @@ public:
     explicit MultiVersion(std::unique_ptr<const T>&& value) : current_version(std::move(value)) {}
 
     /// Obtain current version for read-only usage. Returns shared_ptr, that manages lifetime of version.
-    Version get() const { return std::atomic_load(&current_version); }
-
-    /// TODO: replace atomic_load/store() on shared_ptr (which is deprecated as of C++20) by C++20 std::atomic<std::shared_ptr>.
-    /// Clang 15 currently does not support it.
+    Version get() const { return current_version.load(); }
 
     /// Update an object with new version.
     void set(std::unique_ptr<const T>&& value) {
-        std::atomic_store(&current_version, Version {std::move(value)});
+        current_version.store(Version {std::move(value)});
     }
 
 private:
-    Version current_version;
+    std::atomic<Version> current_version;
 };

--- a/be/src/core/column/column_array.cpp
+++ b/be/src/core/column/column_array.cpp
@@ -841,8 +841,6 @@ ColumnArrayDataOffsets filter_return_new_dispatch(const Filter& filt, ssize_t re
         return filter_number_return_new<TYPE_TIMESTAMPTZ>(filt, result_size_hint, data, offsets);
     if (typeid_cast<const ColumnTimeV2*>(data.get()))
         return filter_number_return_new<TYPE_TIMEV2>(filt, result_size_hint, data, offsets);
-    if (typeid_cast<const ColumnTime*>(data.get()))
-        return filter_number_return_new<TYPE_TIME>(filt, result_size_hint, data, offsets);
     if (typeid_cast<const ColumnIPv4*>(data.get()))
         return filter_number_return_new<TYPE_IPV4>(filt, result_size_hint, data, offsets);
     if (typeid_cast<const ColumnString*>(data.get()))
@@ -909,8 +907,6 @@ size_t filter_inplace_dispatch(const Filter& filter, IColumn& src_data,
         return filter_number_inplace<TYPE_TIMESTAMPTZ>(filter, src_data, src_offsets);
     if (typeid_cast<ColumnTimeV2*>(&src_data))
         return filter_number_inplace<TYPE_TIMEV2>(filter, src_data, src_offsets);
-    if (typeid_cast<ColumnTime*>(&src_data))
-        return filter_number_inplace<TYPE_TIME>(filter, src_data, src_offsets);
     if (typeid_cast<ColumnIPv4*>(&src_data))
         return filter_number_inplace<TYPE_IPV4>(filter, src_data, src_offsets);
     return filter_generic_inplace(filter, src_data, src_offsets);

--- a/be/src/core/column/column_vector.cpp
+++ b/be/src/core/column/column_vector.cpp
@@ -543,7 +543,6 @@ template class ColumnVector<TYPE_DATE>;
 template class ColumnVector<TYPE_DATEV2>;
 template class ColumnVector<TYPE_DATETIME>;
 template class ColumnVector<TYPE_DATETIMEV2>;
-template class ColumnVector<TYPE_TIME>;
 template class ColumnVector<TYPE_TIMEV2>;
 template class ColumnVector<TYPE_TIMESTAMPTZ>;
 template class ColumnVector<TYPE_UINT32>;

--- a/be/src/core/column/column_vector.h
+++ b/be/src/core/column/column_vector.h
@@ -70,7 +70,7 @@ namespace doris {
 template <PrimitiveType T>
 class ColumnVector final : public COWHelper<IColumn, ColumnVector<T>> {
     static_assert(is_int_or_bool(T) || is_ip(T) || is_date_type(T) || is_float_or_double(T) ||
-                  T == TYPE_TIME || T == TYPE_TIMEV2 || T == TYPE_UINT32 || T == TYPE_UINT64 ||
+                  T == TYPE_TIMEV2 || T == TYPE_UINT32 || T == TYPE_UINT64 ||
                   T == TYPE_TIMESTAMPTZ);
 
 private:
@@ -120,7 +120,7 @@ public:
     void insert_many_from(const IColumn& src, size_t position, size_t length) override;
 
     void insert_range_of_integer(value_type begin, value_type end) {
-        if constexpr (!is_float_or_double(T) && T != TYPE_TIME && T != TYPE_TIMEV2 &&
+        if constexpr (!is_float_or_double(T) && T != TYPE_TIMEV2 &&
                       T != TYPE_TIMESTAMPTZ && !is_date_type(T)) {
             auto old_size = data.size();
             auto new_size = old_size + static_cast<size_t>(end - begin);
@@ -425,7 +425,6 @@ using ColumnFloat32 = ColumnVector<TYPE_FLOAT>;
 using ColumnFloat64 = ColumnVector<TYPE_DOUBLE>;
 using ColumnIPv4 = ColumnVector<TYPE_IPV4>;
 using ColumnIPv6 = ColumnVector<TYPE_IPV6>;
-using ColumnTime = ColumnVector<TYPE_TIME>;
 using ColumnTimeV2 = ColumnVector<TYPE_TIMEV2>;
 using ColumnTimeStampTz = ColumnVector<TYPE_TIMESTAMPTZ>;
 using ColumnOffset32 = ColumnVector<TYPE_UINT32>;

--- a/be/src/core/column/column_vector.h
+++ b/be/src/core/column/column_vector.h
@@ -120,8 +120,8 @@ public:
     void insert_many_from(const IColumn& src, size_t position, size_t length) override;
 
     void insert_range_of_integer(value_type begin, value_type end) {
-        if constexpr (!is_float_or_double(T) && T != TYPE_TIMEV2 &&
-                      T != TYPE_TIMESTAMPTZ && !is_date_type(T)) {
+        if constexpr (!is_float_or_double(T) && T != TYPE_TIMEV2 && T != TYPE_TIMESTAMPTZ &&
+                      !is_date_type(T)) {
             auto old_size = data.size();
             auto new_size = old_size + static_cast<size_t>(end - begin);
             data.resize(new_size);

--- a/be/src/core/data_type/data_type.cpp
+++ b/be/src/core/data_type/data_type.cpp
@@ -136,8 +136,6 @@ PGenericType_TypeId IDataType::get_pdata_type(const IDataType* data_type) {
         return PGenericType::JSONB;
     case PrimitiveType::TYPE_MAP:
         return PGenericType::MAP;
-    case PrimitiveType::TYPE_TIME:
-        return PGenericType::TIME;
     case PrimitiveType::TYPE_AGG_STATE:
         return PGenericType::AGG_STATE;
     case PrimitiveType::TYPE_TIMEV2:

--- a/be/src/core/data_type/data_type_number_base.cpp
+++ b/be/src/core/data_type/data_type_number_base.cpp
@@ -93,7 +93,7 @@ Field DataTypeNumberBase<T>::get_field(const TExprNode& node) const {
         return Field::create_field<T>(
                 typename PrimitiveTypeTraits<T>::CppType(node.int_literal.value));
     }
-    if constexpr (is_float_or_double(T) || T == TYPE_TIMEV2 || T == TYPE_TIME) {
+    if constexpr (is_float_or_double(T) || T == TYPE_TIMEV2) {
         return Field::create_field<T>(
                 typename PrimitiveTypeTraits<T>::CppType(node.float_literal.value));
     }
@@ -208,7 +208,6 @@ template class DataTypeNumberBase<TYPE_DATETIME>;
 template class DataTypeNumberBase<TYPE_DATETIMEV2>;
 template class DataTypeNumberBase<TYPE_IPV4>;
 template class DataTypeNumberBase<TYPE_IPV6>;
-template class DataTypeNumberBase<TYPE_TIME>;
 template class DataTypeNumberBase<TYPE_TIMEV2>;
 template class DataTypeNumberBase<TYPE_TIMESTAMPTZ>;
 

--- a/be/src/core/data_type/data_type_number_base.h
+++ b/be/src/core/data_type/data_type_number_base.h
@@ -49,7 +49,7 @@ class IColumn;
 template <PrimitiveType T>
 class DataTypeNumberBase : public IDataType {
     static_assert(is_int_or_bool(T) || is_ip(T) || is_date_type(T) || is_float_or_double(T) ||
-                  T == TYPE_TIME || T == TYPE_TIMEV2 || T == TYPE_TIMESTAMPTZ);
+                  T == TYPE_TIMEV2 || T == TYPE_TIMESTAMPTZ);
 
 public:
     static constexpr bool is_parametric = false;

--- a/be/src/core/data_type/primitive_type.h
+++ b/be/src/core/data_type/primitive_type.h
@@ -115,7 +115,6 @@ using ColumnFloat32 = ColumnVector<TYPE_FLOAT>;
 using ColumnFloat64 = ColumnVector<TYPE_DOUBLE>;
 using ColumnIPv4 = ColumnVector<TYPE_IPV4>;
 using ColumnIPv6 = ColumnVector<TYPE_IPV6>;
-using ColumnTime = ColumnVector<TYPE_TIME>;
 using ColumnTimeV2 = ColumnVector<TYPE_TIMEV2>;
 using ColumnOffset32 = ColumnVector<TYPE_UINT32>;
 using ColumnOffset64 = ColumnVector<TYPE_UINT64>;
@@ -179,7 +178,7 @@ constexpr bool is_date_type(PrimitiveType type) {
 }
 
 constexpr bool is_time_type(PrimitiveType type) {
-    return type == TYPE_TIME || type == TYPE_TIMEV2;
+    return type == TYPE_TIMEV2;
 }
 
 constexpr bool is_timestamptz_type(PrimitiveType type) {
@@ -342,13 +341,6 @@ struct PrimitiveTypeTraits<TYPE_TIMEV2> {
     using StorageFieldType = CppType;
     using DataType = DataTypeTimeV2;
     using ColumnType = ColumnTimeV2;
-};
-template <>
-struct PrimitiveTypeTraits<TYPE_TIME> {
-    using CppType = Float64;
-    using StorageFieldType = CppType;
-    using DataType = DataTypeTimeV2;
-    using ColumnType = ColumnTime;
 };
 template <>
 struct PrimitiveTypeTraits<TYPE_DATE> {

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -166,7 +166,7 @@ Status DataTypeNumberSerDe<T>::deserialize_one_cell_from_json(IColumn& column, S
     if constexpr (T == TYPE_IPV6) {
         // TODO: support for Uint128
         return Status::InvalidArgument("uint128 is not support");
-    } else if constexpr (is_float_or_double(T) || T == TYPE_TIMEV2 || T == TYPE_TIME) {
+    } else if constexpr (is_float_or_double(T) || T == TYPE_TIMEV2) {
         typename PrimitiveTypeTraits<T>::CppType val = 0;
         if (!try_read_float_text(val, str_ref)) {
             return Status::InvalidArgument("parse number fail, string: '{}'", slice.to_string());
@@ -558,7 +558,7 @@ Status DataTypeNumberSerDe<T>::write_column_to_mysql_binary(const IColumn& colum
         buf_ret = result.push_float(data[col_index]);
     } else if constexpr (T == TYPE_DOUBLE) {
         buf_ret = result.push_double(data[col_index]);
-    } else if constexpr (T == TYPE_TIME || T == TYPE_TIMEV2) {
+    } else if constexpr (T == TYPE_TIMEV2) {
         if (std::isnan(data[col_index])) {
             // Handle NaN for double, we should push null value
             buf_ret = result.push_null();
@@ -639,7 +639,7 @@ Status DataTypeNumberSerDe<T>::write_column_to_orc(const std::string& timezone,
         WRITE_INTEGRAL_COLUMN_TO_ORC(orc::LongVectorBatch)
     } else if constexpr (T == TYPE_FLOAT) { // float
         WRITE_INTEGRAL_COLUMN_TO_ORC(orc::FloatVectorBatch)
-    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIME || T == TYPE_TIMEV2) { // double
+    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIMEV2) { // double
         WRITE_INTEGRAL_COLUMN_TO_ORC(orc::DoubleVectorBatch)
     } else if constexpr (T == TYPE_IPV4) { // ipv4
         WRITE_INTEGRAL_COLUMN_TO_ORC(orc::IntVectorBatch)
@@ -674,7 +674,7 @@ void DataTypeNumberSerDe<T>::read_one_cell_from_jsonb(IColumn& column,
         col.insert_value(arg->unpack<JsonbInt128Val>()->val());
     } else if constexpr (T == TYPE_FLOAT) {
         col.insert_value(arg->unpack<JsonbFloatVal>()->val());
-    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIME || T == TYPE_TIMEV2) {
+    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIMEV2) {
         col.insert_value(arg->unpack<JsonbDoubleVal>()->val());
     } else {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
@@ -712,7 +712,7 @@ void DataTypeNumberSerDe<T>::write_one_cell_to_jsonb(const IColumn& column,
     } else if constexpr (T == TYPE_FLOAT) {
         float val = *reinterpret_cast<const float*>(data_ref.data);
         result.writeFloat(val);
-    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIME || T == TYPE_TIMEV2) {
+    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIMEV2) {
         double val = *reinterpret_cast<const double*>(data_ref.data);
         result.writeDouble(val);
     } else {
@@ -1033,7 +1033,7 @@ void value_to_string(const typename PrimitiveTypeTraits<T>::CppType value, Buffe
         CastToString::push_datetimev2(value, scale, bw);
     } else if constexpr (T == TYPE_TIMESTAMPTZ) {
         CastToString::push_timestamptz(value, scale, bw, options);
-    } else if constexpr (T == TYPE_TIME || T == TYPE_TIMEV2) {
+    } else if constexpr (T == TYPE_TIMEV2) {
         CastToString::push_time(value, scale, bw);
     } else if constexpr (T == TYPE_IPV4 || T == TYPE_IPV6) {
         CastToString::push_ip(value, bw);
@@ -1123,7 +1123,6 @@ template class DataTypeNumberSerDe<TYPE_DATETIME>;
 template class DataTypeNumberSerDe<TYPE_DATETIMEV2>;
 template class DataTypeNumberSerDe<TYPE_IPV4>;
 template class DataTypeNumberSerDe<TYPE_IPV6>;
-template class DataTypeNumberSerDe<TYPE_TIME>;
 template class DataTypeNumberSerDe<TYPE_TIMEV2>;
 template class DataTypeNumberSerDe<TYPE_TIMESTAMPTZ>;
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_number_serde.h
+++ b/be/src/core/data_type_serde/data_type_number_serde.h
@@ -50,7 +50,7 @@ class Arena;
 template <PrimitiveType T>
 class DataTypeNumberSerDe : public DataTypeSerDe {
     static_assert(is_int_or_bool(T) || is_ip(T) || is_date_type(T) || is_float_or_double(T) ||
-                  T == TYPE_TIME || T == TYPE_TIMEV2 || T == TYPE_TIMESTAMPTZ);
+                  T == TYPE_TIMEV2 || T == TYPE_TIMESTAMPTZ);
 
 public:
     using ColumnType = typename PrimitiveTypeTraits<T>::ColumnType;
@@ -217,7 +217,7 @@ Status DataTypeNumberSerDe<T>::read_column_from_pb(IColumn& column, const PValue
         for (int i = 0; i < arg.float_value_size(); ++i) {
             data[old_column_size + i] = arg.float_value(i);
         }
-    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIMEV2 || T == TYPE_TIME) {
+    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIMEV2) {
         column.resize(old_column_size + arg.double_value_size());
         auto& data = reinterpret_cast<ColumnType&>(column).get_data();
         for (int i = 0; i < arg.double_value_size(); ++i) {
@@ -301,7 +301,7 @@ Status DataTypeNumberSerDe<T>::write_column_to_pb(const IColumn& column, PValues
         auto* values = result.mutable_float_value();
         values->Reserve(row_count);
         values->Add(data.begin() + start, data.begin() + end);
-    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIMEV2 || T == TYPE_TIME) {
+    } else if constexpr (T == TYPE_DOUBLE || T == TYPE_TIMEV2) {
         ptype->set_id(PGenericType::DOUBLE);
         auto* values = result.mutable_double_value();
         values->Reserve(row_count);

--- a/be/src/core/field.cpp
+++ b/be/src/core/field.cpp
@@ -818,7 +818,6 @@ std::string_view Field::as_string_view() const {
     // MATCH_PRIMITIVE_TYPE(TYPE_MAP);
     // MATCH_PRIMITIVE_TYPE(TYPE_HLL);
     MATCH_PRIMITIVE_TYPE(TYPE_DECIMALV2);
-    MATCH_PRIMITIVE_TYPE(TYPE_TIME);
     // MATCH_PRIMITIVE_TYPE(TYPE_BITMAP);
     // MATCH_PRIMITIVE_TYPE(TYPE_STRING);
     // MATCH_PRIMITIVE_TYPE(TYPE_QUANTILE_STATE);
@@ -951,10 +950,6 @@ std::string Field::to_debug_string(int scale) const {
             typename PrimitiveTypeTraits<TYPE_QUANTILE_STATE>::CppType && rhs);                   \
     template void Field::FUNC_NAME<TYPE_ARRAY>(                                                   \
             typename PrimitiveTypeTraits<TYPE_ARRAY>::CppType && rhs);                            \
-    template void Field::FUNC_NAME<TYPE_TIME>(typename PrimitiveTypeTraits<TYPE_TIME>::CppType && \
-                                              rhs);                                               \
-    template void Field::FUNC_NAME<TYPE_TIME>(                                                    \
-            const typename PrimitiveTypeTraits<TYPE_TIME>::CppType& rhs);                         \
     template void Field::FUNC_NAME<TYPE_NULL>(                                                    \
             const typename PrimitiveTypeTraits<TYPE_NULL>::CppType& rhs);                         \
     template void Field::FUNC_NAME<TYPE_TINYINT>(                                                 \
@@ -1086,7 +1081,6 @@ DECLARE_FUNCTION(TYPE_HLL)
 DECLARE_FUNCTION(TYPE_VARIANT)
 DECLARE_FUNCTION(TYPE_QUANTILE_STATE)
 DECLARE_FUNCTION(TYPE_ARRAY)
-DECLARE_FUNCTION(TYPE_TIME)
 DECLARE_FUNCTION(TYPE_IPV4)
 DECLARE_FUNCTION(TYPE_IPV6)
 DECLARE_FUNCTION(TYPE_BOOLEAN)

--- a/be/src/exprs/aggregate/aggregate_function_approx_count_distinct.h
+++ b/be/src/exprs/aggregate/aggregate_function_approx_count_distinct.h
@@ -97,7 +97,7 @@ public:
              Arena&) const override {
         if constexpr (is_decimal(type) || is_int_or_bool(type) || is_ip(type) ||
                       is_date_type(type) || is_timestamptz_type(type) || is_float_or_double(type) ||
-                      type == TYPE_TIME || type == TYPE_TIMEV2) {
+                      type == TYPE_TIMEV2) {
             auto column =
                     assert_cast<const ColumnDataType*, TypeCheckOnRelease::DISABLE>(columns[0]);
             auto value = column->get_element(row_num);

--- a/be/src/exprs/aggregate/aggregate_function_min_max_impl.h
+++ b/be/src/exprs/aggregate/aggregate_function_min_max_impl.h
@@ -64,7 +64,6 @@ AggregateFunctionPtr create_aggregate_function_single_value(const String& name,
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_TIMESTAMPTZ>>>>(
                 argument_types, result_is_nullable, attr);
-    case PrimitiveType::TYPE_TIME:
     case PrimitiveType::TYPE_TIMEV2:
         return creator_without_type::create_unary_arguments<
                 AggregateFunctionsSingleValue<Data<SingleValueDataFixed<TYPE_TIMEV2>>>>(

--- a/be/src/exprs/function/functions_comparison.h
+++ b/be/src/exprs/function/functions_comparison.h
@@ -601,7 +601,6 @@ public:
             return execute_num_type<TYPE_FLOAT>(block, result, col_left_ptr, col_right_ptr);
         case TYPE_DOUBLE:
             return execute_num_type<TYPE_DOUBLE>(block, result, col_left_ptr, col_right_ptr);
-        case TYPE_TIME:
         case TYPE_TIMEV2:
             return execute_num_type<TYPE_TIMEV2>(block, result, col_left_ptr, col_right_ptr);
         case TYPE_DECIMALV2:

--- a/be/src/exprs/function/round.h
+++ b/be/src/exprs/function/round.h
@@ -450,7 +450,7 @@ struct Dispatcher {
     using FunctionRoundingImpl = std::conditional_t<
             is_decimal(T), DecimalRoundingImpl<T, rounding_mode, tie_breaking_mode>,
             std::conditional_t<
-                    is_float_or_double(T) || T == TYPE_TIME || T == TYPE_TIMEV2,
+                    is_float_or_double(T) || T == TYPE_TIMEV2,
                     FloatRoundingImpl<T, rounding_mode, scale_mode, tie_breaking_mode>,
                     IntegerRoundingImpl<T, rounding_mode, scale_mode, tie_breaking_mode>>>;
 
@@ -459,7 +459,7 @@ struct Dispatcher {
     static ColumnPtr apply_vec_const(const IColumn* col_general, const Int16 scale_arg,
                                      [[maybe_unused]] Int16 result_scale) {
         if constexpr (is_int_or_bool(T) || is_ip(T) || is_date_type(T) || is_float_or_double(T) ||
-                      T == TYPE_TIME || T == TYPE_TIMEV2 || T == TYPE_UINT32 || T == TYPE_UINT64) {
+                      T == TYPE_TIMEV2 || T == TYPE_UINT32 || T == TYPE_UINT64) {
             const auto* const col = check_and_get_column<ColumnVector<T>>(col_general);
             auto col_res = ColumnVector<T>::create();
 
@@ -574,7 +574,7 @@ struct Dispatcher {
         }
 
         if constexpr (is_int_or_bool(T) || is_date_type(T) || is_ip(T) || is_float_or_double(T) ||
-                      T == TYPE_TIMEV2 || T == TYPE_TIME) {
+                      T == TYPE_TIMEV2) {
             const auto* col = assert_cast<const ColumnVector<T>*>(col_general);
             auto col_res = ColumnVector<T>::create();
             typename ColumnVector<T>::Container& vec_res = col_res->get_data();
@@ -764,7 +764,7 @@ struct Dispatcher {
 
             return col_res;
         } else if constexpr (is_int_or_bool(T) || is_date_type(T) || is_ip(T) ||
-                             is_float_or_double(T) || T == TYPE_TIMEV2 || T == TYPE_TIME) {
+                             is_float_or_double(T) || T == TYPE_TIMEV2) {
             const ColumnVector<T>& data_col_general =
                     assert_cast<const ColumnVector<T>&>(const_col_general->get_data_column());
             const auto& general_val = data_col_general.get_data()[0];

--- a/be/src/exprs/lambda_function/varray_sort_function.cpp
+++ b/be/src/exprs/lambda_function/varray_sort_function.cpp
@@ -45,7 +45,7 @@ using ConstColumnVariant =
                      const ColumnDecimal32*, const ColumnDecimal64*, const ColumnDecimal128V2*,
                      const ColumnDecimal128V3*, const ColumnDecimal256*, const ColumnDate*,
                      const ColumnDateTime*, const ColumnDateV2*, const ColumnDateTimeV2*,
-                     const ColumnTime*, const ColumnTimeV2*>;
+                     const ColumnTimeV2*>;
 
 template <typename T>
 struct is_column_vector : std::false_type {};
@@ -256,7 +256,6 @@ public:
             DISPATCH_PRIMITIVE_TYPE(TYPE_DATETIME, ColumnDateTime)
             DISPATCH_PRIMITIVE_TYPE(TYPE_DATEV2, ColumnDateV2)
             DISPATCH_PRIMITIVE_TYPE(TYPE_DATETIMEV2, ColumnDateTimeV2)
-            DISPATCH_PRIMITIVE_TYPE(TYPE_TIME, ColumnTime)
             DISPATCH_PRIMITIVE_TYPE(TYPE_TIMEV2, ColumnTimeV2)
         default:
             return Status::InternalError("Unsupported type in array_sort");

--- a/be/test/exec/operator/sort_operator_test.cpp
+++ b/be/test/exec/operator/sort_operator_test.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <random>
 
 #include "core/block/block.h"
 #include "exec/operator/repeat_operator.h"
@@ -225,7 +226,7 @@ TEST_F(SortOperatorTest, test_sort_type) {
         for (int i = 0; i < 100; i++) {
             vec.push_back(i);
         }
-        std::random_shuffle(vec.begin(), vec.end());
+        std::shuffle(vec.begin(), vec.end(), std::mt19937 {std::random_device {}()});
 
         {
             Block block = ColumnHelper::create_block<DataTypeInt64>(vec);

--- a/be/test/exprs/function/cast/cast_test.h
+++ b/be/test/exprs/function/cast/cast_test.h
@@ -137,8 +137,6 @@ struct FunctionCastTest : public testing::Test {
         case TYPE_BINARY:
             return "binary";
         /* 13 */           // Not implemented
-        case TYPE_DECIMAL: /* 14 */
-            return "decimal";
         case TYPE_CHAR: /* 15 */
             return fmt::format("char({})", precision > 0 ? precision : 64);
 
@@ -153,9 +151,6 @@ struct FunctionCastTest : public testing::Test {
         case TYPE_DECIMALV2: /* 20: v2 128bit */
             return fmt::format("decimalv2({}, {})", precision > 0 ? precision : 27,
                                scale > 0 ? scale : 9);
-
-        case TYPE_TIME: /*TYPE_TIMEV2*/
-            return "time";
 
         case TYPE_BITMAP: /* 22: bitmap */
             return "bitmap";

--- a/be/test/exprs/function/cast/cast_test.h
+++ b/be/test/exprs/function/cast/cast_test.h
@@ -136,7 +136,7 @@ struct FunctionCastTest : public testing::Test {
             return "datetime";
         case TYPE_BINARY:
             return "binary";
-        /* 13 */           // Not implemented
+        /* 13 */        // Not implemented
         case TYPE_CHAR: /* 15 */
             return fmt::format("char({})", precision > 0 ? precision : 64);
 

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -226,7 +226,7 @@ public:
         outfile = std::move(result_file).ValueUnsafe();
 
         ::parquet::WriterProperties::Builder builder;
-        builder.version(::parquet::ParquetVersion::PARQUET_2_0);
+        builder.version(::parquet::ParquetVersion::PARQUET_2_6);
         builder.data_page_version(::parquet::ParquetDataPageVersion::V2);
         builder.enable_write_page_index();
         builder.compression(::parquet::Compression::SNAPPY);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The `-Wno-deprecated-declarations` compiler flag was globally suppressing warnings for `[[deprecated]]` marked items, hiding real code issues. This PR removes the flag and fixes all resulting compilation errors:

1. **Remove all `TYPE_TIME` usage** — `TYPE_TIME` was deprecated long ago in favor of `TYPE_TIMEV2`. Removed references across 15+ files including template instantiations, type traits, switch cases, and column aliases.

2. **Replace deprecated `std::atomic_load`/`std::atomic_store` on `shared_ptr`** — In `multi_version.h`, replaced with C++20 `std::atomic<std::shared_ptr<T>>` using `.load()`/`.store()`.

3. **Replace deprecated `std::random_shuffle`** — In `sort_operator_test.cpp`, replaced with `std::shuffle` + `std::mt19937`.

4. **Replace deprecated `PARQUET_2_0`** — In `parquet_expr_test.cpp`, replaced with `PARQUET_2_6`.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

