### PR TITLE
[fix](fe) Fix deadlock risks in ConcurrentLong2*HashMap

### DIFF
--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMap.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMap.java
@@ -113,7 +113,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
         if (inCallback.get()) {
             throw new IllegalStateException(
                     "Recursive ConcurrentLong2LongHashMap access from within a compute/merge callback. "
-                    + "Callbacks must not modify the same map instance.");
+                    + "Callbacks must not access the same map instance.");
         }
     }
 
@@ -121,6 +121,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public long get(long key) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.readLock().lock();
         try {
@@ -131,6 +132,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public long getOrDefault(long key, long defaultValue) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.readLock().lock();
         try {
@@ -142,6 +144,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public boolean containsKey(long key) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.readLock().lock();
         try {
@@ -153,6 +156,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public boolean containsValue(long value) {
+        checkNotInCallback();
         for (Segment seg : segments) {
             seg.lock.readLock().lock();
             try {
@@ -168,6 +172,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public int size() {
+        checkNotInCallback();
         long total = 0;
         for (Segment seg : segments) {
             seg.lock.readLock().lock();
@@ -182,6 +187,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public boolean isEmpty() {
+        checkNotInCallback();
         for (Segment seg : segments) {
             seg.lock.readLock().lock();
             try {

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMap.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMap.java
@@ -55,9 +55,11 @@ import java.util.function.LongUnaryOperator;
  *
  * <p><b>Callback restriction:</b> The mapping/remapping functions passed to {@code computeIfAbsent},
  * {@code computeIfPresent}, {@code compute}, {@code merge}, and {@code mergeLong} <em>must not</em>
- * attempt to update any other mappings of this map. This restriction is enforced at runtime:
- * reentrant access from a callback throws {@link IllegalStateException}. Violation may also cause
- * deadlock if callbacks attempt cross-segment updates from multiple threads.
+ * access this map in any way while executing, including reads such as {@code get} or
+ * {@code containsKey}, as well as writes. Reentrant write access from a callback is rejected at
+ * runtime with {@link IllegalStateException}. Even read-only cross-segment access from callbacks
+ * can deadlock when multiple threads each hold a segment write-lock and attempt to read the
+ * other's segment.
  */
 public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
@@ -338,7 +340,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             try {
                 newValue = mappingFunction.applyAsLong(key);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             seg.map.put(key, newValue);
             return newValue;
@@ -360,7 +362,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             try {
                 newValue = mappingFunction.get(key);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             seg.map.put(key, newValue);
             return newValue;
@@ -384,7 +386,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             try {
                 newValue = mappingFunction.apply(key);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             if (newValue != null) {
                 seg.map.put(k, newValue.longValue());
@@ -410,7 +412,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             try {
                 newValue = remappingFunction.apply(key, oldValue);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             if (newValue != null) {
                 seg.map.put(key, newValue.longValue());
@@ -435,7 +437,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             try {
                 newValue = remappingFunction.apply(key, oldValue);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             if (newValue != null) {
                 seg.map.put(key, newValue.longValue());
@@ -465,7 +467,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             try {
                 newValue = remappingFunction.apply(oldValue, value);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             if (newValue != null) {
                 seg.map.put(key, newValue.longValue());
@@ -494,7 +496,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             try {
                 newValue = remappingFunction.applyAsLong(oldValue, value);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             seg.map.put(key, newValue);
             return newValue;

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMap.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMap.java
@@ -52,11 +52,19 @@ import java.util.function.LongUnaryOperator;
  * <p><b>Important:</b> All compound operations from both {@link Long2LongMap} and {@link Map}
  * interfaces (computeIfAbsent, computeIfPresent, compute, merge, mergeLong, putIfAbsent,
  * replace, remove) are overridden to ensure atomicity within a segment.
+ *
+ * <p><b>Callback restriction:</b> The mapping/remapping functions passed to {@code computeIfAbsent},
+ * {@code computeIfPresent}, {@code compute}, {@code merge}, and {@code mergeLong} <em>must not</em>
+ * attempt to update any other mappings of this map. This restriction is enforced at runtime:
+ * reentrant access from a callback throws {@link IllegalStateException}. Violation may also cause
+ * deadlock if callbacks attempt cross-segment updates from multiple threads.
  */
 public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     private static final int DEFAULT_SEGMENT_COUNT = 16;
     private static final int DEFAULT_INITIAL_CAPACITY_PER_SEGMENT = 16;
+
+    private final ThreadLocal<Boolean> inCallback = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     private final Segment[] segments;
     private final int segmentMask;
@@ -97,6 +105,14 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     private Segment segmentFor(long key) {
         return segments[(int) (mix(key) >>> (64 - segmentBits)) & segmentMask];
+    }
+
+    private void checkNotInCallback() {
+        if (inCallback.get()) {
+            throw new IllegalStateException(
+                    "Recursive ConcurrentLong2LongHashMap access from within a compute/merge callback. "
+                    + "Callbacks must not modify the same map instance.");
+        }
     }
 
     // ---- Read operations (read-lock) ----
@@ -181,6 +197,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public long put(long key, long value) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -192,6 +209,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public long remove(long key) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -202,6 +220,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public long putIfAbsent(long key, long value) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -216,6 +235,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public boolean replace(long key, long oldValue, long newValue) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -230,6 +250,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public long replace(long key, long value) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -244,6 +265,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public boolean remove(Object key, Object value) {
+        checkNotInCallback();
         if (!(key instanceof Long) || !(value instanceof Long)) {
             return false;
         }
@@ -264,6 +286,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public void clear() {
+        checkNotInCallback();
         for (Segment seg : segments) {
             seg.lock.writeLock().lock();
             try {
@@ -291,6 +314,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
      * @return the new value after the increment
      */
     public long addTo(long key, long increment) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -302,13 +326,20 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public long computeIfAbsent(long key, LongUnaryOperator mappingFunction) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
             if (seg.map.containsKey(key)) {
                 return seg.map.get(key);
             }
-            long newValue = mappingFunction.applyAsLong(key);
+            inCallback.set(Boolean.TRUE);
+            long newValue;
+            try {
+                newValue = mappingFunction.applyAsLong(key);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             seg.map.put(key, newValue);
             return newValue;
         } finally {
@@ -317,13 +348,20 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public long computeIfAbsent(long key, Long2LongFunction mappingFunction) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
             if (seg.map.containsKey(key)) {
                 return seg.map.get(key);
             }
-            long newValue = mappingFunction.get(key);
+            inCallback.set(Boolean.TRUE);
+            long newValue;
+            try {
+                newValue = mappingFunction.get(key);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             seg.map.put(key, newValue);
             return newValue;
         } finally {
@@ -333,6 +371,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     @Override
     public Long computeIfAbsent(Long key, Function<? super Long, ? extends Long> mappingFunction) {
+        checkNotInCallback();
         long k = key.longValue();
         Segment seg = segmentFor(k);
         seg.lock.writeLock().lock();
@@ -340,7 +379,13 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
             if (seg.map.containsKey(k)) {
                 return seg.map.get(k);
             }
-            Long newValue = mappingFunction.apply(key);
+            inCallback.set(Boolean.TRUE);
+            Long newValue;
+            try {
+                newValue = mappingFunction.apply(key);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             if (newValue != null) {
                 seg.map.put(k, newValue.longValue());
             }
@@ -352,6 +397,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     public long computeIfPresent(long key,
             BiFunction<? super Long, ? super Long, ? extends Long> remappingFunction) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -359,7 +405,13 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
                 return defaultReturnValue();
             }
             long oldValue = seg.map.get(key);
-            Long newValue = remappingFunction.apply(key, oldValue);
+            inCallback.set(Boolean.TRUE);
+            Long newValue;
+            try {
+                newValue = remappingFunction.apply(key, oldValue);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             if (newValue != null) {
                 seg.map.put(key, newValue.longValue());
                 return newValue;
@@ -373,11 +425,18 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public long compute(long key, BiFunction<? super Long, ? super Long, ? extends Long> remappingFunction) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
             Long oldValue = seg.map.containsKey(key) ? seg.map.get(key) : null;
-            Long newValue = remappingFunction.apply(key, oldValue);
+            inCallback.set(Boolean.TRUE);
+            Long newValue;
+            try {
+                newValue = remappingFunction.apply(key, oldValue);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             if (newValue != null) {
                 seg.map.put(key, newValue.longValue());
                 return newValue;
@@ -392,6 +451,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
 
     public long merge(long key, long value,
             BiFunction<? super Long, ? super Long, ? extends Long> remappingFunction) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -400,7 +460,13 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
                 return value;
             }
             long oldValue = seg.map.get(key);
-            Long newValue = remappingFunction.apply(oldValue, value);
+            inCallback.set(Boolean.TRUE);
+            Long newValue;
+            try {
+                newValue = remappingFunction.apply(oldValue, value);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             if (newValue != null) {
                 seg.map.put(key, newValue.longValue());
                 return newValue;
@@ -414,6 +480,7 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     public long mergeLong(long key, long value, LongBinaryOperator remappingFunction) {
+        checkNotInCallback();
         Segment seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -422,7 +489,13 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
                 return value;
             }
             long oldValue = seg.map.get(key);
-            long newValue = remappingFunction.applyAsLong(oldValue, value);
+            inCallback.set(Boolean.TRUE);
+            long newValue;
+            try {
+                newValue = remappingFunction.applyAsLong(oldValue, value);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             seg.map.put(key, newValue);
             return newValue;
         } finally {
@@ -493,17 +566,31 @@ public class ConcurrentLong2LongHashMap extends AbstractLong2LongMap {
     }
 
     /**
-     * Applies the given action to each entry under read-lock per segment.
+     * Applies the given action to each entry. Entries are snapshot-copied per segment under
+     * read-lock, then the action is invoked outside the lock. This avoids deadlock when
+     * the action modifies this map (e.g., {@code forEach((k, v) -> map.put(k, v + 1))}).
      */
     public void forEach(LongLongConsumer action) {
         for (Segment seg : segments) {
+            long[] keys;
+            long[] vals;
+            int n;
             seg.lock.readLock().lock();
             try {
+                n = seg.map.size();
+                keys = new long[n];
+                vals = new long[n];
+                int i = 0;
                 for (Long2LongMap.Entry entry : seg.map.long2LongEntrySet()) {
-                    action.accept(entry.getLongKey(), entry.getLongValue());
+                    keys[i] = entry.getLongKey();
+                    vals[i] = entry.getLongValue();
+                    i++;
                 }
             } finally {
                 seg.lock.readLock().unlock();
+            }
+            for (int i = 0; i < n; i++) {
+                action.accept(keys[i], vals[i]);
             }
         }
     }

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMap.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMap.java
@@ -112,7 +112,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
         if (inCallback.get()) {
             throw new IllegalStateException(
                     "Recursive ConcurrentLong2ObjectHashMap access from within a compute/merge callback. "
-                    + "Callbacks must not modify the same map instance.");
+                    + "Callbacks must not access the same map instance.");
         }
     }
 
@@ -120,6 +120,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public V get(long key) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.readLock().lock();
         try {
@@ -130,6 +131,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     public V getOrDefault(long key, V defaultValue) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.readLock().lock();
         try {
@@ -142,6 +144,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public boolean containsKey(long key) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.readLock().lock();
         try {
@@ -153,6 +156,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public boolean containsValue(Object value) {
+        checkNotInCallback();
         for (Segment<V> seg : segments) {
             seg.lock.readLock().lock();
             try {
@@ -168,6 +172,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public int size() {
+        checkNotInCallback();
         long total = 0;
         for (Segment<V> seg : segments) {
             seg.lock.readLock().lock();
@@ -182,6 +187,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public boolean isEmpty() {
+        checkNotInCallback();
         for (Segment<V> seg : segments) {
             seg.lock.readLock().lock();
             try {

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMap.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMap.java
@@ -54,10 +54,11 @@ import java.util.function.LongFunction;
  * are overridden to ensure atomicity within a segment.
  *
  * <p><b>Callback restriction:</b> The mapping/remapping functions passed to {@code computeIfAbsent},
- * {@code computeIfPresent}, {@code compute}, and {@code merge} <em>must not</em> attempt to update
- * any other mappings of this map. This restriction is enforced at runtime: reentrant access from a
- * callback throws {@link IllegalStateException}. Violation may also cause deadlock if callbacks
- * attempt cross-segment updates from multiple threads.
+ * {@code computeIfPresent}, {@code compute}, and {@code merge} <em>must not</em> access this map
+ * in any way while executing, including reads such as {@code get} or {@code containsKey}, as well
+ * as writes. Reentrant write access from a callback is rejected at runtime with
+ * {@link IllegalStateException}. Even read-only cross-segment access from callbacks can deadlock
+ * when multiple threads each hold a segment write-lock and attempt to read the other's segment.
  *
  * @param <V> the type of mapped values
  */
@@ -332,7 +333,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
                 }
                 return newValue;
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
         } finally {
             seg.lock.writeLock().unlock();
@@ -356,7 +357,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
                 }
                 return newValue;
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
         } finally {
             seg.lock.writeLock().unlock();
@@ -380,7 +381,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
                 try {
                     newValue = remappingFunction.apply(key, oldValue);
                 } finally {
-                    inCallback.set(Boolean.FALSE);
+                    inCallback.remove();
                 }
                 if (newValue != null) {
                     seg.map.put(key, newValue);
@@ -406,7 +407,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
             try {
                 newValue = remappingFunction.apply(key, oldValue);
             } finally {
-                inCallback.set(Boolean.FALSE);
+                inCallback.remove();
             }
             if (newValue != null) {
                 seg.map.put(key, newValue);
@@ -431,7 +432,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
                 try {
                     newValue = remappingFunction.apply(oldValue, value);
                 } finally {
-                    inCallback.set(Boolean.FALSE);
+                    inCallback.remove();
                 }
             } else {
                 newValue = value;

--- a/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMap.java
+++ b/fe/fe-foundation/src/main/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMap.java
@@ -53,12 +53,24 @@ import java.util.function.LongFunction;
  * interfaces (computeIfAbsent, computeIfPresent, compute, merge, putIfAbsent, replace, remove)
  * are overridden to ensure atomicity within a segment.
  *
+ * <p><b>Callback restriction:</b> The mapping/remapping functions passed to {@code computeIfAbsent},
+ * {@code computeIfPresent}, {@code compute}, and {@code merge} <em>must not</em> attempt to update
+ * any other mappings of this map. This restriction is enforced at runtime: reentrant access from a
+ * callback throws {@link IllegalStateException}. Violation may also cause deadlock if callbacks
+ * attempt cross-segment updates from multiple threads.
+ *
  * @param <V> the type of mapped values
  */
 public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     private static final int DEFAULT_SEGMENT_COUNT = 16;
     private static final int DEFAULT_INITIAL_CAPACITY_PER_SEGMENT = 16;
+
+    /**
+     * Tracks whether the current thread is inside a callback (compute/merge) on this map instance.
+     * Used to detect reentrant calls that would risk deadlock.
+     */
+    private final ThreadLocal<Boolean> inCallback = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     private final Segment<V>[] segments;
     private final int segmentMask;
@@ -93,6 +105,14 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     private Segment<V> segmentFor(long key) {
         return segments[(int) (mix(key) >>> (64 - segmentBits)) & segmentMask];
+    }
+
+    private void checkNotInCallback() {
+        if (inCallback.get()) {
+            throw new IllegalStateException(
+                    "Recursive ConcurrentLong2ObjectHashMap access from within a compute/merge callback. "
+                    + "Callbacks must not modify the same map instance.");
+        }
     }
 
     // ---- Read operations (read-lock) ----
@@ -178,6 +198,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public V put(long key, V value) {
+        checkNotInCallback();
         Objects.requireNonNull(value, "Null values are not permitted");
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
@@ -190,6 +211,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public V remove(long key) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -200,6 +222,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     public V putIfAbsent(long key, V value) {
+        checkNotInCallback();
         Objects.requireNonNull(value, "Null values are not permitted");
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
@@ -216,6 +239,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     public boolean replace(long key, V oldValue, V newValue) {
+        checkNotInCallback();
         Objects.requireNonNull(newValue, "Null values are not permitted");
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
@@ -232,6 +256,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     public V replace(long key, V value) {
+        checkNotInCallback();
         Objects.requireNonNull(value, "Null values are not permitted");
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
@@ -247,6 +272,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public boolean remove(Object key, Object value) {
+        checkNotInCallback();
         if (!(key instanceof Long)) {
             return false;
         }
@@ -267,6 +293,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
 
     @Override
     public void clear() {
+        checkNotInCallback();
         for (Segment<V> seg : segments) {
             seg.lock.writeLock().lock();
             try {
@@ -289,6 +316,7 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     // to ensure the check-then-act is atomic within a segment's write lock.
 
     public V computeIfAbsent(long key, LongFunction<? extends V> mappingFunction) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -296,17 +324,23 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
             if (val != null || seg.map.containsKey(key)) {
                 return val;
             }
-            V newValue = mappingFunction.apply(key);
-            if (newValue != null) {
-                seg.map.put(key, newValue);
+            inCallback.set(Boolean.TRUE);
+            try {
+                V newValue = mappingFunction.apply(key);
+                if (newValue != null) {
+                    seg.map.put(key, newValue);
+                }
+                return newValue;
+            } finally {
+                inCallback.set(Boolean.FALSE);
             }
-            return newValue;
         } finally {
             seg.lock.writeLock().unlock();
         }
     }
 
     public V computeIfAbsent(long key, Long2ObjectFunction<? extends V> mappingFunction) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
@@ -314,11 +348,16 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
             if (val != null || seg.map.containsKey(key)) {
                 return val;
             }
-            V newValue = mappingFunction.get(key);
-            if (newValue != null) {
-                seg.map.put(key, newValue);
+            inCallback.set(Boolean.TRUE);
+            try {
+                V newValue = mappingFunction.get(key);
+                if (newValue != null) {
+                    seg.map.put(key, newValue);
+                }
+                return newValue;
+            } finally {
+                inCallback.set(Boolean.FALSE);
             }
-            return newValue;
         } finally {
             seg.lock.writeLock().unlock();
         }
@@ -330,12 +369,19 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     public V computeIfPresent(long key, BiFunction<? super Long, ? super V, ? extends V> remappingFunction) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
             V oldValue = seg.map.get(key);
             if (oldValue != null || seg.map.containsKey(key)) {
-                V newValue = remappingFunction.apply(key, oldValue);
+                inCallback.set(Boolean.TRUE);
+                V newValue;
+                try {
+                    newValue = remappingFunction.apply(key, oldValue);
+                } finally {
+                    inCallback.set(Boolean.FALSE);
+                }
                 if (newValue != null) {
                     seg.map.put(key, newValue);
                 } else {
@@ -350,11 +396,18 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     public V compute(long key, BiFunction<? super Long, ? super V, ? extends V> remappingFunction) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
             V oldValue = seg.map.containsKey(key) ? seg.map.get(key) : null;
-            V newValue = remappingFunction.apply(key, oldValue);
+            inCallback.set(Boolean.TRUE);
+            V newValue;
+            try {
+                newValue = remappingFunction.apply(key, oldValue);
+            } finally {
+                inCallback.set(Boolean.FALSE);
+            }
             if (newValue != null) {
                 seg.map.put(key, newValue);
             } else if (seg.map.containsKey(key)) {
@@ -367,13 +420,19 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     public V merge(long key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        checkNotInCallback();
         Segment<V> seg = segmentFor(key);
         seg.lock.writeLock().lock();
         try {
             V oldValue = seg.map.get(key);
             V newValue;
             if (oldValue != null || seg.map.containsKey(key)) {
-                newValue = remappingFunction.apply(oldValue, value);
+                inCallback.set(Boolean.TRUE);
+                try {
+                    newValue = remappingFunction.apply(oldValue, value);
+                } finally {
+                    inCallback.set(Boolean.FALSE);
+                }
             } else {
                 newValue = value;
             }
@@ -452,19 +511,33 @@ public class ConcurrentLong2ObjectHashMap<V> extends AbstractLong2ObjectMap<V> {
     }
 
     /**
-     * Applies the given action to each entry under read-lock per segment.
-     * This is more efficient than iterating {@link #long2ObjectEntrySet()} as it avoids
-     * creating a snapshot.
+     * Applies the given action to each entry. Entries are snapshot-copied per segment under
+     * read-lock, then the action is invoked outside the lock. This avoids deadlock when
+     * the action modifies this map (e.g., {@code forEach((k, v) -> map.put(k, v + 1))}).
      */
     public void forEach(LongObjConsumer<? super V> action) {
         for (Segment<V> seg : segments) {
+            long[] keys;
+            Object[] vals;
+            int n;
             seg.lock.readLock().lock();
             try {
+                n = seg.map.size();
+                keys = new long[n];
+                vals = new Object[n];
+                int i = 0;
                 for (Long2ObjectMap.Entry<V> entry : seg.map.long2ObjectEntrySet()) {
-                    action.accept(entry.getLongKey(), entry.getValue());
+                    keys[i] = entry.getLongKey();
+                    vals[i] = entry.getValue();
+                    i++;
                 }
             } finally {
                 seg.lock.readLock().unlock();
+            }
+            for (int i = 0; i < n; i++) {
+                @SuppressWarnings("unchecked")
+                V val = (V) vals[i];
+                action.accept(keys[i], val);
             }
         }
     }

--- a/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMapTest.java
+++ b/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMapTest.java
@@ -469,6 +469,22 @@ class ConcurrentLong2LongHashMapTest {
         });
     }
 
+    @Test
+    void testReentrantReadFromCallbackThrowsIllegalStateException() {
+        ConcurrentLong2LongHashMap map = new ConcurrentLong2LongHashMap();
+        map.put(1L, 100L);
+        map.put(2L, 200L);
+
+        // Read access (get) from within a compute callback should also throw ISE
+        // to prevent cross-segment ABBA deadlocks
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.compute(1L, (k, v) -> {
+                map.get(2L);
+                return v;
+            });
+        });
+    }
+
     // ---- Gson serialization tests ----
 
     @Test

--- a/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMapTest.java
+++ b/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMapTest.java
@@ -401,6 +401,65 @@ class ConcurrentLong2LongHashMapTest {
         Assertions.assertEquals(0, errors.get());
     }
 
+    // ---- Deadlock-safety tests ----
+
+    @Test
+    void testForEachWithMutatingCallbackDoesNotDeadlock() throws Exception {
+        ConcurrentLong2LongHashMap map = new ConcurrentLong2LongHashMap(1);
+        map.put(1L, 100L);
+        map.put(2L, 200L);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> future = executor.submit(() -> {
+            map.forEach((ConcurrentLong2LongHashMap.LongLongConsumer) (k, v) -> {
+                map.put(k + 1000L, v + 1);
+            });
+        });
+        future.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        executor.shutdown();
+
+        Assertions.assertEquals(101L, map.get(1001L));
+        Assertions.assertEquals(201L, map.get(1002L));
+    }
+
+    @Test
+    void testReentrantComputeThrowsIllegalStateException() {
+        ConcurrentLong2LongHashMap map = new ConcurrentLong2LongHashMap();
+        map.put(1L, 100L);
+
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.compute(1L, (k, v) -> {
+                map.put(2L, 200L);
+                return v;
+            });
+        });
+    }
+
+    @Test
+    void testReentrantComputeIfAbsentThrowsIllegalStateException() {
+        ConcurrentLong2LongHashMap map = new ConcurrentLong2LongHashMap();
+
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.computeIfAbsent(1L, (long k) -> {
+                map.put(2L, 200L);
+                return k * 10;
+            });
+        });
+    }
+
+    @Test
+    void testReentrantMergeLongThrowsIllegalStateException() {
+        ConcurrentLong2LongHashMap map = new ConcurrentLong2LongHashMap();
+        map.put(1L, 100L);
+
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.mergeLong(1L, 50L, (oldVal, newVal) -> {
+                map.remove(2L);
+                return oldVal + newVal;
+            });
+        });
+    }
+
     // ---- Gson serialization tests ----
 
     @Test

--- a/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMapTest.java
+++ b/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2LongHashMapTest.java
@@ -410,13 +410,22 @@ class ConcurrentLong2LongHashMapTest {
         map.put(2L, 200L);
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<?> future = executor.submit(() -> {
-            map.forEach((ConcurrentLong2LongHashMap.LongLongConsumer) (k, v) -> {
-                map.put(k + 1000L, v + 1);
+        Future<?> future = null;
+        try {
+            future = executor.submit(() -> {
+                map.forEach((ConcurrentLong2LongHashMap.LongLongConsumer) (k, v) -> {
+                    map.put(k + 1000L, v + 1);
+                });
             });
-        });
-        future.get(5, java.util.concurrent.TimeUnit.SECONDS);
-        executor.shutdown();
+            future.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            if (future != null && !future.isDone()) {
+                future.cancel(true);
+            }
+            throw e;
+        } finally {
+            executor.shutdownNow();
+        }
 
         Assertions.assertEquals(101L, map.get(1001L));
         Assertions.assertEquals(201L, map.get(1002L));

--- a/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMapTest.java
+++ b/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMapTest.java
@@ -392,6 +392,70 @@ class ConcurrentLong2ObjectHashMapTest {
         Assertions.assertEquals(0, errors.get());
     }
 
+    // ---- Deadlock-safety tests ----
+
+    @Test
+    void testForEachWithMutatingCallbackDoesNotDeadlock() throws Exception {
+        // Before the fix, forEach held a read lock and the callback calling put() would try
+        // to acquire a write lock on the same segment, causing a read-to-write upgrade deadlock.
+        ConcurrentLong2ObjectHashMap<String> map = new ConcurrentLong2ObjectHashMap<>(1);
+        map.put(1L, "one");
+        map.put(2L, "two");
+
+        // Run in a separate thread with a timeout so the test fails fast instead of hanging
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> future = executor.submit(() -> {
+            map.forEach((ConcurrentLong2ObjectHashMap.LongObjConsumer<String>) (k, v) -> {
+                map.put(k + 1000L, v + "-copy");
+            });
+        });
+        // Should complete within 5 seconds; if it deadlocks, get() will time out
+        future.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        executor.shutdown();
+
+        Assertions.assertEquals("one-copy", map.get(1001L));
+        Assertions.assertEquals("two-copy", map.get(1002L));
+    }
+
+    @Test
+    void testReentrantComputeThrowsIllegalStateException() {
+        ConcurrentLong2ObjectHashMap<String> map = new ConcurrentLong2ObjectHashMap<>();
+        map.put(1L, "one");
+
+        // compute callback tries to call put on the same map — should throw ISE
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.compute(1L, (k, v) -> {
+                map.put(2L, "two");
+                return v;
+            });
+        });
+    }
+
+    @Test
+    void testReentrantComputeIfAbsentThrowsIllegalStateException() {
+        ConcurrentLong2ObjectHashMap<String> map = new ConcurrentLong2ObjectHashMap<>();
+
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.computeIfAbsent(1L, (long k) -> {
+                map.put(2L, "two");
+                return "one";
+            });
+        });
+    }
+
+    @Test
+    void testReentrantMergeThrowsIllegalStateException() {
+        ConcurrentLong2ObjectHashMap<String> map = new ConcurrentLong2ObjectHashMap<>();
+        map.put(1L, "one");
+
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.merge(1L, "new", (oldVal, newVal) -> {
+                map.remove(2L);
+                return oldVal + newVal;
+            });
+        });
+    }
+
     // ---- Gson serialization tests ----
 
     @Test

--- a/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMapTest.java
+++ b/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMapTest.java
@@ -465,6 +465,22 @@ class ConcurrentLong2ObjectHashMapTest {
         });
     }
 
+    @Test
+    void testReentrantReadFromCallbackThrowsIllegalStateException() {
+        ConcurrentLong2ObjectHashMap<String> map = new ConcurrentLong2ObjectHashMap<>();
+        map.put(1L, "one");
+        map.put(2L, "two");
+
+        // Read access (get) from within a compute callback should also throw ISE
+        // to prevent cross-segment ABBA deadlocks
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            map.compute(1L, (k, v) -> {
+                map.get(2L);
+                return v;
+            });
+        });
+    }
+
     // ---- Gson serialization tests ----
 
     @Test

--- a/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMapTest.java
+++ b/fe/fe-foundation/src/test/java/org/apache/doris/foundation/util/ConcurrentLong2ObjectHashMapTest.java
@@ -404,14 +404,23 @@ class ConcurrentLong2ObjectHashMapTest {
 
         // Run in a separate thread with a timeout so the test fails fast instead of hanging
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<?> future = executor.submit(() -> {
-            map.forEach((ConcurrentLong2ObjectHashMap.LongObjConsumer<String>) (k, v) -> {
-                map.put(k + 1000L, v + "-copy");
+        Future<?> future = null;
+        try {
+            future = executor.submit(() -> {
+                map.forEach((ConcurrentLong2ObjectHashMap.LongObjConsumer<String>) (k, v) -> {
+                    map.put(k + 1000L, v + "-copy");
+                });
             });
-        });
-        // Should complete within 5 seconds; if it deadlocks, get() will time out
-        future.get(5, java.util.concurrent.TimeUnit.SECONDS);
-        executor.shutdown();
+            // Should complete within 5 seconds; if it deadlocks, get() will time out
+            future.get(5, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            if (future != null && !future.isDone()) {
+                future.cancel(true);
+            }
+            throw e;
+        } finally {
+            executor.shutdownNow();
+        }
 
         Assertions.assertEquals("one-copy", map.get(1001L));
         Assertions.assertEquals("two-copy", map.get(1002L));


### PR DESCRIPTION
## Summary
- **forEach deadlock**: Changed `forEach` in both `ConcurrentLong2ObjectHashMap` and `ConcurrentLong2LongHashMap` from inline iteration under read-lock to snapshot-based iteration. Entries are copied into arrays under the read lock, then callbacks are invoked outside the lock. This eliminates the read-to-write upgrade deadlock (e.g., `forEach((k, v) -> map.put(k, v + 1))`).
- **Reentrant callback guard**: Added a `ThreadLocal<Boolean>` per map instance that is set during compute/merge callback execution. All write operations (`put`, `remove`, `putIfAbsent`, `replace`, `clear`, `addTo`, and all compute/merge variants) check this flag and throw `IllegalStateException` on reentrant access, turning a silent deadlock into a fail-fast error.
- **Documentation**: Added Javadoc on both classes documenting the callback restriction (matching `ConcurrentHashMap`'s contract).

## Test plan
- [x] `testForEachWithMutatingCallbackDoesNotDeadlock` — verifies forEach + put no longer deadlocks (uses 5s timeout)
- [x] `testReentrantComputeThrowsIllegalStateException` — verifies compute callback calling put throws ISE
- [x] `testReentrantComputeIfAbsentThrowsIllegalStateException` — verifies computeIfAbsent callback calling put throws ISE
- [x] `testReentrantMergeThrowsIllegalStateException` / `testReentrantMergeLongThrowsIllegalStateException` — verifies merge callback calling remove throws ISE
- [x] All 64 existing tests pass (33 Long2Long + 31 Long2Object)

🤖 Generated with [Claude Code](https://claude.com/claude-code)