### PR TITLE
[chore](build) plugin selectors in build scripts

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -154,18 +154,6 @@ message(STATUS "build task executor simulator: ${BUILD_TASK_EXECUTOR_SIMULATOR}"
 option(BUILD_FILE_CACHE_LRU_TOOL "ON for building file cache lru tool or OFF for not" OFF)
 message(STATUS "build file cache lru tool: ${BUILD_FILE_CACHE_LRU_TOOL}")
 
-if("${WITH_TDE_DIR}" STREQUAL "enterprise")
-    message(FATAL_ERROR "WITH_TDE_DIR=enterprise is no longer supported; use WITH_TDE_DIR=enterprise/tde")
-endif()
-
-if(NOT "${WITH_TDE_DIR}" STREQUAL "" AND NOT "${WITH_TDE_DIR}" STREQUAL "enterprise/tde")
-    message(FATAL_ERROR "Unsupported WITH_TDE_DIR=${WITH_TDE_DIR}; only enterprise/tde is supported")
-endif()
-
-if(NOT "${WITH_TLS_DIR}" STREQUAL "" AND NOT "${WITH_TLS_DIR}" STREQUAL "enterprise/tls")
-    message(FATAL_ERROR "Unsupported WITH_TLS_DIR=${WITH_TLS_DIR}; only enterprise/tls is supported")
-endif()
-
 option(ENABLE_PAIMON_CPP "Enable Paimon C++ integration" ON)
 set(PAIMON_HOME "" CACHE PATH "Paimon install prefix")
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -154,6 +154,18 @@ message(STATUS "build task executor simulator: ${BUILD_TASK_EXECUTOR_SIMULATOR}"
 option(BUILD_FILE_CACHE_LRU_TOOL "ON for building file cache lru tool or OFF for not" OFF)
 message(STATUS "build file cache lru tool: ${BUILD_FILE_CACHE_LRU_TOOL}")
 
+if("${WITH_TDE_DIR}" STREQUAL "enterprise")
+    message(FATAL_ERROR "WITH_TDE_DIR=enterprise is no longer supported; use WITH_TDE_DIR=enterprise/tde")
+endif()
+
+if(NOT "${WITH_TDE_DIR}" STREQUAL "" AND NOT "${WITH_TDE_DIR}" STREQUAL "enterprise/tde")
+    message(FATAL_ERROR "Unsupported WITH_TDE_DIR=${WITH_TDE_DIR}; only enterprise/tde is supported")
+endif()
+
+if(NOT "${WITH_TLS_DIR}" STREQUAL "" AND NOT "${WITH_TLS_DIR}" STREQUAL "enterprise/tls")
+    message(FATAL_ERROR "Unsupported WITH_TLS_DIR=${WITH_TLS_DIR}; only enterprise/tls is supported")
+endif()
+
 option(ENABLE_PAIMON_CPP "Enable Paimon C++ integration" ON)
 set(PAIMON_HOME "" CACHE PATH "Paimon install prefix")
 

--- a/be/src/io/CMakeLists.txt
+++ b/be/src/io/CMakeLists.txt
@@ -28,7 +28,8 @@ endif()
 
 if(NOT "${WITH_TDE_DIR}" STREQUAL "")
     list(REMOVE_ITEM IO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/fs/encrypted_fs_factory.cpp")
-    file(GLOB_RECURSE EXTRA_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../${WITH_TDE_DIR}/*.cpp")
+    file(GLOB_RECURSE EXTRA_SOURCES CONFIGURE_DEPENDS
+            "${CMAKE_CURRENT_SOURCE_DIR}/../${WITH_TDE_DIR}/*.cpp")
     list(APPEND IO_FILES ${EXTRA_SOURCES})
 endif()
 

--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -102,10 +102,20 @@ if [[ -z ${VERSION} ]]; then
     usage
 fi
 
+if [[ -z "${WITH_TDE_DIR+x}" ]]; then
+    export WITH_TDE_DIR="enterprise/tde"
+fi
+
+if [[ -z "${WITH_TLS_DIR+x}" ]]; then
+    export WITH_TLS_DIR="enterprise/tls"
+fi
+
 echo "Get params:
     VERSION         -- ${VERSION}
     USE_AVX2        -- ${_USE_AVX2}
     TAR             -- ${TAR}
+    WITH_TDE_DIR    -- ${WITH_TDE_DIR}
+    WITH_TLS_DIR    -- ${WITH_TLS_DIR}
 "
 
 ARCH="$(uname -m)"

--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -102,13 +102,8 @@ if [[ -z ${VERSION} ]]; then
     usage
 fi
 
-if [[ -z "${WITH_TDE_DIR+x}" ]]; then
-    export WITH_TDE_DIR="enterprise/tde"
-fi
-
-if [[ -z "${WITH_TLS_DIR+x}" ]]; then
-    export WITH_TLS_DIR="enterprise/tls"
-fi
+export WITH_TDE_DIR="${WITH_TDE_DIR:-}"
+export WITH_TLS_DIR="${WITH_TLS_DIR:-}"
 
 echo "Get params:
     VERSION         -- ${VERSION}

--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,8 @@ Usage: $0 <options>
     DISABLE_BE_JAVA_EXTENSIONS  If set DISABLE_BE_JAVA_EXTENSIONS=ON, we will do not build binary with java-udf,hadoop-hudi-scanner,jdbc-scanner and so on Default is OFF.
     DISABLE_JAVA_CHECK_STYLE    If set DISABLE_JAVA_CHECK_STYLE=ON, it will skip style check of java code in FE.
     DISABLE_BUILD_AZURE         If set DISABLE_BUILD_AZURE=ON, it will not build azure into BE.
+    WITH_TDE_DIR                Optional TDE plugin directory under be/src.
+    WITH_TLS_DIR                Optional TLS plugin directory under be/src.
     DISABLE_BUILD_JUICEFS       If set DISABLE_BUILD_JUICEFS=OFF, it will package juicefs-hadoop jar into FE/BE output. Default is ON (skip).
     DISABLE_BUILD_JINDOFS       If set DISABLE_BUILD_JINDOFS=OFF, it will package jindofs jars into FE/BE output. Default is ON (skip).
 
@@ -551,6 +553,32 @@ if [[ -z "${WITH_TDE_DIR}" ]]; then
     WITH_TDE_DIR=''
 fi
 
+if [[ -n "${WITH_TDE_DIR}" && ! -d "${DORIS_HOME}/be/src/${WITH_TDE_DIR}" ]]; then
+    echo "WITH_TDE_DIR=${WITH_TDE_DIR} requested but be/src/${WITH_TDE_DIR} is missing; skip TDE plugin build"
+    WITH_TDE_DIR=''
+fi
+
+if [[ -z "${WITH_TLS_DIR}" ]]; then
+    WITH_TLS_DIR=''
+fi
+
+if [[ -n "${WITH_TLS_DIR}" && ! -d "${DORIS_HOME}/be/src/${WITH_TLS_DIR}" ]]; then
+    echo "WITH_TLS_DIR=${WITH_TLS_DIR} requested but be/src/${WITH_TLS_DIR} is missing; skip TLS plugin build"
+    WITH_TLS_DIR=''
+fi
+
+FE_EXTRA_MODULE=''
+FE_EXTRA_ARTIFACT=''
+FE_EXTRA_ARGS=()
+if [[ -n "${WITH_TDE_DIR}" || -n "${WITH_TLS_DIR}" ]]; then
+    if [[ -f "${DORIS_HOME}/fe/fe-extra/pom.xml" ]]; then
+        FE_EXTRA_MODULE='fe-extra'
+        FE_EXTRA_ARTIFACT='fe-extra'
+        [[ -n "${WITH_TDE_DIR}" ]] && FE_EXTRA_ARGS+=("-Dfe.extra.tde.enabled=true")
+        [[ -n "${WITH_TLS_DIR}" ]] && FE_EXTRA_ARGS+=("-Dfe.extra.tls.enabled=true")
+    fi
+fi
+
 echo "Get params:
     BUILD_FE                            -- ${BUILD_FE}
     BUILD_BE                            -- ${BUILD_BE}
@@ -580,10 +608,12 @@ echo "Get params:
     DISPLAY_BUILD_TIME                  -- ${DISPLAY_BUILD_TIME}
     ENABLE_PCH                          -- ${ENABLE_PCH}
     WITH_TDE_DIR                        -- ${WITH_TDE_DIR}
+    WITH_TLS_DIR                        -- ${WITH_TLS_DIR}
 "
 
 FEAT=()
 FEAT+=($([[ -n "${WITH_TDE_DIR}" ]] && echo "+TDE" || echo "-TDE"))
+FEAT+=($([[ -n "${WITH_TLS_DIR}" ]] && echo "+TLS" || echo "-TLS"))
 FEAT+=($([[ "${ENABLE_HDFS_STORAGE_VAULT:-OFF}" == "ON" ]] && echo "+HDFS_STORAGE_VAULT" || echo "-HDFS_STORAGE_VAULT"))
 FEAT+=($([[ ${BUILD_UI} -eq 1 ]] && echo "+UI" || echo "-UI"))
 FEAT+=($([[ "${BUILD_AZURE}" == "ON" ]] && echo "+AZURE_BLOB,+AZURE_STORAGE_VAULT" || echo "-AZURE_BLOB,-AZURE_STORAGE_VAULT"))
@@ -615,8 +645,8 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
         fi
     done
     unset _fs_mod
-    if [[ "${WITH_TDE_DIR}" != "" ]]; then
-        modules+=("fe-${WITH_TDE_DIR}")
+    if [[ "${FE_EXTRA_MODULE}" != "" ]]; then
+        modules+=("${FE_EXTRA_MODULE}")
     fi
 fi
 if [[ "${BUILD_HIVE_UDF}" -eq 1 ]]; then
@@ -720,6 +750,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
         -DBUILD_AZURE="${BUILD_AZURE}" \
         -DENABLE_DYNAMIC_ARCH="${ENABLE_DYNAMIC_ARCH}" \
         -DWITH_TDE_DIR="${WITH_TDE_DIR}" \
+        -DWITH_TLS_DIR="${WITH_TLS_DIR}" \
         -DFAISS_ENABLE_GPU="${FAISS_ENABLE_GPU:-OFF}" \
         "${DORIS_HOME}/be"
 
@@ -832,7 +863,7 @@ function build_fe_modules() {
         user_settings_opts=(-gs "${USER_SETTINGS_MVN_REPO}")
     fi
 
-    mvn_cmd+=("${extra_mvn_opts[@]}" "${dependency_mvn_opts[@]}" "${user_settings_opts[@]}" -T "${thread_count}")
+    mvn_cmd+=("${extra_mvn_opts[@]}" "${dependency_mvn_opts[@]}" "${FE_EXTRA_ARGS[@]}" "${user_settings_opts[@]}" -T "${thread_count}")
     log_file="$(mktemp)"
     if "${mvn_cmd[@]}" 2>&1 | tee "${log_file}"; then
         rm -f "${log_file}"
@@ -885,8 +916,11 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     rm -rf "${DORIS_OUTPUT}/fe/lib"/*
     cp -r -p "${DORIS_HOME}/fe/fe-core/target/lib"/* "${DORIS_OUTPUT}/fe/lib"/
     cp -r -p "${DORIS_HOME}/fe/fe-core/target/doris-fe.jar" "${DORIS_OUTPUT}/fe/lib"/
-    if [[ "${WITH_TDE_DIR}" != "" ]]; then
-        cp -r -p "${DORIS_HOME}/fe/fe-${WITH_TDE_DIR}/target/fe-${WITH_TDE_DIR}-1.2-SNAPSHOT.jar" "${DORIS_OUTPUT}/fe/lib"/
+    if [[ "${FE_EXTRA_MODULE}" != "" ]]; then
+        cp -r -p "${DORIS_HOME}/fe/${FE_EXTRA_MODULE}/target/${FE_EXTRA_ARTIFACT}-1.2-SNAPSHOT.jar" "${DORIS_OUTPUT}/fe/lib"/
+        if [[ -d "${DORIS_HOME}/fe/${FE_EXTRA_MODULE}/target/lib" ]]; then
+            cp -r -p "${DORIS_HOME}/fe/${FE_EXTRA_MODULE}/target/lib"/* "${DORIS_OUTPUT}/fe/lib"/
+        fi
     fi
 
     #cp -r -p "${DORIS_HOME}/docs/build/help-resource.zip" "${DORIS_OUTPUT}/fe/lib"/

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -147,13 +147,8 @@ if [[ -z "${WITH_TDE_DIR}" ]]; then
     WITH_TDE_DIR=''
 fi
 
-if [[ "${WITH_TDE_DIR}" == "enterprise" ]]; then
-    echo "WITH_TDE_DIR=enterprise is no longer supported; use WITH_TDE_DIR=enterprise/tde"
-    exit 1
-fi
-
-if [[ -n "${WITH_TDE_DIR}" && "${WITH_TDE_DIR}" != "enterprise/tde" ]]; then
-    echo "Unsupported WITH_TDE_DIR=${WITH_TDE_DIR}; only enterprise/tde is supported"
+if [[ -n "${WITH_TDE_DIR}" && "${WITH_TDE_DIR}" != "extra/tde" ]]; then
+    echo "Unsupported WITH_TDE_DIR=${WITH_TDE_DIR}; only extra/tde is supported"
     exit 1
 fi
 
@@ -166,8 +161,8 @@ if [[ -z "${WITH_TLS_DIR}" ]]; then
     WITH_TLS_DIR=''
 fi
 
-if [[ -n "${WITH_TLS_DIR}" && "${WITH_TLS_DIR}" != "enterprise/tls" ]]; then
-    echo "Unsupported WITH_TLS_DIR=${WITH_TLS_DIR}; only enterprise/tls is supported"
+if [[ -n "${WITH_TLS_DIR}" && "${WITH_TLS_DIR}" != "extra/tls" ]]; then
+    echo "Unsupported WITH_TLS_DIR=${WITH_TLS_DIR}; only extra/tls is supported"
     exit 1
 fi
 

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -147,11 +147,6 @@ if [[ -z "${WITH_TDE_DIR}" ]]; then
     WITH_TDE_DIR=''
 fi
 
-if [[ -n "${WITH_TDE_DIR}" && "${WITH_TDE_DIR}" != "extra/tde" ]]; then
-    echo "Unsupported WITH_TDE_DIR=${WITH_TDE_DIR}; only extra/tde is supported"
-    exit 1
-fi
-
 if [[ -n "${WITH_TDE_DIR}" && ! -d "${DORIS_HOME}/be/src/${WITH_TDE_DIR}" ]]; then
     echo "WITH_TDE_DIR=${WITH_TDE_DIR} requested but be/src/${WITH_TDE_DIR} is missing; skip TDE plugin build"
     WITH_TDE_DIR=''
@@ -159,11 +154,6 @@ fi
 
 if [[ -z "${WITH_TLS_DIR}" ]]; then
     WITH_TLS_DIR=''
-fi
-
-if [[ -n "${WITH_TLS_DIR}" && "${WITH_TLS_DIR}" != "extra/tls" ]]; then
-    echo "Unsupported WITH_TLS_DIR=${WITH_TLS_DIR}; only extra/tls is supported"
-    exit 1
 fi
 
 if [[ -n "${WITH_TLS_DIR}" && ! -d "${DORIS_HOME}/be/src/${WITH_TLS_DIR}" ]]; then

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -143,11 +143,45 @@ fi
 CMAKE_BUILD_TYPE="${BUILD_TYPE_UT:-ASAN}"
 CMAKE_BUILD_TYPE="$(echo "${CMAKE_BUILD_TYPE}" | awk '{ print(toupper($0)) }')"
 
+if [[ -z "${WITH_TDE_DIR}" ]]; then
+    WITH_TDE_DIR=''
+fi
+
+if [[ "${WITH_TDE_DIR}" == "enterprise" ]]; then
+    echo "WITH_TDE_DIR=enterprise is no longer supported; use WITH_TDE_DIR=enterprise/tde"
+    exit 1
+fi
+
+if [[ -n "${WITH_TDE_DIR}" && "${WITH_TDE_DIR}" != "enterprise/tde" ]]; then
+    echo "Unsupported WITH_TDE_DIR=${WITH_TDE_DIR}; only enterprise/tde is supported"
+    exit 1
+fi
+
+if [[ -n "${WITH_TDE_DIR}" && ! -d "${DORIS_HOME}/be/src/${WITH_TDE_DIR}" ]]; then
+    echo "WITH_TDE_DIR=${WITH_TDE_DIR} requested but be/src/${WITH_TDE_DIR} is missing; skip TDE plugin build"
+    WITH_TDE_DIR=''
+fi
+
+if [[ -z "${WITH_TLS_DIR}" ]]; then
+    WITH_TLS_DIR=''
+fi
+
+if [[ -n "${WITH_TLS_DIR}" && "${WITH_TLS_DIR}" != "enterprise/tls" ]]; then
+    echo "Unsupported WITH_TLS_DIR=${WITH_TLS_DIR}; only enterprise/tls is supported"
+    exit 1
+fi
+
+if [[ -n "${WITH_TLS_DIR}" && ! -d "${DORIS_HOME}/be/src/${WITH_TLS_DIR}" ]]; then
+    echo "WITH_TLS_DIR=${WITH_TLS_DIR} requested but be/src/${WITH_TLS_DIR} is missing; skip TLS plugin build"
+    WITH_TLS_DIR=''
+fi
+
 echo "Get params:
     PARALLEL            -- ${PARALLEL}
     CLEAN               -- ${CLEAN}
     ENABLE_PCH          -- ${ENABLE_PCH}
     WITH_TDE_DIR        -- ${WITH_TDE_DIR}
+    WITH_TLS_DIR        -- ${WITH_TLS_DIR}
 "
 echo "Build Backend UT"
 
@@ -270,6 +304,7 @@ cd "${CMAKE_BUILD_DIR}"
     -DDORIS_JAVA_HOME="${JAVA_HOME}" \
     -DBUILD_AZURE="${BUILD_AZURE}" \
     -DWITH_TDE_DIR="${WITH_TDE_DIR}" \
+    -DWITH_TLS_DIR="${WITH_TLS_DIR}" \
     "${DORIS_HOME}/be"
 "${BUILD_SYSTEM}" -j "${PARALLEL}"
 

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -86,6 +86,29 @@ fi
 
 echo "Build Frontend UT"
 
+if [[ -z "${WITH_TDE_DIR}" ]]; then
+    WITH_TDE_DIR=''
+fi
+
+if [[ -z "${WITH_TLS_DIR}" ]]; then
+    WITH_TLS_DIR=''
+fi
+
+FE_EXTRA_ARGS=()
+if [[ -n "${WITH_TDE_DIR}" || -n "${WITH_TLS_DIR}" ]]; then
+    if [[ -f "${DORIS_HOME}/fe/fe-extra/pom.xml" ]]; then
+        [[ -n "${WITH_TDE_DIR}" ]] && FE_EXTRA_ARGS+=("-Dfe.extra.tde.enabled=true")
+        [[ -n "${WITH_TLS_DIR}" ]] && FE_EXTRA_ARGS+=("-Dfe.extra.tls.enabled=true")
+    fi
+fi
+
+echo "Get params:
+    RUN                 -- ${RUN}
+    COVERAGE            -- ${COVERAGE}
+    WITH_TDE_DIR        -- ${WITH_TDE_DIR}
+    WITH_TLS_DIR        -- ${WITH_TLS_DIR}
+"
+
 echo "******************************"
 echo "    Runing DorisFe Unittest    "
 echo "******************************"
@@ -114,15 +137,15 @@ if [[ "${RUN}" -eq 1 ]]; then
     # sh run-fe-ut.sh --run org.apache.doris.utframe.DemoTest#testCreateDbAndTable+test2
 
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dtest="$1"
+        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dtest="$1" "${FE_EXTRA_ARGS[@]}"
     else
-        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false -Dtest="$1"
+        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false -Dtest="$1" "${FE_EXTRA_ARGS[@]}"
     fi
 else
     echo "Run Frontend UT"
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dmaven.test.failure.ignore=true
+        "${MVN_CMD}" test jacoco:report -DfailIfNoTests=false -Dmaven.test.failure.ignore=true "${FE_EXTRA_ARGS[@]}"
     else
-        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false
+        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false "${FE_EXTRA_ARGS[@]}"
     fi
 fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Align the public build and unit-test entrypoints with the new `tde` and `tls` plugin selectors while keeping Apache Doris builds working when optional plugin sources are absent.

### Release note

None

### Check List (For Author)

- Test: Shell syntax checks and selector validation smoke checks
    - Manual test: `bash -n build.sh run-be-ut.sh run-fe-ut.sh build-for-release.sh`
    - Manual test: `WITH_TDE_DIR=tde bash build.sh --be`
    - Manual test: `WITH_TLS_DIR=bad-selector bash run-fe-ut.sh`
- Behavior changed: Yes (build scripts now validate selector values, pass TDE/TLS selectors through BE/UT entrypoints, and skip optional plugin wiring when plugin sources are absent)
- Does this need documentation: No