### PR TITLE
[Chore](tool) enlarge tpch sf1000 supplier buckets number

### DIFF
--- a/tools/tpch-tools/ddl/create-tpch-tables-sf1000.sql
+++ b/tools/tpch-tools/ddl/create-tpch-tables-sf1000.sql
@@ -128,7 +128,7 @@ CREATE TABLE supplier (
 )ENGINE=OLAP
 DUPLICATE KEY(`s_suppkey`)
 COMMENT "OLAP"
-DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 24
+DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 48
 PROPERTIES (
     "replication_num" = "1"
 );


### PR DESCRIPTION
This pull request increases the number of buckets for the `supplier` table in the TPC-H schema to improve data distribution and potentially query performance.

Table distribution changes:

* In `tools/tpch-tools/ddl/create-tpch-tables-sf1000.sql`, the `supplier` table's `DISTRIBUTED BY HASH` clause is updated to use 48 buckets instead of 24.