### PR TITLE
[improvement](build) Disable JuiceFS build and packaging by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,7 +80,7 @@ Usage: $0 <options>
     DISABLE_BE_JAVA_EXTENSIONS  If set DISABLE_BE_JAVA_EXTENSIONS=ON, we will do not build binary with java-udf,hadoop-hudi-scanner,jdbc-scanner and so on Default is OFF.
     DISABLE_JAVA_CHECK_STYLE    If set DISABLE_JAVA_CHECK_STYLE=ON, it will skip style check of java code in FE.
     DISABLE_BUILD_AZURE         If set DISABLE_BUILD_AZURE=ON, it will not build azure into BE.
-    DISABLE_BUILD_JUICEFS       If set DISABLE_BUILD_JUICEFS=ON, it will skip packaging juicefs-hadoop jar into FE/BE output.
+    DISABLE_BUILD_JUICEFS       If set DISABLE_BUILD_JUICEFS=ON, it will skip packaging juicefs-hadoop jar into FE/BE output. Default is ON (juicefs is disabled by default; set DISABLE_BUILD_JUICEFS=OFF to enable).
 
   Eg.
     $0                                      build all
@@ -547,11 +547,7 @@ else
     BUILD_JINDOFS='ON'
 fi
 
-if [[ "$(echo "${DISABLE_BUILD_JUICEFS}" | tr '[:lower:]' '[:upper:]')" == "ON" ]]; then
-    BUILD_JUICEFS='OFF'
-else
-    BUILD_JUICEFS='ON'
-fi
+BUILD_JUICEFS="$(juicefs_packaging_enabled "${DISABLE_BUILD_JUICEFS}")"
 
 if [[ -z "${ENABLE_INJECTION_POINT}" ]]; then
     ENABLE_INJECTION_POINT='OFF'

--- a/build.sh
+++ b/build.sh
@@ -80,7 +80,7 @@ Usage: $0 <options>
     DISABLE_BE_JAVA_EXTENSIONS  If set DISABLE_BE_JAVA_EXTENSIONS=ON, we will do not build binary with java-udf,hadoop-hudi-scanner,jdbc-scanner and so on Default is OFF.
     DISABLE_JAVA_CHECK_STYLE    If set DISABLE_JAVA_CHECK_STYLE=ON, it will skip style check of java code in FE.
     DISABLE_BUILD_AZURE         If set DISABLE_BUILD_AZURE=ON, it will not build azure into BE.
-    DISABLE_BUILD_JUICEFS       If set DISABLE_BUILD_JUICEFS=ON, it will skip packaging juicefs-hadoop jar into FE/BE output. Default is ON (juicefs is disabled by default; set DISABLE_BUILD_JUICEFS=OFF to enable).
+    DISABLE_BUILD_JUICEFS       If set DISABLE_BUILD_JUICEFS=ON, it will skip building JuiceFS thirdparty and packaging juicefs-hadoop jar into FE/BE output. Default is ON (juicefs is disabled by default; set DISABLE_BUILD_JUICEFS=OFF to enable).
 
   Eg.
     $0                                      build all

--- a/docker/thirdparties/jindofs-helpers.sh
+++ b/docker/thirdparties/jindofs-helpers.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,75 +17,70 @@
 # under the License.
 
 # Shared JindoFS helper functions used by build packaging.
