### PR TITLE
[fix](be) Validate stream load content length before group commit

### DIFF
--- a/be/src/service/http/action/stream_load.cpp
+++ b/be/src/service/http/action/stream_load.cpp
@@ -907,12 +907,13 @@ Status StreamLoadAction::_can_group_commit(HttpRequest* req, std::shared_ptr<Str
                                            std::string& group_commit_header,
                                            bool& can_group_commit) {
     int64_t content_length = 0;
-    if (!req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
+    const auto& content_length_str = req->header(HttpHeaders::CONTENT_LENGTH);
+    if (!content_length_str.empty()) {
         try {
-            content_length = std::stoll(req->header(HttpHeaders::CONTENT_LENGTH));
+            content_length = std::stoll(content_length_str);
         } catch (const std::exception& e) {
             return Status::InvalidArgument("invalid HTTP header CONTENT_LENGTH={}: {}",
-                                           req->header(HttpHeaders::CONTENT_LENGTH), e.what());
+                                           content_length_str, e.what());
         }
     }
     if (content_length < 0) {

--- a/be/src/service/http/action/stream_load.cpp
+++ b/be/src/service/http/action/stream_load.cpp
@@ -906,9 +906,15 @@ Status StreamLoadAction::_check_wal_space(const std::string& group_commit_mode,
 Status StreamLoadAction::_can_group_commit(HttpRequest* req, std::shared_ptr<StreamLoadContext> ctx,
                                            std::string& group_commit_header,
                                            bool& can_group_commit) {
-    int64_t content_length = req->header(HttpHeaders::CONTENT_LENGTH).empty()
-                                     ? 0
-                                     : std::stoll(req->header(HttpHeaders::CONTENT_LENGTH));
+    int64_t content_length = 0;
+    if (!req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
+        try {
+            content_length = std::stoll(req->header(HttpHeaders::CONTENT_LENGTH));
+        } catch (const std::exception& e) {
+            return Status::InvalidArgument("invalid HTTP header CONTENT_LENGTH={}: {}",
+                                           req->header(HttpHeaders::CONTENT_LENGTH), e.what());
+        }
+    }
     if (content_length < 0) {
         std::stringstream ss;
         ss << "This stream load content length <0 (" << content_length


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Group commit pre-check parsed Content-Length before the normal request validation path, so malformed values could escape the expected InvalidArgument handling.

### Release note

None

### Check List (For Author)

- Test: No completed automated test run in this environment.
- Behavior changed: Yes. Malformed Content-Length now returns a validation error instead of escaping the normal error path.
- Does this need documentation: No