### PR TITLE
[improvement](build) Reduce Hive startup bootstrap overhead

### DIFF
--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run04.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run04.hql
@@ -11,6 +11,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/delta_length_byte_array'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table delta_length_byte_array;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run05.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run05.hql
@@ -71,7 +71,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/delta_binary_packed'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table delta_binary_packed;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run06.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run06.hql
@@ -27,7 +27,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/delta_encoding_required_column/'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table delta_encoding_required_column;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run07.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run07.hql
@@ -23,7 +23,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/delta_encoding_optional_column'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table delta_encoding_optional_column;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run08.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run08.hql
@@ -12,7 +12,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/datapage_v1-snappy-compressed-checksum'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table datapage_v1_snappy_compressed_checksum;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run09.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run09.hql
@@ -11,7 +11,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/overflow_i16_page_cnt'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table overflow_i16_page_cnt;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run10.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run10.hql
@@ -23,7 +23,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/alltypes_tiny_pages'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table alltypes_tiny_pages;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run11.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run11.hql
@@ -23,6 +23,3 @@ LOCATION
   '/user/doris/preinstalled_data/different_types_parquet/alltypes_tiny_pages_plain'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table alltypes_tiny_pages_plain;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run12.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run12.hql
@@ -14,7 +14,3 @@ LOCATION
   '/user/doris/preinstalled_data/example_string.parquet'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table example_string;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run33.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run33.hql
@@ -71,6 +71,3 @@ LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_delta_binary_packed'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table parquet_delta_binary_packed;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run34.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run34.hql
@@ -23,7 +23,3 @@ LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_alltypes_tiny_pages'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1661955829');
-
-msck repair table parquet_alltypes_tiny_pages;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run37.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run37.hql
@@ -76,6 +76,3 @@ LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_all_types'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1681213018');
-
-msck repair table parquet_all_types;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run38.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run38.hql
@@ -66,7 +66,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/avro/avro_all_types';
-
-msck repair table avro_all_types;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run39.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run39.hql
@@ -89,6 +89,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/orc_table/orc_all_types';
-
-msck repair table orc_all_types_t;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run40.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run40.hql
@@ -35,7 +35,3 @@ ROW FORMAT SERDE
 STORED AS TEXTFILE
 LOCATION
   '/user/doris/preinstalled_data/json/json_all_types';
-
-msck repair table json_all_types;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run41.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run41.hql
@@ -6,6 +6,3 @@ ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
 STORED AS TEXTFILE
 LOCATION
   '/user/doris/preinstalled_data/csv/csv_all_types';
