### PR TITLE
[enhance](nereids) improve masking of user's password for ALTER USER and CREATE USER commands in audit logs

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -1148,7 +1148,7 @@ userIdentify
     ;
 
 grantUserIdentify
-    : userIdentify (IDENTIFIED BY PASSWORD? STRING_LITERAL)?
+    : userIdentify (IDENTIFIED BY PASSWORD? pwd=STRING_LITERAL)?
     ;
 
 explain

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -96,6 +96,38 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
         return super.visitCreateUser(ctx);
     }
 
+    //
+    @Override
+    public LogicalPlan visitAlterUser(DorisParser.AlterUserContext ctx) {
+        DorisParser.GrantUserIdentifyContext grantCtx = ctx.grantUserIdentify();
+        if (grantCtx.pwd != null) {
+            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
+        }
+        return super.visitAlterUser(ctx);
+    }
+
+    // set ldap password clause
+    @Override
+    public SetVarOp visitSetLdapAdminPassword(DorisParser.SetLdapAdminPasswordContext ctx) {
+        encryptPassword(ctx.pwd.getStartIndex(), ctx.pwd.getStopIndex());
+        return super.visitSetLdapAdminPassword(ctx);
+    }
+            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
+        }
+        return super.visitCreateUser(ctx);
+    }
+
+    // set ldap password clause
+    @Override
+    public SetVarOp visitSetLdapAdminPassword(DorisParser.SetLdapAdminPasswordContext ctx) {
+        encryptPassword(ctx.pwd.getStartIndex(), ctx.pwd.getStopIndex());
+        return super.visitSetLdapAdminPassword(ctx);
+    }
+            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
+        }
+        return super.visitCreateUser(ctx);
+    }
+
     // set ldap password clause
     @Override
     public SetVarOp visitSetLdapAdminPassword(DorisParser.SetLdapAdminPasswordContext ctx) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -85,25 +85,13 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
         return super.visitSetPassword(ctx);
     }
 
-    // create user clause
+    // grant user identity clause
     @Override
-    public LogicalPlan visitCreateUser(DorisParser.CreateUserContext ctx) {
-        // get grantUserIdentify ctx with password
-        DorisParser.GrantUserIdentifyContext grantCtx = ctx.grantUserIdentify();
-        if (grantCtx.pwd != null) {
-            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
+    public UserDesc visitGrantUserIdentify(DorisParser.GrantUserIdentifyContext ctx) {
+        if (ctx.pwd != null) {
+            encryptPassword(ctx.pwd.getStartIndex(), ctx.pwd.getStopIndex());
         }
-        return super.visitCreateUser(ctx);
-    }
-
-    // alter user clause
-    @Override
-    public LogicalPlan visitAlterUser(DorisParser.AlterUserContext ctx) {
-        DorisParser.GrantUserIdentifyContext grantCtx = ctx.grantUserIdentify();
-        if (grantCtx.pwd != null) {
-            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
-        }
-        return super.visitAlterUser(ctx);
+        return super.visitGrantUserIdentify(ctx);
     }
 
     // set ldap password clause

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.parser;
 
 import org.apache.doris.analysis.BrokerDesc;
+import org.apache.doris.analysis.UserDesc;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.DatasourcePrintableMap;
 import org.apache.doris.nereids.DorisParser;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -85,6 +85,17 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
         return super.visitSetPassword(ctx);
     }
 
+    // create user clause
+    @Override
+    public LogicalPlan visitCreateUser(DorisParser.CreateUserContext ctx) {
+        // get grantUserIdentify ctx with password
+        DorisParser.GrantUserIdentifyContext grantCtx = ctx.grantUserIdentify();
+        if (grantCtx.pwd != null) {
+            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
+        }
+        return super.visitCreateUser(ctx);
+    }
+
     // set ldap password clause
     @Override
     public SetVarOp visitSetLdapAdminPassword(DorisParser.SetLdapAdminPasswordContext ctx) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -96,7 +96,7 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
         return super.visitCreateUser(ctx);
     }
 
-    //
+    // alter user clause
     @Override
     public LogicalPlan visitAlterUser(DorisParser.AlterUserContext ctx) {
         DorisParser.GrantUserIdentifyContext grantCtx = ctx.grantUserIdentify();
@@ -104,28 +104,6 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
             encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
         }
         return super.visitAlterUser(ctx);
