### PR TITLE
[opt](memory) Move schemaHash from Replica to LocalReplica

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalReplica.java
@@ -30,6 +30,7 @@ public class LocalReplica extends Replica {
 
     @SerializedName(value = "bid", alternate = {"backendId"})
     private long backendId;
+    private int schemaHash = -1;
 
     @SerializedName(value = "rds", alternate = {"remoteDataSize"})
     private volatile long remoteDataSize = 0;
@@ -129,6 +130,7 @@ public class LocalReplica extends Replica {
         super(replicaId, backendId, version, schemaHash, dataSize, remoteDataSize, rowCount, state, lastFailedVersion,
                 lastSuccessVersion);
         this.backendId = backendId;
+        this.schemaHash = schemaHash;
         this.lastFailedVersion = lastFailedVersion;
         if (this.lastFailedVersion > 0) {
             this.lastFailedTimestamp = System.currentTimeMillis();
@@ -155,6 +157,16 @@ public class LocalReplica extends Replica {
     @Override
     public void setBackendId(long backendId) {
         this.backendId = backendId;
+    }
+
+    @Override
+    public int getSchemaHash() {
+        return schemaHash;
+    }
+
+    @Override
+    public void setSchemaHash(int schemaHash) {
+        this.schemaHash = schemaHash;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -88,7 +88,6 @@ public abstract class Replica {
     // the version could be queried
     @SerializedName(value = "v", alternate = {"version"})
     protected volatile long version;
-    private int schemaHash = -1;
     @SerializedName(value = "ds", alternate = {"dataSize"})
     private volatile long dataSize = 0;
     @SerializedName(value = "rc", alternate = {"rowCount"})
@@ -129,7 +128,6 @@ public abstract class Replica {
                        long lastSuccessVersion) {
         this.id = replicaId;
         this.version = version;
-        this.schemaHash = schemaHash;
 
         this.dataSize = dataSize;
         this.rowCount = rowCount;
@@ -144,12 +142,12 @@ public abstract class Replica {
     }
 
     public int getSchemaHash() {
-        return schemaHash;
+        return -1;
     }
 
     // for compatibility
     public void setSchemaHash(int schemaHash) {
-        this.schemaHash = schemaHash;
+        // no-op in base class; overridden in LocalReplica
     }
 
     public long getId() {
@@ -428,7 +426,7 @@ public abstract class Replica {
         strBuffer.append(", lastFailedTimestamp=");
         strBuffer.append(getLastFailedTimestamp());
         strBuffer.append(", schemaHash=");
-        strBuffer.append(schemaHash);
+        strBuffer.append(getSchemaHash());
         strBuffer.append(", state=");
         strBuffer.append(state.name());
         strBuffer.append(", isBad=");

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaTest.java
@@ -214,22 +214,15 @@ public class ReplicaTest {
     }
 
     @Test
-    public void testBaseReplicaSchemaHashReturnsNegativeOne() {
-        // Base Replica (and by extension CloudReplica) should return -1 for schemaHash
-        // since schemaHash is only meaningful for LocalReplica
-        Replica baseReplica = new Replica();
-        Assert.assertEquals(-1, baseReplica.getSchemaHash());
-
-        // setSchemaHash is a no-op on base Replica
-        baseReplica.setSchemaHash(999);
-        Assert.assertEquals(-1, baseReplica.getSchemaHash());
-    }
-
-    @Test
     public void testCloudReplicaSchemaHashReturnsNegativeOne() {
-        // CloudReplica extends Replica (not LocalReplica), so it inherits the -1 stub
+        // CloudReplica extends Replica (not LocalReplica), so it inherits the base -1 stub.
+        // schemaHash=12345 is passed to the constructor but ignored by the base class.
         CloudReplica cloudReplica = new CloudReplica(10000L, 20000L, ReplicaState.NORMAL,
                 3, 12345, 1, 2, 3, 4, -1);
+        Assert.assertEquals(-1, cloudReplica.getSchemaHash());
+
+        // setSchemaHash is a no-op on base Replica, so CloudReplica stays at -1
+        cloudReplica.setSchemaHash(999);
         Assert.assertEquals(-1, cloudReplica.getSchemaHash());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.catalog.Replica.ReplicaState;
+import org.apache.doris.cloud.catalog.CloudReplica;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.persist.gson.GsonUtils;
 
@@ -193,5 +194,42 @@ public class ReplicaTest {
         Assert.assertEquals(18, originalReplica.getLastSuccessVersion());
         Assert.assertEquals(18, originalReplica.getVersion());
         Assert.assertEquals(-1, originalReplica.getLastFailedVersion());
+    }
+
+    @Test
+    public void testLocalReplicaGetSchemaHash() {
+        int schemaHash = 12345;
+        LocalReplica localReplica = new LocalReplica(10000, 20000, 3, schemaHash,
+                100, 0, 78, ReplicaState.NORMAL, 0, 3);
+        Assert.assertEquals(schemaHash, localReplica.getSchemaHash());
+    }
+
+    @Test
+    public void testLocalReplicaSetSchemaHash() {
+        LocalReplica localReplica = new LocalReplica(10000, 20000, 3, 111,
+                100, 0, 78, ReplicaState.NORMAL, 0, 3);
+        Assert.assertEquals(111, localReplica.getSchemaHash());
+        localReplica.setSchemaHash(222);
+        Assert.assertEquals(222, localReplica.getSchemaHash());
+    }
+
+    @Test
+    public void testBaseReplicaSchemaHashReturnsNegativeOne() {
+        // Base Replica (and by extension CloudReplica) should return -1 for schemaHash
+        // since schemaHash is only meaningful for LocalReplica
+        Replica baseReplica = new Replica();
+        Assert.assertEquals(-1, baseReplica.getSchemaHash());
+
+        // setSchemaHash is a no-op on base Replica
+        baseReplica.setSchemaHash(999);
+        Assert.assertEquals(-1, baseReplica.getSchemaHash());
+    }
+
+    @Test
+    public void testCloudReplicaSchemaHashReturnsNegativeOne() {
+        // CloudReplica extends Replica (not LocalReplica), so it inherits the -1 stub
+        CloudReplica cloudReplica = new CloudReplica(10000L, 20000L, ReplicaState.NORMAL,
+                3, 12345, 1, 2, 3, 4, -1);
+        Assert.assertEquals(-1, cloudReplica.getSchemaHash());
     }
 }


### PR DESCRIPTION
## Summary
- Move `schemaHash` field from base `Replica` class to `LocalReplica`, saving 4 bytes per `CloudReplica` instance
- Base `Replica.getSchemaHash()` now returns `-1` (stub), `setSchemaHash()` is a no-op
- `LocalReplica` overrides both methods with actual storage
- Follows the same pattern as `dbId` removal in #62079

## Details
Cloud storage paths don't use `schema_hash`, and callers like `MetadataViewer` already guard with `getSchemaHash() != -1`, so `CloudReplica` returning `-1` is safe and correct.

Changes:
- `Replica.java`: Remove `schemaHash` field; `getSchemaHash()` returns `-1`; `setSchemaHash()` is no-op; `toString()` uses `getSchemaHash()` for polymorphism
- `LocalReplica.java`: Add `schemaHash` field; override `getSchemaHash()`/`setSchemaHash()`; set in constructor
- `CloudReplica.java`: No changes needed (schemaHash param harmlessly ignored by super constructor)

## Test plan
- [ ] `CloudReplica.getSchemaHash()` returns -1
- [ ] `LocalReplica.getSchemaHash()` returns actual value
- [ ] `MetadataViewer` SCHEMA_ERROR check unaffected (guards with `!= -1`)
- [ ] FE unit tests pass (ReplicaTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)