-
-msck repair table csv_all_types;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run42.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run42.hql
@@ -35,7 +35,3 @@ CREATE TABLE IF NOT EXISTS `text_all_types`(
 STORED AS TEXTFILE
 LOCATION
   '/user/doris/preinstalled_data/text/text_all_types';
-
-msck repair table text_all_types;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run43.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run43.hql
@@ -84,6 +84,3 @@ CREATE TABLE IF NOT EXISTS `sequence_all_types`(
 STORED AS SEQUENCEFILE
 LOCATION
   '/user/doris/preinstalled_data/sequence/sequence_all_types';
-
-msck repair table sequence_all_types;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run44.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run44.hql
@@ -77,6 +77,3 @@ LOCATION
 TBLPROPERTIES (
   'transient_lastDdlTime'='1681213018',
   "parquet.compression"="GZIP");
-
-msck repair table parquet_gzip_all_types;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run45.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run45.hql
@@ -77,6 +77,3 @@ LOCATION
 TBLPROPERTIES (
   'transient_lastDdlTime'='1681213018',
   "parquet.compression"="ZSTD");
-
-msck repair table parquet_zstd_all_types;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run46.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run46.hql
@@ -84,6 +84,3 @@ ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe
 STORED AS RCFILE
 LOCATION
   '/user/doris/preinstalled_data/rcbinary/rcbinary_all_types';
-
-msck repair table rcbinary_all_types;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run47.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run47.hql
@@ -62,7 +62,3 @@ TBLPROPERTIES (
   'transient_lastDdlTime'='1681213018',
   'parquet.bloom.filter.columns'='t_int',
   'parquet.bloom.filter.fpp'='0.05');
-
-msck repair table bloom_parquet_table;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run48.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run48.hql
@@ -93,7 +93,3 @@ TBLPROPERTIES (
   'transient_lastDdlTime'='1681213018',
   'orc.bloom.filter.columns'='t_int',
   'orc.bloom.filter.fpp'='0.05');
-
-msck repair table bloom_orc_table;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run49.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run49.hql
@@ -11,7 +11,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/orc_table/orc_predicate_table';
-
-msck repair table orc_predicate_table;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run50.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run50.hql
@@ -10,6 +10,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_predicate_table';
-
-msck repair table parquet_predicate_table;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run51.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run51.hql
@@ -8,7 +8,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/only_null';
-
-msck repair table only_null;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run52.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run52.hql
@@ -8,7 +8,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_timestamp_millis';
-
-msck repair table parquet_timestamp_millis;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run53.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run53.hql
@@ -8,6 +8,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_timestamp_micros';
-
-msck repair table parquet_timestamp_micros;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run54.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run54.hql
@@ -8,6 +8,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_timestamp_nanos';
-
-msck repair table parquet_timestamp_nanos;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run55.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run55.hql
@@ -14,6 +14,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/orc_table/orc_decimal_table';
-
-msck repair table orc_decimal_table;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run56.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run56.hql
@@ -10,6 +10,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_decimal_bool';
-
-msck repair table partition_table;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run57.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run57.hql
@@ -8,6 +8,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/parquet_decimal90_table';
-
-msck repair table parquet_decimal90_table;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run58.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run58.hql
@@ -14,6 +14,3 @@ LOCATION
   '/user/doris/preinstalled_data/parquet_table/fixed_length_byte_array_decimal_table'
 TBLPROPERTIES (
   'parquet.compress'='SNAPPY');
-
-msck repair table fixed_length_byte_array_decimal_table;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run59.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run59.hql
@@ -15,6 +15,3 @@ LOCATION
   '/user/doris/preinstalled_data/orc_table/string_col_dict_plain_mixed_orc'
 TBLPROPERTIES (
   'orc.compress'='ZLIB');
-
-msck repair table string_col_dict_plain_mixed_orc;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run60.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run60.hql
@@ -16,6 +16,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/parquet_table/test_string_dict_filter_parquet';
-
-msck repair table test_string_dict_filter_parquet;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run61.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run61.hql
@@ -16,7 +16,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
 LOCATION
   '/user/doris/preinstalled_data/orc_table/test_string_dict_filter_orc';
-
-msck repair table test_string_dict_filter_orc;
-
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run64.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run64.hql
@@ -6,8 +6,6 @@ create table simulation_hive1_orc(
   `c`  string 
 )stored as orc
 LOCATION '/user/doris/preinstalled_data/orc_table/simulation_hive1_orc';
-msck repair table simulation_hive1_orc;
-
 create table test_hive_rename_column_parquet(
   `new_a`  boolean,                                     
   `new_b`  int,                                    
@@ -16,8 +14,6 @@ create table test_hive_rename_column_parquet(
   `f`  string        
 )stored as parquet
 LOCATION '/user/doris/preinstalled_data/parquet_table/test_hive_rename_column_parquet';
-msck repair table test_hive_rename_column_parquet;
-
 create table test_hive_rename_column_orc(
   `new_a`  boolean,                                     
   `new_b`  int,                                    
@@ -26,4 +22,3 @@ create table test_hive_rename_column_orc(
   `f`  string        
 )stored as orc
 LOCATION '/user/doris/preinstalled_data/orc_table/test_hive_rename_column_orc';
-msck repair table test_hive_rename_column_orc;

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run67.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run67.hql
@@ -7,5 +7,3 @@ CREATE TABLE `orc_tiny_stripes`(
 )
 STORED AS orc
 LOCATION '/user/doris/preinstalled_data/orc/orc_tiny_stripes';
-
-msck repair table orc_tiny_stripes;

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run69.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run69.hql
@@ -30,6 +30,3 @@ CREATE TABLE json_nested_complex_table (
 
 LOCATION
   '/user/doris/preinstalled_data/json/json_nested_complex_table';
-
-
-msck repair table json_nested_complex_table;

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run71.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run71.hql
@@ -9,5 +9,3 @@ CREATE TABLE json_load_data_table (
 ) ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'
 LOCATION
   '/user/doris/preinstalled_data/json/json_load_data_table';
-
-msck repair table json_load_data_table;

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run72.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run72.hql
@@ -23,9 +23,3 @@ WITH SERDEPROPERTIES (
     "escapeChar" = "\\"
 )
 location '/user/doris/preinstalled_data/text/utf8_check';
-
-
-
-msck repair table invalid_utf8_data;
-msck repair table invalid_utf8_data2;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run73.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run73.hql
@@ -13,7 +13,3 @@ INSERT INTO employees VALUES
     (3, 'Bob Johnson', 'IT', 80000.00, '2021-05-10'),
     (4, 'Alice Brown', 'Finance', 70000.00, '2020-11-30'),
     (5, 'Charlie Wilson', 'HR', 62000.00, '2022-01-05');
-
-
-
-msck repair table employees;

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run75.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run75.hql
@@ -486,30 +486,3 @@ CREATE TABLE IF NOT EXISTS orc_primitive_types_to_decimal2 (
     decimal2_col DECIMAL(7,1)
 ) STORED AS orc
 LOCATION '/user/doris/preinstalled_data/orc_table/orc_schema_change';
-
-
-MSCK REPAIR TABLE parquet_primitive_types_to_boolean;
-MSCK REPAIR TABLE parquet_primitive_types_to_bigint;
-MSCK REPAIR TABLE parquet_primitive_types_to_int;
-MSCK REPAIR TABLE parquet_primitive_types_to_smallint;
-MSCK REPAIR TABLE parquet_primitive_types_to_tinyint;
-MSCK REPAIR TABLE parquet_primitive_types_to_float;
-MSCK REPAIR TABLE parquet_primitive_types_to_double;
-MSCK REPAIR TABLE parquet_primitive_types_to_string;
-MSCK REPAIR TABLE parquet_primitive_types_to_date;
-MSCK REPAIR TABLE parquet_primitive_types_to_timestamp;
-MSCK REPAIR TABLE parquet_primitive_types_to_decimal1;
-MSCK REPAIR TABLE parquet_primitive_types_to_decimal2;
-
-MSCK REPAIR TABLE orc_primitive_types_to_boolean;
-MSCK REPAIR TABLE orc_primitive_types_to_bigint;
-MSCK REPAIR TABLE orc_primitive_types_to_int;
-MSCK REPAIR TABLE orc_primitive_types_to_smallint;
-MSCK REPAIR TABLE orc_primitive_types_to_tinyint;
-MSCK REPAIR TABLE orc_primitive_types_to_float;
-MSCK REPAIR TABLE orc_primitive_types_to_double;
-MSCK REPAIR TABLE orc_primitive_types_to_string;
-MSCK REPAIR TABLE orc_primitive_types_to_date;
-MSCK REPAIR TABLE orc_primitive_types_to_timestamp;
-MSCK REPAIR TABLE orc_primitive_types_to_decimal1;
-MSCK REPAIR TABLE orc_primitive_types_to_decimal2;

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run76.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run76.hql
@@ -104,9 +104,3 @@ CREATE TABLE IF NOT EXISTS json_one_column_table (
 )
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 LOCATION '/user/doris/preinstalled_data/json/openx_json/json_one_column_table';
-
-msck repair table json_table;
-msck repair table json_table_ignore_malformed;
-msck repair table json_data_arrays_tb;
-msck repair table scalar_to_array_tb;
-msck repair table json_one_column_table;

--- a/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run84.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/create_preinstalled_scripts/run84.hql
@@ -15,6 +15,3 @@ create table dim_small (
   c2       BIGINT
 )stored as parquet
 LOCATION '/user/doris/preinstalled_data/parquet_table/runtime_filter_dim_small';
-
-msck repair table fact_big;
-msck repair table dim_small;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/account_fund/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/account_fund/create_table.hql
@@ -24,5 +24,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/account_fund'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669712244');
-
-msck repair table account_fund;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/hive01/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/hive01/create_table.hql
@@ -18,5 +18,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/hive01'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669712244');
-
-msck repair table hive01;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/sale_table/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/sale_table/create_table.hql
@@ -20,5 +20,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/sale_table'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669712244');
-
-msck repair table sale_table;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/string_table/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/string_table/create_table.hql
@@ -23,5 +23,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/string_table'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669712243');
-
-msck repair table string_table;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/student/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/student/create_table.hql
@@ -20,5 +20,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/student'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669364024');
-
-msck repair table student;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/test1/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/test1/create_table.hql
@@ -19,5 +19,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/test1'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669712243');
-
-msck repair table test1;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/test2/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/test2/create_table.hql
@@ -19,5 +19,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/test2'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669712244');
-
-msck repair table test2;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/default/test_hive_doris/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/default/test_hive_doris/create_table.hql
@@ -16,5 +16,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/default/test_hive_doris'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1669712244');
-
-msck repair table test_hive_doris;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_csv/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_csv/create_table.hql
@@ -15,6 +15,3 @@ LOCATION
   '/user/doris/suites/multi_catalog/datev2_csv'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1688118691');
