### PR TITLE
[fix](paimon) add jindo oss support and token propagation

### DIFF
--- a/fe/be-java-extensions/paimon-scanner/pom.xml
+++ b/fe/be-java-extensions/paimon-scanner/pom.xml
@@ -45,29 +45,24 @@ under the License.
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-core</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-common</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-hive-connector-3.1</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-format</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-jindo</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
 
     </dependencies>

--- a/fe/be-java-extensions/paimon-scanner/pom.xml
+++ b/fe/be-java-extensions/paimon-scanner/pom.xml
@@ -64,6 +64,11 @@ under the License.
             <artifactId>paimon-format</artifactId>
             <version>${paimon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-jindo</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
 
     </dependencies>
 

--- a/fe/be-java-extensions/paimon-scanner/src/main/resources/package.xml
+++ b/fe/be-java-extensions/paimon-scanner/src/main/resources/package.xml
@@ -38,4 +38,10 @@ under the License.
             </unpackOptions>
         </dependencySet>
     </dependencySets>
+
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
 </assembly>

--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -82,7 +82,6 @@ under the License.
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-s3</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
         <!-- For Avro and Hudi Scanner PreLoad -->
         <dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -541,30 +541,25 @@ under the License.
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-core</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-common</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-format</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-s3</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-jindo</artifactId>
-            <version>${paimon.version}</version>
         </dependency>
 
         <dependency>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -561,6 +561,11 @@ under the License.
             <artifactId>paimon-s3</artifactId>
             <version>${paimon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-jindo</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -318,6 +318,9 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
         hadoopStorageConfig.set("fs.AbstractFileSystem.oss.impl", JINDO_OSS_ABSTRACT_FILE_SYSTEM_IMPL);
         hadoopStorageConfig.set("fs.oss.accessKeyId", accessKey);
         hadoopStorageConfig.set("fs.oss.accessKeySecret", secretKey);
+        if (StringUtils.isNotBlank(sessionToken)) {
+            hadoopStorageConfig.set("fs.oss.securityToken", sessionToken);
+        }
         hadoopStorageConfig.set("fs.oss.endpoint", endpoint);
         hadoopStorageConfig.set("fs.oss.region", region);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/OSSPropertiesTest.java
@@ -277,11 +277,13 @@ public class OSSPropertiesTest {
         Map<String, String> props = Maps.newHashMap();
         props.put("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com");
         props.put("oss.region", "cn-hangzhou");
+        props.put("oss.session_token", "testSessionToken");
         OSSProperties ossProperties = (OSSProperties) StorageProperties.createPrimary(props);
         Assertions.assertEquals(OSSProperties.JINDO_OSS_FILE_SYSTEM_IMPL,
                 ossProperties.hadoopStorageConfig.get("fs.oss.impl"));
         Assertions.assertEquals(OSSProperties.JINDO_OSS_ABSTRACT_FILE_SYSTEM_IMPL,
                 ossProperties.hadoopStorageConfig.get("fs.AbstractFileSystem.oss.impl"));
+        Assertions.assertEquals("testSessionToken", ossProperties.hadoopStorageConfig.get("fs.oss.securityToken"));
         Assertions.assertEquals("cn-hangzhou", ossProperties.hadoopStorageConfig.get("fs.oss.region"));
     }
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1359,6 +1359,36 @@ under the License.
                 <version>${iceberg.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-core</artifactId>
+                <version>${paimon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-common</artifactId>
+                <version>${paimon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-hive-connector-3.1</artifactId>
+                <version>${paimon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-format</artifactId>
+                <version>${paimon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-s3</artifactId>
+                <version>${paimon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.paimon</groupId>
+                <artifactId>paimon-jindo</artifactId>
+                <version>${paimon.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.aliyun.odps</groupId>
                 <artifactId>odps-sdk-core</artifactId>
                 <version>${maxcompute.version}</version>


### PR DESCRIPTION
  This PR adds Jindo OSS support for Paimon and propagates OSS session tokens into Hadoop storage config.

  Changes:
  - add `org.apache.paimon:paimon-jindo` to `fe-core`
  - add `org.apache.paimon:paimon-jindo` to `paimon-scanner`
  - enable `metaInf-services` merge in `paimon-scanner` assembly packaging so Paimon `FileIOLoader` SPI entries are preserved
  - propagate `oss.session_token` to `fs.oss.securityToken` in `OSSProperties.initializeHadoopStorageConfig`
  - add unit test coverage for OSS Hadoop config token propagation

  ## Why

  For Paimon OSS access, Doris needs Jindo FileIO on the classpath.

  Also, Doris already accepts OSS session token inputs, but `OSSProperties.initializeHadoopStorageConfig()` did not forward the token into
  Hadoop OSS config. This can break temporary-credential based OSS access.