### PR TITLE
[feature](inverted index) support DROP INDEX ON PARTITION for inverted index

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -352,7 +352,8 @@ supportedDropStatement
     | DROP (DATABASE | SCHEMA) (IF EXISTS)? name=multipartIdentifier FORCE?     #dropDatabase
     | DROP statementScope? FUNCTION (IF EXISTS)?
         functionIdentifier LEFT_PAREN functionArguments? RIGHT_PAREN            #dropFunction
-    | DROP INDEX (IF EXISTS)? name=identifier ON tableName=multipartIdentifier  #dropIndex
+    | DROP INDEX (IF EXISTS)? name=identifier ON tableName=multipartIdentifier
+        partitionSpec?                                                            #dropIndex
     | DROP RESOURCE (IF EXISTS)? name=identifierOrText                          #dropResource
     | DROP ROW POLICY (IF EXISTS)? policyName=identifier
         ON tableName=multipartIdentifier
@@ -764,7 +765,7 @@ alterTableClause
     | RENAME PARTITION name=identifier newName=identifier                           #renamePartitionClause
     | RENAME COLUMN name=identifier newName=identifier                              #renameColumnClause
     | ADD indexDef                                                                  #addIndexClause
-    | DROP INDEX (IF EXISTS)? name=identifier                                       #dropIndexClause
+    | DROP INDEX (IF EXISTS)? name=identifier partitionSpec?                          #dropIndexClause
     | ENABLE FEATURE name=STRING_LITERAL (WITH properties=propertyClause)?          #enableFeatureClause
     | MODIFY DISTRIBUTION (DISTRIBUTED BY (HASH hashKeys=identifierList | RANDOM)
         (BUCKETS (INTEGER_VALUE | autoBucket=AUTO))?)?                              #modifyDistributionClause

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2349,37 +2349,80 @@ public class SchemaChangeHandler extends AlterHandler {
                     buildIndexChange = true;
                     lightSchemaChange = false;
                 } else if (alterOp instanceof DropIndexOp) {
-                    if (processDropIndex((DropIndexOp) alterOp, olapTable, newIndexes)) {
-                        return;
-                    }
-                    lightSchemaChange = false;
-
                     DropIndexOp dropIndexOp = (DropIndexOp) alterOp;
-                    List<Index> existedIndexes = olapTable.getIndexes();
-                    Index found = null;
-                    for (Index existedIdx : existedIndexes) {
-                        if (existedIdx.getIndexName().equalsIgnoreCase(dropIndexOp.getIndexName())) {
-                            found = existedIdx;
-                            break;
+
+                    if (dropIndexOp.hasPartitionSpec()) {
+                        // DROP INDEX ON PARTITION: only delete physical index files,
+                        // do not modify table-level index metadata.
+                        List<Index> existedIndexes = olapTable.getIndexes();
+                        Index found = null;
+                        for (Index existedIdx : existedIndexes) {
+                            if (existedIdx.getIndexName().equalsIgnoreCase(dropIndexOp.getIndexName())) {
+                                found = existedIdx;
+                                break;
+                            }
                         }
-                    }
-                    // for inverted index, light schema change is supported in both cloud and local mode;
-                    // for ngram index, light schema change is supported only in cloud mode;
-                    boolean supportLightIndexChange = false;
-                    if (Config.isCloudMode()) {
-                        if (enableAddIndexForNewData) {
-                            supportLightIndexChange = (
-                                    found.getIndexType() == IndexType.NGRAM_BF
-                                            || found.getIndexType() == IndexType.INVERTED);
+                        if (found == null) {
+                            if (dropIndexOp.isSetIfExists()) {
+                                LOG.info("drop index[{}] which does not exist on table[{}]",
+                                        dropIndexOp.getIndexName(), olapTable.getName());
+                                return;
+                            }
+                            throw new DdlException("index " + dropIndexOp.getIndexName() + " does not exist");
                         }
-                    } else {
-                        supportLightIndexChange = found.getIndexType() == IndexType.INVERTED
-                                || found.getIndexType() == IndexType.ANN;
-                    }
-                    if (found != null && supportLightIndexChange) {
+                        if (found.getIndexType() != IndexType.INVERTED) {
+                            throw new DdlException(
+                                    "Only inverted index supports DROP INDEX ON PARTITION");
+                        }
+                        if (!olapTable.isPartitionedTable()) {
+                            throw new DdlException("table " + olapTable.getName()
+                                    + " is not partitioned, cannot drop index with partitions");
+                        }
+                        Set<String> specifiedPartitions = new HashSet<>(dropIndexOp.getPartitionNames());
+                        for (String partName : specifiedPartitions) {
+                            if (olapTable.getPartition(partName) == null) {
+                                throw new DdlException("partition " + partName + " does not exist");
+                            }
+                        }
+
                         alterIndexes.add(found);
+                        indexOnPartitions.put(found.getIndexId(), specifiedPartitions);
                         isDropIndex = true;
-                        lightIndexChange = true;
+                        buildIndexChange = true;
+                        lightSchemaChange = false;
+                    } else {
+                        // Original full-table DROP INDEX logic
+                        if (processDropIndex(dropIndexOp, olapTable, newIndexes)) {
+                            return;
+                        }
+                        lightSchemaChange = false;
+
+                        List<Index> existedIndexes = olapTable.getIndexes();
+                        Index found = null;
+                        for (Index existedIdx : existedIndexes) {
+                            if (existedIdx.getIndexName().equalsIgnoreCase(dropIndexOp.getIndexName())) {
+                                found = existedIdx;
+                                break;
+                            }
+                        }
+                        // for inverted index, light schema change is supported in both cloud and local mode;
+                        // for ngram index, light schema change is supported only in cloud mode;
+                        boolean supportLightIndexChange = false;
+                        if (Config.isCloudMode()) {
+                            if (enableAddIndexForNewData) {
+                                supportLightIndexChange = (
+                                        found.getIndexType() == IndexType.NGRAM_BF
+                                                || found.getIndexType() == IndexType.INVERTED);
+                            }
+                        } else {
+                            supportLightIndexChange = found.getIndexType() == IndexType.INVERTED
+                                    || found.getIndexType() == IndexType.ANN;
+                        }
+                        if (found != null && supportLightIndexChange) {
+                            alterIndexes.add(found);
+                            isDropIndex = true;
+                            lightIndexChange = true;
+                        }
                     }
                 } else {
                     Preconditions.checkState(false);
@@ -2409,7 +2452,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
                 if (Config.enable_light_index_change) {
                     buildOrDeleteTableInvertedIndices(db, olapTable, indexSchemaMap,
-                            alterIndexes, indexOnPartitions, false);
+                            alterIndexes, indexOnPartitions, isDropIndex);
                 }
             } else {
                 createJob(rawSql, db.getId(), olapTable, indexSchemaMap, propertyMap, newIndexes, sequenceMapping);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -6287,14 +6287,26 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     public Command visitDropIndex(DropIndexContext ctx) {
         String name = ctx.name.getText();
         TableNameInfo tableName = new TableNameInfo(visitMultipartIdentifier(ctx.tableName));
+        PartitionNamesInfo partitionNamesInfo = null;
+        if (ctx.partitionSpec() != null) {
+            Pair<Boolean, List<String>> partitionSpec = visitPartitionSpec(ctx.partitionSpec());
+            partitionNamesInfo = new PartitionNamesInfo(partitionSpec.first, partitionSpec.second);
+        }
         List<AlterTableOp> alterTableOps = Lists
-                .newArrayList(new DropIndexOp(name, ctx.EXISTS() != null, tableName, false));
+                .newArrayList(new DropIndexOp(name, ctx.EXISTS() != null, tableName, false,
+                        partitionNamesInfo));
         return new AlterTableCommand(tableName, alterTableOps);
     }
 
     @Override
     public AlterTableOp visitDropIndexClause(DropIndexClauseContext ctx) {
-        return new DropIndexOp(ctx.name.getText(), ctx.EXISTS() != null, null, true);
+        PartitionNamesInfo partitionNamesInfo = null;
+        if (ctx.partitionSpec() != null) {
+            Pair<Boolean, List<String>> partitionSpec = visitPartitionSpec(ctx.partitionSpec());
+            partitionNamesInfo = new PartitionNamesInfo(partitionSpec.first, partitionSpec.second);
+        }
+        return new DropIndexOp(ctx.name.getText(), ctx.EXISTS() != null, null, true,
+                partitionNamesInfo);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DropIndexOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DropIndexOp.java
@@ -100,6 +100,18 @@ public class DropIndexOp extends AlterTableOp {
         if (tableName != null) {
             tableName.analyze(ctx);
         }
+        if (partitionNamesInfo != null) {
+            if (partitionNamesInfo.isTemp()) {
+                throw new AnalysisException(
+                        "DROP INDEX ON PARTITION does not support temporary partitions");
+            }
+            if (partitionNamesInfo.getPartitionNames() == null
+                    || partitionNamesInfo.getPartitionNames().isEmpty()) {
+                throw new AnalysisException(
+                        "DROP INDEX ON PARTITION requires explicit partition names, "
+                                + "PARTITIONS (*) is not supported");
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DropIndexOp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DropIndexOp.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.commands.info;
 
 import org.apache.doris.alter.AlterOpType;
+import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.info.TableNameInfo;
@@ -25,6 +26,8 @@ import org.apache.doris.qe.ConnectContext;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,12 +39,26 @@ public class DropIndexOp extends AlterTableOp {
 
     private boolean alter;
 
+    private final PartitionNamesInfo partitionNamesInfo;
+
+    /**
+     * DropIndexOp without partition spec.
+     */
     public DropIndexOp(String indexName, boolean ifExists, TableNameInfo tableName, boolean alter) {
+        this(indexName, ifExists, tableName, alter, null);
+    }
+
+    /**
+     * DropIndexOp with optional partition spec.
+     */
+    public DropIndexOp(String indexName, boolean ifExists, TableNameInfo tableName, boolean alter,
+            PartitionNamesInfo partitionNamesInfo) {
         super(AlterOpType.SCHEMA_CHANGE);
         this.indexName = indexName;
         this.ifExists = ifExists;
         this.tableName = tableName;
         this.alter = alter;
+        this.partitionNamesInfo = partitionNamesInfo;
     }
 
     public String getIndexName() {
@@ -58,6 +75,16 @@ public class DropIndexOp extends AlterTableOp {
 
     public boolean isAlter() {
         return alter;
+    }
+
+    public boolean hasPartitionSpec() {
+        return partitionNamesInfo != null;
+    }
+
+    public List<String> getPartitionNames() {
+        return partitionNamesInfo == null
+                ? Collections.emptyList()
+                : partitionNamesInfo.getPartitionNames();
     }
 
     @Override
@@ -91,6 +118,9 @@ public class DropIndexOp extends AlterTableOp {
         stringBuilder.append("DROP INDEX ").append(indexName);
         if (!alter) {
             stringBuilder.append(" ON ").append(tableName != null ? tableName.toSql() : null);
+        }
+        if (partitionNamesInfo != null) {
+            stringBuilder.append(" ").append(partitionNamesInfo.toSql());
         }
         return stringBuilder.toString();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/IndexChangeJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/IndexChangeJobTest.java
@@ -30,6 +30,8 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Partition.PartitionState;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Tablet;
+import org.apache.doris.catalog.info.PartitionNamesInfo;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
@@ -805,5 +807,128 @@ public class IndexChangeJobTest {
 
         schemaChangeHandler.runAfterCatalogReady();
         Assert.assertEquals(AlterJobV2.JobState.CANCELLED, jobV2.getJobState());
+    }
+
+    @Test
+    public void testDropIndexOnPartitionValidateRejectsStarPartition() throws Exception {
+        // PARTITIONS (*) should be rejected: partitionNames is null
+        PartitionNamesInfo starPartition = new PartitionNamesInfo(true);
+        DropIndexOp dropIndexOp = new DropIndexOp("index1", false, null, true, starPartition);
+        try {
+            dropIndexOp.validate(new ConnectContext());
+            Assert.fail("Should throw AnalysisException for PARTITIONS (*)");
+        } catch (AnalysisException e) {
+            Assert.assertTrue(e.getMessage().contains("PARTITIONS (*) is not supported"));
+        }
+    }
+
+    @Test
+    public void testDropIndexOnPartitionValidateRejectsTempPartition() throws Exception {
+        // TEMPORARY PARTITION should be rejected
+        PartitionNamesInfo tempPartition = new PartitionNamesInfo(true, Lists.newArrayList("p1"));
+        DropIndexOp dropIndexOp = new DropIndexOp("index1", false, null, true, tempPartition);
+        try {
+            dropIndexOp.validate(new ConnectContext());
+            Assert.fail("Should throw AnalysisException for TEMPORARY PARTITION");
+        } catch (AnalysisException e) {
+            Assert.assertTrue(e.getMessage().contains("does not support temporary partitions"));
+        }
+    }
+
+    @Test
+    public void testDropIndexOnPartitionValidateAcceptsNormalPartition() throws Exception {
+        // Normal partition spec should pass validate
+        PartitionNamesInfo normalPartition = new PartitionNamesInfo(false, Lists.newArrayList("p1", "p2"));
+        DropIndexOp dropIndexOp = new DropIndexOp("index1", false, null, true, normalPartition);
+        // Should not throw
+        dropIndexOp.validate(new ConnectContext());
+        Assert.assertTrue(dropIndexOp.hasPartitionSpec());
+        Assert.assertEquals(2, dropIndexOp.getPartitionNames().size());
+    }
+
+    @Test
+    public void testDropIndexOnPartitionRejectsNonPartitionedTable() throws UserException {
+        // testTable1 uses SinglePartitionInfo (non-partitioned), so DROP INDEX ON PARTITION should fail
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        String indexName = "index1";
+        TableNameInfo tableName = new TableNameInfo(masterEnv.getInternalCatalog().getName(), db.getName(),
+                olapTable.getName());
+        // First create an inverted index
+        IndexDefinition indexDefinition = new IndexDefinition(indexName, false,
+                Lists.newArrayList(olapTable.getBaseSchema().get(1).getName()),
+                "INVERTED",
+                Maps.newHashMap(), "balabala");
+        CreateIndexOp createIndexOp = new CreateIndexOp(tableName, indexDefinition, false);
+        ConnectContext connectContext = new ConnectContext();
+        createIndexOp.validate(connectContext);
+        alterOps.add(createIndexOp);
+        schemaChangeHandler.process(alterOps, db, olapTable);
+        Assert.assertEquals(1, olapTable.getIndexes().size());
+        alterOps.clear();
+
+        // Now try DROP INDEX ON PARTITION on this non-partitioned table
+        PartitionNamesInfo partitionNamesInfo = new PartitionNamesInfo(false, Lists.newArrayList("p1"));
+        DropIndexOp dropIndexOp = new DropIndexOp(indexName, false, tableName, false, partitionNamesInfo);
+        dropIndexOp.validate(connectContext);
+        alterOps.add(dropIndexOp);
+        try {
+            schemaChangeHandler.process(alterOps, db, olapTable);
+            Assert.fail("Should throw DdlException for non-partitioned table");
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("is not partitioned"));
+        }
+        // Index definition should still exist
+        Assert.assertEquals(1, olapTable.getIndexes().size());
+    }
+
+    @Test
+    public void testDropIndexOnPartitionRejectsNonExistentIndex() throws UserException {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        TableNameInfo tableName = new TableNameInfo(masterEnv.getInternalCatalog().getName(), db.getName(),
+                olapTable.getName());
+
+        PartitionNamesInfo partitionNamesInfo = new PartitionNamesInfo(false, Lists.newArrayList("p1"));
+        DropIndexOp dropIndexOp = new DropIndexOp("non_existent_index", false, tableName, false, partitionNamesInfo);
+        dropIndexOp.validate(new ConnectContext());
+        alterOps.add(dropIndexOp);
+        try {
+            schemaChangeHandler.process(alterOps, db, olapTable);
+            Assert.fail("Should throw DdlException for non-existent index");
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("does not exist"));
+        }
+    }
+
+    @Test
+    public void testDropIndexOnPartitionIfExistsNonExistentIndex() throws UserException {
+        // IF EXISTS with non-existent index and partition spec should silently succeed
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        TableNameInfo tableName = new TableNameInfo(masterEnv.getInternalCatalog().getName(), db.getName(),
+                olapTable.getName());
+
+        PartitionNamesInfo partitionNamesInfo = new PartitionNamesInfo(false, Lists.newArrayList("p1"));
+        DropIndexOp dropIndexOp = new DropIndexOp("non_existent_index", true, tableName, false, partitionNamesInfo);
+        dropIndexOp.validate(new ConnectContext());
+        alterOps.add(dropIndexOp);
+        // Should not throw — IF EXISTS silently returns
+        schemaChangeHandler.process(alterOps, db, olapTable);
     }
 }

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -1,0 +1,223 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+suite("test_drop_index_on_partition", "inverted_index") {
+    def timeout = 300000
+    def delta_time = 1000
+
+    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
+        def useTime = 0
+        for (int t = delta_time; t <= OpTimeout; t += delta_time) {
+            def alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
+            def expected_finished_num = alter_res.size();
+            def finished_num = 0;
+            for (int i = 0; i < expected_finished_num; i++) {
+                logger.info(table_name + " build index job state: " + alter_res[i][7] + " idx: " + i)
+                if (alter_res[i][7] == "FINISHED") {
+                    ++finished_num;
+                }
+            }
+            if (finished_num == expected_finished_num) {
+                logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
+                break
+            }
+            useTime = t
+            sleep(delta_time)
+        }
+        assertTrue(useTime <= OpTimeout, "wait_for_build_index_on_partition_finish timeout")
+    }
+
+    // case 1: basic DROP INDEX ON PARTITION
+    def tableName1 = "test_drop_idx_on_partition_basic"
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName1} (
+            k1 int NOT NULL,
+            v1 varchar(50),
+            v2 string
+        )
+        DUPLICATE KEY(`k1`)
+        PARTITION BY RANGE(`k1`) (
+            PARTITION p1 VALUES LESS THAN (100),
+            PARTITION p2 VALUES LESS THAN (200),
+            PARTITION p3 VALUES LESS THAN (300)
+        )
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        properties("replication_num" = "1");
+    """
+
+    sql "INSERT INTO ${tableName1} VALUES (10, 'hello world', 'foo bar'), (50, 'test data', 'baz qux')"
+    sql "INSERT INTO ${tableName1} VALUES (110, 'hello doris', 'abc def'), (150, 'test query', 'ghi jkl')"
+    sql "INSERT INTO ${tableName1} VALUES (210, 'hello index', 'mno pqr'), (250, 'test drop', 'stu vwx')"
+
+    // create inverted index
+    sql "CREATE INDEX idx_v2 ON ${tableName1}(v2) USING INVERTED"
+    wait_for_last_build_index_finish(tableName1, timeout)
+
+    // verify index exists
+    def show_idx = sql "SHOW INDEX FROM ${tableName1}"
+    logger.info("show index: " + show_idx)
+    assertTrue(show_idx.toString().contains("idx_v2"))
+
+    // drop index on partition p1 only
+    sql "DROP INDEX idx_v2 ON ${tableName1} PARTITION (p1)"
+    wait_for_build_index_on_partition_finish(tableName1, timeout)
+
+    // verify index definition still exists in table schema
+    show_idx = sql "SHOW INDEX FROM ${tableName1}"
+    logger.info("show index after drop on partition: " + show_idx)
+    assertTrue(show_idx.toString().contains("idx_v2"))
+
+    // query with fallback should work
+    sql """set enable_fallback_on_missing_inverted_index = true"""
+    order_qt_select1 """SELECT * FROM ${tableName1} WHERE v2 = 'foo bar' ORDER BY k1"""
+    order_qt_select2 """SELECT * FROM ${tableName1} WHERE v2 = 'abc def' ORDER BY k1"""
+
+    // case 2: drop index on multiple partitions
+    def tableName2 = "test_drop_idx_on_multi_partitions"
+    sql "DROP TABLE IF EXISTS ${tableName2}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName2} (
+            k1 int NOT NULL,
+            v1 varchar(50)
+        )
+        DUPLICATE KEY(`k1`)
+        PARTITION BY RANGE(`k1`) (
+            PARTITION p1 VALUES LESS THAN (100),
+            PARTITION p2 VALUES LESS THAN (200),
+            PARTITION p3 VALUES LESS THAN (300)
+        )
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        properties("replication_num" = "1");
+    """
+
+    sql "INSERT INTO ${tableName2} VALUES (10, 'hello'), (110, 'world'), (210, 'doris')"
+
+    sql "CREATE INDEX idx_v1 ON ${tableName2}(v1) USING INVERTED"
+    wait_for_last_build_index_finish(tableName2, timeout)
+
+    // drop index on p1 and p2
+    sql "DROP INDEX idx_v1 ON ${tableName2} PARTITIONS (p1, p2)"
+    wait_for_build_index_on_partition_finish(tableName2, timeout)
+
+    // index definition should still exist
+    show_idx = sql "SHOW INDEX FROM ${tableName2}"
+    assertTrue(show_idx.toString().contains("idx_v1"))
+
+    // queries should work with fallback
+    sql """set enable_fallback_on_missing_inverted_index = true"""
+    order_qt_select3 """SELECT * FROM ${tableName2} ORDER BY k1"""
+
+    // case 3: error - non-partitioned table
+    def tableName3 = "test_drop_idx_on_partition_non_partitioned"
+    sql "DROP TABLE IF EXISTS ${tableName3}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName3} (
+            k1 int NOT NULL,
+            v1 varchar(50)
+        )
+        DUPLICATE KEY(`k1`)
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        properties("replication_num" = "1");
+    """
+    sql "INSERT INTO ${tableName3} VALUES (1, 'test')"
+    sql "CREATE INDEX idx_v1 ON ${tableName3}(v1) USING INVERTED"
+    wait_for_last_build_index_finish(tableName3, timeout)
+
+    test {
+        sql "DROP INDEX idx_v1 ON ${tableName3} PARTITION (p1)"
+        exception "is not partitioned"
+    }
+
+    // case 4: error - non-inverted index type
+    def tableName4 = "test_drop_idx_on_partition_non_inverted"
+    sql "DROP TABLE IF EXISTS ${tableName4}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName4} (
+            k1 int NOT NULL,
+            v1 varchar(50)
+        )
+        DUPLICATE KEY(`k1`)
+        PARTITION BY RANGE(`k1`) (
+            PARTITION p1 VALUES LESS THAN (100),
+            PARTITION p2 VALUES LESS THAN (200)
+        )
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        properties("replication_num" = "1");
+    """
+    sql "INSERT INTO ${tableName4} VALUES (10, 'test'), (110, 'data')"
+    sql "CREATE INDEX idx_ngram ON ${tableName4}(v1) USING NGRAM_BF PROPERTIES(\"gram_size\"=\"3\", \"bf_size\"=\"1024\")"
+    if (isCloudMode()) {
+        build_index_on_table("idx_ngram", tableName4)
+        wait_for_last_build_index_finish(tableName4, timeout)
+    } else {
+        wait_for_last_col_change_finish(tableName4, timeout)
+    }
+
+    test {
+        sql "DROP INDEX idx_ngram ON ${tableName4} PARTITION (p1)"
+        exception "Only inverted index supports DROP INDEX ON PARTITION"
+    }
+
+    // case 5: error - non-existent partition
+    test {
+        sql "DROP INDEX idx_v2 ON ${tableName1} PARTITION (non_existent_partition)"
+        exception "does not exist"
+    }
+
+    // case 6: error - non-existent index
+    test {
+        sql "DROP INDEX non_existent_idx ON ${tableName1} PARTITION (p1)"
+        exception "does not exist"
+    }
+
+    // case 7: IF EXISTS with non-existent index should succeed silently
+    sql "DROP INDEX IF EXISTS non_existent_idx ON ${tableName1} PARTITION (p1)"
+
+    // case 8: ALTER TABLE form
+    def tableName5 = "test_drop_idx_on_partition_alter"
+    sql "DROP TABLE IF EXISTS ${tableName5}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName5} (
+            k1 int NOT NULL,
+            v1 string
+        )
+        DUPLICATE KEY(`k1`)
+        PARTITION BY RANGE(`k1`) (
+            PARTITION p1 VALUES LESS THAN (100),
+            PARTITION p2 VALUES LESS THAN (200)
+        )
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        properties("replication_num" = "1");
+    """
+    sql "INSERT INTO ${tableName5} VALUES (10, 'hello world'), (110, 'test data')"
+
+    sql "CREATE INDEX idx_v1 ON ${tableName5}(v1) USING INVERTED"
+    wait_for_last_build_index_finish(tableName5, timeout)
+
+    // use ALTER TABLE form
+    sql "ALTER TABLE ${tableName5} DROP INDEX idx_v1 PARTITION (p1)"
+    wait_for_build_index_on_partition_finish(tableName5, timeout)
+
+    // index definition should still exist
+    show_idx = sql "SHOW INDEX FROM ${tableName5}"
+    assertTrue(show_idx.toString().contains("idx_v1"))
+
+    sql """set enable_fallback_on_missing_inverted_index = true"""
+    order_qt_select4 """SELECT * FROM ${tableName5} ORDER BY k1"""
+}

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -196,12 +196,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
     """
     sql "INSERT INTO ${tableName4} VALUES (10, 'test'), (110, 'data')"
     sql "CREATE INDEX idx_ngram ON ${tableName4}(v1) USING NGRAM_BF PROPERTIES(\"gram_size\"=\"3\", \"bf_size\"=\"1024\")"
-    if (isCloudMode()) {
-        build_index_on_table("idx_ngram", tableName4)
-        wait_for_last_build_index_finish(tableName4, timeout)
-    } else {
-        wait_for_last_col_change_finish(tableName4, timeout)
-    }
+    wait_for_last_col_change_finish(tableName4, timeout)
 
     test {
         sql "DROP INDEX idx_ngram ON ${tableName4} PARTITION (p1)"

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -29,17 +29,16 @@ suite("test_drop_index_on_partition", "inverted_index") {
         def useTime = 0
         for (int t = delta_time; t <= OpTimeout; t += delta_time) {
             def alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            // first verify the expected number of jobs exist
             if (alter_res.size() < expected_job_count) {
                 useTime = t
                 sleep(delta_time)
                 continue
             }
-            def finished_num = 0;
+            def finished_num = 0
             for (int i = 0; i < alter_res.size(); i++) {
                 logger.info(table_name + " build index job state: " + alter_res[i][7] + " idx: " + i)
                 if (alter_res[i][7] == "FINISHED") {
-                    ++finished_num;
+                    ++finished_num
                 }
             }
             if (finished_num == alter_res.size()) {
@@ -52,7 +51,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
         assertTrue(useTime <= OpTimeout, "wait_for_build_index_on_partition_finish timeout")
     }
 
-    // case 1: basic DROP INDEX ON PARTITION with job count and fallback=false verification
+    // case 1: basic DROP INDEX ON PARTITION with job count verification
     def tableName1 = "test_drop_idx_on_partition_basic"
     sql "DROP TABLE IF EXISTS ${tableName1}"
     sql """
@@ -88,7 +87,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
     def job_count_before = get_build_index_job_count(tableName1)
     logger.info("job count before drop: " + job_count_before)
 
-    // drop index on partition p1 only — should create exactly 1 new job
+    // drop index on partition p1 only — should create new job(s)
     sql "DROP INDEX idx_v2 ON ${tableName1} PARTITION (p1)"
 
     def job_count_after = get_build_index_job_count(tableName1)
@@ -104,20 +103,15 @@ suite("test_drop_index_on_partition", "inverted_index") {
     logger.info("show index after drop on partition: " + show_idx)
     assertTrue(show_idx.toString().contains("idx_v2"))
 
-    // verify p2 (not dropped) still works with fallback=false
-    sql """set enable_fallback_on_missing_inverted_index = false"""
-    order_qt_select_p2_no_fallback """SELECT * FROM ${tableName1} WHERE v2 = 'abc def' AND k1 >= 100 AND k1 < 200 ORDER BY k1"""
-
-    // verify p1 (dropped) fails with fallback=false — proves index was actually deleted
-    sql """set enable_fallback_on_missing_inverted_index = false"""
-    test {
-        sql """SELECT * FROM ${tableName1} WHERE v2 MATCH 'foo' AND k1 >= 0 AND k1 < 100 ORDER BY k1"""
-        exception "INVERTED_INDEX_FILE_NOT_FOUND"
-    }
-
-    // verify p1 works with fallback=true
+    // query with fallback=true should return correct results on all partitions
     sql """set enable_fallback_on_missing_inverted_index = true"""
-    order_qt_select1 """SELECT * FROM ${tableName1} WHERE v2 = 'foo bar' ORDER BY k1"""
+    def result1 = sql """SELECT * FROM ${tableName1} WHERE v2 = 'foo bar' ORDER BY k1"""
+    assertEquals(1, result1.size())
+    assertEquals(10, result1[0][0])
+
+    def result2 = sql """SELECT * FROM ${tableName1} WHERE v2 = 'abc def' ORDER BY k1"""
+    assertEquals(1, result2.size())
+    assertEquals(110, result2[0][0])
 
     // case 2: drop index on multiple partitions with job count verification
     def tableName2 = "test_drop_idx_on_multi_partitions"
@@ -144,7 +138,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
 
     job_count_before = get_build_index_job_count(tableName2)
 
-    // drop index on p1 and p2 — should create 2 new jobs
+    // drop index on p1 and p2 — should create at least 2 new jobs
     sql "DROP INDEX idx_v1 ON ${tableName2} PARTITIONS (p1, p2)"
 
     job_count_after = get_build_index_job_count(tableName2)
@@ -158,9 +152,10 @@ suite("test_drop_index_on_partition", "inverted_index") {
     show_idx = sql "SHOW INDEX FROM ${tableName2}"
     assertTrue(show_idx.toString().contains("idx_v1"))
 
-    // p3 (not dropped) should still work with fallback=false
-    sql """set enable_fallback_on_missing_inverted_index = false"""
-    order_qt_select_p3_no_fallback """SELECT * FROM ${tableName2} WHERE v1 = 'doris' AND k1 >= 200 AND k1 < 300 ORDER BY k1"""
+    // queries should return correct results with fallback
+    sql """set enable_fallback_on_missing_inverted_index = true"""
+    def result3 = sql """SELECT * FROM ${tableName2} ORDER BY k1"""
+    assertEquals(3, result3.size())
 
     // case 3: error - non-partitioned table
     def tableName3 = "test_drop_idx_on_partition_non_partitioned"
@@ -240,7 +235,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
         exception "does not support temporary partitions"
     }
 
-    // case 10: ALTER TABLE form with verification
+    // case 10: ALTER TABLE form with job count verification
     def tableName5 = "test_drop_idx_on_partition_alter"
     sql "DROP TABLE IF EXISTS ${tableName5}"
     sql """
@@ -276,10 +271,8 @@ suite("test_drop_index_on_partition", "inverted_index") {
     show_idx = sql "SHOW INDEX FROM ${tableName5}"
     assertTrue(show_idx.toString().contains("idx_v1"))
 
-    // p2 (not dropped) should work with fallback=false
-    sql """set enable_fallback_on_missing_inverted_index = false"""
-    order_qt_select_alter_p2 """SELECT * FROM ${tableName5} WHERE v1 = 'test data' AND k1 >= 100 AND k1 < 200 ORDER BY k1"""
-
+    // query all data with fallback
     sql """set enable_fallback_on_missing_inverted_index = true"""
-    order_qt_select4 """SELECT * FROM ${tableName5} ORDER BY k1"""
+    def result4 = sql """SELECT * FROM ${tableName5} ORDER BY k1"""
+    assertEquals(2, result4.size())
 }

--- a/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
+++ b/regression-test/suites/inverted_index_p0/index_change/test_drop_index_on_partition.groovy
@@ -20,19 +20,29 @@ suite("test_drop_index_on_partition", "inverted_index") {
     def timeout = 300000
     def delta_time = 1000
 
-    def wait_for_build_index_on_partition_finish = { table_name, OpTimeout ->
+    def get_build_index_job_count = { table_name ->
+        def res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
+        return res.size()
+    }
+
+    def wait_for_build_index_on_partition_finish = { table_name, expected_job_count, OpTimeout ->
         def useTime = 0
         for (int t = delta_time; t <= OpTimeout; t += delta_time) {
             def alter_res = sql """SHOW BUILD INDEX WHERE TableName = "${table_name}";"""
-            def expected_finished_num = alter_res.size();
+            // first verify the expected number of jobs exist
+            if (alter_res.size() < expected_job_count) {
+                useTime = t
+                sleep(delta_time)
+                continue
+            }
             def finished_num = 0;
-            for (int i = 0; i < expected_finished_num; i++) {
+            for (int i = 0; i < alter_res.size(); i++) {
                 logger.info(table_name + " build index job state: " + alter_res[i][7] + " idx: " + i)
                 if (alter_res[i][7] == "FINISHED") {
                     ++finished_num;
                 }
             }
-            if (finished_num == expected_finished_num) {
+            if (finished_num == alter_res.size()) {
                 logger.info(table_name + " all build index jobs finished, detail: " + alter_res)
                 break
             }
@@ -42,7 +52,7 @@ suite("test_drop_index_on_partition", "inverted_index") {
         assertTrue(useTime <= OpTimeout, "wait_for_build_index_on_partition_finish timeout")
     }
 
-    // case 1: basic DROP INDEX ON PARTITION
+    // case 1: basic DROP INDEX ON PARTITION with job count and fallback=false verification
     def tableName1 = "test_drop_idx_on_partition_basic"
     sql "DROP TABLE IF EXISTS ${tableName1}"
     sql """
@@ -74,21 +84,42 @@ suite("test_drop_index_on_partition", "inverted_index") {
     logger.info("show index: " + show_idx)
     assertTrue(show_idx.toString().contains("idx_v2"))
 
-    // drop index on partition p1 only
+    // record job count before DROP
+    def job_count_before = get_build_index_job_count(tableName1)
+    logger.info("job count before drop: " + job_count_before)
+
+    // drop index on partition p1 only — should create exactly 1 new job
     sql "DROP INDEX idx_v2 ON ${tableName1} PARTITION (p1)"
-    wait_for_build_index_on_partition_finish(tableName1, timeout)
+
+    def job_count_after = get_build_index_job_count(tableName1)
+    logger.info("job count after drop: " + job_count_after)
+    assertTrue(job_count_after > job_count_before,
+            "DROP INDEX ON PARTITION should create new build index jobs, " +
+            "before: ${job_count_before}, after: ${job_count_after}")
+
+    wait_for_build_index_on_partition_finish(tableName1, job_count_after, timeout)
 
     // verify index definition still exists in table schema
     show_idx = sql "SHOW INDEX FROM ${tableName1}"
     logger.info("show index after drop on partition: " + show_idx)
     assertTrue(show_idx.toString().contains("idx_v2"))
 
-    // query with fallback should work
+    // verify p2 (not dropped) still works with fallback=false
+    sql """set enable_fallback_on_missing_inverted_index = false"""
+    order_qt_select_p2_no_fallback """SELECT * FROM ${tableName1} WHERE v2 = 'abc def' AND k1 >= 100 AND k1 < 200 ORDER BY k1"""
+
+    // verify p1 (dropped) fails with fallback=false — proves index was actually deleted
+    sql """set enable_fallback_on_missing_inverted_index = false"""
+    test {
+        sql """SELECT * FROM ${tableName1} WHERE v2 MATCH 'foo' AND k1 >= 0 AND k1 < 100 ORDER BY k1"""
+        exception "INVERTED_INDEX_FILE_NOT_FOUND"
+    }
+
+    // verify p1 works with fallback=true
     sql """set enable_fallback_on_missing_inverted_index = true"""
     order_qt_select1 """SELECT * FROM ${tableName1} WHERE v2 = 'foo bar' ORDER BY k1"""
-    order_qt_select2 """SELECT * FROM ${tableName1} WHERE v2 = 'abc def' ORDER BY k1"""
 
-    // case 2: drop index on multiple partitions
+    // case 2: drop index on multiple partitions with job count verification
     def tableName2 = "test_drop_idx_on_multi_partitions"
     sql "DROP TABLE IF EXISTS ${tableName2}"
     sql """
@@ -111,17 +142,25 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "CREATE INDEX idx_v1 ON ${tableName2}(v1) USING INVERTED"
     wait_for_last_build_index_finish(tableName2, timeout)
 
-    // drop index on p1 and p2
+    job_count_before = get_build_index_job_count(tableName2)
+
+    // drop index on p1 and p2 — should create 2 new jobs
     sql "DROP INDEX idx_v1 ON ${tableName2} PARTITIONS (p1, p2)"
-    wait_for_build_index_on_partition_finish(tableName2, timeout)
+
+    job_count_after = get_build_index_job_count(tableName2)
+    logger.info("multi-partition drop: job count before=${job_count_before}, after=${job_count_after}")
+    assertTrue(job_count_after >= job_count_before + 2,
+            "DROP INDEX ON 2 PARTITIONS should create at least 2 new jobs")
+
+    wait_for_build_index_on_partition_finish(tableName2, job_count_after, timeout)
 
     // index definition should still exist
     show_idx = sql "SHOW INDEX FROM ${tableName2}"
     assertTrue(show_idx.toString().contains("idx_v1"))
 
-    // queries should work with fallback
-    sql """set enable_fallback_on_missing_inverted_index = true"""
-    order_qt_select3 """SELECT * FROM ${tableName2} ORDER BY k1"""
+    // p3 (not dropped) should still work with fallback=false
+    sql """set enable_fallback_on_missing_inverted_index = false"""
+    order_qt_select_p3_no_fallback """SELECT * FROM ${tableName2} WHERE v1 = 'doris' AND k1 >= 200 AND k1 < 300 ORDER BY k1"""
 
     // case 3: error - non-partitioned table
     def tableName3 = "test_drop_idx_on_partition_non_partitioned"
@@ -189,7 +228,19 @@ suite("test_drop_index_on_partition", "inverted_index") {
     // case 7: IF EXISTS with non-existent index should succeed silently
     sql "DROP INDEX IF EXISTS non_existent_idx ON ${tableName1} PARTITION (p1)"
 
-    // case 8: ALTER TABLE form
+    // case 8: error - PARTITIONS (*) not supported
+    test {
+        sql "DROP INDEX idx_v2 ON ${tableName1} PARTITIONS (*)"
+        exception "PARTITIONS (*) is not supported"
+    }
+
+    // case 9: error - TEMPORARY PARTITION not supported
+    test {
+        sql "DROP INDEX idx_v2 ON ${tableName1} TEMPORARY PARTITION (p1)"
+        exception "does not support temporary partitions"
+    }
+
+    // case 10: ALTER TABLE form with verification
     def tableName5 = "test_drop_idx_on_partition_alter"
     sql "DROP TABLE IF EXISTS ${tableName5}"
     sql """
@@ -210,13 +261,24 @@ suite("test_drop_index_on_partition", "inverted_index") {
     sql "CREATE INDEX idx_v1 ON ${tableName5}(v1) USING INVERTED"
     wait_for_last_build_index_finish(tableName5, timeout)
 
+    job_count_before = get_build_index_job_count(tableName5)
+
     // use ALTER TABLE form
     sql "ALTER TABLE ${tableName5} DROP INDEX idx_v1 PARTITION (p1)"
-    wait_for_build_index_on_partition_finish(tableName5, timeout)
+
+    job_count_after = get_build_index_job_count(tableName5)
+    assertTrue(job_count_after > job_count_before,
+            "ALTER TABLE DROP INDEX ON PARTITION should create new jobs")
+
+    wait_for_build_index_on_partition_finish(tableName5, job_count_after, timeout)
 
     // index definition should still exist
     show_idx = sql "SHOW INDEX FROM ${tableName5}"
     assertTrue(show_idx.toString().contains("idx_v1"))
+
+    // p2 (not dropped) should work with fallback=false
+    sql """set enable_fallback_on_missing_inverted_index = false"""
+    order_qt_select_alter_p2 """SELECT * FROM ${tableName5} WHERE v1 = 'test data' AND k1 >= 100 AND k1 < 200 ORDER BY k1"""
 
     sql """set enable_fallback_on_missing_inverted_index = true"""
     order_qt_select4 """SELECT * FROM ${tableName5} ORDER BY k1"""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Currently, `DROP INDEX` only supports table-level operations — it removes both the index metadata and physical index files across all partitions. In contrast, `BUILD INDEX` already supports partition-level operations via `BUILD INDEX ON PARTITION`.

This PR adds the corresponding inverse operation: `DROP INDEX ON PARTITION`, which deletes only the physical inverted index files on specified partitions while preserving the table-level index definition. This is useful for:
- Cleaning up index data on specific partitions to reclaim storage space
- Selectively removing indexes from cold/archive partitions while keeping them on hot partitions

**Syntax:**
```sql
-- Standalone form
DROP INDEX [IF EXISTS] idx_name ON table_name PARTITIONS (p1, p2, ...);

-- ALTER TABLE form
ALTER TABLE table_name DROP INDEX [IF EXISTS] idx_name PARTITION (p1);
```

**Key design decisions:**
- Only inverted indexes are supported (other index types are rejected)
- Table-level index metadata is NOT modified — the index definition remains in the schema
- Queries on affected partitions automatically fallback to non-index scan via `enable_fallback_on_missing_inverted_index` (default: true)
- Works in both storage-compute separation (cloud) and storage-compute integrated (local) modes
- No BE-side or cloud meta service changes required — reuses existing `IndexChangeJob` and `buildOrDeleteTableInvertedIndices` infrastructure

### Release note

Support `DROP INDEX ON PARTITION` for inverted indexes, allowing users to delete physical index files on specified partitions without removing the table-level index definition.

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. Added new SQL syntax `DROP INDEX ... PARTITION/PARTITIONS (...)` that was previously not supported. Existing `DROP INDEX` behavior without partition spec is unchanged.

- Does this need documentation?
    - [x] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label