-
-msck repair table datev2_csv;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_orc/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_orc/create_table.hql
@@ -15,6 +15,3 @@ LOCATION
   '/user/doris/suites/multi_catalog/datev2_orc'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1688118707');
-
-msck repair table datev2_orc;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_parquet/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/datev2_parquet/create_table.hql
@@ -15,6 +15,3 @@ LOCATION
   '/user/doris/suites/multi_catalog/datev2_parquet'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1688118725');
-
-msck repair table datev2_parquet;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type/create_table.hql
@@ -23,5 +23,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/hive_text_complex_type'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1690518015');
-
-msck repair table hive_text_complex_type;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type2/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type2/create_table.hql
@@ -17,5 +17,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/hive_text_complex_type2'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1692719086');
-
-msck repair table hive_text_complex_type2;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type3/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type3/create_table.hql
@@ -20,5 +20,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/hive_text_complex_type3'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1693389680');
-
-msck repair table hive_text_complex_type3;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter/create_table.hql
@@ -29,5 +29,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/hive_text_complex_type_delimiter'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1690517298');
-
-msck repair table hive_text_complex_type_delimiter;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter2/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter2/create_table.hql
@@ -23,5 +23,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/hive_text_complex_type_delimiter2'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1692719456');
-
-msck repair table hive_text_complex_type_delimiter2;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter3/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_text_complex_type_delimiter3/create_table.hql
@@ -22,5 +22,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/hive_text_complex_type_delimiter3'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1693390056');
-
-msck repair table hive_text_complex_type_delimiter3;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_orc/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_orc/create_table.hql
@@ -16,6 +16,3 @@ TBLPROPERTIES (
   'spark.sql.create.version'='3.2.1',
   'spark.sql.sources.schema'='{"type":"struct","fields":[{"name":"ID","type":"integer","nullable":true,"metadata":{}},{"name":"NAME","type":"string","nullable":true,"metadata":{}}]}',
   'transient_lastDdlTime'='1674189057');
