### PR TITLE
[feature](build) Add local-dev single-container FE+BE Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ thirdparty/src*
 thirdparty/installed*
 thirdparty/doris-thirdparty*.tar.xz
 
+docker/runtime/local-dev/.prebuilt/
+
 docker/thirdparties/docker-compose/mysql/data
 docker/thirdparties/docker-compose/hive/scripts/tpch1.db/
 docker/thirdparties/docker-compose/hive/scripts/tvf_data

--- a/docker/runtime/local-dev/Dockerfile
+++ b/docker/runtime/local-dev/Dockerfile
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Local single-container FE+BE image for development (see README.md in this directory).
+#
+# --- A) Default: copy local tree (source build output/ or extracted release tarball) ---
+#   docker build -f docker/runtime/local-dev/Dockerfile -t doris-local:dev .
+#
+# --- B) Prebuilt: download official binary inside build (no local compile) ---
+#   docker build -f docker/runtime/local-dev/Dockerfile --target doris-local-dev-prebuilt \
+#     --build-arg DORIS_VERSION=3.0.5 -t doris-local:3.0.5 .
+#   For linux/amd64 without AVX2 packages, add: --build-arg BINARY_VARIANT=noavx2
+#   For cross-platform images use buildx, e.g. --platform linux/arm64
+#
+# --- C) Host download script then build target local ---
+#   docker/runtime/local-dev/download-binary.sh -v 3.0.5
+#   docker build -f docker/runtime/local-dev/Dockerfile --target doris-local-dev-local \
+#     --build-arg OUTPUT_PATH=./docker/runtime/local-dev/.prebuilt/apache-doris-3.0.5-bin-arm64 -t doris-local:3.0.5 .
+#
+# Run (example):
+#   docker run -p 9030:9030 -p 8030:8030 -p 8040:8040 \
+#     -v doris-meta:/opt/apache-doris/fe/doris-meta \
+#     -v doris-be-storage:/opt/apache-doris/be/storage \
+#     doris-local:dev
+#
+# Security: default root / admin empty password — only for isolated local use.
+
+# Doris 2.1 / 3.x: JDK 17. Doris 2.0: pass --build-arg JDK_IMAGE=openjdk:8u342-jdk
+ARG JDK_IMAGE=openjdk:17.0.1-jdk-slim
+ARG OUTPUT_PATH=./output
+
+FROM ${JDK_IMAGE} AS base-local-dev
+
+RUN sed -i -e s@/deb.debian.org/@/mirrors.aliyun.com/@g -e s@/security.debian.org/@/mirrors.aliyun.com/@g /etc/apt/sources.list \
+    && apt-get clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        default-mysql-client \
+        curl \
+        procps \
+        tzdata \
+        util-linux \
+    && ln -fs /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV SKIP_CHECK_ULIMIT=true \
+    PATH="/opt/apache-doris/fe/bin:/opt/apache-doris/be/bin:${PATH}"
+
+# Download official release during docker build (matches TARGETARCH: arm64 / amd64).
+FROM base-local-dev AS doris-local-dev-prebuilt
+ARG DORIS_VERSION
+ARG TARGETARCH
+ARG BINARY_VARIANT=
+ARG DOWNLOAD_BASE=https://apache-doris-releases.oss-accelerate.aliyuncs.com
+RUN set -eux; \
+    if [ -z "${DORIS_VERSION}" ]; then \
+        echo "ERROR: pass --build-arg DORIS_VERSION=x.y.z when using target doris-local-dev-prebuilt" >&2; \
+        exit 1; \
+    fi; \
+    case "${TARGETARCH}" in \
+        arm64) D=arm64 ;; \
+        amd64) \
+            if [ "${BINARY_VARIANT}" = "noavx2" ]; then D=x64-noavx2; else D=x64; fi ;; \
+        *) \
+            echo "ERROR: Unsupported TARGETARCH=${TARGETARCH}; use docker buildx --platform linux/arm64 or linux/amd64" >&2; \
+            exit 1 ;; \
+    esac; \
+    PKG="apache-doris-${DORIS_VERSION}-bin-${D}"; \
+    curl -fSL "${DOWNLOAD_BASE}/${PKG}.tar.gz" | tar xz -C /tmp; \
+    mkdir -p /opt/apache-doris; \
+    mv "/tmp/${PKG}/fe" "/tmp/${PKG}/be" /opt/apache-doris/
+RUN sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/be/bin/start_be.sh
+COPY docker/runtime/local-dev/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+WORKDIR /opt/apache-doris
+EXPOSE 8030 8040 8070 9010 9020 9030 9050 9060 8050 8060
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+# Copy fe/ + be/ from build context (e.g. ./output or download-binary.sh output).
+FROM base-local-dev AS doris-local-dev-local
+ARG OUTPUT_PATH
+COPY ${OUTPUT_PATH} /opt/apache-doris/
+RUN sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/be/bin/start_be.sh
+COPY docker/runtime/local-dev/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+WORKDIR /opt/apache-doris
+EXPOSE 8030 8040 8070 9010 9020 9030 9050 9060 8050 8060
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+# Default image when no --target is given (same as before: use OUTPUT_PATH=./output or override).
+FROM doris-local-dev-local

