### PR TITLE
[opt](nereids) Adopt a conservative strategy for bucket shuffle join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -281,12 +281,12 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<List<List<PhysicalP
         if (!isEnableBucketShuffleJoin) {
             return true;
         } else if (!(oneSidePlan instanceof GroupPlan)) {
-            return false;
+            return true;
         } else {
             PhysicalOlapScan candidate = findDownGradeBucketShuffleCandidate((GroupPlan) oneSidePlan);
             if (candidate == null || candidate.getTable() == null
                     || candidate.getTable().getDefaultDistributionInfo() == null) {
-                return false;
+                return true;
             } else {
                 int prunedPartNum = candidate.getSelectedPartitionIds().size();
                 int bucketNum = candidate.getTable().getDefaultDistributionInfo().getBucketNum();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulatorTest.java
@@ -21,14 +21,22 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.cost.Cost;
 import org.apache.doris.nereids.cost.CostCalculator;
+import org.apache.doris.nereids.hint.DistributeHint;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DistributionSpecHash.ShuffleType;
+import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalLimit;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -138,6 +146,212 @@ public class ChildrenPropertiesRegulatorTest {
     @Test
     public void testMustShuffleFilterLimit() {
         testMustShuffleFilter(PhysicalLimit.class);
+    }
+
+    /**
+     * Test that isBucketShuffleDownGrade returns true when oneSidePlan is not a GroupPlan (line 284 change).
+     * Previously this returned false (no downgrade). Now it returns true (conservative downgrade).
+     * With NATURAL+NATURAL distribution on both sides, the left check is triggered and since
+     * hashJoin.child(0) is a plain Plan mock (not GroupPlan), both sides must be downgraded to
+     * EXECUTION_BUCKETED.
+     */
+    @Test
+    public void testBucketShuffleDownGradeWhenOneSidePlanNotGroupPlan() {
+        try (MockedStatic<CostCalculator> mockedCostCalculator = Mockito.mockStatic(CostCalculator.class);
+                MockedStatic<ConnectContext> mockedConnectContext = Mockito.mockStatic(ConnectContext.class)) {
+            mockedCostCalculator.when(() -> CostCalculator.calculateCost(Mockito.any(), Mockito.any(),
+                    Mockito.anyList())).thenReturn(Cost.zero());
+            mockedCostCalculator.when(() -> CostCalculator.addChildCost(Mockito.any(), Mockito.any(),
+                    Mockito.any(), Mockito.any(), Mockito.anyInt())).thenReturn(Cost.zero());
+
+            ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+            SessionVariable sv = Mockito.mock(SessionVariable.class);
+            Mockito.when(connectContext.getSessionVariable()).thenReturn(sv);
+            Mockito.when(sv.isEnableBucketShuffleJoin()).thenReturn(true);
+            Mockito.when(sv.isDisableColocatePlan()).thenReturn(true);
+            mockedConnectContext.when(ConnectContext::get).thenReturn(connectContext);
+
+            ExprId leftExprId = new ExprId(0);
+            ExprId rightExprId = new ExprId(1);
+
+            DistributionSpecHash leftHashSpec = new DistributionSpecHash(
+                    Lists.newArrayList(leftExprId), ShuffleType.NATURAL, 1L, Sets.newHashSet(100L));
+            DistributionSpecHash rightHashSpec = new DistributionSpecHash(
+                    Lists.newArrayList(rightExprId), ShuffleType.NATURAL, 2L, Sets.newHashSet(200L));
+
+            PhysicalProperties leftOriginProp = new PhysicalProperties(leftHashSpec);
+            PhysicalProperties rightOriginProp = new PhysicalProperties(rightHashSpec);
+            List<PhysicalProperties> originProps = Lists.newArrayList(leftOriginProp, rightOriginProp);
+            List<PhysicalProperties> requiredProps = Lists.newArrayList(
+                    new PhysicalProperties(new DistributionSpecHash(
+                            Lists.newArrayList(leftExprId), ShuffleType.NATURAL, 1L, Sets.newHashSet(100L))),
+                    new PhysicalProperties(new DistributionSpecHash(
+                            Lists.newArrayList(rightExprId), ShuffleType.NATURAL, 2L, Sets.newHashSet(200L))));
+
+            // hashJoin.child(0) is NOT a GroupPlan — triggers the "not GroupPlan" branch in isBucketShuffleDownGrade
+            Plan nonGroupPlanChild = Mockito.mock(Plan.class);
+            Mockito.when(nonGroupPlanChild.getAllChildrenTypes()).thenReturn(new BitSet());
+
+            // Right child of the hash join is a normal GroupPlan
+            Group rightInnerGroup = Mockito.mock(Group.class);
+            Mockito.when(rightInnerGroup.getLogicalProperties()).thenReturn(Mockito.mock(LogicalProperties.class));
+            GroupPlan rightGroupPlan = new GroupPlan(rightInnerGroup);
+            Mockito.when(rightInnerGroup.getGroupPlan()).thenReturn(rightGroupPlan);
+
+            // Left GroupExpression for ChildrenPropertiesRegulator's children list
+            Group leftChildGroup = Mockito.mock(Group.class);
+            Mockito.when(leftChildGroup.getLogicalProperties()).thenReturn(Mockito.mock(LogicalProperties.class));
+            GroupPlan leftChildGroupPlan = new GroupPlan(leftChildGroup);
+            Mockito.when(leftChildGroup.getGroupPlan()).thenReturn(leftChildGroupPlan);
+            GroupExpression leftChildGE = Mockito.mock(GroupExpression.class);
+            Mockito.when(leftChildGE.getOwnerGroup()).thenReturn(leftChildGroup);
+            Mockito.when(leftChildGE.getOutputProperties(Mockito.any())).thenReturn(leftOriginProp);
+            Map<PhysicalProperties, Pair<Cost, List<PhysicalProperties>>> leftLCT = Maps.newHashMap();
+            leftLCT.put(leftOriginProp, Pair.of(Cost.zero(), Lists.newArrayList()));
+            Mockito.when(leftChildGE.getLowestCostTable()).thenReturn(leftLCT);
+            Mockito.when(leftChildGE.getPlan()).thenReturn(Mockito.mock(Plan.class));
+
+            // Right GroupExpression for ChildrenPropertiesRegulator's children list
+            GroupExpression rightChildGE = Mockito.mock(GroupExpression.class);
+            Mockito.when(rightChildGE.getOwnerGroup()).thenReturn(rightInnerGroup);
+            Mockito.when(rightChildGE.getOutputProperties(Mockito.any())).thenReturn(rightOriginProp);
+            Map<PhysicalProperties, Pair<Cost, List<PhysicalProperties>>> rightLCT = Maps.newHashMap();
+            rightLCT.put(rightOriginProp, Pair.of(Cost.zero(), Lists.newArrayList()));
+            Mockito.when(rightChildGE.getLowestCostTable()).thenReturn(rightLCT);
+            Mockito.when(rightChildGE.getPlan()).thenReturn(Mockito.mock(Plan.class));
+
+            // Construct hash join with nonGroupPlanChild as first child
+            LogicalProperties logicalProps = Mockito.mock(LogicalProperties.class);
+            PhysicalHashJoin<Plan, GroupPlan> hashJoin = new PhysicalHashJoin<>(
+                    JoinType.INNER_JOIN,
+                    Lists.newArrayList(),
+                    Lists.newArrayList(),
+                    new DistributeHint(DistributeType.NONE),
+                    Optional.empty(),
+                    logicalProps,
+                    nonGroupPlanChild,
+                    rightGroupPlan);
+
+            GroupExpression parent = new GroupExpression(hashJoin);
+            ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(
+                    parent,
+                    Lists.newArrayList(leftChildGE, rightChildGE),
+                    originProps,
+                    requiredProps,
+                    mockedJobContext);
+
+            List<List<PhysicalProperties>> result = regulator.adjustChildrenProperties();
+
+            // Both sides should be downgraded to EXECUTION_BUCKETED because left child is not GroupPlan
+            Assertions.assertEquals(1, result.size());
+            Assertions.assertInstanceOf(DistributionSpecHash.class, result.get(0).get(0).getDistributionSpec());
+            Assertions.assertEquals(ShuffleType.EXECUTION_BUCKETED,
+                    ((DistributionSpecHash) result.get(0).get(0).getDistributionSpec()).getShuffleType());
+        }
+    }
+
+    /**
+     * Test that isBucketShuffleDownGrade returns true when the candidate OlapScan is null (line 289 change).
+     * Previously this returned false (no downgrade). Now it returns true (conservative downgrade).
+     * hashJoin.child(0) IS a GroupPlan, but its group's physical expression is a join node (not an
+     * OlapScan), so findDownGradeBucketShuffleCandidate returns null and downgrade is triggered.
+     */
+    @Test
+    public void testBucketShuffleDownGradeWhenCandidateIsNull() {
+        try (MockedStatic<CostCalculator> mockedCostCalculator = Mockito.mockStatic(CostCalculator.class);
+                MockedStatic<ConnectContext> mockedConnectContext = Mockito.mockStatic(ConnectContext.class)) {
+            mockedCostCalculator.when(() -> CostCalculator.calculateCost(Mockito.any(), Mockito.any(),
+                    Mockito.anyList())).thenReturn(Cost.zero());
+            mockedCostCalculator.when(() -> CostCalculator.addChildCost(Mockito.any(), Mockito.any(),
+                    Mockito.any(), Mockito.any(), Mockito.anyInt())).thenReturn(Cost.zero());
+
+            ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+            SessionVariable sv = Mockito.mock(SessionVariable.class);
+            Mockito.when(connectContext.getSessionVariable()).thenReturn(sv);
+            Mockito.when(sv.isEnableBucketShuffleJoin()).thenReturn(true);
+            Mockito.when(sv.isDisableColocatePlan()).thenReturn(true);
+            mockedConnectContext.when(ConnectContext::get).thenReturn(connectContext);
+
+            ExprId leftExprId = new ExprId(0);
+            ExprId rightExprId = new ExprId(1);
+
+            DistributionSpecHash leftHashSpec = new DistributionSpecHash(
+                    Lists.newArrayList(leftExprId), ShuffleType.NATURAL, 1L, Sets.newHashSet(100L));
+            DistributionSpecHash rightHashSpec = new DistributionSpecHash(
+                    Lists.newArrayList(rightExprId), ShuffleType.NATURAL, 2L, Sets.newHashSet(200L));
+
+            PhysicalProperties leftOriginProp = new PhysicalProperties(leftHashSpec);
+            PhysicalProperties rightOriginProp = new PhysicalProperties(rightHashSpec);
+            List<PhysicalProperties> originProps = Lists.newArrayList(leftOriginProp, rightOriginProp);
+            List<PhysicalProperties> requiredProps = Lists.newArrayList(
+                    new PhysicalProperties(new DistributionSpecHash(
+                            Lists.newArrayList(leftExprId), ShuffleType.NATURAL, 1L, Sets.newHashSet(100L))),
+                    new PhysicalProperties(new DistributionSpecHash(
+                            Lists.newArrayList(rightExprId), ShuffleType.NATURAL, 2L, Sets.newHashSet(200L))));
+
+            // hashJoin.child(0) IS a GroupPlan, but its group's physical expression is a join (not OlapScan)
+            // so findDownGradeBucketShuffleCandidate returns null → isBucketShuffleDownGrade returns true
+            Group innerGroupWithJoin = Mockito.mock(Group.class);
+            GroupExpression joinExpr = new GroupExpression(Mockito.mock(PhysicalHashJoin.class));
+            Mockito.when(innerGroupWithJoin.getPhysicalExpressions()).thenReturn(
+                    Lists.newArrayList(joinExpr));
+            Mockito.when(innerGroupWithJoin.getLogicalProperties()).thenReturn(
+                    Mockito.mock(LogicalProperties.class));
+            GroupPlan leftGroupPlanWithJoin = new GroupPlan(innerGroupWithJoin);
+            Mockito.when(innerGroupWithJoin.getGroupPlan()).thenReturn(leftGroupPlanWithJoin);
+
+            // Right child of the hash join is a normal GroupPlan
+            Group rightInnerGroup = Mockito.mock(Group.class);
+            Mockito.when(rightInnerGroup.getLogicalProperties()).thenReturn(Mockito.mock(LogicalProperties.class));
+            GroupPlan rightGroupPlan = new GroupPlan(rightInnerGroup);
+            Mockito.when(rightInnerGroup.getGroupPlan()).thenReturn(rightGroupPlan);
+
+            // Left GroupExpression for ChildrenPropertiesRegulator's children list
+            GroupExpression leftChildGE = Mockito.mock(GroupExpression.class);
+            Mockito.when(leftChildGE.getOwnerGroup()).thenReturn(innerGroupWithJoin);
+            Mockito.when(leftChildGE.getOutputProperties(Mockito.any())).thenReturn(leftOriginProp);
+            Map<PhysicalProperties, Pair<Cost, List<PhysicalProperties>>> leftLCT = Maps.newHashMap();
+            leftLCT.put(leftOriginProp, Pair.of(Cost.zero(), Lists.newArrayList()));
+            Mockito.when(leftChildGE.getLowestCostTable()).thenReturn(leftLCT);
+            Mockito.when(leftChildGE.getPlan()).thenReturn(Mockito.mock(Plan.class));
+
+            // Right GroupExpression for ChildrenPropertiesRegulator's children list
+            GroupExpression rightChildGE = Mockito.mock(GroupExpression.class);
+            Mockito.when(rightChildGE.getOwnerGroup()).thenReturn(rightInnerGroup);
+            Mockito.when(rightChildGE.getOutputProperties(Mockito.any())).thenReturn(rightOriginProp);
+            Map<PhysicalProperties, Pair<Cost, List<PhysicalProperties>>> rightLCT = Maps.newHashMap();
+            rightLCT.put(rightOriginProp, Pair.of(Cost.zero(), Lists.newArrayList()));
+            Mockito.when(rightChildGE.getLowestCostTable()).thenReturn(rightLCT);
+            Mockito.when(rightChildGE.getPlan()).thenReturn(Mockito.mock(Plan.class));
+
+            // Construct hash join with leftGroupPlanWithJoin (GroupPlan wrapping a join) as first child
+            LogicalProperties logicalProps = Mockito.mock(LogicalProperties.class);
+            PhysicalHashJoin<GroupPlan, GroupPlan> hashJoin = new PhysicalHashJoin<>(
+                    JoinType.INNER_JOIN,
+                    Lists.newArrayList(),
+                    Lists.newArrayList(),
+                    new DistributeHint(DistributeType.NONE),
+                    Optional.empty(),
+                    logicalProps,
+                    leftGroupPlanWithJoin,
+                    rightGroupPlan);
+
+            GroupExpression parent = new GroupExpression(hashJoin);
+            ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(
+                    parent,
+                    Lists.newArrayList(leftChildGE, rightChildGE),
+                    originProps,
+                    requiredProps,
+                    mockedJobContext);
+
+            List<List<PhysicalProperties>> result = regulator.adjustChildrenProperties();
+
+            // Both sides should be downgraded to EXECUTION_BUCKETED because no OlapScan candidate found
+            Assertions.assertEquals(1, result.size());
+            Assertions.assertInstanceOf(DistributionSpecHash.class, result.get(0).get(0).getDistributionSpec());
+            Assertions.assertEquals(ShuffleType.EXECUTION_BUCKETED,
+                    ((DistributionSpecHash) result.get(0).get(0).getDistributionSpec()).getShuffleType());
+        }
     }
 
     private void testMustShuffleFilter(Class<? extends Plan> childClazz) {


### PR DESCRIPTION
### What problem does this PR solve?
If the number of buckets is not large enough, using bucket shuffle join may reduce concurrency and thus degrade performance.The previous strategy was to assume no performance degradation when it could not be determined.Now, undetermined cases are treated as resulting in performance degradation.


Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