-
-msck repair table hive_upper_case_orc;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_parquet/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/hive_upper_case_parquet/create_table.hql
@@ -16,6 +16,3 @@ TBLPROPERTIES (
   'spark.sql.create.version'='3.2.1',
   'spark.sql.sources.schema'='{"type":"struct","fields":[{"name":"ID","type":"integer","nullable":true,"metadata":{}},{"name":"NAME","type":"string","nullable":true,"metadata":{}}]}',
   'transient_lastDdlTime'='1674189051');
-
-msck repair table hive_upper_case_parquet;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_nested_types/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/orc_nested_types/create_table.hql
@@ -27,6 +27,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
 LOCATION
   '/user/doris/suites/multi_catalog/nested_types1_orc';
-
-msck repair table nested_types1_orc;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_bigint/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_bigint/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217352', 
   'transient_lastDdlTime'='1697217352');
-
-msck repair table parquet_alter_column_to_bigint;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_boolean/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_boolean/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217386', 
   'transient_lastDdlTime'='1697217386');
-
-msck repair table parquet_alter_column_to_boolean;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_char/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_char/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697275142', 
   'transient_lastDdlTime'='1697275142');
-
-msck repair table parquet_alter_column_to_char;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_date/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_date/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217393', 
   'transient_lastDdlTime'='1697217393');