-
-JINDOFS_PLATFORM_JAR_PATTERNS_X86_64=(
-    'jindo-core-linux-ubuntu22-x86_64-*.jar'
-)
-
-JINDOFS_PLATFORM_JAR_PATTERNS_AARCH64=(
-    'jindo-core-linux-el7-aarch64-*.jar'
-)
+# Written in POSIX sh so it is compatible with both bash and sh.
 
 jindofs_all_platform_jar_patterns() {
     printf '%s\n' \
-        "${JINDOFS_PLATFORM_JAR_PATTERNS_X86_64[@]}" \
-        "${JINDOFS_PLATFORM_JAR_PATTERNS_AARCH64[@]}"
+        'jindo-core-linux-ubuntu22-x86_64-*.jar' \
+        'jindo-core-linux-el7-aarch64-*.jar'
 }
 
 jindofs_platform_jar_patterns() {
     local target_system="$1"
     local target_arch="$2"
 
-    if [[ "${target_system}" != "Linux" ]]; then
-        return 1
-    fi
+    [ "${target_system}" = "Linux" ] || return 1
 
-    if [[ "${target_arch}" == "x86_64" ]]; then
-        printf '%s\n' "${JINDOFS_PLATFORM_JAR_PATTERNS_X86_64[@]}"
-        return 0
-    fi
-
-    if [[ "${target_arch}" == "aarch64" ]]; then
-        printf '%s\n' "${JINDOFS_PLATFORM_JAR_PATTERNS_AARCH64[@]}"
-        return 0
-    fi
-
-    return 1
+    case "${target_arch}" in
+        x86_64)
+            printf '%s\n' 'jindo-core-linux-ubuntu22-x86_64-*.jar'
+            ;;
+        aarch64)
+            printf '%s\n' 'jindo-core-linux-el7-aarch64-*.jar'
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 jindofs_is_platform_jar() {
     local jar_name="$1"
-    local pattern=""
-    while IFS= read -r pattern; do
-        if [[ -n "${pattern}" && "${jar_name}" == ${pattern} ]]; then
-            return 0
-        fi
-    done < <(jindofs_all_platform_jar_patterns)
-    return 1
+    local pattern
+    jindofs_all_platform_jar_patterns | while IFS= read -r pattern; do
+        case "${jar_name}" in
+            ${pattern})
+                echo "match"
+                return
+                ;;
+        esac
+    done
 }
 
 jindofs_find_common_jars() {
     local jindofs_dir="$1"
-    local jar=""
-    while IFS= read -r jar; do
-        if ! jindofs_is_platform_jar "$(basename "${jar}")"; then
+    local jar
+    for jar in "${jindofs_dir}"/*.jar; do
+        [ -f "${jar}" ] || continue
+        if [ -z "$(jindofs_is_platform_jar "$(basename "${jar}")")" ]; then
             echo "${jar}"
         fi
-    done < <(compgen -G "${jindofs_dir}/*.jar" | sort)
+    done | sort
 }
 
 jindofs_log_source_jars() {
     local jindofs_dir="$1"
     local target_dir="$2"
-    local jar=""
-    local -a jars=()
+    local jar
+    local count=0
 
-    while IFS= read -r jar; do
-        jars+=("${jar}")
-    done < <(compgen -G "${jindofs_dir}/*.jar" | sort)
-
-    echo "JindoFS source jar count for ${target_dir}: ${#jars[@]}"
-    for jar in "${jars[@]}"; do
+    for jar in "${jindofs_dir}"/*.jar; do
+        [ -f "${jar}" ] || continue
+        count=$((count + 1))
+    done
+    echo "JindoFS source jar count for ${target_dir}: ${count}"
+    for jar in "${jindofs_dir}"/*.jar; do
+        [ -f "${jar}" ] || continue
         echo "JindoFS source jar for ${target_dir}: $(basename "${jar}")"
     done
 }
@@ -95,28 +90,28 @@ jindofs_copy_jars() {
     local target_dir="$2"
     local target_system="$3"
     local target_arch="$4"
-    local jar=""
-    local platform_jar_pattern=""
+    local jar
+    local platform_jar_pattern
 
-    if [[ "${target_system}" != "Linux" ]]; then
-        return 0
-    fi
+    [ "${target_system}" = "Linux" ] || return 0
 
-    if [[ "${target_arch}" != "x86_64" && "${target_arch}" != "aarch64" ]]; then
-        return 0
-    fi
+    case "${target_arch}" in
+        x86_64 | aarch64) ;;
+        *) return 0 ;;
+    esac
 
     jindofs_log_source_jars "${jindofs_dir}" "${target_dir}"
 
-    while IFS= read -r jar; do
+    jindofs_find_common_jars "${jindofs_dir}" | while IFS= read -r jar; do
         cp -r -p "${jar}" "${target_dir}/"
         echo "Copy JindoFS jar to ${target_dir}: $(basename "${jar}")"
-    done < <(jindofs_find_common_jars "${jindofs_dir}")
+    done
 
-    while IFS= read -r platform_jar_pattern; do
-        while IFS= read -r jar; do
+    jindofs_platform_jar_patterns "${target_system}" "${target_arch}" | while IFS= read -r platform_jar_pattern; do
+        for jar in "${jindofs_dir}"/${platform_jar_pattern}; do
+            [ -f "${jar}" ] || continue
             cp -r -p "${jar}" "${target_dir}/"
             echo "Copy JindoFS jar to ${target_dir}: $(basename "${jar}")"
-        done < <(compgen -G "${jindofs_dir}/${platform_jar_pattern}" | sort)
-    done < <(jindofs_platform_jar_patterns "${target_system}" "${target_arch}" || true)
+        done
+    done
 }

--- a/docker/thirdparties/juicefs-helpers.sh
+++ b/docker/thirdparties/juicefs-helpers.sh
@@ -46,6 +46,19 @@ juicefs_detect_hadoop_version() {
     echo "${juicefs_jar%.jar}"
 }
 
+juicefs_packaging_enabled() {
+    local disable_build_juicefs="${1:-}"
+
+    case "$(printf '%s' "${disable_build_juicefs}" | tr '[:lower:]' '[:upper:]')" in
+        OFF)
+            echo "ON"
+            ;;
+        *)
+            echo "OFF"
+            ;;
+    esac
+}
+
 juicefs_hadoop_jar_download_url() {
     local juicefs_version="$1"
     local jar_name="juicefs-hadoop-${juicefs_version}.jar"

--- a/docker/thirdparties/test/jindofs-helpers-compat-test.sh
+++ b/docker/thirdparties/test/jindofs-helpers-compat-test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd)"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    [[ "${actual}" == "${expected}" ]] || fail "expected '${expected}', got '${actual}'"
+}
+
+run_copy_case() {
+    local shell_bin="$1"
+    local target_arch="$2"
+    local tmpdir
+    local src_dir
+    local target_dir
+
+    tmpdir="$(mktemp -d)"
+    src_dir="${tmpdir}/src"
+    target_dir="${tmpdir}/target"
+    mkdir -p "${src_dir}" "${target_dir}"
+
+    touch "${src_dir}/jindo-core-6.10.4.jar"
+    touch "${src_dir}/jindo-sdk-6.10.4.jar"
+    touch "${src_dir}/jindo-common-1.0.jar"
+    touch "${src_dir}/jindo-core-linux-ubuntu22-x86_64-6.10.4.jar"
+    touch "${src_dir}/jindo-core-linux-el7-aarch64-6.10.4.jar"
+
+    "${shell_bin}" -c '
+        helper_path="$1"
+        source_dir="$2"
+        output_dir="$3"
+        arch="$4"
+        . "${helper_path}"
+        jindofs_copy_jars "${source_dir}" "${output_dir}" "Linux" "${arch}"
+    ' _ "${ROOT}/jindofs-helpers.sh" "${src_dir}" "${target_dir}" "${target_arch}" || fail "copy failed under ${shell_bin} for ${target_arch}"
+
+    if [[ "${target_arch}" == "x86_64" ]]; then
+        assert_eq $'jindo-common-1.0.jar\njindo-core-6.10.4.jar\njindo-core-linux-ubuntu22-x86_64-6.10.4.jar\njindo-sdk-6.10.4.jar' \
+            "$(find "${target_dir}" -maxdepth 1 -type f -printf '%f\n' | sort)"
+    else
+        assert_eq $'jindo-common-1.0.jar\njindo-core-6.10.4.jar\njindo-core-linux-el7-aarch64-6.10.4.jar\njindo-sdk-6.10.4.jar' \
+            "$(find "${target_dir}" -maxdepth 1 -type f -printf '%f\n' | sort)"
+    fi
+
+    rm -rf "${tmpdir}"
+}
+
+run_copy_case bash x86_64
+run_copy_case bash aarch64
+run_copy_case sh x86_64
+run_copy_case sh aarch64
+
+echo "PASS"

--- a/docker/thirdparties/test/juicefs-helpers-packaging-test.sh
+++ b/docker/thirdparties/test/juicefs-helpers-packaging-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd)"
+. "${ROOT}/juicefs-helpers.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    [[ "${actual}" == "${expected}" ]] || fail "expected '${expected}', got '${actual}'"
+}
+
+assert_eq "OFF" "$(juicefs_packaging_enabled)"
+assert_eq "OFF" "$(juicefs_packaging_enabled ON)"
+assert_eq "ON" "$(juicefs_packaging_enabled OFF)"
+assert_eq "ON" "$(juicefs_packaging_enabled off)"
+
+echo "PASS"

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -2090,7 +2090,6 @@ build_paimon_cpp() {
 if [[ "${#packages[@]}" -eq 0 ]]; then
     packages=(
         jindofs
-        juicefs
         odbc
         openssl
         libevent
@@ -2163,6 +2162,9 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         pugixml
         paimon_cpp
     )
+    if [[ "$(thirdparty_juicefs_build_enabled "${DISABLE_BUILD_JUICEFS}")" == "ON" ]]; then
+        packages=(jindofs juicefs "${packages[@]:1}")
+    fi
     if [[ "$(uname -s)" == 'Darwin' ]]; then
         read -r -a packages <<<"binutils gettext ${packages[*]}"
     elif [[ "$(uname -s)" == 'Linux' ]]; then

--- a/thirdparty/test/juicefs-default-selection-test.sh
+++ b/thirdparty/test/juicefs-default-selection-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd)"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local needle="$1"
+    local haystack="$2"
+    grep -Fxq "${needle}" <<<"${haystack}" || fail "expected '${needle}' in: ${haystack}"
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local haystack="$2"
+    if grep -Fxq "${needle}" <<<"${haystack}"; then
+        fail "did not expect '${needle}' in: ${haystack}"
+    fi
+}
+
+default_archives="$(
+    bash -lc '
+        set -eo pipefail
+        source "'"${ROOT}"'/vars.sh"
+        printf "%s\n" "${TP_ARCHIVES[@]}"
+    '
+)"
+assert_not_contains "JUICEFS" "${default_archives}"
+
+enabled_archives="$(
+    DISABLE_BUILD_JUICEFS=OFF bash -lc '
+        set -eo pipefail
+        source "'"${ROOT}"'/vars.sh"
+        printf "%s\n" "${TP_ARCHIVES[@]}"
+    '
+)"
+assert_contains "JUICEFS" "${enabled_archives}"
+
+echo "PASS"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -559,6 +559,19 @@ JUICEFS_NAME=juicefs-hadoop-1.3.1.jar
 JUICEFS_SOURCE=
 JUICEFS_MD5SUM="f374dfbfbdc4b83417cfea78a6728c54"
 
+thirdparty_juicefs_build_enabled() {
+    local disable_build_juicefs="${1:-}"
+
+    case "$(printf '%s' "${disable_build_juicefs}" | tr '[:lower:]' '[:upper:]')" in
+        OFF)
+            echo "ON"
+            ;;
+        *)
+            echo "OFF"
+            ;;
+    esac
+}
+
 # pugixml
 PUGIXML_DOWNLOAD="https://github.com/zeux/pugixml/releases/download/v1.15/pugixml-1.15.tar.gz"
 PUGIXML_NAME=pugixml-1.15.tar.gz
@@ -653,7 +666,6 @@ export TP_ARCHIVES=(
     'DRAGONBOX'
     'ICU'
     'JINDOFS'
-    'JUICEFS'
     'PUGIXML'
     'PAIMON_CPP'
 )
@@ -672,5 +684,10 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     GETTEXT_MD5SUM='28b1cd4c94a74428723ed966c38cf479'
 
     read -r -a TP_ARCHIVES <<<"${TP_ARCHIVES[*]} BINUTILS GETTEXT"
+    export TP_ARCHIVES
+fi
+
+if [[ "$(thirdparty_juicefs_build_enabled "${DISABLE_BUILD_JUICEFS}")" == "ON" ]]; then
+    TP_ARCHIVES+=('JUICEFS')
     export TP_ARCHIVES
 fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #62068

Problem Summary: Follow up the original JuiceFS default-disable change so local builds no longer download, build, or package JuiceFS by default. Keep the JindoFS helper POSIX sh compatible, disable JuiceFS in the default thirdparty download/build lists, and still allow explicit opt-in via `DISABLE_BUILD_JUICEFS=OFF` for CI or users that need it.

### Release note

JuiceFS thirdparty download/build/package is disabled by default. Set `DISABLE_BUILD_JUICEFS=OFF` to re-enable it.

### Check List (For Author)

- Test: Regression test / Unit Test
    - `bash thirdparty/test/juicefs-default-selection-test.sh`
    - `bash docker/thirdparties/test/juicefs-helpers-packaging-test.sh`
    - `bash docker/thirdparties/test/jindofs-helpers-compat-test.sh`
    - `bash -n build.sh thirdparty/build-thirdparty.sh thirdparty/vars.sh thirdparty/test/juicefs-default-selection-test.sh docker/thirdparties/juicefs-helpers.sh docker/thirdparties/jindofs-helpers.sh docker/thirdparties/test/juicefs-helpers-packaging-test.sh docker/thirdparties/test/jindofs-helpers-compat-test.sh`
- Behavior changed: Yes (JuiceFS is no longer downloaded, built, or packaged by default unless `DISABLE_BUILD_JUICEFS=OFF` is set)
- Does this need documentation: No
