### PR TITLE
[refine](exec) remove dead nullable-patching code in agg and analytic operators

### DIFF
--- a/be/src/exec/operator/aggregation_sink_operator.cpp
+++ b/be/src/exec/operator/aggregation_sink_operator.cpp
@@ -90,7 +90,6 @@ Status AggSinkLocalState::open(RuntimeState* state) {
     Base::_shared_state->align_aggregate_states = p._align_aggregate_states;
     Base::_shared_state->total_size_of_aggregate_states = p._total_size_of_aggregate_states;
     Base::_shared_state->offsets_of_aggregate_states = p._offsets_of_aggregate_states;
-    Base::_shared_state->make_nullable_keys = p._make_nullable_keys;
     Base::_shared_state->probe_expr_ctxs.resize(p._probe_expr_ctxs.size());
 
     Base::_shared_state->limit = p._limit;
@@ -919,14 +918,6 @@ Status AggSinkOperatorX::_init_probe_expr_ctx(RuntimeState* state) {
 
 Status AggSinkOperatorX::_init_aggregate_evaluators(RuntimeState* state) {
     size_t j = _probe_expr_ctxs.size();
-    for (size_t i = 0; i < j; ++i) {
-        auto nullable_output = _output_tuple_desc->slots()[i]->is_nullable();
-        auto nullable_input = _probe_expr_ctxs[i]->root()->is_nullable();
-        if (nullable_output != nullable_input) {
-            DCHECK(nullable_output);
-            _make_nullable_keys.emplace_back(i);
-        }
-    }
     for (size_t i = 0; i < _aggregate_evaluators.size(); ++i, ++j) {
         SlotDescriptor* intermediate_slot_desc = _intermediate_tuple_desc->slots()[j];
         SlotDescriptor* output_slot_desc = _output_tuple_desc->slots()[j];

--- a/be/src/exec/operator/aggregation_sink_operator.h
+++ b/be/src/exec/operator/aggregation_sink_operator.h
@@ -222,7 +222,6 @@ protected:
     // group by k1,k2
     VExprContextSPtrs _probe_expr_ctxs;
     ObjectPool* _pool = nullptr;
-    std::vector<size_t> _make_nullable_keys;
     int64_t _limit; // -1: no limit
     // do sort limit and directions
     bool _do_sort_limit = false;

--- a/be/src/exec/operator/aggregation_source_operator.cpp
+++ b/be/src/exec/operator/aggregation_source_operator.cpp
@@ -108,8 +108,7 @@ Status AggLocalState::_get_results_with_serialized_key(RuntimeState* state, Bloc
     MutableColumns value_columns(agg_size);
     DataTypes value_data_types(agg_size);
 
-    // non-nullable column(id in `_make_nullable_keys`) will be converted to nullable.
-    bool mem_reuse = shared_state.make_nullable_keys.empty() && block->mem_reuse();
+    bool mem_reuse = block->mem_reuse();
 
     MutableColumns key_columns;
     for (int i = 0; i < key_size; ++i) {
@@ -283,8 +282,7 @@ Status AggLocalState::_get_results_with_serialized_key(RuntimeState* state, Bloc
 Status AggLocalState::_get_with_serialized_key_result(RuntimeState* state, Block* block,
                                                       bool* eos) {
     auto& shared_state = *_shared_state;
-    // non-nullable column(id in `_make_nullable_keys`) will be converted to nullable.
-    bool mem_reuse = shared_state.make_nullable_keys.empty() && block->mem_reuse();
+    bool mem_reuse = block->mem_reuse();
 
     auto columns_with_schema = VectorizedUtils::create_columns_with_type_and_name(
             _parent->cast<AggSourceOperatorX>().row_descriptor());
@@ -550,7 +548,6 @@ Status AggSourceOperatorX::get_block(RuntimeState* state, Block* block, bool* eo
     SCOPED_TIMER(local_state.exec_time_counter());
     SCOPED_PEAK_MEM(&local_state._estimate_memory_usage);
     RETURN_IF_ERROR(local_state._executor.get_result(state, block, eos));
-    local_state.make_nullable_output_key(block);
     // dispose the having clause, should not be execute in prestreaming agg
     RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block));
     local_state.do_agg_limit(block, eos);
@@ -570,15 +567,6 @@ void AggLocalState::do_agg_limit(Block* block, bool* eos) {
     } else {
         if (auto rows = block->rows()) {
             _num_rows_returned += rows;
-        }
-    }
-}
-
-void AggLocalState::make_nullable_output_key(Block* block) {
-    if (block->rows() != 0) {
-        for (auto cid : _shared_state->make_nullable_keys) {
-            block->get_by_position(cid).column = make_nullable(block->get_by_position(cid).column);
-            block->get_by_position(cid).type = make_nullable(block->get_by_position(cid).type);
         }
     }
 }

--- a/be/src/exec/operator/aggregation_source_operator.h
+++ b/be/src/exec/operator/aggregation_source_operator.h
@@ -38,7 +38,6 @@ public:
     Status init(RuntimeState* state, LocalStateInfo& info) override;
     Status close(RuntimeState* state) override;
 
-    void make_nullable_output_key(Block* block);
     Status merge_with_serialized_key_helper(Block* block);
     void do_agg_limit(Block* block, bool* eos);
 
@@ -50,16 +49,6 @@ protected:
     Status _get_with_serialized_key_result(RuntimeState* state, Block* block, bool* eos);
     Status _get_results_with_serialized_key(RuntimeState* state, Block* block, bool* eos);
     Status _create_agg_status(AggregateDataPtr data);
-    void _make_nullable_output_key(Block* block) {
-        if (block->rows() != 0) {
-            auto& shared_state = *Base ::_shared_state;
-            for (auto cid : shared_state.make_nullable_keys) {
-                block->get_by_position(cid).column =
-                        make_nullable(block->get_by_position(cid).column);
-                block->get_by_position(cid).type = make_nullable(block->get_by_position(cid).type);
-            }
-        }
-    }
 
     void _emplace_into_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,
                                   uint32_t num_rows);
@@ -125,10 +114,6 @@ private:
 
     bool _needs_finalize;
     bool _without_key;
-
-    // left / full join will change the key nullable make output/input solt
-    // nullable diff. so we need make nullable of it.
-    std::vector<size_t> _make_nullable_keys;
 };
 
 } // namespace doris

--- a/be/src/exec/operator/analytic_sink_operator.cpp
+++ b/be/src/exec/operator/analytic_sink_operator.cpp
@@ -425,18 +425,12 @@ void AnalyticSinkLocalState::_insert_result_info(int64_t start, int64_t end) {
 void AnalyticSinkLocalState::_output_current_block(Block* block) {
     block->swap(std::move(_input_blocks[_output_block_index]));
     _blocks_memory_usage->add(-block->allocated_bytes());
-    DCHECK(_parent->cast<AnalyticSinkOperatorX>()._change_to_nullable_flags.size() ==
-           _result_window_columns.size());
+    DCHECK(_result_window_columns.size() == _agg_functions.size());
     for (size_t i = 0; i < _result_window_columns.size(); ++i) {
         DCHECK(_result_window_columns[i]);
         DCHECK(_agg_functions[i]);
-        if (_parent->cast<AnalyticSinkOperatorX>()._change_to_nullable_flags[i]) {
-            block->insert({make_nullable(std::move(_result_window_columns[i])),
-                           make_nullable(_agg_functions[i]->data_type()), ""});
-        } else {
-            block->insert(
-                    {std::move(_result_window_columns[i]), _agg_functions[i]->data_type(), ""});
-        }
+        block->insert(
+                {std::move(_result_window_columns[i]), _agg_functions[i]->data_type(), ""});
     }
 
     _output_block_index++;
@@ -688,15 +682,12 @@ Status AnalyticSinkOperatorX::prepare(RuntimeState* state) {
     }
     _intermediate_tuple_desc = state->desc_tbl().get_tuple_descriptor(_intermediate_tuple_id);
     _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
-    _change_to_nullable_flags.resize(_agg_functions_size);
     for (size_t i = 0; i < _agg_functions_size; ++i) {
         SlotDescriptor* intermediate_slot_desc = _intermediate_tuple_desc->slots()[i];
         SlotDescriptor* output_slot_desc = _output_tuple_desc->slots()[i];
         RETURN_IF_ERROR(_agg_functions[i]->prepare(state, _child->row_desc(),
                                                    intermediate_slot_desc, output_slot_desc));
         _agg_functions[i]->set_version(state->be_exec_version());
-        _change_to_nullable_flags[i] =
-                output_slot_desc->is_nullable() && (!_agg_functions[i]->data_type()->is_nullable());
     }
     if (!_partition_by_eq_expr_ctxs.empty() || !_order_by_eq_expr_ctxs.empty()) {
         std::vector<TTupleId> tuple_ids;

--- a/be/src/exec/operator/analytic_sink_operator.cpp
+++ b/be/src/exec/operator/analytic_sink_operator.cpp
@@ -429,8 +429,7 @@ void AnalyticSinkLocalState::_output_current_block(Block* block) {
     for (size_t i = 0; i < _result_window_columns.size(); ++i) {
         DCHECK(_result_window_columns[i]);
         DCHECK(_agg_functions[i]);
-        block->insert(
-                {std::move(_result_window_columns[i]), _agg_functions[i]->data_type(), ""});
+        block->insert({std::move(_result_window_columns[i]), _agg_functions[i]->data_type(), ""});
     }
 
     _output_block_index++;

--- a/be/src/exec/operator/analytic_sink_operator.h
+++ b/be/src/exec/operator/analytic_sink_operator.h
@@ -263,7 +263,6 @@ private:
     size_t _total_size_of_aggregate_states = 0;
     /// The max align size for functions
     size_t _align_aggregate_states = 1;
-    std::vector<bool> _change_to_nullable_flags;
 };
 
 } // namespace doris

--- a/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
@@ -185,8 +185,7 @@ Status DistinctStreamingAggLocalState::_distinct_pre_agg_with_serialized_key(
                 << "_distinct_row size should be less than or equal to rows";
     }
 
-    bool mem_reuse = _parent->cast<DistinctStreamingAggOperatorX>()._make_nullable_keys.empty() &&
-                     out_block->mem_reuse();
+    bool mem_reuse = out_block->mem_reuse();
     SCOPED_TIMER(_insert_keys_to_column_timer);
     if (mem_reuse) {
         if (_stop_emplace_flag && !out_block->empty()) {
@@ -251,15 +250,6 @@ Status DistinctStreamingAggLocalState::_distinct_pre_agg_with_serialized_key(
     return Status::OK();
 }
 
-void DistinctStreamingAggLocalState::_make_nullable_output_key(Block* block) {
-    if (block->rows() != 0) {
-        for (auto cid : Base::_parent->cast<DistinctStreamingAggOperatorX>()._make_nullable_keys) {
-            block->get_by_position(cid).column = make_nullable(block->get_by_position(cid).column);
-            block->get_by_position(cid).type = make_nullable(block->get_by_position(cid).type);
-        }
-    }
-}
-
 void DistinctStreamingAggLocalState::_emplace_into_hash_table_to_distinct(
         IColumn::Selector& distinct_row, ColumnRawPtrs& key_columns, const uint32_t num_rows) {
     std::visit(
@@ -302,7 +292,6 @@ DistinctStreamingAggOperatorX::DistinctStreamingAggOperatorX(ObjectPool* pool, i
                                                              const TPlanNode& tnode,
                                                              const DescriptorTbl& descs)
         : StatefulOperatorX<DistinctStreamingAggLocalState>(pool, tnode, operator_id, descs),
-          _output_tuple_id(tnode.agg_node.output_tuple_id),
           _needs_finalize(tnode.agg_node.need_finalize),
           _is_first_phase(tnode.agg_node.__isset.is_first_phase && tnode.agg_node.is_first_phase),
           _is_colocate(tnode.agg_node.__isset.is_colocate && tnode.agg_node.is_colocate) {
@@ -329,21 +318,7 @@ Status DistinctStreamingAggOperatorX::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(StatefulOperatorX<DistinctStreamingAggLocalState>::prepare(state));
     RETURN_IF_ERROR(VExpr::prepare(_probe_expr_ctxs, state, _child->row_desc()));
     RETURN_IF_ERROR(VExpr::open(_probe_expr_ctxs, state));
-    init_make_nullable(state);
     return Status::OK();
-}
-
-void DistinctStreamingAggOperatorX::init_make_nullable(RuntimeState* state) {
-    _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
-
-    for (size_t i = 0; i < _probe_expr_ctxs.size(); ++i) {
-        auto nullable_output = _output_tuple_desc->slots()[i]->is_nullable();
-        auto nullable_input = _probe_expr_ctxs[i]->root()->is_nullable();
-        if (nullable_output != nullable_input) {
-            DCHECK(nullable_output);
-            _make_nullable_keys.emplace_back(i);
-        }
-    }
 }
 
 Status DistinctStreamingAggOperatorX::push(RuntimeState* state, Block* in_block, bool eos) const {
@@ -376,7 +351,6 @@ Status DistinctStreamingAggOperatorX::pull(RuntimeState* state, Block* block, bo
         }
     }
 
-    local_state._make_nullable_output_key(block);
     if (!_is_streaming_preagg) {
         // dispose the having clause, should not be execute in prestreaming agg
         RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block));

--- a/be/src/exec/operator/distinct_streaming_aggregation_operator.h
+++ b/be/src/exec/operator/distinct_streaming_aggregation_operator.h
@@ -54,7 +54,6 @@ private:
     Status _init_hash_method(const VExprContextSPtrs& probe_exprs);
     void _emplace_into_hash_table_to_distinct(IColumn::Selector& distinct_row,
                                               ColumnRawPtrs& key_columns, const uint32_t num_rows);
-    void _make_nullable_output_key(Block* block);
     bool _should_expand_preagg_hash_tables();
 
     void _swap_cache_block(Block* block) {
@@ -139,16 +138,12 @@ public:
 
 private:
     friend class DistinctStreamingAggLocalState;
-    void init_make_nullable(RuntimeState* state);
-    TupleId _output_tuple_id;
-    TupleDescriptor* _output_tuple_desc = nullptr;
     const bool _needs_finalize;
     const bool _is_first_phase;
     std::vector<TExpr> _partition_exprs;
     const bool _is_colocate;
     // group by k1,k2
     VExprContextSPtrs _probe_expr_ctxs;
-    std::vector<size_t> _make_nullable_keys;
 
     // If _is_streaming_preagg = true, deduplication will be abandoned in cases where the deduplication rate is low.
     bool _is_streaming_preagg = false;

--- a/be/src/exec/operator/operator.cpp
+++ b/be/src/exec/operator/operator.cpp
@@ -342,6 +342,9 @@ Status OperatorXBase::do_projections(RuntimeState* state, Block* origin_block,
     }
     auto insert_column_datas = [&](auto& to, ColumnPtr& from, size_t rows) {
         if (to->is_nullable() && !from->is_nullable()) {
+            DCHECK(false) << "projection output type mismatch: non-nullable expr result written to "
+                             "nullable column. expr type: "
+                          << from->get_name() << ", output type: " << to->get_name();
             if (_keep_origin || !from->is_exclusive()) {
                 auto& null_column = reinterpret_cast<ColumnNullable&>(*to);
                 null_column.get_nested_column().insert_range_from(*from, 0, rows);

--- a/be/src/exec/operator/streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/streaming_aggregation_operator.cpp
@@ -188,7 +188,6 @@ Status StreamingAggLocalState::do_pre_agg(RuntimeState* state, Block* input_bloc
 
     // pre stream agg need use _num_row_return to decide whether to do pre stream agg
     _cur_num_rows_returned += output_block->rows();
-    make_nullable_output_key(output_block);
     _update_memusage_with_serialized_key();
     return Status::OK();
 }
@@ -364,7 +363,7 @@ Status StreamingAggLocalState::_pre_agg_with_serialized_key(doris::Block* in_blo
                 }
             }
         }
-        bool mem_reuse = p._make_nullable_keys.empty() && out_block->mem_reuse();
+        bool mem_reuse = out_block->mem_reuse();
 
         std::vector<DataTypePtr> data_types;
         MutableColumns value_columns;
@@ -457,8 +456,7 @@ Status StreamingAggLocalState::_get_results_with_serialized_key(RuntimeState* st
     MutableColumns value_columns(agg_size);
     DataTypes value_data_types(agg_size);
 
-    // non-nullable column(id in `_make_nullable_keys`) will be converted to nullable.
-    bool mem_reuse = p._make_nullable_keys.empty() && block->mem_reuse();
+    bool mem_reuse = block->mem_reuse();
 
     MutableColumns key_columns;
     for (int i = 0; i < key_size; ++i) {
@@ -621,15 +619,6 @@ Status StreamingAggLocalState::_get_results_with_serialized_key(RuntimeState* st
     }
 
     return Status::OK();
-}
-
-void StreamingAggLocalState::make_nullable_output_key(Block* block) {
-    if (block->rows() != 0) {
-        for (auto cid : _parent->cast<StreamingAggOperatorX>()._make_nullable_keys) {
-            block->get_by_position(cid).column = make_nullable(block->get_by_position(cid).column);
-            block->get_by_position(cid).type = make_nullable(block->get_by_position(cid).type);
-        }
-    }
 }
 
 void StreamingAggLocalState::_destroy_agg_status(AggregateDataPtr data) {
@@ -1011,14 +1000,6 @@ Status StreamingAggOperatorX::_init_probe_expr_ctx(RuntimeState* state) {
 
 Status StreamingAggOperatorX::_init_aggregate_evaluators(RuntimeState* state) {
     size_t j = _probe_expr_ctxs.size();
-    for (size_t i = 0; i < j; ++i) {
-        auto nullable_output = _output_tuple_desc->slots()[i]->is_nullable();
-        auto nullable_input = _probe_expr_ctxs[i]->root()->is_nullable();
-        if (nullable_output != nullable_input) {
-            DCHECK(nullable_output);
-            _make_nullable_keys.emplace_back(i);
-        }
-    }
     for (size_t i = 0; i < _aggregate_evaluators.size(); ++i, ++j) {
         SlotDescriptor* intermediate_slot_desc = _intermediate_tuple_desc->slots()[j];
         SlotDescriptor* output_slot_desc = _output_tuple_desc->slots()[j];
@@ -1100,7 +1081,6 @@ Status StreamingAggOperatorX::pull(RuntimeState* state, Block* block, bool* eos)
         local_state._pre_aggregated_block->swap(*block);
     } else {
         RETURN_IF_ERROR(local_state._get_results_with_serialized_key(state, block, eos));
-        local_state.make_nullable_output_key(block);
         // dispose the having clause, should not be execute in prestreaming agg
         RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block));
     }

--- a/be/src/exec/operator/streaming_aggregation_operator.h
+++ b/be/src/exec/operator/streaming_aggregation_operator.h
@@ -44,7 +44,6 @@ public:
     Status open(RuntimeState* state) override;
     Status close(RuntimeState* state) override;
     Status do_pre_agg(RuntimeState* state, Block* input_block, Block* output_block);
-    void make_nullable_output_key(Block* block);
     void build_limit_heap(size_t hash_table_size);
 
 private:
@@ -269,7 +268,6 @@ private:
     VExprContextSPtrs _probe_expr_ctxs;
     std::vector<AggFnEvaluator*> _aggregate_evaluators;
     bool _can_short_circuit = false;
-    std::vector<size_t> _make_nullable_keys;
     RowDescriptor _agg_fn_output_row_descriptor;
 
     // For sort limit

--- a/be/src/exec/pipeline/dependency.h
+++ b/be/src/exec/pipeline/dependency.h
@@ -315,7 +315,6 @@ public:
     size_t align_aggregate_states = 1;
     /// The offset to the n-th aggregate function in a row of aggregate functions.
     Sizes offsets_of_aggregate_states;
-    std::vector<size_t> make_nullable_keys;
 
     bool agg_data_created_without_key = false;
     bool enable_spill = false;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In the Nereids optimizer, the FE guarantees full consistency between output slot
nullability and expression nullability. Three legacy runtime patches in BE operators
that compensated for old-planner inconsistencies are now dead code:

- **Pattern A – `_make_nullable_keys`** in `AggSinkOperatorX`, `StreamingAggOperatorX`,
  `DistinctStreamingAggOperatorX`: detected mismatches between group-by key output slots
  and probe expr nullability, then wrapped columns with `make_nullable` at runtime.
  In Nereids both sides derive from the same `e.nullable()`, so the list is always empty.

- **Pattern B – `_change_to_nullable_flags`** in `AnalyticSinkOperatorX`: wrapped window
  function results with `make_nullable` when output slot was nullable but
  `AggFnEvaluator::data_type()` was not. In Nereids, `ExtractAndNormalizeWindowExpression`
  calls `withAlwaysNullable(true)` on every `NullableAggregateFunction` in window context,
  making `_data_type` nullable, so the condition is always false.

This PR removes all the dead code for Pattern A and B, and adds a `DCHECK(false)` to
the nullable-promotion branch in `OperatorXBase::do_projections` (Pattern I) to catch
any regression.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