-    }
-
-    // set ldap password clause
-    @Override
-    public SetVarOp visitSetLdapAdminPassword(DorisParser.SetLdapAdminPasswordContext ctx) {
-        encryptPassword(ctx.pwd.getStartIndex(), ctx.pwd.getStopIndex());
-        return super.visitSetLdapAdminPassword(ctx);
-    }
-            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
-        }
-        return super.visitCreateUser(ctx);
-    }
-
-    // set ldap password clause
-    @Override
-    public SetVarOp visitSetLdapAdminPassword(DorisParser.SetLdapAdminPasswordContext ctx) {
-        encryptPassword(ctx.pwd.getStartIndex(), ctx.pwd.getStopIndex());
-        return super.visitSetLdapAdminPassword(ctx);
-    }
-            encryptPassword(grantCtx.pwd.getStartIndex(), grantCtx.pwd.getStopIndex());
-        }
-        return super.visitCreateUser(ctx);
     }
 
     // set ldap password clause

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommand.java
@@ -29,7 +29,7 @@ import org.apache.doris.qe.StmtExecutor;
 /**
  * AlterUserCommand
  */
-public class AlterUserCommand extends AlterCommand {
+public class AlterUserCommand extends AlterCommand, NeedAuditEncryption {
 
     private final AlterUserInfo alterUserInfo;
 
@@ -56,5 +56,10 @@ public class AlterUserCommand extends AlterCommand {
     @Override
     public StmtType stmtType() {
         return StmtType.ALTER;
+    }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommand.java
@@ -29,7 +29,7 @@ import org.apache.doris.qe.StmtExecutor;
 /**
  * AlterUserCommand
  */
-public class AlterUserCommand extends AlterCommand, NeedAuditEncryption {
+public class AlterUserCommand extends AlterCommand implements NeedAuditEncryption {
 
     private final AlterUserInfo alterUserInfo;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -467,7 +467,6 @@ public class EncryptSQLTest extends ParserTestBase {
                 })) {
             ctx.setEnv(env);
             ctx.setCurrentUserIdentity(UserIdentity.ROOT);
-            Config.enable_nereids_load = true;
             // testing for https://github.com/apache/doris/issues/62140
             String sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
             String res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
@@ -499,7 +498,6 @@ public class EncryptSQLTest extends ParserTestBase {
                 })) {
             ctx.setEnv(env);
             ctx.setCurrentUserIdentity(UserIdentity.ROOT);
-            Config.enable_nereids_load = true;
             // testing for https://github.com/apache/doris/issues/62140
             String sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
             String res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -288,8 +288,8 @@ public class EncryptSQLTest extends ParserTestBase {
             res = "SET PASSWORD FOR 'admin' = PASSWORD('*XXX')";
             parseAndCheck(sql, res);
 
-        // create s3 job
-        sql = "CREATE JOB my_job"
+            // create s3 job
+            sql = "CREATE JOB my_job"
                 + " ON STREAMING"
                 + " DO"
                 + " INSERT INTO test.`student`"

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -290,19 +290,19 @@ public class EncryptSQLTest extends ParserTestBase {
 
             // create s3 job
             sql = "CREATE JOB my_job"
-                + " ON STREAMING"
-                + " DO"
-                + " INSERT INTO test.`student`"
-                + " SELECT * FROM S3"
-                + " ("
-                + " \"uri\" = \"s3://bucketname/demo/*.csv\","
-                + " \"format\" = \"csv\","
-                + " \"column_separator\" = \",\","
-                + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
-                + " \"s3.region\" = \"ap-southeast-1\","
-                + " \"s3.access_key\" = \"ak\","
-                + " \"s3.secret_key\" = \"abcdefg\""
-                + " );";
+                    + " ON STREAMING"
+                    + " DO"
+                    + " INSERT INTO test.`student`"
+                    + " SELECT * FROM S3"
+                    + " ("
+                    + " \"uri\" = \"s3://bucketname/demo/*.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"column_separator\" = \",\","
+                    + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
+                    + " \"s3.region\" = \"ap-southeast-1\","
+                    + " \"s3.access_key\" = \"ak\","
+                    + " \"s3.secret_key\" = \"abcdefg\""
+                    + " );";
 
             res = "CREATE JOB my_job"
                     + " ON STREAMING"

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -288,21 +288,30 @@ public class EncryptSQLTest extends ParserTestBase {
             res = "SET PASSWORD FOR 'admin' = PASSWORD('*XXX')";
             parseAndCheck(sql, res);
 
-            // create s3 job
-            sql = "CREATE JOB my_job"
-                    + " ON STREAMING"
-                    + " DO"
-                    + " INSERT INTO test.`student`"
-                    + " SELECT * FROM S3"
-                    + " ("
-                    + " \"uri\" = \"s3://bucketname/demo/*.csv\","
-                    + " \"format\" = \"csv\","
-                    + " \"column_separator\" = \",\","
-                    + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
-                    + " \"s3.region\" = \"ap-southeast-1\","
-                    + " \"s3.access_key\" = \"ak\","
-                    + " \"s3.secret_key\" = \"abcdefg\""
-                    + " );";
+        // testing for https://github.com/apache/doris/issues/62140
+        sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        parseAndCheck(sql, res);
+
+        sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        parseAndCheck(sql, res);
+
+        // create s3 job
+        sql = "CREATE JOB my_job"
+                + " ON STREAMING"
+                + " DO"
+                + " INSERT INTO test.`student`"
+                + " SELECT * FROM S3"
+                + " ("
+                + " \"uri\" = \"s3://bucketname/demo/*.csv\","
+                + " \"format\" = \"csv\","
+                + " \"column_separator\" = \",\","
+                + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
+                + " \"s3.region\" = \"ap-southeast-1\","
+                + " \"s3.access_key\" = \"ak\","
+                + " \"s3.secret_key\" = \"abcdefg\""
+                + " );";
 
             res = "CREATE JOB my_job"
                     + " ON STREAMING"

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -454,7 +454,6 @@ public class EncryptSQLTest extends ParserTestBase {
         };
         ctx.setEnv(env);
         Config.enable_nereids_load = true;
-
         // testing for https://github.com/apache/doris/issues/62140
         String sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
         String res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
@@ -472,7 +471,6 @@ public class EncryptSQLTest extends ParserTestBase {
         };
         ctx.setEnv(env);
         Config.enable_nereids_load = true;
-    
         // testing for https://github.com/apache/doris/issues/62140
         String sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
         String res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -459,7 +459,7 @@ public class EncryptSQLTest extends ParserTestBase {
         sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
         res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
         parseAndCheck(sql, res);
-    }        
+    }
 
     @Test
     public void testCreateUserPasswordMasking() throws Exception {
@@ -472,12 +472,12 @@ public class EncryptSQLTest extends ParserTestBase {
         };
         ctx.setEnv(env);
         Config.enable_nereids_load = true;
-                
+
         // testing for https://github.com/apache/doris/issues/62140
         sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
         res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
         parseAndCheck(sql, res);
-    }        
+    }
 
     private void parseAndCheck(String sql, String expected) throws Exception {
         processor.executeQuery(sql);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -456,13 +456,13 @@ public class EncryptSQLTest extends ParserTestBase {
         Config.enable_nereids_load = true;
 
         // testing for https://github.com/apache/doris/issues/62140
-        sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
-        res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        String sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        String res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
         parseAndCheck(sql, res);
     }
 
     @Test
-    public void testCreateUserPasswordMasking() throws Exception {
+    public void AlterUserPasswordMasking() throws Exception {
         ctx.setDatabase("test");
         new MockUp<StmtExecutor>() {
             @Mock
@@ -472,10 +472,10 @@ public class EncryptSQLTest extends ParserTestBase {
         };
         ctx.setEnv(env);
         Config.enable_nereids_load = true;
-
+                
         // testing for https://github.com/apache/doris/issues/62140
-        sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
-        res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        String sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        String res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
         parseAndCheck(sql, res);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -462,7 +462,7 @@ public class EncryptSQLTest extends ParserTestBase {
     }
 
     @Test
-    public void AlterUserPasswordMasking() throws Exception {
+    public void testAlterUserPasswordMasking() throws Exception {
         ctx.setDatabase("test");
         new MockUp<StmtExecutor>() {
             @Mock
@@ -472,7 +472,7 @@ public class EncryptSQLTest extends ParserTestBase {
         };
         ctx.setEnv(env);
         Config.enable_nereids_load = true;
-                
+    
         // testing for https://github.com/apache/doris/issues/62140
         String sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
         String res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -288,15 +288,6 @@ public class EncryptSQLTest extends ParserTestBase {
             res = "SET PASSWORD FOR 'admin' = PASSWORD('*XXX')";
             parseAndCheck(sql, res);
 
-        // testing for https://github.com/apache/doris/issues/62140
-        sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
-        res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
-        parseAndCheck(sql, res);
-
-        sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
-        res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
-        parseAndCheck(sql, res);
-
         // create s3 job
         sql = "CREATE JOB my_job"
                 + " ON STREAMING"
@@ -451,6 +442,42 @@ public class EncryptSQLTest extends ParserTestBase {
                     origFeType);
         }
     }
+
+    @Test
+    public void testCreateUserPasswordMasking() throws Exception {
+        ctx.setDatabase("test");
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public boolean isForwardToMaster() {
+                return false;
+            }
+        };
+        ctx.setEnv(env);
+        Config.enable_nereids_load = true;
+
+        // testing for https://github.com/apache/doris/issues/62140
+        sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        parseAndCheck(sql, res);
+    }        
+
+    @Test
+    public void testCreateUserPasswordMasking() throws Exception {
+        ctx.setDatabase("test");
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public boolean isForwardToMaster() {
+                return false;
+            }
+        };
+        ctx.setEnv(env);
+        Config.enable_nereids_load = true;
+                
+        // testing for https://github.com/apache/doris/issues/62140
+        sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        parseAndCheck(sql, res);
+    }        
 
     private void parseAndCheck(String sql, String expected) throws Exception {
         processor.executeQuery(sql);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -446,35 +446,65 @@ public class EncryptSQLTest extends ParserTestBase {
     @Test
     public void testCreateUserPasswordMasking() throws Exception {
         ctx.setDatabase("test");
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public boolean isForwardToMaster() {
-                return false;
-            }
-        };
-        ctx.setEnv(env);
-        Config.enable_nereids_load = true;
-        // testing for https://github.com/apache/doris/issues/62140
-        String sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
-        String res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
-        parseAndCheck(sql, res);
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doReturn(false).when(mock).isForwardToMaster();
+                    Profile profile = new Profile(false, 0, 0);
+                    Deencapsulation.setField(mock, "profile", profile);
+                    Mockito.doReturn(profile).when(mock).getProfile();
+                    Mockito.doReturn(ctx).when(mock).getContext();
+                    Mockito.doNothing().when(mock).execute();
+                    Deencapsulation.setField(mock, "context", ctx);
+                    if (context.arguments().size() >= 2
+                            && context.arguments().get(1) instanceof StatementBase) {
+                        Deencapsulation.setField(mock, "parsedStmt",
+                                context.arguments().get(1));
+                    }
+                    if (ctx.getStatementContext() == null) {
+                        ctx.setStatementContext(new StatementContext());
+                    }
+                })) {
+            ctx.setEnv(env);
+            ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+            Config.enable_nereids_load = true;
+            // testing for https://github.com/apache/doris/issues/62140
+            String sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+            String res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+            parseAndCheck(sql, res);
+        }
     }
 
     @Test
     public void testAlterUserPasswordMasking() throws Exception {
         ctx.setDatabase("test");
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public boolean isForwardToMaster() {
-                return false;
-            }
-        };
-        ctx.setEnv(env);
-        Config.enable_nereids_load = true;
-        // testing for https://github.com/apache/doris/issues/62140
-        String sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
-        String res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
-        parseAndCheck(sql, res);
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doReturn(false).when(mock).isForwardToMaster();
+                    Profile profile = new Profile(false, 0, 0);
+                    Deencapsulation.setField(mock, "profile", profile);
+                    Mockito.doReturn(profile).when(mock).getProfile();
+                    Mockito.doReturn(ctx).when(mock).getContext();
+                    Mockito.doNothing().when(mock).execute();
+                    Deencapsulation.setField(mock, "context", ctx);
+                    if (context.arguments().size() >= 2
+                            && context.arguments().get(1) instanceof StatementBase) {
+                        Deencapsulation.setField(mock, "parsedStmt",
+                                context.arguments().get(1));
+                    }
+                    if (ctx.getStatementContext() == null) {
+                        ctx.setStatementContext(new StatementContext());
+                    }
+                })) {
+            ctx.setEnv(env);
+            ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+            Config.enable_nereids_load = true;
+            // testing for https://github.com/apache/doris/issues/62140
+            String sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+            String res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+            parseAndCheck(sql, res);
+        }
     }
 
     private void parseAndCheck(String sql, String expected) throws Exception {


### PR DESCRIPTION
### What problem does this PR solve?

This PR adds masking for users passwords for **CREATE USER** and **ALTER USER** commands.
The masked values will be stored in audit table and audit files instead of actual values.
The same functionality already exists for **SET USER PASSWORD** and **SET LDAP_ADMIN_PASSWORD** commands, so we other commands related to passwords should be masked as well.

**Could you please include this PR into 4.x branches, please!**

Issue Number: close #62140

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [X] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

1. EncryptSQLTest.java is updated to include two checks for two mentioned commands - **ALTER USER** and **CREATE USER**

- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