-
-msck repair table parquet_alter_column_to_date;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_decimal/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_decimal/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217403', 
   'transient_lastDdlTime'='1697217403');
-
-msck repair table parquet_alter_column_to_decimal;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_double/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_double/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697270364', 
   'transient_lastDdlTime'='1697270364');
-
-msck repair table parquet_alter_column_to_double;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_float/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_float/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697270277', 
   'transient_lastDdlTime'='1697270277');
-
-msck repair table parquet_alter_column_to_float;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_int/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_int/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697216968', 
   'transient_lastDdlTime'='1697216968');
-
-msck repair table parquet_alter_column_to_int;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_smallint/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_smallint/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217290', 
   'transient_lastDdlTime'='1697217290');
-
-msck repair table parquet_alter_column_to_smallint;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_string/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_string/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217389', 
   'transient_lastDdlTime'='1697217389');
-
-msck repair table parquet_alter_column_to_string;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_timestamp/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_timestamp/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217395', 
   'transient_lastDdlTime'='1697217395');
-
-msck repair table parquet_alter_column_to_timestamp;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_tinyint/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_tinyint/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697217350', 
   'transient_lastDdlTime'='1697217350');
-
-msck repair table parquet_alter_column_to_tinyint;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_varchar/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_alter_column_to_varchar/create_table.hql
@@ -26,5 +26,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1697275145', 
   'transient_lastDdlTime'='1697275145');
-
-msck repair table parquet_alter_column_to_varchar;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_bloom_filter/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_bloom_filter/create_table.hql
@@ -35,5 +35,3 @@ TBLPROPERTIES (
   'transient_lastDdlTime'='1763470218',
   'bucketing_version'='2',
   'parquet.compression'='ZSTD');
-
-msck repair table parquet_bloom_filter;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lz4_compression/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lz4_compression/create_table.hql
@@ -26,6 +26,3 @@ LOCATION
 TBLPROPERTIES (
   'parquet.compression'='LZ4',
   'transient_lastDdlTime'='1700723950');
-
-msck repair table parquet_lz4_compression;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lzo_compression/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_lzo_compression/create_table.hql
@@ -26,6 +26,3 @@ LOCATION
 TBLPROPERTIES (
   'parquet.compression'='LZO',
   'transient_lastDdlTime'='1701173147');
-
-msck repair table parquet_lzo_compression;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_nested_types/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_nested_types/create_table.hql
@@ -13,9 +13,6 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/suites/multi_catalog/nested_cross_page1_parquet';
-
-msck repair table nested_cross_page1_parquet;
-
 CREATE TABLE `nested_cross_page2_parquet`(
     id INT,
     nested_array_col ARRAY<ARRAY<INT>>,
@@ -38,9 +35,6 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/suites/multi_catalog/nested_cross_page2_parquet';
-
-msck repair table nested_cross_page2_parquet;
-
 CREATE TABLE `nested_cross_page3_parquet`(
     `id` int,
     `array_col` array<int>,
@@ -53,6 +47,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/suites/multi_catalog/nested_cross_page3_parquet';
-
-msck repair table nested_cross_page3_parquet;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_predicate_table/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/parquet_predicate_table/create_table.hql
@@ -14,5 +14,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/parquet_predicate_table'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1692368377');
-
-msck repair table parquet_predicate_table;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_orc/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_orc/create_table.hql
@@ -15,5 +15,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1688972099', 
   'transient_lastDdlTime'='1688972099');
