### PR TITLE
[fix](fe) Mask sensitive headers in stream load logs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -680,6 +680,8 @@ public class LoadAction extends RestBaseController {
     private boolean isSensitiveHeader(String headerName) {
         return "Authorization".equalsIgnoreCase(headerName)
                 || "Proxy-Authorization".equalsIgnoreCase(headerName)
+                || "Cookie".equalsIgnoreCase(headerName)
+                || "Set-Cookie".equalsIgnoreCase(headerName)
                 || "token".equalsIgnoreCase(headerName)
                 || "Auth-Token".equalsIgnoreCase(headerName);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -671,10 +671,17 @@ public class LoadAction extends RestBaseController {
         Enumeration<String> headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements()) {
             String headerName = headerNames.nextElement();
-            String headerValue = request.getHeader(headerName);
+            String headerValue = isSensitiveHeader(headerName) ? "***MASKED***" : request.getHeader(headerName);
             headers.append(headerName).append(":").append(headerValue).append(", ");
         }
         return headers.toString();
+    }
+
+    private boolean isSensitiveHeader(String headerName) {
+        return "Authorization".equalsIgnoreCase(headerName)
+                || "Proxy-Authorization".equalsIgnoreCase(headerName)
+                || "token".equalsIgnoreCase(headerName)
+                || "Auth-Token".equalsIgnoreCase(headerName);
     }
 
     private Backend selectBackendForGroupCommit(String clusterName, HttpServletRequest req, long tableId)

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/LoadActionTest.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.httpv2.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class LoadActionTest {
+
+    @Test
+    public void testGetAllHeadersMasksSensitiveHeaders() throws Exception {
+        LoadAction action = new LoadAction();
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getHeaderNames()).thenReturn(Collections.enumeration(Arrays.asList(
+                "Authorization", "Cookie", "Set-Cookie", "token", "label")));
+        Mockito.when(request.getHeader("label")).thenReturn("load_label");
+
+        Method method = LoadAction.class.getDeclaredMethod("getAllHeaders", HttpServletRequest.class);
+        method.setAccessible(true);
+        String headers = (String) method.invoke(action, request);
+
+        Assert.assertTrue(headers.contains("Authorization:***MASKED***"));
+        Assert.assertTrue(headers.contains("Cookie:***MASKED***"));
+        Assert.assertTrue(headers.contains("Set-Cookie:***MASKED***"));
+        Assert.assertTrue(headers.contains("token:***MASKED***"));
+        Assert.assertTrue(headers.contains("label:load_label"));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: FE stream load REST logs printed full request headers, which could leak Authorization and token values into INFO logs.

### Release note

None

### Check List (For Author)

- Test: No completed automated test run in this environment. I attempted a FE build in a worktree and reached fe-core, but did not wait for full FE packaging to finish.
- Behavior changed: No.
- Does this need documentation: No