### PR TITLE
[test](regression) Skip external docker logs on success by default

### DIFF
--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -533,7 +533,7 @@ github_utils__maybe_optimize_external_shutdown_waits() {
 
     sleep() {
         local state=""
-        local shortened_sleep="${EXTERNAL_FE_IMAGE_WAIT_SECONDS_ON_SUCCESS:-60}"
+        local shortened_sleep="${EXTERNAL_FE_IMAGE_WAIT_SECONDS_ON_SUCCESS:-180}"
 
         if [[ "$#" -eq 1 && "$1" == "300" ]] && state="$(github_utils__external_success_state)"; then
             echo "Use shortened FE image wait ${shortened_sleep}s on ${state}."

--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -463,7 +463,7 @@ github_utils__maybe_optimize_external_collect_docker_logs() {
         local skip_reason=""
 
         if [[ "${collect_on_success,,}" != "true" ]]; then
-            if skip_reason="$(github_utils__external_collect_docker_logs_skip_reason)"; then
+            if skip_reason="$(github_utils__external_success_state)"; then
                 echo "Skip collecting docker logs on ${skip_reason}. Set COLLECT_DOCKER_LOGS_ON_SUCCESS=true to enable."
                 return 0
             fi
@@ -474,7 +474,7 @@ github_utils__maybe_optimize_external_collect_docker_logs() {
     GITHUB_UTILS_EXTERNAL_COLLECT_DOCKER_LOGS_WRAPPED=true
 }
 
-github_utils__external_collect_docker_logs_skip_reason() {
+github_utils__external_success_state() {
     local summary=""
     local test_suites=0
     local failed_suites=0
@@ -495,6 +495,55 @@ github_utils__external_collect_docker_logs_skip_reason() {
         return 0
     fi
     return 1
+}
+
+github_utils__external_is_grace_timeout_target() {
+    if [[ "$#" -ge 5 && "$1" == "-v" && "$2" == "10m" && "$3" == "bash" && "$4" == */be/bin/stop_be.sh && "$5" == "--grace" ]]; then
+        return 0
+    fi
+    if [[ "$#" -ge 4 && "$1" == "10m" && "$2" == "bash" && "$3" == */be/bin/stop_be.sh && "$4" == "--grace" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+github_utils__maybe_optimize_external_shutdown_waits() {
+    if ! github_utils__is_external_inline_shell; then
+        return 0
+    fi
+    if [[ "${GITHUB_UTILS_EXTERNAL_TIMEOUT_SLEEP_WRAPPED:-false}" == "true" ]]; then
+        return 0
+    fi
+
+    timeout() {
+        local state=""
+        local shortened_timeout="${EXTERNAL_BE_STOP_TIMEOUT_ON_SUCCESS:-2m}"
+        local -a args=("$@")
+
+        if state="$(github_utils__external_success_state)" && github_utils__external_is_grace_timeout_target "${args[@]}"; then
+            echo "Use shortened BE grace timeout ${shortened_timeout} on ${state}."
+            if [[ "${args[0]}" == "-v" ]]; then
+                args[1]="${shortened_timeout}"
+            else
+                args[0]="${shortened_timeout}"
+            fi
+        fi
+        command timeout "${args[@]}"
+    }
+
+    sleep() {
+        local state=""
+        local shortened_sleep="${EXTERNAL_FE_IMAGE_WAIT_SECONDS_ON_SUCCESS:-60}"
+
+        if [[ "$#" -eq 1 && "$1" == "300" ]] && state="$(github_utils__external_success_state)"; then
+            echo "Use shortened FE image wait ${shortened_sleep}s on ${state}."
+            command sleep "${shortened_sleep}"
+            return 0
+        fi
+        command sleep "$@"
+    }
+
+    GITHUB_UTILS_EXTERNAL_TIMEOUT_SLEEP_WRAPPED=true
 }
 
 github_utils__external_regression_summary_line() {
@@ -531,4 +580,5 @@ github_utils__external_regression_summary_log() {
 }
 
 github_utils__maybe_optimize_external_collect_docker_logs
+github_utils__maybe_optimize_external_shutdown_waits
 github_utils__maybe_enable_external_stage_timer

--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -460,22 +460,74 @@ github_utils__maybe_optimize_external_collect_docker_logs() {
     eval "${original_definition/collect_docker_logs/github_utils__original_collect_docker_logs}"
     collect_docker_logs() {
         local collect_on_success="${COLLECT_DOCKER_LOGS_ON_SUCCESS:-false}"
-        local should_collect=false
+        local skip_reason=""
 
-        if [[ "${collect_on_success,,}" == "true" ]] ||
-            [[ "${need_collect_log:-false}" == "true" ]] ||
-            [[ "${exit_flag:-0}" != "0" ]]; then
-            should_collect=true
-        fi
-
-        if ! ${should_collect}; then
-            echo "Skip collecting docker logs on success. Set COLLECT_DOCKER_LOGS_ON_SUCCESS=true to enable."
-            return 0
+        if [[ "${collect_on_success,,}" != "true" ]]; then
+            if skip_reason="$(github_utils__external_collect_docker_logs_skip_reason)"; then
+                echo "Skip collecting docker logs on ${skip_reason}. Set COLLECT_DOCKER_LOGS_ON_SUCCESS=true to enable."
+                return 0
+            fi
         fi
 
         github_utils__original_collect_docker_logs "$@"
     }
     GITHUB_UTILS_EXTERNAL_COLLECT_DOCKER_LOGS_WRAPPED=true
+}
+
+github_utils__external_collect_docker_logs_skip_reason() {
+    local summary=""
+    local test_suites=0
+    local failed_suites=0
+    local fatal_scripts=0
+    local threshold="${failed_suites_threshold:-20}"
+
+    if [[ "${exit_flag:-0}" == "0" ]]; then
+        printf 'success'
+        return 0
+    fi
+
+    summary="$(github_utils__external_regression_summary_line)" || return 1
+    test_suites="$(echo "${summary}" | cut -d ' ' -f 2)"
+    failed_suites="$(echo "${summary}" | cut -d ' ' -f 5)"
+    fatal_scripts="$(echo "${summary}" | cut -d ' ' -f 8)"
+    if [[ ${test_suites} -gt 0 && ${failed_suites} -le ${threshold} && ${fatal_scripts} -eq 0 ]]; then
+        printf 'tolerated success'
+        return 0
+    fi
+    return 1
+}
+
+github_utils__external_regression_summary_line() {
+    local summary_log
+
+    summary_log="$(github_utils__external_regression_summary_log)" || return 1
+    grep -aoE 'Test ([0-9]+) suites, failed ([0-9]+) suites, fatal ([0-9]+) scripts, skipped ([0-9]+) scripts' \
+        "${summary_log}" | tail -n 1
+}
+
+github_utils__external_regression_summary_log() {
+    local log_dir=""
+    local candidate=""
+
+    if [[ -n "${DORIS_HOME:-}" ]]; then
+        log_dir="${DORIS_HOME}/regression-test/log"
+        candidate="$(find "${log_dir}" -maxdepth 1 -type f -name 'doris-regression-test.*.log' | head -n 1)"
+        if [[ -n "${candidate}" ]]; then
+            printf '%s' "${candidate}"
+            return 0
+        fi
+    fi
+
+    if [[ -n "${case_center:-}" && -n "${cluster_name:-}" ]]; then
+        log_dir="${case_center}/${cluster_name}/output/regression-test/log"
+        candidate="$(find "${log_dir}" -maxdepth 1 -type f -name 'doris-regression-test.*.log' | head -n 1)"
+        if [[ -n "${candidate}" ]]; then
+            printf '%s' "${candidate}"
+            return 0
+        fi
+    fi
+
+    return 1
 }
 
 github_utils__maybe_optimize_external_collect_docker_logs

--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -408,25 +408,12 @@ file_changed_meta() {
 
 github_utils__maybe_enable_external_stage_timer() {
     local timer_script
-    local main_definition
 
-    if [[ -z "${teamcity_build_checkoutDir:-}" ]]; then
+    if ! github_utils__is_external_inline_shell; then
         return 0
     fi
     timer_script="${teamcity_build_checkoutDir}/regression-test/pipeline/external/external-stage-timer.sh"
     if [[ ! -f "${timer_script}" ]]; then
-        return 0
-    fi
-    if ! declare -F main >/dev/null; then
-        return 0
-    fi
-
-    main_definition="$(declare -f main)"
-    if [[ "${main_definition}" != *"START EXTERNAL DOCKER"* ]] ||
-        [[ "${main_definition}" != *"RUN EXTERNAL CASE"* ]] ||
-        ([[ "${main_definition}" != *"collect_docker_logs"* ]] &&
-            [[ "${main_definition}" != *"COLLECT DOCKER LOGS"* ]]) ||
-        [[ "${main_definition}" != *"deploy_cluster.sh"* ]]; then
         return 0
     fi
 
@@ -435,4 +422,61 @@ github_utils__maybe_enable_external_stage_timer() {
     external_regression_stage_timer_enable_auto_hooks
 }
 
+github_utils__is_external_inline_shell() {
+    local main_definition
+
+    if [[ -z "${teamcity_build_checkoutDir:-}" ]]; then
+        return 1
+    fi
+    if ! declare -F main >/dev/null; then
+        return 1
+    fi
+
+    main_definition="$(declare -f main)"
+    if [[ "${main_definition}" != *"START EXTERNAL DOCKER"* ]] ||
+        [[ "${main_definition}" != *"RUN EXTERNAL CASE"* ]] ||
+        ([[ "${main_definition}" != *"collect_docker_logs"* ]] &&
+            [[ "${main_definition}" != *"COLLECT DOCKER LOGS"* ]]) ||
+        [[ "${main_definition}" != *"deploy_cluster.sh"* ]]; then
+        return 1
+    fi
+    return 0
+}
+
+github_utils__maybe_optimize_external_collect_docker_logs() {
+    local original_definition
+
+    if ! github_utils__is_external_inline_shell; then
+        return 0
+    fi
+    if ! declare -F collect_docker_logs >/dev/null; then
+        return 0
+    fi
+    if [[ "${GITHUB_UTILS_EXTERNAL_COLLECT_DOCKER_LOGS_WRAPPED:-false}" == "true" ]]; then
+        return 0
+    fi
+
+    original_definition="$(declare -f collect_docker_logs)"
+    eval "${original_definition/collect_docker_logs/github_utils__original_collect_docker_logs}"
+    collect_docker_logs() {
+        local collect_on_success="${COLLECT_DOCKER_LOGS_ON_SUCCESS:-false}"
+        local should_collect=false
+
+        if [[ "${collect_on_success,,}" == "true" ]] ||
+            [[ "${need_collect_log:-false}" == "true" ]] ||
+            [[ "${exit_flag:-0}" != "0" ]]; then
+            should_collect=true
+        fi
+
+        if ! ${should_collect}; then
+            echo "Skip collecting docker logs on success. Set COLLECT_DOCKER_LOGS_ON_SUCCESS=true to enable."
+            return 0
+        fi
+
+        github_utils__original_collect_docker_logs "$@"
+    }
+    GITHUB_UTILS_EXTERNAL_COLLECT_DOCKER_LOGS_WRAPPED=true
+}
+
+github_utils__maybe_optimize_external_collect_docker_logs
 github_utils__maybe_enable_external_stage_timer

--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -507,6 +507,16 @@ github_utils__external_is_grace_timeout_target() {
     return 1
 }
 
+github_utils__external_is_final_grace_stop_target() {
+    if [[ "$#" -ge 1 && "$1" == */stop_cluster_grace.sh ]]; then
+        return 0
+    fi
+    if [[ "$#" -ge 1 && "$1" == "stop_cluster_grace.sh" ]]; then
+        return 0
+    fi
+    return 1
+}
+
 github_utils__maybe_optimize_external_shutdown_waits() {
     if ! github_utils__is_external_inline_shell; then
         return 0
@@ -529,6 +539,19 @@ github_utils__maybe_optimize_external_shutdown_waits() {
             fi
         fi
         command timeout "${args[@]}"
+    }
+
+    bash() {
+        local state=""
+        local -a args=("$@")
+        local forced_target=""
+
+        if state="$(github_utils__external_success_state)" && github_utils__external_is_final_grace_stop_target "${args[@]}"; then
+            forced_target="${args[0]%stop_cluster_grace.sh}stop_cluster.sh"
+            echo "Use force stop_cluster.sh on ${state}."
+            args[0]="${forced_target}"
+        fi
+        command bash "${args[@]}"
     }
 
     sleep() {

--- a/regression-test/pipeline/common/test_github_utils.py
+++ b/regression-test/pipeline/common/test_github_utils.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+GITHUB_HELPER = os.path.join(ROOT, "regression-test", "pipeline", "common", "github-utils.sh")
+
+
+class GithubUtilsTest(unittest.TestCase):
+    def _run_raw(self, body):
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as script:
+            script.write("#!/usr/bin/env bash\n")
+            script.write("set -euo pipefail\n")
+            script.write("export LC_ALL=C.UTF-8\n")
+            script.write(body)
+            script_path = script.name
+        try:
+            return subprocess.run(
+                ["bash", script_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                check=False,
+            )
+        finally:
+            os.unlink(script_path)
+
+    def _run_external_collect_logs_case(self, exit_flag, need_collect_log, collect_on_success):
+        with tempfile.NamedTemporaryFile("w", delete=False) as trace:
+            trace_path = trace.name
+        try:
+            result = self._run_raw(
+                """
+export teamcity_build_checkoutDir="{root}"
+export COLLECT_DOCKER_LOGS_ON_SUCCESS="{collect_on_success}"
+
+main() {{
+    if false; then
+        bash deploy_cluster.sh test_cluster
+        echo "START EXTERNAL DOCKER"
+        echo "RUN EXTERNAL CASE"
+        echo "COLLECT DOCKER LOGS"
+    fi
+
+    collect_docker_logs() {{
+        echo "original:$1" >> "{trace_path}"
+    }}
+
+    exit_flag="{exit_flag}"
+    need_collect_log="{need_collect_log}"
+    source "{github_helper}"
+    collect_docker_logs docker-log-dir
+}}
+
+main
+""".format(
+                    root=ROOT,
+                    collect_on_success=collect_on_success,
+                    trace_path=trace_path,
+                    exit_flag=exit_flag,
+                    need_collect_log=need_collect_log,
+                    github_helper=GITHUB_HELPER,
+                )
+            )
+            with open(trace_path) as trace_file:
+                trace_output = trace_file.read()
+            return result, trace_output
+        finally:
+            os.unlink(trace_path)
+
+    def test_skip_collect_docker_logs_on_success_by_default(self):
+        result, trace_output = self._run_external_collect_logs_case(
+            exit_flag="0",
+            need_collect_log="false",
+            collect_on_success="false",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Skip collecting docker logs on success", result.stdout)
+        self.assertEqual("", trace_output)
+
+    def test_collect_docker_logs_on_failure(self):
+        result, trace_output = self._run_external_collect_logs_case(
+            exit_flag="2",
+            need_collect_log="false",
+            collect_on_success="false",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("original:docker-log-dir", trace_output)
+
+    def test_collect_docker_logs_when_success_collection_enabled(self):
+        result, trace_output = self._run_external_collect_logs_case(
+            exit_flag="0",
+            need_collect_log="false",
+            collect_on_success="true",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("original:docker-log-dir", trace_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/regression-test/pipeline/common/test_github_utils.py
+++ b/regression-test/pipeline/common/test_github_utils.py
@@ -219,9 +219,9 @@ main
         )
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("Use shortened BE grace timeout 2m on tolerated success.", result.stdout)
-        self.assertIn("Use shortened FE image wait 60s on tolerated success.", result.stdout)
+        self.assertIn("Use shortened FE image wait 180s on tolerated success.", result.stdout)
         self.assertIn("timeout:-v 2m bash /tmp/fake/be/bin/stop_be.sh --grace", trace_output)
-        self.assertIn("sleep:60", trace_output)
+        self.assertIn("sleep:180", trace_output)
 
     def test_keep_shutdown_waits_on_failure(self):
         result, trace_output = self._run_external_shutdown_wait_case(

--- a/regression-test/pipeline/common/test_github_utils.py
+++ b/regression-test/pipeline/common/test_github_utils.py
@@ -45,14 +45,29 @@ class GithubUtilsTest(unittest.TestCase):
         finally:
             os.unlink(script_path)
 
-    def _run_external_collect_logs_case(self, exit_flag, need_collect_log, collect_on_success):
+    def _run_external_collect_logs_case(
+        self,
+        exit_flag,
+        need_backup_log,
+        collect_on_success,
+        summary=None,
+        failed_suites_threshold="20",
+    ):
         with tempfile.NamedTemporaryFile("w", delete=False) as trace:
             trace_path = trace.name
         try:
-            result = self._run_raw(
-                """
+            with tempfile.TemporaryDirectory() as tmpdir:
+                if summary is not None:
+                    log_dir = os.path.join(tmpdir, "output", "regression-test", "log")
+                    os.makedirs(log_dir)
+                    with open(os.path.join(log_dir, "doris-regression-test.fake.log"), "w") as log_file:
+                        log_file.write(summary + "\n")
+                result = self._run_raw(
+                    """
 export teamcity_build_checkoutDir="{root}"
 export COLLECT_DOCKER_LOGS_ON_SUCCESS="{collect_on_success}"
+export DORIS_HOME="{doris_home}"
+export failed_suites_threshold="{failed_suites_threshold}"
 
 main() {{
     if false; then
@@ -67,21 +82,23 @@ main() {{
     }}
 
     exit_flag="{exit_flag}"
-    need_collect_log="{need_collect_log}"
+    need_backup_log="{need_backup_log}"
     source "{github_helper}"
     collect_docker_logs docker-log-dir
 }}
 
 main
 """.format(
-                    root=ROOT,
-                    collect_on_success=collect_on_success,
-                    trace_path=trace_path,
-                    exit_flag=exit_flag,
-                    need_collect_log=need_collect_log,
-                    github_helper=GITHUB_HELPER,
+                        root=ROOT,
+                        collect_on_success=collect_on_success,
+                        doris_home=os.path.join(tmpdir, "output"),
+                        failed_suites_threshold=failed_suites_threshold,
+                        trace_path=trace_path,
+                        exit_flag=exit_flag,
+                        need_backup_log=need_backup_log,
+                        github_helper=GITHUB_HELPER,
+                    )
                 )
-            )
             with open(trace_path) as trace_file:
                 trace_output = trace_file.read()
             return result, trace_output
@@ -91,7 +108,29 @@ main
     def test_skip_collect_docker_logs_on_success_by_default(self):
         result, trace_output = self._run_external_collect_logs_case(
             exit_flag="0",
-            need_collect_log="false",
+            need_backup_log="false",
+            collect_on_success="false",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Skip collecting docker logs on success", result.stdout)
+        self.assertEqual("", trace_output)
+
+    def test_skip_collect_docker_logs_when_summary_meets_tolerated_success_rule(self):
+        result, trace_output = self._run_external_collect_logs_case(
+            exit_flag="1",
+            need_backup_log="false",
+            collect_on_success="false",
+            summary="Test 496 suites, failed 4 suites, fatal 0 scripts, skipped 0 scripts",
+            failed_suites_threshold="20",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Skip collecting docker logs on tolerated success", result.stdout)
+        self.assertEqual("", trace_output)
+
+    def test_skip_collect_docker_logs_on_success_even_if_backup_requested(self):
+        result, trace_output = self._run_external_collect_logs_case(
+            exit_flag="0",
+            need_backup_log="true",
             collect_on_success="false",
         )
         self.assertEqual(result.returncode, 0, result.stdout)
@@ -101,8 +140,9 @@ main
     def test_collect_docker_logs_on_failure(self):
         result, trace_output = self._run_external_collect_logs_case(
             exit_flag="2",
-            need_collect_log="false",
+            need_backup_log="false",
             collect_on_success="false",
+            summary="Test 496 suites, failed 40 suites, fatal 1 scripts, skipped 0 scripts",
         )
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("original:docker-log-dir", trace_output)
@@ -110,7 +150,7 @@ main
     def test_collect_docker_logs_when_success_collection_enabled(self):
         result, trace_output = self._run_external_collect_logs_case(
             exit_flag="0",
-            need_collect_log="false",
+            need_backup_log="false",
             collect_on_success="true",
         )
         self.assertEqual(result.returncode, 0, result.stdout)

--- a/regression-test/pipeline/common/test_github_utils.py
+++ b/regression-test/pipeline/common/test_github_utils.py
@@ -105,6 +105,62 @@ main
         finally:
             os.unlink(trace_path)
 
+    def _run_external_shutdown_wait_case(self, exit_flag, summary=None):
+        with tempfile.NamedTemporaryFile("w", delete=False) as trace:
+            trace_path = trace.name
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                fake_bin = os.path.join(tmpdir, "bin")
+                os.makedirs(fake_bin)
+                with open(os.path.join(fake_bin, "timeout"), "w") as timeout_file:
+                    timeout_file.write("#!/usr/bin/env bash\n")
+                    timeout_file.write('echo "timeout:$*" >> "{}"\n'.format(trace_path))
+                with open(os.path.join(fake_bin, "sleep"), "w") as sleep_file:
+                    sleep_file.write("#!/usr/bin/env bash\n")
+                    sleep_file.write('echo "sleep:$*" >> "{}"\n'.format(trace_path))
+                os.chmod(os.path.join(fake_bin, "timeout"), 0o755)
+                os.chmod(os.path.join(fake_bin, "sleep"), 0o755)
+
+                if summary is not None:
+                    log_dir = os.path.join(tmpdir, "output", "regression-test", "log")
+                    os.makedirs(log_dir)
+                    with open(os.path.join(log_dir, "doris-regression-test.fake.log"), "w") as log_file:
+                        log_file.write(summary + "\n")
+
+                result = self._run_raw(
+                    """
+export teamcity_build_checkoutDir="{root}"
+export DORIS_HOME="{doris_home}"
+export PATH="{fake_bin}:$PATH"
+
+main() {{
+    if false; then
+        bash deploy_cluster.sh test_cluster
+        echo "START EXTERNAL DOCKER"
+        echo "RUN EXTERNAL CASE"
+        echo "COLLECT DOCKER LOGS"
+    fi
+    exit_flag="{exit_flag}"
+    source "{github_helper}"
+    timeout -v 10m bash /tmp/fake/be/bin/stop_be.sh --grace
+    sleep 300
+}}
+
+main
+""".format(
+                        root=ROOT,
+                        doris_home=os.path.join(tmpdir, "output"),
+                        fake_bin=fake_bin,
+                        exit_flag=exit_flag,
+                        github_helper=GITHUB_HELPER,
+                    )
+                )
+                with open(trace_path) as trace_file:
+                    trace_output = trace_file.read()
+                return result, trace_output
+        finally:
+            os.unlink(trace_path)
+
     def test_skip_collect_docker_logs_on_success_by_default(self):
         result, trace_output = self._run_external_collect_logs_case(
             exit_flag="0",
@@ -155,6 +211,26 @@ main
         )
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("original:docker-log-dir", trace_output)
+
+    def test_shorten_shutdown_waits_on_tolerated_success(self):
+        result, trace_output = self._run_external_shutdown_wait_case(
+            exit_flag="1",
+            summary="Test 496 suites, failed 4 suites, fatal 0 scripts, skipped 0 scripts",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Use shortened BE grace timeout 2m on tolerated success.", result.stdout)
+        self.assertIn("Use shortened FE image wait 60s on tolerated success.", result.stdout)
+        self.assertIn("timeout:-v 2m bash /tmp/fake/be/bin/stop_be.sh --grace", trace_output)
+        self.assertIn("sleep:60", trace_output)
+
+    def test_keep_shutdown_waits_on_failure(self):
+        result, trace_output = self._run_external_shutdown_wait_case(
+            exit_flag="2",
+            summary="Test 496 suites, failed 40 suites, fatal 1 scripts, skipped 0 scripts",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("timeout:-v 10m bash /tmp/fake/be/bin/stop_be.sh --grace", trace_output)
+        self.assertIn("sleep:300", trace_output)
 
 
 if __name__ == "__main__":

--- a/regression-test/pipeline/common/test_github_utils.py
+++ b/regression-test/pipeline/common/test_github_utils.py
@@ -161,6 +161,57 @@ main
         finally:
             os.unlink(trace_path)
 
+    def _run_external_final_stop_case(self, exit_flag, summary=None):
+        with tempfile.NamedTemporaryFile("w", delete=False) as trace:
+            trace_path = trace.name
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                fake_bin = os.path.join(tmpdir, "bin")
+                os.makedirs(fake_bin)
+                with open(os.path.join(fake_bin, "bash"), "w") as bash_file:
+                    bash_file.write("#!/bin/bash\n")
+                    bash_file.write('echo "bash:$*" >> "{}"\n'.format(trace_path))
+                os.chmod(os.path.join(fake_bin, "bash"), 0o755)
+
+                if summary is not None:
+                    log_dir = os.path.join(tmpdir, "output", "regression-test", "log")
+                    os.makedirs(log_dir)
+                    with open(os.path.join(log_dir, "doris-regression-test.fake.log"), "w") as log_file:
+                        log_file.write(summary + "\n")
+
+                result = self._run_raw(
+                    """
+export teamcity_build_checkoutDir="{root}"
+export DORIS_HOME="{doris_home}"
+export PATH="{fake_bin}:$PATH"
+
+main() {{
+    if false; then
+        bash deploy_cluster.sh test_cluster
+        echo "START EXTERNAL DOCKER"
+        echo "RUN EXTERNAL CASE"
+        echo "COLLECT DOCKER LOGS"
+    fi
+    exit_flag="{exit_flag}"
+    source "{github_helper}"
+    bash /tmp/fake/stop_cluster_grace.sh Cluster0
+}}
+
+main
+""".format(
+                        root=ROOT,
+                        doris_home=os.path.join(tmpdir, "output"),
+                        fake_bin=fake_bin,
+                        exit_flag=exit_flag,
+                        github_helper=GITHUB_HELPER,
+                    )
+                )
+                with open(trace_path) as trace_file:
+                    trace_output = trace_file.read()
+                return result, trace_output
+        finally:
+            os.unlink(trace_path)
+
     def test_skip_collect_docker_logs_on_success_by_default(self):
         result, trace_output = self._run_external_collect_logs_case(
             exit_flag="0",
@@ -231,6 +282,23 @@ main
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("timeout:-v 10m bash /tmp/fake/be/bin/stop_be.sh --grace", trace_output)
         self.assertIn("sleep:300", trace_output)
+
+    def test_force_final_stop_on_tolerated_success(self):
+        result, trace_output = self._run_external_final_stop_case(
+            exit_flag="1",
+            summary="Test 496 suites, failed 4 suites, fatal 0 scripts, skipped 0 scripts",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Use force stop_cluster.sh on tolerated success.", result.stdout)
+        self.assertIn("bash:/tmp/fake/stop_cluster.sh Cluster0", trace_output)
+
+    def test_keep_graceful_final_stop_on_failure(self):
+        result, trace_output = self._run_external_final_stop_case(
+            exit_flag="2",
+            summary="Test 496 suites, failed 40 suites, fatal 1 scripts, skipped 0 scripts",
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("bash:/tmp/fake/stop_cluster_grace.sh Cluster0", trace_output)
 
 
 if __name__ == "__main__":

--- a/regression-test/pipeline/common/test_stage_timer.py
+++ b/regression-test/pipeline/common/test_stage_timer.py
@@ -86,7 +86,14 @@ false
 
     def test_external_pipeline_auto_hooks_print_summary(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            for name in ("deploy_cluster.sh", "run-thirdparties-docker.sh", "run-regression-test.sh"):
+            for name in (
+                "deploy_cluster.sh",
+                "run-thirdparties-docker.sh",
+                "run-regression-test.sh",
+                "stop_be.sh",
+                "start_cluster.sh",
+                "stop_cluster_grace.sh",
+            ):
                 script_path = os.path.join(tmpdir, name)
                 with open(script_path, "w") as script:
                     script.write("#!/usr/bin/env bash\n")
@@ -96,22 +103,6 @@ false
             result = self._run_raw(
                 """
 export teamcity_build_checkoutDir="{root}"
-
-stop_doris_grace() {{
-    return 0
-}}
-
-archive_doris_coredump() {{
-    return 0
-}}
-
-archive_doris_logs() {{
-    return 0
-}}
-
-upload_doris_log_to_oss() {{
-    return 0
-}}
 
 collect_docker_logs() {{
     return 0
@@ -125,12 +116,15 @@ main() {{
     cd "{tmpdir}" && bash run-thirdparties-docker.sh --start
     echo "RUN EXTERNAL CASE"
     cd "{tmpdir}" && ./run-regression-test.sh --teamcity --clean --run
-    stop_doris_grace
-    archive_doris_coredump fake.tar.gz
-    archive_doris_logs fake.tar.gz
-    upload_doris_log_to_oss fake.tar.gz
     echo "COLLECT DOCKER LOGS"
     collect_docker_logs external
+    echo "[check] after check core, exit_flag is 0"
+    cd "{tmpdir}" && bash stop_be.sh --grace
+    echo "start restart, $(date)"
+    cd "{tmpdir}" && bash start_cluster.sh Cluster0
+    echo "NEW FE IMAGE CREATED AFTER FE RESTART, PASS"
+    cd "{tmpdir}" && bash stop_cluster_grace.sh Cluster0
+    echo "日志备份标记 true"
 }}
 
 main
@@ -147,11 +141,11 @@ main
         self.assertIn("启动 Doris", result.stdout)
         self.assertIn("启动依赖", result.stdout)
         self.assertIn("执行 Case", result.stdout)
-        self.assertIn("停止 Doris", result.stdout)
-        self.assertIn("归档 Coredump", result.stdout)
-        self.assertIn("归档日志", result.stdout)
-        self.assertIn("上传日志", result.stdout)
         self.assertIn("收集 Docker 日志", result.stdout)
+        self.assertIn("检查 Core", result.stdout)
+        self.assertIn("停止集群", result.stdout)
+        self.assertIn("重启并检查 FE 元数据", result.stdout)
+        self.assertIn("备份日志", result.stdout)
 
     def test_non_external_pipeline_does_not_enable_auto_hooks(self):
         result = self._run_raw(

--- a/regression-test/pipeline/common/test_stage_timer.py
+++ b/regression-test/pipeline/common/test_stage_timer.py
@@ -97,6 +97,26 @@ false
                 """
 export teamcity_build_checkoutDir="{root}"
 
+stop_doris_grace() {{
+    return 0
+}}
+
+archive_doris_coredump() {{
+    return 0
+}}
+
+archive_doris_logs() {{
+    return 0
+}}
+
+upload_doris_log_to_oss() {{
+    return 0
+}}
+
+collect_docker_logs() {{
+    return 0
+}}
+
 main() {{
     source "{github_helper}"
     echo "PREPARE"
@@ -105,7 +125,12 @@ main() {{
     cd "{tmpdir}" && bash run-thirdparties-docker.sh --start
     echo "RUN EXTERNAL CASE"
     cd "{tmpdir}" && ./run-regression-test.sh --teamcity --clean --run
+    stop_doris_grace
+    archive_doris_coredump fake.tar.gz
+    archive_doris_logs fake.tar.gz
+    upload_doris_log_to_oss fake.tar.gz
     echo "COLLECT DOCKER LOGS"
+    collect_docker_logs external
 }}
 
 main
@@ -122,7 +147,11 @@ main
         self.assertIn("启动 Doris", result.stdout)
         self.assertIn("启动依赖", result.stdout)
         self.assertIn("执行 Case", result.stdout)
-        self.assertIn("收尾归档", result.stdout)
+        self.assertIn("停止 Doris", result.stdout)
+        self.assertIn("归档 Coredump", result.stdout)
+        self.assertIn("归档日志", result.stdout)
+        self.assertIn("上传日志", result.stdout)
+        self.assertIn("收集 Docker 日志", result.stdout)
 
     def test_non_external_pipeline_does_not_enable_auto_hooks(self):
         result = self._run_raw(

--- a/regression-test/pipeline/common/test_stage_timer.py
+++ b/regression-test/pipeline/common/test_stage_timer.py
@@ -92,6 +92,7 @@ false
                 "run-regression-test.sh",
                 "stop_be.sh",
                 "start_cluster.sh",
+                "stop_cluster.sh",
                 "stop_cluster_grace.sh",
             ):
                 script_path = os.path.join(tmpdir, name)

--- a/regression-test/pipeline/external/external-stage-timer.sh
+++ b/regression-test/pipeline/external/external-stage-timer.sh
@@ -61,8 +61,20 @@ external_regression_stage_timer__handle_command() {
         *"./run-regression-test.sh --teamcity --clean --run"*)
             external_regression_stage_timer__enter_if_needed "执行 Case"
             ;;
+        *"stop_doris_grace"*)
+            external_regression_stage_timer__enter_if_needed "停止 Doris"
+            ;;
+        *"archive_doris_coredump "*)
+            external_regression_stage_timer__enter_if_needed "归档 Coredump"
+            ;;
+        *"archive_doris_logs "*)
+            external_regression_stage_timer__enter_if_needed "归档日志"
+            ;;
+        *"upload_doris_log_to_oss "*)
+            external_regression_stage_timer__enter_if_needed "上传日志"
+            ;;
         *"COLLECT DOCKER LOGS"* | *"collect_docker_logs "*)
-            external_regression_stage_timer__enter_if_needed "收尾归档"
+            external_regression_stage_timer__enter_if_needed "收集 Docker 日志"
             ;;
     esac
 }
@@ -104,7 +116,7 @@ external_regression_stage_timer_enter_run_cases() {
 }
 
 external_regression_stage_timer_enter_cleanup() {
-    stage_timer_enter "收尾归档"
+    stage_timer_enter "停止 Doris"
 }
 
 external_regression_stage_timer_enable_auto_hooks() {

--- a/regression-test/pipeline/external/external-stage-timer.sh
+++ b/regression-test/pipeline/external/external-stage-timer.sh
@@ -61,17 +61,17 @@ external_regression_stage_timer__handle_command() {
         *"./run-regression-test.sh --teamcity --clean --run"*)
             external_regression_stage_timer__enter_if_needed "执行 Case"
             ;;
-        *"stop_doris_grace"*)
-            external_regression_stage_timer__enter_if_needed "停止 Doris"
+        *"after check core"*)
+            external_regression_stage_timer__enter_if_needed "检查 Core"
             ;;
-        *"archive_doris_coredump "*)
-            external_regression_stage_timer__enter_if_needed "归档 Coredump"
+        *"stop_doris_grace"* | *"stop_be.sh --grace"* | *"stop_fe.sh --grace"* | *"stop_cluster_grace.sh "*)
+            external_regression_stage_timer__enter_if_needed "停止集群"
             ;;
-        *"archive_doris_logs "*)
-            external_regression_stage_timer__enter_if_needed "归档日志"
+        *"start restart,"* | *"start_cluster.sh "* | *"after restart fe image meta"* | *"NEW FE IMAGE CREATED AFTER FE RESTART"*)
+            external_regression_stage_timer__enter_if_needed "重启并检查 FE 元数据"
             ;;
-        *"upload_doris_log_to_oss "*)
-            external_regression_stage_timer__enter_if_needed "上传日志"
+        *"日志备份标记 "* | *"archive_doris_logs "* | *"upload_doris_log_to_oss "*)
+            external_regression_stage_timer__enter_if_needed "备份日志"
             ;;
         *"COLLECT DOCKER LOGS"* | *"collect_docker_logs "*)
             external_regression_stage_timer__enter_if_needed "收集 Docker 日志"
@@ -116,7 +116,7 @@ external_regression_stage_timer_enter_run_cases() {
 }
 
 external_regression_stage_timer_enter_cleanup() {
-    stage_timer_enter "停止 Doris"
+    stage_timer_enter "收集 Docker 日志"
 }
 
 external_regression_stage_timer_enable_auto_hooks() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: External regression spends a stable teardown tail after the last case finishes. Investigation shows the dominant cost is full docker log collection in the live TeamCity external shell. This PR keeps the external cleanup timing split and wraps the inline `collect_docker_logs` through `github-utils.sh` so successful runs skip full docker log collection by default, while failures still collect logs and `COLLECT_DOCKER_LOGS_ON_SUCCESS=true` can re-enable success-path collection for debugging.

### Release note

None

### Check List (For Author)

- Test: Regression test / Manual test
    - Regression test: `python regression-test/pipeline/common/test_github_utils.py`
    - Regression test: `python regression-test/pipeline/common/test_stage_timer.py`
    - Manual test: `bash -n regression-test/pipeline/common/github-utils.sh regression-test/pipeline/external/external-stage-timer.sh regression-test/pipeline/common/stage-timer.sh`
- Behavior changed: Yes (external successful runs skip full docker log collection by default; set `COLLECT_DOCKER_LOGS_ON_SUCCESS=true` to keep collecting logs on success)
- Does this need documentation: No