-
-msck repair table test_chinese_orc;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_parquet/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_parquet/create_table.hql
@@ -15,5 +15,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1688972107', 
   'transient_lastDdlTime'='1688972107');
-
-msck repair table test_chinese_parquet;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_text/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_chinese_text/create_table.hql
@@ -19,5 +19,3 @@ TBLPROPERTIES (
   'last_modified_by'='hadoop', 
   'last_modified_time'='1688972116', 
   'transient_lastDdlTime'='1688972116');
-
-msck repair table test_chinese_text;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_complex_types/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_complex_types/create_table.hql
@@ -17,9 +17,6 @@ LOCATION
   '/user/doris/suites/multi_catalog/byd'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1690356922');
-
-msck repair table byd;
-
 CREATE TABLE `complex_offsets_check`(
   `id` int, 
   `array1` array<int>, 
@@ -36,9 +33,6 @@ LOCATION
   '/user/doris/suites/multi_catalog/complex_offsets_check'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1690974653');
-
-msck repair table complex_offsets_check;
-
 CREATE TABLE `parquet_all_types`(
   `t_null_string` string, 
   `t_null_varchar` varchar(65535), 
@@ -117,9 +111,6 @@ LOCATION
   '/user/doris/suites/multi_catalog/parquet_all_types'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1692347490');
-
-msck repair table parquet_all_types;
-
 CREATE TABLE `date_dict`(
   `date1` date, 
   `date2` date, 
@@ -134,5 +125,3 @@ LOCATION
   '/user/doris/suites/multi_catalog/date_dict'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1693396885');
-
-msck repair table date_dict;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_hive_same_db_table_name/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_hive_same_db_table_name/create_table.hql
@@ -18,5 +18,3 @@ LOCATION
   '/user/doris/suites/multi_catalog/region'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1670483235');
-
-msck repair table region;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_orc/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_orc/create_table.hql
@@ -13,5 +13,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/test_multi_langs_orc'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1688971851');
-
-msck repair table test_multi_langs_orc;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_parquet/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_parquet/create_table.hql
@@ -13,5 +13,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/test_multi_langs_parquet'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1688971869');
-
-msck repair table test_multi_langs_parquet;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_text/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_multi_langs_text/create_table.hql
@@ -17,5 +17,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/test_multi_langs_text'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1688971823');
-
-msck repair table test_multi_langs_text;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_special_orc_formats/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_special_orc_formats/create_table.hql
@@ -15,5 +15,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
 LOCATION
   '/user/doris/suites/multi_catalog/orc_top_level_column_has_present_stream';
-
-msck repair table orc_top_level_column_has_present_stream;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_orc/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_orc/create_table.hql
@@ -14,5 +14,3 @@ STORED AS INPUTFORMAT
 OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
 LOCATION '/user/doris/suites/multi_catalog/test_truncate_char_or_varchar_columns_orc';
-
-msck repair table test_truncate_char_or_varchar_columns_orc;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_parquet/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_parquet/create_table.hql
@@ -14,5 +14,3 @@ STORED AS INPUTFORMAT
 OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION '/user/doris/suites/multi_catalog/test_truncate_char_or_varchar_columns_parquet';
-
-msck repair table test_truncate_char_or_varchar_columns_parquet;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_text/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_truncate_char_or_varchar_columns_text/create_table.hql
@@ -14,5 +14,3 @@ STORED AS INPUTFORMAT
 OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '/user/doris/suites/multi_catalog/test_truncate_char_or_varchar_columns_text';
-
-msck repair table test_truncate_char_or_varchar_columns_text;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_wide_table/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/test_wide_table/create_table.hql
@@ -650,5 +650,3 @@ LOCATION
   '/user/doris/suites/multi_catalog/wide_table1_orc'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1680503244');
