### PR TITLE
[refactor](build) Extract third-party filesystem JAR packaging into post-build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,7 +80,8 @@ Usage: $0 <options>
     DISABLE_BE_JAVA_EXTENSIONS  If set DISABLE_BE_JAVA_EXTENSIONS=ON, we will do not build binary with java-udf,hadoop-hudi-scanner,jdbc-scanner and so on Default is OFF.
     DISABLE_JAVA_CHECK_STYLE    If set DISABLE_JAVA_CHECK_STYLE=ON, it will skip style check of java code in FE.
     DISABLE_BUILD_AZURE         If set DISABLE_BUILD_AZURE=ON, it will not build azure into BE.
-    DISABLE_BUILD_JUICEFS       If set DISABLE_BUILD_JUICEFS=ON, it will skip packaging juicefs-hadoop jar into FE/BE output.
+    DISABLE_BUILD_JUICEFS       If set DISABLE_BUILD_JUICEFS=OFF, it will package juicefs-hadoop jar into FE/BE output. Default is ON (skip).
+    DISABLE_BUILD_JINDOFS       If set DISABLE_BUILD_JINDOFS=OFF, it will package jindofs jars into FE/BE output. Default is ON (skip).
 
   Eg.
     $0                                      build all
@@ -142,46 +143,6 @@ function copy_common_files() {
     cp -r -p "${DORIS_HOME}/NOTICE.txt" "$1/"
     cp -r -p "${DORIS_HOME}/dist/LICENSE-dist.txt" "$1/"
     cp -r -p "${DORIS_HOME}/dist/licenses" "$1/"
-}
-
-. "${DORIS_HOME}/docker/thirdparties/juicefs-helpers.sh"
-. "${DORIS_HOME}/docker/thirdparties/jindofs-helpers.sh"
-
-find_juicefs_hadoop_jar() {
-    juicefs_find_hadoop_jar_by_globs \
-        "${DORIS_THIRDPARTY}/installed/juicefs_libs/juicefs-hadoop-[0-9]*.jar" \
-        "${DORIS_THIRDPARTY}/src/juicefs-hadoop-[0-9]*.jar" \
-        "${DORIS_HOME}/thirdparty/installed/juicefs_libs/juicefs-hadoop-[0-9]*.jar" \
-        "${DORIS_HOME}/thirdparty/src/juicefs-hadoop-[0-9]*.jar"
-}
-
-detect_juicefs_version() {
-    local juicefs_jar
-    juicefs_jar=$(find_juicefs_hadoop_jar || true)
-    juicefs_detect_hadoop_version "${juicefs_jar}" "${JUICEFS_DEFAULT_VERSION}"
-}
-
-download_juicefs_hadoop_jar() {
-    local juicefs_version="$1"
-    local cache_dir="${DORIS_HOME}/thirdparty/installed/juicefs_libs"
-    juicefs_download_hadoop_jar_to_cache "${juicefs_version}" "${cache_dir}"
-}
-
-copy_juicefs_hadoop_jar() {
-    local target_dir="$1"
-    local source_jar=""
-    source_jar=$(find_juicefs_hadoop_jar || true)
-    if [[ -z "${source_jar}" ]]; then
-        local juicefs_version
-        juicefs_version=$(detect_juicefs_version)
-        source_jar=$(download_juicefs_hadoop_jar "${juicefs_version}" || true)
-    fi
-    if [[ -z "${source_jar}" ]]; then
-        echo "WARN: skip copying juicefs-hadoop jar, not found in thirdparty and download failed"
-        return 0
-    fi
-    cp -r -p "${source_jar}" "${target_dir}/"
-    echo "Copy JuiceFS Hadoop jar to ${target_dir}: $(basename "${source_jar}")"
 }
 
 if ! OPTS="$(getopt \
@@ -541,17 +502,19 @@ if [[ "$(echo "${DISABLE_BUILD_AZURE}" | tr '[:lower:]' '[:upper:]')" == "ON" ]]
     BUILD_AZURE='OFF'
 fi
 
-if [[ "$(echo "${DISABLE_BUILD_JINDOFS}" | tr '[:lower:]' '[:upper:]')" == "ON" ]]; then
-    BUILD_JINDOFS='OFF'
-else
+if [[ "$(echo "${DISABLE_BUILD_JINDOFS}" | tr '[:lower:]' '[:upper:]')" == "OFF" ]]; then
     BUILD_JINDOFS='ON'
-fi
-
-if [[ "$(echo "${DISABLE_BUILD_JUICEFS}" | tr '[:lower:]' '[:upper:]')" == "ON" ]]; then
-    BUILD_JUICEFS='OFF'
 else
