### PR TITLE
[bugfix] fix doris build failure because of no cuda support scene, and add FAISS_ENABLE_GPU switch to enable it or not by user, default value as OFF

### DIFF
--- a/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
+++ b/be/src/storage/index/ann/cmake-protect/CMakeLists.txt
@@ -42,13 +42,13 @@ else()
         set(DYNAMIC_ARCH ON CACHE BOOL "Enable runtime CPU detection in OpenBLAS")
     endif ()
 endif ()
-
+# Set FAISS_ENABLE_GPU OFF before including FAISS to prevent CUDA language detection
+set(FAISS_ENABLE_GPU OFF CACHE BOOL "Enable GPU support in FAISS")
 # EXCLUDE_FROM_ALL so that binary in openblas is not installed.
 add_subdirectory(${PROJECT_SOURCE_DIR}/../contrib/openblas ${PROJECT_BINARY_DIR}/openblas EXCLUDE_FROM_ALL)
 
 set(OPENBLAS_LIBRARY "${PROJECT_BINARY_DIR}/openblas/lib/libopenblas.a" CACHE PATH "Path to OpenBLAS build directory")
 set(FAISS_ENABLE_MKL OFF CACHE BOOL "Disable MKL support in FAISS")
-set(FAISS_ENABLE_GPU OFF CACHE BOOL "Disable GPU support in FAISS")
 set(FAISS_ENABLE_PYTHON OFF CACHE BOOL "Disable Python support in FAISS")
 set(FAISS_ENABLE_EXTRAS OFF CACHE BOOL "Disable FAISS extras")
 set(BUILD_TESTING OFF CACHE BOOL "Disable FAISS testing")

--- a/build.sh
+++ b/build.sh
@@ -747,6 +747,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
         -DBUILD_AZURE="${BUILD_AZURE}" \
         -DENABLE_DYNAMIC_ARCH="${ENABLE_DYNAMIC_ARCH}" \
         -DWITH_TDE_DIR="${WITH_TDE_DIR}" \
+        -DFAISS_ENABLE_GPU="${FAISS_ENABLE_GPU:-OFF}" \
         "${DORIS_HOME}/be"
 
     if [[ "${OUTPUT_BE_BINARY}" -eq 1 ]]; then


### PR DESCRIPTION
### What problem does this PR solve?

fix doris build failure because of no cuda support scene, and add FAISS_ENABLE_GPU switch to enable it or not by user, default value as OFF

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