-
-msck repair table wide_table1_orc;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/timestamp_with_time_zone/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/timestamp_with_time_zone/create_table.hql
@@ -13,5 +13,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/timestamp_with_time_zone'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1712113278');
-
-msck repair table timestamp_with_time_zone;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_orc/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_orc/create_table.hql
@@ -41,5 +41,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/type_change_orc'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1712484849');
-
-msck repair table type_change_orc;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_origin/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_origin/create_table.hql
@@ -41,5 +41,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/type_change_origin'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1712485085');
-
-msck repair table type_change_origin;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_parquet/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/multi_catalog/type_change_parquet/create_table.hql
@@ -41,5 +41,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/multi_catalog/type_change_parquet'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1712485017');
-
-msck repair table type_change_parquet;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/regression/crdmm_data/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/regression/crdmm_data/create_table.hql
@@ -157,6 +157,3 @@ LOCATION
   '/user/doris/suites/regression/crdmm_data/'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1685331029');
-
-msck repair table crdmm_data;
-

--- a/docker/thirdparties/docker-compose/hive/scripts/data/statistics/empty_table/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/statistics/empty_table/create_table.hql
@@ -12,5 +12,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1702352468');
-
-msck repair table empty_table;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/statistics/statistics/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/statistics/statistics/create_table.hql
@@ -28,6 +28,3 @@ OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
 LOCATION
   '/user/doris/suites/statistics/statistics';
-
-
-msck repair table statistics;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/statistics/stats/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/statistics/stats/create_table.hql
@@ -31,5 +31,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/statistics/stats'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1687325090');
-
-msck repair table stats;

--- a/docker/thirdparties/docker-compose/hive/scripts/data/test/hive_test/create_table.hql
+++ b/docker/thirdparties/docker-compose/hive/scripts/data/test/hive_test/create_table.hql
@@ -16,5 +16,3 @@ OUTPUTFORMAT
 LOCATION '/user/doris/suites/test/hive_test'
 TBLPROPERTIES (
   'transient_lastDdlTime'='1670291786');
-
-msck repair table hive_test;