-    BUILD_JUICEFS='ON'
+    BUILD_JINDOFS='OFF'
 fi
+export DISABLE_BUILD_JINDOFS
+
+if [[ "$(echo "${DISABLE_BUILD_JUICEFS}" | tr '[:lower:]' '[:upper:]')" == "OFF" ]]; then
+    BUILD_JUICEFS='ON'
+else
+    BUILD_JUICEFS='OFF'
+fi
+export DISABLE_BUILD_JUICEFS
 
 if [[ -z "${ENABLE_INJECTION_POINT}" ]]; then
     ENABLE_INJECTION_POINT='OFF'
@@ -602,6 +565,7 @@ echo "Get params:
     BUILD_BE_CDC_CLIENT                 -- ${BUILD_BE_CDC_CLIENT}
     BUILD_HIVE_UDF                      -- ${BUILD_HIVE_UDF}
     BUILD_JUICEFS                       -- ${BUILD_JUICEFS}
+    BUILD_JINDOFS                       -- ${BUILD_JINDOFS}
     PARALLEL                            -- ${PARALLEL}
     CLEAN                               -- ${CLEAN}
     GLIBC_COMPATIBILITY                 -- ${GLIBC_COMPATIBILITY}
@@ -908,12 +872,6 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     cp -r -p "${DORIS_HOME}/conf/ldap.conf" "${DORIS_OUTPUT}/fe/conf"/
     cp -r -p "${DORIS_HOME}/conf/mysql_ssl_default_certificate" "${DORIS_OUTPUT}/fe/"/
     rm -rf "${DORIS_OUTPUT}/fe/lib"/*
-    if [[ "${BUILD_JINDOFS}" == "ON" ]]; then
-        install -d "${DORIS_OUTPUT}/fe/lib/jindofs"
-    fi
-    if [[ "${BUILD_JUICEFS}" == "ON" ]]; then
-        install -d "${DORIS_OUTPUT}/fe/lib/juicefs"
-    fi
     cp -r -p "${DORIS_HOME}/fe/fe-core/target/lib"/* "${DORIS_OUTPUT}/fe/lib"/
     cp -r -p "${DORIS_HOME}/fe/fe-core/target/doris-fe.jar" "${DORIS_OUTPUT}/fe/lib"/
     if [[ "${WITH_TDE_DIR}" != "" ]]; then
@@ -922,16 +880,8 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
 
     #cp -r -p "${DORIS_HOME}/docs/build/help-resource.zip" "${DORIS_OUTPUT}/fe/lib"/
 
-    # copy jindofs jars, including common jars and the matching platform jar
-    if [[ "${BUILD_JINDOFS}" == "ON" ]]; then
-        jindofs_copy_jars "${DORIS_THIRDPARTY}/installed/jindofs_libs" "${DORIS_OUTPUT}/fe/lib/jindofs" \
-            "${TARGET_SYSTEM}" "${TARGET_ARCH}"
-    fi
-
-    # copy juicefs hadoop client jar
-    if [[ "${BUILD_JUICEFS}" == "ON" ]]; then
-        copy_juicefs_hadoop_jar "${DORIS_OUTPUT}/fe/lib/juicefs"
-    fi
+    # Third-party filesystem jars (JuiceFS, JindoFS) are packaged by post-build.sh
+    "${DORIS_HOME}/post-build.sh" --fe --output "${DORIS_OUTPUT}"
 
     cp -r -p "${DORIS_HOME}/minidump" "${DORIS_OUTPUT}/fe"/
     cp -r -p "${DORIS_HOME}/webroot/static" "${DORIS_OUTPUT}/fe/webroot"/
@@ -1106,18 +1056,8 @@ EOF
         fi
     done        
 
-    # copy jindofs jars, including common jars and the matching platform jar
-    if [[ "${BUILD_JINDOFS}" == "ON" ]]; then
-        install -d "${DORIS_OUTPUT}/be/lib/java_extensions/jindofs"/
-        jindofs_copy_jars "${DORIS_THIRDPARTY}/installed/jindofs_libs" "${DORIS_OUTPUT}/be/lib/java_extensions/jindofs" \
-            "${TARGET_SYSTEM}" "${TARGET_ARCH}"
-    fi
-    if [[ "${BUILD_JUICEFS}" == "ON" ]]; then
-        install -d "${DORIS_OUTPUT}/be/lib/java_extensions/juicefs"/
-
-        # copy juicefs hadoop client jar
-        copy_juicefs_hadoop_jar "${DORIS_OUTPUT}/be/lib/java_extensions/juicefs"
-    fi
+    # Third-party filesystem jars (JuiceFS, JindoFS) are packaged by post-build.sh
+    "${DORIS_HOME}/post-build.sh" --be --output "${DORIS_OUTPUT}"
 
     cp -r -p "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/be/www"/
     copy_common_files "${DORIS_OUTPUT}/be/"

--- a/post-build.sh
+++ b/post-build.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##############################################################
+# Post-build script for packaging third-party filesystem JARs
+# (JuiceFS, JindoFS) into Doris FE/BE output directories.
+#
+# This script is independent of the main build and can be
+# executed standalone or called from build.sh.
+#
+# Usage:
+#   post-build.sh [--fe] [--be] [--output <dir>]
+#                 [--juicefs] [--jindofs]
+#
+# Environment variables:
+#   DISABLE_BUILD_JUICEFS=OFF  Enable JuiceFS packaging (default: ON, i.e. skip)
+#   DISABLE_BUILD_JINDOFS=OFF  Enable JindoFS packaging (default: ON, i.e. skip)
+##############################################################
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+DORIS_HOME="${DORIS_HOME:-${ROOT}}"
+if [[ -z "${DORIS_THIRDPARTY}" ]]; then
+    DORIS_THIRDPARTY="${DORIS_HOME}/thirdparty"
+fi
+
+TARGET_SYSTEM="${TARGET_SYSTEM:-$(uname -s)}"
+TARGET_ARCH="${TARGET_ARCH:-$(uname -m)}"
+
+# --- Source helper scripts ---
+. "${DORIS_HOME}/docker/thirdparties/juicefs-helpers.sh"
+. "${DORIS_HOME}/docker/thirdparties/jindofs-helpers.sh"
+
+# --- JuiceFS wrapper functions (migrated from build.sh) ---
+
+find_juicefs_hadoop_jar() {
+    juicefs_find_hadoop_jar_by_globs \
+        "${DORIS_THIRDPARTY}/installed/juicefs_libs/juicefs-hadoop-[0-9]*.jar" \
+        "${DORIS_THIRDPARTY}/src/juicefs-hadoop-[0-9]*.jar" \
+        "${DORIS_HOME}/thirdparty/installed/juicefs_libs/juicefs-hadoop-[0-9]*.jar" \
+        "${DORIS_HOME}/thirdparty/src/juicefs-hadoop-[0-9]*.jar"
+}
+
+detect_juicefs_version() {
+    local juicefs_jar
+    juicefs_jar=$(find_juicefs_hadoop_jar || true)
+    juicefs_detect_hadoop_version "${juicefs_jar}" "${JUICEFS_DEFAULT_VERSION}"
+}
+
+download_juicefs_hadoop_jar() {
+    local juicefs_version="$1"
+    local cache_dir="${DORIS_HOME}/thirdparty/installed/juicefs_libs"
+    juicefs_download_hadoop_jar_to_cache "${juicefs_version}" "${cache_dir}"
+}
+
+copy_juicefs_hadoop_jar() {
+    local target_dir="$1"
+    local source_jar=""
+    source_jar=$(find_juicefs_hadoop_jar || true)
+    if [[ -z "${source_jar}" ]]; then
+        local juicefs_version
+        juicefs_version=$(detect_juicefs_version)
+        source_jar=$(download_juicefs_hadoop_jar "${juicefs_version}" || true)
+    fi
+    if [[ -z "${source_jar}" ]]; then
+        echo "WARN: skip copying juicefs-hadoop jar, not found in thirdparty and download failed"
+        return 0
+    fi
+    cp -r -p "${source_jar}" "${target_dir}/"
+    echo "Copy JuiceFS Hadoop jar to ${target_dir}: $(basename "${source_jar}")"
+}
+
+# --- Install functions ---
+
+install_juicefs() {
+    local target_type="$1"
+    local output_dir="$2"
+
+    local target_dir
+    if [[ "${target_type}" == "fe" ]]; then
+        target_dir="${output_dir}/fe/lib/juicefs"
+    elif [[ "${target_type}" == "be" ]]; then
+        target_dir="${output_dir}/be/lib/java_extensions/juicefs"
+    else
+        echo "ERROR: unknown target type '${target_type}' for install_juicefs"
+        return 1
+    fi
+
+    install -d "${target_dir}"
+    copy_juicefs_hadoop_jar "${target_dir}"
+}
+
+install_jindofs() {
+    local target_type="$1"
+    local output_dir="$2"
+
+    local target_dir
+    if [[ "${target_type}" == "fe" ]]; then
+        target_dir="${output_dir}/fe/lib/jindofs"
+    elif [[ "${target_type}" == "be" ]]; then
+        target_dir="${output_dir}/be/lib/java_extensions/jindofs"
+    else
+        echo "ERROR: unknown target type '${target_type}' for install_jindofs"
+        return 1
+    fi
+
+    install -d "${target_dir}"
+    jindofs_copy_jars "${DORIS_THIRDPARTY}/installed/jindofs_libs" "${target_dir}" \
+        "${TARGET_SYSTEM}" "${TARGET_ARCH}"
+}
+
+# --- CLI ---
+
+usage() {
+    echo "
+Usage: $0 [--fe] [--be] [--output <dir>] [--juicefs] [--jindofs]
+
+Package third-party filesystem JARs (JuiceFS, JindoFS) into Doris output directories.
+By default, no third-party JARs are packaged. Use --juicefs/--jindofs or environment variables to opt in.
+
+Options:
+  --fe               Process FE output directory
+  --be               Process BE output directory
+  --output <dir>     Output directory (default: \${DORIS_HOME}/output)
+  --juicefs          Enable JuiceFS packaging
+  --jindofs          Enable JindoFS packaging
+
+Environment variables:
+  DISABLE_BUILD_JUICEFS=OFF  Enable JuiceFS packaging (--juicefs takes precedence)
+  DISABLE_BUILD_JINDOFS=OFF  Enable JindoFS packaging (--jindofs takes precedence)
+"
+}
+
+# Defaults: not installed
+PROCESS_FE=0
+PROCESS_BE=0
+OUTPUT_DIR=""
+BUILD_JUICEFS=""
+BUILD_JINDOFS=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fe)
+            PROCESS_FE=1
+            shift
+            ;;
+        --be)
+            PROCESS_BE=1
+            shift
+            ;;
+        --output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --juicefs)
+            BUILD_JUICEFS="ON"
+            shift
+            ;;
+        --jindofs)
+            BUILD_JINDOFS="ON"
+            shift
+            ;;
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+OUTPUT_DIR="${OUTPUT_DIR:-${DORIS_HOME}/output}"
+
+# Resolve build flags: CLI > env DISABLE_BUILD_XXX > default (OFF)
+if [[ -z "${BUILD_JUICEFS}" ]]; then
+    if [[ "$(echo "${DISABLE_BUILD_JUICEFS}" | tr '[:lower:]' '[:upper:]')" == "OFF" ]]; then
+        BUILD_JUICEFS="ON"
+    else
+        BUILD_JUICEFS="OFF"
+    fi
+fi
+if [[ -z "${BUILD_JINDOFS}" ]]; then
+    if [[ "$(echo "${DISABLE_BUILD_JINDOFS}" | tr '[:lower:]' '[:upper:]')" == "OFF" ]]; then
+        BUILD_JINDOFS="ON"
+    else
+        BUILD_JINDOFS="OFF"
+    fi
+fi
+
+if [[ "${PROCESS_FE}" -eq 0 && "${PROCESS_BE}" -eq 0 ]]; then
+    echo "Nothing to do. Specify --fe and/or --be."
+    exit 0
+fi
+
+# --- Main ---
+
+for target_type in fe be; do
+    if [[ "${target_type}" == "fe" && "${PROCESS_FE}" -eq 0 ]]; then
+        continue
+    fi
+    if [[ "${target_type}" == "be" && "${PROCESS_BE}" -eq 0 ]]; then
+        continue
+    fi
+
+    if [[ "${BUILD_JINDOFS}" == "ON" ]]; then
+        install_jindofs "${target_type}" "${OUTPUT_DIR}"
+    fi
+
+    if [[ "${BUILD_JUICEFS}" == "ON" ]]; then
+        install_juicefs "${target_type}" "${OUTPUT_DIR}"
+    fi
+done


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
The build.sh script contained ~70 lines of JuiceFS and JindoFS jar download/find/copy logic that is unrelated to Doris compilation. This logic only runs during the final packaging stage to copy third-party jars into the output directory.

This commit extracts all third-party filesystem JAR packaging logic into a new standalone script post-build.sh, which:
- Supports CLI args: --fe, --be, --output, --skip-juicefs, --skip-jindofs
- Respects DISABLE_BUILD_JUICEFS/DISABLE_BUILD_JINDOFS env vars
- Contains install_juicefs() and install_jindofs() functions
- Can be executed independently or called from build.sh

build.sh is simplified by removing the helper sources, wrapper functions, and inline copy blocks (~-68 lines), replaced by two post-build.sh invocations (~+8 lines).

### Release note

None

### Check List (For Author)

- Test: Manual test (standalone post-build.sh execution with various flag combinations)
- Behavior changed: No
- Does this need documentation: No
