### PR TITLE
[Chore](pipeline) make wake up do not return error

### DIFF
--- a/be/src/exec/pipeline/dependency.cpp
+++ b/be/src/exec/pipeline/dependency.cpp
@@ -79,7 +79,7 @@ void Dependency::set_ready() {
     for (auto task : local_block_task) {
         if (auto t = task.lock()) {
             std::unique_lock<std::mutex> lc(_task_lock);
-            THROW_IF_ERROR(t->wake_up(this, lc));
+            t->wake_up(this, lc);
         }
     }
 }

--- a/be/src/exec/pipeline/pipeline_task.cpp
+++ b/be/src/exec/pipeline/pipeline_task.cpp
@@ -1049,8 +1049,6 @@ void PipelineTask::wake_up(Dependency* dep, std::unique_lock<std::mutex>& /* dep
         if (!st.ok()) {
             if (auto frag = fragment_context().lock()) {
                 frag->cancel(st);
-            } else {
-                // do nothing and waitting for FragmentMgr::cancel_worker
             }
         }
     };

--- a/be/src/exec/pipeline/pipeline_task.cpp
+++ b/be/src/exec/pipeline/pipeline_task.cpp
@@ -1044,23 +1044,31 @@ Status PipelineTask::revoke_memory(const std::shared_ptr<SpillContext>& spill_co
     return Status::OK();
 }
 
-Status PipelineTask::wake_up(Dependency* dep, std::unique_lock<std::mutex>& /* dep_lock */) {
+void PipelineTask::wake_up(Dependency* dep, std::unique_lock<std::mutex>& /* dep_lock */) {
+    auto cancel_if_error = [&](const Status& st) {
+        if (!st.ok()) {
+            if (auto frag = fragment_context().lock()) {
+                frag->cancel(st);
+            } else {
+                // do nothing and waitting for FragmentMgr::cancel_worker
+            }
+        }
+    };
     // call by dependency
     DCHECK_EQ(_blocked_dep, dep) << "dep : " << dep->debug_string(0) << "task: " << debug_string();
     _blocked_dep = nullptr;
     auto holder = std::dynamic_pointer_cast<PipelineTask>(shared_from_this());
-    RETURN_IF_ERROR(_state_transition(PipelineTask::State::RUNNABLE));
+    cancel_if_error(_state_transition(PipelineTask::State::RUNNABLE));
     // Under _wake_up_early, FINISHED/FINALIZED → RUNNABLE is a legal no-op
     // (_state_transition returns OK but state stays unchanged). We must not
     // resubmit a terminated task: finalize() clears _sink/_operators, and
     // submit() → is_blockable() would dereference them → SIGSEGV.
     if (_exec_state == State::FINISHED || _exec_state == State::FINALIZED) {
-        return Status::OK();
+        return;
     }
     if (auto f = _fragment_context.lock(); f) {
-        RETURN_IF_ERROR(_state->get_query_ctx()->get_pipe_exec_scheduler()->submit(holder));
+        cancel_if_error(_state->get_query_ctx()->get_pipe_exec_scheduler()->submit(holder));
     }
-    return Status::OK();
 }
 
 Status PipelineTask::_state_transition(State new_state) {

--- a/be/src/exec/pipeline/pipeline_task.h
+++ b/be/src/exec/pipeline/pipeline_task.h
@@ -118,7 +118,7 @@ public:
         return _op_shared_states[id].get();
     }
 
-    Status wake_up(Dependency* dep, std::unique_lock<std::mutex>& /* dep_lock */);
+    void wake_up(Dependency* dep, std::unique_lock<std::mutex>& /* dep_lock */);
 
     DataSinkOperatorPtr sink() const { return _sink; }
 

--- a/be/test/exec/pipeline/pipeline_task_test.cpp
+++ b/be/test/exec/pipeline/pipeline_task_test.cpp
@@ -530,7 +530,7 @@ TEST_F(PipelineTaskTest, TEST_STATE_TRANSITION) {
         auto dep = std::make_shared<Dependency>(0, 0, "test_dep", true);
         task->_blocked_dep = dep.get();
         std::unique_lock<std::mutex> lc(mtx);
-        EXPECT_TRUE(task->wake_up(dep.get(), lc).ok());
+        task->wake_up(dep.get(), lc);
         EXPECT_EQ(task->_exec_state, PipelineTask::State::FINISHED);
         EXPECT_EQ(_task_scheduler->submit_count(), 0);
     }
@@ -541,7 +541,7 @@ TEST_F(PipelineTaskTest, TEST_STATE_TRANSITION) {
         auto dep = std::make_shared<Dependency>(0, 0, "test_dep", true);
         task->_blocked_dep = dep.get();
         std::unique_lock<std::mutex> lc(mtx);
-        EXPECT_TRUE(task->wake_up(dep.get(), lc).ok());
+        task->wake_up(dep.get(), lc);
         EXPECT_EQ(task->_exec_state, PipelineTask::State::FINALIZED);
         EXPECT_EQ(_task_scheduler->submit_count(), 0);
         task->_wake_up_early = false;

--- a/be/test/exec/pipeline/pipeline_task_test.cpp
+++ b/be/test/exec/pipeline/pipeline_task_test.cpp
@@ -554,7 +554,7 @@ TEST_F(PipelineTaskTest, TEST_STATE_TRANSITION) {
         auto dep = std::make_shared<Dependency>(0, 0, "test_dep", true);
         task->_blocked_dep = dep.get();
         std::unique_lock<std::mutex> lc(mtx);
-        EXPECT_TRUE(task->wake_up(dep.get(), lc).ok());
+        task->wake_up(dep.get(), lc);
         EXPECT_EQ(task->_exec_state, PipelineTask::State::RUNNABLE);
         EXPECT_EQ(_task_scheduler->submit_count(), 1);
     }


### PR DESCRIPTION
This pull request refactors the `PipelineTask::wake_up` method to improve error handling and simplify its interface. The method now returns `void` instead of `Status`, and errors are handled internally by canceling the associated fragment if necessary. Corresponding updates are made throughout the codebase and tests to accommodate this change.

**Core Refactoring and Error Handling:**

* Changed the signature of `PipelineTask::wake_up` from returning `Status` to `void`, and updated its implementation to handle errors by canceling the fragment context internally, rather than propagating `Status` up the call stack. [[1]](diffhunk://#diff-b1379f2a0e6db93d3aaeec091b10d8a13e9461322f30af2c3f4a54df5bee702fL1047-L1063) [[2]](diffhunk://#diff-50a5a51e990c7ba87a50a70566949e07fe5f2c80eb497fd2ea0a9426317bf4d4L121-R121)
* Updated the `Dependency::set_ready` method to call the new `wake_up` signature without error checking, since errors are now handled inside `wake_up`.

**Test Adjustments:**

* Modified unit tests in `pipeline_task_test.cpp` to remove checks on the return value of `wake_up` and instead directly call the new `void` method. [[1]](diffhunk://#diff-262afd1bf43b83333335fec0b00b65ab0b0241315fd3ceb98c5b3d568971052fL533-R533) [[2]](diffhunk://#diff-262afd1bf43b83333335fec0b00b65ab0b0241315fd3ceb98c5b3d568971052fL544-R544)