--- a/docker/runtime/local-dev/README.md
+++ b/docker/runtime/local-dev/README.md
@@ -1,0 +1,102 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Local single-container Doris (FE + BE)
+
+For **local development only**: one container runs FE and BE together, with BE startup host checks relaxed via `SKIP_CHECK_ULIMIT=true`.
+
+## Security
+
+- Intended for **isolated machines** only.
+- Default cluster auth is **root with empty password** (fresh metadata). The entrypoint also runs `CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED BY ''` and `GRANT ADMIN_PRIV` — some versions may reject an empty password; check the container log.
+- **Do not** expose ports 9030/8030/8040 to untrusted networks.
+
+## Build options
+
+### 1) Prebuilt binary inside Docker (no `./build.sh`, recommended)
+
+From the Doris repo root, pick a **released** version that exists on the official download host. The image architecture follows the build platform (`TARGETARCH`: `linux/arm64` → `arm64` package, `linux/amd64` → `x64` or `x64-noavx2`).
+
+```bash
+docker build -f docker/runtime/local-dev/Dockerfile --target doris-local-dev-prebuilt \
+  --build-arg DORIS_VERSION=4.0.5 -t doris-local:4.0.5 .
+```
+
+- **CPU without AVX2** (amd64 package): add `--build-arg BINARY_VARIANT=noavx2`.
+- **Cross-arch** (e.g. build `linux/arm64` on x86): use Buildx, for example:
+  `docker buildx build --platform linux/arm64 ...`
+
+### 2) Download tarball on the host, then docker build
+
+Script selects **`arm64` / `x64` / `x64-noavx2`** from the current OS (on Linux x86_64 it checks `/proc/cpuinfo` for `avx2`). Override with `--suffix` if needed.
+
+```bash
+chmod +x docker/runtime/local-dev/download-binary.sh
+./docker/runtime/local-dev/download-binary.sh -v 4.0.5
+# Then run the printed docker build command (OUTPUT_PATH under .prebuilt/).
+```
+
+Artifacts go to `docker/runtime/local-dev/.prebuilt/` (ignored by git).
+
+### 3) Local compile output / any directory with `fe/` and `be/`
+
+```bash
+docker build -f docker/runtime/local-dev/Dockerfile --target doris-local-dev-local \
+  --build-arg OUTPUT_PATH=./output -t doris-local:dev .
+```
+
+Omitting `--target` is equivalent to `--target doris-local-dev-local` (default).
+
+**Doris 2.0** needs JDK 8 in the image, for example:
+
+```bash
+docker build -f docker/runtime/local-dev/Dockerfile --target doris-local-dev-prebuilt \
+  --build-arg JDK_IMAGE=openjdk:8u342-jdk \
+  --build-arg DORIS_VERSION=2.0.15 -t doris-local:2.0.15 .
+```
+
+## Run
+
+```bash
+docker run --name doris-local \
+  -p 9030:9030 -p 8030:8030 -p 8040:8040 \
+  -v doris-meta:/opt/apache-doris/fe/doris-meta \
+  -v doris-be-storage:/opt/apache-doris/be/storage \
+  doris-local:4.0.5
+```
+
+- **JDBC / mysql client**: `127.0.0.1:9030`, user `root` or `admin`, empty password (if accepted).
+- **FE HTTP UI**: `8030`. **BE HTTP** (e.g. stream load): `8040`.
+
+Optional: `docker run ... --ulimit nofile=65535:65535` if you hit file descriptor limits despite `SKIP_CHECK_ULIMIT`.
+
+If FE stays `UNKNOWN` or `SHOW FRONTENDS` never succeeds, wipe volumes and retry so first-boot `priority_networks` / `BE_IP` are applied: `docker rm -f doris-local && docker volume rm doris-meta doris-be-storage` (adjust names).
+
+## Environment variables (entrypoint)
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `SKIP_CHECK_ULIMIT` | `true` | Skip BE `start_be.sh` checks for `vm.max_map_count`, swap, `ulimit -n` |
+| `MYSQL_HOST` | `127.0.0.1` | FE MySQL protocol host (inside container) |
+| `MYSQL_PORT` | `9030` | Query port |
+| `FE_HTTP_PORT` | `8030` | Used only for log hints while waiting for MySQL to accept connections |
+| `BE_IP` | auto: first non-loopback from `hostname -I`, else `127.0.0.1` | Address used in `ALTER SYSTEM ADD BACKEND` (should match BE heartbeat source; Docker often needs the container eth0 IP) |
+| `PRIORITY_NETWORKS` | auto from `BE_IP` (`x.x.x.0/24` or `127.0.0.1/24`) | Override `fe.conf`/`be.conf` `priority_networks` on first boot; semicolon-separated CIDRs allowed |
+| `BE_HEARTBEAT_PORT` | `9050` | Must match `heartbeat_service_port` in `be.conf` |
+| `MAX_WAIT_SECONDS` | `300` | Wait for FE / register BE |

