### PR TITLE
[fix](fe) Return early for non-master stream load precommit

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1456,6 +1456,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TLoadTxnCommitResult result = new TLoadTxnCommitResult();
         TStatus status = checkMaster();
         result.setStatus(status);
+        if (status.getStatusCode() != TStatusCode.OK) {
+            return result;
+        }
 
         try {
             loadTxnPreCommitImpl(request);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: loadTxnPreCommit() kept executing after checkMaster() returned a non-OK status, which made the precommit path inconsistent with the other stream load transaction RPCs.

### Release note

None

### Check List (For Author)

- Test: No completed automated test run in this environment. I attempted a FE build in a worktree and reached fe-core, but did not wait for full FE packaging to finish.
- Behavior changed: Yes. Non-master FE now returns immediately after master check fails.
- Does this need documentation: No