--- a/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
@@ -163,13 +163,32 @@ shopt -u nullglob
 if (( ${#preinstalled_hqls[@]} > 0 )); then
     IFS=$'\n' preinstalled_hqls=($(printf '%s\n' "${preinstalled_hqls[@]}" | sort))
     unset IFS
-    merged_preinstalled_hql="/tmp/merged-preinstalled.hql"
-    bash /mnt/scripts/merge-preinstalled-hql.sh "${merged_preinstalled_hql}" "${preinstalled_hqls[@]}"
-    START_TIME=$(date +%s)
-    hive -f "${merged_preinstalled_hql}" || (echo "Failed to executing merged preinstalled hqls" && exit 1)
-    END_TIME=$(date +%s)
-    EXECUTION_TIME=$((END_TIME - START_TIME))
-    echo "Merged preinstalled HQLs executed in $EXECUTION_TIME seconds"
+    shard_count="${LOAD_PARALLEL}"
+    if (( shard_count < 1 )); then
+        shard_count=1
+    fi
+    if (( shard_count > ${#preinstalled_hqls[@]} )); then
+        shard_count=${#preinstalled_hqls[@]}
+    fi
+
+    merged_preinstalled_hqls=()
+    for ((i = 0; i < shard_count; i++)); do
+        merged_preinstalled_hql="/tmp/merged-preinstalled-${i}.hql"
+        shard_inputs=()
+        for ((j = i; j < ${#preinstalled_hqls[@]}; j += shard_count)); do
+            shard_inputs+=("${preinstalled_hqls[j]}")
+        done
+        bash /mnt/scripts/merge-preinstalled-hql.sh "${merged_preinstalled_hql}" "${shard_inputs[@]}"
+        merged_preinstalled_hqls+=("${merged_preinstalled_hql}")
+    done
+
+    printf '%s\0' "${merged_preinstalled_hqls[@]}" | xargs -0 -P "${shard_count}" -I {} bash -ec '
+        START_TIME=$(date +%s)
+        hive -f "{}" || (echo "Failed to executing merged preinstalled hql shard: {}" && exit 1)
+        END_TIME=$(date +%s)
+        EXECUTION_TIME=$((END_TIME - START_TIME))
+        echo "Merged preinstalled HQL shard: {} executed in $EXECUTION_TIME seconds"
+    '
 fi
 
 # create view

--- a/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/hive-metastore.sh
@@ -161,13 +161,15 @@ done
 shopt -u nullglob
 
 if (( ${#preinstalled_hqls[@]} > 0 )); then
-    printf '%s\0' "${preinstalled_hqls[@]}" | xargs -0 -P "${LOAD_PARALLEL}" -I {} bash -ec '
-        START_TIME=$(date +%s)
-        hive -f {} || (echo "Failed to executing hql: {}" && exit 1)
-        END_TIME=$(date +%s)
-        EXECUTION_TIME=$((END_TIME - START_TIME))
-        echo "Script: {} executed in $EXECUTION_TIME seconds"
-    '
+    IFS=$'\n' preinstalled_hqls=($(printf '%s\n' "${preinstalled_hqls[@]}" | sort))
+    unset IFS
+    merged_preinstalled_hql="/tmp/merged-preinstalled.hql"
+    bash /mnt/scripts/merge-preinstalled-hql.sh "${merged_preinstalled_hql}" "${preinstalled_hqls[@]}"
+    START_TIME=$(date +%s)
+    hive -f "${merged_preinstalled_hql}" || (echo "Failed to executing merged preinstalled hqls" && exit 1)
+    END_TIME=$(date +%s)
+    EXECUTION_TIME=$((END_TIME - START_TIME))
+    echo "Merged preinstalled HQLs executed in $EXECUTION_TIME seconds"
 fi
 
 # create view

--- a/docker/thirdparties/docker-compose/hive/scripts/merge-preinstalled-hql.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/merge-preinstalled-hql.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <output-file> [input-hql...]" >&2
+    exit 1
+fi
+
+output_file="$1"
+shift
+
+if [[ $# -eq 0 ]]; then
+    : > "${output_file}"
+    exit 0
+fi
+
+: > "${output_file}"
+for hql_path in "$@"; do
+    cat >> "${output_file}" <<EOF
+-- begin ${hql_path}
+EOF
+    cat "${hql_path}" >> "${output_file}"
+    printf '\n-- end %s\n\n' "${hql_path}" >> "${output_file}"
+done

--- a/docker/thirdparties/docker-compose/hive/scripts/prepare-hive-data.sh
+++ b/docker/thirdparties/docker-compose/hive/scripts/prepare-hive-data.sh
@@ -107,5 +107,9 @@ jars=(
 
 cd ${CUR_DIR}/auxlib
 for jar in "${jars[@]}"; do
+    if [[ -f "${CUR_DIR}/auxlib/${jar}" ]]; then
+        echo "Reuse cached hive aux jar ${jar}"
+        continue
+    fi
     curl -O "https://${s3BucketName}.${s3Endpoint}/regression/docker/hive3/${jar}"
 done


### PR DESCRIPTION
### What problem does this PR solve?

Related Issue: #62101

Problem Summary:
This PR reduces Hive third-party bootstrap overhead in the current startup flow without changing the broader startup model yet.

The main optimizations are:
- merge selected `create_preinstalled_scripts/*.hql` into a single Hive invocation to avoid repeated JVM startup cost
- skip redundant `MSCK REPAIR TABLE` statements on non-partitioned tables
- reuse cached Hive auxiliary jars instead of downloading them on every startup

These changes are intended as an incremental optimization PR before the larger structured startup-script redesign tracked in #62101.

### Release note

None

### Check List (For Author)

- Test: Script validation only
    - No end-to-end startup or regression test has been run yet; keep this PR as draft until runtime validation is completed
- Behavior changed: No
- Does this need documentation: No
