### PR TITLE
[improve](job) Support internal pass-through properties with "__" prefix in streaming job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobProperties.java
@@ -41,6 +41,7 @@ public class StreamingJobProperties implements JobProperties {
     public static final String S3_MAX_BATCH_FILES_PROPERTY = "s3.max_batch_files";
     public static final String S3_MAX_BATCH_BYTES_PROPERTY = "s3.max_batch_bytes";
     public static final String SESSION_VAR_PREFIX = "session.";
+    public static final String INTERNAL_KEY_PREFIX = "__";
     public static final String OFFSET_PROPERTY = "offset";
     public static final List<String> SUPPORT_STREAM_JOB_PROPS = Arrays.asList(MAX_INTERVAL_SECOND_PROPERTY,
             S3_MAX_BATCH_FILES_PROPERTY, S3_MAX_BATCH_BYTES_PROPERTY, OFFSET_PROPERTY);
@@ -69,6 +70,12 @@ public class StreamingJobProperties implements JobProperties {
     public void validate() throws AnalysisException {
         List<String> invalidProps = new ArrayList<>();
         for (String key : properties.keySet()) {
+            // Keys starting with "__" are internal pass-through properties
+            // that are stored as-is without validation, allowing users
+            // to attach custom metadata.
+            if (key.startsWith(INTERNAL_KEY_PREFIX)) {
+                continue;
+            }
             if (!SUPPORT_STREAM_JOB_PROPS.contains(key) && !key.startsWith(SESSION_VAR_PREFIX)) {
                 invalidProps.add(key);
             }

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_create_alter.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_create_alter.groovy
@@ -196,7 +196,11 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
             sql """INSERT INTO ${mysqlDb}.${table1} (name, age) VALUES ('B1', 2);"""
         }
 
+        // internal pass-through property "__source_subtype" should be accepted in job properties
         sql """CREATE JOB ${jobName}
+                PROPERTIES (
+                    "__source_subtype" = "aws_aurora_mysql"
+                )
                 ON STREAMING
                 FROM MYSQL (
                     "jdbc_url" = "jdbc:mysql://${externalEnvIp}:${mysql_port}",
@@ -205,7 +209,7 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
                     "user" = "root",
                     "password" = "123456",
                     "database" = "${mysqlDb}",
-                    "include_tables" = "${table1}", 
+                    "include_tables" = "${table1}",
                     "offset" = "initial"
                 )
                 TO DATABASE ${currentDb} (
@@ -419,10 +423,11 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
         """
         log.info("jobInfoOrigin: " + jobInfoOrigin)
 
-        // alter job properties
+        // alter job properties with internal pass-through property
         sql """ALTER JOB ${jobName}
                PROPERTIES(
-                "max_interval" = "5"
+                "max_interval" = "5",
+                "__source_subtype" = "aws_rds_mysql"
                ) """
 
         sql "RESUME JOB where jobname =  '${jobName}'";
@@ -452,7 +457,8 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
         log.info("jobInfoCurrent: " + jobInfoCurrent)
         assert jobInfoCurrent.get(0).get(0) == jobInfoOrigin.get(0).get(0)
         assert jobInfoCurrent.get(0).get(1) == jobInfoOrigin.get(0).get(1)
-        assert jobInfoCurrent.get(0).get(2) == "{\"max_interval\":\"5\"}"
+        assert jobInfoCurrent.get(0).get(2).contains("\"max_interval\":\"5\"")
+        assert jobInfoCurrent.get(0).get(2).contains("\"__source_subtype\":\"aws_rds_mysql\"")
         assert jobInfoCurrent.get(0).get(3).contains("latest")
 
         sql """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Currently, streaming job properties are strictly validated against a whitelist. This makes it impossible for users to attach custom metadata (e.g., distinguishing data source variants like `aws_aurora` vs standard `postgres` that share the same protocol) without modifying the kernel code and releasing a new version.

This PR allows properties prefixed with `__` to bypass validation and be stored as-is, enabling users to pass through custom metadata in job properties.

### Release note

Support internal pass-through properties with `__` prefix in streaming job PROPERTIES clause. These properties are stored as-is without validation, allowing users to attach custom metadata to streaming jobs.

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. Properties prefixed with `__` in streaming job PROPERTIES clause are now accepted and stored, previously they would be rejected as invalid.

- Does this need documentation?
    - [ ] No.
    - [x] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label