--- a/docker/runtime/local-dev/docker-entrypoint.sh
+++ b/docker/runtime/local-dev/docker-entrypoint.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+# Prefer eth0/docker IP over loopback so FE/BE agree on published addresses (see log: HostInfo host=192.168.x.x).
+pick_primary_ipv4() {
+    local _tok
+    for _tok in $(hostname -I 2>/dev/null); do
+        [[ "${_tok}" == "127.0.0.1" ]] && continue
+        [[ -n "${_tok}" ]] && echo "${_tok}" && return
+    done
+    echo "127.0.0.1"
+}
+
+_DEFAULT_CONTAINER_IP="$(pick_primary_ipv4)"
+
+readonly DORIS_HOME="/opt/apache-doris"
+readonly FE_HOME="${DORIS_HOME}/fe"
+readonly BE_HOME="${DORIS_HOME}/be"
+readonly MYSQL_HOST="${MYSQL_HOST:-127.0.0.1}"
+readonly MYSQL_PORT="${MYSQL_PORT:-9030}"
+readonly FE_HTTP_PORT="${FE_HTTP_PORT:-8030}"
+readonly BE_HEARTBEAT_PORT="${BE_HEARTBEAT_PORT:-9050}"
+readonly BE_IP="${BE_IP:-${_DEFAULT_CONTAINER_IP}}"
+readonly MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-300}"
+
+log() {
+    echo "$(date -Iseconds) [local-dev] $*"
+}
+
+_cleaned=0
+cleanup() {
+    [[ "${_cleaned}" -eq 1 ]] && return
+    _cleaned=1
+    log "Shutting down (stop BE then FE)..."
+    "${BE_HOME}/bin/stop_be.sh" 2>/dev/null || true
+    sleep 2
+    "${FE_HOME}/bin/stop_fe.sh" 2>/dev/null || true
+}
+
+on_signal() {
+    cleanup
+    exit 143
+}
+trap on_signal SIGTERM
+trap 'cleanup; exit 130' SIGINT
+trap cleanup EXIT
+
+export SKIP_CHECK_ULIMIT="${SKIP_CHECK_ULIMIT:-true}"
+
+mysql_root() {
+    mysql -uroot -h"${MYSQL_HOST}" -P"${MYSQL_PORT}" --protocol=tcp --connect-timeout=5 "$@"
+}
+
+first_fe_bootstrap() {
+    [[ ! -d "${FE_HOME}/doris-meta/image" ]]
+}
+
+priority_networks_value() {
+    if [[ -n "${PRIORITY_NETWORKS:-}" ]]; then
+        echo "${PRIORITY_NETWORKS}"
+    elif [[ "${BE_IP}" == "127.0.0.1" ]]; then
+        echo "127.0.0.1/24"
+    else
+        echo "${BE_IP%.*}.0/24"
+    fi
+}
+
+append_priority_networks() {
+    local f="$1"
+    local pn
+    pn="$(priority_networks_value)"
+    if [[ -f "$f" ]] && ! grep -qE '^[[:space:]]*priority_networks[[:space:]]*=' "$f"; then
+        log "Appending priority_networks = ${pn} to $(basename "$(dirname "$f")")/conf/$(basename "$f")"
+        echo "priority_networks = ${pn}" >>"$f"
+    fi
+}
+
+fe_http_up() {
+    curl -sf --max-time 2 "http://127.0.0.1:${FE_HTTP_PORT}/" &>/dev/null
+}
+
+wait_for_fe() {
+    local i
+    for ((i = 0; i < MAX_WAIT_SECONDS; i++)); do
+        # SELECT 1 can go through Nereids and require a BE (Doris 4.x+), while no BE is running yet — deadlock.
+        if mysql_root -e "SHOW FRONTENDS" &>/dev/null; then
+            log "FE query port is ready (SHOW FRONTENDS)."
+            return 0
+        fi
+        if ((i % 20 == 0)); then
+            if fe_http_up; then
+                log "Waiting for FE MySQL port ${MYSQL_PORT} (HTTP ${FE_HTTP_PORT} is up)... (${i}/${MAX_WAIT_SECONDS}s)"
+            else
+                log "Waiting for FE on ${MYSQL_HOST}:${MYSQL_PORT}... (${i}/${MAX_WAIT_SECONDS}s)"
+            fi
+        fi
+        sleep 1
+    done
+    log "ERROR: FE did not become ready in time."
+    return 1
+}
+
+backend_registered() {
+    mysql_root -N -e "SHOW BACKENDS" 2>/dev/null | grep -w "${BE_IP}" | grep -w "${BE_HEARTBEAT_PORT}" &>/dev/null
+}
+
+register_backend() {
+    if backend_registered; then
+        log "BE ${BE_IP}:${BE_HEARTBEAT_PORT} already registered."
+        return 0
+    fi
+    local i
+    for ((i = 0; i < MAX_WAIT_SECONDS; i++)); do
+        if mysql_root -e "ALTER SYSTEM ADD BACKEND '${BE_IP}:${BE_HEARTBEAT_PORT}'" &>/dev/null; then
+            log "Registered BE ${BE_IP}:${BE_HEARTBEAT_PORT}."
+            return 0
+        fi
+        if ((i % 20 == 0)); then
+            log "Retrying ADD BACKEND... (${i}/${MAX_WAIT_SECONDS}s)"
+        fi
+        sleep 1
+        backend_registered && return 0
+    done
+    log "ERROR: Failed to register BE."
+    return 1
+}
+
+bootstrap_users() {
+    log "Ensuring admin user exists (empty password) and ADMIN_PRIV; root left as cluster default."
+    set +e
+    mysql_root --comments <<'EOSQL'
+CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED BY '';
+GRANT ADMIN_PRIV ON *.*.* TO 'admin'@'%';
+EOSQL
+    local st=$?
+    set -e
+    if [[ $st -ne 0 ]]; then
+        log "WARN: admin bootstrap SQL returned $st (empty password may be rejected on this version)."
+    fi
+}
+
+if first_fe_bootstrap; then
+    append_priority_networks "${BE_HOME}/conf/be.conf"
+    append_priority_networks "${FE_HOME}/conf/fe.conf"
+fi
+
+log "Container primary IPv4: ${_DEFAULT_CONTAINER_IP}; BE_IP=${BE_IP} (ALTER SYSTEM ADD BACKEND); MySQL host=${MYSQL_HOST}"
+
+export JAVA_TOOL_OPTIONS='-XX:-UseContainerSupport'
+
+log "Starting FE..."
+"${FE_HOME}/bin/start_fe.sh" --console &
+
+wait_for_fe || exit 1
+register_backend || exit 1
+bootstrap_users
+
+log "Starting BE (console, SKIP_CHECK_ULIMIT=${SKIP_CHECK_ULIMIT})..."
+"${BE_HOME}/bin/start_be.sh" --console &
+be_pid=$!
+wait "${be_pid}" || true

