### PR TITLE
[fix](fe) Fix SHOW BACKENDS field order mismatch

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -152,9 +152,6 @@ public class BackendsProcDir implements ProcDirInterface {
             // heartbeat failure counter
             backendInfo.add(backend.getHeartbeatFailureCounter());
 
-            // node role, show the value only when backend is alive.
-            backendInfo.add(backend.isAlive() ? backend.getNodeRoleTag().value : "");
-
             // cpu cores
             backendInfo.add(String.valueOf(backend.getCputCores()));
 
@@ -166,6 +163,9 @@ public class BackendsProcDir implements ProcDirInterface {
 
             // runningFragments
             backendInfo.add(String.valueOf(backend.getRunningTasks()));
+
+            // node role, show the value only when backend is alive.
+            backendInfo.add(backend.isAlive() ? backend.getNodeRoleTag().value : "");
 
             comparableBackendInfos.add(backendInfo);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
@@ -209,7 +209,6 @@ public class BackendsProcDirTest {
         ProcResult result = dir.fetchResult();
 
         List<String> columnNames = result.getColumnNames();
-        List<List<String>> rows = result.getRows();
 
         int cpuCoresIdx = columnNames.indexOf("CpuCores");
         int memoryIdx = columnNames.indexOf("Memory");

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
@@ -24,12 +24,15 @@ import org.apache.doris.persist.EditLog;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
+import com.google.common.collect.Lists;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 public class BackendsProcDirTest {
     private Backend b1;
@@ -182,5 +185,41 @@ public class BackendsProcDirTest {
         result = dir.fetchResult();
         Assert.assertNotNull(result);
         Assert.assertTrue(result instanceof BaseProcResult);
+    }
+
+    @Test
+    public void testBackendInfoFieldOrder() throws AnalysisException {
+        b1.setCpuCores(192);
+        b1.setLastUpdateMs(System.currentTimeMillis());
+        b1.setRunningTasks(10L);
+
+        new Expectations() {
+            {
+                systemInfoService.getAllBackendIds(false);
+                minTimes = 0;
+                result = Lists.newArrayList(1000L);
+
+                systemInfoService.getTabletNumByBackendId(1000L);
+                minTimes = 0;
+                result = 10;
+            }
+        };
+
+        BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+        ProcResult result = dir.fetchResult();
+
+        List<String> columnNames = result.getColumnNames();
+        List<List<String>> rows = result.getRows();
+
+        int cpuCoresIdx = columnNames.indexOf("CpuCores");
+        int memoryIdx = columnNames.indexOf("Memory");
+        int liveSinceIdx = columnNames.indexOf("LiveSince");
+        int runningTasksIdx = columnNames.indexOf("RunningTasks");
+        int nodeRoleIdx = columnNames.indexOf("NodeRole");
+
+        Assert.assertTrue("CpuCores should be before Memory", cpuCoresIdx < memoryIdx);
+        Assert.assertTrue("Memory should be before LiveSince", memoryIdx < liveSinceIdx);
+        Assert.assertTrue("LiveSince should be before RunningTasks", liveSinceIdx < runningTasksIdx);
+        Assert.assertTrue("RunningTasks should be before NodeRole", runningTasksIdx < nodeRoleIdx);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -90,9 +90,41 @@ public class ShowBackendsCommandTest {
         List<Column> columnList = showResultSet.getMetaData().getColumns();
         ImmutableList<String> backendsTitleNames = BackendsTableValuedFunction.getBackendsTitleNames();
         Assertions.assertTrue(!columnList.isEmpty() && columnList.size() == backendsTitleNames.size());
+
         for (int i = 0; i < backendsTitleNames.size(); i++) {
-            Assertions.assertTrue(columnList.get(i).getName().equalsIgnoreCase(backendsTitleNames.get(i)));
+            Assertions.assertEquals(backendsTitleNames.get(i), columnList.get(i).getName(),
+                    "Column at index " + i + " should be " + backendsTitleNames.get(i));
         }
+
+        Assertions.assertEquals("BackendId", columnList.get(0).getName());
+        Assertions.assertEquals("Host", columnList.get(1).getName());
+        Assertions.assertEquals("HeartbeatPort", columnList.get(2).getName());
+        Assertions.assertEquals("BePort", columnList.get(3).getName());
+        Assertions.assertEquals("HttpPort", columnList.get(4).getName());
+        Assertions.assertEquals("BrpcPort", columnList.get(5).getName());
+        Assertions.assertEquals("ArrowFlightSqlPort", columnList.get(6).getName());
+        Assertions.assertEquals("LastStartTime", columnList.get(7).getName());
+        Assertions.assertEquals("LastHeartbeat", columnList.get(8).getName());
+        Assertions.assertEquals("Alive", columnList.get(9).getName());
+        Assertions.assertEquals("SystemDecommissioned", columnList.get(10).getName());
+        Assertions.assertEquals("TabletNum", columnList.get(11).getName());
+        Assertions.assertEquals("DataUsedCapacity", columnList.get(12).getName());
+        Assertions.assertEquals("TrashUsedCapacity", columnList.get(13).getName());
+        Assertions.assertEquals("AvailCapacity", columnList.get(14).getName());
+        Assertions.assertEquals("TotalCapacity", columnList.get(15).getName());
+        Assertions.assertEquals("UsedPct", columnList.get(16).getName());
+        Assertions.assertEquals("MaxDiskUsedPct", columnList.get(17).getName());
+        Assertions.assertEquals("RemoteUsedCapacity", columnList.get(18).getName());
+        Assertions.assertEquals("Tag", columnList.get(19).getName());
+        Assertions.assertEquals("ErrMsg", columnList.get(20).getName());
+        Assertions.assertEquals("Version", columnList.get(21).getName());
+        Assertions.assertEquals("Status", columnList.get(22).getName());
+        Assertions.assertEquals("HeartbeatFailureCounter", columnList.get(23).getName());
+        Assertions.assertEquals("CpuCores", columnList.get(24).getName());
+        Assertions.assertEquals("Memory", columnList.get(25).getName());
+        Assertions.assertEquals("LiveSince", columnList.get(26).getName());
+        Assertions.assertEquals("RunningTasks", columnList.get(27).getName());
+        Assertions.assertEquals("NodeRole", columnList.get(28).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
@@ -219,7 +219,7 @@ public class DemoMultiBackendsTest {
                         + "\"lastFragmentUpdateTime\":0}",
                 result.getRows().get(0).get(backendsTitleNames.size() - 7));
         Assert.assertEquals("0", result.getRows().get(0).get(backendsTitleNames.size() - 6));
-        Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(backendsTitleNames.size() - 5));
+        Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(backendsTitleNames.size() - 1));
     }
 
     protected void alterTable(String sql, ConnectContext connectContext) throws Exception {


### PR DESCRIPTION
## Summary
Fix SHOW BACKENDS command output field order mismatch with BackendsTableValuedFunction.SCHEMA definition.

## Problem
The output fields of SHOW BACKENDS command were not in the same order as the BackendsTableValuedFunction.SCHEMA definition, causing field values to be displayed in wrong columns:
- CpuCores showed NodeRole value (mix)
- Memory showed CpuCores value
- NodeRole showed Memory value

## Solution
1. Reorder fields in BackendsProcDir.getBackendInfos() to match SCHEMA:
   - CpuCores -> Memory -> LiveSince -> RunningTasks -> NodeRole
2. Synchronize the same fix in MetadataGenerator.backendsMetadataResult()
3. Add unit test to verify field order

## Test
- Unit test added in BackendsProcDirTest.testBackendInfoFieldOrder()