--- a/docker/runtime/local-dev/download-binary.sh
+++ b/docker/runtime/local-dev/download-binary.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Download official Apache Doris release tarball (fe + be) for the current machine,
+# then you can docker build with --build-arg OUTPUT_PATH=... (see printed hint).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# docker/runtime/local-dev -> Doris repo root
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+VERSION=""
+OUT_DIR=""
+BASE_URL="https://apache-doris-releases.oss-accelerate.aliyuncs.com"
+SUFFIX=""
+
+usage() {
+    cat <<EOF
+Usage: $0 -v <version> [options]
+
+  -v <version>          Doris release version, e.g. 3.0.5
+  -o <dir>              Extract here (default: ${SCRIPT_DIR}/.prebuilt/apache-doris-<ver>-bin-<suffix>/)
+  --base-url <url>      Download host (default: ${BASE_URL})
+  --suffix <name>       Force package suffix: arm64 | x64 | x64-noavx2 (default: auto from OS/CPU)
+
+Examples:
+  $0 -v 3.0.5
+  $0 -v 2.1.7 --suffix x64-noavx2
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v)
+            VERSION="${2:-}"
+            shift 2
+            ;;
+        -o)
+            OUT_DIR="${2:-}"
+            shift 2
+            ;;
+        --base-url)
+            BASE_URL="${2:-}"
+            shift 2
+            ;;
+        --suffix)
+            SUFFIX="${2:-}"
+            shift 2
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${VERSION}" ]]; then
+    usage
+    exit 1
+fi
+
+detect_suffix() {
+    local machine
+    machine="$(uname -m)"
+    case "${machine}" in
+        arm64 | aarch64)
+            echo arm64
+            ;;
+        x86_64 | amd64)
+            if [[ "$(uname -s)" == Linux ]] && [[ -r /proc/cpuinfo ]] && ! grep -q avx2 /proc/cpuinfo; then
+                echo x64-noavx2
+            else
+                echo x64
+            fi
+            ;;
+        *)
+            echo "Unsupported machine: ${machine}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+if [[ -z "${SUFFIX}" ]]; then
+    SUFFIX="$(detect_suffix)"
+fi
+
+INNER_DIR="apache-doris-${VERSION}-bin-${SUFFIX}"
+TARBALL="${INNER_DIR}.tar.gz"
+URL="${BASE_URL}/${TARBALL}"
+
+if [[ -z "${OUT_DIR}" ]]; then
+    OUT_DIR="${SCRIPT_DIR}/.prebuilt/${INNER_DIR}"
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+echo "Downloading ${URL}"
+if command -v curl &>/dev/null; then
+    curl -fSL "${URL}" -o "${TMP}/${TARBALL}"
+else
+    wget -O "${TMP}/${TARBALL}" "${URL}"
+fi
+
+tar -xzf "${TMP}/${TARBALL}" -C "${TMP}"
+rm -rf "${OUT_DIR}"
+mkdir -p "$(dirname "${OUT_DIR}")"
+mv "${TMP}/${INNER_DIR}" "${OUT_DIR}"
+
+rm -rf "${TMP}"
+TMP=""
+trap - EXIT
+
+OUTPUT_REL=""
+if [[ "${OUT_DIR}" == "${REPO_ROOT}"/* ]]; then
+    OUTPUT_REL="${OUT_DIR#"${REPO_ROOT}/"}"
+fi
+
+echo "Extracted fe/ and be/ to: ${OUT_DIR}"
+if [[ -n "${OUTPUT_REL}" ]]; then
+    echo "From repo root (${REPO_ROOT}), build image with:"
+    echo "  docker build -f docker/runtime/local-dev/Dockerfile --target doris-local-dev-local \\"
+    echo "    --build-arg OUTPUT_PATH=./${OUTPUT_REL} -t doris-local:${VERSION} ."
+else
+    echo "OUT_DIR is outside the Doris repo; use either:"
+    echo "  docker build -f docker/runtime/local-dev/Dockerfile --target doris-local-dev-prebuilt \\"
+    echo "    --build-arg DORIS_VERSION=${VERSION} -t doris-local:${VERSION} ."
+    echo "or copy fe/ and be/ under the repo and pass OUTPUT_PATH relative to repo root."
+fi

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -36,6 +36,22 @@ curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 export DORIS_HOME="${curdir}/.."
 export TP_DIR="${curdir}"
 
+# macOS ships BSD getopt, which does not support the -l long options below; require GNU getopt (e.g. from Homebrew).
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if command -v brew &>/dev/null; then
+        _gnu_getopt_bin="$(brew --prefix)/opt/gnu-getopt/bin"
+        if [[ -x "${_gnu_getopt_bin}/getopt" ]]; then
+            PATH="${_gnu_getopt_bin}:${PATH}"
+            export PATH
+        fi
+    fi
+    if ! getopt --version 2>/dev/null | grep -q util-linux; then
+        echo "ERROR: On macOS, GNU getopt is required for this script (BSD getopt breaks option parsing)."
+        echo "Install: brew install gnu-getopt"
+        exit 1
+    fi
+fi
+
 # include custom environment variables
 if [[ -f "${DORIS_HOME}/env.sh" ]]; then
     export DO_NOT_CHECK_JAVA_ENV=1


### PR DESCRIPTION
### What problem does this PR solve?

This PR introduces a new local development mode that enables running both FE and BE nodes within a single container.
* Simplified Setup: This is highly beneficial for setting up lightweight local development environments.
* [Testcontainers](https://testcontainers.com) Integration: It paves the way for seamless integration with Testcontainers, facilitating automated integration testing for downstream applications.

### Release note

Provide a Docker image recipe for running FE and BE in one container for local application development.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [x] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

