### PR TITLE
[refactor](fe) Replace all JMockit usage with Mockito and remove JMockit dependency

### DIFF
--- a/fe/be-java-extensions/max-compute-connector/pom.xml
+++ b/fe/be-java-extensions/max-compute-connector/pom.xml
@@ -101,7 +101,6 @@ under the License.
                     <forkCount>${fe_ut_parallel}</forkCount>
                     <reuseForks>false</reuseForks>
                     <useFile>false</useFile>
-                    <argLine>-javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -816,11 +816,6 @@ under the License.
                     <libDirectory>src/main/antlr4/org/apache/doris/nereids</libDirectory>
                 </configuration>
             </plugin>
-            <!-- jmockit -->
-            <!--fixme  Unify mocking framework usage across the project.
-            Currently, multiple mocking libraries (e.g., JMockit, Powermock) are used, 
-            which increases maintenance complexity and may cause agent conflicts (e.g., with JaCoCo).
-            Evaluate existing usages and standardize on a single framework where possible.-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -831,7 +826,7 @@ under the License.
                     <reuseForks>false</reuseForks>
                     <useFile>false</useFile>
                     <argLine>
-                        -Xmx1024m -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar @{argLine}
+                        -Xmx1024m @{argLine}
                     </argLine>
                 </configuration>
             </plugin>

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/CloudIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/CloudIndexTest.java
@@ -37,7 +37,6 @@ import org.apache.doris.cloud.rpc.MetaServiceProxy;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.UserException;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.Auth;
@@ -48,7 +47,6 @@ import org.apache.doris.nereids.trees.plans.commands.info.CreateIndexOp;
 import org.apache.doris.nereids.trees.plans.commands.info.IndexDefinition;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.resource.computegroup.ComputeGroupMgr;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
@@ -61,15 +59,16 @@ import org.apache.doris.utframe.MockedMetaServerFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -91,136 +90,147 @@ public class CloudIndexTest {
     private static CancelBuildIndexCommand cancelBuildIndexCommand;
     private static SchemaChangeHandler schemaChangeHandler;
 
+    private MockedStatic<MetaServiceProxy> mockedMetaServiceProxy;
+    private MetaServiceProxy mockProxy;
+
+    private static void setField(Object target, Class<?> clazz, String fieldName, Object value)
+            throws Exception {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedMetaServiceProxy != null) {
+            mockedMetaServiceProxy.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+    }
+
     @Before
-    public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException, NoSuchMethodException, SecurityException, UserException {
+    public void setUp() throws Exception {
         FeConstants.runningUnitTest = true;
         // Setup for MetaServiceProxy mock
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
+        mockProxy = Mockito.mock(MetaServiceProxy.class);
+        mockedMetaServiceProxy = Mockito.mockStatic(MetaServiceProxy.class);
+        mockedMetaServiceProxy.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
 
-            @Mock
-            public Cloud.BeginTxnResponse beginTxn(Cloud.BeginTxnRequest request) {
-                Cloud.BeginTxnResponse.Builder beginTxnResponseBuilder = Cloud.BeginTxnResponse.newBuilder();
-                beginTxnResponseBuilder.setTxnId(1000)
-                        .setStatus(
-                                Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
-                return beginTxnResponseBuilder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.BeginTxnResponse.Builder beginTxnResponseBuilder = Cloud.BeginTxnResponse.newBuilder();
+            beginTxnResponseBuilder.setTxnId(1000)
+                    .setStatus(
+                            Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
+            return beginTxnResponseBuilder.build();
+        }).when(mockProxy).beginTxn(Mockito.any());
 
-            @Mock
-            public Cloud.CommitTxnResponse commitTxn(Cloud.CommitTxnRequest request) {
-                Cloud.TxnInfoPB.Builder txnInfoBuilder = Cloud.TxnInfoPB.newBuilder();
-                txnInfoBuilder.setDbId(CatalogTestUtil.testDbId1);
-                txnInfoBuilder.addAllTableIds(Lists.newArrayList(olapTable.getId()));
-                txnInfoBuilder.setLabel("test_label");
-                txnInfoBuilder.setListenerId(-1);
-                Cloud.CommitTxnResponse.Builder commitTxnResponseBuilder = Cloud.CommitTxnResponse.newBuilder();
-                commitTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                                .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .setTxnInfo(txnInfoBuilder.build());
-                return commitTxnResponseBuilder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.TxnInfoPB.Builder txnInfoBuilder = Cloud.TxnInfoPB.newBuilder();
+            txnInfoBuilder.setDbId(CatalogTestUtil.testDbId1);
+            txnInfoBuilder.addAllTableIds(Lists.newArrayList(olapTable != null ? olapTable.getId() : 0L));
+            txnInfoBuilder.setLabel("test_label");
+            txnInfoBuilder.setListenerId(-1);
+            Cloud.CommitTxnResponse.Builder commitTxnResponseBuilder = Cloud.CommitTxnResponse.newBuilder();
+            commitTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setTxnInfo(txnInfoBuilder.build());
+            return commitTxnResponseBuilder.build();
+        }).when(mockProxy).commitTxn(Mockito.any());
 
-            @Mock
-            public Cloud.CheckTxnConflictResponse checkTxnConflict(Cloud.CheckTxnConflictRequest request) {
-                Cloud.CheckTxnConflictResponse.Builder checkTxnConflictResponseBuilder =
-                        Cloud.CheckTxnConflictResponse.newBuilder();
-                checkTxnConflictResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                                .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .setFinished(true);
-                return checkTxnConflictResponseBuilder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.CheckTxnConflictResponse.Builder checkTxnConflictResponseBuilder =
+                    Cloud.CheckTxnConflictResponse.newBuilder();
+            checkTxnConflictResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setFinished(true);
+            return checkTxnConflictResponseBuilder.build();
+        }).when(mockProxy).checkTxnConflict(Mockito.any());
 
-            @Mock
-            public Cloud.GetClusterResponse getCluster(Cloud.GetClusterRequest request) {
-                Cloud.GetClusterResponse.Builder getClusterResponseBuilder = Cloud.GetClusterResponse.newBuilder();
-                Cloud.ClusterPB.Builder clusterBuilder = Cloud.ClusterPB.newBuilder();
-                clusterBuilder.setClusterId("test_id").setClusterName("test_group");
+        Mockito.doAnswer(invocation -> {
+            Cloud.GetClusterResponse.Builder getClusterResponseBuilder = Cloud.GetClusterResponse.newBuilder();
+            Cloud.ClusterPB.Builder clusterBuilder = Cloud.ClusterPB.newBuilder();
+            clusterBuilder.setClusterId("test_id").setClusterName("test_group");
 
-                Cloud.NodeInfoPB.Builder node1 = Cloud.NodeInfoPB.newBuilder();
-                node1.setCloudUniqueId("test_cloud")
-                        .setName("host1")
-                        .setIp("host1")
-                        .setHost("host1")
-                        .setHeartbeatPort(123)
-                        .setEditLogPort(125)
-                        .setStatus(Cloud.NodeStatusPB.NODE_STATUS_RUNNING);
-                clusterBuilder.addNodes(node1.build());
-                getClusterResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                                .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .addCluster(clusterBuilder.build());
-                return getClusterResponseBuilder.build();
-            }
+            Cloud.NodeInfoPB.Builder node1 = Cloud.NodeInfoPB.newBuilder();
+            node1.setCloudUniqueId("test_cloud")
+                    .setName("host1")
+                    .setIp("host1")
+                    .setHost("host1")
+                    .setHeartbeatPort(123)
+                    .setEditLogPort(125)
+                    .setStatus(Cloud.NodeStatusPB.NODE_STATUS_RUNNING);
+            clusterBuilder.addNodes(node1.build());
+            getClusterResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .addCluster(clusterBuilder.build());
+            return getClusterResponseBuilder.build();
+        }).when(mockProxy).getCluster(Mockito.any());
 
-            @Mock
-            public Cloud.CreateTabletsResponse createTablets(Cloud.CreateTabletsRequest request) {
-                Cloud.CreateTabletsResponse.Builder responseBuilder = Cloud.CreateTabletsResponse.newBuilder();
-                responseBuilder.setStatus(
-                        Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
-                return responseBuilder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.CreateTabletsResponse.Builder responseBuilder = Cloud.CreateTabletsResponse.newBuilder();
+            responseBuilder.setStatus(
+                    Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
+            return responseBuilder.build();
+        }).when(mockProxy).createTablets(Mockito.any());
 
-            @Mock
-            public Cloud.FinishTabletJobResponse finishTabletJob(Cloud.FinishTabletJobRequest request) {
-                Cloud.FinishTabletJobResponse.Builder responseBuilder = Cloud.FinishTabletJobResponse.newBuilder();
-                responseBuilder.setStatus(
-                        Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
-                return responseBuilder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.FinishTabletJobResponse.Builder responseBuilder = Cloud.FinishTabletJobResponse.newBuilder();
+            responseBuilder.setStatus(
+                    Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
+            return responseBuilder.build();
+        }).when(mockProxy).finishTabletJob(Mockito.any());
 
-            @Mock
-            public Cloud.IndexResponse prepareIndex(Cloud.IndexRequest request) {
-                Cloud.IndexResponse.Builder builder = Cloud.IndexResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"));
-                return builder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.IndexResponse.Builder builder = Cloud.IndexResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                    .setCode(MetaServiceCode.OK).setMsg("OK"));
+            return builder.build();
+        }).when(mockProxy).prepareIndex(Mockito.any());
 
-            @Mock
-            public Cloud.IndexResponse commitIndex(Cloud.IndexRequest request) {
-                Cloud.IndexResponse.Builder builder = Cloud.IndexResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"));
-                return builder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.IndexResponse.Builder builder = Cloud.IndexResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                    .setCode(MetaServiceCode.OK).setMsg("OK"));
+            return builder.build();
+        }).when(mockProxy).commitIndex(Mockito.any());
 
-            @Mock
-            public Cloud.IndexResponse dropIndex(Cloud.IndexRequest request) {
-                Cloud.IndexResponse.Builder builder = Cloud.IndexResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"));
-                return builder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.IndexResponse.Builder builder = Cloud.IndexResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                    .setCode(MetaServiceCode.OK).setMsg("OK"));
+            return builder.build();
+        }).when(mockProxy).dropIndex(Mockito.any());
 
-            @Mock
-            public Cloud.CheckKVResponse checkKv(Cloud.CheckKVRequest request) {
-                Cloud.CheckKVResponse.Builder builder = Cloud.CheckKVResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"));
-                return builder.build();
-            }
+        Mockito.doAnswer(invocation -> {
+            Cloud.CheckKVResponse.Builder builder = Cloud.CheckKVResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                    .setCode(MetaServiceCode.OK).setMsg("OK"));
+            return builder.build();
+        }).when(mockProxy).checkKv(Mockito.any());
 
-            @Mock
-            public Cloud.GetCurrentMaxTxnResponse getCurrentMaxTxnId(Cloud.GetCurrentMaxTxnRequest request) {
-                Cloud.GetCurrentMaxTxnResponse.Builder builder = Cloud.GetCurrentMaxTxnResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                                .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .setCurrentMaxTxnId(1000);
-                return builder.build();
-            }
-        };
+        Mockito.doAnswer(invocation -> {
+            Cloud.GetCurrentMaxTxnResponse.Builder builder = Cloud.GetCurrentMaxTxnResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setCurrentMaxTxnId(1000);
+            return builder.build();
+        }).when(mockProxy).getCurrentMaxTxnId(Mockito.any());
 
         Config.cloud_unique_id = "test_cloud";
         Config.meta_service_endpoint = MockedMetaServerFactory.METASERVER_DEFAULT_IP + ":" + 20121;
 
         EnvFactory envFactory = EnvFactory.getInstance();
         masterEnv = envFactory.createEnv(false);
-        SystemInfoService cloudSystemInfo = Env.getCurrentSystemInfo();
+        SystemInfoService cloudSystemInfo = masterEnv.getClusterInfo();
         fakeEnv = new FakeEnv();
         FakeEnv.setSystemInfo(cloudSystemInfo);
 
         fakeEditLog = new FakeEditLog();
-        testEditLog = null; // Will be set by MockUp
         FakeEnv.setEnv(masterEnv);
 
         ctx = new ConnectContext();
@@ -232,113 +242,73 @@ public class CloudIndexTest {
         ctx.setCloudCluster("test_group");
         Assert.assertTrue(envFactory instanceof CloudEnvFactory);
         Assert.assertTrue(masterEnv instanceof CloudEnv);
-        new MockUp<Env>() {
-            @Mock
-            public Env getCurrentEnv() {
-                return masterEnv;
+
+        // Replace MockUp<Env> with direct field injection on masterEnv
+        setField(masterEnv, Env.class, "selfNode",
+                new SystemInfoService.HostInfo("127.0.0.1", 9030));
+        testEditLog = Mockito.mock(EditLog.class);
+        setField(masterEnv, Env.class, "editLog", testEditLog);
+        setField(masterEnv, Env.class, "computeGroupMgr", new ComputeGroupMgr(Env.getCurrentSystemInfo()));
+        AccessControllerManager acm = new AccessControllerManager(masterEnv.getAuth()) {
+            @Override
+            public boolean checkTblPriv(ConnectContext ctx, String ctl, String db, String tbl,
+                    PrivPredicate wanted) {
+                return true;
             }
 
-            @Mock
-            public EditLog getEditLog() {
-                if (testEditLog == null) {
-                    // Create a mock EditLog using a no-op approach
-                    testEditLog = new EditLog("test") {
-                        // Override to avoid initialization issues
-                    };
-                }
-                return testEditLog;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return new ComputeGroupMgr(Env.getCurrentSystemInfo());
-            }
-
-            @Mock
-            public SchemaChangeHandler getSchemaChangeHandler() {
-                // Create a new independent SchemaChangeHandler for each call
-                return schemaChangeHandler;
-            }
-
-            @Mock
-            public AccessControllerManager getAccessManager() {
-                return new AccessControllerManager(masterEnv.getAuth()) {
-                    @Override
-                    public boolean checkTblPriv(ConnectContext ctx, String ctl, String db, String tbl, PrivPredicate wanted) {
-                        return true; // Allow all access for test
-                    }
-
-                    @Override
-                    public boolean checkCloudPriv(UserIdentity user, String cluster, PrivPredicate wanted, ResourceTypeEnum resourceType) {
-                        return true; // Allow all cloud privileges for test
-                    }
-                };
+            @Override
+            public boolean checkCloudPriv(UserIdentity user, String cluster, PrivPredicate wanted,
+                    ResourceTypeEnum resourceType) {
+                return true;
             }
         };
+        setField(masterEnv, Env.class, "accessManager", acm);
 
-        new MockUp<Auth>() {
-            @Mock
-            public String getDefaultCloudCluster(String user) {
-                return "test_group"; // Return default cluster for test
+        // Replace MockUp<Auth> with spy
+        Auth authSpy = Mockito.spy(masterEnv.getAuth());
+        Mockito.doReturn("test_group").when(authSpy).getDefaultCloudCluster(Mockito.anyString());
+        Mockito.doAnswer(invocation -> {
+            try {
+                return masterEnv.getComputeGroupMgr().getComputeGroupByName("test_group");
+            } catch (Exception e) {
+                return masterEnv.getComputeGroupMgr().getAllBackendComputeGroup();
             }
+        }).when(authSpy).getComputeGroup(Mockito.anyString());
+        setField(masterEnv, Env.class, "auth", authSpy);
 
-            @Mock
-            public ComputeGroup getComputeGroup(String user) {
-                try {
-                    return masterEnv.getComputeGroupMgr().getComputeGroupByName("test_group");
-                } catch (Exception e) {
-                    return masterEnv.getComputeGroupMgr().getAllBackendComputeGroup();
-                }
-            }
-        };
-
-        // Mock cloud environment permissions
-        new MockUp<CloudEnv>() {
-            @Mock
-            public void checkCloudClusterPriv(String cluster) throws Exception {
-                // Always allow for tests
-            }
-        };
-
-        // Mock ConnectContext to avoid compute group permission check
-        new MockUp<ConnectContext>() {
-            @Mock
-            public String getCloudCluster() {
-                return "test_group";
-            }
-
-            @Mock
-            public UserIdentity getCurrentUserIdentity() {
-                UserIdentity rootUser = new UserIdentity("root", "%");
-                rootUser.setIsAnalyzed();
-                return rootUser;
-            }
-        };
+        // MockUp<CloudEnv> removed: checkCloudClusterPriv not called in test paths
+        // MockUp<ConnectContext> removed: ctx already has correct values via setters
 
         Assert.assertTrue(Env.getCurrentSystemInfo() instanceof CloudSystemInfoService);
-        // Mock addCloudCluster to avoid EditLog issues
-        new MockUp<CloudSystemInfoService>() {
-            @Mock
-            public void addCloudCluster(String clusterName, String clusterId) {
-                // Create backend manually for test
-                Backend backend = new Backend(10001L, "host1", 123);
-                backend.setAlive(true);
-                backend.setBePort(456);
-                backend.setHttpPort(789);
-                backend.setBrpcPort(321);
-                backend.setTagMap(Maps.newHashMap());
-                backend.getTagMap().put("cloud_cluster_id", "test_id");
-                backend.getTagMap().put("cloud_unique_id", "test_cloud");
-                backend.getTagMap().put("cloud_cluster_name", "test_group");
-                backend.getTagMap().put("cloud_cluster_status", "NORMAL");
-                backend.getTagMap().put("location", "default");
-                backend.getTagMap().put("cloud_cluster_private_endpoint", "");
-                backend.getTagMap().put("cloud_cluster_public_endpoint", "");
-                CloudSystemInfoService systemInfo = (CloudSystemInfoService) Env.getCurrentSystemInfo();
-                systemInfo.addBackend(backend);
-            }
-        };
-        ((CloudSystemInfoService) Env.getCurrentSystemInfo()).addCloudCluster("test_group", "");
+        // Replace MockUp<CloudSystemInfoService> with spy
+        CloudSystemInfoService sysInfo = (CloudSystemInfoService) Env.getCurrentSystemInfo();
+        CloudSystemInfoService sysInfoSpy = Mockito.spy(sysInfo);
+        Mockito.doAnswer(invocation -> {
+            Backend backend = new Backend(10001L, "host1", 123);
+            backend.setAlive(true);
+            backend.setBePort(456);
+            backend.setHttpPort(789);
+            backend.setBrpcPort(321);
+            Map<String, String> tagMap = Maps.newHashMap();
+            tagMap.put("location", "default");
+            tagMap.put("cloud_cluster_id", "test_id");
+            tagMap.put("cloud_unique_id", "test_cloud");
+            tagMap.put("cloud_cluster_name", "test_group");
+            tagMap.put("cloud_cluster_status", "NORMAL");
+            tagMap.put("cloud_cluster_private_endpoint", "");
+            tagMap.put("cloud_cluster_public_endpoint", "");
+            backend.setTagMap(tagMap);
+            CloudSystemInfoService self = (CloudSystemInfoService) invocation.getMock();
+            self.addBackend(backend);
+            List<Backend> toAdd = new ArrayList<>();
+            toAdd.add(backend);
+            self.updateCloudClusterMap(toAdd, new ArrayList<>());
+            return null;
+        }).when(sysInfoSpy).addCloudCluster(Mockito.anyString(), Mockito.anyString());
+        setField(masterEnv, Env.class, "systemInfo", sysInfoSpy);
+        FakeEnv.setSystemInfo(sysInfoSpy);
+
+        sysInfoSpy.addCloudCluster("test_group", "");
         List<Backend> backends =
                 ((CloudSystemInfoService) Env.getCurrentSystemInfo()).getBackendsByClusterName("test_group");
         Assert.assertEquals(1, backends.size());
@@ -358,7 +328,13 @@ public class CloudIndexTest {
         Assert.assertTrue(Env.getCurrentSystemInfo() instanceof CloudSystemInfoService);
 
         SystemInfoService cloudSystemInfo = Env.getCurrentSystemInfo();
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         FakeEnv.setSystemInfo(cloudSystemInfo);
@@ -407,7 +383,13 @@ public class CloudIndexTest {
         Assert.assertTrue(Env.getCurrentSystemInfo() instanceof CloudSystemInfoService);
 
         SystemInfoService cloudSystemInfo = Env.getCurrentSystemInfo();
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         FakeEnv.setSystemInfo(cloudSystemInfo);
@@ -472,7 +454,13 @@ public class CloudIndexTest {
         Assert.assertTrue(Env.getCurrentSystemInfo() instanceof CloudSystemInfoService);
 
         SystemInfoService cloudSystemInfo = Env.getCurrentSystemInfo();
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         FakeEnv.setSystemInfo(cloudSystemInfo);
@@ -534,7 +522,13 @@ public class CloudIndexTest {
         Assert.assertTrue(Env.getCurrentSystemInfo() instanceof CloudSystemInfoService);
 
         SystemInfoService cloudSystemInfo = Env.getCurrentSystemInfo();
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         FakeEnv.setSystemInfo(cloudSystemInfo);
@@ -579,7 +573,13 @@ public class CloudIndexTest {
         Assert.assertTrue(Env.getCurrentSystemInfo() instanceof CloudSystemInfoService);
 
         SystemInfoService cloudSystemInfo = Env.getCurrentSystemInfo();
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         FakeEnv.setSystemInfo(cloudSystemInfo);

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/IndexChangeJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/IndexChangeJobTest.java
@@ -53,13 +53,14 @@ import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -79,6 +80,7 @@ public class IndexChangeJobTest {
     private static Env slaveEnv;
 
     private static ConnectContext ctx;
+    private MockedStatic<ConnectContext> mockedConnectContext;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -99,19 +101,37 @@ public class IndexChangeJobTest {
         slaveTransMgr.setEditLog(slaveEnv.getEditLog());
         // Initialize ConnectContext
         ctx = new ConnectContext();
-        new MockUp<ConnectContext>() {
-            @Mock
-            public ConnectContext get() {
-                return ctx;
-            }
-        };
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class);
+        mockedConnectContext.when(ConnectContext::get).thenReturn(ctx);
         FeConstants.runningUnitTest = true;
         AgentTaskQueue.clearAllTasks();
     }
 
+    @After
+    public void tearDown() {
+        if (mockedConnectContext != null) {
+            mockedConnectContext.close();
+        }
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        if (fakeTransactionIDGenerator != null) {
+            fakeTransactionIDGenerator.close();
+        }
+    }
+
     @Test
     public void testCreateIndexIndexChange() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -138,7 +158,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testBuildIndexIndexChange() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -171,7 +197,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testDropIndexIndexChange() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -206,7 +238,13 @@ public class IndexChangeJobTest {
     @Test
     // start a build index job, then normally finish it
     public void testBuildIndexIndexChangeNormal() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -265,7 +303,13 @@ public class IndexChangeJobTest {
     @Test
     // start a drop index job, then normally finish it
     public void testDropIndexIndexChangeNormal() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -323,7 +367,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testCancelBuildIndexIndexChangeNormal() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -371,7 +421,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testBuildIndexIndexChangeWhileTableNotStable() throws  Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -452,7 +508,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testDropIndexIndexChangeWhileTableNotStable() throws  Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -533,7 +595,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testBuildIndexFailedWithMinFailedNum() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -599,7 +667,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testBuildIndexFailedWithMaxFailedNum() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -665,7 +739,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testNgramBfBuildIndex() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         Database db = new Database(CatalogTestUtil.testDbId1, CatalogTestUtil.testDb1);
@@ -753,7 +833,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testCancelNgramBfBuildIndex() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         Database db = new Database(CatalogTestUtil.testDbId1, CatalogTestUtil.testDb1);
@@ -849,7 +935,13 @@ public class IndexChangeJobTest {
     @Test
     public void testDropIndexOnPartitionRejectsNonPartitionedTable() throws UserException {
         // testTable1 uses SinglePartitionInfo (non-partitioned), so DROP INDEX ON PARTITION should fail
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -889,7 +981,13 @@ public class IndexChangeJobTest {
 
     @Test
     public void testDropIndexOnPartitionRejectsNonExistentIndex() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -914,7 +1012,13 @@ public class IndexChangeJobTest {
     @Test
     public void testDropIndexOnPartitionIfExistsNonExistentIndex() throws UserException {
         // IF EXISTS with non-existent index and partition spec should silently succeed
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
@@ -34,11 +34,10 @@ import org.apache.doris.nereids.trees.plans.commands.CreateMaterializedViewComma
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Injectable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Disabled;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.List;
@@ -46,17 +45,12 @@ import java.util.Set;
 
 public class MaterializedViewHandlerTest {
     @Test
-    public void testDifferentBaseTable(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                       @Injectable Database db,
-                                       @Injectable OlapTable olapTable) {
-        new Expectations() {
-            {
-                createMaterializedViewCommand.getBaseIndexName();
-                result = "t1";
-                olapTable.getName();
-                result = "t2";
-            }
-        };
+    public void testDifferentBaseTable() {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        Database db = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        Mockito.when(createMaterializedViewCommand.getBaseIndexName()).thenReturn("t1");
+        Mockito.when(olapTable.getName()).thenReturn("t2");
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView", createMaterializedViewCommand,
@@ -68,20 +62,14 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testNotNormalTable(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                   @Injectable Database db,
-                                   @Injectable OlapTable olapTable) {
+    public void testNotNormalTable() {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        Database db = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
         final String baseIndexName = "t1";
-        new Expectations() {
-            {
-                createMaterializedViewCommand.getBaseIndexName();
-                result = baseIndexName;
-                olapTable.getName();
-                result = baseIndexName;
-                olapTable.getState();
-                result = OlapTable.OlapTableState.ROLLUP;
-            }
-        };
+        Mockito.when(createMaterializedViewCommand.getBaseIndexName()).thenReturn(baseIndexName);
+        Mockito.when(olapTable.getName()).thenReturn(baseIndexName);
+        Mockito.when(olapTable.getState()).thenReturn(OlapTable.OlapTableState.ROLLUP);
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView", createMaterializedViewCommand,
@@ -93,22 +81,15 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testErrorBaseIndexName(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                       @Injectable Database db,
-                                       @Injectable OlapTable olapTable) {
+    public void testErrorBaseIndexName() {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        Database db = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
         final String baseIndexName = "t1";
-        new Expectations() {
-            {
-                createMaterializedViewCommand.getBaseIndexName();
-                result = baseIndexName;
-                olapTable.getName();
-                result = baseIndexName;
-                olapTable.getState();
-                result = OlapTable.OlapTableState.NORMAL;
-                olapTable.getIndexIdByName(baseIndexName);
-                result = null;
-            }
-        };
+        Mockito.when(createMaterializedViewCommand.getBaseIndexName()).thenReturn(baseIndexName);
+        Mockito.when(olapTable.getName()).thenReturn(baseIndexName);
+        Mockito.when(olapTable.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+        Mockito.when(olapTable.getIndexIdByName(baseIndexName)).thenReturn(null);
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView",
@@ -120,31 +101,21 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testRollupReplica(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                  @Injectable Database db,
-                                  @Injectable OlapTable olapTable,
-                                  @Injectable Partition partition,
-                                  @Injectable MaterializedIndex materializedIndex) {
+    public void testRollupReplica() {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        Database db = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        Partition partition = Mockito.mock(Partition.class);
+        MaterializedIndex materializedIndex = Mockito.mock(MaterializedIndex.class);
         final String baseIndexName = "t1";
         final Long baseIndexId = new Long(1);
-        new Expectations() {
-            {
-                createMaterializedViewCommand.getBaseIndexName();
-                result = baseIndexName;
-                olapTable.getName();
-                result = baseIndexName;
-                olapTable.getState();
-                result = OlapTable.OlapTableState.NORMAL;
-                olapTable.getIndexIdByName(baseIndexName);
-                result = baseIndexId;
-                olapTable.getPartitions();
-                result = Lists.newArrayList(partition);
-                partition.getIndex(baseIndexId);
-                result = materializedIndex;
-                materializedIndex.getState();
-                result = MaterializedIndex.IndexState.SHADOW;
-            }
-        };
+        Mockito.when(createMaterializedViewCommand.getBaseIndexName()).thenReturn(baseIndexName);
+        Mockito.when(olapTable.getName()).thenReturn(baseIndexName);
+        Mockito.when(olapTable.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+        Mockito.when(olapTable.getIndexIdByName(baseIndexName)).thenReturn(baseIndexId);
+        Mockito.when(olapTable.getPartitions()).thenReturn(Lists.newArrayList(partition));
+        Mockito.when(partition.getIndex(baseIndexId)).thenReturn(materializedIndex);
+        Mockito.when(materializedIndex.getState()).thenReturn(MaterializedIndex.IndexState.SHADOW);
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             Deencapsulation.invoke(materializedViewHandler, "processCreateMaterializedView",
@@ -156,17 +127,12 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testDuplicateMVName(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                    @Injectable OlapTable olapTable) {
+    public void testDuplicateMVName() {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
         final String mvName = "mv1";
-        new Expectations() {
-            {
-                olapTable.hasMaterializedIndex(mvName);
-                result = true;
-                createMaterializedViewCommand.getMVName();
-                result = mvName;
-            }
-        };
+        Mockito.when(olapTable.hasMaterializedIndex(mvName)).thenReturn(true);
+        Mockito.when(createMaterializedViewCommand.getMVName()).thenReturn(mvName);
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView",
@@ -178,16 +144,11 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testInvalidKeysType(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                    @Injectable OlapTable olapTable) {
-        new Expectations() {
-            {
-                olapTable.getRowStoreCol();
-                result = null;
-                olapTable.getKeysType();
-                result = KeysType.AGG_KEYS;
-            }
-        };
+    public void testInvalidKeysType() {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        Mockito.when(olapTable.getRowStoreCol()).thenReturn(null);
+        Mockito.when(olapTable.getKeysType()).thenReturn(KeysType.AGG_KEYS);
 
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
@@ -200,8 +161,9 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testDuplicateTable(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                   @Injectable OlapTable olapTable) {
+    public void testDuplicateTable() {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
         final String mvName = "mv1";
         final String columnName1 = "k1";
         SlotRef slot = new SlotRef(Type.VARCHAR, false);
@@ -218,20 +180,12 @@ public class MaterializedViewHandlerTest {
         mvColumnItem.setAggregationType(null, false);
         mvColumnItem.getBaseColumnNames().add(columnName1);
         List<MVColumnItem> list = Lists.newArrayList(mvColumnItem);
-        new Expectations() {
-            {
-                olapTable.hasMaterializedIndex(mvName);
-                result = false;
-                createMaterializedViewCommand.getMVName();
-                result = mvName;
-                createMaterializedViewCommand.getMVColumnItemList();
-                result = list;
-                olapTable.getKeysType();
-                result = KeysType.DUP_KEYS;
-                olapTable.getRowStoreCol();
-                result = null;
-            }
-        };
+        Mockito.when(olapTable.getBaseColumn(columnName1)).thenReturn(null);
+        Mockito.when(olapTable.hasMaterializedIndex(mvName)).thenReturn(false);
+        Mockito.when(createMaterializedViewCommand.getMVName()).thenReturn(mvName);
+        Mockito.when(createMaterializedViewCommand.getMVColumnItemList()).thenReturn(list);
+        Mockito.when(olapTable.getKeysType()).thenReturn(KeysType.DUP_KEYS);
+        Mockito.when(olapTable.getRowStoreCol()).thenReturn(null);
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             List<Column> mvColumns = Deencapsulation.invoke(materializedViewHandler,
@@ -251,8 +205,9 @@ public class MaterializedViewHandlerTest {
     }
 
     @Disabled
-    public void checkInvalidPartitionKeyMV(@Injectable CreateMaterializedViewCommand createMaterializedViewCommand,
-                                           @Injectable OlapTable olapTable) throws DdlException {
+    public void checkInvalidPartitionKeyMV() throws DdlException {
+        CreateMaterializedViewCommand createMaterializedViewCommand = Mockito.mock(CreateMaterializedViewCommand.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
         final String mvName = "mv1";
         final String columnName1 = "k1";
 
@@ -272,20 +227,11 @@ public class MaterializedViewHandlerTest {
         List<MVColumnItem> list = Lists.newArrayList(mvColumnItem);
         Set<String> partitionColumnNames = Sets.newHashSet();
         partitionColumnNames.add(columnName1);
-        new Expectations() {
-            {
-                olapTable.hasMaterializedIndex(mvName);
-                result = false;
-                createMaterializedViewCommand.getMVName();
-                result = mvName;
-                createMaterializedViewCommand.getMVColumnItemList();
-                result = list;
-                olapTable.getKeysType();
-                result = KeysType.DUP_KEYS;
-                olapTable.getPartitionColumnNames();
-                result = partitionColumnNames;
-            }
-        };
+        Mockito.when(olapTable.hasMaterializedIndex(mvName)).thenReturn(false);
+        Mockito.when(createMaterializedViewCommand.getMVName()).thenReturn(mvName);
+        Mockito.when(createMaterializedViewCommand.getMVColumnItemList()).thenReturn(list);
+        Mockito.when(olapTable.getKeysType()).thenReturn(KeysType.DUP_KEYS);
+        Mockito.when(olapTable.getPartitionColumnNames()).thenReturn(partitionColumnNames);
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             Deencapsulation.invoke(materializedViewHandler, "checkAndPrepareMaterializedView",
@@ -297,25 +243,17 @@ public class MaterializedViewHandlerTest {
     }
 
     @Test
-    public void testCheckDropMaterializedView(@Injectable OlapTable olapTable, @Injectable Partition partition,
-                                              @Injectable MaterializedIndex materializedIndex) {
+    public void testCheckDropMaterializedView() {
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        Partition partition = Mockito.mock(Partition.class);
+        MaterializedIndex materializedIndex = Mockito.mock(MaterializedIndex.class);
         String mvName = "mv_1";
-        new Expectations() {
-            {
-                olapTable.getName();
-                result = "table1";
-                olapTable.hasMaterializedIndex(mvName);
-                result = true;
-                olapTable.getIndexIdByName(mvName);
-                result = 1L;
-                olapTable.getSchemaHashByIndexId(1L);
-                result = 1;
-                olapTable.getPartitions();
-                result = Lists.newArrayList(partition);
-                partition.getIndex(1L);
-                result = materializedIndex;
-            }
-        };
+        Mockito.when(olapTable.getName()).thenReturn("table1");
+        Mockito.when(olapTable.hasMaterializedIndex(mvName)).thenReturn(true);
+        Mockito.when(olapTable.getIndexIdByName(mvName)).thenReturn(1L);
+        Mockito.when(olapTable.getSchemaHashByIndexId(1L)).thenReturn(1);
+        Mockito.when(olapTable.getPartitions()).thenReturn(Lists.newArrayList(partition));
+        Mockito.when(partition.getIndex(1L)).thenReturn(materializedIndex);
         MaterializedViewHandler materializedViewHandler = new MaterializedViewHandler();
         try {
             Deencapsulation.invoke(materializedViewHandler, "checkDropMaterializedView", mvName, olapTable);

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -53,8 +53,6 @@ import org.apache.doris.transaction.FakeTransactionIDGenerator;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
 
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -114,23 +112,33 @@ public class RollupJobV2Test {
         FeConstants.runningUnitTest = true;
         AgentTaskQueue.clearAllTasks();
 
-        new MockUp<Env>() {
-            @Mock
-            public Env getCurrentEnv() {
-                return masterEnv;
-            }
-        };
+        FakeEnv.setEnv(masterEnv);
     }
 
     @After
     public void tearDown() {
         File file = new File(fileName);
         file.delete();
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        if (fakeTransactionIDGenerator != null) {
+            fakeTransactionIDGenerator.close();
+        }
     }
 
     @Test
     public void testRunRollupJobConcurrentLimit() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
@@ -151,7 +159,13 @@ public class RollupJobV2Test {
 
     @Test
     public void testAddSchemaChange() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
@@ -168,7 +182,13 @@ public class RollupJobV2Test {
     // start a schema change, then finished
     @Test
     public void testSchemaChange1() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
@@ -218,7 +238,13 @@ public class RollupJobV2Test {
 
     @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
@@ -337,7 +363,13 @@ public class RollupJobV2Test {
 
     @Test
     public void testAddRollupForDupTable() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -39,13 +39,12 @@ import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Injectable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
@@ -307,7 +306,6 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
             alterJobs = Env.getCurrentEnv().getSchemaChangeHandler().getAlterJobsV2();
             jobSize++;
             waitAlterJobDone(alterJobs);
-
 
             // positive test
             testAddSingleSubColumn(tbl, tableName, defaultVal);
@@ -617,21 +615,18 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     }
 
     @Test
-    public void testAddValueColumnOnAggMV(@Injectable OlapTable olapTable, @Injectable Column newColumn,
-            @Injectable ColumnPosition columnPosition) {
+    public void testAddValueColumnOnAggMV() {
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        Column newColumn = Mockito.mock(Column.class);
+        ColumnPosition columnPosition = Mockito.mock(ColumnPosition.class);
         SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
-        new Expectations() {
-            {
-                olapTable.getKeysType();
-                result = KeysType.DUP_KEYS;
-                newColumn.getAggregationType();
-                result = null;
-                olapTable.getIndexMetaByIndexId(2).getKeysType();
-                result = KeysType.AGG_KEYS;
-                newColumn.isKey();
-                result = false;
-            }
-        };
+
+        Mockito.when(olapTable.getKeysType()).thenReturn(KeysType.DUP_KEYS);
+        Mockito.when(newColumn.getAggregationType()).thenReturn(null);
+        MaterializedIndexMeta mockMeta = Mockito.mock(MaterializedIndexMeta.class);
+        Mockito.when(olapTable.getIndexMetaByIndexId(2)).thenReturn(mockMeta);
+        Mockito.when(mockMeta.getKeysType()).thenReturn(KeysType.AGG_KEYS);
+        Mockito.when(newColumn.isKey()).thenReturn(false);
 
         try {
             Deencapsulation.invoke(schemaChangeHandler, "addColumnInternal", olapTable, newColumn, columnPosition,

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -57,6 +57,7 @@ import org.apache.doris.nereids.trees.plans.commands.info.ModifyTablePropertiesO
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.task.AgentTask;
+import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.thrift.TStorageFormat;
 import org.apache.doris.thrift.TTaskType;
@@ -65,13 +66,14 @@ import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -93,6 +95,7 @@ public class SchemaChangeJobV2Test {
     private static FakeEditLog fakeEditLog;
     private static FakeEnv fakeEnv;
     private static FakeTransactionIDGenerator fakeTransactionIDGenerator;
+    private static MockedStatic<AgentTaskExecutor> mockedAgentTaskExecutor;
     private static GlobalTransactionMgr masterTransMgr;
     private static GlobalTransactionMgr slaveTransMgr;
     private static Env masterEnv;
@@ -122,11 +125,35 @@ public class SchemaChangeJobV2Test {
 
         FeConstants.runningUnitTest = true;
         AgentTaskQueue.clearAllTasks();
+        mockedAgentTaskExecutor = Mockito.mockStatic(AgentTaskExecutor.class);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedAgentTaskExecutor != null) {
+            mockedAgentTaskExecutor.close();
+            mockedAgentTaskExecutor = null;
+        }
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        if (fakeTransactionIDGenerator != null) {
+            fakeTransactionIDGenerator.close();
+        }
     }
 
     @Test
     public void testAddSchemaChange() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -143,7 +170,13 @@ public class SchemaChangeJobV2Test {
     // start a schema change, then finished
     @Test
     public void testSchemaChange1() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -191,7 +224,7 @@ public class SchemaChangeJobV2Test {
         schemaChangeHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());
 
-        // runWaitingTxnJob, task not finished
+        // runRunningJob, task not finished
         schemaChangeHandler.runAfterCatalogReady();
         Assert.assertEquals(JobState.RUNNING, schemaChangeJob.getJobState());
 
@@ -219,7 +252,13 @@ public class SchemaChangeJobV2Test {
 
     @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -301,7 +340,13 @@ public class SchemaChangeJobV2Test {
 
     @Test
     public void testModifyDynamicPartitionNormal() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -322,7 +367,6 @@ public class SchemaChangeJobV2Test {
         Assert.assertEquals(3, olapTable.getTableProperty().getDynamicPartitionProperty().getEnd());
         Assert.assertEquals("p", olapTable.getTableProperty().getDynamicPartitionProperty().getPrefix());
         Assert.assertEquals(30, olapTable.getTableProperty().getDynamicPartitionProperty().getBuckets());
-
 
         // set dynamic_partition.enable = false
         ArrayList<AlterOp> tmpAlterOps = new ArrayList<>();
@@ -358,6 +402,9 @@ public class SchemaChangeJobV2Test {
 
     public void modifyDynamicPartitionWithoutTableProperty(String propertyKey, String propertyValue)
             throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -387,7 +434,13 @@ public class SchemaChangeJobV2Test {
 
     @Test
     public void testModifyDynamicPartitionWithInvalidProperty() throws UserException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
@@ -451,7 +504,13 @@ public class SchemaChangeJobV2Test {
 
     @Test
     public void testModifyTableDistributionType() throws DdlException {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         Database db = masterEnv.getInternalCatalog().getDb(CatalogTestUtil.testDbId1).get();
@@ -463,59 +522,62 @@ public class SchemaChangeJobV2Test {
     }
 
     @Test
-    public void testAbnormalModifyTableDistributionType1(@Injectable OlapTable table) throws UserException {
+    public void testAbnormalModifyTableDistributionType1() throws UserException {
+        OlapTable table = Mockito.mock(OlapTable.class);
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         Database db = masterEnv.getInternalCatalog().getDb(CatalogTestUtil.testDbId1).get();
-        new Expectations() {
-            {
-                table.isColocateTable();
-                result = true;
-            }
-        };
+        Mockito.when(table.isColocateTable()).thenReturn(true);
         expectedEx.expect(DdlException.class);
         expectedEx.expectMessage("errCode = 2, detailMessage = Cannot change distribution type of colocate table.");
         Env.getCurrentEnv().convertDistributionType(db, table);
     }
 
     @Test
-    public void testAbnormalModifyTableDistributionType2(@Injectable OlapTable table) throws UserException {
+    public void testAbnormalModifyTableDistributionType2() throws UserException {
+        OlapTable table = Mockito.mock(OlapTable.class);
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         Database db = masterEnv.getInternalCatalog().getDb(CatalogTestUtil.testDbId1).get();
-        new Expectations() {
-            {
-                table.isColocateTable();
-                result = false;
-                table.getKeysType();
-                result = KeysType.UNIQUE_KEYS;
-            }
-        };
+        Mockito.when(table.isColocateTable()).thenReturn(false);
+        Mockito.when(table.getKeysType()).thenReturn(KeysType.UNIQUE_KEYS);
         expectedEx.expect(DdlException.class);
         expectedEx.expectMessage("errCode = 2, detailMessage = Cannot change distribution type of unique keys table.");
         Env.getCurrentEnv().convertDistributionType(db, table);
     }
 
     @Test
-    public void testAbnormalModifyTableDistributionType3(@Injectable OlapTable table) throws UserException {
+    public void testAbnormalModifyTableDistributionType3() throws UserException {
+        OlapTable table = Mockito.mock(OlapTable.class);
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
         fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
         fakeEditLog = new FakeEditLog();
         FakeEnv.setEnv(masterEnv);
         Database db = masterEnv.getInternalCatalog().getDb(CatalogTestUtil.testDbId1).get();
-        new Expectations() {
-            {
-                table.isColocateTable();
-                result = false;
-                table.getKeysType();
-                result = KeysType.AGG_KEYS;
-                table.getBaseSchema();
-                result = Lists.newArrayList(
-                    new Column("k1", Type.INT, true, null, "0", ""),
-                    new Column("v1", Type.INT, false, AggregateType.REPLACE, "0", ""));
-            }
-        };
+        Mockito.when(table.isColocateTable()).thenReturn(false);
+        Mockito.when(table.getKeysType()).thenReturn(KeysType.AGG_KEYS);
+        Mockito.when(table.getBaseSchema()).thenReturn(Lists.newArrayList(
+            new Column("k1", Type.INT, true, null, "0", ""),
+            new Column("v1", Type.INT, false, AggregateType.REPLACE, "0", "")));
         expectedEx.expect(DdlException.class);
         expectedEx.expectMessage("errCode = 2, detailMessage = Cannot change "
                 + "distribution type of aggregate keys table which has value columns with REPLACE type.");

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.BrokerMgr;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.FakeEditLog;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
@@ -45,14 +44,14 @@ import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
+import org.mockito.Mockito;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
 public class AccessTestUtil {
-    private static FakeEditLog fakeEditLog;
+    // FakeEditLog field removed - using Mockito.mock(EditLog.class) directly
 
     public static SystemInfoService fetchSystemInfoService() {
         SystemInfoService clusterInfo = new SystemInfoService();
@@ -60,50 +59,32 @@ public class AccessTestUtil {
     }
 
     public static AccessControllerManager fetchAdminAccess() {
-        Auth auth = new Auth();
-        AccessControllerManager accessManager = new AccessControllerManager(auth);
+        Auth auth = Mockito.spy(new Auth());
         try {
-            new Expectations(auth) {
-                {
-                    auth.setPassword((UserIdentity) any, (byte[]) any);
-                    minTimes = 0;
-                }
-            };
-
-            new Expectations(accessManager) {
-                {
-                    accessManager.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
-                    minTimes = 0;
-                    result = true;
-
-                    accessManager.checkDbPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
-                    minTimes = 0;
-                    result = true;
-
-                    accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString,
-                            (PrivPredicate) any);
-                    minTimes = 0;
-                    result = true;
-
-                    accessManager.getAuth();
-                    minTimes = 0;
-                    result = auth;
-                }
-            };
+            Mockito.doNothing().when(auth).setPassword(Mockito.any(UserIdentity.class), Mockito.any(byte[].class));
         } catch (DdlException e) {
             e.printStackTrace();
         }
+        AccessControllerManager accessManager = Mockito.spy(new AccessControllerManager(auth));
+        Mockito.doReturn(true).when(accessManager).checkGlobalPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.any(PrivPredicate.class));
+        Mockito.doReturn(true).when(accessManager).checkDbPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Mockito.doReturn(true).when(accessManager).checkTblPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+                Mockito.any(PrivPredicate.class));
+        Mockito.doReturn(auth).when(accessManager).getAuth();
         return accessManager;
     }
 
     public static Env fetchAdminCatalog() {
         try {
-            Env env = Deencapsulation.newInstance(Env.class);
+            Env env = Mockito.spy(Deencapsulation.newInstance(Env.class));
 
             AccessControllerManager accessManager = fetchAdminAccess();
 
-            fakeEditLog = new FakeEditLog();
-            EditLog editLog = new EditLog("name");
+            EditLog editLog = Mockito.mock(EditLog.class);
+            Mockito.when(editLog.getNumEditStreams()).thenReturn(1);
             env.setEditLog(editLog);
 
             Database db = new Database(50000L, "testDb");
@@ -121,86 +102,28 @@ public class AccessTestUtil {
             table.setBaseIndexId(baseIndex.getId());
             db.registerTable(table);
 
-            InternalCatalog catalog = Deencapsulation.newInstance(InternalCatalog.class);
-            new Expectations(catalog) {
-                {
-                    catalog.getDbNullable(50000L);
-                    minTimes = 0;
-                    result = db;
+            InternalCatalog catalog = Mockito.spy(Deencapsulation.newInstance(InternalCatalog.class));
+            Mockito.doReturn(db).when(catalog).getDbNullable(50000L);
+            Mockito.doReturn(new Database()).when(catalog).getDbNullable(Mockito.anyString());
+            Mockito.doReturn(db).when(catalog).getDbNullable("testDb");
+            Mockito.doReturn(null).when(catalog).getDbNullable("emptyDb");
+            Mockito.doReturn(Lists.newArrayList("testDb")).when(catalog).getDbNames();
 
-                    catalog.getDbNullable("testDb");
-                    minTimes = 0;
-                    result = db;
+            CatalogMgr dsMgr = Mockito.spy(new CatalogMgr());
+            Mockito.doReturn(catalog).when(dsMgr).getCatalog(Mockito.anyString());
+            Mockito.doReturn(catalog).when(dsMgr).getCatalogOrException(Mockito.anyString(),
+                    Mockito.any(Function.class));
+            Mockito.doReturn(catalog).when(dsMgr).getCatalogOrAnalysisException(Mockito.anyString());
 
-                    catalog.getDbNullable("emptyDb");
-                    minTimes = 0;
-                    result = null;
-
-                    catalog.getDbNullable(anyString);
-                    minTimes = 0;
-                    result = new Database();
-
-                    catalog.getDbNames();
-                    minTimes = 0;
-                    result = Lists.newArrayList("testDb");
-                }
-            };
-
-            CatalogMgr dsMgr = new CatalogMgr();
-            new Expectations(dsMgr) {
-                {
-                    dsMgr.getCatalog((String) any);
-                    minTimes = 0;
-                    result = catalog;
-
-                    dsMgr.getCatalogOrException((String) any, (Function) any);
-                    minTimes = 0;
-                    result = catalog;
-
-                    dsMgr.getCatalogOrAnalysisException((String) any);
-                    minTimes = 0;
-                    result = catalog;
-                }
-            };
-
-            new Expectations(env, catalog) {
-                {
-                    env.getAccessManager();
-                    minTimes = 0;
-                    result = accessManager;
-
-                    env.getCurrentCatalog();
-                    minTimes = 0;
-                    result = catalog;
-
-                    env.getInternalCatalog();
-                    minTimes = 0;
-                    result = catalog;
-
-                    env.getEditLog();
-                    minTimes = 0;
-                    result = editLog;
-
-                    env.changeDb((ConnectContext) any, "blockDb");
-                    minTimes = 0;
-                    result = new DdlException("failed");
-
-                    env.changeDb((ConnectContext) any, anyString);
-                    minTimes = 0;
-
-                    env.getBrokerMgr();
-                    minTimes = 0;
-                    result = new BrokerMgr();
-
-                    env.getCatalogMgr();
-                    minTimes = 0;
-                    result = dsMgr;
-
-                    env.isCheckpointThread();
-                    minTimes = 0;
-                    result = false;
-                }
-            };
+            Mockito.doReturn(accessManager).when(env).getAccessManager();
+            Mockito.doReturn(catalog).when(env).getCurrentCatalog();
+            Mockito.doReturn(catalog).when(env).getInternalCatalog();
+            Mockito.doReturn(editLog).when(env).getEditLog();
+            Mockito.doNothing().when(env).changeDb(Mockito.nullable(ConnectContext.class), Mockito.anyString());
+            Mockito.doThrow(new DdlException("failed")).when(env).changeDb(Mockito.nullable(ConnectContext.class),
+                    Mockito.eq("blockDb"));
+            Mockito.doReturn(new BrokerMgr()).when(env).getBrokerMgr();
+            Mockito.doReturn(dsMgr).when(env).getCatalogMgr();
             return env;
         } catch (DdlException e) {
             return null;
@@ -211,22 +134,13 @@ public class AccessTestUtil {
 
     public static AccessControllerManager fetchBlockAccess() {
         Auth auth = new Auth();
-        AccessControllerManager accessManager = new AccessControllerManager(auth);
-        new Expectations(accessManager) {
-            {
-                accessManager.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
-
-                accessManager.checkDbPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
-
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        AccessControllerManager accessManager = Mockito.spy(new AccessControllerManager(auth));
+        Mockito.doReturn(false).when(accessManager).checkGlobalPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.any(PrivPredicate.class));
+        Mockito.doReturn(false).when(accessManager).checkDbPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Mockito.doReturn(false).when(accessManager).checkTblPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class));
         return accessManager;
     }
 
@@ -238,183 +152,66 @@ public class AccessTestUtil {
         Column column5 = new Column("k3", PrimitiveType.VARCHAR);
         Column column6 = new Column("k4", PrimitiveType.BIGINT);
 
-        MaterializedIndex index = new MaterializedIndex();
-        new Expectations(index) {
-            {
-                index.getId();
-                minTimes = 0;
-                result = 30000L;
-            }
-        };
+        MaterializedIndex index = Mockito.spy(new MaterializedIndex());
+        Mockito.doReturn(30000L).when(index).getId();
 
-        Partition partition = Deencapsulation.newInstance(Partition.class);
-        new Expectations(partition) {
-            {
-                partition.getBaseIndex();
-                minTimes = 0;
-                result = index;
+        Partition partition = Mockito.spy(Deencapsulation.newInstance(Partition.class));
+        Mockito.doReturn(index).when(partition).getBaseIndex();
+        Mockito.doReturn(index).when(partition).getIndex(30000L);
 
-                partition.getIndex(30000L);
-                minTimes = 0;
-                result = index;
-            }
-        };
-
-        OlapTable table = new OlapTable();
-        new Expectations(table) {
-            {
-                table.getBaseSchema();
-                minTimes = 0;
-                result = Lists.newArrayList(column1, column2);
-
-                table.getPartition(40000L);
-                minTimes = 0;
-                result = partition;
-
-                table.getColumn("k1");
-                minTimes = 0;
-                result = column3;
-
-                table.getColumn("k2");
-                minTimes = 0;
-                result = column4;
-
-                table.getColumn("k3");
-                minTimes = 0;
-                result = column5;
-
-                table.getColumn("k4");
-                minTimes = 0;
-                result = column6;
-            }
-        };
+        OlapTable table = Mockito.spy(new OlapTable());
+        Mockito.doReturn(Lists.newArrayList(column1, column2)).when(table).getBaseSchema();
+        Mockito.doReturn(partition).when(table).getPartition(40000L);
+        Mockito.doReturn(column3).when(table).getColumn("k1");
+        Mockito.doReturn(column4).when(table).getColumn("k2");
+        Mockito.doReturn(column5).when(table).getColumn("k3");
+        Mockito.doReturn(column6).when(table).getColumn("k4");
         return table;
     }
 
     public static Database mockDb(String name) {
-        Database db = new Database();
+        Database db = Mockito.spy(new Database());
         OlapTable olapTable = mockTable("testTable");
 
-        new Expectations(db) {
-            {
-                db.getTableNullable("testTable");
-                minTimes = 0;
-                result = olapTable;
-
-                db.getTableNullable("t");
-                minTimes = 0;
-                result = olapTable;
-
-                db.getTableNullable("emptyTable");
-                minTimes = 0;
-                result = null;
-
-                db.getTableNamesWithLock();
-                minTimes = 0;
-                result = Sets.newHashSet("testTable");
-
-                db.getTables();
-                minTimes = 0;
-                result = Lists.newArrayList(olapTable);
-
-                db.readLock();
-                minTimes = 0;
-
-                db.readUnlock();
-                minTimes = 0;
-
-                db.getFullName();
-                minTimes = 0;
-                result = name;
-            }
-        };
+        Mockito.doReturn(olapTable).when(db).getTableNullable("testTable");
+        Mockito.doReturn(olapTable).when(db).getTableNullable("t");
+        Mockito.doReturn(null).when(db).getTableNullable("emptyTable");
+        Mockito.doReturn(Sets.newHashSet("testTable")).when(db).getTableNamesWithLock();
+        Mockito.doReturn(Lists.newArrayList(olapTable)).when(db).getTables();
+        Mockito.doNothing().when(db).readLock();
+        Mockito.doNothing().when(db).readUnlock();
+        Mockito.doReturn(name).when(db).getFullName();
         return db;
     }
 
     public static Env fetchBlockCatalog() {
         try {
-            Env env = Deencapsulation.newInstance(Env.class);
+            Env env = Mockito.spy(Deencapsulation.newInstance(Env.class));
 
             AccessControllerManager accessManager = fetchBlockAccess();
             Database db = mockDb("testDb");
 
-            InternalCatalog catalog = Deencapsulation.newInstance(InternalCatalog.class);
-            new Expectations(catalog) {
-                {
-                    catalog.getDbNullable("testDb");
-                    minTimes = 0;
-                    result = db;
+            InternalCatalog catalog = Mockito.spy(Deencapsulation.newInstance(InternalCatalog.class));
+            Mockito.doReturn(new Database()).when(catalog).getDbNullable(Mockito.anyString());
+            Mockito.doReturn(db).when(catalog).getDbNullable("testDb");
+            Mockito.doReturn(db).when(catalog).getDbNullable("testdb");
+            Mockito.doReturn(null).when(catalog).getDbNullable("emptyDb");
+            Mockito.doReturn(null).when(catalog).getDbNullable("emptyCluster");
+            Mockito.doReturn(db).when(catalog).getDbOrAnalysisException("testdb");
+            Mockito.doReturn(Lists.newArrayList("testDb")).when(catalog).getDbNames();
 
-                    catalog.getDbNullable("testdb");
-                    minTimes = 0;
-                    result = db;
+            CatalogMgr ctlMgr = Mockito.spy(new CatalogMgr());
+            Mockito.doReturn(catalog).when(ctlMgr).getCatalog(Mockito.anyString());
+            Mockito.doReturn(catalog).when(ctlMgr).getCatalogOrException(Mockito.anyString(),
+                    Mockito.any(Function.class));
+            Mockito.doReturn(catalog).when(ctlMgr).getCatalogOrAnalysisException(Mockito.anyString());
 
-                    catalog.getDbOrAnalysisException("testdb");
-                    minTimes = 0;
-                    result = db;
-
-                    catalog.getDbNullable("emptyDb");
-                    minTimes = 0;
-                    result = null;
-
-                    catalog.getDbNullable(anyString);
-                    minTimes = 0;
-                    result = new Database();
-
-                    catalog.getDbNames();
-                    minTimes = 0;
-                    result = Lists.newArrayList("testDb");
-
-                    catalog.getDbNullable("emptyCluster");
-                    minTimes = 0;
-                    result = null;
-                }
-            };
-
-            CatalogMgr ctlMgr = new CatalogMgr();
-            new Expectations(ctlMgr) {
-                {
-                    ctlMgr.getCatalog((String) any);
-                    minTimes = 0;
-                    result = catalog;
-
-                    ctlMgr.getCatalogOrException((String) any, (Function) any);
-                    minTimes = 0;
-                    result = catalog;
-
-                    ctlMgr.getCatalogOrAnalysisException((String) any);
-                    minTimes = 0;
-                    result = catalog;
-                }
-            };
-
-            new Expectations(env) {
-                {
-                    env.getAccessManager();
-                    minTimes = 0;
-                    result = accessManager;
-
-                    env.changeDb((ConnectContext) any, anyString);
-                    minTimes = 0;
-                    result = new DdlException("failed");
-
-                    env.getInternalCatalog();
-                    minTimes = 0;
-                    result = catalog;
-
-                    env.getCurrentCatalog();
-                    minTimes = 0;
-                    result = catalog;
-
-                    env.getCatalogMgr();
-                    minTimes = 0;
-                    result = ctlMgr;
-
-                    env.isCheckpointThread();
-                    minTimes = 0;
-                    result = false;
-                }
-            };
+            Mockito.doReturn(accessManager).when(env).getAccessManager();
+            Mockito.doThrow(new DdlException("failed")).when(env).changeDb(Mockito.nullable(ConnectContext.class),
+                    Mockito.anyString());
+            Mockito.doReturn(catalog).when(env).getInternalCatalog();
+            Mockito.doReturn(catalog).when(env).getCurrentCatalog();
+            Mockito.doReturn(ctlMgr).when(env).getCatalogMgr();
             return env;
         } catch (DdlException e) {
             return null;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionExprUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/PartitionExprUtilTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.AutoBucketUtils;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.service.FrontendServiceImpl;
@@ -32,14 +33,15 @@ import org.apache.doris.thrift.TNullableStringLiteral;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PartitionExprUtilTest extends TestWithFeService {
 
@@ -113,49 +115,51 @@ public class PartitionExprUtilTest extends TestWithFeService {
         Partition p1 = table.getPartition(partNames[0]);
         Partition p2 = table.getPartition(partNames[1]);
         Partition p3 = table.getPartition(partNames[2]);
-        new Expectations(p1, p2, p3) {
-            {
-                p1.getDataSizeExcludeEmptyReplica(true);
-                result = 1000 * GB; // ~1 TB uncompressed
-                minTimes = 0;
-                p2.getDataSizeExcludeEmptyReplica(true);
-                result = 1500 * GB; // ~1.5 TB uncompressed
-                minTimes = 0;
-                p3.getDataSizeExcludeEmptyReplica(true);
-                result = 2000 * GB; // ~2 TB uncompressed
-                minTimes = 0;
-            }
-        };
+
+        Partition spyP1 = Mockito.spy(p1);
+        Partition spyP2 = Mockito.spy(p2);
+        Partition spyP3 = Mockito.spy(p3);
+        Mockito.doReturn(1000 * GB).when(spyP1).getDataSizeExcludeEmptyReplica(true); // ~1 TB uncompressed
+        Mockito.doReturn(1500 * GB).when(spyP2).getDataSizeExcludeEmptyReplica(true); // ~1.5 TB uncompressed
+        Mockito.doReturn(2000 * GB).when(spyP3).getDataSizeExcludeEmptyReplica(true); // ~2 TB uncompressed
+
+        // Replace partition objects with spied versions in the table's internal maps
+        Map<String, Partition> nameToPartition = Deencapsulation.getField(table, "nameToPartition");
+        @SuppressWarnings("unchecked")
+        ConcurrentHashMap<Long, Partition> idToPartition = Deencapsulation.getField(table, "idToPartition");
+        nameToPartition.put(partNames[0], spyP1);
+        nameToPartition.put(partNames[1], spyP2);
+        nameToPartition.put(partNames[2], spyP3);
+        idToPartition.put(p1.getId(), spyP1);
+        idToPartition.put(p2.getId(), spyP2);
+        idToPartition.put(p3.getId(), spyP3);
 
         // Directly mock BE disk cap to a very large value so AutoBucketUtils doesn't limit by disks
-        new MockUp<AutoBucketUtils>() {
-            @Mock
-            public int getBucketsNumByBEDisks() { // private static in target, allowed to mock by name
-                return Integer.MAX_VALUE;
-            }
-        };
+        try (MockedStatic<AutoBucketUtils> mockedAutoBucket = Mockito.mockStatic(AutoBucketUtils.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedAutoBucket.when(AutoBucketUtils::getBucketsNumByBEDisks).thenReturn(Integer.MAX_VALUE);
 
-        // Compute expected bucket by reusing scheduler helpers before creating the new partition (2023-08-04)
-        String newPartName = "p20230804000000";
+            // Compute expected bucket by reusing scheduler helpers before creating the new partition (2023-08-04)
+            String newPartName = "p20230804000000";
 
-        // Create the new partition (2023-08-04) and verify bucket num
-        List<List<TNullableStringLiteral>> partitionValues4 = new ArrayList<>();
-        List<TNullableStringLiteral> values4 = new ArrayList<>();
-        TNullableStringLiteral start4 = new TNullableStringLiteral();
-        start4.setValue("2023-08-04 00:00:00");
-        values4.add(start4);
-        partitionValues4.add(values4);
+            // Create the new partition (2023-08-04) and verify bucket num
+            List<List<TNullableStringLiteral>> partitionValues4 = new ArrayList<>();
+            List<TNullableStringLiteral> values4 = new ArrayList<>();
+            TNullableStringLiteral start4 = new TNullableStringLiteral();
+            start4.setValue("2023-08-04 00:00:00");
+            values4.add(start4);
+            partitionValues4.add(values4);
 
-        TCreatePartitionRequest request4 = new TCreatePartitionRequest();
-        request4.setDbId(db.getId());
-        request4.setTableId(table.getId());
-        request4.setPartitionValues(partitionValues4);
-        TCreatePartitionResult result4 = impl.createPartition(request4);
-        Assertions.assertEquals(TStatusCode.OK, result4.getStatus().getStatusCode());
+            TCreatePartitionRequest request4 = new TCreatePartitionRequest();
+            request4.setDbId(db.getId());
+            request4.setTableId(table.getId());
+            request4.setPartitionValues(partitionValues4);
+            TCreatePartitionResult result4 = impl.createPartition(request4);
+            Assertions.assertEquals(TStatusCode.OK, result4.getStatus().getStatusCode());
 
-        Partition p4 = table.getPartition(newPartName);
-        Assertions.assertNotNull(p4);
-        Assertions.assertEquals(p4.getDistributionInfo().getBucketNum(), 500);
+            Partition p4 = table.getPartition(newPartName);
+            Assertions.assertNotNull(p4);
+            Assertions.assertEquals(p4.getDistributionInfo().getBucketNum(), 500);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
@@ -32,7 +32,6 @@ import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.info.TableRefInfo;
@@ -52,15 +51,13 @@ import org.apache.doris.thrift.TStatusCode;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -76,14 +73,12 @@ public class BackupHandlerTest {
 
     private BackupHandler handler;
 
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
-    private BrokerMgr brokerMgr;
-    @Mocked
-    private EditLog editLog;
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+    private BrokerMgr brokerMgr = Mockito.mock(BrokerMgr.class);
+    private EditLog editLog = Mockito.mock(EditLog.class);
+
+    private MockedStatic<Env> mockedEnvStatic;
 
     private Database db;
 
@@ -102,52 +97,27 @@ public class BackupHandlerTest {
         rootDir.mkdirs();
         FeConstants.runningUnitTest = true;
 
-        new Expectations() {
-            {
-                env.getBrokerMgr();
-                minTimes = 0;
-                result = brokerMgr;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
 
-                env.getNextId();
-                minTimes = 0;
-                result = idGen++;
+        Mockito.when(env.getBrokerMgr()).thenReturn(brokerMgr);
+        Mockito.when(env.getNextId()).thenAnswer(inv -> idGen++);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
-
-                Env.getCurrentInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+        mockedEnvStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
 
         db = CatalogMocker.mockDb();
-        catalog = Deencapsulation.newInstance(InternalCatalog.class);
 
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getDbOrDdlException(anyString);
-                minTimes = 0;
-                result = db;
-            }
-        };
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.doReturn(db).when(catalog).getDbOrDdlException(Mockito.anyString());
     }
 
     @After
     public void done() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
         if (rootDir != null) {
             try {
                 Files.walk(Paths.get(Config.tmp_dir),
@@ -170,156 +140,133 @@ public class BackupHandlerTest {
 
     @Test
     public void testCreateAndDropRepository() throws Exception {
-        new Expectations() {
-            {
-                editLog.logCreateRepository((Repository) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logCreateRepository(Repository repo) {
+        Mockito.when(brokerMgr.containsBroker(Mockito.anyString())).thenReturn(true);
 
+        try (MockedConstruction<Repository> mockedRepo = Mockito.mockConstruction(Repository.class,
+                (mock, context) -> {
+                    List<?> args = context.arguments();
+                    if (args.size() >= 2) {
+                        Mockito.when(mock.getName()).thenReturn((String) args.get(1));
+                        Mockito.when(mock.getId()).thenReturn((Long) args.get(0));
                     }
-                };
-
-                editLog.logDropRepository(anyString);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logDropRepository(String repoName) {
-
-                    }
-                };
-            }
-        };
-
-        new MockUp<Repository>() {
-            @Mock
-            public Status initRepository() {
-                return Status.OK;
-            }
-
-            @Mock
-            public Status listSnapshots(List<String> snapshotNames) {
-                snapshotNames.add("ss2");
-                return Status.OK;
-            }
-
-            @Mock
-            public Status getSnapshotInfoFile(String label, String backupTimestamp, List<BackupJobInfo> infos) throws Exception {
-                OlapTable tbl = (OlapTable) db.getTableOrMetaException(CatalogMocker.TEST_TBL_NAME);
-                List<Table> tbls = Lists.newArrayList();
-                tbls.add(tbl);
-                List<Resource> resources = Lists.newArrayList();
-                BackupMeta backupMeta = new BackupMeta(tbls, resources);
-                Map<Long, SnapshotInfo> snapshotInfos = Maps.newHashMap();
-                for (Partition part : tbl.getPartitions()) {
-                    for (MaterializedIndex idx : part.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                        for (Tablet tablet : idx.getTablets()) {
-                            List<String> files = Lists.newArrayList();
-                            SnapshotInfo sinfo = new SnapshotInfo(db.getId(), tbl.getId(), part.getId(), idx.getId(),
-                                    tablet.getId(), -1, 0, "./path", files);
-                            snapshotInfos.put(tablet.getId(), sinfo);
+                    Mockito.when(mock.initRepository()).thenReturn(Status.OK);
+                    Mockito.when(mock.ping()).thenReturn(true);
+                    Mockito.doAnswer(inv -> {
+                        List<String> snapshotNames = inv.getArgument(0);
+                        snapshotNames.add("ss2");
+                        return Status.OK;
+                    }).when(mock).listSnapshots(Mockito.anyList());
+                    Mockito.doAnswer(inv -> {
+                        List<BackupJobInfo> infos = inv.getArgument(2);
+                        OlapTable tbl = (OlapTable) db.getTableOrMetaException(CatalogMocker.TEST_TBL_NAME);
+                        List<Table> tbls = Lists.newArrayList();
+                        tbls.add(tbl);
+                        List<Resource> resources = Lists.newArrayList();
+                        BackupMeta backupMeta = new BackupMeta(tbls, resources);
+                        Map<Long, SnapshotInfo> snapshotInfos = Maps.newHashMap();
+                        for (Partition part : tbl.getPartitions()) {
+                            for (MaterializedIndex idx : part.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                                for (Tablet tablet : idx.getTablets()) {
+                                    List<String> files = Lists.newArrayList();
+                                    SnapshotInfo sinfo = new SnapshotInfo(db.getId(), tbl.getId(), part.getId(), idx.getId(),
+                                            tablet.getId(), -1, 0, "./path", files);
+                                    snapshotInfos.put(tablet.getId(), sinfo);
+                                }
+                            }
                         }
-                    }
-                }
 
-                BackupJobInfo info = BackupJobInfo.fromCatalog(System.currentTimeMillis(),
-                        "ss2", CatalogMocker.TEST_DB_NAME,
-                        CatalogMocker.TEST_DB_ID, BackupCommand.BackupContent.ALL,
-                        backupMeta, snapshotInfos, null);
-                infos.add(info);
-                return Status.OK;
-            }
-        };
+                        BackupJobInfo info = BackupJobInfo.fromCatalog(System.currentTimeMillis(),
+                                "ss2", CatalogMocker.TEST_DB_NAME,
+                                CatalogMocker.TEST_DB_ID, BackupCommand.BackupContent.ALL,
+                                backupMeta, snapshotInfos, null);
+                        infos.add(info);
+                        return Status.OK;
+                    }).when(mock).getSnapshotInfoFile(Mockito.anyString(), Mockito.anyString(), Mockito.anyList());
+                })) {
 
-        new Expectations() {
-            {
-                brokerMgr.containsBroker(anyString);
-                minTimes = 0;
-                result = true;
-            }
-        };
+            // add repo
+            handler = new BackupHandler(env);
+            StorageBackend storageBackend = new StorageBackend("broker", "bos://location",
+                    StorageBackend.StorageType.BROKER, Maps.newHashMap());
 
-        // add repo
-        handler = new BackupHandler(env);
-        StorageBackend storageBackend = new StorageBackend("broker", "bos://location",
-                StorageBackend.StorageType.BROKER, Maps.newHashMap());
+            CreateRepositoryCommand command = new CreateRepositoryCommand(false, "repo", storageBackend);
+            handler.createRepository(command);
 
-        CreateRepositoryCommand command = new CreateRepositoryCommand(false, "repo", storageBackend);
-        handler.createRepository(command);
+            // process backup
+            List<TableRefInfo> tableRefInfos = Lists.newArrayList();
+            tableRefInfos.add(new TableRefInfo(new TableNameInfo(InternalCatalog.INTERNAL_CATALOG_NAME, CatalogMocker.TEST_DB_NAME,
+                    CatalogMocker.TEST_TBL_NAME), null, null, null, null, null, null, null));
+            Map<String, String> properties = Maps.newHashMap();
+            properties.put("backup_timestamp", "2018-08-08-08-08-08");
+            boolean isExclude = false;
+            BackupCommand backupCommand = new BackupCommand(new LabelNameInfo(CatalogMocker.TEST_DB_NAME, "label1"), "repo", tableRefInfos, properties, isExclude);
+            handler.process(backupCommand);
 
-        // process backup
-        List<TableRefInfo> tableRefInfos = Lists.newArrayList();
-        tableRefInfos.add(new TableRefInfo(new TableNameInfo(InternalCatalog.INTERNAL_CATALOG_NAME, CatalogMocker.TEST_DB_NAME,
-                CatalogMocker.TEST_TBL_NAME), null, null, null, null, null, null, null));
-        Map<String, String> properties = Maps.newHashMap();
-        properties.put("backup_timestamp", "2018-08-08-08-08-08");
-        boolean isExclude = false;
-        BackupCommand backupCommand = new BackupCommand(new LabelNameInfo(CatalogMocker.TEST_DB_NAME, "label1"), "repo", tableRefInfos, properties, isExclude);
-        handler.process(backupCommand);
+            // handleFinishedSnapshotTask
+            BackupJob backupJob = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+            SnapshotTask snapshotTask = new SnapshotTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0,
+                    0, 0, 0, 0, 1, false);
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            List<String> snapshotFiles = Lists.newArrayList();
+            request.setSnapshotFiles(snapshotFiles);
+            request.setSnapshotPath("./snapshot/path");
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+            handler.handleFinishedSnapshotTask(snapshotTask, request);
 
-        // handleFinishedSnapshotTask
-        BackupJob backupJob = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
-        SnapshotTask snapshotTask = new SnapshotTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0,
-                0, 0, 0, 0, 1, false);
-        TFinishTaskRequest request = new TFinishTaskRequest();
-        List<String> snapshotFiles = Lists.newArrayList();
-        request.setSnapshotFiles(snapshotFiles);
-        request.setSnapshotPath("./snapshot/path");
-        request.setTaskStatus(new TStatus(TStatusCode.OK));
-        handler.handleFinishedSnapshotTask(snapshotTask, request);
+            // handleFinishedSnapshotUploadTask
+            Map<String, String> srcToDestPath = Maps.newHashMap();
+            UploadTask uploadTask = new UploadTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID,
+                    srcToDestPath, null, null, StorageBackend.StorageType.BROKER, "");
+            request = new TFinishTaskRequest();
+            Map<Long, List<String>> tabletFiles = Maps.newHashMap();
+            request.setTabletFiles(tabletFiles);
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+            handler.handleFinishedSnapshotUploadTask(uploadTask, request);
 
-        // handleFinishedSnapshotUploadTask
-        Map<String, String> srcToDestPath = Maps.newHashMap();
-        UploadTask uploadTask = new UploadTask(null, 0, 0, backupJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath, null, null, StorageBackend.StorageType.BROKER, "");
-        request = new TFinishTaskRequest();
-        Map<Long, List<String>> tabletFiles = Maps.newHashMap();
-        request.setTabletFiles(tabletFiles);
-        request.setTaskStatus(new TStatus(TStatusCode.OK));
-        handler.handleFinishedSnapshotUploadTask(uploadTask, request);
+            // cancel backup
+            handler.cancel(new CancelBackupCommand(CatalogMocker.TEST_DB_NAME, false));
 
-        // cancel backup
-        handler.cancel(new CancelBackupCommand(CatalogMocker.TEST_DB_NAME, false));
+            // process restore
+            List<TableRefInfo> tableRefInfos2 = Lists.newArrayList();
+            tableRefInfos2.add(new TableRefInfo(new TableNameInfo(InternalCatalog.INTERNAL_CATALOG_NAME, CatalogMocker.TEST_DB_NAME,
+                    CatalogMocker.TEST_TBL_NAME), null, null, null, null, null, null, null));
+            Map<String, String> properties02 = Maps.newHashMap();
+            properties02.put("backup_timestamp", "2018-08-08-08-08-08");
+            boolean isExclude02 = false;
+            RestoreCommand restoreCommand = new RestoreCommand(new LabelNameInfo(CatalogMocker.TEST_DB_NAME, "ss2"), "repo", tableRefInfos2, properties02, isExclude02);
+            restoreCommand.analyzeProperties();
+            handler.process(restoreCommand);
 
-        // process restore
-        List<TableRefInfo> tableRefInfos2 = Lists.newArrayList();
-        tableRefInfos2.add(new TableRefInfo(new TableNameInfo(InternalCatalog.INTERNAL_CATALOG_NAME, CatalogMocker.TEST_DB_NAME,
-                CatalogMocker.TEST_TBL_NAME), null, null, null, null, null, null, null));
-        Map<String, String> properties02 = Maps.newHashMap();
-        properties02.put("backup_timestamp", "2018-08-08-08-08-08");
-        boolean isExclude02 = false;
-        RestoreCommand restoreCommand = new RestoreCommand(new LabelNameInfo(CatalogMocker.TEST_DB_NAME, "ss2"), "repo", tableRefInfos2, properties02, isExclude02);
-        restoreCommand.analyzeProperties();
-        handler.process(restoreCommand);
+            // handleFinishedSnapshotTask
+            RestoreJob restoreJob = (RestoreJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+            snapshotTask = new SnapshotTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
+                    0, 0, 0, 0, 0, 0, 1, true);
+            request = new TFinishTaskRequest();
+            request.setSnapshotPath("./snapshot/path");
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+            handler.handleFinishedSnapshotTask(snapshotTask, request);
 
-        // handleFinishedSnapshotTask
-        RestoreJob restoreJob = (RestoreJob) handler.getJob(CatalogMocker.TEST_DB_ID);
-        snapshotTask = new SnapshotTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                0, 0, 0, 0, 0, 0, 1, true);
-        request = new TFinishTaskRequest();
-        request.setSnapshotPath("./snapshot/path");
-        request.setTaskStatus(new TStatus(TStatusCode.OK));
-        handler.handleFinishedSnapshotTask(snapshotTask, request);
+            // handleDownloadSnapshotTask
+            DownloadTask downloadTask = new DownloadTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
+                    srcToDestPath, null, null, StorageBackend.StorageType.BROKER, "", "");
+            request = new TFinishTaskRequest();
+            List<Long> downloadedTabletIds = Lists.newArrayList();
+            request.setDownloadedTabletIds(downloadedTabletIds);
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+            handler.handleDownloadSnapshotTask(downloadTask, request);
 
-        // handleDownloadSnapshotTask
-        DownloadTask downloadTask = new DownloadTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID,
-                srcToDestPath, null, null, StorageBackend.StorageType.BROKER, "", "");
-        request = new TFinishTaskRequest();
-        List<Long> downloadedTabletIds = Lists.newArrayList();
-        request.setDownloadedTabletIds(downloadedTabletIds);
-        request.setTaskStatus(new TStatus(TStatusCode.OK));
-        handler.handleDownloadSnapshotTask(downloadTask, request);
+            // handleDirMoveTask
+            DirMoveTask dirMoveTask = new DirMoveTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0, 0,
+                    0, "", 0, true);
+            request = new TFinishTaskRequest();
+            request.setTaskStatus(new TStatus(TStatusCode.OK));
+            handler.handleDirMoveTask(dirMoveTask, request);
 
-        // handleDirMoveTask
-        DirMoveTask dirMoveTask = new DirMoveTask(null, 0, 0, restoreJob.getJobId(), CatalogMocker.TEST_DB_ID, 0, 0, 0,
-                0, "", 0, true);
-        request = new TFinishTaskRequest();
-        request.setTaskStatus(new TStatus(TStatusCode.OK));
-        handler.handleDirMoveTask(dirMoveTask, request);
+            // cancel restore
+            handler.cancel(new CancelBackupCommand(CatalogMocker.TEST_DB_NAME, true));
 
-        // cancel restore
-        handler.cancel(new CancelBackupCommand(CatalogMocker.TEST_DB_NAME, true));
-
-        // drop repo
-        handler.dropRepository("repo");
+            // drop repo
+            handler.dropRepository("repo");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -17,17 +17,16 @@
 
 package org.apache.doris.backup;
 
+import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.backup.BackupJob.BackupJobState;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.UnitTestUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
@@ -36,7 +35,6 @@ import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.nereids.trees.plans.commands.BackupCommand;
 import org.apache.doris.persist.EditLog;
-import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
@@ -50,16 +48,16 @@ import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -97,47 +95,24 @@ public class BackupJobTest {
     private long repoId = 20000;
     private AtomicLong id = new AtomicLong(50000);
 
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
 
-    private MockBackupHandler backupHandler;
+    private BackupHandler backupHandler;
 
-    private MockRepositoryMgr repoMgr;
+    private RepositoryMgr repoMgr;
 
     public BackupJobTest() throws UserException {
     }
 
-    // Thread is not mockable in Jmockit, use subclass instead
-    private final class MockBackupHandler extends BackupHandler {
-        public MockBackupHandler(Env env) {
-            super(env);
-        }
+    private EditLog editLog = Mockito.mock(EditLog.class);
 
-        @Override
-        public RepositoryMgr getRepoMgr() {
-            return repoMgr;
-        }
-    }
+    private Repository repo = Mockito.spy(new Repository(repoId, "repo", false, "my_repo",
+            BrokerProperties.of("broker", Maps.newHashMap())));
 
-    // Thread is not mockable in Jmockit, use subclass instead
-    private final class MockRepositoryMgr extends RepositoryMgr {
-        public MockRepositoryMgr() {
-            super();
-        }
-
-        @Override
-        public Repository getRepo(long repoId) {
-            return repo;
-        }
-    }
-
-    @Mocked
-    private EditLog editLog;
-
-    private Repository repo = new Repository(repoId, "repo", false, "my_repo",
-            BrokerProperties.of("broker", Maps.newHashMap()));
+    private MockedStatic<Env> mockedEnvStatic;
+    private MockedStatic<AgentTaskExecutor> mockedAgentTaskExecutor;
+    private MockedConstruction<FileSystemDescriptor> mockedFsDescriptor;
 
     @BeforeClass
     public static void start() {
@@ -158,94 +133,62 @@ public class BackupJobTest {
 
     @Before
     public void setUp() {
-
-        repoMgr = new MockRepositoryMgr();
-        backupHandler = new MockBackupHandler(env);
-
-        // Thread is unmockable after Jmockit version 1.48, so use reflection to set field instead.
-        Deencapsulation.setField(env, "backupHandler", backupHandler);
+        repoMgr = Mockito.mock(RepositoryMgr.class);
+        backupHandler = Mockito.mock(BackupHandler.class);
 
         db = UnitTestUtil.createDb(dbId, tblId, partId, idxId, tabletId, backendId, version);
 
         // Create second table in setUp to avoid Env initialization issues
         table2 = UnitTestUtil.createTable(db, tblId2, table2Name, partId2, idxId2, tabletId2, backendId, version);
 
-        catalog = Deencapsulation.newInstance(InternalCatalog.class);
-        new Expectations(env) {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
+        // Mock Env static methods
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
 
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = db;
+        // Mock instance methods on env
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(env.getNextId()).thenAnswer(inv -> id.getAndIncrement());
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(env.getBackupHandler()).thenReturn(backupHandler);
 
-                catalog.getTableByTableId(anyLong);
-                minTimes = 0;
-                result = new Delegate<Table>() {
-                    public Table getTableByTableId(Long tableId) {
-                        // Check if table exists in the database
-                        return db.getTableNullable(tableId);
-                    }
-                };
+        // Mock repository lookup through Env.getCurrentEnv().getBackupHandler().getRepoMgr()
+        Mockito.when(backupHandler.getRepoMgr()).thenReturn(repoMgr);
+        Mockito.when(repoMgr.getRepo(Mockito.anyLong())).thenReturn(repo);
 
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
+        // Mock instance methods on catalog
+        Mockito.when(catalog.getDbNullable(ArgumentMatchers.anyLong())).thenReturn(db);
+        Mockito.when(catalog.getTableByTableId(ArgumentMatchers.anyLong())).thenAnswer(inv -> {
+            Long tableId = inv.getArgument(0);
+            return db.getTableNullable(tableId);
+        });
 
-                env.getNextId();
-                minTimes = 0;
-                result = new Delegate<Long>() {
-                    public Long getNextId() {
-                        return id.getAndIncrement();
-                    }
-                };
+        // Mock editLog
+        Mockito.doAnswer(inv -> {
+            BackupJob job = inv.getArgument(0);
+            System.out.println("log backup job: " + job);
+            return null;
+        }).when(editLog).logBackupJob(ArgumentMatchers.any(BackupJob.class));
 
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
+        // Mock AgentTaskExecutor static method
+        mockedAgentTaskExecutor = Mockito.mockStatic(AgentTaskExecutor.class);
 
-        new Expectations() {
-            {
-                editLog.logBackupJob((BackupJob) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logBackupJob(BackupJob job) {
-                        System.out.println("log backup job: " + job);
-                    }
-                };
-            }
-        };
+        // Mock Repository instance methods via spy
+        Mockito.doReturn(Status.OK).when(repo).upload(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        Mockito.doAnswer(inv -> {
+            List<FsBroker> brokerAddrs = inv.getArgument(2);
+            brokerAddrs.add(new FsBroker());
+            return Status.OK;
+        }).when(repo).getBrokerAddress(ArgumentMatchers.any(Long.class), ArgumentMatchers.any(Env.class), ArgumentMatchers.anyList());
+        FileSystemDescriptor fileSystemDescriptor = Mockito.mock(FileSystemDescriptor.class);
+        Mockito.when(fileSystemDescriptor.getBackendConfigProperties()).thenReturn(Maps.newHashMap());
+        Mockito.when(fileSystemDescriptor.getThriftStorageType()).thenReturn(StorageBackend.StorageType.BROKER);
+        Mockito.doReturn(fileSystemDescriptor).when(repo).getFileSystemDescriptor();
 
-        new MockUp<AgentTaskExecutor>() {
-            @Mock
-            public void submit(AgentBatchTask task) {
-
-            }
-        };
-
-        new MockUp<Repository>() {
-            @Mock
-            Status upload(String localFilePath, String remoteFilePath) {
-                return Status.OK;
-            }
-
-            @Mock
-            Status getBrokerAddress(Long beId, Env env, List<FsBroker> brokerAddrs) {
-                brokerAddrs.add(new FsBroker());
-                return Status.OK;
-            }
-        };
-
-        new MockUp<FileSystemDescriptor>() {
-            @Mock
-            public java.util.Map<String, String> getBackendConfigProperties() {
-                return Maps.newHashMap();
-            }
-        };
+        // Mock FileSystemDescriptor construction
+        mockedFsDescriptor = Mockito.mockConstruction(FileSystemDescriptor.class, (mock, ctx) -> {
+            Mockito.when(mock.getBackendConfigProperties()).thenReturn(Maps.newHashMap());
+        });
 
         // Only include first table to ensure other tests are not affected
         List<TableRefInfo> tableRefs = Lists.newArrayList();
@@ -260,6 +203,19 @@ public class BackupJobTest {
                 new ArrayList<>()));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupCommand.BackupContent.ALL,
                 env, repo.getId(), 0);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
+        if (mockedAgentTaskExecutor != null) {
+            mockedAgentTaskExecutor.close();
+        }
+        if (mockedFsDescriptor != null) {
+            mockedFsDescriptor.close();
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/CatalogMocker.java
@@ -24,7 +24,6 @@ import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.FakeEditLog;
 import org.apache.doris.catalog.HashDistributionInfo;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.LocalReplica;
@@ -65,7 +64,7 @@ import org.apache.doris.thrift.TStorageType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
-import mockit.Expectations;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -207,22 +206,13 @@ public class CatalogMocker {
     }
 
     private static AccessControllerManager fetchAdminAccess() {
-        AccessControllerManager accessManager = new AccessControllerManager(new Auth());
-        new Expectations(accessManager) {
-            {
-                accessManager.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-
-                accessManager.checkDbPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        AccessControllerManager accessManager = Mockito.spy(new AccessControllerManager(new Auth()));
+        Mockito.doReturn(true).when(accessManager).checkGlobalPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.any(PrivPredicate.class));
+        Mockito.doReturn(true).when(accessManager).checkDbPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Mockito.doReturn(true).when(accessManager).checkTblPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class));
         return accessManager;
     }
 
@@ -395,60 +385,26 @@ public class CatalogMocker {
 
     public static Env fetchAdminCatalog() {
         try {
-            FakeEditLog fakeEditLog = new FakeEditLog(); // CHECKSTYLE IGNORE THIS LINE
-
-            Env env = Deencapsulation.newInstance(Env.class);
-            InternalCatalog catalog = Deencapsulation.newInstance(InternalCatalog.class);
+            Env env = Mockito.spy(Deencapsulation.newInstance(Env.class));
+            InternalCatalog catalog = Mockito.spy(Deencapsulation.newInstance(InternalCatalog.class));
 
             Database db = new Database();
             AccessControllerManager accessManager = fetchAdminAccess();
 
-            new Expectations(env, catalog) {
-                {
-                    env.getAccessManager();
-                    minTimes = 0;
-                    result = accessManager;
+            Mockito.doReturn(accessManager).when(env).getAccessManager();
+            Mockito.doReturn(catalog).when(env).getInternalCatalog();
+            Mockito.doReturn(catalog).when(env).getCurrentCatalog();
 
-                    env.getInternalCatalog();
-                    minTimes = 0;
-                    result = catalog;
+            Mockito.doReturn(db).when(catalog).getDbNullable(TEST_DB_ID);
+            Mockito.doReturn(new Database()).when(catalog).getDbNullable(Mockito.anyString());
+            Mockito.doReturn(db).when(catalog).getDbNullable(TEST_DB_NAME);
+            Mockito.doReturn(null).when(catalog).getDbNullable(WRONG_DB);
+            Mockito.doReturn(Lists.newArrayList(TEST_DB_NAME)).when(catalog).getDbNames();
 
-                    env.getCurrentCatalog();
-                    minTimes = 0;
-                    result = catalog;
-
-                    catalog.getDbNullable(TEST_DB_NAME);
-                    minTimes = 0;
-                    result = db;
-
-                    catalog.getDbNullable(WRONG_DB);
-                    minTimes = 0;
-                    result = null;
-
-                    catalog.getDbNullable(TEST_DB_ID);
-                    minTimes = 0;
-                    result = db;
-
-                    catalog.getDbNullable(anyString);
-                    minTimes = 0;
-                    result = new Database();
-
-                    catalog.getDbNames();
-                    minTimes = 0;
-                    result = Lists.newArrayList(TEST_DB_NAME);
-
-                    env.getEditLog();
-                    minTimes = 0;
-                    result = new EditLog("name");
-
-                    env.changeDb((ConnectContext) any, WRONG_DB);
-                    minTimes = 0;
-                    result = new DdlException("failed");
-
-                    env.changeDb((ConnectContext) any, anyString);
-                    minTimes = 0;
-                }
-            };
+            Mockito.doReturn(new EditLog("name")).when(env).getEditLog();
+            Mockito.doNothing().when(env).changeDb(Mockito.nullable(ConnectContext.class), Mockito.anyString());
+            Mockito.doThrow(new DdlException("failed")).when(env).changeDb(Mockito.nullable(ConnectContext.class),
+                    Mockito.eq(WRONG_DB));
             return env;
         } catch (DdlException e) {
             return null;

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -39,15 +39,13 @@ import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -74,73 +72,58 @@ public class RepositoryTest {
 
     private SnapshotInfo info;
 
-    @Mocked
-    private org.apache.doris.filesystem.FileSystem mockFs;
-    @Mocked
-    private DorisOutputFile mockOutputFile;
-    @Mocked
-    private DorisInputFile mockInputFile;
-    @Mocked
-    private Env mockedEnv;
-    @Mocked
-    private BrokerMgr mockedBrokerMgr;
+    private org.apache.doris.filesystem.FileSystem mockFs = Mockito.mock(org.apache.doris.filesystem.FileSystem.class);
+    private DorisOutputFile mockOutputFile = Mockito.mock(DorisOutputFile.class);
+    private DorisInputFile mockInputFile = Mockito.mock(DorisInputFile.class);
+    private Env mockedEnv = Mockito.mock(Env.class);
+    private BrokerMgr mockedBrokerMgr = Mockito.mock(BrokerMgr.class);
+
+    private MockedStatic<Env> mockedEnvStatic;
+    private MockedStatic<FrontendOptions> mockedFrontendOptions;
+    private MockedStatic<FileSystemFactory> mockedFileSystemFactory;
 
     private final BrokerProperties testProps = BrokerProperties.of("broker", Maps.newHashMap());
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         List<String> files = Lists.newArrayList();
         files.add("1.dat");
         files.add("1.hdr");
         files.add("1.idx");
         info = new SnapshotInfo(1, 2, 3, 4, 5, 6, 7, "/path/to/tablet/snapshot/", files);
 
-        new MockUp<FrontendOptions>() {
-            @Mock
-            String getLocalHostAddress() {
-                return "127.0.0.1";
-            }
-        };
+        mockedFrontendOptions = Mockito.mockStatic(FrontendOptions.class);
+        mockedFrontendOptions.when(FrontendOptions::getLocalHostAddress).thenReturn("127.0.0.1");
 
-        // Route all FileSystemFactory.getFileSystem calls to mockFs so that
-        // acquireSpiFs() (broker path) returns the mock without a real connection.
-        new MockUp<FileSystemFactory>() {
-            @Mock
-            public org.apache.doris.filesystem.FileSystem getFileSystem(
-                    Map<String, String> properties) throws IOException {
-                return mockFs;
-            }
+        mockedFileSystemFactory = Mockito.mockStatic(FileSystemFactory.class);
+        mockedFileSystemFactory.when(() -> FileSystemFactory.getFileSystem(Mockito.anyMap())).thenReturn(mockFs);
+        mockedFileSystemFactory.when(() -> FileSystemFactory.getFileSystem(Mockito.any(StorageProperties.class))).thenReturn(mockFs);
+        mockedFileSystemFactory.when(() -> FileSystemFactory.getBrokerFileSystem(
+                Mockito.anyString(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyMap())).thenReturn(mockFs);
 
-            @Mock
-            public org.apache.doris.filesystem.FileSystem getFileSystem(
-                    StorageProperties storageProperties) throws IOException {
-                return mockFs;
-            }
-        };
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(mockedEnv);
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = mockedEnv;
-
-                mockedEnv.getBrokerMgr();
-                minTimes = 0;
-                result = mockedBrokerMgr;
-
-                try {
-                    mockedBrokerMgr.getBroker(anyString, anyString);
-                } catch (AnalysisException ignored) {
-                    // never thrown during JMockit recording phase
-                }
-                minTimes = 0;
-                result = new FsBroker("10.74.167.16", 8111);
-            }
-        };
+        Mockito.when(mockedEnv.getBrokerMgr()).thenReturn(mockedBrokerMgr);
+        Mockito.when(mockedBrokerMgr.getBroker(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new FsBroker("10.74.167.16", 8111));
 
         // initRepository() and ping() short-circuit when runningUnitTest is true,
         // which avoids real filesystem calls in those particular tests.
         FeConstants.runningUnitTest = true;
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
+        if (mockedFrontendOptions != null) {
+            mockedFrontendOptions.close();
+        }
+        if (mockedFileSystemFactory != null) {
+            mockedFileSystemFactory.close();
+        }
     }
 
     @Test
@@ -207,48 +190,36 @@ public class RepositoryTest {
     }
 
     @Test
-    public void testListSnapshots() {
-        new Expectations() {
-            {
-                // Return one snapshot directory (__ss_a) and one non-directory (_ss_b).
-                // Only the directory with the correct prefix should appear in the result.
-                try {
-                    mockFs.list((Location) any);
-                } catch (IOException ignored) {
-                    // never thrown during JMockit recording phase
+    public void testListSnapshots() throws IOException {
+        // Return one snapshot directory (__ss_a) and one non-directory (_ss_b).
+        // Only the directory with the correct prefix should appear in the result.
+        Mockito.when(mockFs.list(Mockito.any(Location.class))).thenAnswer(inv -> {
+            List<FileEntry> entries = Lists.newArrayList(
+                    new FileEntry(
+                            Location.of(location + "/__palo_repository_repo/"
+                                    + Repository.PREFIX_SNAPSHOT_DIR + "a"),
+                            100, true, 0L, null),
+                    new FileEntry(
+                            Location.of(location + "/__palo_repository_repo/_ss_b"),
+                            100, false, 0L, null));
+            return new FileIterator() {
+                private int idx = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return idx < entries.size();
                 }
-                minTimes = 0;
-                result = new Delegate<FileIterator>() {
-                    public FileIterator list(Location loc) throws IOException {
-                        List<FileEntry> entries = Lists.newArrayList(
-                                new FileEntry(
-                                        Location.of(location + "/__palo_repository_repo/"
-                                                + Repository.PREFIX_SNAPSHOT_DIR + "a"),
-                                        100, true, 0L, null),
-                                new FileEntry(
-                                        Location.of(location + "/__palo_repository_repo/_ss_b"),
-                                        100, false, 0L, null));
-                        return new FileIterator() {
-                            private int idx = 0;
 
-                            @Override
-                            public boolean hasNext() {
-                                return idx < entries.size();
-                            }
+                @Override
+                public FileEntry next() throws IOException {
+                    return entries.get(idx++);
+                }
 
-                            @Override
-                            public FileEntry next() throws IOException {
-                                return entries.get(idx++);
-                            }
-
-                            @Override
-                            public void close() {
-                            }
-                        };
-                    }
-                };
-            }
-        };
+                @Override
+                public void close() {
+                }
+            };
+        });
 
         repo = new Repository(10000, "repo", false, location, testProps);
         List<String> snapshotNames = Lists.newArrayList();
@@ -265,57 +236,45 @@ public class RepositoryTest {
      * producing a spurious "content" snapshot name.
      */
     @Test
-    public void testListSnapshotsFlatObjectKeys() {
+    public void testListSnapshotsFlatObjectKeys() throws IOException {
         String repoRoot = location + "/__palo_repository_repo";
-        new Expectations() {
-            {
-                try {
-                    mockFs.list((Location) any);
-                } catch (IOException ignored) {
-                    // never thrown during JMockit recording phase
+        Mockito.when(mockFs.list(Mockito.any(Location.class))).thenAnswer(inv -> {
+            List<FileEntry> entries = Lists.newArrayList(
+                    // A meta file directly under __ss_snap1 (single __ss_ segment)
+                    new FileEntry(
+                            Location.of(repoRoot + "/__ss_snap1/__meta__abc"),
+                            50, false, 0L, null),
+                    // A data file under __ss_snap1/__ss_content (two __ss_ segments)
+                    new FileEntry(
+                            Location.of(repoRoot
+                                    + "/__ss_snap1/__ss_content/__db_1/__tbl_2/data.dat"),
+                            200, false, 0L, null),
+                    // A second snapshot
+                    new FileEntry(
+                            Location.of(repoRoot + "/__ss_snap2/__meta__def"),
+                            50, false, 0L, null),
+                    // An entry without __ss_ prefix — should be skipped
+                    new FileEntry(
+                            Location.of(repoRoot + "/__repo_info"),
+                            10, false, 0L, null));
+            return new FileIterator() {
+                private int idx = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return idx < entries.size();
                 }
-                minTimes = 0;
-                result = new Delegate<FileIterator>() {
-                    public FileIterator list(Location loc) throws IOException {
-                        List<FileEntry> entries = Lists.newArrayList(
-                                // A meta file directly under __ss_snap1 (single __ss_ segment)
-                                new FileEntry(
-                                        Location.of(repoRoot + "/__ss_snap1/__meta__abc"),
-                                        50, false, 0L, null),
-                                // A data file under __ss_snap1/__ss_content (two __ss_ segments)
-                                new FileEntry(
-                                        Location.of(repoRoot
-                                                + "/__ss_snap1/__ss_content/__db_1/__tbl_2/data.dat"),
-                                        200, false, 0L, null),
-                                // A second snapshot
-                                new FileEntry(
-                                        Location.of(repoRoot + "/__ss_snap2/__meta__def"),
-                                        50, false, 0L, null),
-                                // An entry without __ss_ prefix — should be skipped
-                                new FileEntry(
-                                        Location.of(repoRoot + "/__repo_info"),
-                                        10, false, 0L, null));
-                        return new FileIterator() {
-                            private int idx = 0;
 
-                            @Override
-                            public boolean hasNext() {
-                                return idx < entries.size();
-                            }
+                @Override
+                public FileEntry next() throws IOException {
+                    return entries.get(idx++);
+                }
 
-                            @Override
-                            public FileEntry next() throws IOException {
-                                return entries.get(idx++);
-                            }
-
-                            @Override
-                            public void close() {
-                            }
-                        };
-                    }
-                };
-            }
-        };
+                @Override
+                public void close() {
+                }
+            };
+        });
 
         repo = new Repository(10000, "repo", false, location, testProps);
         List<String> snapshotNames = Lists.newArrayList();
@@ -329,29 +288,12 @@ public class RepositoryTest {
     }
 
     @Test
-    public void testUpload() {
-        new Expectations() {
-            {
-                // BROKER path: delete(tmp), upload via newOutputFile, rename, delete(final) are called
-                try {
-                    mockFs.delete((Location) any, anyBoolean);
-                    minTimes = 0;
-
-                    mockFs.newOutputFile((Location) any);
-                    minTimes = 0;
-                    result = mockOutputFile;
-
-                    mockOutputFile.create();
-                    minTimes = 0;
-                    result = new ByteArrayOutputStream();
-
-                    mockFs.rename((Location) any, (Location) any);
-                    minTimes = 0;
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        };
+    public void testUpload() throws IOException {
+        // BROKER path: delete(tmp), upload via newOutputFile, rename, delete(final) are called
+        Mockito.doNothing().when(mockFs).delete(Mockito.any(Location.class), Mockito.anyBoolean());
+        Mockito.when(mockFs.newOutputFile(Mockito.any(Location.class))).thenReturn(mockOutputFile);
+        Mockito.when(mockOutputFile.create()).thenReturn(new ByteArrayOutputStream());
+        Mockito.doNothing().when(mockFs).rename(Mockito.any(Location.class), Mockito.any(Location.class));
 
         repo = new Repository(10000, "repo", false, location, testProps);
         String localFilePath = "./tmp_" + System.currentTimeMillis();
@@ -372,7 +314,7 @@ public class RepositoryTest {
     }
 
     @Test
-    public void testDownload() {
+    public void testDownload() throws Exception {
         String localFilePath = "./tmp_" + System.currentTimeMillis();
         File localFile = new File(localFilePath);
         try {
@@ -383,58 +325,45 @@ public class RepositoryTest {
                 Assert.fail();
             }
 
-            new Expectations() {
-                {
-                    // The remote file has an md5 checksum suffix matching content "a"
-                    try {
-                        // Broker does not support globListWithLimit; fall back to listFiles.
-                        mockFs.globListWithLimit((Location) any, anyString, anyLong, anyLong);
-                        minTimes = 0;
-                        result = new UnsupportedOperationException("broker does not support globListWithLimit");
+            // The remote file has an md5 checksum suffix matching content "a"
+            // Broker does not support globListWithLimit; fall back to listFiles.
+            Mockito.when(mockFs.globListWithLimit(Mockito.any(Location.class), Mockito.anyString(),
+                    Mockito.anyLong(), Mockito.anyLong()))
+                    .thenThrow(new UnsupportedOperationException("broker does not support globListWithLimit"));
 
-                        mockFs.listFiles((Location) any);
-                        minTimes = 0;
-                        result = Lists.newArrayList(
-                                new FileEntry(
-                                        Location.of(location + "/remote_file"
-                                                + ".0cc175b9c0f1b6a831c399e269772661"),
-                                        1, false, 0L, null));
+            Mockito.when(mockFs.listFiles(Mockito.any(Location.class)))
+                    .thenReturn(Lists.newArrayList(
+                            new FileEntry(
+                                    Location.of(location + "/remote_file"
+                                            + ".0cc175b9c0f1b6a831c399e269772661"),
+                                    1, false, 0L, null)));
 
-                        mockFs.newInputFile((Location) any);
-                        minTimes = 0;
-                        result = mockInputFile;
+            Mockito.when(mockFs.newInputFile(Mockito.any(Location.class))).thenReturn(mockInputFile);
 
-                        mockInputFile.newStream();
-                        minTimes = 0;
-                        // Return a DorisInputStream wrapping content "a"
-                        result = new DorisInputStream() {
-                            private final java.io.InputStream delegate =
-                                    new java.io.ByteArrayInputStream("a".getBytes());
+            // Return a DorisInputStream wrapping content "a"
+            Mockito.when(mockInputFile.newStream()).thenReturn(new DorisInputStream() {
+                private final java.io.InputStream delegate =
+                        new java.io.ByteArrayInputStream("a".getBytes());
 
-                            @Override
-                            public int read() throws IOException {
-                                return delegate.read();
-                            }
-
-                            @Override
-                            public int read(byte[] b, int off, int len) throws IOException {
-                                return delegate.read(b, off, len);
-                            }
-
-                            @Override
-                            public long getPos() throws IOException {
-                                return 0;
-                            }
-
-                            @Override
-                            public void seek(long newPos) throws IOException {
-                            }
-                        };
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
+                @Override
+                public int read() throws IOException {
+                    return delegate.read();
                 }
-            };
+
+                @Override
+                public int read(byte[] b, int off, int len) throws IOException {
+                    return delegate.read(b, off, len);
+                }
+
+                @Override
+                public long getPos() throws IOException {
+                    return 0;
+                }
+
+                @Override
+                public void seek(long newPos) throws IOException {
+                }
+            });
 
             repo = new Repository(10000, "repo", false, location, testProps);
             String remoteFilePath = location + "/remote_file";
@@ -446,58 +375,45 @@ public class RepositoryTest {
     }
 
     @Test
-    public void testGetSnapshotInfo() {
-        new Expectations() {
-            {
-                try {
-                    // listSnapshots calls fs.list; return two snapshot directories
-                    mockFs.list((Location) any);
-                    minTimes = 0;
-                    result = new Delegate<FileIterator>() {
-                        public FileIterator list(Location loc) throws IOException {
-                            List<FileEntry> entries = Lists.newArrayList(
-                                    new FileEntry(
-                                            Location.of(location + "/__palo_repository_repo/"
-                                                    + Repository.PREFIX_SNAPSHOT_DIR + "s1"),
-                                            100, true, 0L, null),
-                                    new FileEntry(
-                                            Location.of(location + "/__palo_repository_repo/"
-                                                    + Repository.PREFIX_SNAPSHOT_DIR + "s2"),
-                                            100, true, 0L, null));
-                            return new FileIterator() {
-                                private int idx = 0;
+    public void testGetSnapshotInfo() throws IOException {
+        // listSnapshots calls fs.list; return two snapshot directories
+        Mockito.when(mockFs.list(Mockito.any(Location.class))).thenAnswer(inv -> {
+            List<FileEntry> entries = Lists.newArrayList(
+                    new FileEntry(
+                            Location.of(location + "/__palo_repository_repo/"
+                                    + Repository.PREFIX_SNAPSHOT_DIR + "s1"),
+                            100, true, 0L, null),
+                    new FileEntry(
+                            Location.of(location + "/__palo_repository_repo/"
+                                    + Repository.PREFIX_SNAPSHOT_DIR + "s2"),
+                            100, true, 0L, null));
+            return new FileIterator() {
+                private int idx = 0;
 
-                                @Override
-                                public boolean hasNext() {
-                                    return idx < entries.size();
-                                }
-
-                                @Override
-                                public FileEntry next() throws IOException {
-                                    return entries.get(idx++);
-                                }
-
-                                @Override
-                                public void close() {
-                                }
-                            };
-                        }
-                    };
-
-                    // getSnapshotInfo calls fs.listFiles to find __info_* files
-                    mockFs.listFiles((Location) any);
-                    minTimes = 0;
-                    result = Lists.newArrayList(
-                            new FileEntry(
-                                    Location.of(location + "/__palo_repository_repo/__ss_s1/"
-                                            + "__info_2018-04-18-20-11-00"
-                                            + ".12345678123456781234567812345678"),
-                                    100, false, 0L, null));
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
+                @Override
+                public boolean hasNext() {
+                    return idx < entries.size();
                 }
-            }
-        };
+
+                @Override
+                public FileEntry next() throws IOException {
+                    return entries.get(idx++);
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+        });
+
+        // getSnapshotInfo calls fs.listFiles to find __info_* files
+        Mockito.when(mockFs.listFiles(Mockito.any(Location.class)))
+                .thenReturn(Lists.newArrayList(
+                        new FileEntry(
+                                Location.of(location + "/__palo_repository_repo/__ss_s1/"
+                                        + "__info_2018-04-18-20-11-00"
+                                        + ".12345678123456781234567812345678"),
+                                100, false, 0L, null)));
 
         repo = new Repository(10000, "repo", false, location, testProps);
         String snapshotName = "";
@@ -625,7 +541,7 @@ public class RepositoryTest {
      * {@link BrokerMgr#getBroker(String, String)} when resolving the broker endpoint.
      *
      * <p>The setUp() already mocks {@code FrontendOptions.getLocalHostAddress()} to return
-     * {@code "127.0.0.1"}.  This test uses a JMockit {@link Delegate} to capture the actual
+     * {@code "127.0.0.1"}.  This test captures the actual
      * host argument forwarded to {@code getBroker()} and asserts it equals the mocked value.
      */
     @Test
@@ -633,52 +549,34 @@ public class RepositoryTest {
         java.util.concurrent.atomic.AtomicReference<String> capturedHost =
                 new java.util.concurrent.atomic.AtomicReference<>();
 
-        new Expectations() {
-            {
-                // Override the setUp() expectation for getBroker() with a Delegate that captures
-                // the host argument so we can assert it equals FrontendOptions.getLocalHostAddress().
-                try {
-                    mockedBrokerMgr.getBroker(anyString, anyString);
-                } catch (AnalysisException ignored) {
-                    // never thrown during JMockit recording phase
+        // Override the setUp() stub for getBroker() with an answer that captures
+        // the host argument so we can assert it equals FrontendOptions.getLocalHostAddress().
+        Mockito.when(mockedBrokerMgr.getBroker(Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(inv -> {
+                    String host = inv.getArgument(1);
+                    capturedHost.set(host);
+                    return new FsBroker("10.74.167.16", 8111);
+                });
+
+        // listSnapshots() calls fs.list(); return an empty iterator so the method
+        // completes normally without further interaction.
+        Mockito.when(mockFs.list(Mockito.any(Location.class))).thenAnswer(inv -> {
+            return new FileIterator() {
+                @Override
+                public boolean hasNext() {
+                    return false;
                 }
-                minTimes = 0;
-                result = new Delegate<FsBroker>() {
-                    FsBroker getBroker(String brokerName, String host) throws AnalysisException {
-                        capturedHost.set(host);
-                        return new FsBroker("10.74.167.16", 8111);
-                    }
-                };
 
-                // listSnapshots() calls fs.list(); return an empty iterator so the method
-                // completes normally without further interaction.
-                try {
-                    mockFs.list((Location) any);
-                } catch (IOException ignored) {
-                    // never thrown during JMockit recording phase
+                @Override
+                public FileEntry next() throws IOException {
+                    throw new java.util.NoSuchElementException();
                 }
-                minTimes = 0;
-                result = new Delegate<FileIterator>() {
-                    public FileIterator list(Location loc) throws IOException {
-                        return new FileIterator() {
-                            @Override
-                            public boolean hasNext() {
-                                return false;
-                            }
 
-                            @Override
-                            public FileEntry next() throws IOException {
-                                throw new java.util.NoSuchElementException();
-                            }
-
-                            @Override
-                            public void close() {
-                            }
-                        };
-                    }
-                };
-            }
-        };
+                @Override
+                public void close() {
+                }
+            };
+        });
 
         repo = new Repository(10000, "repo", false, location, testProps);
         List<String> snapshotNames = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -42,21 +42,18 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.BrokerProperties;
 import org.apache.doris.persist.EditLog;
-import org.apache.doris.resource.Tag;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -64,7 +61,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.Adler32;
@@ -82,10 +78,8 @@ public class RestoreJobTest {
 
     private long repoId = 20000;
 
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
 
     private MockBackupHandler backupHandler;
 
@@ -118,16 +112,17 @@ public class RestoreJobTest {
         }
     }
 
-    @Mocked
-    private EditLog editLog;
-    @Mocked
-    private SystemInfoService systemInfoService;
+    private EditLog editLog = Mockito.mock(EditLog.class);
+    private SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
 
-    @Injectable
-    private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
-            BrokerProperties.of("broker", Maps.newHashMap()));
+    private Repository repo = Mockito.spy(new Repository(repoId, "repo", false, "bos://my_repo",
+            BrokerProperties.of("broker", Maps.newHashMap())));
 
     private BackupMeta backupMeta;
+
+    private MockedStatic<Env> mockedEnvStatic;
+    @SuppressWarnings("rawtypes")
+    private MockedConstruction<MarkedCountDownLatch> mockedMarkedCountDownLatch;
 
     @Before
     public void setUp() throws Exception {
@@ -137,90 +132,46 @@ public class RestoreJobTest {
 
         Deencapsulation.setField(env, "backupHandler", backupHandler);
 
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = db;
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(db);
+        Mockito.when(env.getNextId()).thenAnswer(inv -> id.getAndIncrement());
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
+        Mockito.doAnswer(inv -> {
+            List<Long> beIds = Lists.newArrayList();
+            beIds.add(CatalogMocker.BACKEND1_ID);
+            beIds.add(CatalogMocker.BACKEND2_ID);
+            beIds.add(CatalogMocker.BACKEND3_ID);
+            return beIds;
+        }).when(systemInfoService).selectBackendIdsForReplicaCreation(
+                Mockito.any(ReplicaAllocation.class),
+                Mockito.anyMap(),
+                Mockito.any(TStorageMedium.class),
+                Mockito.eq(false),
+                Mockito.eq(true));
 
-                env.getNextId();
-                minTimes = 0;
-                result = id.getAndIncrement();
+        Mockito.doAnswer(inv -> {
+            BackupJob job = inv.getArgument(0);
+            System.out.println("log backup job: " + job);
+            return null;
+        }).when(editLog).logBackupJob(Mockito.any(BackupJob.class));
 
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
+        Mockito.doReturn(Status.OK).when(repo).upload(Mockito.anyString(), Mockito.anyString());
+        Mockito.doAnswer(inv -> {
+            List<BackupMeta> metas = inv.getArgument(1);
+            metas.add(backupMeta);
+            return Status.OK;
+        }).when(repo).getSnapshotMetaFile(Mockito.eq(label), Mockito.anyList(), Mockito.eq(-1));
 
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-            }
-        };
-
-        new Expectations() {
-            {
-                systemInfoService.selectBackendIdsForReplicaCreation((ReplicaAllocation) any,
-                        Maps.newHashMap(), (TStorageMedium) any, false, true);
-                minTimes = 0;
-                result = new Delegate() {
-                    public synchronized List<Long> selectBackendIdsForReplicaCreation(
-                            ReplicaAllocation replicaAlloc, Map<Tag, Integer> nextIndexs,
-                            TStorageMedium medium, boolean isStorageMediumSpecified,
-                            boolean isOnlyForCheck) {
-                        List<Long> beIds = Lists.newArrayList();
-                        beIds.add(CatalogMocker.BACKEND1_ID);
-                        beIds.add(CatalogMocker.BACKEND2_ID);
-                        beIds.add(CatalogMocker.BACKEND3_ID);
-                        return beIds;
-                    }
-                };
-            }
-        };
-
-        new Expectations() {
-            {
-                editLog.logBackupJob((BackupJob) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    public void logBackupJob(BackupJob job) {
-                        System.out.println("log backup job: " + job);
-                    }
-                };
-            }
-        };
-
-        new Expectations() {
-            {
-                repo.upload(anyString, anyString);
-                result = Status.OK;
-                minTimes = 0;
-
-                List<BackupMeta> backupMetas = Lists.newArrayList();
-                repo.getSnapshotMetaFile(label, backupMetas, -1);
-                minTimes = 0;
-                result = new Delegate() {
-                    public Status getSnapshotMetaFile(String label, List<BackupMeta> backupMetas) {
-                        backupMetas.add(backupMeta);
-                        return Status.OK;
-                    }
-                };
-            }
-        };
-
-        new MockUp<MarkedCountDownLatch>() {
-            @Mock
-            boolean await(long timeout, TimeUnit unit) {
-                return true;
-            }
-        };
+        mockedMarkedCountDownLatch = Mockito.mockConstruction(MarkedCountDownLatch.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doReturn(true).when(mock).await(Mockito.anyLong(), Mockito.any(TimeUnit.class));
+                });
 
         // gen BackupJobInfo
         jobInfo = new BackupJobInfo();
@@ -266,6 +217,16 @@ public class RestoreJobTest {
         List<Resource> resources = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);
         backupMeta = new BackupMeta(tbls, resources);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
+        if (mockedMarkedCountDownLatch != null) {
+            mockedMarkedCountDownLatch.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
@@ -32,12 +32,14 @@ import org.apache.doris.thrift.TStatusCode;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -64,6 +66,12 @@ public class BinlogManagerTest {
 
     private boolean enableDbBinlog = false;
 
+    private MockedConstruction<BinlogConfigCache> mockedBinlogConfigCacheConstruction;
+    private MockedConstruction<BinlogConfig> mockedBinlogConfigConstruction;
+    private MockedStatic<Env> mockedEnv;
+    private MockedConstruction<InternalCatalog> mockedInternalCatalogConstruction;
+    private MockedConstruction<Database> mockedDatabaseConstruction;
+
     @BeforeClass
     public static void beforeClass() {
         Config.enable_feature_binlog = true;
@@ -82,60 +90,67 @@ public class BinlogManagerTest {
             frameWork.put(dbId, tableIds);
         }
 
-        new MockUp<BinlogConfigCache>() {
-            @Mock
-            public BinlogConfig getDBBinlogConfig(long dbId) {
-                return new BinlogConfig();
-            }
+        mockedBinlogConfigConstruction = Mockito.mockConstruction(BinlogConfig.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doAnswer(inv -> ttl).when(mock).getTtlSeconds();
+                    Mockito.doAnswer(inv -> enableDbBinlog).when(mock).isEnable();
+                    Mockito.doReturn(BinlogTestUtils.MAX_BYTES).when(mock).getMaxBytes();
+                    Mockito.doReturn(BinlogTestUtils.MAX_HISTORY_NUMS).when(mock).getMaxHistoryNums();
+                });
 
-            @Mock
-            public BinlogConfig getTableBinlogConfig(long dbId, long tableId) {
-                return new BinlogConfig();
-            }
+        mockedBinlogConfigCacheConstruction = Mockito.mockConstruction(BinlogConfigCache.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doAnswer(inv -> new BinlogConfig()).when(mock)
+                            .getDBBinlogConfig(Mockito.anyLong());
+                    Mockito.doAnswer(inv -> new BinlogConfig()).when(mock)
+                            .getTableBinlogConfig(Mockito.anyLong(), Mockito.anyLong());
+                    Mockito.doReturn(true).when(mock)
+                            .isEnableTable(Mockito.anyLong(), Mockito.anyLong());
+                    Mockito.doAnswer(inv -> enableDbBinlog).when(mock)
+                            .isEnableDB(Mockito.anyLong());
+                    Mockito.doReturn(false).when(mock)
+                            .isAsyncMvTable(Mockito.anyLong(), Mockito.anyLong());
+                    Mockito.doReturn(false).when(mock)
+                            .isTemporaryTable(Mockito.anyLong(), Mockito.anyLong());
+                });
 
-            @Mock
-            public boolean isEnableTable(long dbId, long tableId) {
-                return true;
-            }
+        mockedDatabaseConstruction = Mockito.mockConstruction(Database.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doAnswer(inv -> new BinlogConfig()).when(mock).getBinlogConfig();
+                });
 
-            @Mock
-            public boolean isEnableDB(long dbId) {
-                return enableDbBinlog;
-            }
-        };
+        mockedInternalCatalogConstruction = Mockito.mockConstruction(InternalCatalog.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doAnswer(inv -> new Database()).when(mock)
+                            .getDbNullable(Mockito.anyLong());
+                });
 
-        new MockUp<BinlogConfig>() {
-            @Mock
-            public long getTtlSeconds() {
-                return ttl;
-            }
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedEnv.when(Env::getCurrentInternalCatalog)
+                .thenAnswer(inv -> EnvFactory.getInstance().createInternalCatalog());
+    }
 
-            @Mock
-            public boolean isEnable() {
-                return enableDbBinlog;
-            }
-        };
-
-        new MockUp<Env>() {
-            @Mock
-            public InternalCatalog getCurrentInternalCatalog() {
-                return EnvFactory.getInstance().createInternalCatalog();
-            }
-        };
-
-        new MockUp<InternalCatalog>() {
-            @Mock
-            public Database getDbNullable(long dbId) {
-                return new Database();
-            }
-        };
-
-        new MockUp<Database>() {
-            @Mock
-            public BinlogConfig getBinlogConfig() {
-                return new BinlogConfig();
-            }
-        };
+    @After
+    public void tearDown() {
+        if (mockedBinlogConfigCacheConstruction != null) {
+            mockedBinlogConfigCacheConstruction.close();
+        }
+        if (mockedBinlogConfigConstruction != null) {
+            mockedBinlogConfigConstruction.close();
+        }
+        if (mockedEnv != null) {
+            mockedEnv.close();
+        }
+        if (mockedInternalCatalogConstruction != null) {
+            mockedInternalCatalogConstruction.close();
+        }
+        if (mockedDatabaseConstruction != null) {
+            mockedDatabaseConstruction.close();
+        }
     }
 
     @Test
@@ -252,59 +267,58 @@ public class BinlogManagerTest {
     @Test
     public void testReplayGcFromTableLevel() throws NoSuchMethodException, InvocationTargetException,
             IllegalAccessException, NoSuchFieldException {
-        // MockUp
-        new MockUp<BinlogUtils>() {
-            @Mock
-            public long getExpiredMs(long ttl) {
-                return timeNow - ttl;
+        try (MockedStatic<BinlogUtils> mockedBinlogUtils = Mockito.mockStatic(BinlogUtils.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            mockedBinlogUtils.when(() -> BinlogUtils.getExpiredMs(Mockito.anyLong()))
+                    .thenAnswer(invocation -> timeNow - (long) invocation.getArgument(0));
+
+            // reflect BinlogManager
+            // addBinlog method
+            Method addBinlog = BinlogManager.class.getDeclaredMethod("addBinlog", TBinlog.class, Object.class);
+            addBinlog.setAccessible(true);
+            // dbBinlogMap
+            Field dbBinlogMapField = BinlogManager.class.getDeclaredField("dbBinlogMap");
+            dbBinlogMapField.setAccessible(true);
+
+            // init binlog origin & new manager
+            BinlogManager originManager = new BinlogManager();
+            BinlogManager newManager = new BinlogManager();
+
+            // insert binlogs
+            long commitSeq = 0;
+            for (Map.Entry<Long, List<Long>> dbEntry : frameWork.entrySet()) {
+                long dbId = dbEntry.getKey();
+                for (long tableId : dbEntry.getValue()) {
+                    addBinlog.invoke(originManager, BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, timeNow),
+                            null);
+                    addBinlog.invoke(newManager, BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, timeNow), null);
+                    ++commitSeq;
+                }
             }
-        };
 
-        // reflect BinlogManager
-        // addBinlog method
-        Method addBinlog = BinlogManager.class.getDeclaredMethod("addBinlog", TBinlog.class, Object.class);
-        addBinlog.setAccessible(true);
-        // dbBinlogMap
-        Field dbBinlogMapField = BinlogManager.class.getDeclaredField("dbBinlogMap");
-        dbBinlogMapField.setAccessible(true);
+            // origin manager gc & get BinlogGcInfo
+            BinlogGcInfo info = new BinlogGcInfo(originManager.gc());
 
-        // init binlog origin & new manager
-        BinlogManager originManager = new BinlogManager();
-        BinlogManager newManager = new BinlogManager();
+            // new manager replay gc
+            newManager.replayGc(info);
 
-        // insert binlogs
-        long commitSeq = 0;
-        for (Map.Entry<Long, List<Long>> dbEntry : frameWork.entrySet()) {
-            long dbId = dbEntry.getKey();
-            for (long tableId : dbEntry.getValue()) {
-                addBinlog.invoke(originManager, BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, timeNow), null);
-                addBinlog.invoke(newManager, BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, timeNow), null);
-                ++commitSeq;
-            }
-        }
-
-        // origin manager gc & get BinlogGcInfo
-        BinlogGcInfo info = new BinlogGcInfo(originManager.gc());
-
-        // new manager replay gc
-        newManager.replayGc(info);
-
-        // get origin & new dbbinlog's allbinlogs
-        Map<Long, DBBinlog> originDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(originManager);
-        Map<Long, DBBinlog> newDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(newManager);
-        Assert.assertEquals(originDbBinlogMap.size(), newDbBinlogMap.size());
-        for (long dbId : frameWork.keySet()) {
-            List<TBinlog> originBinlogList = Lists.newArrayList();
-            List<TBinlog> newBinlogList = Lists.newArrayList();
-            originDbBinlogMap.get(dbId).getAllBinlogs(originBinlogList);
-            newDbBinlogMap.get(dbId).getAllBinlogs(newBinlogList);
-            Assert.assertEquals(originBinlogList.size(), newBinlogList.size());
-            for (int i = 0; i < originBinlogList.size(); ++i) {
-                TBinlog originBinlog = originBinlogList.get(i);
-                TBinlog newBinlog = newBinlogList.get(i);
-                Assert.assertEquals(originBinlog.getCommitSeq(), newBinlog.getCommitSeq());
-                if (newBinlog.getType() != TBinlogType.DUMMY) {
-                    Assert.assertTrue(newBinlog.getTimestamp() > timeNow - ttl);
+            // get origin & new dbbinlog's allbinlogs
+            Map<Long, DBBinlog> originDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(originManager);
+            Map<Long, DBBinlog> newDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(newManager);
+            Assert.assertEquals(originDbBinlogMap.size(), newDbBinlogMap.size());
+            for (long dbId : frameWork.keySet()) {
+                List<TBinlog> originBinlogList = Lists.newArrayList();
+                List<TBinlog> newBinlogList = Lists.newArrayList();
+                originDbBinlogMap.get(dbId).getAllBinlogs(originBinlogList);
+                newDbBinlogMap.get(dbId).getAllBinlogs(newBinlogList);
+                Assert.assertEquals(originBinlogList.size(), newBinlogList.size());
+                for (int i = 0; i < originBinlogList.size(); ++i) {
+                    TBinlog originBinlog = originBinlogList.get(i);
+                    TBinlog newBinlog = newBinlogList.get(i);
+                    Assert.assertEquals(originBinlog.getCommitSeq(), newBinlog.getCommitSeq());
+                    if (newBinlog.getType() != TBinlogType.DUMMY) {
+                        Assert.assertTrue(newBinlog.getTimestamp() > timeNow - ttl);
+                    }
                 }
             }
         }
@@ -313,64 +327,64 @@ public class BinlogManagerTest {
     @Test
     public void testReplayGcFromDbLevel() throws NoSuchMethodException, InvocationTargetException,
             IllegalAccessException, NoSuchFieldException {
-        // MockUp
-        new MockUp<BinlogUtils>() {
-            @Mock
-            public long getExpiredMs(long ttl) {
-                return timeNow - ttl;
-            }
-        };
-
         // set dbBinlogEnable
         enableDbBinlog = true;
 
-        // reflect BinlogManager
-        // addBinlog method
-        Method addBinlog = BinlogManager.class.getDeclaredMethod("addBinlog", TBinlog.class, Object.class);
-        addBinlog.setAccessible(true);
-        // dbBinlogMap
-        Field dbBinlogMapField = BinlogManager.class.getDeclaredField("dbBinlogMap");
-        dbBinlogMapField.setAccessible(true);
+        try (MockedStatic<BinlogUtils> mockedBinlogUtils = Mockito.mockStatic(BinlogUtils.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            mockedBinlogUtils.when(() -> BinlogUtils.getExpiredMs(Mockito.anyLong()))
+                    .thenAnswer(invocation -> timeNow - (long) invocation.getArgument(0));
 
-        // init binlog origin & new manager
-        BinlogManager originManager = new BinlogManager();
-        BinlogManager newManager = new BinlogManager();
+            // reflect BinlogManager
+            // addBinlog method
+            Method addBinlog = BinlogManager.class.getDeclaredMethod("addBinlog", TBinlog.class, Object.class);
+            addBinlog.setAccessible(true);
+            // dbBinlogMap
+            Field dbBinlogMapField = BinlogManager.class.getDeclaredField("dbBinlogMap");
+            dbBinlogMapField.setAccessible(true);
 
-        // insert binlogs
-        long commitSeq = baseNum;
-        for (Map.Entry<Long, List<Long>> dbEntry : frameWork.entrySet()) {
-            long dbId = dbEntry.getKey();
-            for (long tableId : dbEntry.getValue()) {
-                ++commitSeq;
-                addBinlog.invoke(originManager, BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, commitSeq), null);
-                addBinlog.invoke(newManager, BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, commitSeq), null);
+            // init binlog origin & new manager
+            BinlogManager originManager = new BinlogManager();
+            BinlogManager newManager = new BinlogManager();
+
+            // insert binlogs
+            long commitSeq = baseNum;
+            for (Map.Entry<Long, List<Long>> dbEntry : frameWork.entrySet()) {
+                long dbId = dbEntry.getKey();
+                for (long tableId : dbEntry.getValue()) {
+                    ++commitSeq;
+                    addBinlog.invoke(originManager,
+                            BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, commitSeq), null);
+                    addBinlog.invoke(newManager,
+                            BinlogTestUtils.newBinlog(dbId, tableId, commitSeq, commitSeq), null);
+                }
             }
-        }
-        timeNow = commitSeq;
+            timeNow = commitSeq;
 
-        // origin manager gc & get BinlogGcInfo
-        BinlogGcInfo info = new BinlogGcInfo(originManager.gc());
+            // origin manager gc & get BinlogGcInfo
+            BinlogGcInfo info = new BinlogGcInfo(originManager.gc());
 
-        // new manager replay gc
-        newManager.replayGc(info);
+            // new manager replay gc
+            newManager.replayGc(info);
 
-        // get origin & new dbbinlog's allbinlogs
-        Map<Long, DBBinlog> originDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(originManager);
-        Map<Long, DBBinlog> newDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(newManager);
-        Assert.assertEquals(originDbBinlogMap.size(), newDbBinlogMap.size());
-        for (Map.Entry<Long, List<Long>> dbEntry : frameWork.entrySet()) {
-            long dbId = dbEntry.getKey();
-            List<TBinlog> originBinlogList = Lists.newArrayList();
-            List<TBinlog> newBinlogList = Lists.newArrayList();
-            originDbBinlogMap.get(dbId).getAllBinlogs(originBinlogList);
-            newDbBinlogMap.get(dbId).getAllBinlogs(newBinlogList);
-            Assert.assertEquals(originBinlogList.size(), newBinlogList.size());
-            for (int i = 0; i < originBinlogList.size(); ++i) {
-                TBinlog originBinlog = originBinlogList.get(i);
-                TBinlog newBinlog = newBinlogList.get(i);
-                Assert.assertEquals(originBinlog.getCommitSeq(), newBinlog.getCommitSeq());
-                if (newBinlog.getType() != TBinlogType.DUMMY) {
-                    Assert.assertTrue(newBinlog.getCommitSeq() > timeNow - ttl);
+            // get origin & new dbbinlog's allbinlogs
+            Map<Long, DBBinlog> originDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(originManager);
+            Map<Long, DBBinlog> newDbBinlogMap = (Map<Long, DBBinlog>) dbBinlogMapField.get(newManager);
+            Assert.assertEquals(originDbBinlogMap.size(), newDbBinlogMap.size());
+            for (Map.Entry<Long, List<Long>> dbEntry : frameWork.entrySet()) {
+                long dbId = dbEntry.getKey();
+                List<TBinlog> originBinlogList = Lists.newArrayList();
+                List<TBinlog> newBinlogList = Lists.newArrayList();
+                originDbBinlogMap.get(dbId).getAllBinlogs(originBinlogList);
+                newDbBinlogMap.get(dbId).getAllBinlogs(newBinlogList);
+                Assert.assertEquals(originBinlogList.size(), newBinlogList.size());
+                for (int i = 0; i < originBinlogList.size(); ++i) {
+                    TBinlog originBinlog = originBinlogList.get(i);
+                    TBinlog newBinlog = newBinlogList.get(i);
+                    Assert.assertEquals(originBinlog.getCommitSeq(), newBinlog.getCommitSeq());
+                    if (newBinlog.getType() != TBinlogType.DUMMY) {
+                        Assert.assertTrue(newBinlog.getCommitSeq() > timeNow - ttl);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/DbBinlogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/DbBinlogTest.java
@@ -22,11 +22,12 @@ import org.apache.doris.thrift.TBinlogType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -39,6 +40,7 @@ public class DbBinlogTest {
     private int tableNum = 5;
     private int gcTableNum = 2;
     private List<Long> tableIds;
+    private MockedStatic<BinlogUtils> mockedBinlogUtils;
 
     private int totalBinlogNum = 10;
     private int expiredBinlogNum = 3;
@@ -57,12 +59,16 @@ public class DbBinlogTest {
             tableIds.add(baseTableId + i);
         }
 
-        new MockUp<BinlogUtils>() {
-            @Mock
-            public long getExpiredMs(long direct) {
-                return direct;
-            }
-        };
+        mockedBinlogUtils = Mockito.mockStatic(BinlogUtils.class, Mockito.CALLS_REAL_METHODS);
+        mockedBinlogUtils.when(() -> BinlogUtils.getExpiredMs(Mockito.anyLong()))
+                .thenAnswer(invocation -> (long) invocation.getArgument(0));
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedBinlogUtils != null) {
+            mockedBinlogUtils.close();
+        }
     }
 
     @Test
@@ -258,17 +264,9 @@ public class DbBinlogTest {
         int maxValue = 12;
 
         // mock up
-        new MockUp<BinlogConfigCache>() {
-            @Mock
-            boolean isEnableDB(long dbId) {
-                return true;
-            }
-
-            @Mock
-            boolean isEnableTable(long dbId, long tableId) {
-                return true;
-            }
-        };
+        BinlogConfigCache mockCache = Mockito.mock(BinlogConfigCache.class);
+        Mockito.when(mockCache.isEnableDB(Mockito.anyLong())).thenReturn(true);
+        Mockito.when(mockCache.isEnableTable(Mockito.anyLong(), Mockito.anyLong())).thenReturn(true);
 
         // reflect field
         Field allBinlogsField = DBBinlog.class.getDeclaredField("allBinlogs");
@@ -284,7 +282,7 @@ public class DbBinlogTest {
             }
             TBinlog binlog = BinlogTestUtils.newBinlog(dbId, baseTableId, 1, 1);
             binlog.setType(type);
-            DBBinlog dbBinlog = new DBBinlog(new BinlogConfigCache(), binlog);
+            DBBinlog dbBinlog = new DBBinlog(mockCache, binlog);
 
             dbBinlog.addBinlog(binlog, null);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/TableBinlogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/TableBinlogTest.java
@@ -21,11 +21,11 @@ import org.apache.doris.thrift.TBinlog;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -47,54 +47,53 @@ public class TableBinlogTest {
     @Test
     public void testTtlGc() {
         // mock BinlogUtils
-        new MockUp<BinlogUtils>() {
-            @Mock
-            public long getExpiredMs(long direct) {
-                return direct;
+        try (MockedStatic<BinlogUtils> mockedBinlogUtils = Mockito.mockStatic(BinlogUtils.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            mockedBinlogUtils.when(() -> BinlogUtils.getExpiredMs(Mockito.anyLong()))
+                    .thenAnswer(invocation -> (long) invocation.getArgument(0));
+
+            // init base data
+            long expiredTime = baseNum + expiredBinlogNum;
+            BinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(dbId, tableId, expiredTime);
+
+            // init & add binlogs
+            List<TBinlog> testBinlogs = Lists.newArrayList();
+            for (int i = 0; i < totalBinlogNum; ++i) {
+                TBinlog binlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum + i, baseNum + i);
+                testBinlogs.add(binlog);
             }
-        };
 
-        // init base data
-        long expiredTime = baseNum + expiredBinlogNum;
-        BinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(dbId, tableId, expiredTime);
+            // init TableBinlog
+            TableBinlog tableBinlog = null;
 
-        // init & add binlogs
-        List<TBinlog> testBinlogs = Lists.newArrayList();
-        for (int i = 0; i < totalBinlogNum; ++i) {
-            TBinlog binlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum + i, baseNum + i);
-            testBinlogs.add(binlog);
-        }
-
-        // init TableBinlog
-        TableBinlog tableBinlog = null;
-
-        // insert binlogs
-        for (int i = 0; i < totalBinlogNum; ++i) {
-            if (tableBinlog == null) {
-                tableBinlog = new TableBinlog(binlogConfigCache, testBinlogs.get(i), dbId, tableId);
+            // insert binlogs
+            for (int i = 0; i < totalBinlogNum; ++i) {
+                if (tableBinlog == null) {
+                    tableBinlog = new TableBinlog(binlogConfigCache, testBinlogs.get(i), dbId, tableId);
+                }
+                tableBinlog.addBinlog(testBinlogs.get(i));
             }
-            tableBinlog.addBinlog(testBinlogs.get(i));
-        }
 
-        // trigger ttlGc
-        BinlogTombstone tombstone = tableBinlog.gc();
+            // trigger ttlGc
+            BinlogTombstone tombstone = tableBinlog.gc();
 
-        // check binlog status
-        for (TBinlog binlog : testBinlogs) {
-            if (binlog.getTimestamp() <= expiredTime) {
-                Assert.assertEquals(0, binlog.getTableRef());
-            } else {
-                Assert.assertEquals(1, binlog.getTableRef());
+            // check binlog status
+            for (TBinlog binlog : testBinlogs) {
+                if (binlog.getTimestamp() <= expiredTime) {
+                    Assert.assertEquals(0, binlog.getTableRef());
+                } else {
+                    Assert.assertEquals(1, binlog.getTableRef());
+                }
             }
+
+            // check tombstone
+            Assert.assertFalse(tombstone.isDbBinlogTomstone());
+            Assert.assertEquals(expiredTime, tombstone.getCommitSeq());
+
+            // check dummy
+            TBinlog dummy = tableBinlog.getDummyBinlog();
+            Assert.assertEquals(expiredTime, dummy.getCommitSeq());
         }
-
-        // check tombstone
-        Assert.assertFalse(tombstone.isDbBinlogTomstone());
-        Assert.assertEquals(expiredTime, tombstone.getCommitSeq());
-
-        // check dummy
-        TBinlog dummy = tableBinlog.getDummyBinlog();
-        Assert.assertEquals(expiredTime, dummy.getCommitSeq());
     }
 
     @Test
@@ -145,115 +144,113 @@ public class TableBinlogTest {
     @Test
     public void testTableGcBinlogWithDisable() {
         // mock BinlogUtils
-        new MockUp<BinlogUtils>() {
-            @Mock
-            public long getExpiredMs(long direct) {
-                return direct;
+        try (MockedStatic<BinlogUtils> mockedBinlogUtils = Mockito.mockStatic(BinlogUtils.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            mockedBinlogUtils.when(() -> BinlogUtils.getExpiredMs(Mockito.anyLong()))
+                    .thenAnswer(invocation -> (long) invocation.getArgument(0));
+            Map<String, Long> ttlMap = Maps.newHashMap();
+
+            // init base data
+            long expiredTime = baseNum + expiredBinlogNum;
+            ttlMap.put(String.format("%d_%d", dbId, tableId), expiredTime);
+
+            MockBinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(ttlMap);
+
+            // disable table binlog
+            binlogConfigCache.addTableBinlogConfig(dbId, tableId, false, expiredTime);
+
+            // init & add binlogs
+            List<TBinlog> testBinlogs = Lists.newArrayList();
+            for (int i = 0; i < totalBinlogNum; ++i) {
+                TBinlog binlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum + i, baseNum + i);
+                testBinlogs.add(binlog);
             }
-        };
-        Map<String, Long> ttlMap = Maps.newHashMap();
 
-        // init base data
-        long expiredTime = baseNum + expiredBinlogNum;
-        ttlMap.put(String.format("%d_%d", dbId, tableId), expiredTime);
+            // init TableBinlog
+            TableBinlog tableBinlog = null;
 
-        MockBinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(ttlMap);
-
-        // disable table binlog
-        binlogConfigCache.addTableBinlogConfig(dbId, tableId, false, expiredTime);
-
-        // init & add binlogs
-        List<TBinlog> testBinlogs = Lists.newArrayList();
-        for (int i = 0; i < totalBinlogNum; ++i) {
-            TBinlog binlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum + i, baseNum + i);
-            testBinlogs.add(binlog);
-        }
-
-        // init TableBinlog
-        TableBinlog tableBinlog = null;
-
-        // insert binlogs
-        for (int i = 0; i < totalBinlogNum; ++i) {
-            if (tableBinlog == null) {
-                tableBinlog = new TableBinlog(binlogConfigCache, testBinlogs.get(i), dbId, tableId);
+            // insert binlogs
+            for (int i = 0; i < totalBinlogNum; ++i) {
+                if (tableBinlog == null) {
+                    tableBinlog = new TableBinlog(binlogConfigCache, testBinlogs.get(i), dbId, tableId);
+                }
+                tableBinlog.addBinlog(testBinlogs.get(i));
             }
-            tableBinlog.addBinlog(testBinlogs.get(i));
+
+            // trigger gc
+            BinlogTombstone tombstone = tableBinlog.gc();
+
+            // check binlog status - all binlogs should be cleared when table binlog is disabled
+            for (TBinlog binlog : testBinlogs) {
+                Assert.assertEquals(0, binlog.getTableRef());
+            }
+
+            // check tombstone
+            Assert.assertFalse(tombstone.isDbBinlogTomstone());
+            Assert.assertEquals(baseNum + totalBinlogNum - 1, tombstone.getCommitSeq());
+
+            // check dummy - should have the last commitSeq
+            TBinlog dummy = tableBinlog.getDummyBinlog();
+            Assert.assertEquals(baseNum + totalBinlogNum - 1, dummy.getCommitSeq());
         }
-
-        // trigger gc
-        BinlogTombstone tombstone = tableBinlog.gc();
-
-        // check binlog status - all binlogs should be cleared when table binlog is disabled
-        for (TBinlog binlog : testBinlogs) {
-            Assert.assertEquals(0, binlog.getTableRef());
-        }
-
-        // check tombstone
-        Assert.assertFalse(tombstone.isDbBinlogTomstone());
-        Assert.assertEquals(baseNum + totalBinlogNum - 1, tombstone.getCommitSeq());
-
-        // check dummy - should have the last commitSeq
-        TBinlog dummy = tableBinlog.getDummyBinlog();
-        Assert.assertEquals(baseNum + totalBinlogNum - 1, dummy.getCommitSeq());
     }
 
     @Test
     public void testTableGcBinlogWithEnable() {
         // mock BinlogUtils
-        new MockUp<BinlogUtils>() {
-            @Mock
-            public long getExpiredMs(long direct) {
-                return direct;
+        try (MockedStatic<BinlogUtils> mockedBinlogUtils = Mockito.mockStatic(BinlogUtils.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            mockedBinlogUtils.when(() -> BinlogUtils.getExpiredMs(Mockito.anyLong()))
+                    .thenAnswer(invocation -> (long) invocation.getArgument(0));
+            Map<String, Long> ttlMap = Maps.newHashMap();
+
+            // init base data
+            long expiredTime = baseNum + expiredBinlogNum;
+            ttlMap.put(String.format("%d_%d", dbId, tableId), expiredTime);
+
+            MockBinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(ttlMap);
+
+            // enable table binlog
+            binlogConfigCache.addTableBinlogConfig(dbId, tableId, true, expiredTime);
+
+            // init & add binlogs
+            List<TBinlog> testBinlogs = Lists.newArrayList();
+            for (int i = 0; i < totalBinlogNum; ++i) {
+                TBinlog binlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum + i, baseNum + i);
+                testBinlogs.add(binlog);
             }
-        };
-        Map<String, Long> ttlMap = Maps.newHashMap();
 
-        // init base data
-        long expiredTime = baseNum + expiredBinlogNum;
-        ttlMap.put(String.format("%d_%d", dbId, tableId), expiredTime);
+            // init TableBinlog
+            TableBinlog tableBinlog = null;
 
-        MockBinlogConfigCache binlogConfigCache = BinlogTestUtils.newMockBinlogConfigCache(ttlMap);
-
-        // enable table binlog
-        binlogConfigCache.addTableBinlogConfig(dbId, tableId, true, expiredTime);
-
-        // init & add binlogs
-        List<TBinlog> testBinlogs = Lists.newArrayList();
-        for (int i = 0; i < totalBinlogNum; ++i) {
-            TBinlog binlog = BinlogTestUtils.newBinlog(dbId, tableId, baseNum + i, baseNum + i);
-            testBinlogs.add(binlog);
-        }
-
-        // init TableBinlog
-        TableBinlog tableBinlog = null;
-
-        // insert binlogs
-        for (int i = 0; i < totalBinlogNum; ++i) {
-            if (tableBinlog == null) {
-                tableBinlog = new TableBinlog(binlogConfigCache, testBinlogs.get(i), dbId, tableId);
+            // insert binlogs
+            for (int i = 0; i < totalBinlogNum; ++i) {
+                if (tableBinlog == null) {
+                    tableBinlog = new TableBinlog(binlogConfigCache, testBinlogs.get(i), dbId, tableId);
+                }
+                tableBinlog.addBinlog(testBinlogs.get(i));
             }
-            tableBinlog.addBinlog(testBinlogs.get(i));
-        }
 
-        // trigger gc
-        BinlogTombstone tombstone = tableBinlog.gc();
+            // trigger gc
+            BinlogTombstone tombstone = tableBinlog.gc();
 
-        // check binlog status - only expired binlogs should be cleared
-        for (TBinlog binlog : testBinlogs) {
-            if (binlog.getTimestamp() <= expiredTime) {
-                Assert.assertEquals(0, binlog.getTableRef());
-            } else {
-                Assert.assertEquals(1, binlog.getTableRef());
+            // check binlog status - only expired binlogs should be cleared
+            for (TBinlog binlog : testBinlogs) {
+                if (binlog.getTimestamp() <= expiredTime) {
+                    Assert.assertEquals(0, binlog.getTableRef());
+                } else {
+                    Assert.assertEquals(1, binlog.getTableRef());
+                }
             }
+
+            // check tombstone
+            Assert.assertFalse(tombstone.isDbBinlogTomstone());
+            Assert.assertEquals(expiredTime, tombstone.getCommitSeq());
+
+            // check dummy - should have the expiredTime as commitSeq
+            TBinlog dummy = tableBinlog.getDummyBinlog();
+            Assert.assertEquals(expiredTime, dummy.getCommitSeq());
         }
-
-        // check tombstone
-        Assert.assertFalse(tombstone.isDbBinlogTomstone());
-        Assert.assertEquals(expiredTime, tombstone.getCommitSeq());
-
-        // check dummy - should have the expiredTime as commitSeq
-        TBinlog dummy = tableBinlog.getDummyBinlog();
-        Assert.assertEquals(expiredTime, dummy.getCommitSeq());
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
@@ -27,17 +27,17 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
+import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -85,128 +85,137 @@ public class AIResourceTest {
     }
 
     @Test
-    public void testFromCommand(@Mocked Env env, @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testFromCommand() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        // resource with default settings
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(
-                new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
-        createResourceCommand.getInfo().validate();
+            // resource with default settings
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(
+                    new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
+            createResourceCommand.getInfo().validate();
 
-        AIResource aiResource = (AIResource) Resource.fromCommand(createResourceCommand);
-        Assert.assertEquals(name, aiResource.getName());
-        Assert.assertEquals(type, aiResource.getType().name().toLowerCase());
-        Assert.assertEquals(endpoint, aiResource.getProperty(AIProperties.ENDPOINT));
-        Assert.assertEquals(providerType.toUpperCase(), aiResource.getProperty(AIProperties.PROVIDER_TYPE));
-        Assert.assertEquals(apiKey, aiResource.getProperty(AIProperties.API_KEY));
-        Assert.assertEquals(modelName, aiResource.getProperty(AIProperties.MODEL_NAME));
+            AIResource aiResource = (AIResource) Resource.fromCommand(createResourceCommand);
+            Assert.assertEquals(name, aiResource.getName());
+            Assert.assertEquals(type, aiResource.getType().name().toLowerCase());
+            Assert.assertEquals(endpoint, aiResource.getProperty(AIProperties.ENDPOINT));
+            Assert.assertEquals(providerType.toUpperCase(), aiResource.getProperty(AIProperties.PROVIDER_TYPE));
+            Assert.assertEquals(apiKey, aiResource.getProperty(AIProperties.API_KEY));
+            Assert.assertEquals(modelName, aiResource.getProperty(AIProperties.MODEL_NAME));
 
-        Assert.assertEquals(AIProperties.DEFAULT_TEMPERATURE, aiResource.getProperty(AIProperties.TEMPERATURE));
-        Assert.assertEquals(AIProperties.DEFAULT_MAX_TOKEN, aiResource.getProperty(AIProperties.MAX_TOKEN));
-        Assert.assertEquals(AIProperties.DEFAULT_MAX_RETRIES, aiResource.getProperty(AIProperties.MAX_RETRIES));
-        Assert.assertEquals(AIProperties.DEFAULT_RETRY_DELAY_SECOND, aiResource.getProperty(AIProperties.RETRY_DELAY_SECOND));
+            Assert.assertEquals(AIProperties.DEFAULT_TEMPERATURE,
+                    aiResource.getProperty(AIProperties.TEMPERATURE));
+            Assert.assertEquals(AIProperties.DEFAULT_MAX_TOKEN,
+                    aiResource.getProperty(AIProperties.MAX_TOKEN));
+            Assert.assertEquals(AIProperties.DEFAULT_MAX_RETRIES,
+                    aiResource.getProperty(AIProperties.MAX_RETRIES));
+            Assert.assertEquals(AIProperties.DEFAULT_RETRY_DELAY_SECOND,
+                    aiResource.getProperty(AIProperties.RETRY_DELAY_SECOND));
 
-        // with no default settings
-        aiProperties.put(AIProperties.TEMPERATURE, temperature);
-        aiProperties.put(AIProperties.MAX_TOKEN, maxToken);
-        aiProperties.put(AIProperties.MAX_RETRIES, maxRetries);
-        aiProperties.put(AIProperties.RETRY_DELAY_SECOND, retryDelaySecond);
+            // with no default settings
+            aiProperties.put(AIProperties.TEMPERATURE, temperature);
+            aiProperties.put(AIProperties.MAX_TOKEN, maxToken);
+            aiProperties.put(AIProperties.MAX_RETRIES, maxRetries);
+            aiProperties.put(AIProperties.RETRY_DELAY_SECOND, retryDelaySecond);
 
-        createResourceCommand = new CreateResourceCommand(
-                new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
-        createResourceCommand.getInfo().validate();
+            createResourceCommand = new CreateResourceCommand(
+                    new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
+            createResourceCommand.getInfo().validate();
 
-        aiResource = (AIResource) Resource.fromCommand(createResourceCommand);
-        Assert.assertEquals(name, aiResource.getName());
-        Assert.assertEquals(type, aiResource.getType().name().toLowerCase());
-        Assert.assertEquals(endpoint, aiResource.getProperty(AIProperties.ENDPOINT));
-        Assert.assertEquals(providerType.toUpperCase(), aiResource.getProperty(AIProperties.PROVIDER_TYPE));
-        Assert.assertEquals(apiKey, aiResource.getProperty(AIProperties.API_KEY));
-        Assert.assertEquals(modelName, aiResource.getProperty(AIProperties.MODEL_NAME));
-        Assert.assertEquals(temperature, aiResource.getProperty(AIProperties.TEMPERATURE));
-        Assert.assertEquals(maxToken, aiResource.getProperty(AIProperties.MAX_TOKEN));
-        Assert.assertEquals(maxRetries, aiResource.getProperty(AIProperties.MAX_RETRIES));
-        Assert.assertEquals(retryDelaySecond, aiResource.getProperty(AIProperties.RETRY_DELAY_SECOND));
+            aiResource = (AIResource) Resource.fromCommand(createResourceCommand);
+            Assert.assertEquals(name, aiResource.getName());
+            Assert.assertEquals(type, aiResource.getType().name().toLowerCase());
+            Assert.assertEquals(endpoint, aiResource.getProperty(AIProperties.ENDPOINT));
+            Assert.assertEquals(providerType.toUpperCase(), aiResource.getProperty(AIProperties.PROVIDER_TYPE));
+            Assert.assertEquals(apiKey, aiResource.getProperty(AIProperties.API_KEY));
+            Assert.assertEquals(modelName, aiResource.getProperty(AIProperties.MODEL_NAME));
+            Assert.assertEquals(temperature, aiResource.getProperty(AIProperties.TEMPERATURE));
+            Assert.assertEquals(maxToken, aiResource.getProperty(AIProperties.MAX_TOKEN));
+            Assert.assertEquals(maxRetries, aiResource.getProperty(AIProperties.MAX_RETRIES));
+            Assert.assertEquals(retryDelaySecond, aiResource.getProperty(AIProperties.RETRY_DELAY_SECOND));
+        }
     }
 
     @Test
-    public void testAnthropic(@Mocked Env env, @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testAnthropic() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        Map<String, String> anthropicProps = new HashMap<>(aiProperties);
-        anthropicProps.put("ai.provider_type", "anthropic");
-        anthropicProps.put("ai.endpoint", "https://api.anthropic.com/v1/messages");
-        anthropicProps.put("ai.model_name", "claude-opus-4-20250514");
-        anthropicProps.put("ai.anthropic_version", "2023-06-01");
+            Map<String, String> anthropicProps = new HashMap<>(aiProperties);
+            anthropicProps.put("ai.provider_type", "anthropic");
+            anthropicProps.put("ai.endpoint", "https://api.anthropic.com/v1/messages");
+            anthropicProps.put("ai.model_name", "claude-opus-4-20250514");
+            anthropicProps.put("ai.anthropic_version", "2023-06-01");
 
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(
-                new CreateResourceInfo(true, false, "anthropic-claude", ImmutableMap.copyOf(anthropicProps)));
-        createResourceCommand.getInfo().validate();
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(
+                    new CreateResourceInfo(true, false, "anthropic-claude", ImmutableMap.copyOf(anthropicProps)));
+            createResourceCommand.getInfo().validate();
 
-        AIResource aiResource = (AIResource) Resource.fromCommand(createResourceCommand);
-        Assert.assertEquals("anthropic-claude", aiResource.getName());
-        Assert.assertEquals("ANTHROPIC", aiResource.getProperty(AIProperties.PROVIDER_TYPE));
-        Assert.assertEquals("https://api.anthropic.com/v1/messages", aiResource.getProperty(AIProperties.ENDPOINT));
-        Assert.assertEquals("claude-opus-4-20250514", aiResource.getProperty(AIProperties.MODEL_NAME));
-        Assert.assertEquals("2023-06-01", aiResource.getProperty(AIProperties.ANTHROPIC_VERSION));
+            AIResource aiResource = (AIResource) Resource.fromCommand(createResourceCommand);
+            Assert.assertEquals("anthropic-claude", aiResource.getName());
+            Assert.assertEquals("ANTHROPIC", aiResource.getProperty(AIProperties.PROVIDER_TYPE));
+            Assert.assertEquals("https://api.anthropic.com/v1/messages",
+                    aiResource.getProperty(AIProperties.ENDPOINT));
+            Assert.assertEquals("claude-opus-4-20250514", aiResource.getProperty(AIProperties.MODEL_NAME));
+            Assert.assertEquals("2023-06-01", aiResource.getProperty(AIProperties.ANTHROPIC_VERSION));
+        }
     }
 
     @Test(expected = DdlException.class)
-    public void testAbnormalResource(@Mocked Env env, @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testAbnormalResource() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        aiProperties.remove("ai.endpoint");
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(
-                new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
-        createResourceCommand.getInfo().validate();
+            aiProperties.remove("ai.endpoint");
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(
+                    new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
+            createResourceCommand.getInfo().validate();
 
-        Resource.fromCommand(createResourceCommand);
+            Resource.fromCommand(createResourceCommand);
+        }
     }
 
     @Test(expected = DdlException.class)
-    public void testInvalidProvider(@Mocked Env env, @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testInvalidProvider() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        // Invalid provider type
-        aiProperties.put("ai.provider_type", "invalid_provider");
+            // Invalid provider type
+            aiProperties.put("ai.provider_type", "invalid_provider");
 
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(
-                new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
-        createResourceCommand.getInfo().validate();
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(
+                    new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(aiProperties)));
+            createResourceCommand.getInfo().validate();
 
-        Resource.fromCommand(createResourceCommand);
+            Resource.fromCommand(createResourceCommand);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,6 +69,16 @@ public class BackendTest {
 
         backend = new Backend(backendId, host, heartbeatPort);
         backend.updateOnce(bePort, httpPort, beRpcPort);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ColumnTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +52,13 @@ public class ColumnTest {
 
         FakeEnv.setEnv(env);
         FakeEnv.setMetaVersion(FeConstants.meta_version);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ColumnTypeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ColumnTypeTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.catalog;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,13 @@ public class ColumnTypeTest {
     public void setUp() {
         fakeEnv = new FakeEnv();
         FakeEnv.setMetaVersion(FeConstants.meta_version);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/DatabaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/DatabaseTest.java
@@ -23,17 +23,17 @@ import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.jmockit.Deencapsulation;
-import org.apache.doris.persist.CreateTableInfo;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -48,37 +48,26 @@ public class DatabaseTest {
     private Database db;
     private long dbId = 10000;
 
-    @Mocked
-    private Env env;
-    @Mocked
-    private EditLog editLog;
+    private Env env = Mockito.mock(Env.class);
+    private EditLog editLog = Mockito.mock(EditLog.class);
+
+    private MockedStatic<Env> mockedEnvStatic;
 
     @Before
     public void setup() {
         FeConstants.runningUnitTest = true;
         db = new Database(dbId, "dbTest");
-        new Expectations() {
-            {
-                editLog.logCreateTable((CreateTableInfo) any);
-                minTimes = 0;
 
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-        new Expectations(env) {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+    }
 
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
-            }
-        };
+    @After
+    public void tearDown() {
+        mockedEnvStatic.close();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/EnvTest.java
@@ -22,10 +22,12 @@ import org.apache.doris.common.io.CountingDataOutputStream;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.persist.meta.MetaHeader;
 
-import mockit.Expectations;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
@@ -38,16 +40,20 @@ import java.util.Random;
 
 public class EnvTest {
 
+    private MockedStatic<MetaContext> mockedMetaContext;
+
     @Before
     public void setUp() {
         MetaContext metaContext = new MetaContext();
-        new Expectations(metaContext) {
-            {
-                MetaContext.get();
-                minTimes = 0;
-                result = metaContext;
-            }
-        };
+        mockedMetaContext = Mockito.mockStatic(MetaContext.class);
+        mockedMetaContext.when(MetaContext::get).thenReturn(metaContext);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedMetaContext != null) {
+            mockedMetaContext.close();
+        }
     }
 
     public void mkdir(String dirString) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEditLog.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEditLog.java
@@ -17,108 +17,54 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.alter.AlterJobV2;
-import org.apache.doris.alter.BatchAlterJobPersistInfo;
-import org.apache.doris.cluster.Cluster;
 import org.apache.doris.common.io.Writable;
-import org.apache.doris.persist.BatchRemoveTransactionsOperationV2;
 import org.apache.doris.persist.EditLog;
-import org.apache.doris.persist.ModifyTablePropertyOperationLog;
 import org.apache.doris.persist.OperationType;
-import org.apache.doris.persist.RoutineLoadOperation;
-import org.apache.doris.persist.TableInfo;
-import org.apache.doris.system.Backend;
 import org.apache.doris.transaction.TransactionState;
 
-import mockit.Mock;
-import mockit.MockUp;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class FakeEditLog extends MockUp<EditLog> {
+public class FakeEditLog implements AutoCloseable {
 
     private Map<Long, TransactionState> allTransactionState = new HashMap<>();
+    private MockedConstruction<EditLog> mockedConstruction;
 
-    @Mock
-    public void $init(String nodeName) { // CHECKSTYLE IGNORE THIS LINE
-        // do nothing
+    public FakeEditLog() {
+        mockedConstruction = Mockito.mockConstruction(EditLog.class,
+            (mock, context) -> {
+                Mockito.when(mock.getNumEditStreams()).thenReturn(1);
+                Mockito.doAnswer(inv -> {
+                    TransactionState ts = inv.getArgument(0);
+                    System.out.println("insert transaction manager is called");
+                    allTransactionState.put(ts.getTransactionId(), ts);
+                    return null;
+                }).when(mock).logInsertTransactionState(Mockito.any(TransactionState.class));
+                Mockito.doAnswer(inv -> {
+                    short op = inv.getArgument(0);
+                    Writable writable = inv.getArgument(1);
+                    if (writable instanceof TransactionState) {
+                        TransactionState ts = (TransactionState) writable;
+                        if (op == OperationType.OP_UPSERT_TRANSACTION_STATE) {
+                            allTransactionState.put(ts.getTransactionId(), ts);
+                        } else if (op == OperationType.OP_DELETE_TRANSACTION_STATE) {
+                            allTransactionState.remove(ts.getTransactionId());
+                        }
+                    }
+                    return null;
+                }).when(mock).submitEdit(Mockito.anyShort(), Mockito.any(Writable.class));
+            });
     }
 
-    @Mock
-    public void logInsertTransactionState(TransactionState transactionState) {
-        // do nothing
-        System.out.println("insert transaction manager is called");
-        allTransactionState.put(transactionState.getTransactionId(), transactionState);
-    }
-
-    @Mock
-    public void logDeleteTransactionState(TransactionState transactionState) {
-        // do nothing
-        System.out.println("delete transaction state is deleted");
-        allTransactionState.remove(transactionState.getTransactionId());
-    }
-
-    @Mock
-    public void logSaveNextId(long nextId) {
-        // do nothing
-    }
-
-    @Mock
-    public void logCreateCluster(Cluster cluster) {
-        // do nothing
-    }
-
-    @Mock
-    public void logOpRoutineLoadJob(RoutineLoadOperation operation) {
-    }
-
-    @Mock
-    public void logBackendStateChange(Backend be) {
-    }
-
-    @Mock
-    public void logAlterJob(AlterJobV2 alterJob) {
-
-    }
-
-    @Mock
-    public void logBatchAlterJob(BatchAlterJobPersistInfo batchAlterJobV2) {
-
-    }
-
-    @Mock
-    public void logDynamicPartition(ModifyTablePropertyOperationLog info) {
-
-    }
-
-    @Mock
-    public void logBatchRemoveTransactions(BatchRemoveTransactionsOperationV2 info) {
-
-    }
-
-    @Mock
-    public void logModifyDistributionType(TableInfo tableInfo) {
-
-    }
-
-    @Mock
-    public void logAddBackend(Backend be) {
-        // do nothing for test
-    }
-
-    @Mock
-    public int getNumEditStreams() {
-        return 1; // fake that we have streams
-    }
-
-    @Mock
-    public EditLog.EditLogItem submitEdit(short op, Writable writable) {
-        if (op == OperationType.OP_UPSERT_TRANSACTION_STATE && writable instanceof TransactionState) {
-            TransactionState transactionState = (TransactionState) writable;
-            allTransactionState.put(transactionState.getTransactionId(), transactionState);
+    @Override
+    public void close() {
+        if (mockedConstruction != null) {
+            mockedConstruction.close();
+            mockedConstruction = null;
         }
-        return null;
     }
 
     public TransactionState getTransaction(long transactionId) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEnv.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/FakeEnv.java
@@ -17,18 +17,31 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.system.SystemInfoService;
 
-import mockit.Mock;
-import mockit.MockUp;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-public class FakeEnv extends MockUp<Env> {
+public class FakeEnv implements AutoCloseable {
 
     private static Env env;
     private static int metaVersion;
     private static SystemInfoService systemInfo = new SystemInfoService();
+    private MockedStatic<Env> mockedStatic;
+
+    public FakeEnv() {
+        mockedStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        mockedStatic.when(Env::getCurrentEnv).thenAnswer(inv -> env);
+        mockedStatic.when(Env::getServingEnv).thenAnswer(inv -> env);
+        mockedStatic.when(Env::getCurrentEnvJournalVersion).thenAnswer(inv -> metaVersion);
+        mockedStatic.when(Env::getCurrentSystemInfo).thenAnswer(inv -> systemInfo);
+    }
 
     public static void setEnv(Env env) {
+        // Set feType to MASTER to replicate original isMaster() mock behavior
+        Deencapsulation.setField(env, "feType", FrontendNodeType.MASTER);
         FakeEnv.env = env;
     }
 
@@ -40,29 +53,12 @@ public class FakeEnv extends MockUp<Env> {
         FakeEnv.systemInfo = systemInfo;
     }
 
-    @Mock
-    public static Env getCurrentEnv() {
-        return env;
-    }
-
-    @Mock
-    public static Env getInstance() {
-        return env;
-    }
-
-    @Mock
-    public static int getCurrentEnvJournalVersion() {
-        return metaVersion;
-    }
-
-    @Mock
-    public static SystemInfoService getCurrentSystemInfo() {
-        return systemInfo;
-    }
-
-    @Mock
-    public boolean isMaster() {
-        return true;
+    @Override
+    public void close() {
+        if (mockedStatic != null) {
+            mockedStatic.close();
+            mockedStatic = null;
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcResourceTest.java
@@ -24,17 +24,17 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
+import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
@@ -58,34 +58,35 @@ public class JdbcResourceTest {
     }
 
     @Test
-    public void testJdbcResourceCreateWithDefaultProperties(@Mocked Env env,
-            @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testJdbcResourceCreateWithDefaultProperties() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        jdbcProperties.remove("checksum");
+            jdbcProperties.remove("checksum");
 
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, "jdbc_resource_pg_14", ImmutableMap.copyOf(jdbcProperties)));
-        createResourceCommand.getInfo().validate();
-        resourceMgr.createResource(createResourceCommand);
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(
+                    new CreateResourceInfo(true, false, "jdbc_resource_pg_14",
+                            ImmutableMap.copyOf(jdbcProperties)));
+            createResourceCommand.getInfo().validate();
+            resourceMgr.createResource(createResourceCommand);
 
-        JdbcResource jdbcResource = (JdbcResource) resourceMgr.getResource("jdbc_resource_pg_14");
+            JdbcResource jdbcResource = (JdbcResource) resourceMgr.getResource("jdbc_resource_pg_14");
 
-
-        // Verify the default properties were applied during the replay
-        Map<String, String> properties = jdbcResource.getCopiedProperties();
-        Assert.assertEquals("1", properties.get("connection_pool_min_size"));
-        Assert.assertEquals("30", properties.get("connection_pool_max_size"));
-        Assert.assertEquals("1800000", properties.get("connection_pool_max_life_time"));
-        Assert.assertEquals("5000", properties.get("connection_pool_max_wait_time"));
-        Assert.assertEquals("false", properties.get("connection_pool_keep_alive"));
+            // Verify the default properties were applied during the replay
+            Map<String, String> properties = jdbcResource.getCopiedProperties();
+            Assert.assertEquals("1", properties.get("connection_pool_min_size"));
+            Assert.assertEquals("30", properties.get("connection_pool_max_size"));
+            Assert.assertEquals("1800000", properties.get("connection_pool_max_life_time"));
+            Assert.assertEquals("5000", properties.get("connection_pool_max_wait_time"));
+            Assert.assertEquals("false", properties.get("connection_pool_keep_alive"));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexTest.java
@@ -22,10 +22,11 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.persist.gson.GsonUtils;
 
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -41,8 +42,7 @@ public class MaterializedIndexTest {
     private long indexId;
 
     private List<Column> columns;
-    @Mocked
-    private Env env;
+    private Env env = Mockito.mock(Env.class);
 
     private FakeEnv fakeEnv;
 
@@ -59,6 +59,13 @@ public class MaterializedIndexTest {
         fakeEnv = new FakeEnv();
         FakeEnv.setEnv(env);
         FakeEnv.setMetaVersion(FeConstants.meta_version);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MetadataViewerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MetadataViewerTest.java
@@ -25,12 +25,13 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -41,14 +42,13 @@ public class MetadataViewerTest {
     private static Method getTabletStatusMethod;
     private static Method getTabletDistributionMethod;
 
-    @Mocked
-    private Env env;
+    private Env env = Mockito.mock(Env.class);
 
-    @Mocked
-    private InternalCatalog internalCatalog;
+    private InternalCatalog internalCatalog = Mockito.mock(InternalCatalog.class);
 
-    @Mocked
-    private SystemInfoService infoService;
+    private SystemInfoService infoService = Mockito.mock(SystemInfoService.class);
+
+    private MockedStatic<Env> mockedEnvStatic;
 
     private static Database db;
 
@@ -67,38 +67,21 @@ public class MetadataViewerTest {
 
     @Before
     public void before() throws Exception {
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
 
-        new Expectations() {
-            {
-                internalCatalog.getDbOrDdlException(anyString);
-                minTimes = 0;
-                result = db;
-            }
-        };
+        Mockito.when(internalCatalog.getDbOrDdlException(Mockito.anyString())).thenReturn(db);
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getInternalCatalog()).thenReturn(internalCatalog);
 
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = internalCatalog;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(infoService);
+        Mockito.when(infoService.getAllBackendIds(Mockito.anyBoolean()))
+                .thenReturn(Lists.newArrayList(10000L, 10001L, 10002L));
+    }
 
-        new Expectations() {
-            {
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = infoService;
-
-                infoService.getAllBackendIds(anyBoolean);
-                minTimes = 0;
-                result = Lists.newArrayList(10000L, 10001L, 10002L);
-            }
-        };
+    @After
+    public void after() {
+        mockedEnvStatic.close();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MysqlTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MysqlTableTest.java
@@ -23,10 +23,11 @@ import org.apache.doris.common.FeConstants;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
@@ -42,8 +43,7 @@ public class MysqlTableTest {
     private List<Column> columns;
     private Map<String, String> properties;
 
-    @Mocked
-    private Env env;
+    private Env env = Mockito.mock(Env.class);
 
     private FakeEnv fakeEnv;
 
@@ -65,6 +65,13 @@ public class MysqlTableTest {
         fakeEnv = new FakeEnv();
         FakeEnv.setEnv(env);
         FakeEnv.setMetaVersion(FeConstants.meta_version);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -38,10 +38,10 @@ import org.apache.doris.utframe.UtFrameUtils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -59,36 +59,33 @@ public class OlapTableTest {
     @Test
     public void test() throws IOException {
 
-        new MockUp<Env>() {
-            @Mock
-            int getCurrentEnvJournalVersion() {
-                return FeConstants.meta_version;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+
+            Database db = UnitTestUtil.createDb(1, 2, 3, 4, 5, 6, 7);
+            List<Table> tables = db.getTables();
+
+            for (Table table : tables) {
+                if (table.getType() != TableType.OLAP) {
+                    continue;
+                }
+                OlapTable tbl = (OlapTable) table;
+                tbl.setIndexes(Lists.newArrayList(new Index(0, "index", Lists.newArrayList("col"),
+                        IndexType.BITMAP, null, "xxxxxx")));
+                System.out.println("orig table id: " + tbl.getId());
+
+                FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(byteArrayOutputStream);
+                tbl.write(out);
+
+                out.flush();
+                out.close();
+
+                DataInputStream in = new DataInputStream(byteArrayOutputStream.getInputStream());
+                Table copiedTbl = OlapTable.read(in);
+                System.out.println("copied table id: " + copiedTbl.getId());
+                in.close();
             }
-        };
-
-        Database db = UnitTestUtil.createDb(1, 2, 3, 4, 5, 6, 7);
-        List<Table> tables = db.getTables();
-
-        for (Table table : tables) {
-            if (table.getType() != TableType.OLAP) {
-                continue;
-            }
-            OlapTable tbl = (OlapTable) table;
-            tbl.setIndexes(Lists.newArrayList(new Index(0, "index", Lists.newArrayList("col"),
-                    IndexType.BITMAP, null, "xxxxxx")));
-            System.out.println("orig table id: " + tbl.getId());
-
-            FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();
-            DataOutputStream out = new DataOutputStream(byteArrayOutputStream);
-            tbl.write(out);
-
-            out.flush();
-            out.close();
-
-            DataInputStream in = new DataInputStream(byteArrayOutputStream.getInputStream());
-            Table copiedTbl = OlapTable.read(in);
-            System.out.println("copied table id: " + copiedTbl.getId());
-            in.close();
         }
 
     }
@@ -204,7 +201,7 @@ public class OlapTableTest {
 
     @Test
     public void testGetSchemaAllIndexes() {
-        OlapTable table = new OlapTable();
+        OlapTable table = Mockito.spy(new OlapTable());
         List<Column> schema1 = Lists.newArrayList();
         Column col1 = new Column("col1", PrimitiveType.INT);
         Column col2 = new Column("col2", PrimitiveType.INT);
@@ -227,12 +224,7 @@ public class OlapTableTest {
         table.addIndexNameToIdForUnitTest("index2", 2L);
 
         MaterializedIndex index1 = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
-        new MockUp<OlapTable>() {
-            @Mock
-            public List<MaterializedIndex> getVisibleIndex() {
-                return Lists.newArrayList(index1);
-            }
-        };
+        Mockito.doReturn(Lists.newArrayList(index1)).when(table).getVisibleIndex();
 
         Set<Column> schemaAllIndexes = table.getSchemaAllIndexes(false);
         Assert.assertEquals(2, schemaAllIndexes.size());
@@ -242,12 +234,7 @@ public class OlapTableTest {
         Assert.assertTrue(schemaAllIndexes.contains(col2));
 
         MaterializedIndex index2 = new MaterializedIndex(2, MaterializedIndex.IndexState.NORMAL);
-        new MockUp<OlapTable>() {
-            @Mock
-            public List<MaterializedIndex> getVisibleIndex() {
-                return Lists.newArrayList(index2);
-            }
-        };
+        Mockito.doReturn(Lists.newArrayList(index2)).when(table).getVisibleIndex();
         schemaAllIndexes = table.getSchemaAllIndexes(false);
         Assert.assertEquals(2, schemaAllIndexes.size());
         Assert.assertTrue(schemaAllIndexes.contains(col3));
@@ -255,12 +242,7 @@ public class OlapTableTest {
         Assert.assertFalse(schemaAllIndexes.contains(col1));
         Assert.assertFalse(schemaAllIndexes.contains(col2));
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public List<MaterializedIndex> getVisibleIndex() {
-                return Lists.newArrayList(index1, index2);
-            }
-        };
+        Mockito.doReturn(Lists.newArrayList(index1, index2)).when(table).getVisibleIndex();
         schemaAllIndexes = table.getSchemaAllIndexes(false);
         Assert.assertEquals(4, schemaAllIndexes.size());
         Assert.assertTrue(schemaAllIndexes.contains(col3));
@@ -310,14 +292,6 @@ public class OlapTableTest {
 
     @Test
     public void testTableVersionCacheWithRpc() throws Exception {
-        // Mock cloud mode
-        new MockUp<Config>() {
-            @Mock
-            public boolean isNotCloudMode() {
-                return false;
-            }
-        };
-
         // Create table and database
         final Database db = new Database(1L, "test_db");
 
@@ -334,95 +308,98 @@ public class OlapTableTest {
         final long[] versions = {100L, 200L, 300L};
         final int[] callCount = {0};
 
-        new MockUp<VersionHelper>() {
-            @Mock
-            public Cloud.GetVersionResponse getVersionFromMeta(Cloud.GetVersionRequest req) {
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<VersionHelper> mockedVH = Mockito.mockStatic(VersionHelper.class, Mockito.CALLS_REAL_METHODS)) {
+            // Mock cloud mode
+            mockedConfig.when(Config::isNotCloudMode).thenReturn(false);
+
+            mockedVH.when(() -> VersionHelper.getVersionFromMeta(Mockito.any())).thenAnswer(invocation -> {
                 Cloud.GetVersionResponse.Builder builder = Cloud.GetVersionResponse.newBuilder();
                 builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                         .setCode(Cloud.MetaServiceCode.OK).build());
                 builder.setVersion(versions[callCount[0]]);
                 callCount[0]++;
                 return builder.build();
+            });
+
+            // Create ConnectContext with SessionVariable
+            ConnectContext ctx = new ConnectContext();
+            ctx.setSessionVariable(new SessionVariable());
+            ctx.setThreadLocalInfo();
+
+            try {
+                // Test 1: Initial state with TTL set, should still call RPC for first time
+                ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 100000; // Set long TTL
+                Assert.assertEquals(-1, table.getCachedTableVersion()); // Initial state
+                Assert.assertTrue(table.isCachedTableVersionExpired()); // Should be expired due to -1
+
+                long ver0 = table.getVisibleVersion();
+                Assert.assertEquals(100, ver0); // Should get from MS
+                Assert.assertEquals(1, callCount[0]); // First RPC call
+                Assert.assertEquals(100, table.getCachedTableVersion()); // Cache updated
+
+                // Second call should use cache
+                long ver0Again = table.getVisibleVersion();
+                Assert.assertEquals(100, ver0Again); // Should use cached version
+                Assert.assertEquals(1, callCount[0]); // No new RPC call
+
+                // Test 2: Disable cache (TTL = 0), should always call RPC
+                ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 0;
+                long ver1 = table.getVisibleVersion();
+                Assert.assertEquals(200, ver1);
+                Assert.assertEquals(2, callCount[0]); // Second RPC call
+
+                long ver2 = table.getVisibleVersion();
+                Assert.assertEquals(300, ver2);
+                Assert.assertEquals(3, callCount[0]); // Third RPC call
+                Assert.assertEquals(300, table.getCachedTableVersion()); // Cache updated to 300
+
+                // Test 3: Enable cache with long TTL, should use cached version
+                ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 100000; // 100 seconds
+                table.setCachedTableVersion(350); // Set cache to a larger version
+                long ver3 = table.getVisibleVersion();
+                Assert.assertEquals(350, ver3); // Should return cached version (350)
+                Assert.assertEquals(3, callCount[0]); // No new RPC call
+
+                // Test 4: Test setCachedTableVersion only updates when version is greater
+                ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 500; // 500ms TTL
+
+                // At this point, cache is 350 from Test 3
+                // Set a larger version to 400
+                table.setCachedTableVersion(400);
+                Assert.assertEquals(400, table.getCachedTableVersion());
+                Assert.assertFalse(table.isCachedTableVersionExpired()); // Not expired yet
+
+                Thread.sleep(300); // Sleep 300ms
+
+                // Try to set a smaller version (380), should NOT update version or timestamp
+                table.setCachedTableVersion(380);
+                Assert.assertEquals(400, table.getCachedTableVersion()); // Version should remain 400
+
+                Thread.sleep(300); // Total 600ms since setCachedTableVersion(400)
+                // Cache should be expired (600ms > 500ms TTL)
+                // If timestamp was incorrectly reset by setCachedTableVersion(380), cache would not be expired
+                Assert.assertTrue(table.isCachedTableVersionExpired());
+
+                // Test 5: Setting a greater version should update both version and timestamp
+                ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 500; // 500ms TTL
+                table.setCachedTableVersion(500); // Set to 500
+                Assert.assertEquals(500, table.getCachedTableVersion());
+                Assert.assertFalse(table.isCachedTableVersionExpired()); // Not expired
+
+                Thread.sleep(300); // Sleep 300ms
+
+                // Set a greater version (550), should update both version and timestamp
+                table.setCachedTableVersion(550);
+                Assert.assertEquals(550, table.getCachedTableVersion()); // Version updated to 550
+                Assert.assertFalse(table.isCachedTableVersionExpired()); // Timestamp reset, not expired yet
+
+                Thread.sleep(300); // Sleep another 300ms (total 600ms from first setCachedTableVersion(500), but only 300ms from setCachedTableVersion(550))
+                Assert.assertFalse(table.isCachedTableVersionExpired()); // Still not expired (300ms < 500ms TTL)
+
+            } finally {
+                ConnectContext.remove();
             }
-        };
-
-        // Create ConnectContext with SessionVariable
-        ConnectContext ctx = new ConnectContext();
-        ctx.setSessionVariable(new SessionVariable());
-        ctx.setThreadLocalInfo();
-
-        try {
-            // Test 1: Initial state with TTL set, should still call RPC for first time
-            ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 100000; // Set long TTL
-            Assert.assertEquals(-1, table.getCachedTableVersion()); // Initial state
-            Assert.assertTrue(table.isCachedTableVersionExpired()); // Should be expired due to -1
-
-            long ver0 = table.getVisibleVersion();
-            Assert.assertEquals(100, ver0); // Should get from MS
-            Assert.assertEquals(1, callCount[0]); // First RPC call
-            Assert.assertEquals(100, table.getCachedTableVersion()); // Cache updated
-
-            // Second call should use cache
-            long ver0Again = table.getVisibleVersion();
-            Assert.assertEquals(100, ver0Again); // Should use cached version
-            Assert.assertEquals(1, callCount[0]); // No new RPC call
-
-            // Test 2: Disable cache (TTL = 0), should always call RPC
-            ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 0;
-            long ver1 = table.getVisibleVersion();
-            Assert.assertEquals(200, ver1);
-            Assert.assertEquals(2, callCount[0]); // Second RPC call
-
-            long ver2 = table.getVisibleVersion();
-            Assert.assertEquals(300, ver2);
-            Assert.assertEquals(3, callCount[0]); // Third RPC call
-            Assert.assertEquals(300, table.getCachedTableVersion()); // Cache updated to 300
-
-            // Test 3: Enable cache with long TTL, should use cached version
-            ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 100000; // 100 seconds
-            table.setCachedTableVersion(350); // Set cache to a larger version
-            long ver3 = table.getVisibleVersion();
-            Assert.assertEquals(350, ver3); // Should return cached version (350)
-            Assert.assertEquals(3, callCount[0]); // No new RPC call
-
-            // Test 4: Test setCachedTableVersion only updates when version is greater
-            ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 500; // 500ms TTL
-
-            // At this point, cache is 350 from Test 3
-            // Set a larger version to 400
-            table.setCachedTableVersion(400);
-            Assert.assertEquals(400, table.getCachedTableVersion());
-            Assert.assertFalse(table.isCachedTableVersionExpired()); // Not expired yet
-
-            Thread.sleep(300); // Sleep 300ms
-
-            // Try to set a smaller version (380), should NOT update version or timestamp
-            table.setCachedTableVersion(380);
-            Assert.assertEquals(400, table.getCachedTableVersion()); // Version should remain 400
-
-            Thread.sleep(300); // Total 600ms since setCachedTableVersion(400)
-            // Cache should be expired (600ms > 500ms TTL)
-            // If timestamp was incorrectly reset by setCachedTableVersion(380), cache would not be expired
-            Assert.assertTrue(table.isCachedTableVersionExpired());
-
-            // Test 5: Setting a greater version should update both version and timestamp
-            ctx.getSessionVariable().cloudTableVersionCacheTtlMs = 500; // 500ms TTL
-            table.setCachedTableVersion(500); // Set to 500
-            Assert.assertEquals(500, table.getCachedTableVersion());
-            Assert.assertFalse(table.isCachedTableVersionExpired()); // Not expired
-
-            Thread.sleep(300); // Sleep 300ms
-
-            // Set a greater version (550), should update both version and timestamp
-            table.setCachedTableVersion(550);
-            Assert.assertEquals(550, table.getCachedTableVersion()); // Version updated to 550
-            Assert.assertFalse(table.isCachedTableVersionExpired()); // Timestamp reset, not expired yet
-
-            Thread.sleep(300); // Sleep another 300ms (total 600ms from first setCachedTableVersion(500), but only 300ms from setCachedTableVersion(550))
-            Assert.assertFalse(table.isCachedTableVersionExpired()); // Still not expired (300ms < 500ms TTL)
-
-        } finally {
-            ConnectContext.remove();
         }
     }
 
@@ -451,18 +428,6 @@ public class OlapTableTest {
 
     @Test
     public void testGetVisibleVersionInBatchCached() throws Exception {
-        new MockUp<Config>() {
-            @Mock
-            public boolean isNotCloudMode() {
-                return false;
-            }
-
-            @Mock
-            public boolean isCloudMode() {
-                return true;
-            }
-        };
-
         final Database db = new Database(1L, "test_db");
         List<OlapTable> tables = new ArrayList<>();
         for (long i = 0; i < 3; i++) {
@@ -477,21 +442,23 @@ public class OlapTableTest {
         ));
         final int[] callCount = {0};
 
-        new MockUp<VersionHelper>() {
-            @Mock
-            public Cloud.GetVersionResponse getVersionFromMeta(Cloud.GetVersionRequest req) {
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<VersionHelper> mockedVH = Mockito.mockStatic(VersionHelper.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedConfig.when(Config::isNotCloudMode).thenReturn(false);
+            mockedConfig.when(Config::isCloudMode).thenReturn(true);
+
+            mockedVH.when(() -> VersionHelper.getVersionFromMeta(Mockito.any())).thenAnswer(invocation -> {
                 Cloud.GetVersionResponse.Builder builder = Cloud.GetVersionResponse.newBuilder();
                 builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                         .setCode(Cloud.MetaServiceCode.OK).build());
                 builder.addAllVersions(batchVersions.get(callCount[0]));
                 callCount[0]++;
                 return builder.build();
-            }
-        };
+            });
 
-        ConnectContext ctx = new ConnectContext();
-        ctx.setSessionVariable(new SessionVariable());
-        ctx.setThreadLocalInfo();
+            ConnectContext ctx = new ConnectContext();
+            ctx.setSessionVariable(new SessionVariable());
+            ctx.setThreadLocalInfo();
 
         // CHECKSTYLE OFF
         try {
@@ -550,6 +517,7 @@ public class OlapTableTest {
             }
         } finally {
             ConnectContext.remove();
+        }
         }
         // CHECKSTYLE ONca
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
@@ -29,12 +29,12 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Maps;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -42,27 +42,31 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.Map;
 
 public class ReplicaAllocationTest {
-    @Mocked
-    SystemInfoService systemInfoService;
+    private SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
+    private MockedStatic<Env> mockedEnvStatic;
 
     @Before
     public void setUp() throws DdlException {
-        new Expectations() {
-            {
-                systemInfoService.selectBackendIdsForReplicaCreation((ReplicaAllocation) any, Maps.newHashMap(),
-                        (TStorageMedium) any, false, true);
-                minTimes = 0;
-                result = new Delegate() {
-                    Pair<Map<Tag, List<Long>>, TStorageMedium> selectBackendIdsForReplicaCreation() {
-                        return Pair.of(Maps.newHashMap(), TStorageMedium.HDD);
-                    }
-                };
-            }
-        };
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+
+        Mockito.doAnswer(invocation -> Pair.of(Maps.newHashMap(), TStorageMedium.HDD))
+                .when(systemInfoService).selectBackendIdsForReplicaCreation(
+                        Mockito.any(ReplicaAllocation.class),
+                        Mockito.anyMap(),
+                        Mockito.nullable(TStorageMedium.class),
+                        Mockito.eq(false),
+                        Mockito.eq(true));
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaTest.java
@@ -21,10 +21,10 @@ import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.persist.gson.GsonUtils;
 
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -37,8 +37,7 @@ import java.util.List;
 public class ReplicaTest {
 
     // replica serialize and deserialize test will use catalog so that it should be mocked
-    @Mocked
-    Env env;
+    private Env env = Mockito.mock(Env.class);
 
     private Replica replica;
     private long replicaId;

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ResourceMgrTest.java
@@ -28,12 +28,11 @@ import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -76,60 +75,59 @@ public class ResourceMgrTest {
     }
 
     @Test
-    public void testAddAlterDropResource(@Injectable BrokerMgr brokerMgr, @Injectable EditLog editLog,
-            @Mocked Env env, @Injectable AccessControllerManager accessManager) throws UserException {
-        new Expectations() {
-            {
-                env.getEditLog();
-                result = editLog;
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testAddAlterDropResource() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        // s3 resource
-        ResourceMgr mgr = new ResourceMgr();
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, s3ResName, ImmutableMap.copyOf(s3Properties)));
-        createResourceCommand.getInfo().validate();
-        Assert.assertEquals(0, mgr.getResourceNum());
-        mgr.createResource(createResourceCommand);
-        Assert.assertEquals(1, mgr.getResourceNum());
+            // s3 resource
+            ResourceMgr mgr = new ResourceMgr();
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, s3ResName, ImmutableMap.copyOf(s3Properties)));
+            createResourceCommand.getInfo().validate();
+            Assert.assertEquals(0, mgr.getResourceNum());
+            mgr.createResource(createResourceCommand);
+            Assert.assertEquals(1, mgr.getResourceNum());
 
-        // alter
-        s3Region = "sh";
-        Map<String, String> copiedS3Properties = Maps.newHashMap(s3Properties);
-        copiedS3Properties.put("AWS_REGION", s3Region);
-        copiedS3Properties.remove("type");
-        // current not support modify s3 property
-        // mgr.alterResource(alterResourceStmt);
-        // Assert.assertEquals(s3Region, ((S3Resource) mgr.getResource(s3ResName)).getProperty("AWS_REGION"));
+            // alter
+            s3Region = "sh";
+            Map<String, String> copiedS3Properties = Maps.newHashMap(s3Properties);
+            copiedS3Properties.put("AWS_REGION", s3Region);
+            copiedS3Properties.remove("type");
+            // current not support modify s3 property
+            // mgr.alterResource(alterResourceStmt);
+            // Assert.assertEquals(s3Region, ((S3Resource) mgr.getResource(s3ResName)).getProperty("AWS_REGION"));
+        }
     }
 
     @Test(expected = DdlException.class)
-    public void testAddResourceExist(@Injectable BrokerMgr brokerMgr, @Mocked Env env,
-            @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testAddResourceExist() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        // add
-        ResourceMgr mgr = new ResourceMgr();
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, s3ResName, ImmutableMap.copyOf(s3Properties)));
-        createResourceCommand.getInfo().validate();
+            // add
+            ResourceMgr mgr = new ResourceMgr();
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, s3ResName, ImmutableMap.copyOf(s3Properties)));
+            createResourceCommand.getInfo().validate();
 
-        Assert.assertEquals(0, mgr.getResourceNum());
-        mgr.createResource(createResourceCommand);
-        Assert.assertEquals(1, mgr.getResourceNum());
+            Assert.assertEquals(0, mgr.getResourceNum());
+            mgr.createResource(createResourceCommand);
+            Assert.assertEquals(1, mgr.getResourceNum());
 
-        // add again
-        mgr.createResource(createResourceCommand);
+            // add again
+            mgr.createResource(createResourceCommand);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
@@ -31,15 +31,14 @@ import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -90,72 +89,71 @@ public class S3ResourceTest {
     }
 
     @Test
-    public void testFromStmt(@Mocked Env env, @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testFromStmt() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        // resource with default settings
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(s3Properties)));
-        createResourceCommand.getInfo().validate();
+            // resource with default settings
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(s3Properties)));
+            createResourceCommand.getInfo().validate();
 
-        S3Resource s3Resource = (S3Resource) Resource.fromCommand(createResourceCommand);
-        Assert.assertEquals(name, s3Resource.getName());
-        Assert.assertEquals(type, s3Resource.getType().name().toLowerCase());
-        Assert.assertEquals(s3Endpoint, s3Resource.getProperty(S3Properties.ENDPOINT));
-        Assert.assertEquals(s3Region, s3Resource.getProperty(S3Properties.REGION));
-        Assert.assertEquals(s3RootPath, s3Resource.getProperty(S3Properties.ROOT_PATH));
-        Assert.assertEquals(s3AccessKey, s3Resource.getProperty(S3Properties.ACCESS_KEY));
-        Assert.assertEquals(s3SecretKey, s3Resource.getProperty(S3Properties.SECRET_KEY));
-        Assert.assertEquals(s3MaxConnections, s3Resource.getProperty(S3Properties.MAX_CONNECTIONS));
-        Assert.assertEquals(s3ReqTimeoutMs, s3Resource.getProperty(S3Properties.REQUEST_TIMEOUT_MS));
-        Assert.assertEquals(s3ConnTimeoutMs, s3Resource.getProperty(S3Properties.CONNECTION_TIMEOUT_MS));
+            S3Resource s3Resource = (S3Resource) Resource.fromCommand(createResourceCommand);
+            Assert.assertEquals(name, s3Resource.getName());
+            Assert.assertEquals(type, s3Resource.getType().name().toLowerCase());
+            Assert.assertEquals(s3Endpoint, s3Resource.getProperty(S3Properties.ENDPOINT));
+            Assert.assertEquals(s3Region, s3Resource.getProperty(S3Properties.REGION));
+            Assert.assertEquals(s3RootPath, s3Resource.getProperty(S3Properties.ROOT_PATH));
+            Assert.assertEquals(s3AccessKey, s3Resource.getProperty(S3Properties.ACCESS_KEY));
+            Assert.assertEquals(s3SecretKey, s3Resource.getProperty(S3Properties.SECRET_KEY));
+            Assert.assertEquals(s3MaxConnections, s3Resource.getProperty(S3Properties.MAX_CONNECTIONS));
+            Assert.assertEquals(s3ReqTimeoutMs, s3Resource.getProperty(S3Properties.REQUEST_TIMEOUT_MS));
+            Assert.assertEquals(s3ConnTimeoutMs, s3Resource.getProperty(S3Properties.CONNECTION_TIMEOUT_MS));
 
-        // with no default settings
-        s3Properties.put(S3Properties.MAX_CONNECTIONS, "100");
-        s3Properties.put(S3Properties.REQUEST_TIMEOUT_MS, "2000");
-        s3Properties.put(S3Properties.CONNECTION_TIMEOUT_MS, "2000");
-        s3Properties.put(S3Properties.VALIDITY_CHECK, "false");
+            // with no default settings
+            s3Properties.put(S3Properties.MAX_CONNECTIONS, "100");
+            s3Properties.put(S3Properties.REQUEST_TIMEOUT_MS, "2000");
+            s3Properties.put(S3Properties.CONNECTION_TIMEOUT_MS, "2000");
+            s3Properties.put(S3Properties.VALIDITY_CHECK, "false");
 
-        createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(s3Properties)));
-        createResourceCommand.getInfo().validate();
+            createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(s3Properties)));
+            createResourceCommand.getInfo().validate();
 
-        s3Resource = (S3Resource) Resource.fromCommand(createResourceCommand);
-        Assert.assertEquals(name, s3Resource.getName());
-        Assert.assertEquals(type, s3Resource.getType().name().toLowerCase());
-        Assert.assertEquals(s3Endpoint, s3Resource.getProperty(S3Properties.ENDPOINT));
-        Assert.assertEquals(s3Region, s3Resource.getProperty(S3Properties.REGION));
-        Assert.assertEquals(s3RootPath, s3Resource.getProperty(S3Properties.ROOT_PATH));
-        Assert.assertEquals(s3AccessKey, s3Resource.getProperty(S3Properties.ACCESS_KEY));
-        Assert.assertEquals(s3SecretKey, s3Resource.getProperty(S3Properties.SECRET_KEY));
-        Assert.assertEquals("100", s3Resource.getProperty(S3Properties.MAX_CONNECTIONS));
-        Assert.assertEquals("2000", s3Resource.getProperty(S3Properties.REQUEST_TIMEOUT_MS));
-        Assert.assertEquals("2000", s3Resource.getProperty(S3Properties.CONNECTION_TIMEOUT_MS));
+            s3Resource = (S3Resource) Resource.fromCommand(createResourceCommand);
+            Assert.assertEquals(name, s3Resource.getName());
+            Assert.assertEquals(type, s3Resource.getType().name().toLowerCase());
+            Assert.assertEquals(s3Endpoint, s3Resource.getProperty(S3Properties.ENDPOINT));
+            Assert.assertEquals(s3Region, s3Resource.getProperty(S3Properties.REGION));
+            Assert.assertEquals(s3RootPath, s3Resource.getProperty(S3Properties.ROOT_PATH));
+            Assert.assertEquals(s3AccessKey, s3Resource.getProperty(S3Properties.ACCESS_KEY));
+            Assert.assertEquals(s3SecretKey, s3Resource.getProperty(S3Properties.SECRET_KEY));
+            Assert.assertEquals("100", s3Resource.getProperty(S3Properties.MAX_CONNECTIONS));
+            Assert.assertEquals("2000", s3Resource.getProperty(S3Properties.REQUEST_TIMEOUT_MS));
+            Assert.assertEquals("2000", s3Resource.getProperty(S3Properties.CONNECTION_TIMEOUT_MS));
+        }
     }
 
     @Test(expected = DdlException.class)
-    public void testAbnormalResource(@Mocked Env env, @Injectable AccessControllerManager accessManager)
-            throws UserException {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
-        s3Properties.remove("AWS_ENDPOINT");
+    public void testAbnormalResource() throws UserException {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN)))
+                    .thenReturn(true);
 
-        CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(s3Properties)));
-        createResourceCommand.getInfo().validate();
+            s3Properties.remove("AWS_ENDPOINT");
 
-        Resource.fromCommand(createResourceCommand);
+            CreateResourceCommand createResourceCommand = new CreateResourceCommand(new CreateResourceInfo(true, false, name, ImmutableMap.copyOf(s3Properties)));
+            createResourceCommand.getInfo().validate();
+
+            Resource.fromCommand(createResourceCommand);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TableTest.java
@@ -27,6 +27,7 @@ import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,6 +74,13 @@ public class TableTest {
         Env env = Deencapsulation.newInstance(Env.class);
         FakeEnv.setEnv(env);
         FakeEnv.setMetaVersion(FeConstants.meta_version);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletTest.java
@@ -27,11 +27,12 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -48,8 +49,9 @@ public class TabletTest {
     private TabletInvertedIndex invertedIndex;
     private SystemInfoService  infoService;
 
-    @Mocked
-    private Env env;
+    private Env env = Mockito.mock(Env.class);
+
+    private MockedStatic<Env> mockedEnvStatic;
 
     @Before
     public void makeTablet() {
@@ -60,25 +62,12 @@ public class TabletTest {
             be.setAlive(true);
             infoService.addBackend(be);
         }
-        new Expectations(env) {
-            {
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
 
-                Env.getCurrentInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = infoService;
-
-                Env.isCheckpointThread();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+        mockedEnvStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(infoService);
+        mockedEnvStatic.when(Env::isCheckpointThread).thenReturn(false);
 
         tablet = new LocalTablet(1);
         TabletMeta tabletMeta = new TabletMeta(10, 20, 30, 40, 1, TStorageMedium.HDD);
@@ -89,6 +78,11 @@ public class TabletTest {
         tablet.addReplica(replica1);
         tablet.addReplica(replica2);
         tablet.addReplica(replica3);
+    }
+
+    @After
+    public void tearDown() {
+        mockedEnvStatic.close();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/UserPropertyTest.java
@@ -32,50 +32,41 @@ import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 
 public class UserPropertyTest {
     private FakeEnv fakeEnv;
-    @Mocked
-    private Env env;
-    @Mocked
-    private SqlBlockRuleMgr sqlBlockRuleMgr;
+    private Env env = Mockito.mock(Env.class);
+    private SqlBlockRuleMgr sqlBlockRuleMgr = Mockito.mock(SqlBlockRuleMgr.class);
+    private MockedStatic<Env> mockedStaticEnv;
 
     @Before
     public void setUp() {
-        new Expectations(env) {
-            {
-                env.getSqlBlockRuleMgr();
-                minTimes = 0;
-                result = sqlBlockRuleMgr;
+        mockedStaticEnv = Mockito.mockStatic(Env.class);
+        mockedStaticEnv.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getSqlBlockRuleMgr()).thenReturn(sqlBlockRuleMgr);
+        Mockito.when(sqlBlockRuleMgr.existRule("rule1")).thenReturn(true);
+        Mockito.when(sqlBlockRuleMgr.existRule("rule2")).thenReturn(true);
+        Mockito.when(sqlBlockRuleMgr.existRule("test1")).thenReturn(true);
+        Mockito.when(sqlBlockRuleMgr.existRule("test2")).thenReturn(true);
+        Mockito.when(sqlBlockRuleMgr.existRule("test3")).thenReturn(true);
+    }
 
-                sqlBlockRuleMgr.existRule("rule1");
-                minTimes = 0;
-                result = true;
-
-                sqlBlockRuleMgr.existRule("rule2");
-                minTimes = 0;
-                result = true;
-
-                sqlBlockRuleMgr.existRule("test1");
-                minTimes = 0;
-                result = true;
-
-                sqlBlockRuleMgr.existRule("test2");
-                minTimes = 0;
-                result = true;
-
-                sqlBlockRuleMgr.existRule("test3");
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @After
+    public void tearDown() {
+        if (mockedStaticEnv != null) {
+            mockedStaticEnv.close();
+        }
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test
@@ -165,24 +156,19 @@ public class UserPropertyTest {
     }
 
     @Test
-    public void testUpdateInitCatalog(@Mocked Env env, @Mocked CatalogMgr catalogMgr) throws UserException {
+    public void testUpdateInitCatalog() throws UserException {
+        Env localEnv = Mockito.mock(Env.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
         CatalogIf internalCatalog = new InternalCatalog();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 1;
-                result = env;
 
-                env.getCatalogMgr();
-                minTimes = 1;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 2;
-                result = null;
-                result = internalCatalog;
-            }
-        };
+        // Re-configure the static mock for this test
+        mockedStaticEnv.close();
+        mockedStaticEnv = Mockito.mockStatic(Env.class);
+        mockedStaticEnv.when(Env::getCurrentEnv).thenReturn(localEnv);
+        Mockito.when(localEnv.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString()))
+            .thenReturn(null)
+                .thenReturn(internalCatalog);
 
         // for non exist catalog, use internal
         List<Pair<String, String>> properties = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
@@ -38,12 +38,10 @@ import org.apache.doris.thrift.TStorageMedium;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.HashSet;
 import java.util.List;
@@ -125,47 +123,24 @@ public class ColocateTableCheckerAndBalancerTest {
     }
 
     @Test
-    public void testBalance(@Mocked SystemInfoService infoService,
-            @Mocked LoadStatisticForTag statistic) {
-        new Expectations() {
-            {
-                infoService.getBackend(1L);
-                result = backend1;
-                minTimes = 0;
-                infoService.getBackend(2L);
-                result = backend2;
-                minTimes = 0;
-                infoService.getBackend(3L);
-                result = backend3;
-                minTimes = 0;
-                infoService.getBackend(4L);
-                result = backend4;
-                minTimes = 0;
-                infoService.getBackend(5L);
-                result = backend5;
-                minTimes = 0;
-                infoService.getBackend(6L);
-                result = backend6;
-                minTimes = 0;
-                infoService.getBackend(7L);
-                result = backend7;
-                minTimes = 0;
-                infoService.getBackend(8L);
-                result = backend8;
-                minTimes = 0;
-                infoService.getBackend(9L);
-                result = backend9;
-                minTimes = 0;
+    public void testBalance() {
+        SystemInfoService infoService = Mockito.mock(SystemInfoService.class);
+        LoadStatisticForTag statistic = Mockito.mock(LoadStatisticForTag.class);
 
-                statistic.getBackendLoadStatistic(anyLong);
-                result = new Delegate<BackendLoadStatistic>() {
-                    BackendLoadStatistic delegate(Long beId) {
-                        return new FakeBackendLoadStatistic(beId, null, null);
-                    }
-                };
-                minTimes = 0;
-            }
-        };
+        Mockito.when(infoService.getBackend(1L)).thenReturn(backend1);
+        Mockito.when(infoService.getBackend(2L)).thenReturn(backend2);
+        Mockito.when(infoService.getBackend(3L)).thenReturn(backend3);
+        Mockito.when(infoService.getBackend(4L)).thenReturn(backend4);
+        Mockito.when(infoService.getBackend(5L)).thenReturn(backend5);
+        Mockito.when(infoService.getBackend(6L)).thenReturn(backend6);
+        Mockito.when(infoService.getBackend(7L)).thenReturn(backend7);
+        Mockito.when(infoService.getBackend(8L)).thenReturn(backend8);
+        Mockito.when(infoService.getBackend(9L)).thenReturn(backend9);
+
+        Mockito.when(statistic.getBackendLoadStatistic(Mockito.anyLong())).thenAnswer(inv -> {
+            Long beId = inv.getArgument(0);
+            return new FakeBackendLoadStatistic(beId, null, null);
+        });
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", PrimitiveType.INT));
@@ -208,46 +183,24 @@ public class ColocateTableCheckerAndBalancerTest {
     }
 
     @Test
-    public void testFixBalanceEndlessLoop(@Mocked SystemInfoService infoService,
-            @Mocked LoadStatisticForTag statistic) {
-        new Expectations() {
-            {
-                infoService.getBackend(1L);
-                result = backend1;
-                minTimes = 0;
-                infoService.getBackend(2L);
-                result = backend2;
-                minTimes = 0;
-                infoService.getBackend(3L);
-                result = backend3;
-                minTimes = 0;
-                infoService.getBackend(4L);
-                result = backend4;
-                minTimes = 0;
-                infoService.getBackend(5L);
-                result = backend5;
-                minTimes = 0;
-                infoService.getBackend(6L);
-                result = backend6;
-                minTimes = 0;
-                infoService.getBackend(7L);
-                result = backend7;
-                minTimes = 0;
-                infoService.getBackend(8L);
-                result = backend8;
-                minTimes = 0;
-                infoService.getBackend(9L);
-                result = backend9;
-                minTimes = 0;
-                statistic.getBackendLoadStatistic(anyLong);
-                result = new Delegate<BackendLoadStatistic>() {
-                    BackendLoadStatistic delegate(Long beId) {
-                        return new FakeBackendLoadStatistic(beId, null, null);
-                    }
-                };
-                minTimes = 0;
-            }
-        };
+    public void testFixBalanceEndlessLoop() {
+        SystemInfoService infoService = Mockito.mock(SystemInfoService.class);
+        LoadStatisticForTag statistic = Mockito.mock(LoadStatisticForTag.class);
+
+        Mockito.when(infoService.getBackend(1L)).thenReturn(backend1);
+        Mockito.when(infoService.getBackend(2L)).thenReturn(backend2);
+        Mockito.when(infoService.getBackend(3L)).thenReturn(backend3);
+        Mockito.when(infoService.getBackend(4L)).thenReturn(backend4);
+        Mockito.when(infoService.getBackend(5L)).thenReturn(backend5);
+        Mockito.when(infoService.getBackend(6L)).thenReturn(backend6);
+        Mockito.when(infoService.getBackend(7L)).thenReturn(backend7);
+        Mockito.when(infoService.getBackend(8L)).thenReturn(backend8);
+        Mockito.when(infoService.getBackend(9L)).thenReturn(backend9);
+
+        Mockito.when(statistic.getBackendLoadStatistic(Mockito.anyLong())).thenAnswer(inv -> {
+            Long beId = inv.getArgument(0);
+            return new FakeBackendLoadStatistic(beId, null, null);
+        });
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         distributionCols.add(new Column("k1", PrimitiveType.INT));
@@ -285,19 +238,14 @@ public class ColocateTableCheckerAndBalancerTest {
     }
 
     @Test
-    public void testFixBalanceEndlessLoop2(@Mocked SystemInfoService infoService,
-            @Mocked LoadStatisticForTag statistic) {
-        new Expectations() {
-            {
-                statistic.getBackendLoadStatistic(anyLong);
-                result = new Delegate<BackendLoadStatistic>() {
-                    BackendLoadStatistic delegate(Long beId) {
-                        return new FakeBackendLoadStatistic(beId, null, null);
-                    }
-                };
-                minTimes = 0;
-            }
-        };
+    public void testFixBalanceEndlessLoop2() {
+        SystemInfoService infoService = Mockito.mock(SystemInfoService.class);
+        LoadStatisticForTag statistic = Mockito.mock(LoadStatisticForTag.class);
+
+        Mockito.when(statistic.getBackendLoadStatistic(Mockito.anyLong())).thenAnswer(inv -> {
+            Long beId = inv.getArgument(0);
+            return new FakeBackendLoadStatistic(beId, null, null);
+        });
         GroupId groupId = new GroupId(10000, 10001);
         List<Column> distributionCols = Lists.newArrayList();
         ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId, distributionCols, 5, new ReplicaAllocation((short) 1));
@@ -318,18 +266,13 @@ public class ColocateTableCheckerAndBalancerTest {
     }
 
     @Test
-    public void testGetSortedBackendReplicaNumPairs(@Mocked LoadStatisticForTag statistic) {
-        new Expectations() {
-            {
-                statistic.getBackendLoadStatistic(anyLong);
-                result = new Delegate<BackendLoadStatistic>() {
-                    BackendLoadStatistic delegate(Long beId) {
-                        return new FakeBackendLoadStatistic(beId, null, null);
-                    }
-                };
-                minTimes = 0;
-            }
-        };
+    public void testGetSortedBackendReplicaNumPairs() {
+        LoadStatisticForTag statistic = Mockito.mock(LoadStatisticForTag.class);
+
+        Mockito.when(statistic.getBackendLoadStatistic(Mockito.anyLong())).thenAnswer(inv -> {
+            Long beId = inv.getArgument(0);
+            return new FakeBackendLoadStatistic(beId, null, null);
+        });
 
         GlobalColocateStatistic globalColocateStatistic = new GlobalColocateStatistic();
         // all buckets are on different be
@@ -376,101 +319,51 @@ public class ColocateTableCheckerAndBalancerTest {
     }
 
     @Test
-    public void testGetUnavailableBeIdsInGroup(@Mocked ColocateTableIndex colocateTableIndex,
-                                               @Mocked SystemInfoService infoService,
-                                               @Mocked Backend myBackend2,
-                                               @Mocked Backend myBackend3,
-                                               @Mocked Backend myBackend4,
-                                               @Mocked Backend myBackend5
-    ) {
+    public void testGetUnavailableBeIdsInGroup() {
+        ColocateTableIndex colocateTableIndex = Mockito.mock(ColocateTableIndex.class);
+        SystemInfoService infoService = Mockito.mock(SystemInfoService.class);
+        Backend myBackend2 = Mockito.mock(Backend.class);
+        Backend myBackend3 = Mockito.mock(Backend.class);
+        Backend myBackend4 = Mockito.mock(Backend.class);
+        Backend myBackend5 = Mockito.mock(Backend.class);
+
         GroupId groupId = new GroupId(10000, 10001);
         Tag tag = Tag.DEFAULT_BACKEND_TAG;
         Set<Long> allBackendsInGroup = Sets.newHashSet(1L, 2L, 3L, 4L, 5L);
-        new Expectations() {
-            {
-                infoService.getBackend(1L);
-                result = null;
-                minTimes = 0;
 
-                // backend2 is available
-                infoService.getBackend(2L);
-                result = myBackend2;
-                minTimes = 0;
-                myBackend2.isScheduleAvailable();
-                result = true;
-                minTimes = 0;
-                myBackend2.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend2.isMixNode();
-                result = true;
-                minTimes = 0;
+        Mockito.when(infoService.getBackend(1L)).thenReturn(null);
 
-                // backend3 not available, and dead for a long time
-                infoService.getBackend(3L);
-                result = myBackend3;
-                minTimes = 0;
-                myBackend3.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend3.isAlive();
-                result = false;
-                minTimes = 0;
-                myBackend3.getLastUpdateMs();
-                result = System.currentTimeMillis() - (Config.colocate_group_relocate_delay_second + 20) * 1000;
-                minTimes = 0;
-                myBackend3.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend3.isMixNode();
-                result = true;
-                minTimes = 0;
+        // backend2 is available
+        Mockito.when(infoService.getBackend(2L)).thenReturn(myBackend2);
+        Mockito.when(myBackend2.isScheduleAvailable()).thenReturn(true);
+        Mockito.when(myBackend2.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend2.isMixNode()).thenReturn(true);
 
-                // backend4 not available, and dead for a short time
-                infoService.getBackend(4L);
-                result = myBackend4;
-                minTimes = 0;
-                myBackend4.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend4.isAlive();
-                result = false;
-                minTimes = 0;
-                myBackend4.getLastUpdateMs();
-                result = System.currentTimeMillis();
-                minTimes = 0;
-                myBackend4.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend4.isMixNode();
-                result = true;
-                minTimes = 0;
+        // backend3 not available, and dead for a long time
+        Mockito.when(infoService.getBackend(3L)).thenReturn(myBackend3);
+        Mockito.when(myBackend3.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend3.isAlive()).thenReturn(false);
+        Mockito.when(myBackend3.getLastUpdateMs()).thenReturn(System.currentTimeMillis() - (Config.colocate_group_relocate_delay_second + 20) * 1000);
+        Mockito.when(myBackend3.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend3.isMixNode()).thenReturn(true);
 
-                // backend5 not available, and in decommission
-                infoService.getBackend(5L);
-                result = myBackend5;
-                minTimes = 0;
-                myBackend5.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend5.isAlive();
-                result = true;
-                minTimes = 0;
-                myBackend5.isDecommissioned();
-                result = true;
-                minTimes = 0;
-                myBackend5.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend5.isMixNode();
-                result = true;
-                minTimes = 0;
+        // backend4 not available, and dead for a short time
+        Mockito.when(infoService.getBackend(4L)).thenReturn(myBackend4);
+        Mockito.when(myBackend4.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend4.isAlive()).thenReturn(false);
+        Mockito.when(myBackend4.getLastUpdateMs()).thenReturn(System.currentTimeMillis());
+        Mockito.when(myBackend4.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend4.isMixNode()).thenReturn(true);
 
-                colocateTableIndex.getBackendsByGroup(groupId, tag);
-                result = allBackendsInGroup;
-                minTimes = 0;
-            }
-        };
+        // backend5 not available, and in decommission
+        Mockito.when(infoService.getBackend(5L)).thenReturn(myBackend5);
+        Mockito.when(myBackend5.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend5.isAlive()).thenReturn(true);
+        Mockito.when(myBackend5.isDecommissioned()).thenReturn(true);
+        Mockito.when(myBackend5.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend5.isMixNode()).thenReturn(true);
+
+        Mockito.when(colocateTableIndex.getBackendsByGroup(groupId, tag)).thenReturn(allBackendsInGroup);
 
         Set<Long> unavailableBeIds = Deencapsulation.invoke(balancer, "getUnavailableBeIdsInGroup",
                 infoService, colocateTableIndex, groupId, Tag.DEFAULT_BACKEND_TAG);
@@ -479,163 +372,73 @@ public class ColocateTableCheckerAndBalancerTest {
     }
 
     @Test
-    public void testGetAvailableBeIds(@Mocked SystemInfoService infoService,
-                                      @Mocked Backend myBackend2,
-                                      @Mocked Backend myBackend3,
-                                      @Mocked Backend myBackend4,
-                                      @Mocked Backend myBackend5,
-                                      @Mocked Backend myBackend6,
-                                      @Mocked Backend myBackend7,
-                                      @Mocked Backend myBackend8) throws AnalysisException {
+    public void testGetAvailableBeIds() throws AnalysisException {
+        SystemInfoService infoService = Mockito.mock(SystemInfoService.class);
+        Backend myBackend2 = Mockito.mock(Backend.class);
+        Backend myBackend3 = Mockito.mock(Backend.class);
+        Backend myBackend4 = Mockito.mock(Backend.class);
+        Backend myBackend5 = Mockito.mock(Backend.class);
+        Backend myBackend6 = Mockito.mock(Backend.class);
+        Backend myBackend7 = Mockito.mock(Backend.class);
+        Backend myBackend8 = Mockito.mock(Backend.class);
+
         List<Long> clusterBackendIds = Lists.newArrayList(1L, 2L, 3L, 4L, 5L);
-        new Expectations() {
-            {
-                infoService.getAllBackendIds(false);
-                result = clusterBackendIds;
-                minTimes = 0;
 
-                infoService.getBackend(1L);
-                result = null;
-                minTimes = 0;
+        Mockito.when(infoService.getAllBackendIds(false)).thenReturn(clusterBackendIds);
 
-                // backend2 is available
-                infoService.getBackend(2L);
-                result = myBackend2;
-                minTimes = 0;
-                myBackend2.isScheduleAvailable();
-                result = true;
-                minTimes = 0;
-                myBackend2.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend2.isMixNode();
-                result = true;
-                minTimes = 0;
+        Mockito.when(infoService.getBackend(1L)).thenReturn(null);
 
-                // backend3 not available, and dead for a long time
-                infoService.getBackend(3L);
-                result = myBackend3;
-                minTimes = 0;
-                myBackend3.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend3.isAlive();
-                result = false;
-                minTimes = 0;
-                myBackend3.getLastUpdateMs();
-                result = System.currentTimeMillis() - (Config.colocate_group_relocate_delay_second + 20) * 1000;
-                minTimes = 0;
-                myBackend3.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend3.isMixNode();
-                result = true;
-                minTimes = 0;
+        // backend2 is available
+        Mockito.when(infoService.getBackend(2L)).thenReturn(myBackend2);
+        Mockito.when(myBackend2.isScheduleAvailable()).thenReturn(true);
+        Mockito.when(myBackend2.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend2.isMixNode()).thenReturn(true);
 
-                // backend4 available, not alive but dead for a short time
-                infoService.getBackend(4L);
-                result = myBackend4;
-                minTimes = 0;
-                myBackend4.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend4.isAlive();
-                result = false;
-                minTimes = 0;
-                myBackend4.getLastUpdateMs();
-                result = System.currentTimeMillis();
-                minTimes = 0;
-                myBackend4.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend4.isMixNode();
-                result = true;
-                minTimes = 0;
+        // backend3 not available, and dead for a long time
+        Mockito.when(infoService.getBackend(3L)).thenReturn(myBackend3);
+        Mockito.when(myBackend3.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend3.isAlive()).thenReturn(false);
+        Mockito.when(myBackend3.getLastUpdateMs()).thenReturn(System.currentTimeMillis() - (Config.colocate_group_relocate_delay_second + 20) * 1000);
+        Mockito.when(myBackend3.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend3.isMixNode()).thenReturn(true);
 
-                // backend5 not available, and in decommission
-                infoService.getBackend(5L);
-                result = myBackend5;
-                minTimes = 0;
-                myBackend5.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend5.isAlive();
-                result = true;
-                minTimes = 0;
-                myBackend5.isDecommissioned();
-                result = true;
-                minTimes = 0;
-                myBackend5.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend5.isMixNode();
-                result = true;
-                minTimes = 0;
+        // backend4 available, not alive but dead for a short time
+        Mockito.when(infoService.getBackend(4L)).thenReturn(myBackend4);
+        Mockito.when(myBackend4.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend4.isAlive()).thenReturn(false);
+        Mockito.when(myBackend4.getLastUpdateMs()).thenReturn(System.currentTimeMillis());
+        Mockito.when(myBackend4.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend4.isMixNode()).thenReturn(true);
 
-                // backend6 is available, but with different tag
-                infoService.getBackend(5L);
-                result = myBackend6;
-                minTimes = 0;
-                myBackend6.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend6.isAlive();
-                result = true;
-                minTimes = 0;
-                myBackend6.isDecommissioned();
-                result = false;
-                minTimes = 0;
-                myBackend6.getLocationTag();
-                result = Tag.create(Tag.TYPE_LOCATION, "new_loc");
-                minTimes = 0;
-                myBackend6.isMixNode();
-                result = true;
-                minTimes = 0;
+        // backend5 not available, and in decommission
+        Mockito.when(infoService.getBackend(5L)).thenReturn(myBackend5);
+        Mockito.when(myBackend5.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend5.isAlive()).thenReturn(true);
+        Mockito.when(myBackend5.isDecommissioned()).thenReturn(true);
+        Mockito.when(myBackend5.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend5.isMixNode()).thenReturn(true);
 
-                // backend7 is available, but in exclude sets
-                infoService.getBackend(5L);
-                result = myBackend7;
-                minTimes = 0;
-                myBackend7.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend7.isAlive();
-                result = true;
-                minTimes = 0;
-                myBackend7.isDecommissioned();
-                result = false;
-                minTimes = 0;
-                myBackend7.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend7.isMixNode();
-                result = true;
-                minTimes = 0;
-                myBackend7.getId();
-                result = 999L;
-                minTimes = 0;
+        // backend6 is available, but with different tag
+        Mockito.when(myBackend6.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend6.isAlive()).thenReturn(true);
+        Mockito.when(myBackend6.isDecommissioned()).thenReturn(false);
+        Mockito.when(myBackend6.getLocationTag()).thenReturn(Tag.create(Tag.TYPE_LOCATION, "new_loc"));
+        Mockito.when(myBackend6.isMixNode()).thenReturn(true);
 
-                // backend8 is available, it's a compute node.
-                infoService.getBackend(5L);
-                result = myBackend8;
-                minTimes = 0;
-                myBackend8.isScheduleAvailable();
-                result = false;
-                minTimes = 0;
-                myBackend8.isAlive();
-                result = true;
-                minTimes = 0;
-                myBackend8.isDecommissioned();
-                result = false;
-                minTimes = 0;
-                myBackend8.getLocationTag();
-                result = Tag.DEFAULT_BACKEND_TAG;
-                minTimes = 0;
-                myBackend8.isMixNode();
-                result = false;
-                minTimes = 0;
-            }
-        };
+        // backend7 is available, but in exclude sets
+        Mockito.when(myBackend7.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend7.isAlive()).thenReturn(true);
+        Mockito.when(myBackend7.isDecommissioned()).thenReturn(false);
+        Mockito.when(myBackend7.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend7.isMixNode()).thenReturn(true);
+        Mockito.when(myBackend7.getId()).thenReturn(999L);
+
+        // backend8 is available, it's a compute node.
+        Mockito.when(myBackend8.isScheduleAvailable()).thenReturn(false);
+        Mockito.when(myBackend8.isAlive()).thenReturn(true);
+        Mockito.when(myBackend8.isDecommissioned()).thenReturn(false);
+        Mockito.when(myBackend8.getLocationTag()).thenReturn(Tag.DEFAULT_BACKEND_TAG);
+        Mockito.when(myBackend8.isMixNode()).thenReturn(false);
 
         List<Long> availableBeIds = Deencapsulation.invoke(balancer, "getAvailableBeIds",
                 Tag.DEFAULT_BACKEND_TAG, Sets.newHashSet(999L), infoService);

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/DiskRebalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/DiskRebalanceTest.java
@@ -41,33 +41,33 @@ import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.StorageMediaMigrationTask;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TransactionIdGenerator;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.LongStream;
 
 public class DiskRebalanceTest {
     private static final Logger LOG = LogManager.getLogger(DiskRebalanceTest.class);
 
-    @Mocked
     private Env env;
-    @Mocked
     private InternalCatalog catalog;
+    private MockedStatic<Env> mockedEnvStatic;
 
     private long id = 10086;
 
@@ -85,56 +85,40 @@ public class DiskRebalanceTest {
         Config.used_capacity_percent_max_diff = 1.0;
         Config.balance_slot_num_per_path = 1;
         db = new Database(1, "test db");
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
 
-                catalog.getDbIds();
-                minTimes = 0;
-                result = db.getId();
+        env = Mockito.mock(Env.class);
+        catalog = Mockito.mock(InternalCatalog.class);
 
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = db;
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getDbIds()).thenReturn(Lists.newArrayList(db.getId()));
+        Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(db);
+        Mockito.when(catalog.getDbOrException(Mockito.anyLong(), Mockito.any())).thenReturn(db);
+        Mockito.when(env.getNextId()).thenAnswer(inv -> id++);
 
-                catalog.getDbOrException(anyLong, (Function<Long, SchedException>) any);
-                minTimes = 0;
-                result = db;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+        mockedEnvStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
 
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
+        GlobalTransactionMgrIface mockGtm = Mockito.mock(GlobalTransactionMgrIface.class);
+        TransactionIdGenerator mockTig = Mockito.mock(TransactionIdGenerator.class);
+        mockedEnvStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(mockGtm);
+        Mockito.when(mockGtm.getTransactionIDGenerator()).thenReturn(mockTig);
+        Mockito.when(mockTig.getNextTransactionId()).thenReturn(111L);
+        Mockito.when(mockGtm.isPreviousTransactionsFinished(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList())).thenReturn(true);
 
-                env.getNextId();
-                minTimes = 0;
-                result = new Delegate() {
-                    long ignored() {
-                        return id++;
-                    }
-                };
-
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-
-                Env.getCurrentInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-
-                Env.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
-                result = 111;
-
-                Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(anyLong, anyLong, (List<Long>) any);
-                result = true;
-            }
-        };
         // Test mock validation
         Assert.assertEquals(111,
                 Env.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId());
         Assert.assertTrue(
                 Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(1, 2, Lists.newArrayList(3L)));
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
     private void generateStatisticsAndPathSlots() {

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/RebalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/RebalanceTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.clone;
 
+import org.apache.doris.alter.Alter;
+import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
@@ -49,36 +51,37 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTabletInfo;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TransactionIdGenerator;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.MoreCollectors;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 public class RebalanceTest {
     private static final Logger LOG = LogManager.getLogger(RebalanceTest.class);
 
-    @Mocked
     private Env env;
-    @Mocked
     private InternalCatalog catalog;
+    private MockedStatic<Env> mockedEnvStatic;
 
     private long id = 10086;
 
@@ -93,55 +96,36 @@ public class RebalanceTest {
     public void setUp() throws Exception {
         FeConstants.runningUnitTest = true;
         db = new Database(1, "test db");
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
 
-                catalog.getDbIds();
-                minTimes = 0;
-                result = db.getId();
+        env = Mockito.mock(Env.class);
+        catalog = Mockito.mock(InternalCatalog.class);
+        Alter alter = Mockito.mock(Alter.class);
+        ColocateTableIndex colocateTableIndex = Mockito.mock(ColocateTableIndex.class);
 
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = db;
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getDbIds()).thenReturn(Lists.newArrayList(db.getId()));
+        Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(db);
+        Mockito.when(catalog.getDbOrException(Mockito.anyLong(), Mockito.any())).thenReturn(db);
+        Mockito.when(env.getNextId()).thenAnswer(inv -> id++);
+        Mockito.when(env.getAlterInstance()).thenReturn(alter);
+        Mockito.when(alter.getUnfinishedAlterTableIds()).thenReturn(Collections.emptySet());
+        Mockito.when(env.getColocateTableIndex()).thenReturn(colocateTableIndex);
+        Mockito.when(colocateTableIndex.isColocateTable(Mockito.anyLong())).thenReturn(false);
 
-                catalog.getDbOrException(anyLong, (Function<Long, SchedException>) any);
-                minTimes = 0;
-                result = db;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+        mockedEnvStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
+        mockedEnvStatic.when(Env::getCurrentColocateIndex).thenReturn(colocateTableIndex);
 
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        GlobalTransactionMgrIface mockGtm = Mockito.mock(GlobalTransactionMgrIface.class);
+        TransactionIdGenerator mockTig = Mockito.mock(TransactionIdGenerator.class);
+        mockedEnvStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(mockGtm);
+        Mockito.when(mockGtm.getTransactionIDGenerator()).thenReturn(mockTig);
+        Mockito.when(mockTig.getNextTransactionId()).thenReturn(111L);
+        Mockito.when(mockGtm.isPreviousTransactionsFinished(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList())).thenReturn(true);
 
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
-
-                env.getNextId();
-                minTimes = 0;
-                result = new Delegate() {
-                    long ignored() {
-                        return id++;
-                    }
-                };
-
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-
-                Env.getCurrentInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-
-                Env.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
-                result = 111;
-
-                Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(anyLong, anyLong, (List<Long>) any);
-                result = true;
-            }
-        };
         // Test mock validation
         Assert.assertEquals(111,
                 Env.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId());
@@ -174,6 +158,13 @@ public class RebalanceTest {
         // be4(10004) doesn't have any replica
 
         generateStatisticMap();
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
     private void generateStatisticMap() {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/backup/CloudRestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/backup/CloudRestoreJobTest.java
@@ -51,14 +51,12 @@ import org.apache.doris.thrift.TSortType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -84,12 +82,13 @@ public class CloudRestoreJobTest {
     private static Env cloudEnv;
     private SystemInfoService cloudSystemInfoService;
     private ConnectContext ctx;
-    @Mocked
-    private StorageVaultMgr storageVaultMgr;
+    private StorageVaultMgr storageVaultMgr = Mockito.mock(StorageVaultMgr.class);
 
-    @Injectable
     private Repository repo = new Repository(repoId, "repo", false, "bos://my_repo",
             BrokerProperties.of("broker", Maps.newHashMap()));
+
+    private MockedStatic<MetaServiceProxy> mockedMetaServiceProxy;
+    private MetaServiceProxy mockMetaServiceProxyInstance;
 
     @Before
     public void setUp() throws Exception {
@@ -112,47 +111,39 @@ public class CloudRestoreJobTest {
         Assert.assertTrue(cloudEnv instanceof CloudEnv);
         Assert.assertTrue(cloudSystemInfoService instanceof CloudSystemInfoService);
 
-        new Expectations() {
-            {
-                storageVaultMgr.getVaultNameById(anyString);
-                minTimes = 0;
-                result = "test_vault";
-            }
-        };
+        Mockito.when(storageVaultMgr.getVaultNameById(Mockito.anyString())).thenReturn("test_vault");
 
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.CreateTabletsResponse createTablets(Cloud.CreateTabletsRequest request) {
-                Cloud.CreateTabletsResponse.Builder responseBuilder = Cloud.CreateTabletsResponse.newBuilder();
-                responseBuilder.setStatus(
-                        Cloud.MetaServiceResponseStatus.newBuilder().setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
-                return responseBuilder.build();
-            }
+        mockMetaServiceProxyInstance = Mockito.mock(MetaServiceProxy.class);
+        mockedMetaServiceProxy = Mockito.mockStatic(MetaServiceProxy.class);
+        mockedMetaServiceProxy.when(MetaServiceProxy::getInstance).thenReturn(mockMetaServiceProxyInstance);
 
-            @Mock
-            public Cloud.PartitionResponse preparePartition(Cloud.PartitionRequest request) {
-                Cloud.PartitionResponse.Builder builder = Cloud.PartitionResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
-                return builder.build();
-            }
+        Mockito.when(mockMetaServiceProxyInstance.createTablets(Mockito.any())).thenAnswer(inv -> {
+            Cloud.CreateTabletsResponse.Builder responseBuilder = Cloud.CreateTabletsResponse.newBuilder();
+            responseBuilder.setStatus(
+                    Cloud.MetaServiceResponseStatus.newBuilder().setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
+            return responseBuilder.build();
+        });
 
-            @Mock
-            public Cloud.PartitionResponse commitPartition(Cloud.PartitionRequest request) {
-                Cloud.PartitionResponse.Builder builder = Cloud.PartitionResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
-                return builder.build();
-            }
+        Mockito.when(mockMetaServiceProxyInstance.preparePartition(Mockito.any())).thenAnswer(inv -> {
+            Cloud.PartitionResponse.Builder builder = Cloud.PartitionResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                    .setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
+            return builder.build();
+        });
 
-            @Mock
-            public Cloud.PartitionResponse dropPartition(Cloud.PartitionRequest request) {
-                Cloud.PartitionResponse.Builder builder = Cloud.PartitionResponse.newBuilder();
-                builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
-                return builder.build();
-            }
-        };
+        Mockito.when(mockMetaServiceProxyInstance.commitPartition(Mockito.any())).thenAnswer(inv -> {
+            Cloud.PartitionResponse.Builder builder = Cloud.PartitionResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                    .setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
+            return builder.build();
+        });
+
+        Mockito.when(mockMetaServiceProxyInstance.dropPartition(Mockito.any())).thenAnswer(inv -> {
+            Cloud.PartitionResponse.Builder builder = Cloud.PartitionResponse.newBuilder();
+            builder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                    .setCode(Cloud.MetaServiceCode.OK).setMsg("OK"));
+            return builder.build();
+        });
 
         db = CatalogTestUtil.createSimpleDb(TEST_DB_ID, TEST_TBL_ID, TEST_TBL_ID, TEST_PARTITION_ID, TEST_TABLET_ID, TEST_VERSION);
         cloudEnv.unprotectCreateDb(db);
@@ -207,6 +198,22 @@ public class CloudRestoreJobTest {
                 false, false, cloudEnv, repo.getId(), "test_vault");
     }
 
+    @After
+    public void tearDown() {
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+            fakeEditLog = null;
+        }
+        if (fakeEnv != null) {
+            fakeEnv.close();
+            fakeEnv = null;
+        }
+        if (mockedMetaServiceProxy != null) {
+            mockedMetaServiceProxy.close();
+            mockedMetaServiceProxy = null;
+        }
+    }
+
     @Test
     public void testStorageVaultCheck() throws UserException {
         // Case 1: Storage vault exists
@@ -224,23 +231,17 @@ public class CloudRestoreJobTest {
 
     @Test
     public void testCloudClusterCheck() throws UserException {
+        CloudSystemInfoService spySysInfo = Mockito.spy((CloudSystemInfoService) cloudSystemInfoService);
+        Deencapsulation.setField(cloudEnv, "systemInfo", spySysInfo);
+        FakeEnv.setSystemInfo(spySysInfo);
+
         // Case 1: Cloud cluster exists
-        new MockUp<CloudSystemInfoService>() {
-            @Mock
-            public String getCloudClusterIdByName(String clusterName) {
-                return "test_cluster_id";
-            }
-        };
+        Mockito.doReturn("test_cluster_id").when(spySysInfo).getCloudClusterIdByName(Mockito.anyString());
         job.checkIfNeedCancel();
         Assert.assertTrue(job.getStatus().ok());
 
         // Case 2: Cloud cluster not exists
-        new MockUp<CloudSystemInfoService>() {
-            @Mock
-            public String getCloudClusterIdByName(String clusterName) {
-                return null;
-            }
-        };
+        Mockito.doReturn(null).when(spySysInfo).getCloudClusterIdByName(Mockito.anyString());
         job.checkIfNeedCancel();
         Assert.assertFalse(job.getStatus().ok());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
@@ -27,10 +27,9 @@ import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Triple;
 import org.apache.doris.system.Backend;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -45,70 +44,51 @@ public class CacheHotspotManagerTest {
 
     @Test
     public void testWarmUpNewClusterByTable() {
-        partition = new Partition(0, null, null, null);
-        new MockUp<Partition>() {
-
-            @Mock
-            public long getDataSize(boolean singleReplica) {
-                return 10000000L;
-            }
-
-            @Mock
-            public List<MaterializedIndex> getMaterializedIndices(IndexExtState extState) {
-                List<MaterializedIndex> list = new ArrayList<>();
-                MaterializedIndex ind = new MaterializedIndex();
-                list.add(ind);
-                return list;
-            }
-        };
-
         cloudSystemInfoService = new CloudSystemInfoService();
-        cacheHotspotManager = new CacheHotspotManager(cloudSystemInfoService);
-        new MockUp<CacheHotspotManager>() {
-
-            @Mock
-            Long getFileCacheCapacity(String clusterName) throws RuntimeException {
-                return 100L;
+        // Use mock with CALLS_REAL_METHODS to avoid package-private access issues
+        // (CacheHotspotManager's helper methods are package-private)
+        cacheHotspotManager = Mockito.mock(CacheHotspotManager.class, invocation -> {
+            String methodName = invocation.getMethod().getName();
+            switch (methodName) {
+                case "getFileCacheCapacity":
+                    return 100L;
+                case "getPartitionsFromTriple": {
+                    List<Partition> partitions = new ArrayList<>();
+                    Partition spyPartition = Mockito.spy(new Partition(1, "p1", null, null));
+                    Mockito.doReturn(10000000L).when(spyPartition).getDataSize(Mockito.anyBoolean());
+                    List<MaterializedIndex> list = new ArrayList<>();
+                    list.add(new MaterializedIndex());
+                    Mockito.doReturn(list).when(spyPartition)
+                            .getMaterializedIndices(Mockito.any(IndexExtState.class));
+                    partitions.add(spyPartition);
+                    return partitions;
+                }
+                case "getBackendsFromCluster": {
+                    String dstClusterName = (String) invocation.getArgument(0);
+                    List<Backend> backends = new ArrayList<>();
+                    backends.add(new Backend(11, dstClusterName, 0));
+                    return backends;
+                }
+                case "getTabletsFromIndexs": {
+                    List<Tablet> list = new ArrayList<>();
+                    list.add(new CloudTablet(1001L));
+                    return list;
+                }
+                case "getTabletIdsFromBe": {
+                    Set<Long> tabletIds = new HashSet<>();
+                    tabletIds.add(1001L);
+                    return tabletIds;
+                }
+                default:
+                    return invocation.callRealMethod();
             }
-
-            @Mock
-            List<Partition> getPartitionsFromTriple(Triple<String, String, String> tableTriple) {
-                List<Partition> partitions = new ArrayList<>();
-                partition = new Partition(1, "p1", null, null);
-                partitions.add(partition);
-                return partitions;
-            }
-
-            @Mock
-            List<Backend> getBackendsFromCluster(String dstClusterName) {
-                List<Backend> backends = new ArrayList<>();
-                Backend backend = new Backend(11, dstClusterName, 0);
-                backends.add(backend);
-                return backends;
-            }
-
-            @Mock
-            public List<Tablet> getTabletsFromIndexs(List<MaterializedIndex> indexes) {
-                List<Tablet> list = new ArrayList<>();
-                Tablet tablet = new CloudTablet(1001L);
-                list.add(tablet);
-                return list;
-            }
-
-            @Mock
-            Set<Long> getTabletIdsFromBe(long beId) {
-                Set<Long> tabletIds = new HashSet<Long>();
-                tabletIds.add(1001L);
-                return tabletIds;
-            }
-        };
+        });
 
         // Setup mock data
         long jobId = 1L;
         String dstClusterName = "test_cluster";
         List<Triple<String, String, String>> tables = new ArrayList<>();
         tables.add(Triple.of("test_db", "test_table", ""));
-
 
         // force = true
         Map<Long, List<Tablet>> result = cacheHotspotManager.warmUpNewClusterByTable(

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudPartitionTest.java
@@ -23,11 +23,11 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.rpc.RpcException;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,20 +96,19 @@ public class CloudPartitionTest {
         ));
         final Integer[] callCount = {0};
 
-        new MockUp<VersionHelper>(VersionHelper.class) {
-            @Mock
-            public Cloud.GetVersionResponse getVersionFromMeta(Cloud.GetVersionRequest req) {
-                Cloud.GetVersionResponse.Builder builder = Cloud.GetVersionResponse.newBuilder();
-                builder.setVersion(singleVersions.get(callCount[0]));
-                builder.addAllVersions(batchVersions.get(callCount[0]));
-                ++callCount[0];
-                return builder.build();
-            }
-        };
         // CHECKSTYLE ON
+        try (MockedStatic<VersionHelper> mockedVersionHelper = Mockito.mockStatic(VersionHelper.class)) {
+            mockedVersionHelper.when(() -> VersionHelper.getVersionFromMeta(Mockito.any(Cloud.GetVersionRequest.class)))
+                    .thenAnswer(invocation -> {
+                        Cloud.GetVersionResponse.Builder builder = Cloud.GetVersionResponse.newBuilder();
+                        builder.setVersion(singleVersions.get(callCount[0]));
+                        builder.addAllVersions(batchVersions.get(callCount[0]));
+                        ++callCount[0];
+                        return builder.build();
+                    });
 
-        ctx.getSessionVariable().cloudPartitionVersionCacheTtlMs = -1; // disable cache
-            {
+            ctx.getSessionVariable().cloudPartitionVersionCacheTtlMs = -1; // disable cache
+                {
                 // test single get version
                 Assertions.assertEquals(2, part.getVisibleVersion()); // should not get from cache
                 Assertions.assertEquals(1, callCount[0]); // issue a rpc call to meta-service
@@ -124,11 +123,11 @@ public class CloudPartitionTest {
                     }
                     Assertions.assertEquals(exp, versions.get(i));
                 }
-            }
+                }
 
-        // enable change expiration and make it cached in long duration
-        ctx.getSessionVariable().cloudPartitionVersionCacheTtlMs = 100000;
-            {
+            // enable change expiration and make it cached in long duration
+            ctx.getSessionVariable().cloudPartitionVersionCacheTtlMs = 100000;
+                {
                 // test single get version
                 Assertions.assertEquals(2, part.getVisibleVersion()); // cached version
                 Assertions.assertEquals(2, callCount[0]); // issue a rpc call to meta-service
@@ -143,24 +142,24 @@ public class CloudPartitionTest {
                     }
                     Assertions.assertEquals(exp, versions.get(i));
                 }
+                }
+
+            // enable change expiration and make it expired
+            ctx.getSessionVariable().cloudPartitionVersionCacheTtlMs = 500;
+            try {
+                Thread.sleep(550);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
             }
+            // make some partition not expired, these partitions will not get version from meta-service
+            CloudPartition hotPartition = parts.get(0);
+            hotPartition.setCachedVisibleVersion(hotPartition.getCachedVisibleVersion(), 10086L);
+            Assertions.assertEquals(2, hotPartition.getCachedVisibleVersion());
+            Assertions.assertFalse(hotPartition.isCachedVersionExpired());
+            Assertions.assertTrue(parts.get(1).isCachedVersionExpired());
+            Assertions.assertTrue(parts.get(2).isCachedVersionExpired());
 
-        // enable change expiration and make it expired
-        ctx.getSessionVariable().cloudPartitionVersionCacheTtlMs = 500;
-        try {
-            Thread.sleep(550);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        // make some partition not expired, these partitions will not get version from meta-service
-        CloudPartition hotPartition = parts.get(0);
-        hotPartition.setCachedVisibleVersion(hotPartition.getCachedVisibleVersion(), 10086L);
-        Assertions.assertEquals(2, hotPartition.getCachedVisibleVersion());
-        Assertions.assertFalse(hotPartition.isCachedVersionExpired());
-        Assertions.assertTrue(parts.get(1).isCachedVersionExpired());
-        Assertions.assertTrue(parts.get(2).isCachedVersionExpired());
-
-            {
+                {
                 // test single get version
                 Assertions.assertEquals(4, part.getVisibleVersion()); // should not get from cache
                 Assertions.assertEquals(3, callCount[0]); // issue a rpc call to meta-service
@@ -178,6 +177,7 @@ public class CloudPartitionTest {
                 }
                 // hot partition version not changed
                 Assertions.assertEquals(2, hotPartition.getCachedVisibleVersion());
-            }
+                }
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/HdfsStorageVaultTest.java
@@ -27,22 +27,20 @@ import org.apache.doris.cloud.proto.Cloud.MetaServiceResponseStatus;
 import org.apache.doris.cloud.rpc.MetaServiceProxy;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.property.storage.S3Properties;
 import org.apache.doris.nereids.trees.plans.commands.CreateStorageVaultCommand;
-import org.apache.doris.rpc.RpcException;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -67,162 +65,165 @@ public class HdfsStorageVaultTest {
 
     @Test
     public void testAlterMetaServiceNormal() throws Exception {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.AlterObjStoreInfoResponse
-                    alterStorageVault(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
-                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
-                resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
-                resp.setStorageVaultId("1");
-                return resp.build();
-            }
-        };
-        StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
-                "type", "hdfs",
-                "path", "abs/",
-                S3Properties.VALIDITY_CHECK, "false",
-                HdfsStorageVault.PropertyKey.HADOOP_FS_NAME, "default"));
-        Map<String, String> properties = vault.getCopiedProperties();
-        // To check if the properties is carried correctly
-        Assertions.assertEquals(properties.get(HdfsStorageVault.PropertyKey.HADOOP_FS_NAME), "default");
-        mgr.createHdfsVault(vault);
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedProxyStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedProxyStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            Mockito.when(mockProxy.alterStorageVault(Mockito.any(Cloud.AlterObjStoreInfoRequest.class)))
+                    .thenAnswer(invocation -> {
+                        Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                        resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
+                        resp.setStorageVaultId("1");
+                        return resp.build();
+                    });
+            StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
+                    "type", "hdfs",
+                    "path", "abs/",
+                    S3Properties.VALIDITY_CHECK, "false",
+                    HdfsStorageVault.PropertyKey.HADOOP_FS_NAME, "default"));
+            Map<String, String> properties = vault.getCopiedProperties();
+            // To check if the properties is carried correctly
+            Assertions.assertEquals(properties.get(HdfsStorageVault.PropertyKey.HADOOP_FS_NAME), "default");
+            mgr.createHdfsVault(vault);
+        }
     }
 
     @Test
     public void testAlterMetaServiceWithDuplicateName() throws Exception {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            private Set<String> existed = new HashSet<>();
-            @Mock
-            public Cloud.AlterObjStoreInfoResponse
-                    alterStorageVault(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
-                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
-                MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
-                if (existed.contains(request.getVault().getName())) {
-                    status.setCode(MetaServiceCode.ALREADY_EXISTED);
-                } else {
-                    status.setCode(MetaServiceCode.OK);
-                    existed.add(request.getVault().getName());
-                }
-                resp.setStatus(status.build());
-                resp.setStorageVaultId("1");
-                return resp.build();
-            }
-        };
-        StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
-                "type", "hdfs",
-                "path", "abs/",
-                S3Properties.VALIDITY_CHECK, "false"));
-        mgr.createHdfsVault(vault);
-        Assertions.assertThrows(DdlException.class,
-                () -> {
-                    mgr.createHdfsVault(vault);
-                });
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedProxyStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedProxyStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            Set<String> existed = new HashSet<>();
+            Mockito.when(mockProxy.alterStorageVault(Mockito.any(Cloud.AlterObjStoreInfoRequest.class)))
+                    .thenAnswer(invocation -> {
+                        Cloud.AlterObjStoreInfoRequest request = invocation.getArgument(0);
+                        Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                        MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
+                        if (existed.contains(request.getVault().getName())) {
+                            status.setCode(MetaServiceCode.ALREADY_EXISTED);
+                        } else {
+                            status.setCode(MetaServiceCode.OK);
+                            existed.add(request.getVault().getName());
+                        }
+                        resp.setStatus(status.build());
+                        resp.setStorageVaultId("1");
+                        return resp.build();
+                    });
+            StorageVault vault = createHdfsVault("hdfs", ImmutableMap.of(
+                    "type", "hdfs",
+                    "path", "abs/",
+                    S3Properties.VALIDITY_CHECK, "false"));
+            mgr.createHdfsVault(vault);
+            Assertions.assertThrows(DdlException.class,
+                    () -> {
+                        mgr.createHdfsVault(vault);
+                    });
+        }
     }
 
     @Test
     public void testAlterMetaServiceWithMissingFiels() throws Exception {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.AlterObjStoreInfoResponse
-                    alterStorageVault(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
-                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
-                if (!request.getVault().hasName() || request.getVault().getName().isEmpty()) {
-                    resp.setStatus(MetaServiceResponseStatus.newBuilder()
-                                .setCode(MetaServiceCode.INVALID_ARGUMENT).build());
-                } else {
-                    resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
-                }
-                resp.setStorageVaultId("1");
-                return resp.build();
-            }
-        };
-        StorageVault vault = createHdfsVault("", ImmutableMap.of(
-                "type", "hdfs",
-                "path", "abs/",
-                S3Properties.VALIDITY_CHECK, "false"));
-        Assertions.assertThrows(DdlException.class,
-                () -> {
-                    mgr.createHdfsVault(vault);
-                });
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedProxyStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedProxyStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            Mockito.when(mockProxy.alterStorageVault(Mockito.any(Cloud.AlterObjStoreInfoRequest.class)))
+                    .thenAnswer(invocation -> {
+                        Cloud.AlterObjStoreInfoRequest request = invocation.getArgument(0);
+                        Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                        if (!request.getVault().hasName() || request.getVault().getName().isEmpty()) {
+                            resp.setStatus(MetaServiceResponseStatus.newBuilder()
+                                    .setCode(MetaServiceCode.INVALID_ARGUMENT).build());
+                        } else {
+                            resp.setStatus(MetaServiceResponseStatus.newBuilder().build());
+                        }
+                        resp.setStorageVaultId("1");
+                        return resp.build();
+                    });
+            StorageVault vault = createHdfsVault("", ImmutableMap.of(
+                    "type", "hdfs",
+                    "path", "abs/",
+                    S3Properties.VALIDITY_CHECK, "false"));
+            Assertions.assertThrows(DdlException.class,
+                    () -> {
+                        mgr.createHdfsVault(vault);
+                    });
+        }
     }
 
     @Test
     public void testAlterMetaServiceIfNotExists() throws Exception {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            private Set<String> existed = new HashSet<>();
-            @Mock
-            public Cloud.AlterObjStoreInfoResponse
-                    alterStorageVault(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
-                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
-                MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
-                if (existed.contains(request.getVault().getName())) {
-                    status.setCode(MetaServiceCode.ALREADY_EXISTED);
-                } else {
-                    status.setCode(MetaServiceCode.OK);
-                    existed.add(request.getVault().getName());
-                }
-                resp.setStatus(status.build());
-                resp.setStorageVaultId("1");
-                return resp.build();
-            }
-        };
-        StorageVault vault = new HdfsStorageVault("name", true, false);
-        vault.modifyProperties(ImmutableMap.of(
-                "type", "hdfs",
-                "path", "abs/",
-                S3Properties.VALIDITY_CHECK, "false"));
-        mgr.createHdfsVault(vault);
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedProxyStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedProxyStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            Set<String> existed = new HashSet<>();
+            Mockito.when(mockProxy.alterStorageVault(Mockito.any(Cloud.AlterObjStoreInfoRequest.class)))
+                    .thenAnswer(invocation -> {
+                        Cloud.AlterObjStoreInfoRequest request = invocation.getArgument(0);
+                        Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                        MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
+                        if (existed.contains(request.getVault().getName())) {
+                            status.setCode(MetaServiceCode.ALREADY_EXISTED);
+                        } else {
+                            status.setCode(MetaServiceCode.OK);
+                            existed.add(request.getVault().getName());
+                        }
+                        resp.setStatus(status.build());
+                        resp.setStorageVaultId("1");
+                        return resp.build();
+                    });
+            StorageVault vault = new HdfsStorageVault("name", true, false);
+            vault.modifyProperties(ImmutableMap.of(
+                    "type", "hdfs",
+                    "path", "abs/",
+                    S3Properties.VALIDITY_CHECK, "false"));
+            mgr.createHdfsVault(vault);
+        }
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSetDefaultVault() throws Exception {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            private Pair<String, String> defaultVaultInfo;
-            private HashSet<String> existed = new HashSet<>();
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedProxyStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedProxyStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            HashSet<String> existed = new HashSet<>();
 
-            @Mock
-            public Pair getDefaultStorageVault() {
-                return defaultVaultInfo;
-            }
-
-            @Mock
-            public Cloud.AlterObjStoreInfoResponse
-                    alterStorageVault(Cloud.AlterObjStoreInfoRequest request) throws RpcException {
-                Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
-                MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
-                if (request.getOp() == Operation.ADD_HDFS_INFO) {
-                    if (existed.contains(request.getVault().getName())) {
-                        status.setCode(MetaServiceCode.ALREADY_EXISTED);
-                    } else {
-                        status.setCode(MetaServiceCode.OK);
-                        existed.add(request.getVault().getName());
-                    }
-                } else if (request.getOp() == Operation.SET_DEFAULT_VAULT) {
-                    if (!existed.contains(request.getVault().getName())) {
-                        status.setCode(MetaServiceCode.INVALID_ARGUMENT);
-                    } else {
-                        this.defaultVaultInfo = Pair.of(request.getVault().getName(), "1");
-                        status.setCode(MetaServiceCode.OK);
-                    }
-                }
-                resp.setStatus(status.build());
-                resp.setStorageVaultId(String.valueOf(existed.size()));
-                return resp.build();
-            }
-        };
-        StorageVault vault = new HdfsStorageVault("name", true, false);
-        Assertions.assertThrows(DdlException.class,
-                () -> {
-                    mgr.setDefaultStorageVault("non_existent");
-                });
-        vault.modifyProperties(ImmutableMap.of(
-                "type", "hdfs",
-                "path", "abs/",
-                S3Properties.VALIDITY_CHECK, "false"));
-        mgr.createHdfsVault(vault);
-        Assertions.assertTrue(mgr.getDefaultStorageVault() == null);
-        mgr.setDefaultStorageVault(vault.getName());
-        Assertions.assertTrue(mgr.getDefaultStorageVault().first.equals(vault.getName()));
+            Mockito.when(mockProxy.alterStorageVault(Mockito.any(Cloud.AlterObjStoreInfoRequest.class)))
+                    .thenAnswer(invocation -> {
+                        Cloud.AlterObjStoreInfoRequest request = invocation.getArgument(0);
+                        Cloud.AlterObjStoreInfoResponse.Builder resp = Cloud.AlterObjStoreInfoResponse.newBuilder();
+                        MetaServiceResponseStatus.Builder status = MetaServiceResponseStatus.newBuilder();
+                        if (request.getOp() == Operation.ADD_HDFS_INFO) {
+                            if (existed.contains(request.getVault().getName())) {
+                                status.setCode(MetaServiceCode.ALREADY_EXISTED);
+                            } else {
+                                status.setCode(MetaServiceCode.OK);
+                                existed.add(request.getVault().getName());
+                            }
+                        } else if (request.getOp() == Operation.SET_DEFAULT_VAULT) {
+                            if (!existed.contains(request.getVault().getName())) {
+                                status.setCode(MetaServiceCode.INVALID_ARGUMENT);
+                            } else {
+                                status.setCode(MetaServiceCode.OK);
+                            }
+                        }
+                        resp.setStatus(status.build());
+                        resp.setStorageVaultId(String.valueOf(existed.size()));
+                        return resp.build();
+                    });
+            StorageVault vault = new HdfsStorageVault("name", true, false);
+            Assertions.assertThrows(DdlException.class,
+                    () -> {
+                        mgr.setDefaultStorageVault("non_existent");
+                    });
+            vault.modifyProperties(ImmutableMap.of(
+                    "type", "hdfs",
+                    "path", "abs/",
+                    S3Properties.VALIDITY_CHECK, "false"));
+            mgr.createHdfsVault(vault);
+            Assertions.assertTrue(mgr.getDefaultStorageVault() == null);
+            mgr.setDefaultStorageVault(vault.getName());
+            Assertions.assertTrue(mgr.getDefaultStorageVault().first.equals(vault.getName()));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CopyJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CopyJobTest.java
@@ -39,6 +39,7 @@ import org.apache.doris.thrift.TUniqueId;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,6 +73,16 @@ public class CopyJobTest {
         MetaContext metaContext = new MetaContext();
         metaContext.setMetaVersion(FeMetaVersion.VERSION_CURRENT);
         metaContext.setThreadLocalInfo();
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CopyLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CopyLoadPendingTaskTest.java
@@ -37,11 +37,10 @@ import org.apache.doris.utframe.TestWithFeService;
 import org.apache.doris.utframe.UtFrameUtils;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -64,6 +63,8 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
     // In-memory file store served by MockObjFileSystem
     private Map<String, RemoteObject> objectStore = new LinkedHashMap<>();
     MockInternalCatalog mockInternalCatalog = new MockInternalCatalog();
+    private MockedStatic<FileSystemFactory> mockedFileSystemFactory;
+    private MockedStatic<Env> mockedEnvStatic;
 
     private class MockInternalCatalog extends CloudInternalCatalog {
         @Override
@@ -152,15 +153,36 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
         FeConstants.runningUnitTest = true;
     }
 
-    /** Registers a MockUp on FileSystemFactory to serve requests from the test's objectStore. */
+    @Override
+    protected void runBeforeEach() throws Exception {
+        closeMocks();
+    }
+
+    @Override
+    protected void runAfterAll() throws Exception {
+        closeMocks();
+    }
+
+    private void closeMocks() {
+        if (mockedFileSystemFactory != null) {
+            mockedFileSystemFactory.close();
+            mockedFileSystemFactory = null;
+        }
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+            mockedEnvStatic = null;
+        }
+    }
+
+    /** Registers a mock on FileSystemFactory to serve requests from the test's objectStore. */
     private void setupObjFsMock() {
         MockObjFileSystem mockObjFs = new MockObjFileSystem();
-        new MockUp<FileSystemFactory>() {
-            @Mock
-            public org.apache.doris.filesystem.FileSystem getFileSystem(StorageProperties sp) throws IOException {
-                return mockObjFs;
-            }
-        };
+        if (mockedFileSystemFactory != null) {
+            mockedFileSystemFactory.close();
+        }
+        mockedFileSystemFactory = Mockito.mockStatic(FileSystemFactory.class);
+        mockedFileSystemFactory.when(() -> FileSystemFactory.getFileSystem(Mockito.any(StorageProperties.class)))
+                .thenReturn(mockObjFs);
     }
 
     @Test
@@ -212,13 +234,7 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
             }
         }
         setupObjFsMock();
-        new Expectations(ctx.getEnv(), ctx.getEnv().getInternalCatalog()) {
-            {
-                Env.getCurrentInternalCatalog();
-                minTimes = 0;
-                result = mockInternalCatalog;
-            }
-        };
+        setupEnvMock();
 
         String stageId = "1";
         long tableId = 100;
@@ -310,15 +326,24 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
         }
     }
 
-    /** Registers a paginating MockUp on FileSystemFactory with the given page size. */
+    /** Registers a paginating mock on FileSystemFactory with the given page size. */
     private void setupPaginatingObjFsMock(int pageSize) {
         PaginatingMockObjFileSystem mockObjFs = new PaginatingMockObjFileSystem(pageSize);
-        new MockUp<FileSystemFactory>() {
-            @Mock
-            public org.apache.doris.filesystem.FileSystem getFileSystem(StorageProperties sp) throws IOException {
-                return mockObjFs;
-            }
-        };
+        if (mockedFileSystemFactory != null) {
+            mockedFileSystemFactory.close();
+        }
+        mockedFileSystemFactory = Mockito.mockStatic(FileSystemFactory.class);
+        mockedFileSystemFactory.when(() -> FileSystemFactory.getFileSystem(Mockito.any(StorageProperties.class)))
+                .thenReturn(mockObjFs);
+    }
+
+    /** Sets up a MockedStatic for Env to return the mock internal catalog. */
+    private void setupEnvMock() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
+        mockedEnvStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        mockedEnvStatic.when(Env::getCurrentInternalCatalog).thenReturn(mockInternalCatalog);
     }
 
     @Test
@@ -340,13 +365,7 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
         }
         // Use paginating mock with page size 3 to force multiple continuation token rounds
         setupPaginatingObjFsMock(3);
-        new Expectations(ctx.getEnv(), ctx.getEnv().getInternalCatalog()) {
-            {
-                Env.getCurrentInternalCatalog();
-                minTimes = 0;
-                result = mockInternalCatalog;
-            }
-        };
+        setupEnvMock();
 
         String stageId = "1";
         long tableId = 100;
@@ -392,13 +411,7 @@ public class CopyLoadPendingTaskTest extends TestWithFeService {
             objectStore.put(objectFile.getKey(), objectFile);
         }
         setupObjFsMock();
-        new Expectations(ctx.getEnv(), ctx.getEnv().getInternalCatalog()) {
-            {
-                Env.getCurrentInternalCatalog();
-                minTimes = 0;
-                result = mockInternalCatalog;
-            }
-        };
+        setupEnvMock();
 
         String stageId = "1";
         long tableId = 300;

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/master/CloudReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/master/CloudReportHandlerTest.java
@@ -20,44 +20,36 @@ package org.apache.doris.cloud.master;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.catalog.CloudEnv;
 
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
-import mockit.Verifications;
+import org.junit.After;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 
 public class CloudReportHandlerTest {
 
-    @Mocked
-    private CloudEnv mockCloudEnv;
+    private CloudEnv mockCloudEnv = Mockito.mock(CloudEnv.class);
+    private MockedStatic<Env> mockedEnvStatic;
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+            mockedEnvStatic = null;
+        }
+    }
 
     @Test
     public void testTabletReportWhenTabletRebalancerNotInitialized() {
-        new MockUp<Env>() {
-            @Mock
-            public Env getCurrentEnv() {
-                return mockCloudEnv;
-            }
-        };
-        new Expectations() {
-            {
-                mockCloudEnv.isRebalancerInited();
-                result = false;
-            }
-        };
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(mockCloudEnv);
+        Mockito.when(mockCloudEnv.isRebalancerInited()).thenReturn(false);
 
         CloudReportHandler handler = new CloudReportHandler();
         handler.tabletReport(1001L, new HashMap<>(), new HashMap<>(), 1L, 10L);
         // If the tabletRebalancer is not initialized,
         // the tabletReport should not call mockCloudEnv.getCurrentSystemInfo
-        new Verifications() {
-            {
-                mockCloudEnv.getCurrentSystemInfo();
-                times = 0;
-            }
-        };
+        Mockito.verify(mockCloudEnv, Mockito.never()).getCurrentSystemInfo();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/stage/StageUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/stage/StageUtilTest.java
@@ -23,9 +23,7 @@ import org.apache.doris.cloud.proto.Cloud.ObjectFilePB;
 import org.apache.doris.cloud.proto.Cloud.ObjectStoreInfoPB.Provider;
 import org.apache.doris.cloud.storage.ObjectInfo;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
-import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.filesystem.spi.ObjFileSystem;
 import org.apache.doris.filesystem.spi.RemoteObject;
@@ -33,16 +31,15 @@ import org.apache.doris.filesystem.spi.RemoteObjects;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.thrift.TBrokerFileStatus;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,106 +67,52 @@ public class StageUtilTest {
         List<String> keys = readMockedOssUrl();
         Assert.assertEquals(4956, keys.size());
 
-        // Mock FileSystemFactory to return an ObjFileSystem stub.
-        // The MockUp<ObjFileSystem> below will replace listObjectsWithPrefix and close.
-        new MockUp<FileSystemFactory>() {
-            @Mock
-            public org.apache.doris.filesystem.FileSystem getFileSystem(StorageProperties sp) throws IOException {
-                return new ObjFileSystem("test", null) {
-                    @Override
-                    public org.apache.doris.filesystem.FileIterator list(
-                            org.apache.doris.filesystem.Location location) {
-                        throw new UnsupportedOperationException();
+        // Mock FileSystemFactory and related dependencies
+        ObjFileSystem mockFs = Mockito.mock(ObjFileSystem.class);
+        Mockito.when(mockFs.listObjectsWithPrefix(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenAnswer(invocation -> {
+                    List<RemoteObject> objectFiles = new ArrayList<>();
+                    for (String key : keys) {
+                        objectFiles.add(new RemoteObject(key, key, "fake-etag-for-test", 100, 0));
                     }
+                    return new RemoteObjects(objectFiles, false, null);
+                });
 
-                    @Override
-                    public void mkdirs(org.apache.doris.filesystem.Location location) {
+        CloudInternalCatalog mockCatalog = Mockito.mock(CloudInternalCatalog.class);
+        Mockito.when(mockCatalog.filterCopyFiles(Mockito.anyString(), Mockito.anyLong(), Mockito.anyList()))
+                .thenAnswer(invocation -> {
+                    List<RemoteObject> objectFiles = invocation.getArgument(2);
+                    List<ObjectFilePB> objectFilePbs = new ArrayList<ObjectFilePB>();
+                    for (RemoteObject objectFile : objectFiles) {
+                        objectFilePbs.add(ObjectFilePB.newBuilder().setRelativePath(objectFile.getRelativePath())
+                                .setEtag(objectFile.getEtag()).setSize(objectFile.getSize()).build());
                     }
+                    return objectFilePbs;
+                });
 
-                    @Override
-                    public void delete(org.apache.doris.filesystem.Location location, boolean r) {
-                    }
+        try (MockedStatic<FileSystemFactory> mockedFactory = Mockito.mockStatic(FileSystemFactory.class);
+                MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedFactory.when(() -> FileSystemFactory.getFileSystem(Mockito.any(StorageProperties.class)))
+                    .thenReturn(mockFs);
+            mockedEnv.when(Env::getCurrentInternalCatalog).thenReturn(mockCatalog);
 
-                    @Override
-                    public void rename(org.apache.doris.filesystem.Location s,
-                            org.apache.doris.filesystem.Location d) {
-                    }
+            String copyId = "copyId";
+            String filePattern = "mc_holo/ext_traditional/jd_09/item_part1*.orc";
+            String stageId = "stageId";
+            long tableId = 1;
+            long sizeLimit = 100000000;
 
-                    @Override
-                    public org.apache.doris.filesystem.DorisInputFile newInputFile(
-                            org.apache.doris.filesystem.Location location) {
-                        throw new UnsupportedOperationException();
-                    }
+            ObjectInfo objectInfo = new ObjectInfo(Provider.OSS, "test_ak", "test_sk", "test_bucket",
+                    "test_endpoint", "test_region", "test_prefix");
+            List<Pair<TBrokerFileStatus, ObjectFilePB>> fileStatus = new ArrayList();
 
-                    @Override
-                    public org.apache.doris.filesystem.DorisOutputFile newOutputFile(
-                            org.apache.doris.filesystem.Location location) {
-                        throw new UnsupportedOperationException();
-                    }
-
-                    @Override
-                    public void close() {
-                    }
-                };
-            }
-        };
-
-        // Mock ObjFileSystem.listObjectsWithPrefix to return all test keys
-        new MockUp<ObjFileSystem>() {
-            @Mock
-            public RemoteObjects listObjectsWithPrefix(String prefix, String subPrefix, String continuationToken)
-                    throws IOException {
-                List<RemoteObject> objectFiles = new ArrayList<>();
-                for (String key : keys) {
-                    objectFiles.add(new RemoteObject(key, key, "fake-etag-for-test", 100, 0));
-                }
-                return new RemoteObjects(objectFiles, false, null);
-            }
-
-            @Mock
-            public void close() throws IOException {
-                // no-op
-            }
-        };
-
-        // Mock CloudInternalCatalog.filterCopyFiles to pass through all files
-        new MockUp<CloudInternalCatalog>() {
-            @Mock
-            public List<ObjectFilePB> filterCopyFiles(String stageId, long tableId, List<RemoteObject> objectFiles)
-                    throws DdlException {
-                List<ObjectFilePB> objectFilePbs = new ArrayList<ObjectFilePB>();
-                for (RemoteObject objectFile : objectFiles) {
-                    objectFilePbs.add(ObjectFilePB.newBuilder().setRelativePath(objectFile.getRelativePath())
-                            .setEtag(objectFile.getEtag()).setSize(objectFile.getSize()).build());
-                }
-                return objectFilePbs;
-            }
-        };
-
-        // Mock Env.getCurrentInternalCatalog to return a CloudInternalCatalog
-        new MockUp<Env>() {
-            @Mock
-            public InternalCatalog getCurrentInternalCatalog() {
-                return new CloudInternalCatalog();
-            }
-        };
-
-        String copyId = "copyId";
-        String filePattern = "mc_holo/ext_traditional/jd_09/item_part1*.orc";
-        String stageId = "stageId";
-        long tableId = 1;
-        long sizeLimit = 100000000;
-
-        ObjectInfo objectInfo = new ObjectInfo(Provider.OSS, "test_ak", "test_sk", "test_bucket",
-                "test_endpoint", "test_region", "test_prefix");
-        List<Pair<TBrokerFileStatus, ObjectFilePB>> fileStatus = new ArrayList();
-
-        Triple<Integer, Integer, String> triple = StageUtil.listAndFilterFilesV2(
-                objectInfo, filePattern, copyId, stageId, tableId, false, sizeLimit,
-                1000, Config.max_meta_size_per_copy_into_job, fileStatus);
-        LOG.info("triple:{}, fileStatus.size():{}", triple, fileStatus.size());
-        // All 4956 test keys match the pattern, but the meta size limit (51200 bytes)
-        // caps the result at 500 files (5 batches of cloud_filter_copy_file_num_limit=100).
-        Assert.assertEquals(500, fileStatus.size());
+            Triple<Integer, Integer, String> triple = StageUtil.listAndFilterFilesV2(
+                    objectInfo, filePattern, copyId, stageId, tableId, false, sizeLimit,
+                    1000, Config.max_meta_size_per_copy_into_job, fileStatus);
+            LOG.info("triple:{}, fileStatus.size():{}", triple, fileStatus.size());
+            // All 4956 test keys match the pattern, but the meta size limit (51200 bytes)
+            // caps the result at 500 files (5 batches of cloud_filter_copy_file_num_limit=100).
+            Assert.assertEquals(500, fileStatus.size());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -31,27 +31,23 @@ import org.apache.doris.cloud.proto.Cloud.GetCurrentMaxTxnResponse;
 import org.apache.doris.cloud.proto.Cloud.MetaServiceCode;
 import org.apache.doris.cloud.proto.Cloud.TxnInfoPB;
 import org.apache.doris.cloud.rpc.MetaServiceProxy;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DuplicatedRequestException;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.LabelAlreadyUsedException;
-import org.apache.doris.common.MetaNotFoundException;
-import org.apache.doris.common.QuotaExceedException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
 import org.apache.doris.transaction.TransactionState;
 
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CloudGlobalTransactionMgrTest {
@@ -65,8 +61,7 @@ public class CloudGlobalTransactionMgrTest {
             TransactionState.TxnSourceType.FE, 0, "localfe", System.currentTimeMillis());
 
     @Before
-    public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException, NoSuchMethodException, SecurityException {
+    public void setUp() throws Exception {
 
         Config.cloud_unique_id = "cloud_unique_id";
         Config.meta_service_endpoint = "127.0.0.1:20121";
@@ -77,188 +72,196 @@ public class CloudGlobalTransactionMgrTest {
         masterTransMgr = masterEnv.getGlobalTransactionMgr();
     }
 
-    @Test
-    public void testBeginTransaction() throws LabelAlreadyUsedException, AnalysisException,
-            BeginTransactionException, DuplicatedRequestException, QuotaExceedException, MetaNotFoundException {
-        AtomicLong id = new AtomicLong(1000);
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.BeginTxnResponse beginTxn(Cloud.BeginTxnRequest request) {
-                BeginTxnResponse.Builder beginTxnResponseBuilder = BeginTxnResponse.newBuilder();
-                beginTxnResponseBuilder.setTxnId(id.getAndIncrement())
-                        .setStatus(Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
-
-                return beginTxnResponseBuilder.build();
-            }
-        };
-
-        long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
-                CatalogTestUtil.testTxnLabel1,
-                transactionSource,
-                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
-
-        Assert.assertEquals(transactionId + 1, id.get());
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
     }
 
     @Test
-    public void testBeginTransactionConflict() throws LabelAlreadyUsedException, AnalysisException,
-            BeginTransactionException, DuplicatedRequestException, QuotaExceedException, MetaNotFoundException {
+    public void testBeginTransaction() throws Exception {
         AtomicLong id = new AtomicLong(1000);
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            int times = 1;
-            @Mock
-            public Cloud.BeginTxnResponse beginTxn(Cloud.BeginTxnRequest request) {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            Mockito.doAnswer(invocation -> {
                 BeginTxnResponse.Builder beginTxnResponseBuilder = BeginTxnResponse.newBuilder();
-                if (times > 5) {
+                beginTxnResponseBuilder.setTxnId(id.getAndIncrement())
+                        .setStatus(Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
+                return beginTxnResponseBuilder.build();
+            }).when(mockProxy).beginTxn(Mockito.any());
+
+            long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
+                    CatalogTestUtil.testTxnLabel1,
+                    transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+
+            Assert.assertEquals(transactionId + 1, id.get());
+        }
+    }
+
+    @Test
+    public void testBeginTransactionConflict() throws Exception {
+        AtomicLong id = new AtomicLong(1000);
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            final int[] times = {1};
+            Mockito.doAnswer(invocation -> {
+                BeginTxnResponse.Builder beginTxnResponseBuilder = BeginTxnResponse.newBuilder();
+                if (times[0] > 5) {
                     beginTxnResponseBuilder.setTxnId(id.getAndIncrement())
                             .setStatus(Cloud.MetaServiceResponseStatus.newBuilder().setCode(MetaServiceCode.OK).setMsg("OK"));
                 } else {
                     beginTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                             .setCode(MetaServiceCode.KV_TXN_CONFLICT).setMsg("kv txn conflict"));
                 }
-                times++;
+                times[0]++;
                 return beginTxnResponseBuilder.build();
-            }
-        };
+            }).when(mockProxy).beginTxn(Mockito.any());
 
-        long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
-                CatalogTestUtil.testTxnLabel1,
-                transactionSource,
-                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
+                    CatalogTestUtil.testTxnLabel1,
+                    transactionSource,
+                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
 
-        Assert.assertEquals(transactionId + 1, id.get());
+            Assert.assertEquals(transactionId + 1, id.get());
+        }
     }
 
     @Test
-    public void testBeginTransactionLabelAlreadyUsedException() throws LabelAlreadyUsedException, AnalysisException,
-            BeginTransactionException, DuplicatedRequestException, QuotaExceedException, MetaNotFoundException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.BeginTxnResponse beginTxn(Cloud.BeginTxnRequest request) {
-                BeginTxnResponse.Builder beginTxnResponseBuilder = BeginTxnResponse.newBuilder();
-                beginTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.TXN_LABEL_ALREADY_USED).setMsg("label already used"));
-                return beginTxnResponseBuilder.build();
-            }
-        };
+    public void testBeginTransactionLabelAlreadyUsedException() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            BeginTxnResponse response = BeginTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.TXN_LABEL_ALREADY_USED).setMsg("label already used"))
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).beginTxn(Mockito.any());
 
-        Assertions.assertThrows(LabelAlreadyUsedException.class,
-                () -> {
-                        masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
-                                CatalogTestUtil.testTxnLabel1,
-                                transactionSource,
-                                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
-            });
+            Assertions.assertThrows(LabelAlreadyUsedException.class,
+                    () -> {
+                            masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
+                                    CatalogTestUtil.testTxnLabel1,
+                                    transactionSource,
+                                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                });
+        }
     }
 
     @Test
-    public void testBeginTransactionDuplicatedRequestException() throws LabelAlreadyUsedException, AnalysisException,
-            BeginTransactionException, DuplicatedRequestException, QuotaExceedException, MetaNotFoundException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.BeginTxnResponse beginTxn(Cloud.BeginTxnRequest request) {
-                BeginTxnResponse.Builder beginTxnResponseBuilder = BeginTxnResponse.newBuilder();
-                beginTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.TXN_DUPLICATED_REQ).setMsg("duplicated request"));
-                return beginTxnResponseBuilder.build();
-            }
-        };
+    public void testBeginTransactionDuplicatedRequestException() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            BeginTxnResponse response = BeginTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.TXN_DUPLICATED_REQ).setMsg("duplicated request"))
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).beginTxn(Mockito.any());
 
-        Assertions.assertThrows(DuplicatedRequestException.class,
-                () -> {
-                        masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
-                                CatalogTestUtil.testTxnLabel1,
-                                transactionSource,
-                                TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
-            });
+            Assertions.assertThrows(DuplicatedRequestException.class,
+                    () -> {
+                            masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1),
+                                    CatalogTestUtil.testTxnLabel1,
+                                    transactionSource,
+                                    TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                });
+        }
     }
 
     @Test
-    public void testCommitTransaction() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.CommitTxnResponse commitTxn(Cloud.CommitTxnRequest request) {
-                TxnInfoPB.Builder txnInfoBuilder = TxnInfoPB.newBuilder();
-                txnInfoBuilder.setDbId(CatalogTestUtil.testTableId1);
-                txnInfoBuilder.addAllTableIds(Lists.newArrayList(CatalogTestUtil.testTableId1));
-                txnInfoBuilder.setLabel(CatalogTestUtil.testTxnLabel1);
-                txnInfoBuilder.setListenerId(-1);
+    public void testCommitTransaction() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            TxnInfoPB.Builder txnInfoBuilder = TxnInfoPB.newBuilder();
+            txnInfoBuilder.setDbId(CatalogTestUtil.testTableId1);
+            txnInfoBuilder.addAllTableIds(Lists.newArrayList(CatalogTestUtil.testTableId1));
+            txnInfoBuilder.setLabel(CatalogTestUtil.testTxnLabel1);
+            txnInfoBuilder.setListenerId(-1);
+            CommitTxnResponse response = CommitTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setTxnInfo(txnInfoBuilder.build())
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).commitTxn(Mockito.any());
+
+            long transactionId = 123533;
+            Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
+                    .getTableOrMetaException(CatalogTestUtil.testTableId1);
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
+                    transactionId, null, null);
+        }
+    }
+
+    @Test
+    public void testCommitTransactionAlreadyVisible() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            TxnInfoPB.Builder txnInfoBuilder = TxnInfoPB.newBuilder();
+            txnInfoBuilder.setDbId(CatalogTestUtil.testTableId1);
+            txnInfoBuilder.addAllTableIds(Lists.newArrayList(CatalogTestUtil.testTableId1));
+            txnInfoBuilder.setLabel(CatalogTestUtil.testTxnLabel1);
+            txnInfoBuilder.setListenerId(-1);
+            CommitTxnResponse response = CommitTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.TXN_ALREADY_VISIBLE).setMsg("txn already visible"))
+                    .setTxnInfo(txnInfoBuilder.build())
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).commitTxn(Mockito.any());
+
+            long transactionId = 123533;
+            Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
+                    .getTableOrMetaException(CatalogTestUtil.testTableId1);
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
+                    transactionId, null, null);
+        }
+    }
+
+    @Test
+    public void testCommitTransactionAlreadyAborted() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            TxnInfoPB.Builder txnInfoBuilder = TxnInfoPB.newBuilder();
+            txnInfoBuilder.setDbId(CatalogTestUtil.testTableId1);
+            txnInfoBuilder.addAllTableIds(Lists.newArrayList(CatalogTestUtil.testTableId1));
+            txnInfoBuilder.setLabel(CatalogTestUtil.testTxnLabel1);
+            txnInfoBuilder.setListenerId(-1);
+            CommitTxnResponse response = CommitTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.TXN_ALREADY_ABORTED).setMsg("txn already aborted"))
+                    .setTxnInfo(txnInfoBuilder.build())
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).commitTxn(Mockito.any());
+
+            Assertions.assertThrows(UserException.class,
+                    () -> {
+                            long transactionId = 123533;
+                            Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
+                                    .getTableOrMetaException(CatalogTestUtil.testTableId1);
+                            masterTransMgr.commitTransactionWithoutLock(
+                                    CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId, null, null);
+                });
+        }
+    }
+
+    @Test
+    public void testCommitTransactionConflict() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            final int[] times = {1};
+            Mockito.doAnswer(invocation -> {
                 CommitTxnResponse.Builder commitTxnResponseBuilder = CommitTxnResponse.newBuilder();
-                commitTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .setTxnInfo(txnInfoBuilder.build());
-                return commitTxnResponseBuilder.build();
-            }
-        };
-
-        long transactionId = 123533;
-        Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
-                .getTableOrMetaException(CatalogTestUtil.testTableId1);
-        masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
-                transactionId, null, null);
-    }
-
-    @Test
-    public void testCommitTransactionAlreadyVisible() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.CommitTxnResponse commitTxn(Cloud.CommitTxnRequest request) {
-                TxnInfoPB.Builder txnInfoBuilder = TxnInfoPB.newBuilder();
-                txnInfoBuilder.setDbId(CatalogTestUtil.testTableId1);
-                txnInfoBuilder.addAllTableIds(Lists.newArrayList(CatalogTestUtil.testTableId1));
-                txnInfoBuilder.setLabel(CatalogTestUtil.testTxnLabel1);
-                txnInfoBuilder.setListenerId(-1);
-                CommitTxnResponse.Builder commitTxnResponseBuilder = CommitTxnResponse.newBuilder();
-                commitTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.TXN_ALREADY_VISIBLE).setMsg("txn already visible"))
-                        .setTxnInfo(txnInfoBuilder.build());
-                return commitTxnResponseBuilder.build();
-            }
-        };
-
-        long transactionId = 123533;
-        Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
-                .getTableOrMetaException(CatalogTestUtil.testTableId1);
-        masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
-                transactionId, null, null);
-    }
-
-    @Test
-    public void testCommitTransactionAlreadyAborted() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.CommitTxnResponse commitTxn(Cloud.CommitTxnRequest request) {
-                TxnInfoPB.Builder txnInfoBuilder = TxnInfoPB.newBuilder();
-                txnInfoBuilder.setDbId(CatalogTestUtil.testTableId1);
-                txnInfoBuilder.addAllTableIds(Lists.newArrayList(CatalogTestUtil.testTableId1));
-                txnInfoBuilder.setLabel(CatalogTestUtil.testTxnLabel1);
-                txnInfoBuilder.setListenerId(-1);
-                CommitTxnResponse.Builder commitTxnResponseBuilder = CommitTxnResponse.newBuilder();
-                commitTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.TXN_ALREADY_ABORTED).setMsg("txn already aborted"))
-                        .setTxnInfo(txnInfoBuilder.build());
-                return commitTxnResponseBuilder.build();
-            }
-        };
-
-        Assertions.assertThrows(UserException.class,
-                () -> {
-                        long transactionId = 123533;
-                        Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
-                                .getTableOrMetaException(CatalogTestUtil.testTableId1);
-                        masterTransMgr.commitTransactionWithoutLock(
-                                CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1), transactionId, null, null);
-            });
-    }
-
-    @Test
-    public void testCommitTransactionConflict() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            int times = 1;
-            @Mock
-            public Cloud.CommitTxnResponse commitTxn(Cloud.CommitTxnRequest request) {
-                CommitTxnResponse.Builder commitTxnResponseBuilder = CommitTxnResponse.newBuilder();
-                if (times > 5) {
+                if (times[0] > 5) {
                     TxnInfoPB.Builder txnInfoBuilder = TxnInfoPB.newBuilder();
                     txnInfoBuilder.setDbId(CatalogTestUtil.testTableId1);
                     txnInfoBuilder.addAllTableIds(Lists.newArrayList(CatalogTestUtil.testTableId1));
@@ -271,54 +274,55 @@ public class CloudGlobalTransactionMgrTest {
                     commitTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                             .setCode(MetaServiceCode.KV_TXN_CONFLICT).setMsg("kv txn conflict"));
                 }
-                times++;
+                times[0]++;
                 return commitTxnResponseBuilder.build();
-            }
-        };
-        long transactionId = 123533;
-        Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
-                .getTableOrMetaException(CatalogTestUtil.testTableId1);
-        masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
-                transactionId, null, null);
+            }).when(mockProxy).commitTxn(Mockito.any());
+            long transactionId = 123533;
+            Table testTable1 = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
+                    .getTableOrMetaException(CatalogTestUtil.testTableId1);
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(testTable1),
+                    transactionId, null, null);
+        }
     }
 
     @Test
-    public void testAbortTransaction() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.AbortTxnResponse abortTxn(Cloud.AbortTxnRequest request) {
-                AbortTxnResponse.Builder abortTxnResponseBuilder = AbortTxnResponse.newBuilder();
-                abortTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"));
-                return abortTxnResponseBuilder.build();
-            }
-        };
-        long transactionId = 123533;
-        masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, transactionId, "User Cancelled");
+    public void testAbortTransaction() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            AbortTxnResponse response = AbortTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).abortTxn(Mockito.any());
+            long transactionId = 123533;
+            masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, transactionId, "User Cancelled");
+        }
     }
 
     @Test
-    public void testAbortTransactionByLabel() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.AbortTxnResponse abortTxn(Cloud.AbortTxnRequest request) {
-                AbortTxnResponse.Builder abortTxnResponseBuilder = AbortTxnResponse.newBuilder();
-                abortTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"));
-                return abortTxnResponseBuilder.build();
-            }
-        };
-        masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, CatalogTestUtil.testTxnLabel1, "User Cancelled");
+    public void testAbortTransactionByLabel() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            AbortTxnResponse response = AbortTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).abortTxn(Mockito.any());
+            masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, CatalogTestUtil.testTxnLabel1, "User Cancelled");
+        }
     }
 
     @Test
-    public void testAbortTransactionConflict() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            int times = 1;
-            @Mock
-            public Cloud.AbortTxnResponse abortTxn(Cloud.AbortTxnRequest request) {
+    public void testAbortTransactionConflict() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            final int[] times = {1};
+            Mockito.doAnswer(invocation -> {
                 AbortTxnResponse.Builder abortTxnResponseBuilder = AbortTxnResponse.newBuilder();
-                if (times > 5) {
+                if (times[0] > 5) {
                     abortTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                             .setCode(MetaServiceCode.OK).setMsg("OK"));
                     return abortTxnResponseBuilder.build();
@@ -326,22 +330,23 @@ public class CloudGlobalTransactionMgrTest {
                     abortTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                             .setCode(MetaServiceCode.KV_TXN_CONFLICT).setMsg("kv txn conflict"));
                 }
-                times++;
+                times[0]++;
                 return abortTxnResponseBuilder.build();
-            }
-        };
-        long transactionId = 123533;
-        masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, transactionId, "User Cancelled");
+            }).when(mockProxy).abortTxn(Mockito.any());
+            long transactionId = 123533;
+            masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, transactionId, "User Cancelled");
+        }
     }
 
     @Test
-    public void testAbortTransactionByLabelConflict() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            int times = 1;
-            @Mock
-            public Cloud.AbortTxnResponse abortTxn(Cloud.AbortTxnRequest request) {
+    public void testAbortTransactionByLabelConflict() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            final int[] times = {1};
+            Mockito.doAnswer(invocation -> {
                 AbortTxnResponse.Builder abortTxnResponseBuilder = AbortTxnResponse.newBuilder();
-                if (times > 5) {
+                if (times[0] > 5) {
                     abortTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                             .setCode(MetaServiceCode.OK).setMsg("OK"));
                     return abortTxnResponseBuilder.build();
@@ -349,60 +354,60 @@ public class CloudGlobalTransactionMgrTest {
                     abortTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
                             .setCode(MetaServiceCode.KV_TXN_CONFLICT).setMsg("kv txn conflict"));
                 }
-                times++;
+                times[0]++;
                 return abortTxnResponseBuilder.build();
-            }
-        };
-        masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, CatalogTestUtil.testTxnLabel1, "User Cancelled");
+            }).when(mockProxy).abortTxn(Mockito.any());
+            masterTransMgr.abortTransaction(CatalogTestUtil.testDbId1, CatalogTestUtil.testTxnLabel1, "User Cancelled");
+        }
     }
 
     @Test
-    public void testIsPreviousTransactionsFinished() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.CheckTxnConflictResponse checkTxnConflict(Cloud.CheckTxnConflictRequest request) {
-                CheckTxnConflictResponse.Builder checkTxnConflictResponseBuilder = CheckTxnConflictResponse.newBuilder();
-                checkTxnConflictResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .setFinished(true);
-                return checkTxnConflictResponseBuilder.build();
-            }
-        };
-        boolean result = masterTransMgr.isPreviousTransactionsFinished(12131231,
-                CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1));
-        Assert.assertEquals(result, true);
+    public void testIsPreviousTransactionsFinished() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            CheckTxnConflictResponse response = CheckTxnConflictResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setFinished(true)
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).checkTxnConflict(Mockito.any());
+            boolean result = masterTransMgr.isPreviousTransactionsFinished(12131231,
+                    CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1));
+            Assert.assertEquals(result, true);
+        }
     }
 
     @Test
-    public void testIsPreviousTransactionsFinishedException() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.CheckTxnConflictResponse checkTxnConflict(Cloud.CheckTxnConflictRequest request) {
-                CheckTxnConflictResponse.Builder checkTxnConflictResponseBuilder = CheckTxnConflictResponse.newBuilder();
-                checkTxnConflictResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .setFinished(false);
-                return checkTxnConflictResponseBuilder.build();
-            }
-        };
-        boolean result = masterTransMgr.isPreviousTransactionsFinished(12131231,
-                CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1));
-        Assert.assertEquals(result, false);
+    public void testIsPreviousTransactionsFinishedException() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            CheckTxnConflictResponse response = CheckTxnConflictResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setFinished(false)
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).checkTxnConflict(Mockito.any());
+            boolean result = masterTransMgr.isPreviousTransactionsFinished(12131231,
+                    CatalogTestUtil.testDbId1, Lists.newArrayList(CatalogTestUtil.testTableId1));
+            Assert.assertEquals(result, false);
+        }
     }
 
     @Test
-    public void testGetNextTransactionId() throws UserException {
-        new MockUp<MetaServiceProxy>(MetaServiceProxy.class) {
-            @Mock
-            public Cloud.GetCurrentMaxTxnResponse getCurrentMaxTxnId(Cloud.GetCurrentMaxTxnRequest request) {
-                GetCurrentMaxTxnResponse.Builder getCurrentMaxTxnResponseBuilder = GetCurrentMaxTxnResponse.newBuilder();
-                getCurrentMaxTxnResponseBuilder.setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
-                        .setCode(MetaServiceCode.OK).setMsg("OK"))
-                        .setCurrentMaxTxnId(1000);
-                return getCurrentMaxTxnResponseBuilder.build();
-            }
-        };
-        long result = masterTransMgr.getNextTransactionId();
-        Assert.assertEquals(1000, result);
+    public void testGetNextTransactionId() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            GetCurrentMaxTxnResponse response = GetCurrentMaxTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setCurrentMaxTxnId(1000)
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).getCurrentMaxTxnId(Mockito.any());
+            long result = masterTransMgr.getNextTransactionId();
+            Assert.assertEquals(1000, result);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/SystemInfoServiceTest.java
@@ -37,11 +37,12 @@ import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
@@ -52,18 +53,14 @@ import java.io.IOException;
 
 public class SystemInfoServiceTest {
 
-    @Mocked
-    private EditLog editLog;
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
+    private EditLog editLog = Mockito.mock(EditLog.class);
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
     private SystemInfoService systemInfoService;
     private TabletInvertedIndex invertedIndex;
-    @Mocked
-    private Database db;
-    @Mocked
-    private Table table;
+    private Database db = Mockito.mock(Database.class);
+    private Table table = Mockito.mock(Table.class);
+    private MockedStatic<Env> mockedEnvStatic;
 
 
     private String hostPort;
@@ -72,66 +69,29 @@ public class SystemInfoServiceTest {
 
     @Before
     public void setUp() throws IOException {
-        new Expectations() {
-            {
-                editLog.logAddBackend((Backend) any);
-                minTimes = 0;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
 
-                editLog.logDropBackend((Backend) any);
-                minTimes = 0;
+        Mockito.when(env.getNextId()).thenReturn(backendId);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(db);
+        Mockito.when(db.getTableNullable(Mockito.anyLong())).thenReturn(table);
 
-                editLog.logBackendStateChange((Backend) any);
-                minTimes = 0;
+        systemInfoService = new SystemInfoService();
+        invertedIndex = new LocalTabletInvertedIndex();
 
-                table.readLock();
-                minTimes = 0;
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+        mockedEnvStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
+        mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeConstants.meta_version);
+    }
 
-                table.readUnlock();
-                minTimes = 0;
-
-                env.getNextId();
-                minTimes = 0;
-                result = backendId;
-
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = db;
-
-                db.getTableNullable(anyLong);
-                minTimes = 0;
-                result = table;
-
-                env.clear();
-                minTimes = 0;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                systemInfoService = new SystemInfoService();
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-
-                invertedIndex = new LocalTabletInvertedIndex();
-                Env.getCurrentInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeConstants.meta_version;
-            }
-        };
-
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
     public void mkdir(String dirString) {

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendProcNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendProcNodeTest.java
@@ -26,52 +26,31 @@ import org.apache.doris.system.Backend;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
 public class BackendProcNodeTest {
     private Backend b1;
-    @Mocked
     private Env env;
-    @Mocked
     private EditLog editLog;
+    private MockedStatic<Env> mockedEnv;
 
     @Before
     public void setUp() {
-        new Expectations() {
-            {
-                editLog.logAddBackend((Backend) any);
-                minTimes = 0;
+        env = Mockito.mock(Env.class);
+        editLog = Mockito.mock(EditLog.class);
 
-                editLog.logDropBackend((Backend) any);
-                minTimes = 0;
+        Mockito.when(env.getNextId()).thenReturn(10000L);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-                editLog.logBackendStateChange((Backend) any);
-                minTimes = 0;
-
-                env.getNextId();
-                minTimes = 0;
-                result = 10000L;
-
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-
-        new Expectations(env) {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-            }
-        };
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
         b1 = new Backend(1000, "host1", 10000);
         b1.updateOnce(10001, 10003, 10005);
@@ -83,6 +62,9 @@ public class BackendProcNodeTest {
 
     @After
     public void tearDown() {
+        if (mockedEnv != null) {
+            mockedEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
@@ -25,12 +25,12 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -38,14 +38,11 @@ public class BackendsProcDirTest {
     private Backend b1;
     private Backend b2;
 
-    @Mocked
-    private SystemInfoService systemInfoService;
-    @Mocked
-    private TabletInvertedIndex tabletInvertedIndex;
-    @Mocked
-    private Env env;
-    @Mocked
-    private EditLog editLog;
+    private SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
+    private TabletInvertedIndex tabletInvertedIndex = Mockito.mock(TabletInvertedIndex.class);
+    private Env env = Mockito.mock(Env.class);
+    private EditLog editLog = Mockito.mock(EditLog.class);
+    private MockedStatic<Env> mockedEnvStatic;
 
     @Before
     public void setUp() {
@@ -54,71 +51,24 @@ public class BackendsProcDirTest {
         b2 = new Backend(1001, "host2", 20000);
         b2.updateOnce(20001, 20003, 20005);
 
-        new Expectations() {
-            {
-                editLog.logAddBackend((Backend) any);
-                minTimes = 0;
+        Mockito.when(env.getNextId()).thenReturn(10000L);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(systemInfoService.getBackend(1000)).thenReturn(b1);
+        Mockito.when(systemInfoService.getBackend(1001)).thenReturn(b2);
+        Mockito.when(systemInfoService.getBackend(1002)).thenReturn(null);
+        Mockito.when(tabletInvertedIndex.getTabletNumByBackendId(Mockito.anyLong())).thenReturn(2);
 
-                editLog.logDropBackend((Backend) any);
-                minTimes = 0;
-
-                editLog.logBackendStateChange((Backend) any);
-                minTimes = 0;
-
-                env.getNextId();
-                minTimes = 0;
-                result = 10000L;
-
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                env.clear();
-                minTimes = 0;
-
-                systemInfoService.getBackend(1000);
-                minTimes = 0;
-                result = b1;
-
-                systemInfoService.getBackend(1001);
-                minTimes = 0;
-                result = b2;
-
-                systemInfoService.getBackend(1002);
-                minTimes = 0;
-                result = null;
-
-                tabletInvertedIndex.getTabletNumByBackendId(anyLong);
-                minTimes = 0;
-                result = 2;
-            }
-        };
-
-        new Expectations(env) {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                Env.getCurrentInvertedIndex();
-                minTimes = 0;
-                result = tabletInvertedIndex;
-
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-            }
-        };
-
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentInvertedIndex).thenReturn(tabletInvertedIndex);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
     }
 
     @After
     public void tearDown() {
-        // systemInfoService = null;
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
     @Test
@@ -193,17 +143,8 @@ public class BackendsProcDirTest {
         b1.setLastUpdateMs(System.currentTimeMillis());
         b1.setRunningTasks(10L);
 
-        new Expectations() {
-            {
-                systemInfoService.getAllBackendIds(false);
-                minTimes = 0;
-                result = Lists.newArrayList(1000L);
-
-                systemInfoService.getTabletNumByBackendId(1000L);
-                minTimes = 0;
-                result = 10;
-            }
-        };
+        Mockito.when(systemInfoService.getAllBackendIds(false)).thenReturn(Lists.newArrayList(1000L));
+        Mockito.when(systemInfoService.getTabletNumByBackendId(1000L)).thenReturn(10);
 
         BackendsProcDir dir = new BackendsProcDir(systemInfoService);
         ProcResult result = dir.fetchResult();

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/DbsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/DbsProcDirTest.java
@@ -22,38 +22,28 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.datasource.ExternalCatalog;
-import org.apache.doris.datasource.ExternalDatabase;
-import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergExternalDatabase;
 import org.apache.doris.datasource.iceberg.IcebergHadoopExternalCatalog;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
 public class DbsProcDirTest {
     private Database db1;
     private Database db2;
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
 
-    @Mocked
-    GlobalTransactionMgr transactionMgr;
+    GlobalTransactionMgr transactionMgr = Mockito.mock(GlobalTransactionMgr.class);
 
     // construct test case
     //  catalog
@@ -81,37 +71,13 @@ public class DbsProcDirTest {
 
     @Test(expected = AnalysisException.class)
     public void testLookupNormal() throws AnalysisException {
-        new Expectations(env, catalog) {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getDbNullable("db1");
-                minTimes = 0;
-                result = db1;
-
-                catalog.getDbNullable("db2");
-                minTimes = 0;
-                result = db2;
-
-                catalog.getDbNullable("db3");
-                minTimes = 0;
-                result = null;
-
-                catalog.getDbNullable(db1.getId());
-                minTimes = 0;
-                result = db1;
-
-                catalog.getDbNullable(db2.getId());
-                minTimes = 0;
-                result = db2;
-
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = null;
-            }
-        };
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getDbNullable("db1")).thenReturn(db1);
+        Mockito.when(catalog.getDbNullable("db2")).thenReturn(db2);
+        Mockito.when(catalog.getDbNullable("db3")).thenReturn(null);
+        Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(null);
+        Mockito.when(catalog.getDbNullable(db1.getId())).thenReturn(db1);
+        Mockito.when(catalog.getDbNullable(db2.getId())).thenReturn(db2);
 
         DbsProcDir dir;
         ProcNodeInterface node;
@@ -161,53 +127,17 @@ public class DbsProcDirTest {
 
     @Test
     public void testFetchResultNormal() throws AnalysisException {
-        new Expectations(env, catalog) {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                env.getGlobalTransactionMgr();
-                minTimes = 0;
-                result = transactionMgr;
-
-                transactionMgr.getRunningTxnNums(db1.getId());
-                minTimes = 0;
-                result = 10;
-
-                transactionMgr.getRunningTxnNums(db2.getId());
-                minTimes = 0;
-                result = 20;
-
-                catalog.getDbNames();
-                minTimes = 0;
-                result = Lists.newArrayList("db1", "db2");
-
-                catalog.getDbNullable("db1");
-                minTimes = 0;
-                result = db1;
-
-                catalog.getDbNullable("db2");
-                minTimes = 0;
-                result = db2;
-
-                catalog.getDbNullable("db3");
-                minTimes = 0;
-                result = null;
-
-                catalog.getDbNullable(db1.getId());
-                minTimes = 0;
-                result = db1;
-
-                catalog.getDbNullable(db2.getId());
-                minTimes = 0;
-                result = db2;
-
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = null;
-            }
-        };
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(env.getGlobalTransactionMgr()).thenReturn(transactionMgr);
+        Mockito.when(transactionMgr.getRunningTxnNums(db1.getId())).thenReturn(10);
+        Mockito.when(transactionMgr.getRunningTxnNums(db2.getId())).thenReturn(20);
+        Mockito.when(catalog.getDbNames()).thenReturn(Lists.newArrayList("db1", "db2"));
+        Mockito.when(catalog.getDbNullable("db1")).thenReturn(db1);
+        Mockito.when(catalog.getDbNullable("db2")).thenReturn(db2);
+        Mockito.when(catalog.getDbNullable("db3")).thenReturn(null);
+        Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(null);
+        Mockito.when(catalog.getDbNullable(db1.getId())).thenReturn(db1);
+        Mockito.when(catalog.getDbNullable(db2.getId())).thenReturn(db2);
 
         DbsProcDir dir;
         ProcResult result;
@@ -230,17 +160,8 @@ public class DbsProcDirTest {
 
     @Test
     public void testFetchResultInvalid() throws AnalysisException {
-        new Expectations(env, catalog) {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getDbNames();
-                minTimes = 0;
-                result = null;
-            }
-        };
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getDbNames()).thenReturn(null);
 
         DbsProcDir dir;
         ProcResult result;
@@ -264,27 +185,14 @@ public class DbsProcDirTest {
 
     @Test
     public void testListTableNameFailed() throws AnalysisException {
-        HashMap<String, String> props = new HashMap<>();
-        props.put("warehouse", "file:///tmp");
-        IcebergHadoopExternalCatalog ctlg = new IcebergHadoopExternalCatalog(1, "iceberg", "iceberg", props, null);
-        new MockUp<ExternalCatalog>(ExternalCatalog.class) {
-            @Mock
-            public List<String> getDbNames() {
-                return Lists.newArrayList("db1");
-            }
+        IcebergHadoopExternalCatalog ctlg = Mockito.mock(IcebergHadoopExternalCatalog.class);
+        Mockito.when(ctlg.getDbNames()).thenReturn(Lists.newArrayList("db1"));
 
-            @Mock
-            public ExternalDatabase<? extends ExternalTable> getDbNullable(String dbName) {
-                return new IcebergExternalDatabase(ctlg, 3L, "db1", "db1");
-            }
-        };
+        IcebergExternalDatabase mockDb = Mockito.mock(IcebergExternalDatabase.class);
+        Mockito.when(mockDb.getId()).thenReturn(3L);
+        Mockito.when(mockDb.getTables()).thenThrow(new RuntimeException("list table failed"));
+        Mockito.doReturn(mockDb).when(ctlg).getDbNullable("db1");
 
-        new MockUp<ExternalDatabase>(ExternalDatabase.class) {
-            @Mock
-            public List getTables() {
-                throw new RuntimeException("list table failed");
-            }
-        };
         DbsProcDir dbsProcDir = new DbsProcDir(env, ctlg);
         ProcResult procResult = dbsProcDir.fetchResult();
         List<List<String>> rows = procResult.getRows();

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/AutoProfileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/AutoProfileTest.java
@@ -20,11 +20,11 @@ package org.apache.doris.common.profile;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.thrift.TUniqueId;
 
-import mockit.Expectations;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,17 +53,12 @@ public class AutoProfileTest {
     @Test
     public void testAutoProfile() throws InterruptedException {
         Profile profile = createProfile();
-        SummaryProfile summaryProfile = new SummaryProfile();
+        SummaryProfile summaryProfile = Mockito.spy(new SummaryProfile());
         profile.setSummaryProfile(summaryProfile);
         Map<String, String> summaryInfo = new HashMap<>();
 
-        new Expectations(summaryProfile) {
-            {
-                summaryProfile.update(summaryInfo);
-                summaryProfile.getQueryBeginTime();
-                result = System.currentTimeMillis();
-            }
-        };
+        Mockito.doNothing().when(summaryProfile).update(summaryInfo);
+        Mockito.doReturn(System.currentTimeMillis()).when(summaryProfile).getQueryBeginTime();
         profile.autoProfileDurationMs = 10000;
         Thread.sleep(100);
         profile.updateSummary(summaryInfo, true, null);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileManagerTest.java
@@ -23,7 +23,6 @@ import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,6 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -402,20 +402,11 @@ class ProfileManagerTest {
             TUniqueId queryId = new TUniqueId(taskId.getMostSignificantBits(), taskId.getLeastSignificantBits());
             List<Integer> fragments = new ArrayList<>();
             profile.addExecutionProfile(new ExecutionProfile(queryId, fragments));
+            profile = Mockito.spy(profile);
             if (i % 2 == 0) {
-                new Expectations(profile) {
-                    {
-                        profile.shouldStoreToStorage();
-                        result = true;
-                    }
-                };
+                Mockito.doReturn(true).when(profile).shouldStoreToStorage();
             } else {
-                new Expectations(profile) {
-                    {
-                        profile.shouldStoreToStorage();
-                        result = false;
-                    }
-                };
+                Mockito.doReturn(false).when(profile).shouldStoreToStorage();
             }
             profileManager.pushProfile(profile);
         }
@@ -428,6 +419,7 @@ class ProfileManagerTest {
 
     @Test
     void testWriteProfileToStorage() throws InterruptedException {
+        List<Profile> spyProfiles = new ArrayList<>();
         // Create some test profile files
         for (int i = 0; i < 30; i++) {
             // Sleep 200 ms, so that query finish time is different.
@@ -444,19 +436,19 @@ class ProfileManagerTest {
             }
 
             // Make sure all profile is released
-            new Expectations(profile) {
-                {
-                    profile.shouldStoreToStorage();
-                    result = true;
-                    profile.releaseMemory();
-                    times = 1;
-                }
-            };
+            profile = Mockito.spy(profile);
+            Mockito.doReturn(true).when(profile).shouldStoreToStorage();
+            Mockito.doNothing().when(profile).releaseMemory();
 
+            spyProfiles.add(profile);
             profileManager.pushProfile(profile);
         }
 
         profileManager.writeProfileToStorage();
+
+        for (Profile spy : spyProfiles) {
+            Mockito.verify(spy, Mockito.times(1)).releaseMemory();
+        }
 
         // Verify result
         File[] files = tempDir.listFiles();
@@ -487,12 +479,8 @@ class ProfileManagerTest {
                 for (ExecutionProfile executionProfile : profile.getExecutionProfiles()) {
                     profileManager.addExecutionProfile(executionProfile);
                 }
-                new Expectations(profile) {
-                    {
-                        profile.profileHasBeenStored();
-                        result = true;
-                    }
-                };
+                profile = Mockito.spy(profile);
+                Mockito.doReturn(true).when(profile).profileHasBeenStored();
 
                 profileManager.pushProfile(profile);
             }
@@ -531,21 +519,17 @@ class ProfileManagerTest {
             Config.max_spilled_profile_num = 10;
 
             // Create test profiles
+            List<Profile> spyProfiles = new ArrayList<>();
             for (int i = 0; i < 30; i++) {
                 Thread.sleep(100);
                 Profile profile = ProfilePersistentTest.constructRandomProfile(1);
                 profile.isQueryFinished = true;
                 profile.setQueryFinishTimestamp(System.currentTimeMillis());
-                int finalI = i;
-                new Expectations(profile) {
-                    {
-                        profile.profileHasBeenStored();
-                        result = true;
-                        profile.deleteFromStorage();
-                        times = finalI < 20 ? 1 : 0; // First 20 should be deleted
-                    }
-                };
+                profile = Mockito.spy(profile);
+                Mockito.doReturn(true).when(profile).profileHasBeenStored();
+                Mockito.doNothing().when(profile).deleteFromStorage();
 
+                spyProfiles.add(profile);
                 profileManager.pushProfile(profile);
             }
 
@@ -555,6 +539,9 @@ class ProfileManagerTest {
 
             // Verify correct profiles were deleted
             Assertions.assertEquals(10, profileManager.queryIdToProfileMap.size());
+            for (int j = 0; j < spyProfiles.size(); j++) {
+                Mockito.verify(spyProfiles.get(j), Mockito.times(j < 20 ? 1 : 0)).deleteFromStorage();
+            }
 
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
@@ -874,12 +861,8 @@ class ProfileManagerTest {
                 profile.isQueryFinished = true;
                 profile.setQueryFinishTimestamp(System.currentTimeMillis());
 
-                new Expectations(profile) {
-                    {
-                        profile.profileHasBeenStored();
-                        result = true;
-                    }
-                };
+                profile = Mockito.spy(profile);
+                Mockito.doReturn(true).when(profile).profileHasBeenStored();
 
                 profileManager.pushProfile(profile);
                 profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
@@ -938,22 +921,18 @@ class ProfileManagerTest {
             Config.max_spilled_profile_num = 5;
 
             // Create and store profiles
+            List<Profile> spyProfiles = new ArrayList<>();
             for (int i = 0; i < 10; i++) {
                 Thread.sleep(100);
                 Profile profile = ProfilePersistentTest.constructRandomProfile(1);
                 profile.isQueryFinished = true;
                 profile.setQueryFinishTimestamp(System.currentTimeMillis());
 
-                int finalI = i;
-                new Expectations(profile) {
-                    {
-                        profile.profileHasBeenStored();
-                        result = true;
-                        profile.deleteFromStorage();
-                        times = finalI < 5 ? 1 : 0; // First 5 should be deleted
-                    }
-                };
+                profile = Mockito.spy(profile);
+                Mockito.doReturn(true).when(profile).profileHasBeenStored();
+                Mockito.doNothing().when(profile).deleteFromStorage();
 
+                spyProfiles.add(profile);
                 profileManager.pushProfile(profile);
                 profile.writeToStorage(ProfileManager.PROFILE_STORAGE_PATH);
             }
@@ -961,6 +940,11 @@ class ProfileManagerTest {
             // Trigger cleanup - should directly delete old profiles
             profileManager.isProfileLoaded = true;
             profileManager.deleteOutdatedProfilesFromStorage();
+
+            // Verify delete invocations
+            for (int j = 0; j < spyProfiles.size(); j++) {
+                Mockito.verify(spyProfiles.get(j), Mockito.times(j < 5 ? 1 : 0)).deleteFromStorage();
+            }
 
             // Verify no pending or archive directories were created
             File pendingDir = new File(ProfileManager.PROFILE_STORAGE_PATH + "/pending");

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileTest.java
@@ -22,12 +22,12 @@ import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.SafeStringBuilder;
 import org.apache.doris.thrift.TUniqueId;
 
-import mockit.Expectations;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -96,12 +96,9 @@ public class ProfileTest {
         Assertions.assertFalse(profile.shouldStoreToStorage());
 
 
-        new Expectations(executionProfile) {
-            {
-                executionProfile.isCompleted();
-                result = true;
-            }
-        };
+        executionProfile = Mockito.spy(executionProfile);
+        profile.getExecutionProfiles().set(0, executionProfile);
+        Mockito.doReturn(true).when(executionProfile).isCompleted();
         // Now it should be ready to store
         Assertions.assertTrue(profile.shouldStoreToStorage());
     }
@@ -111,12 +108,9 @@ public class ProfileTest {
         // Prepare for storage
         profile.markQueryFinished();
         profile.setQueryFinishTimestamp(System.currentTimeMillis());
-        new Expectations(executionProfile) {
-            {
-                executionProfile.isCompleted();
-                result = true;
-            }
-        };
+        executionProfile = Mockito.spy(executionProfile);
+        profile.getExecutionProfiles().set(0, executionProfile);
+        Mockito.doReturn(true).when(executionProfile).isCompleted();
 
         // Should be true before we write
         Assertions.assertTrue(profile.shouldStoreToStorage());
@@ -139,12 +133,9 @@ public class ProfileTest {
         profile.setQueryFinishTimestamp(System.currentTimeMillis());
 
         // Mock that execution profile is not completed
-        new Expectations(executionProfile) {
-            {
-                executionProfile.isCompleted();
-                result = false;
-            }
-        };
+        executionProfile = Mockito.spy(executionProfile);
+        profile.getExecutionProfiles().set(0, executionProfile);
+        Mockito.doReturn(false).when(executionProfile).isCompleted();
 
         // Should be false before we write because execution profile isn't complete
         Assertions.assertFalse(profile.shouldStoreToStorage());

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketCalculatorTest.java
@@ -21,32 +21,19 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.util.AutoBucketCalculator.AutoBucketContext;
 import org.apache.doris.common.util.AutoBucketCalculator.AutoBucketResult;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class AutoBucketCalculatorTest {
 
-    @Mocked
-    OlapTable table;
+    OlapTable table = Mockito.mock(OlapTable.class);
 
     @Test
     public void testCalculateAutoBucketsNotAutoBucket() {
-        new Expectations() {
-            {
-                table.isAutoBucket();
-                result = false;
-
-                table.getName();
-                result = "test_table";
-                minTimes = 0;
-
-                table.getId();
-                result = 1L;
-                minTimes = 0;
-            }
-        };
+        Mockito.when(table.isAutoBucket()).thenReturn(false);
+        Mockito.when(table.getName()).thenReturn("test_table");
+        Mockito.when(table.getId()).thenReturn(1L);
 
         AutoBucketContext context = new AutoBucketContext(table, "p1", "p2", false, 10);
         AutoBucketResult result = AutoBucketCalculator.calculateAutoBuckets(context);
@@ -58,20 +45,9 @@ public class AutoBucketCalculatorTest {
 
     @Test
     public void testCalculateAutoBucketsExecuteFirstTime() {
-        new Expectations() {
-            {
-                table.isAutoBucket();
-                result = true;
-
-                table.getName();
-                result = "test_table";
-                minTimes = 0;
-
-                table.getId();
-                result = 1L;
-                minTimes = 0;
-            }
-        };
+        Mockito.when(table.isAutoBucket()).thenReturn(true);
+        Mockito.when(table.getName()).thenReturn("test_table");
+        Mockito.when(table.getId()).thenReturn(1L);
 
         AutoBucketContext context = new AutoBucketContext(table, "p1", "p2", true, 10);
         AutoBucketResult result = AutoBucketCalculator.calculateAutoBuckets(context);
@@ -83,20 +59,9 @@ public class AutoBucketCalculatorTest {
 
     @Test
     public void testCalculateAutoBucketsWithBoundsCheck() {
-        new Expectations() {
-            {
-                table.isAutoBucket();
-                result = false;
-
-                table.getName();
-                result = "test_table";
-                minTimes = 0;
-
-                table.getId();
-                result = 1L;
-                minTimes = 0;
-            }
-        };
+        Mockito.when(table.isAutoBucket()).thenReturn(false);
+        Mockito.when(table.getName()).thenReturn("test_table");
+        Mockito.when(table.getId()).thenReturn(1L);
 
         AutoBucketContext context = new AutoBucketContext(table, "p1", "p2", false, 10);
         int buckets = AutoBucketCalculator.calculateAutoBucketsWithBoundsCheck(context);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
@@ -18,7 +18,6 @@
 package org.apache.doris.common.util;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.persist.EditLog;
@@ -32,13 +31,13 @@ import org.apache.doris.utframe.UtFrameUtils;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -97,34 +96,14 @@ public class AutoBucketUtilsTest {
         be.updateDisks(backendDisks);
     }
 
-    private void expectations(Env env, EditLog editLog, SystemInfoService systemInfoService,
-            ImmutableMap<Long, Backend> backends) throws AnalysisException {
-        new Expectations() {
-            {
-                Env.getServingEnv();
-                minTimes = 0;
-                result = env;
+    private void expectations(MockedStatic<Env> mockedEnv, Env env, EditLog editLog,
+            SystemInfoService systemInfoService, ImmutableMap<Long, Backend> backends) throws Exception {
+        mockedEnv.when(Env::getServingEnv).thenReturn(env);
+        mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-
-                systemInfoService.getAllBackendsByAllCluster();
-                minTimes = 0;
-                result = backends;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                editLog.logBackendStateChange((Backend) any);
-                minTimes = 0;
-            }
-        };
+        Mockito.doReturn(backends).when(systemInfoService).getAllBackendsByAllCluster();
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
     }
 
     @Before
@@ -139,7 +118,11 @@ public class AutoBucketUtilsTest {
 
     @After
     public void tearDown() {
-        Env.getCurrentEnv().clear();
+        try {
+            Env.getCurrentEnv().clear();
+        } catch (Exception e) {
+            // ignore when env is not mocked
+        }
         UtFrameUtils.cleanDorisFeDir(runningDirBase);
     }
 
@@ -177,103 +160,143 @@ public class AutoBucketUtilsTest {
 
     @Ignore
     @Test
-    public void test100MB(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test100MB() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = AutoBucketUtils.SIZE_100MB;
         ImmutableMap<Long, Backend> backends = createBackends(10, 3, 2000000000);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(1, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(1, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test500MB(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test500MB() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = 5 * AutoBucketUtils.SIZE_100MB;
         ImmutableMap<Long, Backend> backends = createBackends(10, 3, 2000000000);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(1, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(1, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test1G(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test1G() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = AutoBucketUtils.SIZE_1GB;
         ImmutableMap<Long, Backend> backends = createBackends(3, 2, 500 * AutoBucketUtils.SIZE_1GB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(2, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(2, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test100G(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test100G() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = 100 * AutoBucketUtils.SIZE_1GB;
         ImmutableMap<Long, Backend> backends = createBackends(3, 2, 500 * AutoBucketUtils.SIZE_1GB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(20, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(20, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test500G_0(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test500G_0() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = 500 * AutoBucketUtils.SIZE_1GB;
         ImmutableMap<Long, Backend> backends = createBackends(3, 1, AutoBucketUtils.SIZE_1TB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(63, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(63, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test500G_1(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test500G_1() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = 500 * AutoBucketUtils.SIZE_1GB;
         ImmutableMap<Long, Backend> backends = createBackends(10, 3, 2 * AutoBucketUtils.SIZE_1TB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(100, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(100, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test500G_2(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test500G_2() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = 500 * AutoBucketUtils.SIZE_1GB;
         ImmutableMap<Long, Backend> backends = createBackends(1, 1, 100 * AutoBucketUtils.SIZE_1TB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(100, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(100, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test1T_0(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test1T_0() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = AutoBucketUtils.SIZE_1TB;
         ImmutableMap<Long, Backend> backends = createBackends(10, 3, 2 * AutoBucketUtils.SIZE_1TB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(128, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(128, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test1T_1(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test1T_1() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         long estimatePartitionSize = AutoBucketUtils.SIZE_1TB;
         ImmutableMap<Long, Backend> backends = createBackends(200, 7, 4 * AutoBucketUtils.SIZE_1TB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(128, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(128, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 
     @Ignore
     @Test
-    public void test1T_1_In_Cloud(@Mocked Env env, @Mocked EditLog editLog, @Mocked SystemInfoService systemInfoService)
-            throws Exception {
+    public void test1T_1_In_Cloud() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
         Config.autobucket_partition_size_per_bucket_gb = 5;
         Config.cloud_unique_id = "cloud_mode";
         long estimatePartitionSize = AutoBucketUtils.SIZE_1TB;
         ImmutableMap<Long, Backend> backends = createBackends(10, 7, 4 * AutoBucketUtils.SIZE_1TB);
-        expectations(env, editLog, systemInfoService, backends);
-        Assert.assertEquals(41, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            expectations(mockedEnv, env, editLog, systemInfoService, backends);
+            Assert.assertEquals(41, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -25,11 +25,12 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.FeConstants;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
@@ -41,19 +42,20 @@ import java.util.TimeZone;
 
 public class TimeUtilsTest {
 
-    @Mocked
-    TimeUtils timeUtils;
+    private MockedStatic<TimeUtils> mockedTimeUtils;
 
     @Before
     public void setUp() {
         TimeZone tz = TimeZone.getTimeZone(ZoneId.of("Asia/Shanghai"));
-        new Expectations(timeUtils) {
-            {
-                TimeUtils.getTimeZone();
-                minTimes = 0;
-                result = tz;
-            }
-        };
+        mockedTimeUtils = Mockito.mockStatic(TimeUtils.class, Mockito.CALLS_REAL_METHODS);
+        mockedTimeUtils.when(TimeUtils::getTimeZone).thenReturn(tz);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedTimeUtils != null) {
+            mockedTimeUtils.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalEqualsTest.java
@@ -21,15 +21,13 @@ import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalDatabase;
 import org.apache.doris.datasource.test.TestExternalTable;
 
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class ExternalEqualsTest {
-    @Mocked
-    private TestExternalCatalog ctl1;
-    @Mocked
-    private TestExternalCatalog ctl2;
+    private TestExternalCatalog ctl1 = Mockito.mock(TestExternalCatalog.class);
+    private TestExternalCatalog ctl2 = Mockito.mock(TestExternalCatalog.class);
 
     @Test
     public void testEquals() {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalMetaCacheRouteResolverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalMetaCacheRouteResolverTest.java
@@ -29,10 +29,11 @@ import org.apache.doris.datasource.metacache.MetaCacheEntry;
 import org.apache.doris.datasource.metacache.MetaCacheEntryStats;
 import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
 
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +43,16 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ExternalMetaCacheRouteResolverTest {
+
+    private MockedStatic<Env> envMockedStatic;
+
+    @After
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+            envMockedStatic = null;
+        }
+    }
 
     @Test
     public void testEngineAliasCompatibility() {
@@ -217,14 +228,13 @@ public class ExternalMetaCacheRouteResolverTest {
 
     private void mockCurrentCatalog(long catalogId,
             CatalogIf<? extends DatabaseIf<? extends TableIf>> catalog) {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
         CatalogMgr catalogMgr = new TestingCatalogMgr(catalogId, catalog);
         Env env = new TestingEnv(catalogMgr);
-        new MockUp<Env>() {
-            @Mock
-            Env getCurrentEnv() {
-                return env;
-            }
-        };
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
     }
 
     private static final class TestingCatalogMgr extends CatalogMgr {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
@@ -20,14 +20,15 @@ package org.apache.doris.datasource;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.ThreadPoolManager;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 import java.util.Optional;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ExternalRowCountCacheTest {
     @Test
@@ -35,48 +36,51 @@ public class ExternalRowCountCacheTest {
         ThreadPoolExecutor executor = ThreadPoolManager.newDaemonFixedThreadPool(
                 1, Integer.MAX_VALUE, "TEST", true);
         AtomicInteger counter = new AtomicInteger(0);
+        AtomicReference<ExternalRowCountCache.RowCountCacheLoader> loaderRef = new AtomicReference<>();
 
-        new MockUp<ExternalRowCountCache.RowCountCacheLoader>() {
-            @Mock
-            protected Optional<Long> doLoad(ExternalRowCountCache.RowCountKey rowCountKey) {
-                counter.incrementAndGet();
-                return null;
-            }
-        };
-        ExternalRowCountCache cache = new ExternalRowCountCache(executor);
-        long cachedRowCount = cache.getCachedRowCount(1, 1, 1);
-        Assertions.assertEquals(TableIf.UNKNOWN_ROW_COUNT, cachedRowCount);
-        for (int i = 0; i < 60; i++) {
-            if (counter.get() == 1) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
-        Assertions.assertEquals(1, counter.get());
+        try (MockedConstruction<ExternalRowCountCache.RowCountCacheLoader> mocked =
+                Mockito.mockConstruction(ExternalRowCountCache.RowCountCacheLoader.class,
+                        Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                        (mock, context) -> {
+                            loaderRef.set(mock);
+                            Mockito.doAnswer(inv -> {
+                                counter.incrementAndGet();
+                                return null;
+                            }).when(mock).doLoad(Mockito.any());
+                        })) {
 
-        new MockUp<ExternalRowCountCache.RowCountCacheLoader>() {
-            @Mock
-            protected Optional<Long> doLoad(ExternalRowCountCache.RowCountKey rowCountKey) {
+            ExternalRowCountCache cache = new ExternalRowCountCache(executor);
+            long cachedRowCount = cache.getCachedRowCount(1, 1, 1);
+            Assertions.assertEquals(TableIf.UNKNOWN_ROW_COUNT, cachedRowCount);
+            for (int i = 0; i < 60; i++) {
+                if (counter.get() == 1) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+            Assertions.assertEquals(1, counter.get());
+
+            // Re-stub for second behavior
+            Mockito.doAnswer(inv -> {
                 counter.incrementAndGet();
                 return Optional.of(100L);
-            }
-        };
-        cache.getCachedRowCount(1, 1, 1);
-        for (int i = 0; i < 60; i++) {
-            cachedRowCount = cache.getCachedRowCount(1, 1, 1);
-            if (cachedRowCount != TableIf.UNKNOWN_ROW_COUNT) {
-                Assertions.assertEquals(100, cachedRowCount);
-                break;
-            }
-            Thread.sleep(1000);
-        }
-        cachedRowCount = cache.getCachedRowCount(1, 1, 1);
-        Assertions.assertEquals(100, cachedRowCount);
-        Assertions.assertEquals(2, counter.get());
+            }).when(loaderRef.get()).doLoad(Mockito.any());
 
-        new MockUp<ExternalRowCountCache.RowCountCacheLoader>() {
-            @Mock
-            protected Optional<Long> doLoad(ExternalRowCountCache.RowCountKey rowCountKey) {
+            cache.getCachedRowCount(1, 1, 1);
+            for (int i = 0; i < 60; i++) {
+                cachedRowCount = cache.getCachedRowCount(1, 1, 1);
+                if (cachedRowCount != TableIf.UNKNOWN_ROW_COUNT) {
+                    Assertions.assertEquals(100, cachedRowCount);
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+            cachedRowCount = cache.getCachedRowCount(1, 1, 1);
+            Assertions.assertEquals(100, cachedRowCount);
+            Assertions.assertEquals(2, counter.get());
+
+            // Re-stub for third behavior
+            Mockito.doAnswer(inv -> {
                 counter.incrementAndGet();
                 try {
                     Thread.sleep(2000);
@@ -84,19 +88,20 @@ public class ExternalRowCountCacheTest {
                     e.printStackTrace();
                 }
                 return Optional.of(100L);
-            }
-        };
-        cachedRowCount = cache.getCachedRowCount(2, 2, 2);
-        Assertions.assertEquals(100, cachedRowCount);
-        Thread.sleep(1000);
-        cachedRowCount = cache.getCachedRowCount(2, 2, 2);
-        Assertions.assertEquals(100, cachedRowCount);
-        for (int i = 0; i < 60; i++) {
-            if (counter.get() == 3) {
-                break;
-            }
+            }).when(loaderRef.get()).doLoad(Mockito.any());
+
+            cachedRowCount = cache.getCachedRowCount(2, 2, 2);
+            Assertions.assertEquals(100, cachedRowCount);
             Thread.sleep(1000);
+            cachedRowCount = cache.getCachedRowCount(2, 2, 2);
+            Assertions.assertEquals(100, cachedRowCount);
+            for (int i = 0; i < 60; i++) {
+                if (counter.get() == 3) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+            Assertions.assertEquals(3, counter.get());
         }
-        Assertions.assertEquals(3, counter.get());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/SplitAssignmentTest.java
@@ -24,13 +24,10 @@ import org.apache.doris.thrift.TScanRangeLocations;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,22 +41,16 @@ import java.util.concurrent.TimeUnit;
 
 public class SplitAssignmentTest {
 
-    @Injectable
     private FederationBackendPolicy mockBackendPolicy;
 
-    @Injectable
     private SplitGenerator mockSplitGenerator;
 
-    @Injectable
     private SplitToScanRange mockSplitToScanRange;
 
-    @Mocked
     private Split mockSplit;
 
-    @Mocked
     private Backend mockBackend;
 
-    @Mocked
     private TScanRangeLocations mockScanRangeLocations;
 
     private SplitAssignment splitAssignment;
@@ -68,6 +59,13 @@ public class SplitAssignmentTest {
 
     @BeforeEach
     void setUp() {
+        mockBackendPolicy = Mockito.mock(FederationBackendPolicy.class);
+        mockSplitGenerator = Mockito.mock(SplitGenerator.class);
+        mockSplitToScanRange = Mockito.mock(SplitToScanRange.class);
+        mockSplit = Mockito.mock(Split.class);
+        mockBackend = Mockito.mock(Backend.class);
+        mockScanRangeLocations = Mockito.mock(TScanRangeLocations.class);
+
         locationProperties = new HashMap<>();
         pathPartitionKeys = new ArrayList<>();
 
@@ -88,16 +86,9 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {
-            {
-                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-                result = batch;
-
-                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys,
-                        true);
-                result = mockScanRangeLocations;
-            }
-        };
+        Mockito.when(mockBackendPolicy.computeScanRangeAssignment(Mockito.any())).thenReturn(batch);
+        Mockito.when(mockSplitToScanRange.getScanRange(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean())).thenReturn(mockScanRangeLocations);
 
         // Start a thread to simulate split generation after a short delay
         Thread splitGeneratorThread = new Thread(() -> {
@@ -123,23 +114,18 @@ public class SplitAssignmentTest {
 
     @Test
     void testInitTimeout() throws Exception {
-        // Use MockUp to simulate timeout behavior quickly instead of waiting 30 seconds
-        SplitAssignment testAssignment = new SplitAssignment(
+        // Use spy to simulate timeout behavior quickly instead of waiting 30 seconds
+        SplitAssignment testAssignment = Mockito.spy(new SplitAssignment(
                 mockBackendPolicy,
                 mockSplitGenerator,
                 mockSplitToScanRange,
                 locationProperties,
                 pathPartitionKeys,
                 true
-        );
+        ));
 
-        new MockUp<SplitAssignment>() {
-            @mockit.Mock
-            public void init() throws UserException {
-                // Directly throw timeout exception to simulate the timeout scenario quickly
-                throw new UserException("Failed to get first split after waiting for 0 seconds.");
-            }
-        };
+        Mockito.doThrow(new UserException("Failed to get first split after waiting for 0 seconds."))
+                .when(testAssignment).init();
 
         // Test & Verify - should timeout immediately now
         UserException exception = Assertions.assertThrows(UserException.class, () -> testAssignment.init());
@@ -194,16 +180,9 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {
-            {
-                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-                result = batch;
-
-                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys,
-                        true);
-                result = mockScanRangeLocations;
-            }
-        };
+        Mockito.when(mockBackendPolicy.computeScanRangeAssignment(Mockito.any())).thenReturn(batch);
+        Mockito.when(mockSplitToScanRange.getScanRange(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean())).thenReturn(mockScanRangeLocations);
 
         // Mock setup
         List<Split> splits = Collections.singletonList(mockSplit);
@@ -224,18 +203,9 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {
-            {
-                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-                result = batch;
-                minTimes = 0;
-
-                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys,
-                        true);
-                result = mockScanRangeLocations;
-                minTimes = 0;
-            }
-        };
+        Mockito.when(mockBackendPolicy.computeScanRangeAssignment(Mockito.any())).thenReturn(batch);
+        Mockito.when(mockSplitToScanRange.getScanRange(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean())).thenReturn(mockScanRangeLocations);
 
         // Setup: First call to set sample split
         List<Split> firstSplits = Collections.singletonList(mockSplit);
@@ -257,16 +227,9 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {
-            {
-                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-                result = batch;
-
-                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys,
-                        true);
-                result = mockScanRangeLocations;
-            }
-        };
+        Mockito.when(mockBackendPolicy.computeScanRangeAssignment(Mockito.any())).thenReturn(batch);
+        Mockito.when(mockSplitToScanRange.getScanRange(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean())).thenReturn(mockScanRangeLocations);
 
         // This test simulates a scenario where appendBatch might experience queue blocking
         // by adding multiple batches rapidly
@@ -288,16 +251,9 @@ public class SplitAssignmentTest {
         Multimap<Backend, Split> batch = ArrayListMultimap.create();
         batch.put(mockBackend, mockSplit);
 
-        new Expectations() {
-            {
-                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-                result = batch;
-
-                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys,
-                        true);
-                result = mockScanRangeLocations;
-            }
-        };
+        Mockito.when(mockBackendPolicy.computeScanRangeAssignment(Mockito.any())).thenReturn(batch);
+        Mockito.when(mockSplitToScanRange.getScanRange(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean())).thenReturn(mockScanRangeLocations);
 
         // Test concurrent access to addToQueue method
         List<Split> splits = Collections.singletonList(mockSplit);
@@ -338,19 +294,12 @@ public class SplitAssignmentTest {
 
     @Test
     void testInitAndAddToQueueIntegration() throws Exception {
-        new Expectations() {
-            {
-                Multimap<Backend, Split> batch = ArrayListMultimap.create();
-                batch.put(mockBackend, mockSplit);
+        Multimap<Backend, Split> batch = ArrayListMultimap.create();
+        batch.put(mockBackend, mockSplit);
 
-                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-                result = batch;
-
-                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys,
-                        true);
-                result = mockScanRangeLocations;
-            }
-        };
+        Mockito.when(mockBackendPolicy.computeScanRangeAssignment(Mockito.any())).thenReturn(batch);
+        Mockito.when(mockSplitToScanRange.getScanRange(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean())).thenReturn(mockScanRangeLocations);
 
         List<Split> splits = Collections.singletonList(mockSplit);
 
@@ -383,19 +332,12 @@ public class SplitAssignmentTest {
 
     @Test
     void testAppendBatchTimeoutBehavior() throws Exception {
-        new Expectations() {
-            {
-                Multimap<Backend, Split> batch = ArrayListMultimap.create();
-                batch.put(mockBackend, mockSplit);
+        Multimap<Backend, Split> batch = ArrayListMultimap.create();
+        batch.put(mockBackend, mockSplit);
 
-                mockBackendPolicy.computeScanRangeAssignment((List<Split>) any);
-                result = batch;
-
-                mockSplitToScanRange.getScanRange(mockBackend, locationProperties, mockSplit, pathPartitionKeys,
-                        true);
-                result = mockScanRangeLocations;
-            }
-        };
+        Mockito.when(mockBackendPolicy.computeScanRangeAssignment(Mockito.any())).thenReturn(batch);
+        Mockito.when(mockSplitToScanRange.getScanRange(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean())).thenReturn(mockScanRangeLocations);
 
         // This test verifies that appendBatch properly handles queue offer timeouts
         // We'll simulate this by first filling the assignment and then trying to add more

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSExternalTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HMSExternalTableTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.doris.datasource.hive;
 
-import mockit.Injectable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 
 /**
@@ -37,8 +37,7 @@ public class HMSExternalTableTest {
     // Expected SQL query after decoding and parsing
     private static final String EXPECTED_SQL = "SELECT\n  department\n, length(department) department_length\n, date_trunc('year', hire_date) year\nFROM\n  employees\n";
 
-    @Injectable
-    private HMSExternalCatalog mockCatalog;
+    private HMSExternalCatalog mockCatalog = Mockito.mock(HMSExternalCatalog.class);
 
     private HMSExternalDatabase mockDb;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveDDLAndDMLPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HiveDDLAndDMLPlanTest.java
@@ -25,9 +25,8 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.DatabaseMetadata;
-import org.apache.doris.datasource.ExternalDatabase;
-import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.TableMetadata;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
@@ -54,15 +53,14 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -77,14 +75,17 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
     private static final String mockedDbName = "mockedDb";
     private final NereidsParser nereidsParser = new NereidsParser();
 
-    @Mocked
-    private ThriftHMSCachedClient mockedHiveClient;
+    private MockedConstruction<ThriftHMSCachedClient> mockedClientConstruction;
+    private HMSExternalCatalog hmsExternalCatalog;
 
     private List<FieldSchema> checkedHiveCols;
 
     private final Set<String> createdDbs = new HashSet<>();
 
     private final Set<Table> createdTables = new HashSet<>();
+
+    private volatile List<Column> mockTableSchema;
+    private volatile Set<String> mockTablePartNames;
 
     @Override
     protected void runBeforeAll() throws Exception {
@@ -113,12 +114,76 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
                 + "  'replication_num' = '1')";
         createTable(createSourceInterPTable, true);
 
+        // Set up MockedConstruction for ThriftHMSCachedClient before catalog creation
+        mockedClientConstruction = Mockito.mockConstruction(ThriftHMSCachedClient.class,
+            (mock, context) -> {
+                Mockito.doAnswer(inv -> {
+                    DatabaseMetadata db = inv.getArgument(0);
+                    if (db instanceof HiveDatabaseMetadata) {
+                        Database hiveDb = HiveUtil.toHiveDatabase((HiveDatabaseMetadata) db);
+                        createdDbs.add(hiveDb.getName());
+                    }
+                    return null;
+                }).when(mock).createDatabase(Mockito.any(DatabaseMetadata.class));
+
+                Mockito.doAnswer(inv -> {
+                    String dbName = inv.getArgument(0);
+                    if (createdDbs.contains(dbName)) {
+                        return new Database(dbName, "", "", null);
+                    }
+                    return null;
+                }).when(mock).getDatabase(Mockito.anyString());
+
+                Mockito.doAnswer(inv -> {
+                    String dbName = inv.getArgument(0);
+                    String tblName = inv.getArgument(1);
+                    for (Table table : createdTables) {
+                        if (table.getDbName().equals(dbName) && table.getTableName().equals(tblName)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }).when(mock).tableExists(Mockito.anyString(), Mockito.anyString());
+
+                Mockito.doAnswer(inv -> new ArrayList<>(createdDbs))
+                    .when(mock).getAllDatabases();
+
+                Mockito.doAnswer(inv -> {
+                    TableMetadata tbl = inv.getArgument(0);
+                    if (tbl instanceof HiveTableMetadata) {
+                        Table table = HiveUtil.toHiveTable((HiveTableMetadata) tbl);
+                        createdTables.add(table);
+                        if (checkedHiveCols != null) {
+                            List<FieldSchema> fieldSchemas = table.getSd().getCols();
+                            Assertions.assertEquals(checkedHiveCols.size(), fieldSchemas.size());
+                            for (int i = 0; i < checkedHiveCols.size(); i++) {
+                                FieldSchema checkedCol = checkedHiveCols.get(i);
+                                FieldSchema actualCol = fieldSchemas.get(i);
+                                Assertions.assertEquals(checkedCol.getName(), actualCol.getName().toLowerCase());
+                                Assertions.assertEquals(checkedCol.getType(), actualCol.getType().toLowerCase());
+                            }
+                        }
+                    }
+                    return null;
+                }).when(mock).createTable(Mockito.any(TableMetadata.class), Mockito.anyBoolean());
+
+                Mockito.doAnswer(inv -> {
+                    String dbName = inv.getArgument(0);
+                    String tblName = inv.getArgument(1);
+                    for (Table createdTable : createdTables) {
+                        if (createdTable.getDbName().equals(dbName) && createdTable.getTableName().equals(tblName)) {
+                            return createdTable;
+                        }
+                    }
+                    return null;
+                }).when(mock).getTable(Mockito.anyString(), Mockito.anyString());
+            });
+
         // create external catalog and switch it
         String hiveCatalog = "create catalog " + mockedCtlName
                 + " properties('type' = 'hms',"
                 + " 'hive.metastore.uris' = 'thrift://192.168.0.1:9083');";
 
-        NereidsParser nereidsParser = new NereidsParser();
         LogicalPlan logicalPlan = nereidsParser.parseSingle(hiveCatalog);
         if (logicalPlan instanceof CreateCatalogCommand) {
             ((CreateCatalogCommand) logicalPlan).run(connectContext, null);
@@ -128,68 +193,6 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
         // create db and use it
         Map<String, String> dbProps = new HashMap<>();
         dbProps.put(HiveMetadataOps.LOCATION_URI_KEY, "file://loc/db");
-        new MockUp<ThriftHMSCachedClient>(ThriftHMSCachedClient.class) {
-            @Mock
-            public void createDatabase(DatabaseMetadata db) {
-                if (db instanceof HiveDatabaseMetadata) {
-                    Database hiveDb = HiveUtil.toHiveDatabase((HiveDatabaseMetadata) db);
-                    createdDbs.add(hiveDb.getName());
-                }
-            }
-
-            @Mock
-            public Database getDatabase(String dbName) {
-                if (createdDbs.contains(dbName)) {
-                    return new Database(dbName, "", "", null);
-                }
-                return null;
-            }
-
-            @Mock
-            public boolean tableExists(String dbName, String tblName) {
-                for (Table table : createdTables) {
-                    if (table.getDbName().equals(dbName) && table.getTableName().equals(tblName)) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            @Mock
-            public List<String> getAllDatabases() {
-                return new ArrayList<>(createdDbs);
-            }
-
-            @Mock
-            public void createTable(TableMetadata tbl, boolean ignoreIfExists) {
-                if (tbl instanceof HiveTableMetadata) {
-                    Table table = HiveUtil.toHiveTable((HiveTableMetadata) tbl);
-                    createdTables.add(table);
-                    if (checkedHiveCols == null) {
-                        // if checkedHiveCols is null, skip column check
-                        return;
-                    }
-                    List<FieldSchema> fieldSchemas = table.getSd().getCols();
-                    Assertions.assertEquals(checkedHiveCols.size(), fieldSchemas.size());
-                    for (int i = 0; i < checkedHiveCols.size(); i++) {
-                        FieldSchema checkedCol = checkedHiveCols.get(i);
-                        FieldSchema actualCol = fieldSchemas.get(i);
-                        Assertions.assertEquals(checkedCol.getName(), actualCol.getName().toLowerCase());
-                        Assertions.assertEquals(checkedCol.getType(), actualCol.getType().toLowerCase());
-                    }
-                }
-            }
-
-            @Mock
-            public Table getTable(String dbName, String tblName) {
-                for (Table createdTable : createdTables) {
-                    if (createdTable.getDbName().equals(dbName) && createdTable.getTableName().equals(tblName)) {
-                        return createdTable;
-                    }
-                }
-                return null;
-            }
-        };
         CreateDatabaseCommand command = new CreateDatabaseCommand(true, new DbName("hive", mockedDbName), dbProps);
         Env.getCurrentEnv().createDb(command);
         // checkout ifNotExists
@@ -217,33 +220,46 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
                 + "  'file_format'='orc')";
         createTable(createSourceExtTable, true);
 
-        HMSExternalCatalog hmsExternalCatalog = (HMSExternalCatalog) Env.getCurrentEnv().getCatalogMgr()
+        hmsExternalCatalog = (HMSExternalCatalog) Env.getCurrentEnv().getCatalogMgr()
                 .getCatalog(mockedCtlName);
-        new MockUp<HMSExternalCatalog>(HMSExternalCatalog.class) {
-            // mock after ThriftHMSCachedClient is mocked
-            @Mock
-            public ExternalDatabase<? extends ExternalTable> getDbNullable(String dbName) {
-                if (createdDbs.contains(dbName)) {
-                    return new HMSExternalDatabase(hmsExternalCatalog, RandomUtils.nextLong(), dbName, dbName);
-                }
-                return null;
-            }
-        };
-        new MockUp<HMSExternalDatabase>(HMSExternalDatabase.class) {
-            // mock after ThriftHMSCachedClient is mocked
-            @Mock
-            HMSExternalTable getTableNullable(String tableName) {
-                for (Table table : createdTables) {
-                    if (table.getTableName().equals(tableName)) {
-                        return new HMSExternalTable(0, tableName, tableName, hmsExternalCatalog, (HMSExternalDatabase) hmsExternalCatalog.getDbNullable(mockedDbName));
+        // Spy on the catalog to override getDbNullable
+        HMSExternalCatalog spyCatalog = Mockito.spy(hmsExternalCatalog);
+        Mockito.doAnswer(inv -> {
+            String dbName = inv.getArgument(0);
+            if (createdDbs.contains(dbName)) {
+                // Create a real HMSExternalDatabase and spy on it
+                HMSExternalDatabase realDb = new HMSExternalDatabase(spyCatalog, RandomUtils.nextLong(), dbName, dbName);
+                HMSExternalDatabase spyDb = Mockito.spy(realDb);
+                Mockito.doAnswer(inv2 -> {
+                    String tableName = inv2.getArgument(0);
+                    for (Table table : createdTables) {
+                        if (table.getTableName().equals(tableName)) {
+                            // Create a real HMSExternalTable and spy on it
+                            HMSExternalTable realTable = new HMSExternalTable(0, tableName, tableName,
+                                    spyCatalog, spyDb);
+                            HMSExternalTable spyTable = Mockito.spy(realTable);
+                            if (mockTableSchema != null) {
+                                Mockito.doReturn(false).when(spyTable).isView();
+                                Mockito.doReturn(mockTableSchema).when(spyTable).getFullSchema();
+                                Mockito.doReturn(mockTablePartNames != null ? mockTablePartNames : new HashSet<>())
+                                        .when(spyTable).getPartitionColumnNames();
+                            }
+                            return spyTable;
+                        }
                     }
-                }
-                return null;
+                    return null;
+                }).when(spyDb).getTableNullable(Mockito.anyString());
+                return spyDb;
             }
-        };
-        new MockUp<HMSExternalTable>(HMSExternalTable.class) {
-            // mock after ThriftHMSCachedClient is mocked
-        };
+            return null;
+        }).when(spyCatalog).getDbNullable(Mockito.anyString());
+        // Replace catalog in CatalogMgr with the spy
+        @SuppressWarnings("unchecked")
+        Map<String, CatalogIf> nameMap = (Map<String, CatalogIf>)
+                org.apache.doris.common.jmockit.Deencapsulation.getField(
+                        Env.getCurrentEnv().getCatalogMgr(), "nameToCatalog");
+        nameMap.put(mockedCtlName, spyCatalog);
+        hmsExternalCatalog = spyCatalog;
     }
 
     private void switchHive() throws Exception {
@@ -261,8 +277,8 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
         switchHive();
         String dropDbStmtStr = "DROP DATABASE IF EXISTS " + mockedDbName;
 
-        NereidsParser nereidsParser = new NereidsParser();
-        LogicalPlan logicalPlan = nereidsParser.parseSingle(dropDbStmtStr);
+        NereidsParser parser = new NereidsParser();
+        LogicalPlan logicalPlan = parser.parseSingle(dropDbStmtStr);
         if (logicalPlan instanceof DropDatabaseCommand) {
             ((DropDatabaseCommand) logicalPlan).run(connectContext, null);
         }
@@ -275,6 +291,10 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
                 dropDatabaseInfo.getDatabaseName(),
                 dropDatabaseInfo.isIfExists(),
                 dropDatabaseInfo.isForce());
+
+        if (mockedClientConstruction != null) {
+            mockedClientConstruction.close();
+        }
     }
 
     @Test
@@ -489,23 +509,9 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
         Assertions.assertEquals(16, createTableInfo.getDistributionDesc().getBuckets());
     }
 
-    private static void mockTargetTable(List<Column> schema, Set<String> partNames) {
-        new MockUp<HMSExternalTable>(HMSExternalTable.class) {
-            @Mock
-            public boolean isView() {
-                return false;
-            }
-
-            @Mock
-            public List<Column> getFullSchema() {
-                return schema;
-            }
-
-            @Mock
-            public Set<String> getPartitionColumnNames() {
-                return partNames;
-            }
-        };
+    private void mockTargetTable(List<Column> schema, Set<String> partNames) {
+        mockTableSchema = schema;
+        mockTablePartNames = partNames;
     }
 
     @Test
@@ -692,7 +698,6 @@ public class HiveDDLAndDMLPlanTest extends TestWithFeService {
         columns = ((CreateTableCommand) plan).getCreateTableInfo().getColumns();
         Assertions.assertEquals(4, columns.size());
         dropTableWithSql("drop table complex_type_struct");
-
 
         String compoundTypeTable1 = "CREATE TABLE complex_type_compound1(\n"
                 + "  `col1` ARRAY<MAP<string,double>> COMMENT 'col1',\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hive/HmsCommitTest.java
@@ -35,8 +35,6 @@ import org.apache.doris.thrift.TUpdateMode;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -46,8 +44,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -58,10 +59,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 public class HmsCommitTest {
 
@@ -79,6 +81,8 @@ public class HmsCommitTest {
     static String uri = "thrift://127.0.0.1:9083";
     static boolean hasRealHmsService = false;
     private ConnectContext connectContext;
+    private final List<AutoCloseable> mockedConstructions = new ArrayList<>();
+    private Consumer<HMSTransaction> transactionSpySetup;
 
     @BeforeClass
     public static void beforeClass() throws Throwable {
@@ -156,6 +160,15 @@ public class HmsCommitTest {
     public void after() {
         hmsClient.dropTable(dbName, tbWithoutPartition);
         hmsClient.dropTable(dbName, tbWithPartition);
+        for (AutoCloseable mc : mockedConstructions) {
+            try {
+                mc.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        mockedConstructions.clear();
+        transactionSpySetup = null;
     }
 
     @Test
@@ -172,25 +185,30 @@ public class HmsCommitTest {
         pus.add(createRandomAppend(null));
         pus.add(createRandomAppend(null));
         pus.add(createRandomAppend(null));
-        new MockUp<HMSTransaction.HmsCommitter>(HMSTransaction.HmsCommitter.class) {
-            @Mock
-            private void doNothing() {
-                Assert.assertFalse(fsExists(getWritePath()));
-            }
-        };
-        commit(dbName, tbWithoutPartition, pus);
-        Table table = hmsClient.getTable(dbName, tbWithoutPartition);
-        assertNumRows(3, table);
+        try (MockedConstruction<HMSTransaction.HmsCommitter> mocked = Mockito.mockConstruction(
+                HMSTransaction.HmsCommitter.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    initHmsCommitterFields(mock, context);
+                    Mockito.doAnswer(inv -> {
+                        Assert.assertFalse(fsExists(getWritePath()));
+                        return null;
+                    }).when(mock).doNothing();
+                })) {
+            commit(dbName, tbWithoutPartition, pus);
+            Table table = hmsClient.getTable(dbName, tbWithoutPartition);
+            assertNumRows(3, table);
 
 
-        genQueryID();
-        List<THivePartitionUpdate> pus2 = new ArrayList<>();
-        pus2.add(createRandomAppend(null));
-        pus2.add(createRandomAppend(null));
-        pus2.add(createRandomAppend(null));
-        commit(dbName, tbWithoutPartition, pus2);
-        table = hmsClient.getTable(dbName, tbWithoutPartition);
-        assertNumRows(6, table);
+            genQueryID();
+            List<THivePartitionUpdate> pus2 = new ArrayList<>();
+            pus2.add(createRandomAppend(null));
+            pus2.add(createRandomAppend(null));
+            pus2.add(createRandomAppend(null));
+            commit(dbName, tbWithoutPartition, pus2);
+            table = hmsClient.getTable(dbName, tbWithoutPartition);
+            assertNumRows(6, table);
+        }
     }
 
     @Test
@@ -209,28 +227,33 @@ public class HmsCommitTest {
 
     @Test
     public void testNewPartitionForPartitionedTable() throws IOException {
-        new MockUp<HMSTransaction.HmsCommitter>(HMSTransaction.HmsCommitter.class) {
-            @Mock
-            private void doNothing() {
-                Assert.assertFalse(fsExists(getWritePath()));
-            }
-        };
-        genQueryID();
-        List<THivePartitionUpdate> pus = new ArrayList<>();
-        pus.add(createRandomNew("a"));
-        pus.add(createRandomNew("a"));
-        pus.add(createRandomNew("a"));
-        pus.add(createRandomNew("b"));
-        pus.add(createRandomNew("b"));
-        pus.add(createRandomNew("c"));
-        commit(dbName, tbWithPartition, pus);
+        try (MockedConstruction<HMSTransaction.HmsCommitter> mocked = Mockito.mockConstruction(
+                HMSTransaction.HmsCommitter.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    initHmsCommitterFields(mock, context);
+                    Mockito.doAnswer(inv -> {
+                        Assert.assertFalse(fsExists(getWritePath()));
+                        return null;
+                    }).when(mock).doNothing();
+                })) {
+            genQueryID();
+            List<THivePartitionUpdate> pus = new ArrayList<>();
+            pus.add(createRandomNew("a"));
+            pus.add(createRandomNew("a"));
+            pus.add(createRandomNew("a"));
+            pus.add(createRandomNew("b"));
+            pus.add(createRandomNew("b"));
+            pus.add(createRandomNew("c"));
+            commit(dbName, tbWithPartition, pus);
 
-        Partition pa = hmsClient.getPartition(dbName, tbWithPartition, Lists.newArrayList("a"));
-        assertNumRows(3, pa);
-        Partition pb = hmsClient.getPartition(dbName, tbWithPartition, Lists.newArrayList("b"));
-        assertNumRows(2, pb);
-        Partition pc = hmsClient.getPartition(dbName, tbWithPartition, Lists.newArrayList("c"));
-        assertNumRows(1, pc);
+            Partition pa = hmsClient.getPartition(dbName, tbWithPartition, Lists.newArrayList("a"));
+            assertNumRows(3, pa);
+            Partition pb = hmsClient.getPartition(dbName, tbWithPartition, Lists.newArrayList("b"));
+            assertNumRows(2, pb);
+            Partition pc = hmsClient.getPartition(dbName, tbWithPartition, Lists.newArrayList("c"));
+            assertNumRows(1, pc);
+        }
     }
 
     @Test
@@ -408,6 +431,10 @@ public class HmsCommitTest {
             String tableName,
             List<THivePartitionUpdate> hivePUs) {
         HMSTransaction hmsTransaction = new HMSTransaction(hmsOps, fileSystemProvider, fileSystemExecutor);
+        if (transactionSpySetup != null) {
+            hmsTransaction = Mockito.spy(hmsTransaction);
+            transactionSpySetup.accept(hmsTransaction);
+        }
         hmsTransaction.setHivePartitionUpdates(hivePUs);
         HiveInsertCommandContext ctx = new HiveInsertCommandContext();
         String queryId = DebugUtil.printId(ConnectContext.get().queryId());
@@ -419,48 +446,56 @@ public class HmsCommitTest {
     }
 
     public void mockAddPartitionTaskException(Runnable runnable) {
-        new MockUp<HMSTransaction.AddPartitionsTask>(HMSTransaction.AddPartitionsTask.class) {
-            @Mock
-            private void run(HiveMetadataOps hiveOps) {
-                runnable.run();
-                throw new RuntimeException("failed to add partition");
-            }
-        };
+        MockedConstruction<HMSTransaction.AddPartitionsTask> mc = Mockito.mockConstruction(
+                HMSTransaction.AddPartitionsTask.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    initAddPartitionsTaskFields(mock);
+                    Mockito.doAnswer(inv -> {
+                        runnable.run();
+                        throw new RuntimeException("failed to add partition");
+                    }).when(mock).run(Mockito.any());
+                });
+        mockedConstructions.add(mc);
     }
 
     public void mockAsyncRenameDir(Runnable runnable) {
-        new MockUp<HMSTransaction>(HMSTransaction.class) {
-            @Mock
-            private void wrapperAsyncRenameDirWithProfileSummary(Executor executor,
-                    List<CompletableFuture<?>> renameFileFutures,
-                    AtomicBoolean cancelled,
-                    String origFilePath,
-                    String destFilePath,
-                    Runnable runWhenPathNotExist) {
+        transactionSpySetup = tx -> {
+            Mockito.doAnswer(inv -> {
                 runnable.run();
                 throw new RuntimeException("failed to rename dir");
-            }
+            }).when(tx).wrapperAsyncRenameDirWithProfileSummary(
+                    Mockito.any(), Mockito.any(), Mockito.any(),
+                    Mockito.any(), Mockito.any(), Mockito.any());
         };
     }
 
     public void mockDoOther(Runnable runnable) {
-        new MockUp<HMSTransaction.HmsCommitter>(HMSTransaction.HmsCommitter.class) {
-            @Mock
-            private void doNothing() {
-                runnable.run();
-                throw new RuntimeException("failed to do nothing");
-            }
-        };
+        MockedConstruction<HMSTransaction.HmsCommitter> mc = Mockito.mockConstruction(
+                HMSTransaction.HmsCommitter.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    initHmsCommitterFields(mock, context);
+                    Mockito.doAnswer(inv -> {
+                        runnable.run();
+                        throw new RuntimeException("failed to do nothing");
+                    }).when(mock).doNothing();
+                });
+        mockedConstructions.add(mc);
     }
 
     public void mockUpdateStatisticsTaskException(Runnable runnable) {
-        new MockUp<HMSTransaction.UpdateStatisticsTask>(HMSTransaction.UpdateStatisticsTask.class) {
-            @Mock
-            private void run(HiveMetadataOps hiveOps) {
-                runnable.run();
-                throw new RuntimeException("failed to update partition");
-            }
-        };
+        MockedConstruction<HMSTransaction.UpdateStatisticsTask> mc = Mockito.mockConstruction(
+                HMSTransaction.UpdateStatisticsTask.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    initUpdateStatisticsTaskFields(mock, context);
+                    Mockito.doAnswer(inv -> {
+                        runnable.run();
+                        throw new RuntimeException("failed to update partition");
+                    }).when(mock).run(Mockito.any());
+                });
+        mockedConstructions.add(mc);
     }
 
     public void genQueryID() {
@@ -715,5 +750,47 @@ public class HmsCommitTest {
         } catch (Throwable t) {
             Assert.fail();
         }
+    }
+
+    private void initHmsCommitterFields(Object mock, MockedConstruction.Context context) throws Exception {
+        Class<?> clazz = HMSTransaction.HmsCommitter.class;
+        setField(clazz, mock, "updateStatisticsTasks", new ArrayList<>());
+        setField(clazz, mock, "updateStatisticsExecutor", Executors.newFixedThreadPool(16));
+        setField(clazz, mock, "addPartitionsTask", new HMSTransaction.AddPartitionsTask());
+        setField(clazz, mock, "fileSystemTaskCancelled", new AtomicBoolean(false));
+        setField(clazz, mock, "asyncFileSystemTaskFutures", new ArrayList<>());
+        setField(clazz, mock, "directoryCleanUpTasksForAbort", new ConcurrentLinkedQueue<>());
+        setField(clazz, mock, "renameDirectoryTasksForAbort", new ArrayList<>());
+        setField(clazz, mock, "clearDirsForFinish", new ArrayList<>());
+        setField(clazz, mock, "s3cleanWhenSuccess", new ArrayList<>());
+        // Set the outer class reference (HMSTransaction instance)
+        if (!context.arguments().isEmpty()) {
+            Field outerRef = clazz.getDeclaredField("this$0");
+            outerRef.setAccessible(true);
+            outerRef.set(mock, context.arguments().get(0));
+        }
+    }
+
+    private void initAddPartitionsTaskFields(Object mock) throws Exception {
+        Class<?> clazz = HMSTransaction.AddPartitionsTask.class;
+        setField(clazz, mock, "partitions", new ArrayList<>());
+        setField(clazz, mock, "createdPartitionValues", new ArrayList<>());
+    }
+
+    private void initUpdateStatisticsTaskFields(Object mock, MockedConstruction.Context context) throws Exception {
+        Class<?> clazz = HMSTransaction.UpdateStatisticsTask.class;
+        List<?> args = context.arguments();
+        if (args.size() >= 4) {
+            setField(clazz, mock, "nameMapping", args.get(0));
+            setField(clazz, mock, "partitionName", args.get(1));
+            setField(clazz, mock, "updatePartitionStat", args.get(2));
+            setField(clazz, mock, "merge", args.get(3));
+        }
+    }
+
+    private void setField(Class<?> clazz, Object obj, String fieldName, Object value) throws Exception {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(obj, value);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/hudi/HudiUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/hudi/HudiUtilsTest.java
@@ -28,13 +28,13 @@ import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.datasource.hive.HiveMetaStoreClientHelper;
 
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,6 +42,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class HudiUtilsTest {
+
+    private MockedStatic<Env> envMockedStatic;
+
+    @org.junit.After
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+            envMockedStatic = null;
+        }
+    }
 
     @Test
     public void testGetHudiSchemaWithCleanCommit() throws IOException {
@@ -159,17 +169,6 @@ public class HudiUtilsTest {
         File meta = new File(hudiTable + "/.hoodie");
         Assert.assertTrue(meta.mkdirs());
 
-        new MockUp<HMSExternalTable>(HMSExternalTable.class) {
-            @Mock
-            public org.apache.hadoop.hive.metastore.api.Table getRemoteTable() {
-                Table table = new Table();
-                StorageDescriptor storageDescriptor = new StorageDescriptor();
-                storageDescriptor.setLocation("file://" + hudiTable.toAbsolutePath());
-                table.setSd(storageDescriptor);
-                return table;
-            }
-        };
-
         // 2. generate properties and commit
         File prop = new File(meta + "/hoodie.properties");
         Files.write(prop.toPath(), propContent.getBytes());
@@ -177,13 +176,18 @@ public class HudiUtilsTest {
         Files.write(commit1.toPath(), commitContent1.getBytes());
 
         // 3. now, we can get the schema from this table.
-        HMSExternalCatalog catalog = new HMSExternalCatalog(10001, "hudi_ut", null, Maps.newHashMap(), "");
+        HMSExternalCatalog catalog = Mockito.spy(new HMSExternalCatalog(10001, "hudi_ut", null, Maps.newHashMap(), ""));
         Env env = mockCurrentEnvWithCatalog(catalog);
         Assert.assertNotNull(env);
         env.getExtMetaCacheMgr().prepareCatalogByEngine(catalog.getId(), HudiExternalMetaCache.ENGINE,
                 catalog.getProperties());
-        HMSExternalDatabase db = new HMSExternalDatabase(catalog, 1, "db", "db");
-        HMSExternalTable hmsExternalTable = new HMSExternalTable(2, "tb", "tb", catalog, db);
+        HMSExternalDatabase db = Mockito.spy(new HMSExternalDatabase(catalog, 1, "db", "db"));
+        HMSExternalTable hmsExternalTable = Mockito.spy(new HMSExternalTable(2, "tb", "tb", catalog, db));
+        Table remoteTable = new Table();
+        StorageDescriptor storageDescriptor = new StorageDescriptor();
+        storageDescriptor.setLocation("file://" + hudiTable.toAbsolutePath());
+        remoteTable.setSd(storageDescriptor);
+        Mockito.doReturn(remoteTable).when(hmsExternalTable).getRemoteTable();
         mockCatalogLookup(catalog, db, hmsExternalTable);
         HiveMetaStoreClientHelper.getHudiTableSchema(hmsExternalTable, new boolean[] {false}, "20241219214518880");
 
@@ -212,33 +216,22 @@ public class HudiUtilsTest {
     private Env mockCurrentEnvWithCatalog(HMSExternalCatalog catalog) {
         CatalogMgr catalogMgr = new TestingCatalogMgr(catalog);
         Env env = new TestingEnv(catalogMgr);
-        new MockUp<Env>() {
-            @Mock
-            Env getCurrentEnv() {
-                return env;
-            }
-        };
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
         return env;
     }
 
     private void mockCatalogLookup(HMSExternalCatalog catalog, HMSExternalDatabase db, HMSExternalTable table) {
-        new MockUp<HMSExternalCatalog>(HMSExternalCatalog.class) {
-            @Mock
-            public HMSExternalDatabase getDbNullable(String dbName) {
-                return "db".equals(dbName) ? db : null;
-            }
+        Mockito.doAnswer(invocation -> {
+            String dbName = invocation.getArgument(0);
+            return "db".equals(dbName) ? db : null;
+        }).when(catalog).getDbNullable(Mockito.anyString());
+        Mockito.doReturn(new Configuration()).when(catalog).getConfiguration();
 
-            @Mock
-            public Configuration getConfiguration() {
-                return new Configuration();
-            }
-        };
-        new MockUp<HMSExternalDatabase>(HMSExternalDatabase.class) {
-            @Mock
-            public HMSExternalTable getTableNullable(String tableName) {
-                return "tb".equals(tableName) ? table : null;
-            }
-        };
+        Mockito.doAnswer(invocation -> {
+            String tableName = invocation.getArgument(0);
+            return "tb".equals(tableName) ? table : null;
+        }).when(db).getTableNullable(Mockito.anyString());
     }
 
     private static final class TestingCatalogMgr extends CatalogMgr {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/source/JdbcScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/source/JdbcScanNodeTest.java
@@ -35,29 +35,24 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.datasource.jdbc.JdbcExternalTable;
 import org.apache.doris.thrift.TOdbcTableType;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class JdbcScanNodeTest {
 
-    @Mocked
-    private JdbcExternalTable mockTable;
+    private JdbcExternalTable mockTable = Mockito.mock(JdbcExternalTable.class);
 
     @Test
     public void testSimpleBinaryPredicate() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         SlotRef idSlot = new SlotRef(null, "ID");
         IntLiteral intLiteral = new IntLiteral(1);
@@ -72,14 +67,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testSimpleCompoundPredicate() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         SlotRef idSlot = new SlotRef(null, "ID");
         IntLiteral intLiteral = new IntLiteral(1);
@@ -97,14 +89,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testNestedCompoundPredicate() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // ID = 1 OR (NAME = 'test' AND AGE > 18)
         SlotRef idSlot = new SlotRef(null, "ID");
@@ -129,14 +118,11 @@ public class JdbcScanNodeTest {
     @Test
     public void testComplexNestedCompoundPredicate() {
 
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // (ID = 1 OR NAME = 'test') AND (AGE > 18 OR DEPT = 'HR')
         SlotRef idSlot = new SlotRef(null, "ID");
@@ -165,14 +151,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralOracle() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         DateLiteral dateLiteral = new DateLiteral(2023, 1, 1, 12, 34, 56, Type.DATETIME);
 
@@ -186,14 +169,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralTrino() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         DateLiteral dateLiteral = new DateLiteral(2023, 1, 1, 12, 34, 56, Type.DATETIME);
 
@@ -207,14 +187,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralCompoundPredicateOracle() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // ID = 1 OR CREATE_TIME >= '2023-01-01'
         SlotRef idSlot = new SlotRef(null, "ID");
@@ -245,14 +222,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testComplexPredicateWithDateComparisons() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // (ID = 1 OR NAME = 'test') AND (CREATE_TIME >= '2023-01-01' AND UPDATE_TIME <= '2023-12-31')
         SlotRef idSlot = new SlotRef(null, "ID");
@@ -299,14 +273,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDifferentComparisonOperators() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         SlotRef ageSlot = new SlotRef(null, "AGE");
         IntLiteral ageLiteral = new IntLiteral(30);
@@ -339,14 +310,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testIsNullPredicates() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // NAME IS NULL
         SlotRef nameSlot = new SlotRef(null, "NAME");
@@ -362,14 +330,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testCompoundIsNullPredicates() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // ID = 1 AND NAME IS NULL
         SlotRef idSlot = new SlotRef(null, "ID");
@@ -387,14 +352,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testLikePredicates() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // NAME LIKE 'test%'
         SlotRef nameSlot = new SlotRef(null, "NAME");
@@ -408,14 +370,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testFloatLiteral() {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // SALARY > 5000.50
         SlotRef salarySlot = new SlotRef(null, "SALARY");
@@ -429,14 +388,11 @@ public class JdbcScanNodeTest {
     @Test
     public void testVeryComplexNestedPredicate() {
 
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // (ID > 10 AND ID < 100) OR (NAME LIKE 'test%' AND (DEPT = 'HR' OR SALARY > 5000.0))
         SlotRef idSlot = new SlotRef(null, "ID");
@@ -471,14 +427,11 @@ public class JdbcScanNodeTest {
     @Test
     public void testTripleNestedCompoundPredicate() {
 
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // (ID = 1 OR (NAME = 'test' AND (AGE > 18 OR DEPT = 'HR')))
         SlotRef idSlot = new SlotRef(null, "ID");
@@ -507,14 +460,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralSQLServerDatetime() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // Test DATETIME type with SQL Server
         DateLiteral dateLiteral = new DateLiteral(2026, 2, 28, 12, 30, 12, Type.DATETIME);
@@ -529,14 +479,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralSQLServerDate() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // Test DATE type with SQL Server
         DateLiteral dateLiteral = new DateLiteral(2026, 2, 28, Type.DATEV2);
@@ -551,14 +498,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralSQLServerDatetimeV2WithFractionalSeconds() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // Test DATETIMEV2 type with fractional seconds (as SQL Server datetime maps to DATETIMEV2)
         DateLiteral dateLiteral = new DateLiteral(2026, 2, 28, 12, 30, 12, 123000,
@@ -574,14 +518,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralSQLServerInPredicate() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // Test IN predicate with datetime literals for SQL Server
         SlotRef dateSlot = new SlotRef(null, "data_time");
@@ -601,14 +542,11 @@ public class JdbcScanNodeTest {
 
     @Test
     public void testDateLiteralSQLServerCompoundPredicate() throws Exception {
-        new Expectations() {{
-                mockTable.getProperRemoteColumnName((TOdbcTableType) any, anyString);
-                result = new mockit.Delegate() {
-                    String getProperColumnName(TOdbcTableType tableType, String colName) {
-                        return "\"" + colName + "\"";
-                    }
-                };
-            }};
+        Mockito.when(mockTable.getProperRemoteColumnName(Mockito.nullable(TOdbcTableType.class), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String colName = invocation.getArgument(1);
+                    return "\"" + colName + "\"";
+                });
 
         // Test compound predicate: ID = 1 AND data_time > '2026-02-28 12:30:12'
         SlotRef idSlot = new SlotRef(null, "ID");

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchemaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchemaTest.java
@@ -17,33 +17,24 @@
 
 package org.apache.doris.datasource.jdbc.util;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.sql.ResultSetMetaData;
 import java.sql.Types;
 
 public class JdbcFieldSchemaTest {
 
-    @Mocked
-    private ResultSetMetaData metaData;
+    private ResultSetMetaData metaData = Mockito.mock(ResultSetMetaData.class);
 
     @Test
     public void testUseColumnLabelForQueryAlias() throws Exception {
-        new Expectations() {{
-                metaData.getColumnLabel(1);
-                result = "t1";
-                metaData.getColumnType(1);
-                result = Types.VARCHAR;
-                metaData.getColumnTypeName(1);
-                result = "VARCHAR";
-                metaData.getPrecision(1);
-                result = 64;
-                metaData.getScale(1);
-                result = 0;
-            }};
+        Mockito.when(metaData.getColumnLabel(1)).thenReturn("t1");
+        Mockito.when(metaData.getColumnType(1)).thenReturn(Types.VARCHAR);
+        Mockito.when(metaData.getColumnTypeName(1)).thenReturn("VARCHAR");
+        Mockito.when(metaData.getPrecision(1)).thenReturn(64);
+        Mockito.when(metaData.getScale(1)).thenReturn(0);
 
         JdbcFieldSchema schema = new JdbcFieldSchema(metaData, 1);
 
@@ -52,20 +43,12 @@ public class JdbcFieldSchemaTest {
 
     @Test
     public void testFallbackToColumnNameWhenLabelMissing() throws Exception {
-        new Expectations() {{
-                metaData.getColumnLabel(1);
-                result = "";
-                metaData.getColumnName(1);
-                result = "username";
-                metaData.getColumnType(1);
-                result = Types.VARCHAR;
-                metaData.getColumnTypeName(1);
-                result = "VARCHAR";
-                metaData.getPrecision(1);
-                result = 64;
-                metaData.getScale(1);
-                result = 0;
-            }};
+        Mockito.when(metaData.getColumnLabel(1)).thenReturn("");
+        Mockito.when(metaData.getColumnName(1)).thenReturn("username");
+        Mockito.when(metaData.getColumnType(1)).thenReturn(Types.VARCHAR);
+        Mockito.when(metaData.getColumnTypeName(1)).thenReturn("VARCHAR");
+        Mockito.when(metaData.getPrecision(1)).thenReturn(64);
+        Mockito.when(metaData.getScale(1)).thenReturn(0);
 
         JdbcFieldSchema schema = new JdbcFieldSchema(metaData, 1);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
@@ -22,11 +22,11 @@ import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.UserException;
 
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
@@ -46,8 +46,7 @@ public class S3PropertiesTest {
     private static String accessKey = "";
     private static String hdfsPath = "";
 
-    @Mocked
-    StsClient mockStsClient;
+    StsClient mockStsClient = Mockito.mock(StsClient.class);
 
     @BeforeEach
     public void setUp() {
@@ -250,58 +249,54 @@ public class S3PropertiesTest {
 
 
     @Test
-    public void testGetAwsCredentialsProviderWithIamRoleAndExternalId(@Mocked StsClientBuilder mockBuilder,
-                                                                      @Mocked StsClient mockStsClient) {
+    public void testGetAwsCredentialsProviderWithIamRoleAndExternalId() {
+        StsClientBuilder mockBuilder = Mockito.mock(StsClientBuilder.class);
+        StsClient localMockStsClient = Mockito.mock(StsClient.class);
 
-        new Expectations() {
-            {
-                StsClient.builder();
-                result = mockBuilder;
-                mockBuilder.credentialsProvider((AwsCredentialsProvider) any);
-                result = mockBuilder;
-                mockBuilder.build();
-                result = mockStsClient;
-            }
-        };
+        try (MockedStatic<StsClient> mockedStsClient = Mockito.mockStatic(StsClient.class)) {
+            mockedStsClient.when(StsClient::builder).thenReturn(mockBuilder);
+            Mockito.when(mockBuilder.region(Mockito.any())).thenReturn(mockBuilder);
+            Mockito.when(mockBuilder.credentialsProvider(Mockito.any(AwsCredentialsProvider.class))).thenReturn(mockBuilder);
+            Mockito.when(mockBuilder.build()).thenReturn(localMockStsClient);
 
-        origProps.put("s3.endpoint", "s3.us-west-2.amazonaws.com");
-        origProps.put("s3.role_arn", "arn:aws:iam::123456789012:role/MyTestRole");
-        origProps.put("s3.external_id", "external-123");
-        origProps.put("s3.region", "us-west-2");
-        S3Properties s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
-        AwsCredentialsProvider provider = s3Props.getAwsCredentialsProvider();
-        Assertions.assertNotNull(provider);
-        Assertions.assertTrue(provider instanceof StsAssumeRoleCredentialsProvider);
-        origProps.put("s3.credentials_provider_type", "instance_profile");
-        s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
-        provider = s3Props.getAwsCredentialsProvider();
-        Assertions.assertEquals(StsAssumeRoleCredentialsProvider.class.getName(), provider.getClass().getName());
-        Assertions.assertEquals(InstanceProfileCredentialsProvider.class.getName(), s3Props.getHadoopStorageConfig().get("fs.s3a.assumed.role.credentials.provider"));
-        origProps.remove("s3.external_id");
-        origProps.remove("s3.role_arn");
-        origProps.remove("s3.credentials_provider_type");
-        s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
-        provider = s3Props.getAwsCredentialsProvider();
-        Assertions.assertNotNull(provider);
-        Assertions.assertTrue(provider instanceof AwsCredentialsProviderChain);
-        origProps.put("s3.credentials_provider_type", "instance_profile");
-        s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
-        provider = s3Props.getAwsCredentialsProvider();
-        Assertions.assertNotNull(provider);
-        Assertions.assertTrue(provider instanceof InstanceProfileCredentialsProvider);
-        Assertions.assertEquals(InstanceProfileCredentialsProvider.class.getName(), s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
-        origProps.put("s3.credentials_provider_type", "static");
-        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class, "Unsupported AWS credentials provider mode: static", () -> StorageProperties.createPrimary(origProps));
-        origProps.put("s3.credentials_provider_type", "anonymous");
-        s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
-        Assertions.assertEquals(AnonymousCredentialsProvider.class.getName(), s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
-        origProps.remove("s3.credentials_provider_type");
-        s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
-        provider = s3Props.getAwsCredentialsProvider();
-        Assertions.assertNotNull(provider);
-        Assertions.assertTrue(provider instanceof AwsCredentialsProviderChain);
-        Assertions.assertEquals("software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider,software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider,software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider,software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider", s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
-
+            origProps.put("s3.endpoint", "s3.us-west-2.amazonaws.com");
+            origProps.put("s3.role_arn", "arn:aws:iam::123456789012:role/MyTestRole");
+            origProps.put("s3.external_id", "external-123");
+            origProps.put("s3.region", "us-west-2");
+            S3Properties s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
+            AwsCredentialsProvider provider = s3Props.getAwsCredentialsProvider();
+            Assertions.assertNotNull(provider);
+            Assertions.assertTrue(provider instanceof StsAssumeRoleCredentialsProvider);
+            origProps.put("s3.credentials_provider_type", "instance_profile");
+            s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
+            provider = s3Props.getAwsCredentialsProvider();
+            Assertions.assertEquals(StsAssumeRoleCredentialsProvider.class.getName(), provider.getClass().getName());
+            Assertions.assertEquals(InstanceProfileCredentialsProvider.class.getName(), s3Props.getHadoopStorageConfig().get("fs.s3a.assumed.role.credentials.provider"));
+            origProps.remove("s3.external_id");
+            origProps.remove("s3.role_arn");
+            origProps.remove("s3.credentials_provider_type");
+            s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
+            provider = s3Props.getAwsCredentialsProvider();
+            Assertions.assertNotNull(provider);
+            Assertions.assertTrue(provider instanceof AwsCredentialsProviderChain);
+            origProps.put("s3.credentials_provider_type", "instance_profile");
+            s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
+            provider = s3Props.getAwsCredentialsProvider();
+            Assertions.assertNotNull(provider);
+            Assertions.assertTrue(provider instanceof InstanceProfileCredentialsProvider);
+            Assertions.assertEquals(InstanceProfileCredentialsProvider.class.getName(), s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
+            origProps.put("s3.credentials_provider_type", "static");
+            ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class, "Unsupported AWS credentials provider mode: static", () -> StorageProperties.createPrimary(origProps));
+            origProps.put("s3.credentials_provider_type", "anonymous");
+            s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
+            Assertions.assertEquals(AnonymousCredentialsProvider.class.getName(), s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
+            origProps.remove("s3.credentials_provider_type");
+            s3Props = (S3Properties) StorageProperties.createPrimary(origProps);
+            provider = s3Props.getAwsCredentialsProvider();
+            Assertions.assertNotNull(provider);
+            Assertions.assertTrue(provider instanceof AwsCredentialsProviderChain);
+            Assertions.assertEquals("software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider,software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider,software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider,software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider", s3Props.getHadoopStorageConfig().get("fs.s3a.aws.credentials.provider"));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/systable/IcebergSysTableResolverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/systable/IcebergSysTableResolverTest.java
@@ -23,18 +23,15 @@ import org.apache.doris.datasource.iceberg.IcebergExternalTable;
 import org.apache.doris.datasource.iceberg.IcebergSysExternalTable;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Optional;
 
 public class IcebergSysTableResolverTest {
-    @Mocked
-    private IcebergExternalCatalog catalog;
-    @Mocked
-    private IcebergExternalDatabase db;
+    private IcebergExternalCatalog catalog = Mockito.mock(IcebergExternalCatalog.class);
+    private IcebergExternalDatabase db = Mockito.mock(IcebergExternalDatabase.class);
 
     @Test
     public void testSupportedSysTablesExcludePositionDeletes() {
@@ -68,32 +65,11 @@ public class IcebergSysTableResolverTest {
     }
 
     private IcebergExternalTable newIcebergTable() throws Exception {
-        new Expectations() {
-            {
-                catalog.getId();
-                minTimes = 0;
-                result = 1L;
-
-                db.getFullName();
-                minTimes = 0;
-                result = "test_db";
-
-                db.getRemoteName();
-                minTimes = 0;
-                result = "test_db";
-
-                catalog.getDbOrAnalysisException("test_db");
-                minTimes = 0;
-                result = db;
-
-                db.getId();
-                minTimes = 0;
-                result = 2L;
-
-                db.makeSureInitialized();
-                minTimes = 0;
-            }
-        };
+        Mockito.when(catalog.getId()).thenReturn(1L);
+        Mockito.when(db.getFullName()).thenReturn("test_db");
+        Mockito.when(db.getRemoteName()).thenReturn("test_db");
+        Mockito.doReturn(db).when(catalog).getDbOrAnalysisException("test_db");
+        Mockito.when(db.getId()).thenReturn(2L);
         return new IcebergExternalTable(3L, "tbl", "tbl", catalog, db);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsTestCase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsTestCase.java
@@ -21,8 +21,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.datasource.es.EsExternalTable;
 import org.apache.doris.datasource.es.EsUtil;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.mockito.Mockito;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -39,8 +38,7 @@ import java.util.List;
  **/
 public class EsTestCase {
 
-    @Mocked
-    protected EsExternalTable mockEsExternalTable;
+    protected EsExternalTable mockEsExternalTable = Mockito.mock(EsExternalTable.class);
 
     protected String loadJsonFromFile(String fileName)
             throws IOException, URISyntaxException {
@@ -60,45 +58,15 @@ public class EsTestCase {
 
     protected EsExternalTable fakeEsTable(String table, String index,
             String type, List<Column> columns) {
-        new Expectations(mockEsExternalTable) {
-            {
-                mockEsExternalTable.getIndexName();
-                result = index;
-                minTimes = 0;
-
-                mockEsExternalTable.getMappingType();
-                result = type;
-                minTimes = 0;
-
-                mockEsExternalTable.isEnableDocValueScan();
-                result = true;
-                minTimes = 0;
-
-                mockEsExternalTable.isEnableKeywordSniff();
-                result = true;
-                minTimes = 0;
-
-                mockEsExternalTable.getMaxDocValueFields();
-                result = 20;
-                minTimes = 0;
-
-                mockEsExternalTable.getColumn2typeMap();
-                result = new HashMap<>();
-                minTimes = 0;
-
-                mockEsExternalTable.getFullSchema();
-                result = columns;
-                minTimes = 0;
-
-                mockEsExternalTable.isNodesDiscovery();
-                result = true;
-                minTimes = 0;
-
-                mockEsExternalTable.getName();
-                result = table;
-                minTimes = 0;
-            }
-        };
+        Mockito.when(mockEsExternalTable.getIndexName()).thenReturn(index);
+        Mockito.when(mockEsExternalTable.getMappingType()).thenReturn(type);
+        Mockito.when(mockEsExternalTable.isEnableDocValueScan()).thenReturn(true);
+        Mockito.when(mockEsExternalTable.isEnableKeywordSniff()).thenReturn(true);
+        Mockito.when(mockEsExternalTable.getMaxDocValueFields()).thenReturn(20);
+        Mockito.when(mockEsExternalTable.getColumn2typeMap()).thenReturn(new HashMap<>());
+        Mockito.when(mockEsExternalTable.getFullSchema()).thenReturn(columns);
+        Mockito.when(mockEsExternalTable.isNodesDiscovery()).thenReturn(true);
+        Mockito.when(mockEsExternalTable.getName()).thenReturn(table);
         return mockEsExternalTable;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
@@ -28,13 +28,12 @@ import org.apache.doris.datasource.es.MappingPhase;
 import org.apache.doris.datasource.es.SearchContext;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import mockit.Expectations;
-import mockit.Injectable;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -94,17 +93,12 @@ public class EsUtilTest extends EsTestCase {
     }
 
     @Test
-    public void testWorkFlow(@Injectable EsRestClient client) throws Exception {
+    public void testWorkFlow() throws Exception {
+        EsRestClient client = Mockito.mock(EsRestClient.class);
         EsExternalTable table = fakeEsTable("fake", "test", "doc", columns);
         SearchContext searchContext1 = new SearchContext(table);
         String jsonMapping = loadJsonFromFile("data/es/test_index_mapping.json");
-        new Expectations(client) {
-            {
-                client.getMapping(anyString);
-                minTimes = 0;
-                result = jsonMapping;
-            }
-        };
+        Mockito.when(client.getMapping(Mockito.anyString())).thenReturn(jsonMapping);
         MappingPhase mappingPhase = new MappingPhase(client);
         ExceptionChecker.expectThrowsNoException(() -> mappingPhase.execute(searchContext1));
         ExceptionChecker.expectThrowsNoException(() -> mappingPhase.postProcess(searchContext1));

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/PartitionPhaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/PartitionPhaseTest.java
@@ -29,10 +29,9 @@ import org.apache.doris.datasource.es.SearchContext;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import mockit.Expectations;
-import mockit.Injectable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,7 +41,8 @@ import java.util.Map;
 public class PartitionPhaseTest extends EsTestCase {
 
     @Test
-    public void testWorkFlow(@Injectable EsRestClient client) throws Exception {
+    public void testWorkFlow() throws Exception {
+        EsRestClient client = Mockito.mock(EsRestClient.class);
         final EsShardPartitions[] esShardPartitions = {null};
         ExceptionChecker.expectThrowsNoException(() ->
                 esShardPartitions[0] = EsShardPartitions.findShardPartitions("doe",
@@ -59,17 +59,8 @@ public class PartitionPhaseTest extends EsTestCase {
             }
         }
 
-        new Expectations(client) {
-            {
-                client.getHttpNodes();
-                minTimes = 0;
-                result = nodesMap;
-
-                client.searchShards("doe");
-                minTimes = 0;
-                result = esShardPartitions[0];
-            }
-        };
+        Mockito.when(client.getHttpNodes()).thenReturn(nodesMap);
+        Mockito.when(client.searchShards("doe")).thenReturn(esShardPartitions[0]);
         List<Column> columns = new ArrayList<>();
         Column k1 = new Column("k1", PrimitiveType.BIGINT);
         columns.add(k1);

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/HmsCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/HmsCatalogTest.java
@@ -41,11 +41,10 @@ import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Optional;
@@ -56,16 +55,11 @@ public class HmsCatalogTest extends AnalyzeCheckTestBase {
     private Env env;
     private CatalogMgr mgr;
 
-    @Mocked
-    private HMSExternalTable tbl;
-    @Mocked
-    private HMSExternalTable view1;
-    @Mocked
-    private HMSExternalTable view2;
-    @Mocked
-    private HMSExternalTable view3;
-    @Mocked
-    private HMSExternalTable view4;
+    private HMSExternalTable tbl = Mockito.mock(HMSExternalTable.class);
+    private HMSExternalTable view1 = Mockito.mock(HMSExternalTable.class);
+    private HMSExternalTable view2 = Mockito.mock(HMSExternalTable.class);
+    private HMSExternalTable view3 = Mockito.mock(HMSExternalTable.class);
+    private HMSExternalTable view4 = Mockito.mock(HMSExternalTable.class);
 
     @Override
     protected void runBeforeAll() throws Exception {
@@ -117,61 +111,19 @@ public class HmsCatalogTest extends AnalyzeCheckTestBase {
         Deencapsulation.setField(tbl, "dlaTable", new HiveDlaTable(tbl));
         Deencapsulation.setField(tbl, "dlaType", DLAType.HIVE);
         long now = System.currentTimeMillis();
-        new Expectations(tbl) {
-            {
-                tbl.getId();
-                minTimes = 0;
-                result = 10001;
-
-                tbl.getName();
-                minTimes = 0;
-                result = "hms_tbl";
-
-                tbl.getDbName();
-                minTimes = 0;
-                result = "hms_db";
-
-                tbl.getFullSchema();
-                minTimes = 0;
-                result = schema;
-
-                tbl.isSupportedHmsTable();
-                minTimes = 0;
-                result = true;
-
-                tbl.isView();
-                minTimes = 0;
-                result = false;
-
-                tbl.getType();
-                minTimes = 0;
-                result = TableIf.TableType.HMS_EXTERNAL_TABLE;
-
-                tbl.getCatalog();
-                minTimes = 0;
-                result = hmsCatalog;
-
-                tbl.getSchemaCacheValue();
-                minTimes = 0;
-                result = Optional.of(schemaCacheValue);
-
-                tbl.initSchemaAndUpdateTime((SchemaCacheKey) any);
-                minTimes = 0;
-                result = Optional.of(schemaCacheValue);
-
-                tbl.getDatabase();
-                minTimes = 0;
-                result = db;
-
-                tbl.getDlaType();
-                minTimes = 0;
-                result = DLAType.HIVE;
-
-                tbl.getNewestUpdateVersionOrTime();
-                minTimes = 0;
-                result = now;
-            }
-        };
+        Mockito.when(tbl.getId()).thenReturn(10001L);
+        Mockito.when(tbl.getName()).thenReturn("hms_tbl");
+        Mockito.when(tbl.getDbName()).thenReturn("hms_db");
+        Mockito.when(tbl.getFullSchema()).thenReturn(schema);
+        Mockito.when(tbl.isSupportedHmsTable()).thenReturn(true);
+        Mockito.when(tbl.isView()).thenReturn(false);
+        Mockito.when(tbl.getType()).thenReturn(TableIf.TableType.HMS_EXTERNAL_TABLE);
+        Mockito.when(tbl.getCatalog()).thenReturn(hmsCatalog);
+        Mockito.when(tbl.getSchemaCacheValue()).thenReturn(Optional.of(schemaCacheValue));
+        Mockito.when(tbl.initSchemaAndUpdateTime(Mockito.any(SchemaCacheKey.class))).thenReturn(Optional.of(schemaCacheValue));
+        Mockito.when(tbl.getDatabase()).thenReturn(db);
+        Mockito.when(tbl.getDlaType()).thenReturn(DLAType.HIVE);
+        Mockito.when(tbl.getNewestUpdateVersionOrTime()).thenReturn(now);
 
         Deencapsulation.setField(view1, "objectCreated", true);
         Deencapsulation.setField(view1, "updateTime", NOW);
@@ -180,49 +132,16 @@ public class HmsCatalogTest extends AnalyzeCheckTestBase {
         Deencapsulation.setField(view1, "name", "hms_view1");
         Deencapsulation.setField(view1, "dlaType", DLAType.HIVE);
 
-        new Expectations(view1) {
-            {
-                view1.getId();
-                minTimes = 0;
-                result = 10002;
-
-                view1.getName();
-                minTimes = 0;
-                result = "hms_view1";
-
-                view1.getDbName();
-                minTimes = 0;
-                result = "hms_db";
-
-                view1.isView();
-                minTimes = 0;
-                result = true;
-
-                view1.getCatalog();
-                minTimes = 0;
-                result = hmsCatalog;
-
-                view1.getType();
-                minTimes = 0;
-                result = TableIf.TableType.HMS_EXTERNAL_TABLE;
-
-                view1.getFullSchema();
-                minTimes = 0;
-                result = schema;
-
-                view1.getViewText();
-                minTimes = 0;
-                result = "SELECT * FROM hms_db.hms_tbl";
-
-                view1.isSupportedHmsTable();
-                minTimes = 0;
-                result = true;
-
-                view1.getDatabase();
-                minTimes = 0;
-                result = db;
-            }
-        };
+        Mockito.when(view1.getId()).thenReturn(10002L);
+        Mockito.when(view1.getName()).thenReturn("hms_view1");
+        Mockito.when(view1.getDbName()).thenReturn("hms_db");
+        Mockito.when(view1.isView()).thenReturn(true);
+        Mockito.when(view1.getCatalog()).thenReturn(hmsCatalog);
+        Mockito.when(view1.getType()).thenReturn(TableIf.TableType.HMS_EXTERNAL_TABLE);
+        Mockito.when(view1.getFullSchema()).thenReturn(schema);
+        Mockito.when(view1.getViewText()).thenReturn("SELECT * FROM hms_db.hms_tbl");
+        Mockito.when(view1.isSupportedHmsTable()).thenReturn(true);
+        Mockito.when(view1.getDatabase()).thenReturn(db);
 
         Deencapsulation.setField(view2, "objectCreated", true);
         Deencapsulation.setField(view2, "updateTime", NOW);
@@ -231,50 +150,16 @@ public class HmsCatalogTest extends AnalyzeCheckTestBase {
         Deencapsulation.setField(view2, "name", "hms_view2");
         Deencapsulation.setField(view2, "dlaType", DLAType.HIVE);
 
-        new Expectations(view2) {
-            {
-
-                view2.getId();
-                minTimes = 0;
-                result = 10003;
-
-                view2.getName();
-                minTimes = 0;
-                result = "hms_view2";
-
-                view2.getDbName();
-                minTimes = 0;
-                result = "hms_db";
-
-                view2.getCatalog();
-                minTimes = 0;
-                result = hmsCatalog;
-
-                view2.isView();
-                minTimes = 0;
-                result = true;
-
-                view2.getType();
-                minTimes = 0;
-                result = TableIf.TableType.HMS_EXTERNAL_TABLE;
-
-                view2.getFullSchema();
-                minTimes = 0;
-                result = schema;
-
-                view2.getViewText();
-                minTimes = 0;
-                result = "SELECT * FROM (SELECT * FROM hms_db.hms_view1) t1";
-
-                view2.isSupportedHmsTable();
-                minTimes = 0;
-                result = true;
-
-                view2.getDatabase();
-                minTimes = 0;
-                result = db;
-            }
-        };
+        Mockito.when(view2.getId()).thenReturn(10003L);
+        Mockito.when(view2.getName()).thenReturn("hms_view2");
+        Mockito.when(view2.getDbName()).thenReturn("hms_db");
+        Mockito.when(view2.getCatalog()).thenReturn(hmsCatalog);
+        Mockito.when(view2.isView()).thenReturn(true);
+        Mockito.when(view2.getType()).thenReturn(TableIf.TableType.HMS_EXTERNAL_TABLE);
+        Mockito.when(view2.getFullSchema()).thenReturn(schema);
+        Mockito.when(view2.getViewText()).thenReturn("SELECT * FROM (SELECT * FROM hms_db.hms_view1) t1");
+        Mockito.when(view2.isSupportedHmsTable()).thenReturn(true);
+        Mockito.when(view2.getDatabase()).thenReturn(db);
 
         Deencapsulation.setField(view3, "objectCreated", true);
         Deencapsulation.setField(view3, "updateTime", NOW);
@@ -283,50 +168,16 @@ public class HmsCatalogTest extends AnalyzeCheckTestBase {
         Deencapsulation.setField(view3, "name", "hms_view3");
         Deencapsulation.setField(view3, "dlaType", DLAType.HIVE);
 
-        new Expectations(view3) {
-            {
-
-                view3.getId();
-                minTimes = 0;
-                result = 10004;
-
-                view3.getName();
-                minTimes = 0;
-                result = "hms_view3";
-
-                view3.getDbName();
-                minTimes = 0;
-                result = "hms_db";
-
-                view3.getCatalog();
-                minTimes = 0;
-                result = hmsCatalog;
-
-                view3.isView();
-                minTimes = 0;
-                result = true;
-
-                view3.getType();
-                minTimes = 0;
-                result = TableIf.TableType.HMS_EXTERNAL_TABLE;
-
-                view3.getFullSchema();
-                minTimes = 0;
-                result = schema;
-
-                view3.getViewText();
-                minTimes = 0;
-                result = "SELECT * FROM hms_db.hms_view1 UNION ALL SELECT * FROM hms_db.hms_view2";
-
-                view3.isSupportedHmsTable();
-                minTimes = 0;
-                result = true;
-
-                view3.getDatabase();
-                minTimes = 0;
-                result = db;
-            }
-        };
+        Mockito.when(view3.getId()).thenReturn(10004L);
+        Mockito.when(view3.getName()).thenReturn("hms_view3");
+        Mockito.when(view3.getDbName()).thenReturn("hms_db");
+        Mockito.when(view3.getCatalog()).thenReturn(hmsCatalog);
+        Mockito.when(view3.isView()).thenReturn(true);
+        Mockito.when(view3.getType()).thenReturn(TableIf.TableType.HMS_EXTERNAL_TABLE);
+        Mockito.when(view3.getFullSchema()).thenReturn(schema);
+        Mockito.when(view3.getViewText()).thenReturn("SELECT * FROM hms_db.hms_view1 UNION ALL SELECT * FROM hms_db.hms_view2");
+        Mockito.when(view3.isSupportedHmsTable()).thenReturn(true);
+        Mockito.when(view3.getDatabase()).thenReturn(db);
 
         Deencapsulation.setField(view4, "objectCreated", true);
         Deencapsulation.setField(view4, "updateTime", NOW);
@@ -335,50 +186,16 @@ public class HmsCatalogTest extends AnalyzeCheckTestBase {
         Deencapsulation.setField(view4, "name", "hms_view4");
         Deencapsulation.setField(view4, "dlaType", DLAType.HIVE);
 
-        new Expectations(view4) {
-            {
-
-                view4.getId();
-                minTimes = 0;
-                result = 10005;
-
-                view4.getName();
-                minTimes = 0;
-                result = "hms_view4";
-
-                view4.getDbName();
-                minTimes = 0;
-                result = "hms_db";
-
-                view4.getCatalog();
-                minTimes = 0;
-                result = hmsCatalog;
-
-                view4.isView();
-                minTimes = 0;
-                result = true;
-
-                view4.getType();
-                minTimes = 0;
-                result = TableIf.TableType.HMS_EXTERNAL_TABLE;
-
-                view4.getFullSchema();
-                minTimes = 0;
-                result = schema;
-
-                view4.getViewText();
-                minTimes = 0;
-                result = "SELECT not_exists_func(k1) FROM hms_db.hms_tbl";
-
-                view4.isSupportedHmsTable();
-                minTimes = 0;
-                result = true;
-
-                view4.getDatabase();
-                minTimes = 0;
-                result = db;
-            }
-        };
+        Mockito.when(view4.getId()).thenReturn(10005L);
+        Mockito.when(view4.getName()).thenReturn("hms_view4");
+        Mockito.when(view4.getDbName()).thenReturn("hms_db");
+        Mockito.when(view4.getCatalog()).thenReturn(hmsCatalog);
+        Mockito.when(view4.isView()).thenReturn(true);
+        Mockito.when(view4.getType()).thenReturn(TableIf.TableType.HMS_EXTERNAL_TABLE);
+        Mockito.when(view4.getFullSchema()).thenReturn(schema);
+        Mockito.when(view4.getViewText()).thenReturn("SELECT not_exists_func(k1) FROM hms_db.hms_tbl");
+        Mockito.when(view4.isSupportedHmsTable()).thenReturn(true);
+        Mockito.when(view4.getDatabase()).thenReturn(db);
 
         db.addTableForTest(tbl);
         db.addTableForTest(view1);

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/SpiSwitchingFileSystemTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/SpiSwitchingFileSystemTest.java
@@ -23,11 +23,10 @@ import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.filesystem.FileSystem;
 
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -45,8 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class SpiSwitchingFileSystemTest {
 
-    @Mocked
-    private FileSystem mockDelegate;
+    private final FileSystem mockDelegate = Mockito.mock(FileSystem.class);
 
     /**
      * H2: When {@link FileSystemFactory#getFileSystem(StorageProperties)} throws {@link IOException},
@@ -60,36 +58,36 @@ public class SpiSwitchingFileSystemTest {
      */
     @Test
     public void testForPathPropagatesIOExceptionNotRuntimeException() {
-        // Mock LocationPath.of() so it returns a LocationPath with a non-null StorageProperties,
-        // allowing execution to reach FileSystemFactory.getFileSystem().
-        // JMockit @Mock does not use the 'static' keyword — it mirrors the target signature without it.
         BrokerProperties bp = BrokerProperties.of("test-broker", Maps.newHashMap());
-        new MockUp<LocationPath>() {
-            @Mock
-            public LocationPath of(String location,
-                    Map<StorageProperties.Type, StorageProperties> storagePropertiesMap) {
-                return LocationPath.ofDirect(location, "broker", "broker://", bp);
-            }
-        };
-
-        // Mock FileSystemFactory to throw IOException — this is the scenario under test.
         IOException rootCause = new IOException("simulated connection failure");
-        new MockUp<FileSystemFactory>() {
-            @Mock
-            public FileSystem getFileSystem(StorageProperties storageProperties) throws IOException {
-                throw rootCause;
-            }
-        };
 
-        SpiSwitchingFileSystem spiFs = new SpiSwitchingFileSystem(Collections.emptyMap());
-        try {
-            spiFs.forPath("broker://host/path");
-            Assert.fail("Expected IOException but no exception was thrown");
-        } catch (IOException e) {
-            // Correct: IOException propagated as-is.
-            Assert.assertSame("forPath() must rethrow the original IOException", rootCause, e);
-        } catch (RuntimeException e) {
-            Assert.fail("forPath() wrapped IOException in RuntimeException: " + e.getClass().getName());
+        try (MockedStatic<LocationPath> mockedLocationPath = Mockito.mockStatic(LocationPath.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<FileSystemFactory> mockedFactory =
+                        Mockito.mockStatic(FileSystemFactory.class)) {
+            // Mock LocationPath.of() so it returns a LocationPath with a non-null StorageProperties,
+            // allowing execution to reach FileSystemFactory.getFileSystem().
+            mockedLocationPath.when(() -> LocationPath.of(Mockito.anyString(), Mockito.anyMap()))
+                    .thenAnswer(inv -> {
+                        String location = inv.getArgument(0);
+                        return LocationPath.ofDirect(location, "broker", "broker://", bp);
+                    });
+
+            // Mock FileSystemFactory to throw IOException — this is the scenario under test.
+            mockedFactory.when(() -> FileSystemFactory.getFileSystem(
+                            Mockito.any(StorageProperties.class)))
+                    .thenThrow(rootCause);
+
+            SpiSwitchingFileSystem spiFs = new SpiSwitchingFileSystem(Collections.emptyMap());
+            try {
+                spiFs.forPath("broker://host/path");
+                Assert.fail("Expected IOException but no exception was thrown");
+            } catch (IOException e) {
+                // Correct: IOException propagated as-is.
+                Assert.assertSame("forPath() must rethrow the original IOException", rootCause, e);
+            } catch (RuntimeException e) {
+                Assert.fail("forPath() wrapped IOException in RuntimeException: "
+                        + e.getClass().getName());
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/TransactionScopeCachingDirectoryListerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/TransactionScopeCachingDirectoryListerTest.java
@@ -28,11 +28,11 @@ import org.apache.doris.filesystem.RemoteIterator;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.mockito.Mockito;
 
 import java.util.Iterator;
 import java.util.List;
@@ -47,8 +47,9 @@ public class TransactionScopeCachingDirectoryListerTest {
     }
 
     @Test
-    public void testConcurrentDirectoryListing(@Mocked TableIf table)
+    public void testConcurrentDirectoryListing()
             throws FileSystemIOException {
+        TableIf table = Mockito.mock(TableIf.class);
         FileEntry firstFile = fileEntry("file:/x/x");
         FileEntry secondFile = fileEntry("file:/x/y");
         FileEntry thirdFile = fileEntry("file:/y/z");
@@ -94,8 +95,9 @@ public class TransactionScopeCachingDirectoryListerTest {
     }
 
     @Test
-    public void testConcurrentDirectoryListingException(@Mocked TableIf table)
+    public void testConcurrentDirectoryListingException()
             throws FileSystemIOException {
+        TableIf table = Mockito.mock(TableIf.class);
         FileEntry file = fileEntry("file:/x/x");
 
         String path = "file:/x";

--- a/fe/fe-core/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/http/DorisHttpTestCase.java
@@ -60,10 +60,6 @@ import org.apache.doris.thrift.TStorageType;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import junit.framework.AssertionFailedError;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import okhttp3.Credentials;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -71,15 +67,17 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 public abstract class DorisHttpTestCase {
 
@@ -132,8 +130,9 @@ public abstract class DorisHttpTestCase {
         DORIS_HOME = dorisHome;
     }
 
-    @Mocked
-    private static EditLog editLog;
+    private static EditLog editLog = Mockito.mock(EditLog.class);
+
+    private Env originalEnvInstance;
 
     public static OlapTable newTable(String name) {
         Env.getCurrentInvertedIndex().clear();
@@ -182,96 +181,38 @@ public abstract class DorisHttpTestCase {
         return table;
     }
 
-
-
     private static Env newDelegateCatalog() {
         try {
-            Env env = Deencapsulation.newInstance(Env.class);
+            Env env = Mockito.spy(Deencapsulation.newInstance(Env.class));
             Auth auth = new Auth();
             AccessControllerManager accessManager = new AccessControllerManager(auth);
-            //EasyMock.expect(catalog.getAuth()).andReturn(paloAuth).anyTimes();
             Database db = new Database(testDbId, "testDb");
             OlapTable table = newTable(TABLE_NAME);
             db.registerTable(table);
             OlapTable table1 = newTable(TABLE_NAME + 1);
             db.registerTable(table1);
 
+            InternalCatalog internalCatalog = Mockito.spy(Deencapsulation.newInstance(InternalCatalog.class));
+            // anyString catch-all first, then specific overrides
+            Mockito.doReturn(new Database()).when(internalCatalog).getDbNullable(Mockito.anyString());
+            Mockito.doReturn(db).when(internalCatalog).getDbNullable("" + DB_NAME);
+            Mockito.doReturn(null).when(internalCatalog).getDbNullable("emptyDb");
+            Mockito.doReturn(db).when(internalCatalog).getDbNullable(db.getId());
+            Mockito.doReturn(Lists.newArrayList("testDb")).when(internalCatalog).getDbNames();
 
-            InternalCatalog internalCatalog = Deencapsulation.newInstance(InternalCatalog.class);
-            new Expectations(internalCatalog) {
-                {
-                    internalCatalog.getDbNullable(db.getId());
-                    minTimes = 0;
-                    result = db;
+            CatalogMgr dsMgr = Mockito.spy(new CatalogMgr());
+            Mockito.doReturn(internalCatalog).when(dsMgr).getCatalog(Mockito.anyString());
+            Mockito.doReturn(internalCatalog).when(dsMgr).getCatalogOrException(Mockito.anyString(), Mockito.any());
+            Mockito.doReturn(internalCatalog).when(dsMgr).getCatalogOrAnalysisException(Mockito.anyString());
 
-                    internalCatalog.getDbNullable("" + DB_NAME);
-                    minTimes = 0;
-                    result = db;
+            Mockito.doReturn(accessManager).when(env).getAccessManager();
+            Mockito.doReturn(true).when(env).isMaster();
+            Mockito.doReturn(editLog).when(env).getEditLog();
+            Mockito.doReturn(internalCatalog).when(env).getInternalCatalog();
+            Mockito.doReturn(internalCatalog).when(env).getCurrentCatalog();
+            Mockito.doNothing().when(env).changeDb(Mockito.nullable(ConnectContext.class), Mockito.anyString());
+            Mockito.doReturn(dsMgr).when(env).getCatalogMgr();
 
-                    internalCatalog.getDbNullable("emptyDb");
-                    minTimes = 0;
-                    result = null;
-
-                    internalCatalog.getDbNullable(anyString);
-                    minTimes = 0;
-                    result = new Database();
-
-                    internalCatalog.getDbNames();
-                    minTimes = 0;
-                    result = Lists.newArrayList("testDb");
-                }
-            };
-
-            CatalogMgr dsMgr = new CatalogMgr();
-            new Expectations(dsMgr) {
-                {
-                    dsMgr.getCatalog((String) any);
-                    minTimes = 0;
-                    result = internalCatalog;
-
-                    dsMgr.getCatalogOrException((String) any, (Function) any);
-                    minTimes = 0;
-                    result = internalCatalog;
-
-                    dsMgr.getCatalogOrAnalysisException((String) any);
-                    minTimes = 0;
-                    result = internalCatalog;
-                }
-            };
-
-            new Expectations(env) {
-                {
-                    env.getAccessManager();
-                    minTimes = 0;
-                    result = accessManager;
-
-                    env.isMaster();
-                    minTimes = 0;
-                    result = true;
-
-                    env.getEditLog();
-                    minTimes = 0;
-                    result = editLog;
-
-                    env.getInternalCatalog();
-                    minTimes = 0;
-                    result = internalCatalog;
-
-                    env.getCurrentCatalog();
-                    minTimes = 0;
-                    result = internalCatalog;
-
-                    env.changeDb((ConnectContext) any, "blockDb");
-                    minTimes = 0;
-
-                    env.changeDb((ConnectContext) any, anyString);
-                    minTimes = 0;
-
-                    env.getCatalogMgr();
-                    minTimes = 0;
-                    result = dsMgr;
-                }
-            };
             return env;
         } catch (DdlException e) {
             return null;
@@ -332,46 +273,63 @@ public abstract class DorisHttpTestCase {
         file.delete();
     }
 
-
     @Before
     public void setUp() {
         Env env = newDelegateCatalog();
         SystemInfoService systemInfoService = new SystemInfoService();
         TabletInvertedIndex tabletInvertedIndex = new LocalTabletInvertedIndex();
-        new MockUp<Env>() {
-            @Mock
-            SchemaChangeHandler getSchemaChangeHandler() {
-                return new SchemaChangeHandler();
-            }
 
-            @Mock
-            MaterializedViewHandler getMaterializedViewHandler() {
-                return new MaterializedViewHandler();
-            }
+        Mockito.doReturn(new SchemaChangeHandler()).when(env).getSchemaChangeHandler();
+        Mockito.doReturn(new MaterializedViewHandler()).when(env).getMaterializedViewHandler();
+        Mockito.doReturn(systemInfoService).when(env).getClusterInfo();
+        Mockito.doReturn(tabletInvertedIndex).when(env).getTabletInvertedIndex();
 
-            @Mock
-            Env getCurrentEnv() {
-                return env;
-            }
+        // Replace SingletonHolder.INSTANCE with our spy for cross-thread visibility.
+        // Mockito.mockStatic is thread-local and invisible to HTTP handler threads.
+        try {
+            originalEnvInstance = replaceEnvSingleton(env);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set SingletonHolder.INSTANCE", e);
+        }
 
-            @Mock
-            SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-
-            @Mock
-            TabletInvertedIndex getCurrentInvertedIndex() {
-                return tabletInvertedIndex;
-            }
-        };
         assignBackends();
         doSetUp();
     }
 
     @After
     public void tearDown() {
+        if (originalEnvInstance != null) {
+            try {
+                replaceEnvSingleton(originalEnvInstance);
+                originalEnvInstance = null;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to restore SingletonHolder.INSTANCE", e);
+            }
+        }
     }
 
+    /**
+     * Replace Env.SingletonHolder.INSTANCE using sun.misc.Unsafe via reflection.
+     * Returns the previous INSTANCE value. This is needed because mockStatic is
+     * thread-local and HTTP handler threads cannot see it.
+     */
+    private static Env replaceEnvSingleton(Env newInstance) throws Exception {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+        unsafeField.setAccessible(true);
+        Object unsafe = unsafeField.get(null);
+        Class<?> singletonHolder = Class.forName("org.apache.doris.catalog.Env$SingletonHolder");
+        Field instanceField = singletonHolder.getDeclaredField("INSTANCE");
+        Method staticFieldOffset = unsafeClass.getMethod("staticFieldOffset", Field.class);
+        Method staticFieldBase = unsafeClass.getMethod("staticFieldBase", Field.class);
+        Method getObject = unsafeClass.getMethod("getObject", Object.class, long.class);
+        Method putObject = unsafeClass.getMethod("putObject", Object.class, long.class, Object.class);
+        long offset = (long) staticFieldOffset.invoke(unsafe, instanceField);
+        Object base = staticFieldBase.invoke(unsafe, instanceField);
+        Env old = (Env) getObject.invoke(unsafe, base, offset);
+        putObject.invoke(unsafe, base, offset, newInstance);
+        return old;
+    }
 
     public void doSetUp() {
 

--- a/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/CopyIntoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/httpv2/rest/CopyIntoTest.java
@@ -19,14 +19,15 @@ package org.apache.doris.httpv2.rest;
 
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.http.DorisHttpTestCase;
 import org.apache.doris.httpv2.util.ExecutionResultSet;
+import org.apache.doris.httpv2.util.StatementSubmitter;
 import org.apache.doris.httpv2.util.StatementSubmitter.StmtContext;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.utframe.MockedMetaServerFactory;
 import org.apache.doris.utframe.UtFrameUtils;
 
-import mockit.Expectations;
 import okhttp3.Credentials;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -37,13 +38,14 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.Future;
 
 public class CopyIntoTest extends DorisHttpTestCase {
     protected static final String runningDir = "fe/mocked/" + CopyIntoTest.class.getSimpleName() + "/" + UUID.randomUUID() + "/";
@@ -140,8 +142,6 @@ public class CopyIntoTest extends DorisHttpTestCase {
         String exception = (String) jsonObject.get("data");
         Assert.assertTrue(exception.contains("POST body must contain [sql] root object"));
 
-        java.util.concurrent.FutureTask<ExecutionResultSet> ret = new FutureTask<>(() -> new ExecutionResultSet(new HashMap<>()));
-
         HashMap<String, Object> om = new HashMap<>();
         HashMap<String, Object> im = new HashMap<>();
         im.put("copyId", "copy_1296997def6d4887_9e7ff31a7f3842cc");
@@ -155,17 +155,13 @@ public class CopyIntoTest extends DorisHttpTestCase {
         om.put("result", im);
         ExecutionResultSet e = new ExecutionResultSet(om);
 
-        new Expectations(CopyIntoAction.getStmtSubmitter(), ret) {
-            {
-                CopyIntoAction.getStmtSubmitter().submitBlock((StmtContext) any);
-                minTimes = 0;
-                result = ret;
-
-                ret.get();
-                minTimes = 0;
-                result = e;
-            }
-        };
+        CopyIntoAction.getStmtSubmitter();
+        StatementSubmitter mockSubmitter = Mockito.mock(StatementSubmitter.class);
+        @SuppressWarnings("unchecked")
+        Future<ExecutionResultSet> mockRet = Mockito.mock(Future.class);
+        Mockito.when(mockSubmitter.submitBlock(Mockito.any(StmtContext.class))).thenReturn(mockRet);
+        Mockito.when(mockRet.get()).thenReturn(e);
+        Deencapsulation.setField(CopyIntoAction.class, "stmtSubmitter", mockSubmitter);
 
         Map<String, String> m = new HashMap<>();
         m.put("sql", "copy into db1.t2 from @~(\"{t3.dat}\")");

--- a/fe/fe-core/src/test/java/org/apache/doris/info/TableNameInfoUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/info/TableNameInfoUtilsTest.java
@@ -23,25 +23,20 @@ import org.apache.doris.catalog.NameSpaceContext;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.datasource.CatalogIf;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class TableNameInfoUtilsTest {
 
     @Test
-    public void testFromDbWithCatalog(@Mocked Database db, @Mocked CatalogIf catalog) {
-        new Expectations() {
-            {
-                db.getCatalog();
-                result = catalog;
-                catalog.getName();
-                result = "test_catalog";
-                db.getFullName();
-                result = "test_db";
-            }
-        };
+    public void testFromDbWithCatalog() {
+        Database db = Mockito.mock(Database.class);
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
+
+        Mockito.when(db.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getName()).thenReturn("test_catalog");
+        Mockito.when(db.getFullName()).thenReturn("test_db");
 
         TableNameInfo info = TableNameInfoUtils.fromDb(db, "test_table");
         Assertions.assertEquals("test_catalog", info.getCtl());
@@ -50,15 +45,11 @@ public class TableNameInfoUtilsTest {
     }
 
     @Test
-    public void testFromDbWithNullCatalog(@Mocked Database db) {
-        new Expectations() {
-            {
-                db.getCatalog();
-                result = null;
-                db.getFullName();
-                result = "test_db";
-            }
-        };
+    public void testFromDbWithNullCatalog() {
+        Database db = Mockito.mock(Database.class);
+
+        Mockito.when(db.getCatalog()).thenReturn(null);
+        Mockito.when(db.getFullName()).thenReturn("test_db");
 
         TableNameInfo info = TableNameInfoUtils.fromDb(db, "test_table");
         Assertions.assertEquals(NameSpaceContext.INTERNAL_CATALOG_NAME, info.getCtl());
@@ -67,15 +58,12 @@ public class TableNameInfoUtilsTest {
     }
 
     @Test
-    public void testFromCatalogDbWithString(@Mocked CatalogIf catalog, @Mocked DatabaseIf db) {
-        new Expectations() {
-            {
-                catalog.getName();
-                result = "my_catalog";
-                db.getFullName();
-                result = "my_db";
-            }
-        };
+    public void testFromCatalogDbWithString() {
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
+        DatabaseIf db = Mockito.mock(DatabaseIf.class);
+
+        Mockito.when(catalog.getName()).thenReturn("my_catalog");
+        Mockito.when(db.getFullName()).thenReturn("my_db");
 
         TableNameInfo info = TableNameInfoUtils.fromCatalogDb(catalog, db, "my_table");
         Assertions.assertEquals("my_catalog", info.getCtl());
@@ -84,18 +72,14 @@ public class TableNameInfoUtilsTest {
     }
 
     @Test
-    public void testFromCatalogDbWithTableIf(@Mocked CatalogIf catalog, @Mocked DatabaseIf db,
-            @Mocked TableIf table) {
-        new Expectations() {
-            {
-                catalog.getName();
-                result = "cat1";
-                db.getFullName();
-                result = "db1";
-                table.getName();
-                result = "tbl1";
-            }
-        };
+    public void testFromCatalogDbWithTableIf() {
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
+        DatabaseIf db = Mockito.mock(DatabaseIf.class);
+        TableIf table = Mockito.mock(TableIf.class);
+
+        Mockito.when(catalog.getName()).thenReturn("cat1");
+        Mockito.when(db.getFullName()).thenReturn("db1");
+        Mockito.when(table.getName()).thenReturn("tbl1");
 
         TableNameInfo info = TableNameInfoUtils.fromCatalogDb(catalog, db, table);
         Assertions.assertEquals("cat1", info.getCtl());
@@ -104,22 +88,16 @@ public class TableNameInfoUtilsTest {
     }
 
     @Test
-    public void testFromTableOrNullWithDbAndCatalog(@Mocked TableIf table, @Mocked DatabaseIf db,
-            @Mocked CatalogIf catalog) {
-        new Expectations() {
-            {
-                table.getDatabase();
-                result = db;
-                db.getCatalog();
-                result = catalog;
-                catalog.getName();
-                result = "ext_catalog";
-                db.getFullName();
-                result = "ext_db";
-                table.getName();
-                result = "ext_table";
-            }
-        };
+    public void testFromTableOrNullWithDbAndCatalog() {
+        TableIf table = Mockito.mock(TableIf.class);
+        DatabaseIf db = Mockito.mock(DatabaseIf.class);
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
+
+        Mockito.when(table.getDatabase()).thenReturn(db);
+        Mockito.when(db.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getName()).thenReturn("ext_catalog");
+        Mockito.when(db.getFullName()).thenReturn("ext_db");
+        Mockito.when(table.getName()).thenReturn("ext_table");
 
         TableNameInfo info = TableNameInfoUtils.fromTableOrNull(table);
         Assertions.assertNotNull(info);
@@ -129,32 +107,24 @@ public class TableNameInfoUtilsTest {
     }
 
     @Test
-    public void testFromTableOrNullWithNullDb(@Mocked TableIf table) {
-        new Expectations() {
-            {
-                table.getName();
-                result = "some_table";
-                table.getDatabase();
-                result = null;
-            }
-        };
+    public void testFromTableOrNullWithNullDb() {
+        TableIf table = Mockito.mock(TableIf.class);
+
+        Mockito.when(table.getName()).thenReturn("some_table");
+        Mockito.when(table.getDatabase()).thenReturn(null);
 
         TableNameInfo info = TableNameInfoUtils.fromTableOrNull(table);
         Assertions.assertNull(info);
     }
 
     @Test
-    public void testFromTableOrNullWithNullCatalog(@Mocked TableIf table, @Mocked DatabaseIf db) {
-        new Expectations() {
-            {
-                table.getName();
-                result = "internal_table";
-                table.getDatabase();
-                result = db;
-                db.getCatalog();
-                result = null;
-            }
-        };
+    public void testFromTableOrNullWithNullCatalog() {
+        TableIf table = Mockito.mock(TableIf.class);
+        DatabaseIf db = Mockito.mock(DatabaseIf.class);
+
+        Mockito.when(table.getName()).thenReturn("internal_table");
+        Mockito.when(table.getDatabase()).thenReturn(db);
+        Mockito.when(db.getCatalog()).thenReturn(null);
 
         TableNameInfo info = TableNameInfoUtils.fromTableOrNull(table);
         Assertions.assertNull(info);
@@ -167,13 +137,10 @@ public class TableNameInfoUtilsTest {
     }
 
     @Test
-    public void testFromTableOrNullWithEmptyName(@Mocked TableIf table) {
-        new Expectations() {
-            {
-                table.getName();
-                result = "";
-            }
-        };
+    public void testFromTableOrNullWithEmptyName() {
+        TableIf table = Mockito.mock(TableIf.class);
+
+        Mockito.when(table.getName()).thenReturn("");
 
         TableNameInfo info = TableNameInfoUtils.fromTableOrNull(table);
         Assertions.assertNull(info);

--- a/fe/fe-core/src/test/java/org/apache/doris/insertoverwrite/InsertOverwriteManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/insertoverwrite/InsertOverwriteManagerTest.java
@@ -25,64 +25,32 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mockito.Mockito;
 
 public class InsertOverwriteManagerTest {
-    @Mocked
-    private DatabaseIf db;
+    private DatabaseIf db = Mockito.mock(DatabaseIf.class);
 
-    @Mocked
-    private OlapTable table;
+    private OlapTable table = Mockito.mock(OlapTable.class);
 
-    @Mocked
-    private HMSExternalTable hmsExternalTable;
+    private HMSExternalTable hmsExternalTable = Mockito.mock(HMSExternalTable.class);
 
-    @Mocked
-    private MTMV mtmv;
+    private MTMV mtmv = Mockito.mock(MTMV.class);
 
     @Before
     public void setUp()
             throws NoSuchMethodException, SecurityException, AnalysisException, DdlException, MetaNotFoundException {
 
-        new Expectations() {
-            {
-                db.getId();
-                minTimes = 0;
-                result = 1L;
-
-                db.getFullName();
-                minTimes = 0;
-                result = "db1";
-
-                table.getId();
-                minTimes = 0;
-                result = 2L;
-
-                table.getName();
-                minTimes = 0;
-                result = "table1";
-
-                hmsExternalTable.getId();
-                minTimes = 0;
-                result = 3L;
-
-                hmsExternalTable.getName();
-                minTimes = 0;
-                result = "hmsTable";
-
-                mtmv.getId();
-                minTimes = 0;
-                result = 4L;
-
-                mtmv.getName();
-                minTimes = 0;
-                result = "mtmv1";
-            }
-        };
+        Mockito.when(db.getId()).thenReturn(1L);
+        Mockito.when(db.getFullName()).thenReturn("db1");
+        Mockito.when(table.getId()).thenReturn(2L);
+        Mockito.when(table.getName()).thenReturn("table1");
+        Mockito.when(hmsExternalTable.getId()).thenReturn(3L);
+        Mockito.when(hmsExternalTable.getName()).thenReturn("hmsTable");
+        Mockito.when(mtmv.getId()).thenReturn(4L);
+        Mockito.when(mtmv.getName()).thenReturn("mtmv1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/job/manager/JobManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/manager/JobManagerTest.java
@@ -23,9 +23,10 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Sets;
-import mockit.Expectations;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -35,31 +36,28 @@ public class JobManagerTest {
     public void testJobAuth() throws IOException, AnalysisException {
         UserIdentity user1 = new UserIdentity("testJobAuthUser", "%");
         user1.analyze();
-        new Expectations() {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = TestWithFeService.createCtx(user1, "%");
+        ConnectContext ctx = TestWithFeService.createCtx(user1, "%");
+        try (MockedStatic<ConnectContext> mocked = Mockito.mockStatic(ConnectContext.class)) {
+            mocked.when(ConnectContext::get).thenReturn(ctx);
+            JobManager manager = new JobManager();
+            HashSet<String> tableNames = Sets.newHashSet();
+            try {
+                // should check db auth
+                manager.checkJobAuth("ctl1", "db1", tableNames);
+                throw new RuntimeException("should exception");
+            } catch (AnalysisException e) {
+                Assert.assertTrue(e.getMessage().contains("Admin_priv,Load_priv"));
+                Assert.assertTrue(e.getMessage().contains("db1"));
             }
-        };
-        JobManager manager = new JobManager();
-        HashSet<String> tableNames = Sets.newHashSet();
-        try {
-            // should check db auth
-            manager.checkJobAuth("ctl1", "db1", tableNames);
-            throw new RuntimeException("should exception");
-        } catch (AnalysisException e) {
-            Assert.assertTrue(e.getMessage().contains("Admin_priv,Load_priv"));
-            Assert.assertTrue(e.getMessage().contains("db1"));
-        }
-        tableNames.add("table1");
-        try {
-            // should check db auth
-            manager.checkJobAuth("ctl1", "db1", tableNames);
-            throw new RuntimeException("should exception");
-        } catch (AnalysisException e) {
-            Assert.assertTrue(e.getMessage().contains("Admin_priv,Load_priv"));
-            Assert.assertTrue(e.getMessage().contains("table1"));
+            tableNames.add("table1");
+            try {
+                // should check db auth
+                manager.checkJobAuth("ctl1", "db1", tableNames);
+                throw new RuntimeException("should exception");
+            } catch (AnalysisException e) {
+                Assert.assertTrue(e.getMessage().contains("Admin_priv,Load_priv"));
+                Assert.assertTrue(e.getMessage().contains("table1"));
+            }
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBDebuggerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBDebuggerTest.java
@@ -26,14 +26,14 @@ import org.apache.doris.system.SystemInfoService.HostInfo;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,72 +104,56 @@ public class BDBDebuggerTest {
         String nodeName = Env.genFeNodeName("127.0.0.1", port, false);
         long replayedJournalId = 0;
         File tmpDir = createTmpDir();
-        new MockUp<Env>() {
-            HostInfo selfNode = new HostInfo("127.0.0.1", port);
-            @Mock
-            public String getBdbDir() {
-                return tmpDir.getAbsolutePath();
-            }
+        Env mockEnv = Mockito.mock(Env.class);
+        HostInfo selfNode = new HostInfo("127.0.0.1", port);
+        Mockito.when(mockEnv.getBdbDir()).thenReturn(tmpDir.getAbsolutePath());
+        Mockito.when(mockEnv.getSelfNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.getHelperNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.isElectable()).thenReturn(true);
+        Mockito.when(mockEnv.getReplayedJournalId()).thenReturn(replayedJournalId);
 
-            @Mock
-            public HostInfo getSelfNode() {
-                return this.selfNode;
-            }
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnvStatic.when(Env::getServingEnv).thenReturn(mockEnv);
 
-            @Mock
-            public HostInfo getHelperNode() {
-                return this.selfNode;
+            LOG.info("BdbDir:{}, selfNode:{}, nodeName:{}", Env.getServingEnv().getBdbDir(),
+                    Env.getServingEnv().getBdbDir(), nodeName);
+            Assertions.assertEquals(tmpDir.getAbsolutePath(), Env.getServingEnv().getBdbDir());
+            BDBJEJournal journal = new BDBJEJournal(nodeName);
+            journal.open();
+            // BDBEnvrinment need several seconds election from unknown to master
+            for (int i = 0; i < 10; i++) {
+                if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
+                        .equals(ReplicatedEnvironment.State.MASTER)) {
+                    break;
+                }
+                Thread.sleep(1000);
             }
+            Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
+                    journal.getBDBEnvironment().getReplicatedEnvironment().getState());
 
-            @Mock
-            public boolean isElectable() {
-                return true;
+            journal.rollJournal();
+            for (int i = 0; i < 10; i++) {
+                Timestamp ts = new Timestamp();
+                journal.write(OperationType.OP_TIMESTAMP, ts);
             }
+            JournalEntity journalEntity = journal.read(1);
+            Assertions.assertEquals(OperationType.OP_TIMESTAMP, journalEntity.getOpCode());
+            journal.close();
 
-            @Mock
-            public long getReplayedJournalId() {
-                return replayedJournalId;
-            }
-        };
+            Deencapsulation.invoke(BDBDebugger.get(), "initDebugEnv", tmpDir.getAbsolutePath());
+            // BDBDebugger.BDBDebugEnv bdbDebugEnv = new BDBDebugger.BDBDebugEnv(tmpDir.getAbsolutePath());
+            // bdbDebugEnv.init();
+            BDBDebugger.BDBDebugEnv bdbDebugEnv = BDBDebugger.get().getEnv();
 
-        LOG.info("BdbDir:{}, selfNode:{}, nodeName:{}", Env.getServingEnv().getBdbDir(),
-                Env.getServingEnv().getBdbDir(), nodeName);
-        Assertions.assertEquals(tmpDir.getAbsolutePath(), Env.getServingEnv().getBdbDir());
-        BDBJEJournal journal = new BDBJEJournal(nodeName);
-        journal.open();
-        // BDBEnvrinment need several seconds election from unknown to master
-        for (int i = 0; i < 10; i++) {
-            if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
-                    .equals(ReplicatedEnvironment.State.MASTER)) {
-                break;
-            }
-            Thread.sleep(1000);
+            LOG.info("{}|{}|{}", bdbDebugEnv.listDbNames(), bdbDebugEnv.getJournalIds("1"),
+                    bdbDebugEnv.getJournalNumber("1"));
+            Assertions.assertEquals(2, bdbDebugEnv.listDbNames().size());
+            Assertions.assertEquals(10, bdbDebugEnv.getJournalIds("1").size());
+            Assertions.assertEquals(10, bdbDebugEnv.getJournalNumber("1"));
+            BDBDebugger.JournalEntityWrapper entityWrapper = bdbDebugEnv.getJournalEntity("1", 5L);
+            Assertions.assertEquals(5, entityWrapper.journalId);
+            Assertions.assertEquals(OperationType.OP_TIMESTAMP, entityWrapper.entity.getOpCode());
+            bdbDebugEnv.close();
         }
-        Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
-                journal.getBDBEnvironment().getReplicatedEnvironment().getState());
-
-        journal.rollJournal();
-        for (int i = 0; i < 10; i++) {
-            Timestamp ts = new Timestamp();
-            journal.write(OperationType.OP_TIMESTAMP, ts);
-        }
-        JournalEntity journalEntity = journal.read(1);
-        Assertions.assertEquals(OperationType.OP_TIMESTAMP, journalEntity.getOpCode());
-        journal.close();
-
-        Deencapsulation.invoke(BDBDebugger.get(), "initDebugEnv", tmpDir.getAbsolutePath());
-        // BDBDebugger.BDBDebugEnv bdbDebugEnv = new BDBDebugger.BDBDebugEnv(tmpDir.getAbsolutePath());
-        // bdbDebugEnv.init();
-        BDBDebugger.BDBDebugEnv bdbDebugEnv = BDBDebugger.get().getEnv();
-
-        LOG.info("{}|{}|{}", bdbDebugEnv.listDbNames(), bdbDebugEnv.getJournalIds("1"),
-                bdbDebugEnv.getJournalNumber("1"));
-        Assertions.assertEquals(2, bdbDebugEnv.listDbNames().size());
-        Assertions.assertEquals(10, bdbDebugEnv.getJournalIds("1").size());
-        Assertions.assertEquals(10, bdbDebugEnv.getJournalNumber("1"));
-        BDBDebugger.JournalEntityWrapper entityWrapper = bdbDebugEnv.getJournalEntity("1", 5L);
-        Assertions.assertEquals(5, entityWrapper.journalId);
-        Assertions.assertEquals(OperationType.OP_TIMESTAMP, entityWrapper.entity.getOpCode());
-        bdbDebugEnv.close();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBEnvironmentTest.java
@@ -36,9 +36,6 @@ import com.sleepycat.je.rep.InsufficientAcksException;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
 import com.sleepycat.je.rep.impl.RepImpl;
 import com.sleepycat.je.rep.util.ReplicationGroupAdmin;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,6 +43,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.RepeatedTest;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -177,27 +176,29 @@ public class BDBEnvironmentTest {
         Assertions.assertEquals(OperationStatus.SUCCESS, epochDb.get(null, key, readValue2, LockMode.DEFAULT));
         Assertions.assertEquals(new String(value.getData()), new String(readValue2.getData()));
 
-        new MockUp<Env>() {
-            int i = 0;
-            @Mock
-            public List<Frontend> getFrontends(FrontendNodeType nodeType) {
-                ArrayList<Frontend> frontends = new ArrayList<Frontend>();
-                if (i == 0) {
-                    i++;
-                    return frontends;
-                }
-                Frontend frontend = new Frontend(FrontendNodeType.FOLLOWER, selfNodeName,
-                        "127.0.0.1", port);
-                frontend.setIsAlive(true);
-                frontends.add(frontend);
+        Env mockEnv = Mockito.mock(Env.class);
+        java.util.concurrent.atomic.AtomicInteger callCounter = new java.util.concurrent.atomic.AtomicInteger(0);
+        Mockito.when(mockEnv.getFrontends(Mockito.any())).thenAnswer(inv -> {
+            ArrayList<Frontend> frontends = new ArrayList<Frontend>();
+            if (callCounter.getAndIncrement() == 0) {
                 return frontends;
             }
-        };
+            Frontend frontend = new Frontend(FrontendNodeType.FOLLOWER, selfNodeName,
+                    "127.0.0.1", port);
+            frontend.setIsAlive(true);
+            frontends.add(frontend);
+            return frontends;
+        });
 
-        ReplicationGroupAdmin replicationGroupAdmin = bdbEnvironment.getReplicationGroupAdmin();
-        Assertions.assertNull(replicationGroupAdmin);
-        replicationGroupAdmin = bdbEnvironment.getReplicationGroupAdmin();
-        Assertions.assertNotNull(replicationGroupAdmin);
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class)) {
+            mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(mockEnv);
+            mockedEnvStatic.when(Env::getCurrentEnvJournalVersion).thenCallRealMethod();
+
+            ReplicationGroupAdmin replicationGroupAdmin = bdbEnvironment.getReplicationGroupAdmin();
+            Assertions.assertNull(replicationGroupAdmin);
+            replicationGroupAdmin = bdbEnvironment.getReplicationGroupAdmin();
+            Assertions.assertNotNull(replicationGroupAdmin);
+        }
 
         bdbEnvironment.close();
         exception = Assertions.assertThrows(IllegalStateException.class, () -> {
@@ -696,18 +697,19 @@ public class BDBEnvironmentTest {
                 Assertions.assertEquals(new String(value.getData()), new String(readValue.getData()));
             }
 
+            ReplicatedEnvironment replicatedEnvironment = masterPair.first.getReplicatedEnvironment();
             Field envImplField = ReplicatedEnvironment.class.getDeclaredField("repEnvironmentImpl");
             envImplField.setAccessible(true);
-            RepImpl impl = (RepImpl) envImplField.get(masterPair.first.getReplicatedEnvironment());
+            RepImpl impl = (RepImpl) envImplField.get(replicatedEnvironment);
             Assertions.assertNotNull(impl);
 
-            new Expectations(impl) {{
-                    // Below method will replicate log item to followers.
-                    impl.registerVLSN(withNotNull());
-                    // Below method will wait until the logs are replicated.
-                    impl.postLogCommitHook(withNotNull(), withNotNull());
-                    result = new InsufficientAcksException("mocked");
-                }};
+            Field environmentImplField = com.sleepycat.je.Environment.class.getDeclaredField("environmentImpl");
+            environmentImplField.setAccessible(true);
+            RepImpl implSpy = Mockito.spy(impl);
+            envImplField.set(replicatedEnvironment, implSpy);
+            environmentImplField.set(replicatedEnvironment, implSpy);
+            Mockito.doThrow(new InsufficientAcksException("mocked"))
+                    .when(implSpy).postLogCommitHook(Mockito.any(), Mockito.any());
 
             long count = masterDb.count();
             final Database oldMasterDb = masterDb;

--- a/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBJEJournalTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/journal/bdbje/BDBJEJournalTest.java
@@ -31,14 +31,14 @@ import org.apache.doris.system.SystemInfoService.HostInfo;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.sleepycat.je.rep.ReplicatedEnvironment;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataOutput;
 import java.io.File;
@@ -110,121 +110,105 @@ public class BDBJEJournalTest { // CHECKSTYLE IGNORE THIS LINE: BDBJE should use
         String nodeName = Env.genFeNodeName("127.0.0.1", port, false);
         long replayedJournalId = 0;
         File tmpDir = createTmpDir();
-        new MockUp<Env>() {
-            HostInfo selfNode = new HostInfo("127.0.0.1", port);
-            @Mock
-            public String getBdbDir() {
-                return tmpDir.getAbsolutePath();
+        Env mockEnv = Mockito.mock(Env.class);
+        HostInfo selfNode = new HostInfo("127.0.0.1", port);
+        Mockito.when(mockEnv.getBdbDir()).thenReturn(tmpDir.getAbsolutePath());
+        Mockito.when(mockEnv.getSelfNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.getHelperNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.isElectable()).thenReturn(true);
+        Mockito.when(mockEnv.getReplayedJournalId()).thenReturn(replayedJournalId);
+
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnvStatic.when(Env::getServingEnv).thenReturn(mockEnv);
+
+            LOG.info("BdbDir:{}, selfNode:{}, nodeName:{}", Env.getServingEnv().getBdbDir(),
+                    Env.getServingEnv().getBdbDir(), nodeName);
+            Assertions.assertEquals(tmpDir.getAbsolutePath(), Env.getServingEnv().getBdbDir());
+            BDBJEJournal journal = new BDBJEJournal(nodeName);
+            journal.open();
+            // BDBEnvrinment need several seconds election from unknown to master
+            for (int i = 0; i < 10; i++) {
+                if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
+                        .equals(ReplicatedEnvironment.State.MASTER)) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+            Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
+                    journal.getBDBEnvironment().getReplicatedEnvironment().getState());
+
+            journal.rollJournal();
+            for (int i = 0; i < 10; i++) {
+                journal.write(OperationType.OP_TIMESTAMP, new Timestamp());
             }
 
-            @Mock
-            public HostInfo getSelfNode() {
-                return this.selfNode;
+            Assertions.assertEquals(10, journal.getMaxJournalId());
+            Assertions.assertEquals(10, journal.getJournalNum());
+            Assertions.assertEquals(1, journal.getMinJournalId());
+            Assertions.assertEquals(0, journal.getFinalizedJournalId());
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
+            }
+            Assertions.assertEquals(1, journal.getDatabaseNames().size());
+            Assertions.assertEquals(1, journal.getDatabaseNames().get(0));
+
+            JournalEntity journalEntity = journal.read(1);
+            Assertions.assertEquals(OperationType.OP_TIMESTAMP, journalEntity.getOpCode());
+
+            for (int i = 10; i < 50; i++) {
+                if (i % 10 == 0) {
+                    journal.rollJournal();
+                }
+                journal.write(OperationType.OP_TIMESTAMP, new Timestamp());
             }
 
-            @Mock
-            public HostInfo getHelperNode() {
-                return this.selfNode;
+            Assertions.assertEquals(50, journal.getMaxJournalId());
+            Assertions.assertEquals(10, journal.getJournalNum());
+            Assertions.assertEquals(1, journal.getMinJournalId());
+            Assertions.assertEquals(40, journal.getFinalizedJournalId());
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
+            }
+            Assertions.assertEquals(5, journal.getDatabaseNames().size());
+            Assertions.assertEquals(41, journal.getDatabaseNames().get(4));
+
+            JournalCursor cursor = journal.read(1, 51);
+            Assertions.assertNotNull(cursor);
+            for (int i = 0; i < 50; i++) {
+                Pair<Long, JournalEntity> kv = cursor.next();
+                Assertions.assertNotNull(kv);
+                JournalEntity entity = kv.second;
+                Assertions.assertEquals(OperationType.OP_TIMESTAMP, entity.getOpCode());
             }
 
-            @Mock
-            public boolean isElectable() {
-                return true;
+            Assertions.assertNull(cursor.next());
+
+            journal.close();
+            Assertions.assertNull(journal.getBDBEnvironment());
+
+            journal.open();
+            Assertions.assertNotNull(journal.getBDBEnvironment());
+            // BDBEnvrinment need several seconds election from unknown to master
+            for (int i = 0; i < 10; i++) {
+                if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
+                        .equals(ReplicatedEnvironment.State.MASTER)) {
+                    break;
+                }
+                Thread.sleep(1000);
             }
 
-            @Mock
-            public long getReplayedJournalId() {
-                return replayedJournalId;
+            Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
+                    journal.getBDBEnvironment().getReplicatedEnvironment().getState());
+            journal.deleteJournals(21);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
             }
-        };
-
-        LOG.info("BdbDir:{}, selfNode:{}, nodeName:{}", Env.getServingEnv().getBdbDir(),
-                Env.getServingEnv().getBdbDir(), nodeName);
-        Assertions.assertEquals(tmpDir.getAbsolutePath(), Env.getServingEnv().getBdbDir());
-        BDBJEJournal journal = new BDBJEJournal(nodeName);
-        journal.open();
-        // BDBEnvrinment need several seconds election from unknown to master
-        for (int i = 0; i < 10; i++) {
-            if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
-                    .equals(ReplicatedEnvironment.State.MASTER)) {
-                break;
-            }
-            Thread.sleep(1000);
+            Assertions.assertEquals(3, journal.getDatabaseNames().size());
+            Assertions.assertEquals(21, journal.getDatabaseNames().get(0));
+            journal.close();
         }
-        Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
-                journal.getBDBEnvironment().getReplicatedEnvironment().getState());
-
-        journal.rollJournal();
-        for (int i = 0; i < 10; i++) {
-            journal.write(OperationType.OP_TIMESTAMP, new Timestamp());
-        }
-
-        Assertions.assertEquals(10, journal.getMaxJournalId());
-        Assertions.assertEquals(10, journal.getJournalNum());
-        Assertions.assertEquals(1, journal.getMinJournalId());
-        Assertions.assertEquals(0, journal.getFinalizedJournalId());
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
-        }
-        Assertions.assertEquals(1, journal.getDatabaseNames().size());
-        Assertions.assertEquals(1, journal.getDatabaseNames().get(0));
-
-        JournalEntity journalEntity = journal.read(1);
-        Assertions.assertEquals(OperationType.OP_TIMESTAMP, journalEntity.getOpCode());
-
-        for (int i = 10; i < 50; i++) {
-            if (i % 10 == 0) {
-                journal.rollJournal();
-            }
-            journal.write(OperationType.OP_TIMESTAMP, new Timestamp());
-        }
-
-        Assertions.assertEquals(50, journal.getMaxJournalId());
-        Assertions.assertEquals(10, journal.getJournalNum());
-        Assertions.assertEquals(1, journal.getMinJournalId());
-        Assertions.assertEquals(40, journal.getFinalizedJournalId());
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
-        }
-        Assertions.assertEquals(5, journal.getDatabaseNames().size());
-        Assertions.assertEquals(41, journal.getDatabaseNames().get(4));
-
-        JournalCursor cursor = journal.read(1, 51);
-        Assertions.assertNotNull(cursor);
-        for (int i = 0; i < 50; i++) {
-            Pair<Long, JournalEntity> kv = cursor.next();
-            Assertions.assertNotNull(kv);
-            JournalEntity entity = kv.second;
-            Assertions.assertEquals(OperationType.OP_TIMESTAMP, entity.getOpCode());
-        }
-
-        Assertions.assertNull(cursor.next());
-
-        journal.close();
-        Assertions.assertNull(journal.getBDBEnvironment());
-
-        journal.open();
-        Assertions.assertNotNull(journal.getBDBEnvironment());
-        // BDBEnvrinment need several seconds election from unknown to master
-        for (int i = 0; i < 10; i++) {
-            if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
-                    .equals(ReplicatedEnvironment.State.MASTER)) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
-
-        Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
-                journal.getBDBEnvironment().getReplicatedEnvironment().getState());
-        journal.deleteJournals(21);
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
-        }
-        Assertions.assertEquals(3, journal.getDatabaseNames().size());
-        Assertions.assertEquals(21, journal.getDatabaseNames().get(0));
-        journal.close();
     }
 
     @RepeatedTest(1)
@@ -234,81 +218,65 @@ public class BDBJEJournalTest { // CHECKSTYLE IGNORE THIS LINE: BDBJE should use
         String nodeName = Env.genFeNodeName("127.0.0.1", port, false);
         long replayedJournalId = 0;
         File tmpDir = createTmpDir();
-        new MockUp<Env>() {
-            HostInfo selfNode = new HostInfo("127.0.0.1", port);
-            @Mock
-            public String getBdbDir() {
-                return tmpDir.getAbsolutePath();
-            }
+        Env mockEnv = Mockito.mock(Env.class);
+        HostInfo selfNode = new HostInfo("127.0.0.1", port);
+        Mockito.when(mockEnv.getBdbDir()).thenReturn(tmpDir.getAbsolutePath());
+        Mockito.when(mockEnv.getSelfNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.getHelperNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.isElectable()).thenReturn(true);
+        Mockito.when(mockEnv.getReplayedJournalId()).thenReturn(replayedJournalId);
 
-            @Mock
-            public HostInfo getSelfNode() {
-                return this.selfNode;
-            }
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnvStatic.when(Env::getServingEnv).thenReturn(mockEnv);
 
-            @Mock
-            public HostInfo getHelperNode() {
-                return this.selfNode;
-            }
-
-            @Mock
-            public boolean isElectable() {
-                return true;
-            }
-
-            @Mock
-            public long getReplayedJournalId() {
-                return replayedJournalId;
-            }
-        };
-
-        String oldRecovery = System.getProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY);
-        String oldMetadataRecovery = System.getProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY);
-        BDBJEJournal journal = new BDBJEJournal(nodeName);
-        try {
-            System.clearProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY);
-            System.setProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY, "5");
-
-            journal.open();
-            for (int i = 0; i < 10; i++) {
-                if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
-                        .equals(ReplicatedEnvironment.State.MASTER)) {
-                    break;
-                }
-                Thread.sleep(1000);
-            }
-            Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
-                    journal.getBDBEnvironment().getReplicatedEnvironment().getState());
-            for (int i = 0; i < 10; i++) {
-                journal.write(OperationType.OP_TIMESTAMP, new Timestamp());
-            }
-            Assertions.assertEquals(10, journal.getMaxJournalId());
-            journal.close();
-
-            journal.open();
-            for (int i = 0; i < 10; i++) {
-                if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
-                        .equals(ReplicatedEnvironment.State.MASTER)) {
-                    break;
-                }
-                Thread.sleep(1000);
-            }
-            Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
-                    journal.getBDBEnvironment().getReplicatedEnvironment().getState());
-            Assertions.assertEquals(10, journal.getMaxJournalId());
-        } finally {
-            if (journal.getBDBEnvironment() != null) {
-                journal.close();
-            }
-            if (oldRecovery == null) {
-                System.clearProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY);
-            } else {
-                System.setProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY, oldRecovery);
-            }
-            if (oldMetadataRecovery == null) {
+            String oldRecovery = System.getProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY);
+            String oldMetadataRecovery = System.getProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY);
+            BDBJEJournal journal = new BDBJEJournal(nodeName);
+            try {
                 System.clearProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY);
-            } else {
-                System.setProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY, oldMetadataRecovery);
+                System.setProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY, "5");
+
+                journal.open();
+                for (int i = 0; i < 10; i++) {
+                    if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
+                            .equals(ReplicatedEnvironment.State.MASTER)) {
+                        break;
+                    }
+                    Thread.sleep(1000);
+                }
+                Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
+                        journal.getBDBEnvironment().getReplicatedEnvironment().getState());
+                for (int i = 0; i < 10; i++) {
+                    journal.write(OperationType.OP_TIMESTAMP, new Timestamp());
+                }
+                Assertions.assertEquals(10, journal.getMaxJournalId());
+                journal.close();
+
+                journal.open();
+                for (int i = 0; i < 10; i++) {
+                    if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
+                            .equals(ReplicatedEnvironment.State.MASTER)) {
+                        break;
+                    }
+                    Thread.sleep(1000);
+                }
+                Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
+                        journal.getBDBEnvironment().getReplicatedEnvironment().getState());
+                Assertions.assertEquals(10, journal.getMaxJournalId());
+            } finally {
+                if (journal.getBDBEnvironment() != null) {
+                    journal.close();
+                }
+                if (oldRecovery == null) {
+                    System.clearProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY);
+                } else {
+                    System.setProperty(FeConstants.RECOVERY_JOURNAL_ID_KEY, oldRecovery);
+                }
+                if (oldMetadataRecovery == null) {
+                    System.clearProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY);
+                } else {
+                    System.setProperty(FeConstants.METADATA_FAILURE_RECOVERY_KEY, oldMetadataRecovery);
+                }
             }
         }
     }
@@ -320,94 +288,78 @@ public class BDBJEJournalTest { // CHECKSTYLE IGNORE THIS LINE: BDBJE should use
         String nodeName = Env.genFeNodeName("127.0.0.1", port, false);
         long replayedJournalId = 0;
         File tmpDir = createTmpDir();
-        new MockUp<Env>() {
-            HostInfo selfNode = new HostInfo("127.0.0.1", port);
-            @Mock
-            public String getBdbDir() {
-                return tmpDir.getAbsolutePath();
-            }
+        Env mockEnv = Mockito.mock(Env.class);
+        HostInfo selfNode = new HostInfo("127.0.0.1", port);
+        Mockito.when(mockEnv.getBdbDir()).thenReturn(tmpDir.getAbsolutePath());
+        Mockito.when(mockEnv.getSelfNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.getHelperNode()).thenReturn(selfNode);
+        Mockito.when(mockEnv.isElectable()).thenReturn(true);
+        Mockito.when(mockEnv.getReplayedJournalId()).thenReturn(replayedJournalId);
 
-            @Mock
-            public HostInfo getSelfNode() {
-                return this.selfNode;
-            }
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnvStatic.when(Env::getServingEnv).thenReturn(mockEnv);
 
-            @Mock
-            public HostInfo getHelperNode() {
-                return this.selfNode;
-            }
-
-            @Mock
-            public boolean isElectable() {
-                return true;
-            }
-
-            @Mock
-            public long getReplayedJournalId() {
-                return replayedJournalId;
-            }
-        };
-
-        LOG.info("BdbDir:{}, selfNode:{}, nodeName:{}", Env.getServingEnv().getBdbDir(),
-                Env.getServingEnv().getBdbDir(), nodeName);
-        Assertions.assertEquals(tmpDir.getAbsolutePath(), Env.getServingEnv().getBdbDir());
-        BDBJEJournal journal = new BDBJEJournal(nodeName);
-        journal.open();
-        // BDBEnvironment need several seconds election from unknown to master
-        for (int i = 0; i < 10; i++) {
-            if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
-                    .equals(ReplicatedEnvironment.State.MASTER)) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
-        Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
-                journal.getBDBEnvironment().getReplicatedEnvironment().getState());
-
-        journal.rollJournal();
-        JournalBatch batch = new JournalBatch(10);
-        for (int i = 0; i < 10; i++) {
-            String data = "JournalBatch item " + i;
-            Writable writable = new Writable() {
-                @Override
-                public void write(DataOutput out) throws IOException {
-                    Text.writeString(out, data);
+            LOG.info("BdbDir:{}, selfNode:{}, nodeName:{}", Env.getServingEnv().getBdbDir(),
+                    Env.getServingEnv().getBdbDir(), nodeName);
+            Assertions.assertEquals(tmpDir.getAbsolutePath(), Env.getServingEnv().getBdbDir());
+            BDBJEJournal journal = new BDBJEJournal(nodeName);
+            journal.open();
+            // BDBEnvironment need several seconds election from unknown to master
+            for (int i = 0; i < 10; i++) {
+                if (journal.getBDBEnvironment().getReplicatedEnvironment().getState()
+                        .equals(ReplicatedEnvironment.State.MASTER)) {
+                    break;
                 }
-            };
-            // OP_START_ROLLUP is deprecated, and safe to write any data.
-            batch.addJournal(OperationType.OP_START_ROLLUP, writable);
+                Thread.sleep(1000);
+            }
+            Assertions.assertEquals(ReplicatedEnvironment.State.MASTER,
+                    journal.getBDBEnvironment().getReplicatedEnvironment().getState());
+
+            journal.rollJournal();
+            JournalBatch batch = new JournalBatch(10);
+            for (int i = 0; i < 10; i++) {
+                String data = "JournalBatch item " + i;
+                Writable writable = new Writable() {
+                    @Override
+                    public void write(DataOutput out) throws IOException {
+                        Text.writeString(out, data);
+                    }
+                };
+                // OP_START_ROLLUP is deprecated, and safe to write any data.
+                batch.addJournal(OperationType.OP_START_ROLLUP, writable);
+            }
+            long journalId = journal.write(batch);
+            Assertions.assertEquals(1, journalId);
+
+            Assertions.assertEquals(10, journal.getMaxJournalId());
+            Assertions.assertEquals(10, journal.getJournalNum());
+            Assertions.assertEquals(1, journal.getMinJournalId());
+            Assertions.assertEquals(0, journal.getFinalizedJournalId());
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
+            }
+            Assertions.assertEquals(1, journal.getDatabaseNames().size());
+            Assertions.assertEquals(1, journal.getDatabaseNames().get(0));
+
+            JournalEntity journalEntity = journal.read(1);
+            Assertions.assertEquals(OperationType.OP_START_ROLLUP, journalEntity.getOpCode());
+
+            batch = new JournalBatch(10);
+            for (int i = 0; i < 10; i++) {
+                String data = "JournalBatch 2 item " + i;
+                Writable writable = new Writable() {
+                    @Override
+                    public void write(DataOutput out) throws IOException {
+                        Text.writeString(out, data);
+                    }
+                };
+                batch.addJournal(OperationType.OP_START_ROLLUP, writable);
+            }
+            journalId = journal.write(batch);
+            Assertions.assertEquals(11, journalId);
+
+            journal.close();
         }
-        long journalId = journal.write(batch);
-        Assertions.assertEquals(1, journalId);
-
-        Assertions.assertEquals(10, journal.getMaxJournalId());
-        Assertions.assertEquals(10, journal.getJournalNum());
-        Assertions.assertEquals(1, journal.getMinJournalId());
-        Assertions.assertEquals(0, journal.getFinalizedJournalId());
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("journal.getDatabaseNames(): {}", journal.getDatabaseNames());
-        }
-        Assertions.assertEquals(1, journal.getDatabaseNames().size());
-        Assertions.assertEquals(1, journal.getDatabaseNames().get(0));
-
-        JournalEntity journalEntity = journal.read(1);
-        Assertions.assertEquals(OperationType.OP_START_ROLLUP, journalEntity.getOpCode());
-
-        batch = new JournalBatch(10);
-        for (int i = 0; i < 10; i++) {
-            String data = "JournalBatch 2 item " + i;
-            Writable writable = new Writable() {
-                @Override
-                public void write(DataOutput out) throws IOException {
-                    Text.writeString(out, data);
-                }
-            };
-            batch.addJournal(OperationType.OP_START_ROLLUP, writable);
-        }
-        journalId = journal.write(batch);
-        Assertions.assertEquals(11, journalId);
-
-        journal.close();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/DeleteJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/DeleteJobTest.java
@@ -32,11 +32,12 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +51,8 @@ public class DeleteJobTest {
     private static final long TABLET_ID = 4L;
 
     private final Database database = new Database(DB_ID, "db");
-    private final InternalCatalog catalog = Deencapsulation.newInstance(InternalCatalog.class);
+    private InternalCatalog catalog = Deencapsulation.newInstance(InternalCatalog.class);
+    private MockedStatic<Env> mockedEnvStatic;
     private final TabletInvertedIndex invertedIndex = new TabletInvertedIndex() {
         @Override
         public List<Replica> getReplicas(Long tabletId) {
@@ -85,27 +87,22 @@ public class DeleteJobTest {
     };
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         invertedIndex.addTablet(TABLET_ID, new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, 5L, 6, TStorageMedium.HDD));
 
-        new MockUp<Env>() {
-            @Mock
-            public InternalCatalog getCurrentInternalCatalog() {
-                return catalog;
-            }
+        catalog = Mockito.spy(catalog);
+        Mockito.doReturn(database).when(catalog).getDbOrMetaException(DB_ID);
 
-            @Mock
-            public TabletInvertedIndex getCurrentInvertedIndex() {
-                return invertedIndex;
-            }
-        };
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+        mockedEnvStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
+    }
 
-        new MockUp<InternalCatalog>() {
-            @Mock
-            public Database getDbOrMetaException(long dbId) {
-                return database;
-            }
-        };
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/load/TabletLoadInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/TabletLoadInfoTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.load;
 import org.apache.doris.catalog.FakeEnv;
 import org.apache.doris.common.FeConstants;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,6 +32,13 @@ import java.io.FileOutputStream;
 
 public class TabletLoadInfoTest {
     private FakeEnv fakeEnv;
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+    }
 
     @Test
     public void testSerialization() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
@@ -17,11 +17,14 @@
 
 package org.apache.doris.load.loadv2;
 
+import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.TableProperty;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.Status;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.load.BrokerFileGroup;
@@ -29,20 +32,29 @@ import org.apache.doris.load.BrokerFileGroupAggInfo;
 import org.apache.doris.load.BrokerFileGroupAggInfo.FileGroupAggKey;
 import org.apache.doris.load.EtlStatus;
 import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.nereids.load.NereidsBrokerFileGroup;
 import org.apache.doris.nereids.load.NereidsLoadingTaskPlanner;
+import org.apache.doris.persist.EditLog;
+import org.apache.doris.resource.computegroup.ComputeGroup;
+import org.apache.doris.resource.computegroup.ComputeGroupMgr;
 import org.apache.doris.task.MasterTaskExecutor;
+import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TStatusCode;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
 import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TxnStateCallbackFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,9 +68,13 @@ public class BrokerLoadJobTest {
     }
 
     @Test
-    public void testGetTableNames(@Injectable BrokerFileGroupAggInfo fileGroupAggInfo,
-                                  @Injectable BrokerFileGroup brokerFileGroup, @Mocked Env env, @Mocked InternalCatalog catalog,
-                                  @Injectable Database database, @Injectable Table table) throws MetaNotFoundException {
+    public void testGetTableNames() throws MetaNotFoundException {
+        BrokerFileGroupAggInfo fileGroupAggInfo = Mockito.mock(BrokerFileGroupAggInfo.class);
+        BrokerFileGroup brokerFileGroup = Mockito.mock(BrokerFileGroup.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table table = Mockito.mock(Table.class);
+
         List<BrokerFileGroup> brokerFileGroups = Lists.newArrayList();
         brokerFileGroups.add(brokerFileGroup);
         Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToFileGroups = Maps.newHashMap();
@@ -67,44 +83,41 @@ public class BrokerLoadJobTest {
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
         Deencapsulation.setField(brokerLoadJob, "fileGroupAggInfo", fileGroupAggInfo);
         String tableName = "table";
-        new Expectations() {
-            {
-                fileGroupAggInfo.getAggKeyToFileGroups();
-                minTimes = 0;
-                result = aggKeyToFileGroups;
-                fileGroupAggInfo.getAllTableIds();
-                minTimes = 0;
-                result = Sets.newHashSet(1L);
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDb(anyLong);
-                minTimes = 0;
-                result = Optional.of(database);
-                database.getTable(1L);
-                minTimes = 0;
-                result = Optional.of(table);
-                table.getName();
-                minTimes = 0;
-                result = tableName;
-            }
-        };
 
-        Assert.assertEquals(1, brokerLoadJob.getTableNamesForShow().size());
-        Assert.assertTrue(brokerLoadJob.getTableNamesForShow().contains(tableName));
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+
+            Mockito.when(fileGroupAggInfo.getAggKeyToFileGroups()).thenReturn(aggKeyToFileGroups);
+            Mockito.when(fileGroupAggInfo.getAllTableIds()).thenReturn(Sets.newHashSet(1L));
+            Mockito.doReturn(Optional.of(database)).when(catalog).getDb(Mockito.anyLong());
+            Mockito.doReturn(Optional.of(table)).when(database).getTable(1L);
+            Mockito.when(table.getName()).thenReturn(tableName);
+
+            Assert.assertEquals(1, brokerLoadJob.getTableNamesForShow().size());
+            Assert.assertTrue(brokerLoadJob.getTableNamesForShow().contains(tableName));
+        }
     }
 
     @Test
-    public void testExecuteJob(@Mocked MasterTaskExecutor masterTaskExecutor) {
-        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        brokerLoadJob.unprotectedExecuteJob();
+    public void testExecuteJob() {
+        Env env = Mockito.mock(Env.class);
+        MasterTaskExecutor masterTaskExecutor = Mockito.mock(MasterTaskExecutor.class);
 
-        Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
-        Assert.assertEquals(1, idToTasks.size());
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getPendingLoadTaskScheduler()).thenReturn(masterTaskExecutor);
+
+            BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+            brokerLoadJob.unprotectedExecuteJob();
+
+            Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
+            Assert.assertEquals(1, idToTasks.size());
+        }
     }
 
     @Test
-    public void testPendingTaskOnFinishedWithJobCancelled(@Injectable BrokerPendingTaskAttachment attachment) {
+    public void testPendingTaskOnFinishedWithJobCancelled() {
+        BrokerPendingTaskAttachment attachment = Mockito.mock(BrokerPendingTaskAttachment.class);
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
         Deencapsulation.setField(brokerLoadJob, "state", JobState.CANCELLED);
         brokerLoadJob.onTaskFinished(attachment);
@@ -114,20 +127,15 @@ public class BrokerLoadJobTest {
     }
 
     @Test
-    public void testPendingTaskOnFinishedWithDuplicated(@Injectable BrokerPendingTaskAttachment attachment) {
+    public void testPendingTaskOnFinishedWithDuplicated() {
+        BrokerPendingTaskAttachment attachment = Mockito.mock(BrokerPendingTaskAttachment.class);
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
         Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
         Set<Long> finishedTaskIds = Sets.newHashSet();
         long taskId = 1L;
         finishedTaskIds.add(taskId);
         Deencapsulation.setField(brokerLoadJob, "finishedTaskIds", finishedTaskIds);
-        new Expectations() {
-            {
-                attachment.getTaskId();
-                minTimes = 0;
-                result = taskId;
-            }
-        };
+        Mockito.when(attachment.getTaskId()).thenReturn(taskId);
 
         brokerLoadJob.onTaskFinished(attachment);
         Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
@@ -135,89 +143,124 @@ public class BrokerLoadJobTest {
     }
 
     @Test
-    public void testPendingTaskOnFinished(@Injectable BrokerPendingTaskAttachment attachment, @Mocked Env env,
-                                          @Mocked InternalCatalog catalog, @Injectable Database database,
-                                          @Injectable BrokerFileGroupAggInfo fileGroupAggInfo, @Injectable BrokerFileGroup brokerFileGroup1,
-                                          @Injectable BrokerFileGroup brokerFileGroup2, @Injectable BrokerFileGroup brokerFileGroup3,
-                                          @Mocked MasterTaskExecutor masterTaskExecutor, @Injectable OlapTable olapTable,
-                                          @Mocked NereidsLoadingTaskPlanner loadingTaskPlanner) {
-        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
-        long taskId = 1L;
-        long tableId1 = 1L;
-        long tableId2 = 2L;
-        long partitionId1 = 3L;
-        long partitionId2 = 4;
+    public void testPendingTaskOnFinished() throws Exception {
+        BrokerPendingTaskAttachment attachment = Mockito.mock(BrokerPendingTaskAttachment.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        BrokerFileGroupAggInfo fileGroupAggInfo = Mockito.mock(BrokerFileGroupAggInfo.class);
+        BrokerFileGroup brokerFileGroup1 = Mockito.mock(BrokerFileGroup.class);
+        BrokerFileGroup brokerFileGroup2 = Mockito.mock(BrokerFileGroup.class);
+        BrokerFileGroup brokerFileGroup3 = Mockito.mock(BrokerFileGroup.class);
+        NereidsBrokerFileGroup nereidsBfg1 = Mockito.mock(NereidsBrokerFileGroup.class);
+        NereidsBrokerFileGroup nereidsBfg2 = Mockito.mock(NereidsBrokerFileGroup.class);
+        NereidsBrokerFileGroup nereidsBfg3 = Mockito.mock(NereidsBrokerFileGroup.class);
+        Mockito.when(brokerFileGroup1.toNereidsBrokerFileGroup()).thenReturn(nereidsBfg1);
+        Mockito.when(brokerFileGroup2.toNereidsBrokerFileGroup()).thenReturn(nereidsBfg2);
+        Mockito.when(brokerFileGroup3.toNereidsBrokerFileGroup()).thenReturn(nereidsBfg3);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        MasterTaskExecutor loadingTaskExecutor = Mockito.mock(MasterTaskExecutor.class);
+        GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        ProgressManager progressManager = Mockito.mock(ProgressManager.class);
+        TransactionState txnState = Mockito.mock(TransactionState.class);
+        ComputeGroupMgr computeGroupMgr = Mockito.mock(ComputeGroupMgr.class);
+        TableProperty tableProperty = Mockito.mock(TableProperty.class);
 
-        Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToFileGroups = Maps.newHashMap();
-        List<BrokerFileGroup> fileGroups1 = Lists.newArrayList();
-        fileGroups1.add(brokerFileGroup1);
-        aggKeyToFileGroups.put(new FileGroupAggKey(tableId1, null), fileGroups1);
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class);
+                MockedConstruction<NereidsLoadingTaskPlanner> ignored =
+                        Mockito.mockConstruction(NereidsLoadingTaskPlanner.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envMockedStatic.when(Env::getCurrentProgressManager).thenReturn(progressManager);
+            envMockedStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
 
-        List<BrokerFileGroup> fileGroups2 = Lists.newArrayList();
-        fileGroups2.add(brokerFileGroup2);
-        fileGroups2.add(brokerFileGroup3);
-        aggKeyToFileGroups.put(new FileGroupAggKey(tableId2, Lists.newArrayList(partitionId1)), fileGroups2);
-        // add another file groups with different partition id
-        aggKeyToFileGroups.put(new FileGroupAggKey(tableId2, Lists.newArrayList(partitionId2)), fileGroups2);
+            BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+            Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
+            BrokerDesc brokerDesc = Mockito.mock(BrokerDesc.class);
+            Deencapsulation.setField(brokerLoadJob, "brokerDesc", brokerDesc);
+            long taskId = 1L;
+            long tableId1 = 1L;
+            long tableId2 = 2L;
+            long partitionId1 = 3L;
+            long partitionId2 = 4;
 
-        Deencapsulation.setField(brokerLoadJob, "fileGroupAggInfo", fileGroupAggInfo);
-        new Expectations() {
-            {
-                attachment.getTaskId();
-                minTimes = 0;
-                result = taskId;
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                fileGroupAggInfo.getAggKeyToFileGroups();
-                minTimes = 0;
-                result = aggKeyToFileGroups;
-                database.getTableNullable(anyLong);
-                minTimes = 0;
-                result = olapTable;
-                env.getNextId();
-                minTimes = 0;
-                result = 1L;
-                result = 2L;
-                result = 3L;
-            }
-        };
+            Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToFileGroups = Maps.newHashMap();
+            List<BrokerFileGroup> fileGroups1 = Lists.newArrayList();
+            fileGroups1.add(brokerFileGroup1);
+            FileGroupAggKey aggKey1 = new FileGroupAggKey(tableId1, null);
+            aggKeyToFileGroups.put(aggKey1, fileGroups1);
 
-        brokerLoadJob.onTaskFinished(attachment);
-        Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
-        Assert.assertEquals(1, finishedTaskIds.size());
-        Assert.assertEquals(true, finishedTaskIds.contains(taskId));
-        Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
-        Assert.assertEquals(3, idToTasks.size());
+            List<BrokerFileGroup> fileGroups2 = Lists.newArrayList();
+            fileGroups2.add(brokerFileGroup2);
+            fileGroups2.add(brokerFileGroup3);
+            FileGroupAggKey aggKey2 = new FileGroupAggKey(tableId2, Lists.newArrayList(partitionId1));
+            aggKeyToFileGroups.put(aggKey2, fileGroups2);
+            // add another file groups with different partition id
+            FileGroupAggKey aggKey3 = new FileGroupAggKey(tableId2, Lists.newArrayList(partitionId2));
+            aggKeyToFileGroups.put(aggKey3, fileGroups2);
+
+            Deencapsulation.setField(brokerLoadJob, "fileGroupAggInfo", fileGroupAggInfo);
+
+            Mockito.when(attachment.getTaskId()).thenReturn(taskId);
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyLong());
+            Mockito.doReturn(Lists.newArrayList()).when(database)
+                    .getTablesOnIdOrderOrThrowException(Mockito.anyList());
+            Mockito.when(fileGroupAggInfo.getAggKeyToFileGroups()).thenReturn(aggKeyToFileGroups);
+            Mockito.when(fileGroupAggInfo.getAllTableIds()).thenReturn(Sets.newHashSet(tableId1, tableId2));
+            Mockito.doReturn(olapTable).when(database).getTableNullable(Mockito.anyLong());
+            Mockito.when(olapTable.isTemporary()).thenReturn(false);
+            Mockito.when(olapTable.getTableProperty()).thenReturn(tableProperty);
+            Mockito.when(tableProperty.getUseSchemaLightChange()).thenReturn(false);
+            Mockito.when(olapTable.getIndexes()).thenReturn(null);
+            List<List<TBrokerFileStatus>> fileStatuses1 =
+                    Collections.singletonList(Collections.singletonList(new TBrokerFileStatus()));
+            List<List<TBrokerFileStatus>> fileStatuses2 = Lists.newArrayList(
+                    Collections.singletonList(new TBrokerFileStatus()),
+                    Collections.singletonList(new TBrokerFileStatus()));
+            Mockito.when(attachment.getFileStatusByTable(aggKey1)).thenReturn(fileStatuses1);
+            Mockito.when(attachment.getFileNumByTable(aggKey1)).thenReturn(1);
+            Mockito.when(attachment.getFileStatusByTable(aggKey2)).thenReturn(fileStatuses2);
+            Mockito.when(attachment.getFileNumByTable(aggKey2)).thenReturn(2);
+            Mockito.when(attachment.getFileStatusByTable(aggKey3)).thenReturn(fileStatuses2);
+            Mockito.when(attachment.getFileNumByTable(aggKey3)).thenReturn(2);
+            Mockito.when(env.getNextId()).thenReturn(1L, 2L, 3L);
+            Mockito.when(env.getLoadingLoadTaskScheduler()).thenReturn(loadingTaskExecutor);
+            Mockito.when(env.getComputeGroupMgr()).thenReturn(computeGroupMgr);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(computeGroupMgr.getAllBackendComputeGroup())
+                    .thenReturn(new ComputeGroup("default", "default", null));
+            Mockito.when(globalTxnMgr.getTransactionState(Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(txnState);
+            TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+
+            brokerLoadJob.onTaskFinished(attachment);
+            Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
+            Assert.assertEquals(1, finishedTaskIds.size());
+            Assert.assertEquals(true, finishedTaskIds.contains(taskId));
+            Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
+            Assert.assertEquals(3, idToTasks.size());
+        }
     }
 
     @Test
-    public void testLoadingTaskOnFinishedWithUnfinishedTask(@Injectable BrokerLoadingTaskAttachment attachment,
-                                                            @Injectable LoadTask loadTask1,
-                                                            @Injectable LoadTask loadTask2) {
+    public void testLoadingTaskOnFinishedWithUnfinishedTask() {
+        BrokerLoadingTaskAttachment attachment = Mockito.mock(BrokerLoadingTaskAttachment.class);
+        LoadTask loadTask1 = Mockito.mock(LoadTask.class);
+        LoadTask loadTask2 = Mockito.mock(LoadTask.class);
+
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
         Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
         Map<Long, LoadTask> idToTasks = Maps.newHashMap();
         idToTasks.put(1L, loadTask1);
         idToTasks.put(2L, loadTask2);
         Deencapsulation.setField(brokerLoadJob, "idToTasks", idToTasks);
-        new Expectations() {
-            {
-                attachment.getCounter(BrokerLoadJob.DPP_NORMAL_ALL);
-                minTimes = 0;
-                result = 10;
-                attachment.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL);
-                minTimes = 0;
-                result = 1;
-                attachment.getTaskId();
-                minTimes = 0;
-                result = 1L;
-            }
-        };
+
+        Mockito.when(attachment.getCounter(BrokerLoadJob.DPP_NORMAL_ALL)).thenReturn("10");
+        Mockito.when(attachment.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL)).thenReturn("1");
+        Mockito.when(attachment.getTaskId()).thenReturn(1L);
 
         brokerLoadJob.onTaskFinished(attachment);
         Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
@@ -230,115 +273,107 @@ public class BrokerLoadJobTest {
     }
 
     @Test
-    public void testLoadingTaskOnFinishedWithErrorNum(@Injectable BrokerLoadingTaskAttachment attachment1,
-                                                      @Injectable BrokerLoadingTaskAttachment attachment2,
-                                                      @Injectable LoadTask loadTask1,
-                                                      @Injectable LoadTask loadTask2,
-                                                      @Mocked Env env) {
-        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
-        Map<Long, LoadTask> idToTasks = Maps.newHashMap();
-        idToTasks.put(1L, loadTask1);
-        idToTasks.put(2L, loadTask2);
-        Deencapsulation.setField(brokerLoadJob, "idToTasks", idToTasks);
-        new Expectations() {
-            {
-                attachment1.getCounter(BrokerLoadJob.DPP_NORMAL_ALL);
-                minTimes = 0;
-                result = 10;
-                attachment2.getCounter(BrokerLoadJob.DPP_NORMAL_ALL);
-                minTimes = 0;
-                result = 20;
-                attachment1.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL);
-                minTimes = 0;
-                result = 1;
-                attachment2.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL);
-                minTimes = 0;
-                result = 2;
-                attachment1.getTaskId();
-                minTimes = 0;
-                result = 1L;
-                attachment2.getTaskId();
-                minTimes = 0;
-                result = 2L;
-            }
-        };
+    public void testLoadingTaskOnFinishedWithErrorNum() {
+        BrokerLoadingTaskAttachment attachment1 = Mockito.mock(BrokerLoadingTaskAttachment.class);
+        BrokerLoadingTaskAttachment attachment2 = Mockito.mock(BrokerLoadingTaskAttachment.class);
+        LoadTask loadTask1 = Mockito.mock(LoadTask.class);
+        LoadTask loadTask2 = Mockito.mock(LoadTask.class);
+        Env env = Mockito.mock(Env.class);
+        GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
 
-        brokerLoadJob.onTaskFinished(attachment1);
-        brokerLoadJob.onTaskFinished(attachment2);
-        Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
-        Assert.assertEquals(2, finishedTaskIds.size());
-        EtlStatus loadingStatus = Deencapsulation.getField(brokerLoadJob, "loadingStatus");
-        Assert.assertEquals("30", loadingStatus.getCounters().get(BrokerLoadJob.DPP_NORMAL_ALL));
-        Assert.assertEquals("3", loadingStatus.getCounters().get(BrokerLoadJob.DPP_ABNORMAL_ALL));
-        int progress = Deencapsulation.getField(brokerLoadJob, "progress");
-        Assert.assertEquals(99, progress);
-        Assert.assertEquals(JobState.CANCELLED, Deencapsulation.getField(brokerLoadJob, "state"));
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+
+            BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+            Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
+            Map<Long, LoadTask> idToTasks = Maps.newHashMap();
+            idToTasks.put(1L, loadTask1);
+            idToTasks.put(2L, loadTask2);
+            Deencapsulation.setField(brokerLoadJob, "idToTasks", idToTasks);
+
+            Mockito.when(attachment1.getCounter(BrokerLoadJob.DPP_NORMAL_ALL)).thenReturn("10");
+            Mockito.when(attachment2.getCounter(BrokerLoadJob.DPP_NORMAL_ALL)).thenReturn("20");
+            Mockito.when(attachment1.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL)).thenReturn("1");
+            Mockito.when(attachment2.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL)).thenReturn("2");
+            Mockito.when(attachment1.getTaskId()).thenReturn(1L);
+            Mockito.when(attachment2.getTaskId()).thenReturn(2L);
+
+            brokerLoadJob.onTaskFinished(attachment1);
+            brokerLoadJob.onTaskFinished(attachment2);
+            Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
+            Assert.assertEquals(2, finishedTaskIds.size());
+            EtlStatus loadingStatus = Deencapsulation.getField(brokerLoadJob, "loadingStatus");
+            Assert.assertEquals("30", loadingStatus.getCounters().get(BrokerLoadJob.DPP_NORMAL_ALL));
+            Assert.assertEquals("3", loadingStatus.getCounters().get(BrokerLoadJob.DPP_ABNORMAL_ALL));
+            int progress = Deencapsulation.getField(brokerLoadJob, "progress");
+            Assert.assertEquals(99, progress);
+            Assert.assertEquals(JobState.CANCELLED, Deencapsulation.getField(brokerLoadJob, "state"));
+        }
     }
 
     @Test
-    public void testLoadingTaskOnFinished(@Injectable BrokerLoadingTaskAttachment attachment1,
-                                          @Injectable LoadTask loadTask1, @Mocked Env env, @Mocked InternalCatalog catalog,
-                                          @Injectable Database database) {
-        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
-        Map<Long, LoadTask> idToTasks = Maps.newHashMap();
-        idToTasks.put(1L, loadTask1);
-        Deencapsulation.setField(brokerLoadJob, "idToTasks", idToTasks);
-        new Expectations() {
-            {
-                attachment1.getCounter(BrokerLoadJob.DPP_NORMAL_ALL);
-                minTimes = 0;
-                result = 10;
-                attachment1.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL);
-                minTimes = 0;
-                result = 0;
-                attachment1.getTaskId();
-                minTimes = 0;
-                result = 1L;
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-            }
-        };
+    public void testLoadingTaskOnFinished() throws Exception {
+        BrokerLoadingTaskAttachment attachment1 = Mockito.mock(BrokerLoadingTaskAttachment.class);
+        LoadTask loadTask1 = Mockito.mock(LoadTask.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        Status status = Mockito.mock(Status.class);
 
-        brokerLoadJob.onTaskFinished(attachment1);
-        Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
-        Assert.assertEquals(1, finishedTaskIds.size());
-        EtlStatus loadingStatus = Deencapsulation.getField(brokerLoadJob, "loadingStatus");
-        Assert.assertEquals("10", loadingStatus.getCounters().get(BrokerLoadJob.DPP_NORMAL_ALL));
-        Assert.assertEquals("0", loadingStatus.getCounters().get(BrokerLoadJob.DPP_ABNORMAL_ALL));
-        int progress = Deencapsulation.getField(brokerLoadJob, "progress");
-        Assert.assertEquals(99, progress);
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envMockedStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+
+            Mockito.when(env.getEditLog()).thenReturn(Mockito.mock(EditLog.class));
+
+            BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+            Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
+            Map<Long, LoadTask> idToTasks = Maps.newHashMap();
+            idToTasks.put(1L, loadTask1);
+            Deencapsulation.setField(brokerLoadJob, "idToTasks", idToTasks);
+
+            Mockito.when(attachment1.getCounter(BrokerLoadJob.DPP_NORMAL_ALL)).thenReturn("10");
+            Mockito.when(attachment1.getCounter(BrokerLoadJob.DPP_ABNORMAL_ALL)).thenReturn("0");
+            Mockito.when(attachment1.getTaskId()).thenReturn(1L);
+            Mockito.when(attachment1.getStatus()).thenReturn(status);
+            Mockito.when(status.getErrorCode()).thenReturn(TStatusCode.OK);
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyLong());
+            Mockito.doReturn(Lists.newArrayList()).when(database)
+                    .getTablesOnIdOrderOrThrowException(Mockito.anyList());
+
+            brokerLoadJob.onTaskFinished(attachment1);
+            Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
+            Assert.assertEquals(1, finishedTaskIds.size());
+            EtlStatus loadingStatus = Deencapsulation.getField(brokerLoadJob, "loadingStatus");
+            Assert.assertEquals("10", loadingStatus.getCounters().get(BrokerLoadJob.DPP_NORMAL_ALL));
+            Assert.assertEquals("0", loadingStatus.getCounters().get(BrokerLoadJob.DPP_ABNORMAL_ALL));
+            int progress = Deencapsulation.getField(brokerLoadJob, "progress");
+            Assert.assertEquals(99, progress);
+        }
     }
 
     @Test
-    public void testExecuteReplayOnAborted(@Injectable TransactionState txnState,
-                                           @Injectable LoadJobFinalOperation attachment,
-                                           @Injectable EtlStatus etlStatus) {
+    public void testExecuteReplayOnAborted() {
+        TransactionState txnState = Mockito.mock(TransactionState.class);
+        LoadJobFinalOperation attachment = Mockito.mock(LoadJobFinalOperation.class);
+        EtlStatus etlStatus = Mockito.mock(EtlStatus.class);
+
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        new Expectations() {
-            {
-                txnState.getTxnCommitAttachment();
-                minTimes = 0;
-                result = attachment;
-                attachment.getLoadingStatus();
-                minTimes = 0;
-                result = etlStatus;
-                attachment.getProgress();
-                minTimes = 0;
-                result = 99;
-                attachment.getFinishTimestamp();
-                minTimes = 0;
-                result = 1;
-                attachment.getJobState();
-                minTimes = 0;
-                result = JobState.CANCELLED;
-            }
-        };
+
+        Mockito.when(txnState.getTxnCommitAttachment()).thenReturn(attachment);
+        Mockito.when(attachment.getLoadingStatus()).thenReturn(etlStatus);
+        Mockito.when(attachment.getProgress()).thenReturn(99);
+        Mockito.when(attachment.getFinishTimestamp()).thenReturn(1L);
+        Mockito.when(attachment.getJobState()).thenReturn(JobState.CANCELLED);
+
         brokerLoadJob.replayTxnAttachment(txnState);
         Assert.assertEquals(99, (int) Deencapsulation.getField(brokerLoadJob, "progress"));
         Assert.assertEquals(1, brokerLoadJob.getFinishTimestamp());
@@ -347,29 +382,19 @@ public class BrokerLoadJobTest {
 
 
     @Test
-    public void testExecuteReplayOnVisible(@Injectable TransactionState txnState,
-                                           @Injectable LoadJobFinalOperation attachment,
-                                           @Injectable EtlStatus etlStatus) {
+    public void testExecuteReplayOnVisible() {
+        TransactionState txnState = Mockito.mock(TransactionState.class);
+        LoadJobFinalOperation attachment = Mockito.mock(LoadJobFinalOperation.class);
+        EtlStatus etlStatus = Mockito.mock(EtlStatus.class);
+
         BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        new Expectations() {
-            {
-                txnState.getTxnCommitAttachment();
-                minTimes = 0;
-                result = attachment;
-                attachment.getLoadingStatus();
-                minTimes = 0;
-                result = etlStatus;
-                attachment.getProgress();
-                minTimes = 0;
-                result = 99;
-                attachment.getFinishTimestamp();
-                minTimes = 0;
-                result = 1;
-                attachment.getJobState();
-                minTimes = 0;
-                result = JobState.LOADING;
-            }
-        };
+
+        Mockito.when(txnState.getTxnCommitAttachment()).thenReturn(attachment);
+        Mockito.when(attachment.getLoadingStatus()).thenReturn(etlStatus);
+        Mockito.when(attachment.getProgress()).thenReturn(99);
+        Mockito.when(attachment.getFinishTimestamp()).thenReturn(1L);
+        Mockito.when(attachment.getJobState()).thenReturn(JobState.LOADING);
+
         brokerLoadJob.replayTxnAttachment(txnState);
         Assert.assertEquals(99, (int) Deencapsulation.getField(brokerLoadJob, "progress"));
         Assert.assertEquals(1, brokerLoadJob.getFinishTimestamp());

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadPendingTaskTest.java
@@ -30,13 +30,10 @@ import org.apache.doris.load.BrokerFileGroupAggInfo.FileGroupAggKey;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Collection;
 import java.util.List;
@@ -112,35 +109,40 @@ public class BrokerLoadPendingTaskTest {
     }
 
     @Test
-    public void testExecuteTask(@Injectable BrokerLoadJob brokerLoadJob,
-                                @Injectable BrokerFileGroup brokerFileGroup,
-                                @Injectable BrokerDesc brokerDesc,
-                                @Mocked Env env) throws UserException {
-        Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToFileGroups = Maps.newHashMap();
-        List<BrokerFileGroup> brokerFileGroups = Lists.newArrayList();
-        brokerFileGroups.add(brokerFileGroup);
-        FileGroupAggKey aggKey = new FileGroupAggKey(1L, null);
-        aggKeyToFileGroups.put(aggKey, brokerFileGroups);
-        new Expectations() {
-            {
-                env.getNextId();
-                result = 1L;
-                brokerFileGroup.getFilePaths();
-                result = "hdfs://localhost:8900/test_column";
-            }
-        };
+    public void testExecuteTask() throws UserException {
+        BrokerLoadJob brokerLoadJob = Mockito.mock(BrokerLoadJob.class);
+        BrokerFileGroup brokerFileGroup = Mockito.mock(BrokerFileGroup.class);
+        BrokerDesc brokerDesc = Mockito.mock(BrokerDesc.class);
+        Env env = Mockito.mock(Env.class);
 
-        new MockUp<FileSystemFactory>() {
-            @Mock
-            public org.apache.doris.filesystem.FileSystem getFileSystem(BrokerDesc desc) {
-                return new SingleFileSystem(1L);
-            }
-        };
+        MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class);
+        MockedStatic<FileSystemFactory> mockedFsFactory = Mockito.mockStatic(FileSystemFactory.class);
+        try {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getNextId()).thenReturn(1L);
+            Mockito.when(brokerFileGroup.getFilePaths())
+                    .thenReturn(Lists.newArrayList("hdfs://localhost:8900/test_column"));
 
-        BrokerLoadPendingTask brokerLoadPendingTask = new BrokerLoadPendingTask(brokerLoadJob, aggKeyToFileGroups, brokerDesc, LoadTask.Priority.NORMAL);
-        brokerLoadPendingTask.executeTask();
-        BrokerPendingTaskAttachment brokerPendingTaskAttachment = Deencapsulation.getField(brokerLoadPendingTask, "attachment");
-        Assert.assertEquals(1, brokerPendingTaskAttachment.getFileNumByTable(aggKey));
-        Assert.assertEquals(1L, brokerPendingTaskAttachment.getFileStatusByTable(aggKey).get(0).get(0).size);
+            mockedFsFactory.when(() -> FileSystemFactory.getFileSystem(Mockito.any(BrokerDesc.class)))
+                    .thenReturn(new SingleFileSystem(1L));
+
+            Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToFileGroups = Maps.newHashMap();
+            List<BrokerFileGroup> brokerFileGroups = Lists.newArrayList();
+            brokerFileGroups.add(brokerFileGroup);
+            FileGroupAggKey aggKey = new FileGroupAggKey(1L, null);
+            aggKeyToFileGroups.put(aggKey, brokerFileGroups);
+
+            BrokerLoadPendingTask brokerLoadPendingTask = new BrokerLoadPendingTask(brokerLoadJob,
+                    aggKeyToFileGroups, brokerDesc, LoadTask.Priority.NORMAL);
+            brokerLoadPendingTask.executeTask();
+            BrokerPendingTaskAttachment brokerPendingTaskAttachment =
+                    Deencapsulation.getField(brokerLoadPendingTask, "attachment");
+            Assert.assertEquals(1, brokerPendingTaskAttachment.getFileNumByTable(aggKey));
+            Assert.assertEquals(1L,
+                    brokerPendingTaskAttachment.getFileStatusByTable(aggKey).get(0).get(0).size);
+        } finally {
+            mockedFsFactory.close();
+            mockedEnv.close();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/ExportMgrTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.load.loadv2;
 
 import org.apache.doris.analysis.BrokerDesc;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
@@ -27,11 +28,14 @@ import org.apache.doris.load.ExportJobState;
 import org.apache.doris.load.ExportMgr;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.MockedAuth;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -40,8 +44,7 @@ import java.util.List;
 public class ExportMgrTest {
     private final ExportMgr exportMgr = new ExportMgr();
 
-    @Mocked
-    private AccessControllerManager accessManager;
+    private AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
 
     @Before
     public void setUp() {
@@ -50,33 +53,42 @@ public class ExportMgrTest {
 
     @Test
     public void testShowExport() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-        ExportJob job1 = makeExportJob(1, "aabbcc");
-        ExportJob job2 = makeExportJob(2, "aabbdd");
-        ExportJob job3 = makeExportJob(3, "eebbcc");
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> connectContextStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            connectContextStatic.when(ConnectContext::get).thenReturn(connectContext);
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(connectContext.getSessionVariable()).thenReturn(new SessionVariable());
 
-        exportMgr.unprotectAddJob(job1);
-        exportMgr.unprotectAddJob(job2);
-        exportMgr.unprotectAddJob(job3);
+            ExportJob job1 = makeExportJob(1, "aabbcc");
+            ExportJob job2 = makeExportJob(2, "aabbdd");
+            ExportJob job3 = makeExportJob(3, "eebbcc");
 
-        List<List<String>> r1 = exportMgr.getExportJobInfosByIdOrState(-1, 3, "", true, null, null, -1);
-        Assert.assertEquals(r1.size(), 1);
+            exportMgr.unprotectAddJob(job1);
+            exportMgr.unprotectAddJob(job2);
+            exportMgr.unprotectAddJob(job3);
 
-        List<List<String>> r2 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "", false, null, null, -1);
-        Assert.assertEquals(r2.size(), 3);
+            List<List<String>> r1 = exportMgr.getExportJobInfosByIdOrState(-1, 3, "", true, null, null, -1);
+            Assert.assertEquals(r1.size(), 1);
 
-        List<List<String>> r3 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "aabbcc", false, null, null, -1);
-        Assert.assertEquals(r3.size(), 1);
+            List<List<String>> r2 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "", false, null, null, -1);
+            Assert.assertEquals(r2.size(), 3);
 
-        List<List<String>> r4 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "%bb%", true, null, null, -1);
-        Assert.assertEquals(r4.size(), 3);
+            List<List<String>> r3 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "aabbcc", false, null, null, -1);
+            Assert.assertEquals(r3.size(), 1);
 
-        List<List<String>> r5 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "aabb%", true, null, null, -1);
-        Assert.assertEquals(r5.size(), 2);
+            List<List<String>> r4 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "%bb%", true, null, null, -1);
+            Assert.assertEquals(r4.size(), 3);
 
-        List<List<String>> r6 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "%dd", true, null, null, -1);
-        Assert.assertEquals(r6.size(), 1);
+            List<List<String>> r5 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "aabb%", true, null, null, -1);
+            Assert.assertEquals(r5.size(), 2);
 
+            List<List<String>> r6 = exportMgr.getExportJobInfosByIdOrState(-1, 0, "%dd", true, null, null, -1);
+            Assert.assertEquals(r6.size(), 1);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/InsertLoadJobTest.java
@@ -25,11 +25,10 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Optional;
 import java.util.Set;
@@ -37,29 +36,32 @@ import java.util.Set;
 public class InsertLoadJobTest {
 
     @Test
-    public void testGetTableNames(@Mocked Env env, @Mocked InternalCatalog catalog, @Injectable Database database,
-            @Injectable Table table) throws MetaNotFoundException {
-        UserIdentity userInfo = new UserIdentity("root", "localhost");
-        InsertLoadJob insertLoadJob = new InsertLoadJob("label", 1L, 1L, 1L, 1000, "", "", "", userInfo);
-        String tableName = "table1";
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDb(anyLong);
-                result = Optional.of(database);
-                database.getTable(anyLong);
-                result = Optional.of(table);
-                table.getName();
-                result = tableName;
-            }
-        };
-        Set<String> tableNames = insertLoadJob.getTableNamesForShow();
-        Assert.assertEquals(1, tableNames.size());
-        Assert.assertTrue(tableNames.contains(tableName));
-        Assert.assertEquals(JobState.FINISHED, insertLoadJob.getState());
-        Assert.assertEquals(Integer.valueOf(100), Deencapsulation.getField(insertLoadJob, "progress"));
+    public void testGetTableNames() throws MetaNotFoundException {
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+            Database database = Mockito.mock(Database.class);
+            Table table = Mockito.mock(Table.class);
 
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+
+            UserIdentity userInfo = new UserIdentity("root", "localhost");
+            Mockito.when(catalog.getDbOrMetaException(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(database.getFullName()).thenReturn("db1");
+            Mockito.when(database.getTableOrMetaException(Mockito.anyLong())).thenReturn(table);
+            InsertLoadJob insertLoadJob = new InsertLoadJob("label", 1L, 1L, 1L, 1000, "", "", "", userInfo);
+            String tableName = "table1";
+
+            Mockito.when(catalog.getDb(Mockito.anyLong())).thenReturn(Optional.of(database));
+            Mockito.when(database.getTable(Mockito.anyLong())).thenReturn(Optional.of(table));
+            Mockito.when(table.getName()).thenReturn(tableName);
+
+            Set<String> tableNames = insertLoadJob.getTableNamesForShow();
+            Assert.assertEquals(1, tableNames.size());
+            Assert.assertTrue(tableNames.contains(tableName));
+            Assert.assertEquals(JobState.FINISHED, insertLoadJob.getState());
+            Assert.assertEquals(Integer.valueOf(100), Deencapsulation.getField(insertLoadJob, "progress"));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
@@ -18,32 +18,22 @@
 package org.apache.doris.load.loadv2;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.DuplicatedRequestException;
-import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.LoadException;
-import org.apache.doris.common.MetaNotFoundException;
-import org.apache.doris.common.QuotaExceedException;
 import org.apache.doris.common.jmockit.Deencapsulation;
-import org.apache.doris.metric.LongCounterMetric;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.task.MasterTaskExecutor;
-import org.apache.doris.thrift.TUniqueId;
-import org.apache.doris.transaction.BeginTransactionException;
-import org.apache.doris.transaction.GlobalTransactionMgr;
-import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TxnStateCallbackFactory;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
@@ -88,27 +78,24 @@ public class LoadJobTest {
     }
 
     @Test
-    public void testExecute(@Mocked GlobalTransactionMgr globalTransactionMgr,
-                            @Mocked MasterTaskExecutor masterTaskExecutor)
-            throws LabelAlreadyUsedException, BeginTransactionException, AnalysisException, DuplicatedRequestException,
-            QuotaExceedException, MetaNotFoundException, InterruptedException {
-        LoadJob loadJob = new BrokerLoadJob();
-        new Expectations() {
-            {
-                globalTransactionMgr.beginTransaction(anyLong, Lists.newArrayList(), anyString, (TUniqueId) any,
-                        (TransactionState.TxnCoordinator) any,
-                        (TransactionState.LoadJobSourceType) any, anyLong, anyLong);
-                minTimes = 0;
-                result = 1;
-            }
-        };
+    public void testExecute() {
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            MasterTaskExecutor taskScheduler = Mockito.mock(MasterTaskExecutor.class);
+            GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
 
-        try {
-            loadJob.execute();
-        } catch (LoadException e) {
-            Assert.fail(e.getMessage());
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
+            Mockito.when(env.getPendingLoadTaskScheduler()).thenReturn(taskScheduler);
+
+            LoadJob loadJob = new BrokerLoadJob();
+            try {
+                loadJob.execute();
+            } catch (LoadException e) {
+                Assert.fail(e.getMessage());
+            }
+            Assert.assertEquals(JobState.PENDING, loadJob.getState());
         }
-        Assert.assertEquals(JobState.PENDING, loadJob.getState());
     }
 
     @Test
@@ -139,19 +126,25 @@ public class LoadJobTest {
     }
 
     @Test
-    public void testProcessTimeout(@Mocked Env env, @Mocked EditLog editLog) {
-        LoadJob loadJob = new BrokerLoadJob();
-        loadJob.setTimeout(0);
-        new Expectations() {
-            {
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
+    public void testProcessTimeout() {
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+            TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
 
-        loadJob.processTimeout();
-        Assert.assertEquals(JobState.CANCELLED, loadJob.getState());
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(txnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+
+            LoadJob loadJob = new BrokerLoadJob();
+            loadJob.setTimeout(0);
+            Deencapsulation.setField(loadJob, "createTimestamp", 0L);
+
+            loadJob.processTimeout();
+            Assert.assertEquals(JobState.CANCELLED, loadJob.getState());
+        }
     }
 
     @Test
@@ -163,21 +156,26 @@ public class LoadJobTest {
     }
 
     @Test
-    public void testUpdateStateToFinished(@Mocked MetricRepo metricRepo,
-                                          @Injectable LoadTask loadTask1,
-                                          @Mocked LongCounterMetric longCounterMetric) {
-        LoadJob loadJob = new BrokerLoadJob();
-        loadJob.idToTasks.put(1L, loadTask1);
+    public void testUpdateStateToFinished() {
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+            TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
+            LoadTask loadTask1 = Mockito.mock(LoadTask.class);
 
-        // TxnStateCallbackFactory factory = Catalog.getCurrentEnv().getGlobalTransactionMgr().getCallbackFactory();
-        Env env = Env.getCurrentEnv();
-        GlobalTransactionMgr mgr = new GlobalTransactionMgr(env);
-        Deencapsulation.setField(env, "globalTransactionMgr", mgr);
-        Assert.assertEquals(1, loadJob.idToTasks.size());
-        loadJob.updateState(JobState.FINISHED);
-        Assert.assertEquals(JobState.FINISHED, loadJob.getState());
-        Assert.assertNotEquals(-1, (long) Deencapsulation.getField(loadJob, "finishTimestamp"));
-        Assert.assertEquals(100, (int) Deencapsulation.getField(loadJob, "progress"));
-        Assert.assertEquals(0, loadJob.idToTasks.size());
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
+            Mockito.when(txnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+
+            LoadJob loadJob = new BrokerLoadJob();
+            loadJob.idToTasks.put(1L, loadTask1);
+
+            Assert.assertEquals(1, loadJob.idToTasks.size());
+            loadJob.updateState(JobState.FINISHED);
+            Assert.assertEquals(JobState.FINISHED, loadJob.getState());
+            Assert.assertNotEquals(-1, (long) Deencapsulation.getField(loadJob, "finishTimestamp"));
+            Assert.assertEquals(100, (int) Deencapsulation.getField(loadJob, "progress"));
+            Assert.assertEquals(0, loadJob.idToTasks.size());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadManagerTest.java
@@ -25,15 +25,13 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
-import org.apache.doris.meta.MetaContext;
 
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -67,122 +65,111 @@ public class LoadManagerTest {
     }
 
     @Test
-    public void testSerializationNormal(@Mocked Env env, @Mocked InternalCatalog catalog, @Injectable Database database,
-            @Injectable Table table) throws Exception {
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                database.getTableNullable(anyLong);
-                minTimes = 0;
-                result = table;
-                table.getName();
-                minTimes = 0;
-                result = "tablename";
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeMetaVersion.VERSION_CURRENT;
-            }
-        };
+    public void testSerializationNormal() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table table = Mockito.mock(Table.class);
 
-        loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
-        Deencapsulation.invoke(loadManager, "addLoadJob", job1);
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envMockedStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeMetaVersion.VERSION_CURRENT);
 
-        File file = serializeToFile(loadManager);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(catalog.getDbOrMetaException(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(database.getTableNullable(Mockito.anyLong())).thenReturn(table);
+            Mockito.when(database.getTableOrMetaException(Mockito.anyLong())).thenReturn(table);
+            Mockito.when(table.getName()).thenReturn("tablename");
 
-        // make it deserialized
-        LoadManager newLoadManager = deserializeFromFile(file);
+            loadManager = new LoadManager(new LoadJobScheduler());
+            LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
+            Deencapsulation.invoke(loadManager, "addLoadJob", job1);
 
-        Map<Long, LoadJob> loadJobs = Deencapsulation.getField(loadManager, fieldName);
-        Map<Long, LoadJob> newLoadJobs = Deencapsulation.getField(newLoadManager, fieldName);
-        Assert.assertEquals(loadJobs, newLoadJobs);
+            File file = serializeToFile(loadManager);
+
+            LoadManager newLoadManager = deserializeFromFile(file);
+
+            Map<Long, LoadJob> loadJobs = Deencapsulation.getField(loadManager, fieldName);
+            Map<Long, LoadJob> newLoadJobs = Deencapsulation.getField(newLoadManager, fieldName);
+            Assert.assertEquals(loadJobs, newLoadJobs);
+        }
     }
 
     @Test
-    public void testSerializationWithJobRemoved(@Mocked MetaContext metaContext, @Mocked Env env,
-            @Mocked InternalCatalog catalog, @Injectable Database database, @Injectable Table table) throws Exception {
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                database.getTableNullable(anyLong);
-                minTimes = 0;
-                result = table;
-                table.getName();
-                minTimes = 0;
-                result = "tablename";
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeMetaVersion.VERSION_CURRENT;
-            }
-        };
+    public void testSerializationWithJobRemoved() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table table = Mockito.mock(Table.class);
 
-        loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
-        Deencapsulation.invoke(loadManager, "addLoadJob", job1);
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envMockedStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeMetaVersion.VERSION_CURRENT);
 
-        // make job1 don't serialize
-        Config.streaming_label_keep_max_second = 1;
-        Thread.sleep(2000);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(catalog.getDbOrMetaException(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(database.getTableNullable(Mockito.anyLong())).thenReturn(table);
+            Mockito.when(database.getTableOrMetaException(Mockito.anyLong())).thenReturn(table);
+            Mockito.when(table.getName()).thenReturn("tablename");
 
-        File file = serializeToFile(loadManager);
+            loadManager = new LoadManager(new LoadJobScheduler());
+            LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
+            Deencapsulation.invoke(loadManager, "addLoadJob", job1);
 
-        LoadManager newLoadManager = deserializeFromFile(file);
-        Map<Long, LoadJob> newLoadJobs = Deencapsulation.getField(newLoadManager, fieldName);
+            // make job1 don't serialize
+            Config.streaming_label_keep_max_second = 1;
+            Thread.sleep(2000);
 
-        Assert.assertEquals(0, newLoadJobs.size());
+            File file = serializeToFile(loadManager);
+
+            LoadManager newLoadManager = deserializeFromFile(file);
+            Map<Long, LoadJob> newLoadJobs = Deencapsulation.getField(newLoadManager, fieldName);
+
+            Assert.assertEquals(0, newLoadJobs.size());
+        }
     }
 
     @Test
-    public void testCleanOverLimitJobs(@Mocked Env env,
-            @Mocked InternalCatalog catalog, @Injectable Database database, @Injectable Table table) throws Exception {
-        new Expectations() {
-            {
-                env.getNextId();
-                returns(1L, 2L);
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                database.getTableNullable(anyLong);
-                minTimes = 0;
-                result = table;
-                table.getName();
-                minTimes = 0;
-                result = "tablename";
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeMetaVersion.VERSION_CURRENT;
-            }
-        };
+    public void testCleanOverLimitJobs() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table table = Mockito.mock(Table.class);
 
-        loadManager = new LoadManager(new LoadJobScheduler());
-        LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
-        Thread.sleep(100);
-        LoadJob job2 = new InsertLoadJob("job2", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
-        Deencapsulation.invoke(loadManager, "addLoadJob", job2);
-        Deencapsulation.invoke(loadManager, "addLoadJob", job1);
-        Config.label_num_threshold = 1;
-        loadManager.removeOverLimitLoadJob();
-        Map<Long, LoadJob> idToJobs = Deencapsulation.getField(loadManager, fieldName);
-        Map<Long, Map<String, List<LoadJob>>> dbIdToLabelToLoadJobs = Deencapsulation.getField(loadManager,
-                "dbIdToLabelToLoadJobs");
-        Assert.assertEquals(1, idToJobs.size());
-        Assert.assertEquals(1, dbIdToLabelToLoadJobs.size());
-        LoadJob loadJob = idToJobs.get(job2.getId());
-        Assert.assertEquals("job2", loadJob.getLabel());
-        Assert.assertNotNull(dbIdToLabelToLoadJobs.get(1L).get("job2"));
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envMockedStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeMetaVersion.VERSION_CURRENT);
+
+            Mockito.when(env.getNextId()).thenReturn(1L, 2L);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(catalog.getDbOrMetaException(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(database.getTableNullable(Mockito.anyLong())).thenReturn(table);
+            Mockito.when(database.getTableOrMetaException(Mockito.anyLong())).thenReturn(table);
+            Mockito.when(table.getName()).thenReturn("tablename");
+
+            loadManager = new LoadManager(new LoadJobScheduler());
+            LoadJob job1 = new InsertLoadJob("job1", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
+            Thread.sleep(100);
+            LoadJob job2 = new InsertLoadJob("job2", 1L, 1L, 1L, System.currentTimeMillis(), "", "", "", userInfo);
+            Deencapsulation.invoke(loadManager, "addLoadJob", job2);
+            Deencapsulation.invoke(loadManager, "addLoadJob", job1);
+            Config.label_num_threshold = 1;
+            loadManager.removeOverLimitLoadJob();
+            Map<Long, LoadJob> idToJobs = Deencapsulation.getField(loadManager, fieldName);
+            Map<Long, Map<String, List<LoadJob>>> dbIdToLabelToLoadJobs = Deencapsulation.getField(loadManager,
+                    "dbIdToLabelToLoadJobs");
+            Assert.assertEquals(1, idToJobs.size());
+            Assert.assertEquals(1, dbIdToLabelToLoadJobs.size());
+            LoadJob loadJob = idToJobs.get(job2.getId());
+            Assert.assertEquals("job2", loadJob.getLabel());
+            Assert.assertNotNull(dbIdToLabelToLoadJobs.get(1L).get("job2"));
+        }
     }
 
     private File serializeToFile(LoadManager loadManager) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
@@ -23,16 +23,15 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.LabelAlreadyUsedException;
-import org.apache.doris.common.LoadException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.kafka.KafkaUtil;
 import org.apache.doris.load.RoutineLoadDesc;
 import org.apache.doris.load.loadv2.LoadTask;
@@ -44,26 +43,20 @@ import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.nereids.trees.plans.commands.load.LoadProperty;
 import org.apache.doris.nereids.trees.plans.commands.load.LoadSeparator;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TResourceInfo;
-import org.apache.doris.transaction.BeginTransactionException;
-import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
-import mockit.Verifications;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,48 +82,36 @@ public class KafkaRoutineLoadJobTest {
 
     private ImportSequenceStmt sequenceStmt = new ImportSequenceStmt("source_sequence");
 
-    @Mocked
-    ConnectContext connectContext;
-    @Mocked
-    TResourceInfo tResourceInfo;
+    ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+    TResourceInfo tResourceInfo = Mockito.mock(TResourceInfo.class);
+
+    private MockedStatic<ConnectContext> connectContextStatic;
 
     @Before
     public void init() {
-        MockedAuth.mockedConnectContext(connectContext, "root", "192.168.1.1");
+        connectContextStatic = MockedAuth.mockedConnectContext(connectContext, "root", "192.168.1.1");
 
         List<String> partitionNameList = Lists.newArrayList();
         partitionNameList.add("p1");
         partitionNames = new PartitionNamesInfo(false, partitionNameList);
     }
 
+    @After
+    public void tearDown() {
+        if (connectContextStatic != null) {
+            connectContextStatic.close();
+        }
+    }
+
     @Test
-    public void testRoutineLoadTaskConcurrentNum(@Injectable PartitionInfo partitionInfo1,
-                             @Injectable PartitionInfo partitionInfo2,
-                             @Mocked Env env,
-                             @Mocked SystemInfoService systemInfoService,
-                             @Mocked Database database,
-                             @Mocked RoutineLoadDesc routineLoadDesc) throws MetaNotFoundException {
+    public void testRoutineLoadTaskConcurrentNum() throws MetaNotFoundException {
+        Config.max_routine_load_task_concurrent_num = 6;
+
         List<Integer> partitionList1 = Lists.newArrayList(1, 2);
         List<Integer> partitionList2 = Lists.newArrayList(1, 2, 3);
         List<Integer> partitionList3 = Lists.newArrayList(1, 2, 3, 4);
         List<Integer> partitionList4 = Lists.newArrayList(1, 2, 3, 4, 5, 6, 7);
-        List<Long> beIds1 = Lists.newArrayList(1L);
-        List<Long> beIds2 = Lists.newArrayList(1L, 2L, 3L, 4L);
 
-        new Expectations() {
-            {
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                result = beIds1;
-                systemInfoService.getAllBackendIds(true);
-                result = beIds2;
-                minTimes = 0;
-            }
-        };
-        Config.max_routine_load_task_concurrent_num = 6;
         // 2 partitions, 1 be
         RoutineLoadJob routineLoadJob =
                 new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
@@ -157,166 +138,147 @@ public class KafkaRoutineLoadJobTest {
         Assert.assertEquals(6, routineLoadJob.calculateCurrentConcurrentTaskNum());
     }
 
-
     @Test
-    public void testDivideRoutineLoadJob(@Injectable RoutineLoadManager routineLoadManager,
-                                         @Mocked RoutineLoadDesc routineLoadDesc)
-            throws UserException {
+    public void testDivideRoutineLoadJob() throws UserException {
+        RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
+        Env env = Mockito.mock(Env.class);
+        RoutineLoadTaskScheduler routineLoadTaskScheduler = Mockito.mock(RoutineLoadTaskScheduler.class);
 
-        Env env = Deencapsulation.newInstance(Env.class);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+            Mockito.when(env.getRoutineLoadTaskScheduler()).thenReturn(routineLoadTaskScheduler);
 
-        RoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
-                        1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
+            RoutineLoadJob routineLoadJob =
+                    new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
+                            1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
 
-        new Expectations(env) {
-            {
-                env.getRoutineLoadManager();
-                minTimes = 0;
-                result = routineLoadManager;
-            }
-        };
+            Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", Arrays.asList(1, 4, 6));
 
-        RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadManager);
-        Deencapsulation.setField(env, "routineLoadTaskScheduler", routineLoadTaskScheduler);
+            routineLoadJob.divideRoutineLoadJob(2);
 
-        Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", Arrays.asList(1, 4, 6));
-
-        routineLoadJob.divideRoutineLoadJob(2);
-
-        // todo(ml): assert
-        List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
-        Assert.assertEquals(2, routineLoadTaskInfoList.size());
-        for (RoutineLoadTaskInfo routineLoadTaskInfo : routineLoadTaskInfoList) {
-            KafkaTaskInfo kafkaTaskInfo = (KafkaTaskInfo) routineLoadTaskInfo;
-            Assert.assertEquals(false, kafkaTaskInfo.isRunning());
-            if (kafkaTaskInfo.getPartitions().size() == 2) {
-                Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(1));
-                Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(6));
-            } else if (kafkaTaskInfo.getPartitions().size() == 1) {
-                Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(4));
-            } else {
-                Assert.fail();
+            // todo(ml): assert
+            List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
+            Assert.assertEquals(2, routineLoadTaskInfoList.size());
+            for (RoutineLoadTaskInfo routineLoadTaskInfo : routineLoadTaskInfoList) {
+                KafkaTaskInfo kafkaTaskInfo = (KafkaTaskInfo) routineLoadTaskInfo;
+                Assert.assertEquals(false, kafkaTaskInfo.isRunning());
+                if (kafkaTaskInfo.getPartitions().size() == 2) {
+                    Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(1));
+                    Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(6));
+                } else if (kafkaTaskInfo.getPartitions().size() == 1) {
+                    Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(4));
+                } else {
+                    Assert.fail();
+                }
             }
         }
     }
 
     @Test
-    public void testProcessTimeOutTasks(@Injectable GlobalTransactionMgr globalTransactionMgr,
-                                        @Injectable RoutineLoadManager routineLoadManager,
-                                        @Mocked RoutineLoadDesc routineLoadDesc)
-            throws AnalysisException, LabelAlreadyUsedException,
-            BeginTransactionException {
+    public void testProcessTimeOutTasks() throws Exception {
+        RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
+        Env env = Mockito.mock(Env.class);
+        RoutineLoadTaskScheduler routineLoadTaskScheduler = Mockito.mock(RoutineLoadTaskScheduler.class);
 
-        Env env = Deencapsulation.newInstance(Env.class);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+            Mockito.when(env.getRoutineLoadTaskScheduler()).thenReturn(routineLoadTaskScheduler);
 
-        RoutineLoadJob routineLoadJob =
-                new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
-                        1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
-        long maxBatchIntervalS = 10;
-        Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", maxBatchIntervalS);
-        new Expectations() {
-            {
-                env.getRoutineLoadManager();
-                minTimes = 0;
-                result = routineLoadManager;
-            }
-        };
+            RoutineLoadJob routineLoadJob =
+                    new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
+                            1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
+            long maxBatchIntervalS = 10;
+            Deencapsulation.setField(routineLoadJob, "maxBatchIntervalS", maxBatchIntervalS);
 
-        List<RoutineLoadTaskInfo> routineLoadTaskInfoList = new ArrayList<>();
-        Map<Integer, Long> partitionIdsToOffset = Maps.newHashMap();
-        partitionIdsToOffset.put(100, 0L);
-        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(new UUID(1, 1), 1L,
-                maxBatchIntervalS * 2 * 1000, partitionIdsToOffset, false, -1, false);
-        kafkaTaskInfo.setExecuteStartTimeMs(System.currentTimeMillis() - maxBatchIntervalS * 2 * 1000 - 1);
-        routineLoadTaskInfoList.add(kafkaTaskInfo);
+            List<RoutineLoadTaskInfo> routineLoadTaskInfoList = new ArrayList<>();
+            Map<Integer, Long> partitionIdsToOffset = Maps.newHashMap();
+            partitionIdsToOffset.put(100, 0L);
+            KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(new UUID(1, 1), 1L,
+                    maxBatchIntervalS * 2 * 1000, partitionIdsToOffset, false, -1, false);
+            kafkaTaskInfo.setExecuteStartTimeMs(System.currentTimeMillis() - maxBatchIntervalS * 2 * 1000 - 1);
+            routineLoadTaskInfoList.add(kafkaTaskInfo);
 
-        Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
+            Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
 
-        routineLoadJob.processTimeoutTasks();
-        new Verifications() {
-            {
-                List<RoutineLoadTaskInfo> idToRoutineLoadTask =
-                        Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
-                Assert.assertNotEquals("1", idToRoutineLoadTask.get(0).getId());
-                Assert.assertEquals(1, idToRoutineLoadTask.size());
-            }
-        };
+            routineLoadJob.processTimeoutTasks();
+
+            List<RoutineLoadTaskInfo> idToRoutineLoadTask =
+                    Deencapsulation.getField(routineLoadJob, "routineLoadTaskInfoList");
+            Assert.assertNotEquals("1", idToRoutineLoadTask.get(0).getId());
+            Assert.assertEquals(1, idToRoutineLoadTask.size());
+        }
     }
 
     @Test
-    public void testFromCreateStmt(@Mocked Env env,
-                                   @Injectable Database database,
-            @Injectable OlapTable table) throws UserException {
-        CreateRoutineLoadInfo createRoutineLoadInfo = initCreateRoutineLoadInfo();
-        createRoutineLoadInfo.validate(connectContext);
-        RoutineLoadDesc routineLoadDesc = new RoutineLoadDesc(columnSeparator, null, null, null, null, partitionNames, null,
-                LoadTask.MergeType.APPEND, sequenceStmt.getSequenceColName());
-        Deencapsulation.setField(createRoutineLoadInfo, "routineLoadDesc", routineLoadDesc);
-        List<Pair<Integer, Long>> partitionIdToOffset = Lists.newArrayList();
-        List<PartitionInfo> kafkaPartitionInfoList = Lists.newArrayList();
-        for (String s : kafkaPartitionString.split(",")) {
-            partitionIdToOffset.add(Pair.of(Integer.valueOf(s), 0L));
-            PartitionInfo partitionInfo = new PartitionInfo(topicName, Integer.valueOf(s), null, null, null);
-            kafkaPartitionInfoList.add(partitionInfo);
+    public void testFromCreateStmt() throws UserException {
+        Env env = Mockito.mock(Env.class);
+        Database database = Mockito.mock(Database.class);
+        OlapTable table = Mockito.mock(OlapTable.class);
+        InternalCatalog internalCatalog = Mockito.mock(InternalCatalog.class);
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<KafkaUtil> kafkaUtilStatic = Mockito.mockStatic(KafkaUtil.class)) {
+
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(internalCatalog);
+
+            long dbId = 1L;
+            long tableId = 2L;
+
+            Mockito.doReturn(database).when(internalCatalog).getDbOrDdlException(dbName);
+            Mockito.doReturn(database).when(internalCatalog).getDbOrAnalysisException(dbName);
+            Mockito.doReturn(table).when(database).getOlapTableOrDdlException(tableNameString);
+            Mockito.doReturn(table).when(database).getTableOrAnalysisException(tableNameString);
+            Mockito.when(database.getId()).thenReturn(dbId);
+            Mockito.when(table.getId()).thenReturn(tableId);
+            Mockito.when(table.getType()).thenReturn(Table.TableType.OLAP);
+            Mockito.doReturn(Mockito.mock(Partition.class)).when(table)
+                    .getPartition(Mockito.anyString(), Mockito.anyBoolean());
+
+            kafkaUtilStatic.when(() -> KafkaUtil.getAllKafkaPartitions(
+                    Mockito.anyString(), Mockito.anyString(), Mockito.anyMap()))
+                    .thenReturn(Lists.newArrayList(1, 2, 3));
+
+            kafkaUtilStatic.when(() -> KafkaUtil.getRealOffsets(
+                    Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyList()))
+                    .thenAnswer(invocation -> {
+                        List<Pair<Integer, Long>> pairList = new ArrayList<>();
+                        pairList.add(Pair.of(1, 0L));
+                        pairList.add(Pair.of(2, 0L));
+                        pairList.add(Pair.of(3, 0L));
+                        return pairList;
+                    });
+
+            CreateRoutineLoadInfo createRoutineLoadInfo = initCreateRoutineLoadInfo();
+            createRoutineLoadInfo.validate(connectContext);
+            RoutineLoadDesc routineLoadDesc = new RoutineLoadDesc(columnSeparator, null, null, null, null, partitionNames, null,
+                    LoadTask.MergeType.APPEND, sequenceStmt.getSequenceColName());
+            Deencapsulation.setField(createRoutineLoadInfo, "routineLoadDesc", routineLoadDesc);
+            List<Pair<Integer, Long>> partitionIdToOffset = Lists.newArrayList();
+            List<PartitionInfo> kafkaPartitionInfoList = Lists.newArrayList();
+            for (String s : kafkaPartitionString.split(",")) {
+                partitionIdToOffset.add(Pair.of(Integer.valueOf(s), 0L));
+                PartitionInfo partitionInfo = new PartitionInfo(topicName, Integer.valueOf(s), null, null, null);
+                kafkaPartitionInfoList.add(partitionInfo);
+            }
+            KafkaDataSourceProperties dsProperties = new KafkaDataSourceProperties(null);
+            dsProperties.setKafkaPartitionOffsets(partitionIdToOffset);
+            Deencapsulation.setField(dsProperties, "brokerList", serverAddress);
+            Deencapsulation.setField(dsProperties, "topic", topicName);
+            Deencapsulation.setField(createRoutineLoadInfo, "dataSourceProperties", dsProperties);
+
+            KafkaRoutineLoadJob kafkaRoutineLoadJob = KafkaRoutineLoadJob.fromCreateInfo(createRoutineLoadInfo, connectContext);
+            Assert.assertEquals(jobName, kafkaRoutineLoadJob.getName());
+            Assert.assertEquals(dbId, kafkaRoutineLoadJob.getDbId());
+            Assert.assertEquals(tableId, kafkaRoutineLoadJob.getTableId());
+            Assert.assertEquals(serverAddress, Deencapsulation.getField(kafkaRoutineLoadJob, "brokerList"));
+            Assert.assertEquals(topicName, Deencapsulation.getField(kafkaRoutineLoadJob, "topic"));
+            List<Integer> kafkaPartitionResult = Deencapsulation.getField(kafkaRoutineLoadJob, "customKafkaPartitions");
+            Assert.assertEquals(kafkaPartitionString, Joiner.on(",").join(kafkaPartitionResult));
+            Assert.assertEquals(sequenceStmt.getSequenceColName(), kafkaRoutineLoadJob.getSequenceCol());
         }
-        KafkaDataSourceProperties dsProperties = new KafkaDataSourceProperties(null);
-        dsProperties.setKafkaPartitionOffsets(partitionIdToOffset);
-        Deencapsulation.setField(dsProperties, "brokerList", serverAddress);
-        Deencapsulation.setField(dsProperties, "topic", topicName);
-        Deencapsulation.setField(createRoutineLoadInfo, "dataSourceProperties", dsProperties);
-
-        long dbId = 1L;
-        long tableId = 2L;
-
-        new Expectations() {
-            {
-                database.getTableNullable(tableNameString);
-                minTimes = 0;
-                result = table;
-                database.getId();
-                minTimes = 0;
-                result = dbId;
-                table.getId();
-                minTimes = 0;
-                result = tableId;
-                table.getType();
-                minTimes = 0;
-                result = Table.TableType.OLAP;
-            }
-        };
-
-        new MockUp<KafkaUtil>() {
-            @Mock
-            public List<Integer> getAllKafkaPartitions(String brokerList, String topic,
-                    Map<String, String> convertedCustomProperties) throws UserException {
-                return Lists.newArrayList(1, 2, 3);
-            }
-        };
-
-        new MockUp<KafkaUtil>() {
-            @Mock
-            public List<Pair<Integer, Long>> getRealOffsets(String brokerList, String topic,
-                                                             Map<String, String> convertedCustomProperties,
-                                                             List<Pair<Integer, Long>> offsetFlags)
-                                                             throws LoadException {
-                List<Pair<Integer, Long>> pairList = new ArrayList<>();
-                pairList.add(Pair.of(1, 0L));
-                pairList.add(Pair.of(2, 0L));
-                pairList.add(Pair.of(3, 0L));
-                return pairList;
-            }
-        };
-
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = KafkaRoutineLoadJob.fromCreateInfo(createRoutineLoadInfo, connectContext);
-        Assert.assertEquals(jobName, kafkaRoutineLoadJob.getName());
-        Assert.assertEquals(dbId, kafkaRoutineLoadJob.getDbId());
-        Assert.assertEquals(tableId, kafkaRoutineLoadJob.getTableId());
-        Assert.assertEquals(serverAddress, Deencapsulation.getField(kafkaRoutineLoadJob, "brokerList"));
-        Assert.assertEquals(topicName, Deencapsulation.getField(kafkaRoutineLoadJob, "topic"));
-        List<Integer> kafkaPartitionResult = Deencapsulation.getField(kafkaRoutineLoadJob, "customKafkaPartitions");
-        Assert.assertEquals(kafkaPartitionString, Joiner.on(",").join(kafkaPartitionResult));
-        Assert.assertEquals(sequenceStmt.getSequenceColName(), kafkaRoutineLoadJob.getSequenceCol());
     }
 
     private CreateRoutineLoadInfo initCreateRoutineLoadInfo() {

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
@@ -22,29 +22,28 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.InternalErrorCode;
-import org.apache.doris.common.LoadException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.kafka.KafkaUtil;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateRoutineLoadInfo;
+import org.apache.doris.persist.EditLog;
 import org.apache.doris.thrift.TKafkaRLTaskProgress;
 import org.apache.doris.thrift.TUniqueKeyUpdateMode;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
 import org.apache.doris.transaction.TransactionException;
 import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TxnStateCallbackFactory;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.kafka.common.PartitionInfo;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,43 +51,38 @@ import java.util.Map;
 
 public class RoutineLoadJobTest {
     @Test
-    public void testAfterAbortedReasonOffsetOutOfRange(@Mocked Env env,
-                                                       @Injectable TransactionState transactionState,
-                                                       @Injectable RoutineLoadTaskInfo routineLoadTaskInfo)
-            throws UserException {
+    public void testAfterAbortedReasonOffsetOutOfRange() throws UserException {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        TransactionState transactionState = Mockito.mock(TransactionState.class);
+        RoutineLoadTaskInfo routineLoadTaskInfo = Mockito.mock(RoutineLoadTaskInfo.class);
 
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         long txnId = 1L;
 
-        new Expectations() {
-            {
-                transactionState.getTransactionId();
-                minTimes = 0;
-                result = txnId;
-                routineLoadTaskInfo.getTxnId();
-                minTimes = 0;
-                result = txnId;
-            }
-        };
+        Mockito.when(transactionState.getTransactionId()).thenReturn(txnId);
+        Mockito.when(routineLoadTaskInfo.getTxnId()).thenReturn(txnId);
 
-        new MockUp<RoutineLoadJob>() {
-            @Mock
-            void writeUnlock() {
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-        String txnStatusChangeReasonString = TransactionState.TxnStatusChangeReason.OFFSET_OUT_OF_RANGE.toString();
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
-        routineLoadJob.afterAborted(transactionState, true, txnStatusChangeReasonString);
+            String txnStatusChangeReasonString = TransactionState.TxnStatusChangeReason.OFFSET_OUT_OF_RANGE.toString();
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
+            routineLoadJob.writeLock();
+            routineLoadJob.afterAborted(transactionState, true, txnStatusChangeReasonString);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+            Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+        }
     }
 
     @Test
-    public void testAfterAborted(@Injectable TransactionState transactionState,
-                                 @Injectable KafkaTaskInfo routineLoadTaskInfo) throws UserException {
+    public void testAfterAborted() throws UserException {
+        TransactionState transactionState = Mockito.mock(TransactionState.class);
+        KafkaTaskInfo routineLoadTaskInfo = Mockito.mock(KafkaTaskInfo.class);
+
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         long txnId = 1L;
@@ -101,34 +95,17 @@ public class RoutineLoadJobTest {
 
         KafkaProgress currentProgress = new KafkaProgress(tKafkaRLTaskProgress);
 
-        new Expectations() {
-            {
-                transactionState.getTransactionId();
-                minTimes = 0;
-                result = txnId;
-                routineLoadTaskInfo.getTxnId();
-                minTimes = 0;
-                result = txnId;
-                transactionState.getTxnCommitAttachment();
-                minTimes = 0;
-                result = attachment;
-                routineLoadTaskInfo.getPartitions();
-                minTimes = 0;
-                result = Lists.newArrayList();
-            }
-        };
-
-        new MockUp<RoutineLoadJob>() {
-            @Mock
-            void writeUnlock() {
-            }
-        };
+        Mockito.when(transactionState.getTransactionId()).thenReturn(txnId);
+        Mockito.when(routineLoadTaskInfo.getTxnId()).thenReturn(txnId);
+        Mockito.doReturn(attachment).when(transactionState).getTxnCommitAttachment();
+        Mockito.when(routineLoadTaskInfo.getPartitions()).thenReturn(Lists.newArrayList());
 
         String txnStatusChangeReasonString = "no data";
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
         Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
         Deencapsulation.setField(routineLoadJob, "progress", currentProgress);
+        routineLoadJob.writeLock();
         routineLoadJob.afterAborted(transactionState, true, txnStatusChangeReasonString);
         RoutineLoadStatistic jobStatistic = Deencapsulation.getField(routineLoadJob, "jobStatistic");
 
@@ -137,31 +114,22 @@ public class RoutineLoadJobTest {
     }
 
     @Test
-    public void testAfterCommittedWhileTaskAborted(@Mocked Env env,
-                                                   @Injectable TransactionState transactionState,
-                                                   @Injectable KafkaProgress progress) throws UserException {
+    public void testAfterCommittedWhileTaskAborted() throws UserException {
+        Mockito.mock(Env.class);
+        TransactionState transactionState = Mockito.mock(TransactionState.class);
+        KafkaProgress progress = Mockito.mock(KafkaProgress.class);
+
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
         long txnId = 1L;
 
-        new Expectations() {
-            {
-                transactionState.getTransactionId();
-                minTimes = 0;
-                result = txnId;
-            }
-        };
-
-        new MockUp<RoutineLoadJob>() {
-            @Mock
-            void writeUnlock() {
-            }
-        };
+        Mockito.when(transactionState.getTransactionId()).thenReturn(txnId);
 
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
         Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
         Deencapsulation.setField(routineLoadJob, "progress", progress);
         try {
+            routineLoadJob.writeLock();
             routineLoadJob.afterCommitted(transactionState, true);
         } catch (TransactionException e) {
             Assert.fail();
@@ -169,14 +137,12 @@ public class RoutineLoadJobTest {
     }
 
     @Test
-    public void testGetShowInfo(@Mocked KafkaProgress kafkaProgress, @Injectable UserIdentity userIdentity) {
-        new Expectations() {
-            {
-                userIdentity.getQualifiedUser();
-                minTimes = 0;
-                result = "root";
-            }
-        };
+    public void testGetShowInfo() {
+        KafkaProgress kafkaProgress = Mockito.mock(KafkaProgress.class);
+        UserIdentity userIdentity = Mockito.mock(UserIdentity.class);
+
+        Mockito.when(userIdentity.getQualifiedUser()).thenReturn("root");
+
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
         ErrorReason errorReason = new ErrorReason(InternalErrorCode.INTERNAL_ERR,
@@ -191,108 +157,111 @@ public class RoutineLoadJobTest {
     }
 
     @Test
-    public void testUpdateWhileDbDeleted(@Mocked Env env, @Mocked InternalCatalog catalog) throws UserException {
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-            }
-        };
+    public void testUpdateWhileDbDeleted() throws UserException {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
 
-        new Expectations() {
-            {
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = null;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+            Mockito.doReturn(null).when(catalog).getDbNullable(Mockito.anyLong());
 
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        routineLoadJob.update();
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            routineLoadJob.update();
 
-        Assert.assertEquals(RoutineLoadJob.JobState.CANCELLED, routineLoadJob.getState());
+            Assert.assertEquals(RoutineLoadJob.JobState.CANCELLED, routineLoadJob.getState());
+        }
     }
 
     @Test
-    public void testUpdateWhileTableDeleted(@Mocked Env env, @Mocked InternalCatalog catalog,
-            @Injectable Database database) throws UserException {
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                database.getTableNullable(anyLong);
-                minTimes = 0;
-                result = null;
-            }
-        };
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        routineLoadJob.update();
+    public void testUpdateWhileTableDeleted() throws UserException {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.CANCELLED, routineLoadJob.getState());
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+            Mockito.doReturn(database).when(catalog).getDbNullable(Mockito.anyLong());
+            Mockito.doReturn(null).when(database).getTableNullable(Mockito.anyLong());
+
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            routineLoadJob.update();
+
+            Assert.assertEquals(RoutineLoadJob.JobState.CANCELLED, routineLoadJob.getState());
+        }
     }
 
     @Test
-    public void testUpdateWhilePartitionChanged(@Mocked Env env, @Mocked InternalCatalog catalog,
-            @Injectable Database database, @Injectable Table table, @Injectable PartitionInfo partitionInfo,
-            @Injectable KafkaProgress kafkaProgress) throws UserException {
+    public void testUpdateWhilePartitionChanged() throws UserException {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table table = Mockito.mock(Table.class);
+        PartitionInfo partitionInfo = Mockito.mock(PartitionInfo.class);
+        KafkaProgress kafkaProgress = Mockito.mock(KafkaProgress.class);
+
         List<PartitionInfo> partitionInfoList = Lists.newArrayList();
         partitionInfoList.add(partitionInfo);
 
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                database.getTableNullable(anyLong);
-                minTimes = 0;
-                result = table;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<KafkaUtil> kafkaUtilStatic = Mockito.mockStatic(KafkaUtil.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.doReturn(database).when(catalog).getDbNullable(Mockito.anyLong());
+            Mockito.doReturn(table).when(database).getTableNullable(Mockito.anyLong());
 
-        new MockUp<KafkaUtil>() {
-            @Mock
-            public List<Integer> getAllKafkaPartitions(String brokerList, String topic,
-                    Map<String, String> convertedCustomProperties) throws UserException {
-                return Lists.newArrayList(1, 2, 3);
-            }
-        };
+            kafkaUtilStatic.when(() -> KafkaUtil.getAllKafkaPartitions(
+                    Mockito.anyString(), Mockito.anyString(), Mockito.anyMap()))
+                    .thenReturn(Lists.newArrayList(1, 2, 3));
 
-        new MockUp<KafkaUtil>() {
-            @Mock
-            public List<Pair<Integer, Long>> getRealOffsets(String brokerList, String topic,
-                                                             Map<String, String> convertedCustomProperties,
-                                                             List<Pair<Integer, Long>> offsetFlags)
-                                                             throws LoadException {
-                List<Pair<Integer, Long>> pairList = new ArrayList<>();
-                pairList.add(Pair.of(1, 0L));
-                return pairList;
-            }
-        };
+            kafkaUtilStatic.when(() -> KafkaUtil.getRealOffsets(
+                    Mockito.anyString(), Mockito.anyString(), Mockito.anyMap(), Mockito.anyList()))
+                    .thenAnswer(inv -> {
+                        List<Pair<Integer, Long>> pairList = new ArrayList<>();
+                        pairList.add(Pair.of(1, 0L));
+                        return pairList;
+                    });
 
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
-        routineLoadJob.update();
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+            routineLoadJob.update();
 
-        Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+            Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+        }
     }
 
     @Test
-    public void testUpdateNumOfDataErrorRowMoreThanMax(@Mocked Env env) {
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        Deencapsulation.setField(routineLoadJob, "maxErrorNum", 0);
-        Deencapsulation.setField(routineLoadJob, "maxBatchRows", 0);
-        Deencapsulation.invoke(routineLoadJob, "updateNumOfData", 1L, 1L, 0L, 1L, 1L, false);
+    public void testUpdateNumOfDataErrorRowMoreThanMax() {
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, Deencapsulation.getField(routineLoadJob, "state"));
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
 
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            Deencapsulation.setField(routineLoadJob, "maxErrorNum", 0);
+            Deencapsulation.setField(routineLoadJob, "maxBatchRows", 0);
+            Deencapsulation.invoke(routineLoadJob, "updateNumOfData", 1L, 1L, 0L, 1L, 1L, false);
+
+            Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, Deencapsulation.getField(routineLoadJob, "state"));
+        }
     }
 
     @Test
@@ -313,24 +282,18 @@ public class RoutineLoadJobTest {
     }
 
     @Test
-    public void testGetBeIdToConcurrentTaskNum(@Injectable RoutineLoadTaskInfo routineLoadTaskInfo,
-                                               @Injectable RoutineLoadTaskInfo routineLoadTaskInfo1) {
+    public void testGetBeIdToConcurrentTaskNum() {
+        RoutineLoadTaskInfo routineLoadTaskInfo = Mockito.mock(RoutineLoadTaskInfo.class);
+        RoutineLoadTaskInfo routineLoadTaskInfo1 = Mockito.mock(RoutineLoadTaskInfo.class);
+
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         List<RoutineLoadTaskInfo> routineLoadTaskInfoList = Lists.newArrayList();
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         routineLoadTaskInfoList.add(routineLoadTaskInfo1);
         Deencapsulation.setField(routineLoadJob, "routineLoadTaskInfoList", routineLoadTaskInfoList);
 
-        new Expectations() {
-            {
-                routineLoadTaskInfo.getBeId();
-                minTimes = 0;
-                result = 1L;
-                routineLoadTaskInfo1.getBeId();
-                minTimes = 0;
-                result = 1L;
-            }
-        };
+        Mockito.when(routineLoadTaskInfo.getBeId()).thenReturn(1L);
+        Mockito.when(routineLoadTaskInfo1.getBeId()).thenReturn(1L);
 
         Map<Long, Integer> beIdConcurrentTasksNum = routineLoadJob.getBeCurrentTasksNumMap();
         Assert.assertEquals(2, (int) beIdConcurrentTasksNum.get(1L));

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
@@ -46,20 +46,19 @@ import org.apache.doris.nereids.trees.plans.commands.load.StopRoutineLoadCommand
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.persist.RoutineLoadOperation;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.system.BeSelectionPolicy;
+import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.system.SystemInfoService;
-import org.apache.doris.thrift.TResourceInfo;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TxnStateCallbackFactory;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -71,14 +70,18 @@ public class RoutineLoadManagerTest {
 
     private static final Logger LOG = LogManager.getLogger(RoutineLoadManagerTest.class);
 
-    @Mocked
-    private SystemInfoService systemInfoService;
+    private SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
+
+    private void mockSessionVariable(ConnectContext connectContext) {
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(VariableMgr.newSessionVariable());
+    }
 
     @Test
-    public void testCreateJobAuthDeny(@Injectable AccessControllerManager accessManager,
-            @Injectable TResourceInfo tResourceInfo,
-            @Mocked ConnectContext connectContext,
-            @Mocked Env env) {
+    public void testCreateJobAuthDeny() {
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+        Env env = Mockito.mock(Env.class);
+
         String jobName = "job1";
         String dbName = "db1";
         LabelNameInfo labelNameInfo = new LabelNameInfo(dbName, jobName);
@@ -97,252 +100,225 @@ public class RoutineLoadManagerTest {
         CreateRoutineLoadInfo createRoutineLoadInfo = new CreateRoutineLoadInfo(labelNameInfo, tableNameString,
                 loadPropertyMap, properties, typeName, customProperties, LoadTask.MergeType.APPEND, "");
 
-        new Expectations() {
-            {
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, PrivPredicate.LOAD);
-                minTimes = 0;
-                result = false;
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
+            Mockito.when(connectContext.getState()).thenReturn(new org.apache.doris.qe.QueryState());
+
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                    Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.LOAD))).thenReturn(false);
+
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            try {
+                createRoutineLoadInfo.checkJobProperties();
+                routineLoadManager.createRoutineLoadJob(createRoutineLoadInfo, connectContext);
+                Assert.fail();
+            } catch (LoadException | DdlException e) {
+                Assert.fail();
+            } catch (AnalysisException e) {
+                LOG.info("Access deny");
+            } catch (UserException e) {
+                e.printStackTrace();
             }
-        };
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        try {
-            createRoutineLoadInfo.checkJobProperties();
-            routineLoadManager.createRoutineLoadJob(createRoutineLoadInfo, connectContext);
-            Assert.fail();
-        } catch (LoadException | DdlException e) {
-            Assert.fail();
-        } catch (AnalysisException e) {
-            LOG.info("Access deny");
-        } catch (UserException e) {
-            e.printStackTrace();
         }
     }
 
     @Test
-    public void testCreateWithSameName(@Mocked ConnectContext connectContext) {
-        String jobName = "job1";
-        String topicName = "topic1";
-        String serverAddress = "http://127.0.0.1:8080";
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, 1L, 1L,
-                serverAddress, topicName, UserIdentity.ADMIN);
+    public void testCreateWithSameName() {
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+        try (MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
 
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newConcurrentMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName,
-                1L, 1L, serverAddress, topicName, UserIdentity.ADMIN);
-        routineLoadJobList.add(kafkaRoutineLoadJobWithSameName);
-        nameToRoutineLoadJob.put(jobName, routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            String jobName = "job1";
+            String topicName = "topic1";
+            String serverAddress = "http://127.0.0.1:8080";
+            KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, 1L, 1L,
+                    serverAddress, topicName, UserIdentity.ADMIN);
 
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
-        try {
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newConcurrentMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName,
+                    1L, 1L, serverAddress, topicName, UserIdentity.ADMIN);
+            routineLoadJobList.add(kafkaRoutineLoadJobWithSameName);
+            nameToRoutineLoadJob.put(jobName, routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+            try {
+                routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob, "db", "table");
+                Assert.fail();
+            } catch (UserException e) {
+                LOG.info(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testCreateWithSameNameOfStoppedJob() throws UserException {
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
+
+            String jobName = "job1";
+            String topicName = "topic1";
+            String serverAddress = "http://127.0.0.1:8080";
+            KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, 1L, 1L,
+                    serverAddress, topicName, UserIdentity.ADMIN);
+
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newConcurrentMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName,
+                    1L, 1L, serverAddress, topicName, UserIdentity.ADMIN);
+            Deencapsulation.setField(kafkaRoutineLoadJobWithSameName, "state", RoutineLoadJob.JobState.STOPPED);
+            routineLoadJobList.add(kafkaRoutineLoadJobWithSameName);
+            nameToRoutineLoadJob.put(jobName, routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Map<String, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
+            idToRoutineLoadJob.put(UUID.randomUUID().toString(), kafkaRoutineLoadJobWithSameName);
+
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
             routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob, "db", "table");
-            Assert.fail();
-        } catch (UserException e) {
-            LOG.info(e.getMessage());
+
+            Map<Long, Map<String, List<RoutineLoadJob>>> result =
+                    Deencapsulation.getField(routineLoadManager, "dbToNameToRoutineLoadJob");
+            Map<String, RoutineLoadJob> result1 = Deencapsulation.getField(routineLoadManager, "idToRoutineLoadJob");
+            Assert.assertEquals(1, result.size());
+            Assert.assertEquals(Long.valueOf(1L), result.keySet().iterator().next());
+            Map<String, List<RoutineLoadJob>> resultNameToRoutineLoadJob = result.get(1L);
+            Assert.assertEquals(jobName, resultNameToRoutineLoadJob.keySet().iterator().next());
+            Assert.assertEquals(2, resultNameToRoutineLoadJob.values().iterator().next().size());
+            Assert.assertEquals(2, result1.values().size());
         }
     }
 
     @Test
-    public void testCreateWithSameNameOfStoppedJob(@Mocked ConnectContext connectContext,
-                                                   @Mocked Env env,
-                                                   @Mocked EditLog editLog) throws UserException {
-        String jobName = "job1";
-        String topicName = "topic1";
-        String serverAddress = "http://127.0.0.1:8080";
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, jobName, 1L, 1L,
-                serverAddress, topicName, UserIdentity.ADMIN);
+    public void testGetMinTaskBeId() throws LoadException {
+        RoutineLoadJob routineLoadJob = Mockito.mock(RoutineLoadJob.class);
 
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-
-        new Expectations() {
-            {
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newConcurrentMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        KafkaRoutineLoadJob kafkaRoutineLoadJobWithSameName = new KafkaRoutineLoadJob(1L, jobName,
-                1L, 1L, serverAddress, topicName, UserIdentity.ADMIN);
-        Deencapsulation.setField(kafkaRoutineLoadJobWithSameName, "state", RoutineLoadJob.JobState.STOPPED);
-        routineLoadJobList.add(kafkaRoutineLoadJobWithSameName);
-        nameToRoutineLoadJob.put(jobName, routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Map<String, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
-        idToRoutineLoadJob.put(UUID.randomUUID().toString(), kafkaRoutineLoadJobWithSameName);
-
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
-        routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob, "db", "table");
-
-        Map<Long, Map<String, List<RoutineLoadJob>>> result =
-                Deencapsulation.getField(routineLoadManager, "dbToNameToRoutineLoadJob");
-        Map<String, RoutineLoadJob> result1 = Deencapsulation.getField(routineLoadManager, "idToRoutineLoadJob");
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals(Long.valueOf(1L), result.keySet().iterator().next());
-        Map<String, List<RoutineLoadJob>> resultNameToRoutineLoadJob = result.get(1L);
-        Assert.assertEquals(jobName, resultNameToRoutineLoadJob.keySet().iterator().next());
-        Assert.assertEquals(2, resultNameToRoutineLoadJob.values().iterator().next().size());
-        Assert.assertEquals(2, result1.values().size());
-    }
-
-    @Test
-    public void testGetMinTaskBeId(@Injectable RoutineLoadJob routineLoadJob) throws LoadException {
         List<Long> beIds = Lists.newArrayList();
         beIds.add(1L);
         beIds.add(2L);
 
-        new Expectations() {
-            {
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                result = beIds;
-            }
-        };
+        Mockito.when(systemInfoService.getAllBackendIds(true)).thenReturn(beIds);
 
-        new MockUp<Env>() {
-            SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-        Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
-        idToRoutineLoadJob.put(1L, routineLoadJob);
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Integer> beIdToConcurrentTaskMap = Maps.newHashMap();
-        beIdToConcurrentTaskMap.put(1L, 1);
+            Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
+            idToRoutineLoadJob.put(1L, routineLoadJob);
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Integer> beIdToConcurrentTaskMap = Maps.newHashMap();
+            beIdToConcurrentTaskMap.put(1L, 1);
 
-        new Expectations(routineLoadJob) {
-            {
-                routineLoadJob.getBeCurrentTasksNumMap();
-                result = beIdToConcurrentTaskMap;
-                routineLoadJob.getState();
-                result = RoutineLoadJob.JobState.RUNNING;
-            }
-        };
+            Mockito.when(routineLoadJob.getBeCurrentTasksNumMap()).thenReturn(beIdToConcurrentTaskMap);
+            Mockito.when(routineLoadJob.getState()).thenReturn(RoutineLoadJob.JobState.RUNNING);
 
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
 
-        Assert.assertEquals(2L, routineLoadManager.getMinTaskBeId("default"));
+            Assert.assertEquals(2L, routineLoadManager.getMinTaskBeId("default"));
+        }
     }
 
     @Test
     public void testGetMinTaskBeIdWhileClusterDeleted() {
-        new Expectations() {
-            {
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                result = null;
-            }
-        };
+        Mockito.when(systemInfoService.getAllBackendIds(true)).thenReturn(null);
 
-        new MockUp<Env>() {
-            SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        try {
-            routineLoadManager.getMinTaskBeId("default");
-            Assert.fail();
-        } catch (LoadException e) {
-            // do nothing
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            try {
+                routineLoadManager.getMinTaskBeId("default");
+                Assert.fail();
+            } catch (LoadException e) {
+                // do nothing
+            }
         }
 
     }
 
     @Test
-    public void testGetMinTaskBeIdWhileNoSlot(@Injectable RoutineLoadJob routineLoadJob) {
+    public void testGetMinTaskBeIdWhileNoSlot() {
+        RoutineLoadJob routineLoadJob = Mockito.mock(RoutineLoadJob.class);
+
         List<Long> beIds = Lists.newArrayList();
         beIds.add(1L);
         Map<Long, Integer> beIdToConcurrentTaskMap = Maps.newHashMap();
         beIdToConcurrentTaskMap.put(1L, 11);
 
-        new Expectations() {
-            {
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                result = beIds;
-                routineLoadJob.getBeCurrentTasksNumMap();
-                minTimes = 0;
-                result = beIdToConcurrentTaskMap;
-                routineLoadJob.getState();
-                minTimes = 0;
-                result = RoutineLoadJob.JobState.RUNNING;
+        Mockito.when(systemInfoService.getAllBackendIds(true)).thenReturn(beIds);
+        Mockito.when(routineLoadJob.getBeCurrentTasksNumMap()).thenReturn(beIdToConcurrentTaskMap);
+        Mockito.when(routineLoadJob.getState()).thenReturn(RoutineLoadJob.JobState.RUNNING);
+
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Config.max_routine_load_task_num_per_be = 0;
+            Map<Long, RoutineLoadJob> routineLoadJobMap = Maps.newHashMap();
+            routineLoadJobMap.put(1L, routineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", routineLoadJobMap);
+
+            try {
+                Assert.assertEquals(-1, routineLoadManager.getMinTaskBeId("default"));
+            } catch (LoadException e) {
+                e.printStackTrace();
+                Assert.fail();
             }
-        };
-
-        new MockUp<Env>() {
-            SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-        };
-
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Config.max_routine_load_task_num_per_be = 0;
-        Map<Long, RoutineLoadJob> routineLoadJobMap = Maps.newHashMap();
-        routineLoadJobMap.put(1L, routineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", routineLoadJobMap);
-
-
-        try {
-            Assert.assertEquals(-1, routineLoadManager.getMinTaskBeId("default"));
-        } catch (LoadException e) {
-            e.printStackTrace();
-            Assert.fail();
         }
     }
 
     @Test
-    public void testGetTotalIdleTaskNum(@Injectable RoutineLoadJob routineLoadJob) {
+    public void testGetTotalIdleTaskNum() {
+        RoutineLoadJob routineLoadJob = Mockito.mock(RoutineLoadJob.class);
+
         List<Long> beIds = Lists.newArrayList();
         beIds.add(1L);
         beIds.add(2L);
 
-        new Expectations() {
-            {
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                result = beIds;
-            }
-        };
+        Mockito.when(systemInfoService.getAllBackendIds(true)).thenReturn(beIds);
 
-        new MockUp<Env>() {
-            SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-        Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
-        idToRoutineLoadJob.put(1L, routineLoadJob);
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Integer> beIdToConcurrentTaskMap = Maps.newHashMap();
-        beIdToConcurrentTaskMap.put(1L, 1);
+            Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
+            idToRoutineLoadJob.put(1L, routineLoadJob);
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Integer> beIdToConcurrentTaskMap = Maps.newHashMap();
+            beIdToConcurrentTaskMap.put(1L, 1);
 
-        new Expectations(routineLoadJob) {
-            {
-                routineLoadJob.getBeCurrentTasksNumMap();
-                result = beIdToConcurrentTaskMap;
-                routineLoadJob.getState();
-                result = RoutineLoadJob.JobState.RUNNING;
-            }
-        };
+            Mockito.when(routineLoadJob.getBeCurrentTasksNumMap()).thenReturn(beIdToConcurrentTaskMap);
+            Mockito.when(routineLoadJob.getState()).thenReturn(RoutineLoadJob.JobState.RUNNING);
 
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
-        routineLoadManager.updateBeIdToMaxConcurrentTasks();
-        Assert.assertEquals(Config.max_routine_load_task_num_per_be * 2 - 1,
-                routineLoadManager.getClusterIdleSlotNum());
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
+            routineLoadManager.updateBeIdToMaxConcurrentTasks();
+            Assert.assertEquals(Config.max_routine_load_task_num_per_be * 2 - 1,
+                    routineLoadManager.getClusterIdleSlotNum());
+        }
     }
 
     @Test
@@ -355,28 +331,22 @@ public class RoutineLoadManagerTest {
         newBeIds.add(1L);
         newBeIds.add(3L);
 
-        new Expectations() {
-            {
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                returns(oldBeIds, newBeIds);
-            }
-        };
+        Mockito.when(systemInfoService.getAllBackendIds(true)).thenReturn(oldBeIds).thenReturn(newBeIds);
 
-        new MockUp<Env>() {
-            SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        routineLoadManager.updateBeIdToMaxConcurrentTasks();
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            routineLoadManager.updateBeIdToMaxConcurrentTasks();
+        }
     }
 
     @Test
-    public void testGetJobByName(@Injectable RoutineLoadJob routineLoadJob1,
-                                 @Injectable RoutineLoadJob routineLoadJob2,
-                                 @Injectable RoutineLoadJob routineLoadJob3) {
+    public void testGetJobByName() {
+        RoutineLoadJob routineLoadJob1 = Mockito.mock(RoutineLoadJob.class);
+        RoutineLoadJob routineLoadJob2 = Mockito.mock(RoutineLoadJob.class);
+        RoutineLoadJob routineLoadJob3 = Mockito.mock(RoutineLoadJob.class);
+
         String jobName = "ilovedoris";
         List<RoutineLoadJob> routineLoadJobList1 = Lists.newArrayList();
         routineLoadJobList1.add(routineLoadJob1);
@@ -393,16 +363,8 @@ public class RoutineLoadManagerTest {
         dbToNameRoutineLoadList.put("db1", nameToRoutineLoadList1);
         dbToNameRoutineLoadList.put("db2", nameToRoutineLoadList2);
 
-        new Expectations() {
-            {
-                routineLoadJob1.isFinal();
-                minTimes = 0;
-                result = true;
-                routineLoadJob2.isFinal();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(routineLoadJob1.isFinal()).thenReturn(true);
+        Mockito.when(routineLoadJob2.isFinal()).thenReturn(false);
 
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
         Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameRoutineLoadList);
@@ -416,33 +378,18 @@ public class RoutineLoadManagerTest {
     }
 
     @Test
-    public void testGetJob(@Injectable RoutineLoadJob routineLoadJob1,
-            @Injectable RoutineLoadJob routineLoadJob2,
-            @Injectable RoutineLoadJob routineLoadJob3) throws MetaNotFoundException,
+    public void testGetJob() throws MetaNotFoundException,
             PatternMatcherException {
+        RoutineLoadJob routineLoadJob1 = Mockito.mock(RoutineLoadJob.class);
+        RoutineLoadJob routineLoadJob2 = Mockito.mock(RoutineLoadJob.class);
+        RoutineLoadJob routineLoadJob3 = Mockito.mock(RoutineLoadJob.class);
 
-        new Expectations() {
-            {
-                routineLoadJob1.isFinal();
-                minTimes = 0;
-                result = true;
-                routineLoadJob2.isFinal();
-                minTimes = 0;
-                result = false;
-                routineLoadJob3.isFinal();
-                minTimes = 0;
-                result = true;
-                routineLoadJob1.getName();
-                minTimes = 0;
-                result = "routine_load_job_test1";
-                routineLoadJob2.getName();
-                minTimes = 0;
-                result = "routine_load_job";
-                routineLoadJob3.getName();
-                minTimes = 0;
-                result = "routine_load_job_test2";
-            }
-        };
+        Mockito.when(routineLoadJob1.isFinal()).thenReturn(true);
+        Mockito.when(routineLoadJob2.isFinal()).thenReturn(false);
+        Mockito.when(routineLoadJob3.isFinal()).thenReturn(true);
+        Mockito.when(routineLoadJob1.getName()).thenReturn("routine_load_job_test1");
+        Mockito.when(routineLoadJob2.getName()).thenReturn("routine_load_job");
+        Mockito.when(routineLoadJob3.getName()).thenReturn("routine_load_job_test2");
 
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
         Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newHashMap();
@@ -465,330 +412,317 @@ public class RoutineLoadManagerTest {
     }
 
     @Test
-    public void testGetJobIncludeHistory(@Injectable RoutineLoadJob routineLoadJob1,
-            @Injectable RoutineLoadJob routineLoadJob2, @Injectable RoutineLoadJob routineLoadJob3, @Mocked Env env,
-            @Mocked InternalCatalog catalog, @Mocked Database database)
-            throws MetaNotFoundException {
-        new Expectations() {
-            {
-                routineLoadJob1.isFinal();
-                minTimes = 0;
-                result = true;
-                routineLoadJob2.isFinal();
-                minTimes = 0;
-                result = false;
-                routineLoadJob3.isFinal();
-                minTimes = 0;
-                result = true;
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyString);
-                minTimes = 0;
-                result = database;
-                database.getId();
-                minTimes = 0;
-                result = 1L;
-            }
-        };
+    public void testGetJobIncludeHistory() throws MetaNotFoundException {
+        RoutineLoadJob routineLoadJob1 = Mockito.mock(RoutineLoadJob.class);
+        RoutineLoadJob routineLoadJob2 = Mockito.mock(RoutineLoadJob.class);
+        RoutineLoadJob routineLoadJob3 = Mockito.mock(RoutineLoadJob.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
 
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        routineLoadJobList.add(routineLoadJob1);
-        routineLoadJobList.add(routineLoadJob2);
-        routineLoadJobList.add(routineLoadJob3);
-        nameToRoutineLoadJob.put("", routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
-        List<RoutineLoadJob> result = routineLoadManager.getJob("", "", true, null);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
 
-        Assert.assertEquals(3, result.size());
-        Assert.assertEquals(routineLoadJob2, result.get(0));
-        Assert.assertEquals(routineLoadJob1, result.get(1));
-        Assert.assertEquals(routineLoadJob3, result.get(2));
+            Mockito.when(routineLoadJob1.isFinal()).thenReturn(true);
+            Mockito.when(routineLoadJob2.isFinal()).thenReturn(false);
+            Mockito.when(routineLoadJob3.isFinal()).thenReturn(true);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable(Mockito.anyString())).thenReturn(database);
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyString());
+            Mockito.when(database.getId()).thenReturn(1L);
+
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            routineLoadJobList.add(routineLoadJob1);
+            routineLoadJobList.add(routineLoadJob2);
+            routineLoadJobList.add(routineLoadJob3);
+            nameToRoutineLoadJob.put("", routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+            List<RoutineLoadJob> result = routineLoadManager.getJob("", "", true, null);
+
+            Assert.assertEquals(3, result.size());
+            Assert.assertEquals(routineLoadJob2, result.get(0));
+            Assert.assertEquals(routineLoadJob1, result.get(1));
+            Assert.assertEquals(routineLoadJob3, result.get(2));
+        }
     }
 
     @Test
-    public void testPauseRoutineLoadJob(@Injectable PauseRoutineLoadCommand pauseRoutineLoadCommand, @Mocked Env env,
-                                        @Mocked InternalCatalog catalog, @Mocked Database database, @Mocked Table tbl,
-                                        @Mocked AccessControllerManager accessManager,
-                                        @Mocked ConnectContext connectContext) throws UserException {
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        routineLoadJobList.add(routineLoadJob);
-        nameToRoutineLoadJob.put("", routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+    public void testPauseRoutineLoadJob() throws UserException {
+        PauseRoutineLoadCommand pauseRoutineLoadCommand = Mockito.mock(PauseRoutineLoadCommand.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table tbl = Mockito.mock(Table.class);
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-        Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
-        idToRoutineLoadJob.put(routineLoadJob.getId(), routineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-        new Expectations() {
-            {
-                pauseRoutineLoadCommand.getDbFullName();
-                minTimes = 0;
-                result = "";
-                pauseRoutineLoadCommand.getLabel();
-                minTimes = 0;
-                result = "";
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable("");
-                minTimes = 0;
-                result = database;
-                database.getId();
-                minTimes = 0;
-                result = 1L;
-                database.getTableOrAnalysisException(anyLong);
-                minTimes = 0;
-                result = tbl;
-                tbl.getName();
-                minTimes = 0;
-                result = "tbl";
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            routineLoadJobList.add(routineLoadJob);
+            nameToRoutineLoadJob.put("", routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
 
-        routineLoadManager.pauseRoutineLoadJob(pauseRoutineLoadCommand);
+            Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
+            idToRoutineLoadJob.put(routineLoadJob.getId(), routineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+            Mockito.when(pauseRoutineLoadCommand.getDbFullName()).thenReturn("");
+            Mockito.when(pauseRoutineLoadCommand.getLabel()).thenReturn("");
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable("")).thenReturn(database);
+            Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(database);
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyString());
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyLong());
+            Mockito.when(database.getId()).thenReturn(1L);
+            Mockito.when(database.getFullName()).thenReturn("");
+            Mockito.when(database.getTableNullable(Mockito.anyLong())).thenReturn(tbl);
+            Mockito.doReturn(tbl).when(database).getTableOrAnalysisException(Mockito.anyLong());
+            Mockito.doReturn(tbl).when(database).getTableOrMetaException(Mockito.anyLong());
+            Mockito.when(tbl.getName()).thenReturn("tbl");
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                    Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class))).thenReturn(true);
 
-        for (int i = 0; i < 3; i++) {
-            Deencapsulation.setField(routineLoadJob, "pauseReason",
-                    new ErrorReason(InternalErrorCode.REPLICA_FEW_ERR, ""));
-            try {
-                Thread.sleep(((long) Math.pow(2, i) * 10 * 1000L));
-            } catch (InterruptedException e) {
-                throw new UserException("thread sleep failed");
+            routineLoadManager.pauseRoutineLoadJob(pauseRoutineLoadCommand);
+
+            Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+
+            for (int i = 0; i < 3; i++) {
+                Deencapsulation.setField(routineLoadJob, "pauseReason",
+                        new ErrorReason(InternalErrorCode.REPLICA_FEW_ERR, ""));
+                try {
+                    Thread.sleep(((long) Math.pow(2, i) * 10 * 1000L));
+                } catch (InterruptedException e) {
+                    throw new UserException("thread sleep failed");
+                }
+                routineLoadManager.updateRoutineLoadJob();
+                Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
             }
             routineLoadManager.updateRoutineLoadJob();
             Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
         }
-        routineLoadManager.updateRoutineLoadJob();
-        Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
     }
 
     @Test
-    public void testResumeRoutineLoadJob(@Injectable ResumeRoutineLoadCommand resumeRoutineLoadCommand, @Mocked Env env,
-                                         @Mocked InternalCatalog catalog, @Mocked Database database, @Mocked Table tbl,
-                                         @Mocked AccessControllerManager accessManager,
-                                         @Mocked ConnectContext connectContext) throws UserException {
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        routineLoadJobList.add(routineLoadJob);
-        nameToRoutineLoadJob.put("", routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+    public void testResumeRoutineLoadJob() throws UserException {
+        ResumeRoutineLoadCommand resumeRoutineLoadCommand = Mockito.mock(ResumeRoutineLoadCommand.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table tbl = Mockito.mock(Table.class);
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-        new Expectations() {
-            {
-                resumeRoutineLoadCommand.getDbFullName();
-                minTimes = 0;
-                result = "";
-                resumeRoutineLoadCommand.getLabel();
-                minTimes = 0;
-                result = "";
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable("");
-                minTimes = 0;
-                result = database;
-                database.getId();
-                minTimes = 0;
-                result = 1L;
-                database.getTableOrAnalysisException(anyLong);
-                minTimes = 0;
-                result = tbl;
-                tbl.getName();
-                minTimes = 0;
-                result = "tbl";
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-        routineLoadManager.resumeRoutineLoadJob(resumeRoutineLoadCommand);
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            routineLoadJobList.add(routineLoadJob);
+            nameToRoutineLoadJob.put("", routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+            Mockito.when(resumeRoutineLoadCommand.getDbFullName()).thenReturn("");
+            Mockito.when(resumeRoutineLoadCommand.getLabel()).thenReturn("");
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable("")).thenReturn(database);
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyString());
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyLong());
+            Mockito.when(database.getId()).thenReturn(1L);
+            Mockito.when(database.getFullName()).thenReturn("");
+            Mockito.doReturn(tbl).when(database).getTableOrAnalysisException(Mockito.anyLong());
+            Mockito.doReturn(tbl).when(database).getTableOrMetaException(Mockito.anyLong());
+            Mockito.when(tbl.getName()).thenReturn("tbl");
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                    Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class))).thenReturn(true);
+
+            routineLoadManager.resumeRoutineLoadJob(resumeRoutineLoadCommand);
+
+            Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
+        }
     }
 
     @Test
-    public void testStopRoutineLoadJob(@Injectable StopRoutineLoadCommand stopRoutineLoadCommand, @Mocked Env env,
-                                       @Mocked InternalCatalog catalog, @Mocked Database database, @Mocked Table tbl,
-                                       @Mocked AccessControllerManager accessManager,
-                                       @Mocked ConnectContext connectContext) throws UserException {
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        routineLoadJobList.add(routineLoadJob);
-        nameToRoutineLoadJob.put("", routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+    public void testStopRoutineLoadJob() throws UserException {
+        StopRoutineLoadCommand stopRoutineLoadCommand = Mockito.mock(StopRoutineLoadCommand.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table tbl = Mockito.mock(Table.class);
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-        new Expectations() {
-            {
-                stopRoutineLoadCommand.getDbFullName();
-                minTimes = 0;
-                result = "";
-                stopRoutineLoadCommand.getLabel();
-                minTimes = 0;
-                result = "";
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable("");
-                minTimes = 0;
-                result = database;
-                database.getId();
-                minTimes = 0;
-                result = 1L;
-                database.getTableOrAnalysisException(anyLong);
-                minTimes = 0;
-                result = tbl;
-                tbl.getName();
-                minTimes = 0;
-                result = "tbl";
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+            TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            envStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
 
-        routineLoadManager.stopRoutineLoadJob(stopRoutineLoadCommand);
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            routineLoadJobList.add(routineLoadJob);
+            nameToRoutineLoadJob.put("", routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.STOPPED, routineLoadJob.getState());
+            Mockito.when(stopRoutineLoadCommand.getDbFullName()).thenReturn("");
+            Mockito.when(stopRoutineLoadCommand.getLabel()).thenReturn("");
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable("")).thenReturn(database);
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyString());
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyLong());
+            Mockito.when(database.getId()).thenReturn(1L);
+            Mockito.when(database.getFullName()).thenReturn("");
+            Mockito.doReturn(tbl).when(database).getTableOrAnalysisException(Mockito.anyLong());
+            Mockito.doReturn(tbl).when(database).getTableOrMetaException(Mockito.anyLong());
+            Mockito.when(tbl.getName()).thenReturn("tbl");
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                    Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class))).thenReturn(true);
+
+            routineLoadManager.stopRoutineLoadJob(stopRoutineLoadCommand);
+
+            Assert.assertEquals(RoutineLoadJob.JobState.STOPPED, routineLoadJob.getState());
+        }
     }
 
     @Test
-    public void testCheckBeToTask(@Mocked Env env,
-                                  @Mocked SystemInfoService systemInfoService) throws UserException {
-        List<Long> beIdsInCluster = Lists.newArrayList();
-        beIdsInCluster.add(1L);
-        Map<Long, Integer> beIdToMaxConcurrentTasks = Maps.newHashMap();
-        beIdToMaxConcurrentTasks.put(1L, 10);
-        new Expectations() {
-            {
-                systemInfoService.selectBackendIdsByPolicy((BeSelectionPolicy) any, anyInt);
-                minTimes = 0;
-                result = beIdsInCluster;
-            }
-        };
+    public void testCheckBeToTask() throws UserException {
+        Env env = Mockito.mock(Env.class);
+        SystemInfoService localSystemInfoService = Mockito.mock(SystemInfoService.class);
+        GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
 
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        KafkaRoutineLoadJob job = new KafkaRoutineLoadJob(1L, "testjob",
-                10000, 10001, "192.168.1.1:9090", "testtopic", UserIdentity.ADMIN);
-        routineLoadManager.addRoutineLoadJob(job, "testdb", "testtable");
-        Config.max_routine_load_task_num_per_be = 10;
-        Deencapsulation.setField(routineLoadManager, "beIdToMaxConcurrentTasks", beIdToMaxConcurrentTasks);
-        Assert.assertEquals(-1L, routineLoadManager.getAvailableBeForTask(1L, 1L));
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(localSystemInfoService);
+            envStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
+
+            RoutineLoadManager routineLoadManager = Mockito.spy(new RoutineLoadManager());
+            Mockito.doReturn(Lists.newArrayList()).when(routineLoadManager)
+                    .getAvailableBackendIds(Mockito.anyLong());
+
+            KafkaRoutineLoadJob job = new KafkaRoutineLoadJob(1L, "testjob",
+                    10000, 10001, "192.168.1.1:9090", "testtopic", UserIdentity.ADMIN);
+            routineLoadManager.addRoutineLoadJob(job, "testdb", "testtable");
+            Assert.assertEquals(-1L, routineLoadManager.getAvailableBeForTask(1L, 1L));
+        }
     }
 
     @Test
-    public void testCleanOldRoutineLoadJobs(@Injectable RoutineLoadJob routineLoadJob,
-                                            @Mocked Env env,
-                                            @Mocked EditLog editLog) {
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        routineLoadJobList.add(routineLoadJob);
-        nameToRoutineLoadJob.put("", routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newHashMap();
-        idToRoutineLoadJob.put(1L, routineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+    public void testCleanOldRoutineLoadJobs() {
+        RoutineLoadJob routineLoadJob = Mockito.mock(RoutineLoadJob.class);
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
 
-        new Expectations() {
-            {
-                routineLoadJob.isExpired();
-                minTimes = 0;
-                result = true;
-                routineLoadJob.getDbId();
-                minTimes = 0;
-                result = 1L;
-                routineLoadJob.getName();
-                minTimes = 0;
-                result = "";
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        routineLoadManager.cleanOldRoutineLoadJobs();
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
 
-        Assert.assertEquals(0, dbToNameToRoutineLoadJob.size());
-        Assert.assertEquals(0, idToRoutineLoadJob.size());
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            routineLoadJobList.add(routineLoadJob);
+            nameToRoutineLoadJob.put("", routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newHashMap();
+            idToRoutineLoadJob.put(1L, routineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+
+            Mockito.when(routineLoadJob.isExpired()).thenReturn(true);
+            Mockito.when(routineLoadJob.getDbId()).thenReturn(1L);
+            Mockito.when(routineLoadJob.getName()).thenReturn("");
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+
+            routineLoadManager.cleanOldRoutineLoadJobs();
+
+            Assert.assertEquals(0, dbToNameToRoutineLoadJob.size());
+            Assert.assertEquals(0, idToRoutineLoadJob.size());
+        }
     }
 
     @Test
-    public void testCleanOverLimitRoutineLoadJobs(@Injectable RoutineLoadJob routineLoadJob,
-            @Mocked Env env, @Mocked EditLog editLog) {
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        routineLoadJobList.add(routineLoadJob);
-        nameToRoutineLoadJob.put("", routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newHashMap();
-        idToRoutineLoadJob.put(1L, routineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+    public void testCleanOverLimitRoutineLoadJobs() {
+        RoutineLoadJob routineLoadJob = Mockito.mock(RoutineLoadJob.class);
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
 
-        new Expectations() {
-            {
-                routineLoadJob.getId();
-                minTimes = 0;
-                result = 1L;
-                routineLoadJob.isFinal();
-                minTimes = 0;
-                result = true;
-                routineLoadJob.getDbId();
-                minTimes = 0;
-                result = 1L;
-                routineLoadJob.getName();
-                minTimes = 0;
-                result = "";
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-            }
-        };
-        Config.label_num_threshold = 0;
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
 
-        routineLoadManager.cleanOverLimitRoutineLoadJobs();
-        Assert.assertEquals(0, dbToNameToRoutineLoadJob.size());
-        Assert.assertEquals(0, idToRoutineLoadJob.size());
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            routineLoadJobList.add(routineLoadJob);
+            nameToRoutineLoadJob.put("", routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newHashMap();
+            idToRoutineLoadJob.put(1L, routineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+
+            Mockito.when(routineLoadJob.getId()).thenReturn(1L);
+            Mockito.when(routineLoadJob.isFinal()).thenReturn(true);
+            Mockito.when(routineLoadJob.getDbId()).thenReturn(1L);
+            Mockito.when(routineLoadJob.getName()).thenReturn("");
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+
+            Config.label_num_threshold = 0;
+
+            routineLoadManager.cleanOverLimitRoutineLoadJobs();
+            Assert.assertEquals(0, dbToNameToRoutineLoadJob.size());
+            Assert.assertEquals(0, idToRoutineLoadJob.size());
+        }
     }
 
     @Test
-    public void testGetBeIdConcurrentTaskMaps(@Injectable RoutineLoadJob routineLoadJob) {
+    public void testGetBeIdConcurrentTaskMaps() {
+        RoutineLoadJob routineLoadJob = Mockito.mock(RoutineLoadJob.class);
+
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
         Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newHashMap();
         idToRoutineLoadJob.put(1L, routineLoadJob);
@@ -796,16 +730,8 @@ public class RoutineLoadManagerTest {
         Map<Long, Integer> beIdToConcurrenTaskNum = Maps.newHashMap();
         beIdToConcurrenTaskNum.put(1L, 1);
 
-        new Expectations() {
-            {
-                routineLoadJob.getState();
-                minTimes = 0;
-                result = RoutineLoadJob.JobState.RUNNING;
-                routineLoadJob.getBeCurrentTasksNumMap();
-                minTimes = 0;
-                result = beIdToConcurrenTaskNum;
-            }
-        };
+        Mockito.when(routineLoadJob.getState()).thenReturn(RoutineLoadJob.JobState.RUNNING);
+        Mockito.when(routineLoadJob.getBeCurrentTasksNumMap()).thenReturn(beIdToConcurrenTaskNum);
 
         Map<Long, Integer> result = Deencapsulation.invoke(routineLoadManager, "getBeCurrentTasksNumMap");
         Assert.assertEquals(1, (int) result.get(1L));
@@ -813,8 +739,10 @@ public class RoutineLoadManagerTest {
     }
 
     @Test
-    public void testReplayRemoveOldRoutineLoad(@Injectable RoutineLoadOperation operation,
-                                               @Injectable RoutineLoadJob routineLoadJob) {
+    public void testReplayRemoveOldRoutineLoad() {
+        RoutineLoadOperation operation = Mockito.mock(RoutineLoadOperation.class);
+        RoutineLoadJob routineLoadJob = Mockito.mock(RoutineLoadJob.class);
+
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
         Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newHashMap();
         idToRoutineLoadJob.put(1L, routineLoadJob);
@@ -827,26 +755,18 @@ public class RoutineLoadManagerTest {
         dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
         Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
 
-        new Expectations() {
-            {
-                routineLoadJob.getName();
-                minTimes = 0;
-                result = "";
-                routineLoadJob.getDbId();
-                minTimes = 0;
-                result = 1L;
-                operation.getId();
-                minTimes = 0;
-                result = 1L;
-            }
-        };
+        Mockito.when(routineLoadJob.getName()).thenReturn("");
+        Mockito.when(routineLoadJob.getDbId()).thenReturn(1L);
+        Mockito.when(operation.getId()).thenReturn(1L);
 
         routineLoadManager.replayRemoveOldRoutineLoad(operation);
         Assert.assertEquals(0, idToRoutineLoadJob.size());
     }
 
     @Test
-    public void testReplayChangeRoutineLoadJob(@Injectable RoutineLoadOperation operation) {
+    public void testReplayChangeRoutineLoadJob() {
+        RoutineLoadOperation operation = Mockito.mock(RoutineLoadOperation.class);
+
         RoutineLoadManager routineLoadManager = new RoutineLoadManager();
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         Deencapsulation.setField(routineLoadJob, "name", "");
@@ -862,142 +782,133 @@ public class RoutineLoadManagerTest {
         dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
         Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
 
-        new Expectations() {
-            {
-                operation.getId();
-                minTimes = 0;
-                result = 1L;
-                operation.getJobState();
-                minTimes = 0;
-                result = RoutineLoadJob.JobState.PAUSED;
-            }
-        };
+        Mockito.when(operation.getId()).thenReturn(1L);
+        Mockito.when(operation.getJobState()).thenReturn(RoutineLoadJob.JobState.PAUSED);
 
         routineLoadManager.replayChangeRoutineLoadJob(operation);
         Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
     }
 
     @Test
-    public void testAlterRoutineLoadJob(@Injectable StopRoutineLoadCommand stopRoutineLoadCommand, @Mocked Env env,
-            @Mocked InternalCatalog catalog, @Mocked Database database, @Mocked Table tbl,
-            @Mocked AccessControllerManager accessManager,
-            @Mocked ConnectContext connectContext) throws UserException {
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
-        List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        routineLoadJobList.add(routineLoadJob);
-        nameToRoutineLoadJob.put("", routineLoadJobList);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+    public void testAlterRoutineLoadJob() throws UserException {
+        StopRoutineLoadCommand stopRoutineLoadCommand = Mockito.mock(StopRoutineLoadCommand.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table tbl = Mockito.mock(Table.class);
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-        new Expectations() {
-            {
-                stopRoutineLoadCommand.getDbFullName();
-                minTimes = 0;
-                result = "";
-                stopRoutineLoadCommand.getLabel();
-                minTimes = 0;
-                result = "";
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable("");
-                minTimes = 0;
-                result = database;
-                database.getId();
-                minTimes = 0;
-                result = 1L;
-                database.getTableOrAnalysisException(anyLong);
-                minTimes = 0;
-                result = tbl;
-                tbl.getName();
-                minTimes = 0;
-                result = "tbl";
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            GlobalTransactionMgrIface globalTxnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+            TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            envStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(globalTxnMgr);
+            Mockito.when(globalTxnMgr.getCallbackFactory()).thenReturn(callbackFactory);
 
-        routineLoadManager.stopRoutineLoadJob(stopRoutineLoadCommand);
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+            List<RoutineLoadJob> routineLoadJobList = Lists.newArrayList();
+            RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            routineLoadJobList.add(routineLoadJob);
+            nameToRoutineLoadJob.put("", routineLoadJobList);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.STOPPED, routineLoadJob.getState());
+            Mockito.when(stopRoutineLoadCommand.getDbFullName()).thenReturn("");
+            Mockito.when(stopRoutineLoadCommand.getLabel()).thenReturn("");
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable("")).thenReturn(database);
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyString());
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyLong());
+            Mockito.when(database.getId()).thenReturn(1L);
+            Mockito.when(database.getFullName()).thenReturn("");
+            Mockito.doReturn(tbl).when(database).getTableOrAnalysisException(Mockito.anyLong());
+            Mockito.doReturn(tbl).when(database).getTableOrMetaException(Mockito.anyLong());
+            Mockito.when(tbl.getName()).thenReturn("tbl");
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                    Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class))).thenReturn(true);
+
+            routineLoadManager.stopRoutineLoadJob(stopRoutineLoadCommand);
+
+            Assert.assertEquals(RoutineLoadJob.JobState.STOPPED, routineLoadJob.getState());
+        }
     }
 
     @Test
-    public void testPauseAndResumeAllRoutineLoadJob(@Injectable PauseRoutineLoadCommand pauseRoutineLoadCommand,
-                                                    @Injectable ResumeRoutineLoadCommand resumeRoutineLoadCommand, @Mocked Env env, @Mocked InternalCatalog catalog,
-                                                    @Mocked Database database, @Mocked Table tbl, @Mocked AccessControllerManager accessManager,
-                                                    @Mocked ConnectContext connectContext) throws UserException {
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
-        Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
+    public void testPauseAndResumeAllRoutineLoadJob() throws UserException {
+        PauseRoutineLoadCommand pauseRoutineLoadCommand = Mockito.mock(PauseRoutineLoadCommand.class);
+        ResumeRoutineLoadCommand resumeRoutineLoadCommand = Mockito.mock(ResumeRoutineLoadCommand.class);
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table tbl = Mockito.mock(Table.class);
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-        List<RoutineLoadJob> routineLoadJobList1 = Lists.newArrayList();
-        RoutineLoadJob routineLoadJob1 = new KafkaRoutineLoadJob();
-        Deencapsulation.setField(routineLoadJob1, "id", 1000L);
-        routineLoadJobList1.add(routineLoadJob1);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<ConnectContext> ctxStatic = Mockito.mockStatic(ConnectContext.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            ctxStatic.when(ConnectContext::get).thenReturn(connectContext);
+            mockSessionVariable(connectContext);
+            EditLog editLog = Mockito.mock(EditLog.class);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
 
-        List<RoutineLoadJob> routineLoadJobList2 = Lists.newArrayList();
-        RoutineLoadJob routineLoadJob2 = new KafkaRoutineLoadJob();
-        Deencapsulation.setField(routineLoadJob2, "id", 1002L);
-        routineLoadJobList2.add(routineLoadJob2);
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newHashMap();
+            Map<String, List<RoutineLoadJob>> nameToRoutineLoadJob = Maps.newHashMap();
 
-        nameToRoutineLoadJob.put("job1", routineLoadJobList1);
-        nameToRoutineLoadJob.put("job2", routineLoadJobList2);
-        dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
-        Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
+            List<RoutineLoadJob> routineLoadJobList1 = Lists.newArrayList();
+            RoutineLoadJob routineLoadJob1 = new KafkaRoutineLoadJob();
+            Deencapsulation.setField(routineLoadJob1, "id", 1000L);
+            routineLoadJobList1.add(routineLoadJob1);
 
-        Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob1.getState());
-        Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob1.getState());
+            List<RoutineLoadJob> routineLoadJobList2 = Lists.newArrayList();
+            RoutineLoadJob routineLoadJob2 = new KafkaRoutineLoadJob();
+            Deencapsulation.setField(routineLoadJob2, "id", 1002L);
+            routineLoadJobList2.add(routineLoadJob2);
 
-        new Expectations() {
-            {
-                pauseRoutineLoadCommand.isAll();
-                minTimes = 0;
-                result = true;
-                pauseRoutineLoadCommand.getDbFullName();
-                minTimes = 0;
-                result = "";
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDb("");
-                minTimes = 0;
-                result = database;
-                database.getId();
-                minTimes = 0;
-                result = 1L;
-                database.getTableOrAnalysisException(anyLong);
-                minTimes = 0;
-                result = tbl;
-                tbl.getName();
-                minTimes = 0;
-                result = "tbl";
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-                resumeRoutineLoadCommand.isAll();
-                minTimes = 0;
-                result = true;
-            }
-        };
+            nameToRoutineLoadJob.put("job1", routineLoadJobList1);
+            nameToRoutineLoadJob.put("job2", routineLoadJobList2);
+            dbToNameToRoutineLoadJob.put(1L, nameToRoutineLoadJob);
+            Deencapsulation.setField(routineLoadManager, "dbToNameToRoutineLoadJob", dbToNameToRoutineLoadJob);
 
-        routineLoadManager.pauseRoutineLoadJob(pauseRoutineLoadCommand);
-        Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob1.getState());
-        Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob2.getState());
+            Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob1.getState());
+            Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob1.getState());
 
-        routineLoadManager.resumeRoutineLoadJob(resumeRoutineLoadCommand);
-        Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob1.getState());
-        Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob2.getState());
+            Mockito.when(pauseRoutineLoadCommand.isAll()).thenReturn(true);
+            Mockito.when(pauseRoutineLoadCommand.getDbFullName()).thenReturn("");
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.doReturn(database).when(catalog).getDbOrDdlException(Mockito.anyString());
+            Mockito.doReturn(database).when(catalog).getDbOrMetaException(Mockito.anyLong());
+            Mockito.when(database.getId()).thenReturn(1L);
+            Mockito.when(database.getFullName()).thenReturn("");
+            Mockito.doReturn(tbl).when(database).getTableOrAnalysisException(Mockito.anyLong());
+            Mockito.doReturn(tbl).when(database).getTableOrMetaException(Mockito.anyLong());
+            Mockito.when(tbl.getName()).thenReturn("tbl");
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                    Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class))).thenReturn(true);
+            Mockito.when(resumeRoutineLoadCommand.isAll()).thenReturn(true);
+            Mockito.when(resumeRoutineLoadCommand.getDbFullName()).thenReturn("");
+
+            routineLoadManager.pauseRoutineLoadJob(pauseRoutineLoadCommand);
+            Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob1.getState());
+            Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob2.getState());
+
+            routineLoadManager.resumeRoutineLoadJob(resumeRoutineLoadCommand);
+            Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob1.getState());
+            Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob2.getState());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadSchedulerTest.java
@@ -34,148 +34,123 @@ import org.apache.doris.thrift.TResourceInfo;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-
 public class RoutineLoadSchedulerTest {
 
-    @Mocked
-    ConnectContext connectContext;
-    @Mocked
-    TResourceInfo tResourceInfo;
+    ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+    TResourceInfo tResourceInfo = Mockito.mock(TResourceInfo.class);
 
     @Test
-    public void testNormalRunOneCycle(@Mocked Env env, @Mocked InternalCatalog catalog,
-            @Injectable RoutineLoadManager routineLoadManager, @Injectable SystemInfoService systemInfoService,
-            @Injectable Database database, @Injectable RoutineLoadDesc routineLoadDesc,
-            @Injectable OlapTable olapTable)
-            throws LoadException, MetaNotFoundException {
-        List<Long> beIds = Lists.newArrayList();
-        beIds.add(1L);
-        beIds.add(2L);
+    public void testNormalRunOneCycle() throws LoadException, MetaNotFoundException {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
+        Database database = Mockito.mock(Database.class);
+        Mockito.mock(RoutineLoadDesc.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
 
-        List<Integer> partitions = Lists.newArrayList();
-        partitions.add(100);
-        partitions.add(200);
-        partitions.add(300);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-        RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadManager);
-        Deencapsulation.setField(env, "routineLoadTaskScheduler", routineLoadTaskScheduler);
+            List<Long> beIds = Lists.newArrayList();
+            beIds.add(1L);
+            beIds.add(2L);
 
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L,
-                "xxx", "test", UserIdentity.ADMIN);
-        Deencapsulation.setField(kafkaRoutineLoadJob, "state", RoutineLoadJob.JobState.NEED_SCHEDULE);
-        List<RoutineLoadJob> routineLoadJobList = new ArrayList<>();
-        routineLoadJobList.add(kafkaRoutineLoadJob);
+            List<Integer> partitions = Lists.newArrayList();
+            partitions.add(100);
+            partitions.add(200);
+            partitions.add(300);
 
-        Deencapsulation.setField(kafkaRoutineLoadJob, "customKafkaPartitions", partitions);
-        Deencapsulation.setField(kafkaRoutineLoadJob, "desireTaskConcurrentNum", 3);
+            RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadManager);
+            Deencapsulation.setField(env, "routineLoadTaskScheduler", routineLoadTaskScheduler);
 
-        new Expectations() {
-            {
-                env.getRoutineLoadManager();
-                minTimes = 0;
-                result = routineLoadManager;
-                routineLoadManager.getRoutineLoadJobByState(Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE));
-                minTimes = 0;
-                result = routineLoadJobList;
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                database.getTableNullable(1L);
-                minTimes = 0;
-                result = olapTable;
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                result = beIds;
-                routineLoadManager.getSizeOfIdToRoutineLoadTask();
-                minTimes = 0;
-                result = 1;
-                routineLoadManager.getTotalMaxConcurrentTaskNum();
-                minTimes = 0;
-                result = 10;
-            }
-        };
+            KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L,
+                    "xxx", "test", UserIdentity.ADMIN);
+            Deencapsulation.setField(kafkaRoutineLoadJob, "state", RoutineLoadJob.JobState.NEED_SCHEDULE);
+            List<RoutineLoadJob> routineLoadJobList = new ArrayList<>();
+            routineLoadJobList.add(kafkaRoutineLoadJob);
 
-        RoutineLoadScheduler routineLoadScheduler = new RoutineLoadScheduler();
-        Deencapsulation.setField(routineLoadScheduler, "routineLoadManager", routineLoadManager);
-        routineLoadScheduler.runAfterCatalogReady();
+            Deencapsulation.setField(kafkaRoutineLoadJob, "customKafkaPartitions", partitions);
+            Deencapsulation.setField(kafkaRoutineLoadJob, "desireTaskConcurrentNum", 3);
 
-        List<RoutineLoadTaskInfo> routineLoadTaskInfoList =
-                Deencapsulation.getField(kafkaRoutineLoadJob, "routineLoadTaskInfoList");
-        for (RoutineLoadTaskInfo routineLoadTaskInfo : routineLoadTaskInfoList) {
-            KafkaTaskInfo kafkaTaskInfo = (KafkaTaskInfo) routineLoadTaskInfo;
-            if (kafkaTaskInfo.getPartitions().size() == 2) {
-                Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(100));
-                Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(300));
-            } else {
-                Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(200));
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+            Mockito.when(routineLoadManager.getRoutineLoadJobByState(
+                    Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE))).thenReturn(routineLoadJobList);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(database.getTableNullable(1L)).thenReturn(olapTable);
+            Mockito.when(systemInfoService.getAllBackendIds(true)).thenReturn(beIds);
+            Mockito.when(routineLoadManager.getSizeOfIdToRoutineLoadTask()).thenReturn(1);
+            Mockito.when(routineLoadManager.getTotalMaxConcurrentTaskNum()).thenReturn(10);
+
+            RoutineLoadScheduler routineLoadScheduler = new RoutineLoadScheduler();
+            Deencapsulation.setField(routineLoadScheduler, "routineLoadManager", routineLoadManager);
+            routineLoadScheduler.runAfterCatalogReady();
+
+            List<RoutineLoadTaskInfo> routineLoadTaskInfoList =
+                    Deencapsulation.getField(kafkaRoutineLoadJob, "routineLoadTaskInfoList");
+            for (RoutineLoadTaskInfo routineLoadTaskInfo : routineLoadTaskInfoList) {
+                KafkaTaskInfo kafkaTaskInfo = (KafkaTaskInfo) routineLoadTaskInfo;
+                if (kafkaTaskInfo.getPartitions().size() == 2) {
+                    Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(100));
+                    Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(300));
+                } else {
+                    Assert.assertTrue(kafkaTaskInfo.getPartitions().contains(200));
+                }
             }
         }
     }
 
-    public void functionTest(@Mocked Env env, @Mocked InternalCatalog catalog,
-            @Mocked SystemInfoService systemInfoService, @Injectable Database database)
-            throws UserException, InterruptedException {
-        new Expectations() {
-            {
-                minTimes = 0;
-                result = tResourceInfo;
-            }
-        };
+    public void functionTest() throws UserException, InterruptedException {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
+        Database database = Mockito.mock(Database.class);
 
-        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L,
-                "10.74.167.16:8092", "test", UserIdentity.ADMIN);
-        RoutineLoadManager routineLoadManager = new RoutineLoadManager();
-        routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob, "db", "table");
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-        List<Long> backendIds = new ArrayList<>();
-        backendIds.add(1L);
+            KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob(1L, "test", 1L, 1L,
+                    "10.74.167.16:8092", "test", UserIdentity.ADMIN);
+            RoutineLoadManager routineLoadManager = new RoutineLoadManager();
+            routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob, "db", "table");
 
-        new Expectations() {
-            {
-                env.getRoutineLoadManager();
-                minTimes = 0;
-                result = routineLoadManager;
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                systemInfoService.getAllBackendIds(true);
-                minTimes = 0;
-                result = backendIds;
-            }
-        };
+            List<Long> backendIds = new ArrayList<>();
+            backendIds.add(1L);
 
-        RoutineLoadScheduler routineLoadScheduler = new RoutineLoadScheduler();
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(systemInfoService.getAllBackendIds(true)).thenReturn(backendIds);
 
-        RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
-        routineLoadTaskScheduler.setInterval(5000);
+            RoutineLoadScheduler routineLoadScheduler = new RoutineLoadScheduler();
 
-        ExecutorService executorService = ThreadPoolManager.newDaemonFixedThreadPool(2, 2, "routine-load-task-scheduler", false);
-        executorService.submit(routineLoadScheduler);
-        executorService.submit(routineLoadTaskScheduler);
+            RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
+            routineLoadTaskScheduler.setInterval(5000);
 
-        KafkaRoutineLoadJob kafkaRoutineLoadJob1 = new KafkaRoutineLoadJob(1L, "test_custom_partition",
-                1L, 1L, "xxx", "test_1", UserIdentity.ADMIN);
-        List<Integer> customKafkaPartitions = new ArrayList<>();
-        customKafkaPartitions.add(2);
-        Deencapsulation.setField(kafkaRoutineLoadJob1, "customKafkaPartitions", customKafkaPartitions);
-        routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob1, "db", "table");
+            ExecutorService executorService = ThreadPoolManager.newDaemonFixedThreadPool(2, 2, "routine-load-task-scheduler", false);
+            executorService.submit(routineLoadScheduler);
+            executorService.submit(routineLoadTaskScheduler);
 
-        Thread.sleep(10000);
+            KafkaRoutineLoadJob kafkaRoutineLoadJob1 = new KafkaRoutineLoadJob(1L, "test_custom_partition",
+                    1L, 1L, "xxx", "test_1", UserIdentity.ADMIN);
+            List<Integer> customKafkaPartitions = new ArrayList<>();
+            customKafkaPartitions.add(2);
+            Deencapsulation.setField(kafkaRoutineLoadJob1, "customKafkaPartitions", customKafkaPartitions);
+            routineLoadManager.addRoutineLoadJob(kafkaRoutineLoadJob1, "db", "table");
+
+            Thread.sleep(10000);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -31,10 +31,11 @@ import org.apache.doris.transaction.BeginTransactionException;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 import java.util.UUID;
@@ -43,78 +44,65 @@ import java.util.concurrent.LinkedBlockingDeque;
 
 public class RoutineLoadTaskSchedulerTest {
 
-    @Mocked
-    private RoutineLoadManager routineLoadManager;
-    @Mocked
-    private Env env;
-    @Mocked
-    private AgentTaskExecutor agentTaskExecutor;
+    private RoutineLoadManager routineLoadManager = Mockito.mock(RoutineLoadManager.class);
+    private Env env = Mockito.mock(Env.class);
+    private AgentTaskExecutor agentTaskExecutor = Mockito.mock(AgentTaskExecutor.class);
+    private MockedStatic<Env> envStatic;
+
+    @Before
+    public void setUp() {
+        envStatic = Mockito.mockStatic(Env.class);
+        envStatic.when(Env::getCurrentEnv).thenReturn(env);
+    }
+
+    @After
+    public void tearDown() {
+        envStatic.close();
+    }
 
     @Test
-    public void testRunOneCycle(@Injectable KafkaRoutineLoadJob kafkaRoutineLoadJob1,
-                                @Injectable KafkaRoutineLoadJob routineLoadJob,
-                                @Injectable RoutineLoadDesc routineLoadDesc,
-                                @Mocked GlobalTransactionMgr globalTransactionMgr,
-                                @Mocked BackendService.Client client,
-                                @Mocked ClientPool clientPool) throws LoadException,
+    public void testRunOneCycle() throws LoadException,
             MetaNotFoundException, AnalysisException, LabelAlreadyUsedException, BeginTransactionException {
-        long beId = 100L;
+        KafkaRoutineLoadJob kafkaRoutineLoadJob1 = Mockito.mock(KafkaRoutineLoadJob.class);
+        KafkaRoutineLoadJob routineLoadJob = Mockito.mock(KafkaRoutineLoadJob.class);
+        Mockito.mock(RoutineLoadDesc.class);
+        Mockito.mock(GlobalTransactionMgr.class);
+        Mockito.mock(BackendService.Client.class);
 
-        ConcurrentMap<Integer, Long> partitionIdToOffset = Maps.newConcurrentMap();
-        partitionIdToOffset.put(1, 100L);
-        partitionIdToOffset.put(2, 200L);
-        KafkaProgress kafkaProgress = new KafkaProgress();
-        Deencapsulation.setField(kafkaProgress, "partitionIdToOffset", partitionIdToOffset);
+        try (MockedStatic<ClientPool> clientPoolStatic = Mockito.mockStatic(ClientPool.class)) {
+            long beId = 100L;
 
-        LinkedBlockingDeque<RoutineLoadTaskInfo> routineLoadTaskInfoQueue = new LinkedBlockingDeque<>();
-        KafkaTaskInfo routineLoadTaskInfo1 = new KafkaTaskInfo(new UUID(1, 1), 1L, 20000,
-                partitionIdToOffset, false, -1, false);
-        routineLoadTaskInfoQueue.addFirst(routineLoadTaskInfo1);
+            ConcurrentMap<Integer, Long> partitionIdToOffset = Maps.newConcurrentMap();
+            partitionIdToOffset.put(1, 100L);
+            partitionIdToOffset.put(2, 200L);
+            KafkaProgress kafkaProgress = new KafkaProgress();
+            Deencapsulation.setField(kafkaProgress, "partitionIdToOffset", partitionIdToOffset);
 
-        Map<Long, RoutineLoadTaskInfo> idToRoutineLoadTask = Maps.newHashMap();
-        idToRoutineLoadTask.put(1L, routineLoadTaskInfo1);
+            LinkedBlockingDeque<RoutineLoadTaskInfo> routineLoadTaskInfoQueue = new LinkedBlockingDeque<>();
+            KafkaTaskInfo routineLoadTaskInfo1 = new KafkaTaskInfo(new UUID(1, 1), 1L, 20000,
+                    partitionIdToOffset, false, -1, false);
+            routineLoadTaskInfoQueue.addFirst(routineLoadTaskInfo1);
 
-        Map<String, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
-        idToRoutineLoadJob.put("1", routineLoadJob);
+            Map<Long, RoutineLoadTaskInfo> idToRoutineLoadTask = Maps.newHashMap();
+            idToRoutineLoadTask.put(1L, routineLoadTaskInfo1);
 
-        Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
+            Map<String, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
+            idToRoutineLoadJob.put("1", routineLoadJob);
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-                env.getRoutineLoadManager();
-                minTimes = 0;
-                result = routineLoadManager;
+            Deencapsulation.setField(routineLoadManager, "idToRoutineLoadJob", idToRoutineLoadJob);
 
-                routineLoadManager.getClusterIdleSlotNum();
-                minTimes = 0;
-                result = 1;
-                routineLoadManager.checkTaskInJob((RoutineLoadTaskInfo) any);
-                minTimes = 0;
-                result = true;
+            Mockito.when(env.getRoutineLoadManager()).thenReturn(routineLoadManager);
+            Mockito.when(routineLoadManager.getClusterIdleSlotNum()).thenReturn(1);
+            Mockito.when(routineLoadManager.checkTaskInJob(Mockito.any(RoutineLoadTaskInfo.class))).thenReturn(true);
+            Mockito.when(kafkaRoutineLoadJob1.getDbId()).thenReturn(1L);
+            Mockito.when(kafkaRoutineLoadJob1.getTableId()).thenReturn(1L);
+            Mockito.when(kafkaRoutineLoadJob1.getName()).thenReturn("");
+            Mockito.when(routineLoadManager.getMinTaskBeId(Mockito.anyString())).thenReturn(beId);
+            Mockito.when(routineLoadManager.getJob(Mockito.anyLong())).thenReturn(kafkaRoutineLoadJob1);
 
-                kafkaRoutineLoadJob1.getDbId();
-                minTimes = 0;
-                result = 1L;
-                kafkaRoutineLoadJob1.getTableId();
-                minTimes = 0;
-                result = 1L;
-                kafkaRoutineLoadJob1.getName();
-                minTimes = 0;
-                result = "";
-                routineLoadManager.getMinTaskBeId(anyString);
-                minTimes = 0;
-                result = beId;
-                routineLoadManager.getJob(anyLong);
-                minTimes = 0;
-                result = kafkaRoutineLoadJob1;
-            }
-        };
-
-        RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
-        Deencapsulation.setField(routineLoadTaskScheduler, "needScheduleTasksQueue", routineLoadTaskInfoQueue);
-        routineLoadTaskScheduler.runAfterCatalogReady();
+            RoutineLoadTaskScheduler routineLoadTaskScheduler = new RoutineLoadTaskScheduler();
+            Deencapsulation.setField(routineLoadTaskScheduler, "needScheduleTasksQueue", routineLoadTaskInfoQueue);
+            routineLoadTaskScheduler.runAfterCatalogReady();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/master/MasterImplDeleteTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/master/MasterImplDeleteTaskTest.java
@@ -32,12 +32,13 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class MasterImplDeleteTaskTest {
     private static final long BACKEND_ID = 10000L;
@@ -54,6 +55,8 @@ public class MasterImplDeleteTaskTest {
     private static final int BE_PORT = 9060;
 
     private MasterImpl masterImpl;
+    private MockedStatic<Env> mockedEnvStatic;
+    private MockedConstruction<ReportHandler> mockedReportHandlerConstruction;
 
     @Before
     public void setUp() {
@@ -64,18 +67,13 @@ public class MasterImplDeleteTaskTest {
         backend.setBePort(BE_PORT);
         systemInfoService.addBackend(backend);
 
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return systemInfoService;
-            }
-        };
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
 
-        new MockUp<ReportHandler>() {
-            @Mock
-            public void start() {
-            }
-        };
+        mockedReportHandlerConstruction = Mockito.mockConstruction(ReportHandler.class,
+                (mock, context) -> {
+                    Mockito.doNothing().when(mock).start();
+                });
 
         masterImpl = new MasterImpl();
     }
@@ -83,6 +81,12 @@ public class MasterImplDeleteTaskTest {
     @After
     public void tearDown() {
         AgentTaskQueue.clearAllTasks();
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
+        if (mockedReportHandlerConstruction != null) {
+            mockedReportHandlerConstruction.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionCheckUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionCheckUtilTest.java
@@ -33,106 +33,62 @@ import org.apache.doris.common.util.DynamicPartitionUtil.StartOfDate;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 
 public class MTMVPartitionCheckUtilTest {
-    @Mocked
-    private HMSExternalTable hmsExternalTable;
-    @Mocked
-    private OlapTable originalTable;
-    @Mocked
-    private OlapTable relatedTable;
-    @Mocked
-    private DynamicPartitionUtil dynamicPartitionUtil;
-    @Mocked
-    private PartitionExprUtil partitionExprUtil;
-    @Mocked
-    private PartitionInfo originalPartitionInfo;
-    @Mocked
-    private PartitionInfo relatedPartitionInfo;
-    @Mocked
-    private TableProperty originalTableProperty;
-    @Mocked
-    private TableProperty relatedTableProperty;
-    @Mocked
-    private DynamicPartitionProperty originalDynamicPartitionProperty;
-    @Mocked
-    private DynamicPartitionProperty relatedDynamicPartitionProperty;
-    @Mocked
-    private Expr expr1;
+    private HMSExternalTable hmsExternalTable = Mockito.mock(HMSExternalTable.class);
+    private OlapTable originalTable = Mockito.mock(OlapTable.class);
+    private OlapTable relatedTable = Mockito.mock(OlapTable.class);
+    private PartitionInfo originalPartitionInfo = Mockito.mock(PartitionInfo.class);
+    private PartitionInfo relatedPartitionInfo = Mockito.mock(PartitionInfo.class);
+    private TableProperty originalTableProperty = Mockito.mock(TableProperty.class);
+    private TableProperty relatedTableProperty = Mockito.mock(TableProperty.class);
+    private DynamicPartitionProperty originalDynamicPartitionProperty = Mockito.mock(DynamicPartitionProperty.class);
+    private DynamicPartitionProperty relatedDynamicPartitionProperty = Mockito.mock(DynamicPartitionProperty.class);
+    private Expr expr1 = Mockito.mock(Expr.class);
+    private PartitionExprUtil partitionExprUtilInstance = new PartitionExprUtil();
     private ArrayList<Expr> originalExprs = Lists.newArrayList();
     private ArrayList<Expr> relatedExprs = Lists.newArrayList(expr1);
 
+    private MockedStatic<DynamicPartitionUtil> dynamicPartitionUtilStatic;
+    private MockedStatic<PartitionExprUtil> partitionExprUtilStatic;
 
     @Before
     public void setUp()
             throws NoSuchMethodException, SecurityException, AnalysisException, DdlException, MetaNotFoundException {
 
-        new Expectations() {
-            {
-                originalTable.getPartitionInfo();
-                minTimes = 0;
-                result = originalPartitionInfo;
+        dynamicPartitionUtilStatic = Mockito.mockStatic(DynamicPartitionUtil.class);
+        partitionExprUtilStatic = Mockito.mockStatic(PartitionExprUtil.class);
 
-                originalTable.getPartitionType();
-                minTimes = 0;
-                result = PartitionType.RANGE;
+        Mockito.when(originalTable.getPartitionInfo()).thenReturn(originalPartitionInfo);
+        Mockito.when(originalTable.getPartitionType()).thenReturn(PartitionType.RANGE);
+        Mockito.when(originalTable.getTableProperty()).thenReturn(originalTableProperty);
+        Mockito.when(originalTableProperty.getDynamicPartitionProperty()).thenReturn(originalDynamicPartitionProperty);
+        Mockito.when(relatedTable.getPartitionInfo()).thenReturn(relatedPartitionInfo);
+        Mockito.when(relatedTable.getPartitionType()).thenReturn(PartitionType.RANGE);
+        Mockito.when(relatedTable.getTableProperty()).thenReturn(relatedTableProperty);
+        Mockito.when(relatedTableProperty.getDynamicPartitionProperty()).thenReturn(relatedDynamicPartitionProperty);
+        dynamicPartitionUtilStatic.when(() -> DynamicPartitionUtil.isDynamicPartitionTable(relatedTable))
+                .thenReturn(true);
+        Mockito.when(originalDynamicPartitionProperty.getStartOfMonth()).thenReturn(new StartOfDate(1, 1, 1));
+        Mockito.when(relatedDynamicPartitionProperty.getStartOfMonth()).thenReturn(new StartOfDate(1, 1, 1));
+        Mockito.when(relatedDynamicPartitionProperty.getStartOfWeek()).thenReturn(new StartOfDate(1, 1, 1));
+        Mockito.when(originalDynamicPartitionProperty.getStartOfWeek()).thenReturn(new StartOfDate(1, 1, 1));
+        Mockito.when(originalPartitionInfo.getPartitionExprs()).thenReturn(originalExprs);
+        Mockito.when(relatedPartitionInfo.getPartitionExprs()).thenReturn(relatedExprs);
+    }
 
-                originalTable.getTableProperty();
-                minTimes = 0;
-                result = originalTableProperty;
-
-                originalTableProperty.getDynamicPartitionProperty();
-                minTimes = 0;
-                result = originalDynamicPartitionProperty;
-
-                relatedTable.getPartitionInfo();
-                minTimes = 0;
-                result = relatedPartitionInfo;
-
-                relatedTable.getTableProperty();
-                minTimes = 0;
-                result = relatedTableProperty;
-
-                relatedTableProperty.getDynamicPartitionProperty();
-                minTimes = 0;
-                result = relatedDynamicPartitionProperty;
-
-                dynamicPartitionUtil.isDynamicPartitionTable(relatedTable);
-                minTimes = 0;
-                result = true;
-
-                originalDynamicPartitionProperty.getStartOfMonth();
-                minTimes = 0;
-                result = new StartOfDate(1, 1, 1);
-
-                relatedDynamicPartitionProperty.getStartOfMonth();
-                minTimes = 0;
-                result = new StartOfDate(1, 1, 1);
-
-                relatedDynamicPartitionProperty.getStartOfWeek();
-                minTimes = 0;
-                result = new StartOfDate(1, 1, 1);
-
-                originalDynamicPartitionProperty.getStartOfWeek();
-                minTimes = 0;
-                result = new StartOfDate(1, 1, 1);
-
-                originalPartitionInfo.getPartitionExprs();
-                minTimes = 0;
-                result = originalExprs;
-
-                relatedPartitionInfo.getPartitionExprs();
-                minTimes = 0;
-                result = relatedExprs;
-            }
-        };
+    @After
+    public void tearDown() {
+        partitionExprUtilStatic.close();
+        dynamicPartitionUtilStatic.close();
     }
 
     @Test
@@ -144,13 +100,7 @@ public class MTMVPartitionCheckUtilTest {
 
     @Test
     public void testCheckIfAllowMultiTablePartitionRefreshNotRangePartition() {
-        new Expectations() {
-            {
-                originalTable.getPartitionType();
-                minTimes = 0;
-                result = PartitionType.LIST;
-            }
-        };
+        Mockito.when(originalTable.getPartitionType()).thenReturn(PartitionType.LIST);
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.checkIfAllowMultiTablePartitionRefresh(
                 originalTable);
         Assert.assertFalse(res.first);
@@ -158,17 +108,9 @@ public class MTMVPartitionCheckUtilTest {
 
     @Test
     public void testCheckIfAllowMultiTablePartitionRefreshNotDynamicAndAuto() {
-        new Expectations() {
-            {
-                originalPartitionInfo.enableAutomaticPartition();
-                minTimes = 0;
-                result = false;
-
-                dynamicPartitionUtil.isDynamicPartitionTable(originalTable);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(originalPartitionInfo.enableAutomaticPartition()).thenReturn(false);
+        dynamicPartitionUtilStatic.when(() -> DynamicPartitionUtil.isDynamicPartitionTable(originalTable))
+                .thenReturn(false);
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.checkIfAllowMultiTablePartitionRefresh(
                 originalTable);
         Assert.assertFalse(res.first);
@@ -176,17 +118,9 @@ public class MTMVPartitionCheckUtilTest {
 
     @Test
     public void testCheckIfAllowMultiTablePartitionRefreshDynamic() {
-        new Expectations() {
-            {
-                originalPartitionInfo.enableAutomaticPartition();
-                minTimes = 0;
-                result = true;
-
-                dynamicPartitionUtil.isDynamicPartitionTable(originalTable);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(originalPartitionInfo.enableAutomaticPartition()).thenReturn(true);
+        dynamicPartitionUtilStatic.when(() -> DynamicPartitionUtil.isDynamicPartitionTable(originalTable))
+                .thenReturn(false);
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.checkIfAllowMultiTablePartitionRefresh(
                 originalTable);
         Assert.assertTrue(res.first);
@@ -194,17 +128,9 @@ public class MTMVPartitionCheckUtilTest {
 
     @Test
     public void testCheckIfAllowMultiTablePartitionRefreshAuto() {
-        new Expectations() {
-            {
-                originalPartitionInfo.enableAutomaticPartition();
-                minTimes = 0;
-                result = false;
-
-                dynamicPartitionUtil.isDynamicPartitionTable(originalTable);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(originalPartitionInfo.enableAutomaticPartition()).thenReturn(false);
+        dynamicPartitionUtilStatic.when(() -> DynamicPartitionUtil.isDynamicPartitionTable(originalTable))
+                .thenReturn(true);
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.checkIfAllowMultiTablePartitionRefresh(
                 originalTable);
         Assert.assertTrue(res.first);
@@ -218,55 +144,33 @@ public class MTMVPartitionCheckUtilTest {
 
     @Test
     public void testCompareDynamicPartitionNotEqual() throws AnalysisException {
-        new Expectations() {
-            {
-                relatedDynamicPartitionProperty.getStartOfWeek();
-                minTimes = 0;
-                result = new StartOfDate(1, 1, 1);
-
-                originalDynamicPartitionProperty.getStartOfWeek();
-                minTimes = 0;
-                result = new StartOfDate(1, 1, 2);
-            }
-        };
+        Mockito.when(relatedDynamicPartitionProperty.getStartOfWeek()).thenReturn(new StartOfDate(1, 1, 1));
+        Mockito.when(originalDynamicPartitionProperty.getStartOfWeek()).thenReturn(new StartOfDate(1, 1, 2));
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.compareDynamicPartition(originalTable, relatedTable);
         Assert.assertFalse(res.first);
     }
 
     @Test
     public void testCompareAutoPartition() throws AnalysisException {
-        new Expectations() {
-            {
-                relatedPartitionInfo.enableAutomaticPartition();
-                minTimes = 0;
-                result = true;
-
-                partitionExprUtil.getFunctionIntervalInfo(originalExprs, (PartitionType) any);
-                minTimes = 0;
-                result = partitionExprUtil.new FunctionIntervalInfo("datetrunc", "week", 1);
-
-                partitionExprUtil.getFunctionIntervalInfo(relatedExprs, (PartitionType) any);
-                minTimes = 0;
-                result = partitionExprUtil.new FunctionIntervalInfo("datetrunc", "week", 1);
-            }
-        };
+        Mockito.when(relatedPartitionInfo.enableAutomaticPartition()).thenReturn(true);
+        partitionExprUtilStatic.when(() -> PartitionExprUtil.getFunctionIntervalInfo(
+                Mockito.eq(originalExprs), Mockito.any(PartitionType.class)))
+                .thenReturn(partitionExprUtilInstance.new FunctionIntervalInfo("datetrunc", "week", 1));
+        partitionExprUtilStatic.when(() -> PartitionExprUtil.getFunctionIntervalInfo(
+                Mockito.eq(relatedExprs), Mockito.any(PartitionType.class)))
+                .thenReturn(partitionExprUtilInstance.new FunctionIntervalInfo("datetrunc", "week", 1));
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.compareAutoPartition(originalTable, relatedTable);
         Assert.assertTrue(res.first);
     }
 
     @Test
     public void testCompareAutoPartitionNotEqual() throws AnalysisException {
-        new Expectations() {
-            {
-                partitionExprUtil.getFunctionIntervalInfo(originalExprs, (PartitionType) any);
-                minTimes = 0;
-                result = partitionExprUtil.new FunctionIntervalInfo("datetrunc", "week", 1);
-
-                partitionExprUtil.getFunctionIntervalInfo(relatedExprs, (PartitionType) any);
-                minTimes = 0;
-                result = partitionExprUtil.new FunctionIntervalInfo("datetrunc", "week", 2);
-            }
-        };
+        partitionExprUtilStatic.when(() -> PartitionExprUtil.getFunctionIntervalInfo(
+                Mockito.eq(originalExprs), Mockito.any(PartitionType.class)))
+                .thenReturn(partitionExprUtilInstance.new FunctionIntervalInfo("datetrunc", "week", 1));
+        partitionExprUtilStatic.when(() -> PartitionExprUtil.getFunctionIntervalInfo(
+                Mockito.eq(relatedExprs), Mockito.any(PartitionType.class)))
+                .thenReturn(partitionExprUtilInstance.new FunctionIntervalInfo("datetrunc", "week", 2));
         Pair<Boolean, String> res = MTMVPartitionCheckUtil.compareAutoPartition(originalTable, relatedTable);
         Assert.assertFalse(res.first);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
@@ -31,11 +31,12 @@ import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -43,146 +44,91 @@ import java.util.Optional;
 import java.util.Set;
 
 public class MTMVPartitionUtilTest {
-    @Mocked
-    private MTMV mtmv;
-    @Mocked
-    private Partition p1;
-    @Mocked
-    private MTMVRelation relation;
-    @Mocked
-    private BaseTableInfo baseTableInfo;
-    @Mocked
-    private MTMVPartitionInfo mtmvPartitionInfo;
-    @Mocked
-    private OlapTable baseOlapTable;
-    @Mocked
-    private DatabaseIf databaseIf;
-    @Mocked
-    private CatalogIf catalogIf;
-    @Mocked
-    private MTMVSnapshotIf baseSnapshotIf;
-    @Mocked
-    private MTMVRefreshSnapshot refreshSnapshot;
-    @Mocked
-    private MTMVUtil mtmvUtil;
-    @Mocked
-    private MTMVRefreshContext context;
-    @Mocked
-    private MTMVBaseVersions versions;
+    private MTMV mtmv = Mockito.mock(MTMV.class);
+    private Partition p1 = Mockito.mock(Partition.class);
+    private MTMVRelation relation = Mockito.mock(MTMVRelation.class);
+    private BaseTableInfo baseTableInfo = Mockito.mock(BaseTableInfo.class);
+    private MTMVPartitionInfo mtmvPartitionInfo = Mockito.mock(MTMVPartitionInfo.class);
+    private OlapTable baseOlapTable = Mockito.mock(OlapTable.class);
+    private DatabaseIf databaseIf = Mockito.mock(DatabaseIf.class);
+    private CatalogIf catalogIf = Mockito.mock(CatalogIf.class);
+    private MTMVSnapshotIf baseSnapshotIf = Mockito.mock(MTMVSnapshotIf.class);
+    private MTMVRefreshSnapshot refreshSnapshot = Mockito.mock(MTMVRefreshSnapshot.class);
+    private MockedStatic<MTMVUtil> mtmvUtilStatic;
+    private MockedStatic<MTMVRefreshContext> refreshContextStatic;
+    private MTMVRefreshContext context = Mockito.mock(MTMVRefreshContext.class);
+    private MTMVBaseVersions versions = Mockito.mock(MTMVBaseVersions.class);
 
     private Set<BaseTableInfo> baseTables = Sets.newHashSet();
 
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException, AnalysisException {
         baseTables.add(baseTableInfo);
-        new Expectations() {
-            {
-                mtmv.getRelation();
-                minTimes = 0;
-                result = relation;
 
-                context.getMtmv();
-                minTimes = 0;
-                result = mtmv;
+        mtmvUtilStatic = Mockito.mockStatic(MTMVUtil.class);
+        refreshContextStatic = Mockito.mockStatic(MTMVRefreshContext.class);
+        refreshContextStatic.when(() -> MTMVRefreshContext.buildContext(Mockito.any(MTMV.class))).thenReturn(context);
 
-                context.getPartitionMappings();
-                minTimes = 0;
-                result = Maps.newHashMap();
+        Mockito.when(mtmv.getRelation()).thenReturn(relation);
 
-                context.getBaseVersions();
-                minTimes = 0;
-                result = versions;
+        Mockito.when(context.getMtmv()).thenReturn(mtmv);
 
-                context.getBaseTableSnapshotCache();
-                minTimes = 0;
-                result = Maps.newHashMap();
+        Mockito.when(context.getPartitionMappings()).thenReturn(Maps.newHashMap());
 
-                mtmv.getPartitions();
-                minTimes = 0;
-                result = Lists.newArrayList(p1);
+        Mockito.when(context.getBaseVersions()).thenReturn(versions);
 
-                mtmv.getPartitionNames();
-                minTimes = 0;
-                result = Sets.newHashSet("name1");
+        Mockito.when(context.getBaseTableSnapshotCache()).thenReturn(Maps.newHashMap());
 
-                p1.getName();
-                minTimes = 0;
-                result = "name1";
+        Mockito.when(mtmv.getPartitions()).thenReturn(Lists.newArrayList(p1));
 
-                mtmv.getMvPartitionInfo();
-                minTimes = 0;
-                result = mtmvPartitionInfo;
+        Mockito.when(mtmv.getPartitionNames()).thenReturn(Sets.newHashSet("name1"));
 
-                mtmvPartitionInfo.getPartitionType();
-                minTimes = 0;
-                result = MTMVPartitionType.SELF_MANAGE;
+        Mockito.when(p1.getName()).thenReturn("name1");
 
-                mtmvUtil.getTable(baseTableInfo);
-                minTimes = 0;
-                result = baseOlapTable;
+        Mockito.when(mtmv.getMvPartitionInfo()).thenReturn(mtmvPartitionInfo);
 
-                baseOlapTable.needAutoRefresh();
-                minTimes = 0;
-                result = true;
+        Mockito.when(mtmvPartitionInfo.getPartitionType()).thenReturn(MTMVPartitionType.SELF_MANAGE);
 
-                baseOlapTable.getTableSnapshot((MTMVRefreshContext) any, (Optional) any);
-                minTimes = 0;
-                result = baseSnapshotIf;
+        mtmvUtilStatic.when(() -> MTMVUtil.getTable(Mockito.any(BaseTableInfo.class)))
+                .thenReturn(baseOlapTable);
 
-                mtmv.getRefreshSnapshot();
-                minTimes = 0;
-                result = refreshSnapshot;
+        Mockito.when(baseOlapTable.needAutoRefresh()).thenReturn(true);
 
-                refreshSnapshot.equalsWithBaseTable(anyString, (BaseTableInfo) any, (MTMVSnapshotIf) any);
-                minTimes = 0;
-                result = true;
+        Mockito.when(baseOlapTable.getTableSnapshot(Mockito.any(MTMVRefreshContext.class), Mockito.any(Optional.class)))
+                .thenReturn(baseSnapshotIf);
 
-                relation.getBaseTablesOneLevelAndFromView();
-                minTimes = 0;
-                result = baseTables;
+        Mockito.when(mtmv.getRefreshSnapshot()).thenReturn(refreshSnapshot);
 
-                baseOlapTable.needAutoRefresh();
-                minTimes = 0;
-                result = true;
+        Mockito.when(refreshSnapshot.equalsWithBaseTable(Mockito.anyString(), Mockito.any(BaseTableInfo.class), Mockito.any(MTMVSnapshotIf.class)))
+                .thenReturn(true);
 
-                baseOlapTable.getPartitionSnapshot(anyString, (MTMVRefreshContext) any, (Optional) any);
-                minTimes = 0;
-                result = baseSnapshotIf;
+        Mockito.when(relation.getBaseTablesOneLevelAndFromView()).thenReturn(baseTables);
 
-                refreshSnapshot.equalsWithPct(anyString, anyString, (MTMVSnapshotIf) any,
-                        (BaseTableInfo) any);
-                minTimes = 0;
-                result = true;
+        Mockito.when(baseOlapTable.getPartitionSnapshot(Mockito.anyString(), Mockito.any(MTMVRefreshContext.class), Mockito.any(Optional.class)))
+                .thenReturn(baseSnapshotIf);
 
-                refreshSnapshot.getPctSnapshots(anyString, (BaseTableInfo) any);
-                minTimes = 0;
-                result = Sets.newHashSet("name2");
+        Mockito.when(refreshSnapshot.equalsWithPct(Mockito.anyString(), Mockito.anyString(), Mockito.any(MTMVSnapshotIf.class),
+                Mockito.any(BaseTableInfo.class)))
+                .thenReturn(true);
 
-                baseOlapTable.getName();
-                minTimes = 0;
-                result = "t1";
+        Mockito.when(refreshSnapshot.getPctSnapshots(Mockito.anyString(), Mockito.any(BaseTableInfo.class)))
+                .thenReturn(Sets.newHashSet("name2"));
 
-                baseOlapTable.getDatabase();
-                minTimes = 0;
-                result = databaseIf;
+        Mockito.when(baseOlapTable.getName()).thenReturn("t1");
 
-                databaseIf.getFullName();
-                minTimes = 0;
-                result = "db1";
+        Mockito.when(baseOlapTable.getDatabase()).thenReturn(databaseIf);
 
-                databaseIf.getCatalog();
-                minTimes = 0;
-                result = catalogIf;
+        Mockito.when(databaseIf.getFullName()).thenReturn("db1");
 
-                databaseIf.getCatalog();
-                minTimes = 0;
-                result = catalogIf;
+        Mockito.when(databaseIf.getCatalog()).thenReturn(catalogIf);
 
-                catalogIf.getName();
-                minTimes = 0;
-                result = "ctl1";
-            }
-        };
+        Mockito.when(catalogIf.getName()).thenReturn("ctl1");
+    }
+
+    @After
+    public void tearDown() {
+        mtmvUtilStatic.close();
+        refreshContextStatic.close();
     }
 
     @Test
@@ -193,13 +139,8 @@ public class MTMVPartitionUtilTest {
 
     @Test
     public void testIsMTMVSyncNotSync() {
-        new Expectations() {
-            {
-                refreshSnapshot.equalsWithBaseTable(anyString, (BaseTableInfo) any, (MTMVSnapshotIf) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(refreshSnapshot.equalsWithBaseTable(Mockito.anyString(), Mockito.any(BaseTableInfo.class), Mockito.any(MTMVSnapshotIf.class)))
+                .thenReturn(false);
         boolean mtmvSync = MTMVPartitionUtil.isMTMVSync(mtmv);
         Assert.assertFalse(mtmvSync);
     }
@@ -213,13 +154,8 @@ public class MTMVPartitionUtilTest {
 
     @Test
     public void testIsSyncWithPartitionNotEqual() throws AnalysisException {
-        new Expectations() {
-            {
-                refreshSnapshot.getPctSnapshots(anyString, (BaseTableInfo) any);
-                minTimes = 0;
-                result = Sets.newHashSet("name2", "name3");
-            }
-        };
+        Mockito.when(refreshSnapshot.getPctSnapshots(Mockito.anyString(), Mockito.any(BaseTableInfo.class)))
+                .thenReturn(Sets.newHashSet("name2", "name3"));
         boolean isSyncWithPartition = MTMVPartitionUtil
                 .isSyncWithPartitions(context, "name1", Sets.newHashSet("name2"), baseOlapTable);
         Assert.assertFalse(isSyncWithPartition);
@@ -227,14 +163,9 @@ public class MTMVPartitionUtilTest {
 
     @Test
     public void testIsSyncWithPartitionNotSync() throws AnalysisException {
-        new Expectations() {
-            {
-                refreshSnapshot.equalsWithPct(anyString, anyString, (MTMVSnapshotIf) any,
-                        (BaseTableInfo) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(refreshSnapshot.equalsWithPct(Mockito.anyString(), Mockito.anyString(), Mockito.any(MTMVSnapshotIf.class),
+                Mockito.any(BaseTableInfo.class)))
+                .thenReturn(false);
         boolean isSyncWithPartition = MTMVPartitionUtil
                 .isSyncWithPartitions(context, "name1", Sets.newHashSet("name2"), baseOlapTable);
         Assert.assertFalse(isSyncWithPartition);
@@ -307,13 +238,7 @@ public class MTMVPartitionUtilTest {
     @Test
     public void testGetTableSnapshotFromContext() throws AnalysisException {
         Map<BaseTableInfo, MTMVSnapshotIf> cache = Maps.newHashMap();
-        new Expectations() {
-            {
-                context.getBaseTableSnapshotCache();
-                minTimes = 0;
-                result = cache;
-            }
-        };
+        Mockito.when(context.getBaseTableSnapshotCache()).thenReturn(cache);
         Assert.assertTrue(cache.isEmpty());
         MTMVPartitionUtil.getTableSnapshotFromContext(baseOlapTable, context);
         Assert.assertEquals(1, cache.size());

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPlanUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPlanUtilTest.java
@@ -49,11 +49,10 @@ import org.apache.doris.nereids.types.VarcharType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -145,26 +144,13 @@ public class MTMVPlanUtilTest extends SqlTestBase {
     }
 
     @Test
-    public void testGetDataType(@Mocked SlotReference slot, @Mocked TableIf slotTable) {
-        new Expectations() {
-            {
-                slot.getDataType();
-                minTimes = 0;
-                result = StringType.INSTANCE;
-
-                slot.isColumnFromTable();
-                minTimes = 0;
-                result = true;
-
-                slot.getOriginalTable();
-                minTimes = 0;
-                result = Optional.empty();
-
-                slot.getName();
-                minTimes = 0;
-                result = "slot_name";
-            }
-        };
+    public void testGetDataType() {
+        SlotReference slot = Mockito.mock(SlotReference.class);
+        TableIf slotTable = Mockito.mock(TableIf.class);
+        Mockito.when(slot.getDataType()).thenReturn(StringType.INSTANCE);
+        Mockito.when(slot.isColumnFromTable()).thenReturn(true);
+        Mockito.when(slot.getOriginalTable()).thenReturn(Optional.empty());
+        Mockito.when(slot.getName()).thenReturn("slot_name");
         // test i=0
         DataType dataType = MTMVPlanUtil.getDataType(slot, 0, connectContext, "pcol", Sets.newHashSet("dcol"));
         Assert.assertEquals(VarcharType.MAX_VARCHAR_TYPE, dataType);
@@ -181,34 +167,16 @@ public class MTMVPlanUtilTest extends SqlTestBase {
         dataType = MTMVPlanUtil.getDataType(slot, 1, connectContext, "pcol", Sets.newHashSet("slot_name"));
         Assert.assertEquals(VarcharType.MAX_VARCHAR_TYPE, dataType);
         // test managed table
-        new Expectations() {
-            {
-                slot.getOriginalTable();
-                minTimes = 0;
-                result = Optional.of(slotTable);
-
-                slotTable.isManagedTable();
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(slot.getOriginalTable()).thenReturn(Optional.of(slotTable));
+        Mockito.when(slotTable.isManagedTable()).thenReturn(true);
 
         dataType = MTMVPlanUtil.getDataType(slot, 1, connectContext, "pcol", Sets.newHashSet("slot_name"));
         Assert.assertEquals(StringType.INSTANCE, dataType);
 
         // test is not column table
         boolean originalUseMaxLengthOfVarcharInCtas = connectContext.getSessionVariable().useMaxLengthOfVarcharInCtas;
-        new Expectations() {
-            {
-                slot.getDataType();
-                minTimes = 0;
-                result = new VarcharType(10);
-
-                slot.isColumnFromTable();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(slot.getDataType()).thenReturn(new VarcharType(10));
+        Mockito.when(slot.isColumnFromTable()).thenReturn(false);
         connectContext.getSessionVariable().useMaxLengthOfVarcharInCtas = true;
         dataType = MTMVPlanUtil.getDataType(slot, 1, connectContext, "pcol", Sets.newHashSet("slot_name"));
         Assert.assertEquals(VarcharType.MAX_VARCHAR_TYPE, dataType);
@@ -220,24 +188,12 @@ public class MTMVPlanUtilTest extends SqlTestBase {
         connectContext.getSessionVariable().useMaxLengthOfVarcharInCtas = originalUseMaxLengthOfVarcharInCtas;
 
         // test null type
-        new Expectations() {
-            {
-                slot.getDataType();
-                minTimes = 0;
-                result = NullType.INSTANCE;
-            }
-        };
+        Mockito.when(slot.getDataType()).thenReturn(NullType.INSTANCE);
         dataType = MTMVPlanUtil.getDataType(slot, 1, connectContext, "pcol", Sets.newHashSet("slot_name"));
         Assert.assertEquals(TinyIntType.INSTANCE, dataType);
 
         // test decimal type
-        new Expectations() {
-            {
-                slot.getDataType();
-                minTimes = 0;
-                result = DecimalV2Type.createDecimalV2Type(1, 1);
-            }
-        };
+        Mockito.when(slot.getDataType()).thenReturn(DecimalV2Type.createDecimalV2Type(1, 1));
         boolean originalEnableDecimalConversion = Config.enable_decimal_conversion;
         Config.enable_decimal_conversion = false;
         dataType = MTMVPlanUtil.getDataType(slot, 1, connectContext, "pcol", Sets.newHashSet("slot_name"));
@@ -247,25 +203,15 @@ public class MTMVPlanUtilTest extends SqlTestBase {
     }
 
     @Test
-    public void testGenerateColumns(@Mocked SlotReference slot, @Mocked Plan plan) {
-        new Expectations() {
-            {
-                plan.getOutput();
-                minTimes = 0;
-                result = Lists.newArrayList();
-            }
-        };
+    public void testGenerateColumns() {
+        SlotReference slot = Mockito.mock(SlotReference.class);
+        Plan plan = Mockito.mock(Plan.class);
+        Mockito.when(plan.getOutput()).thenReturn(Lists.newArrayList());
         // test slots is empty
         Assertions.assertThrows(org.apache.doris.nereids.exceptions.AnalysisException.class, () ->
                 MTMVPlanUtil.generateColumns(plan, connectContext, null, null, null, null));
 
-        new Expectations() {
-            {
-                plan.getOutput();
-                minTimes = 0;
-                result = Lists.newArrayList(slot);
-            }
-        };
+        Mockito.when(plan.getOutput()).thenReturn(Lists.newArrayList(slot));
 
         // test size of slots and SimpleColumnDefinitions is different
         Assertions.assertThrows(org.apache.doris.nereids.exceptions.AnalysisException.class, () ->
@@ -278,13 +224,9 @@ public class MTMVPlanUtilTest extends SqlTestBase {
                 MTMVPlanUtil.generateColumns(plan, connectContext, null, null,
                         Lists.newArrayList(new SimpleColumnDefinition("", "c1")), null));
 
-        new Expectations() {
-            {
-                plan.getOutput();
-                minTimes = 0;
-                result = Lists.newArrayList(slot, slot);
-            }
-        };
+        Mockito.when(slot.getDataType()).thenReturn(BigIntType.INSTANCE);
+        Mockito.when(slot.nullable()).thenReturn(true);
+        Mockito.when(plan.getOutput()).thenReturn(Lists.newArrayList(slot, slot));
         // test repeat col name
         Assertions.assertThrows(org.apache.doris.nereids.exceptions.AnalysisException.class, () ->
                 MTMVPlanUtil.generateColumns(plan, connectContext, null, null,

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRefreshSnapshotTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRefreshSnapshotTest.java
@@ -21,11 +21,10 @@ import org.apache.doris.common.AnalysisException;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
@@ -37,48 +36,20 @@ public class MTMVRefreshSnapshotTest {
     private MTMVRefreshSnapshot refreshSnapshot = new MTMVRefreshSnapshot();
     private MTMVVersionSnapshot p1Snapshot = new MTMVVersionSnapshot(correctVersion, 0);
     private MTMVVersionSnapshot t1Snapshot = new MTMVVersionSnapshot(correctVersion, 0);
-    @Mocked
-    private BaseTableInfo existTable;
-    @Mocked
-    private BaseTableInfo nonExistTable;
+    private BaseTableInfo existTable = Mockito.mock(BaseTableInfo.class);
+    private BaseTableInfo nonExistTable = Mockito.mock(BaseTableInfo.class);
 
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException, AnalysisException {
-        new Expectations() {
-            {
-                existTable.getCtlName();
-                minTimes = 0;
-                result = "ctl1";
+        Mockito.when(existTable.getCtlName()).thenReturn("ctl1");
+        Mockito.when(existTable.getDbName()).thenReturn("db1");
+        Mockito.when(existTable.getTableName()).thenReturn("t1");
+        Mockito.when(existTable.getTableId()).thenReturn(1L);
 
-                existTable.getDbName();
-                minTimes = 0;
-                result = "db1";
-
-                existTable.getTableName();
-                minTimes = 0;
-                result = "t1";
-
-                existTable.getTableId();
-                minTimes = 0;
-                result = 1L;
-
-                nonExistTable.getCtlName();
-                minTimes = 0;
-                result = "ctl1";
-
-                nonExistTable.getDbName();
-                minTimes = 0;
-                result = "db1";
-
-                nonExistTable.getTableName();
-                minTimes = 0;
-                result = "t2";
-
-                nonExistTable.getTableId();
-                minTimes = 0;
-                result = 2L;
-            }
-        };
+        Mockito.when(nonExistTable.getCtlName()).thenReturn("ctl1");
+        Mockito.when(nonExistTable.getDbName()).thenReturn("db1");
+        Mockito.when(nonExistTable.getTableName()).thenReturn("t2");
+        Mockito.when(nonExistTable.getTableId()).thenReturn(2L);
 
         Map<String, MTMVRefreshPartitionSnapshot> partitionSnapshots = Maps.newHashMap();
         MTMVRefreshPartitionSnapshot mvp1PartitionSnapshot = new MTMVRefreshPartitionSnapshot();

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRelatedPartitionDescRollUpGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRelatedPartitionDescRollUpGeneratorTest.java
@@ -29,116 +29,83 @@ import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class MTMVRelatedPartitionDescRollUpGeneratorTest {
-    @Mocked
-    private MTMVPartitionUtil mtmvPartitionUtil;
-    @Mocked
-    private MTMVPartitionInfo mtmvPartitionInfo;
+    private MTMVPartitionInfo mtmvPartitionInfo = Mockito.mock(MTMVPartitionInfo.class);
 
     @Test
     public void testRollUpRange() throws AnalysisException {
         FunctionCallExpr expr = new FunctionCallExpr("date_trunc",
                 Lists.newArrayList(new SlotRef(null, null), new StringLiteral("month")), true);
-        new Expectations() {
-            {
-                mtmvPartitionUtil.getPartitionColumnType((MTMVRelatedTableIf) any, (String) any);
-                minTimes = 0;
-                result = Type.DATE;
+        try (MockedStatic<MTMVPartitionUtil> mtmvPartitionUtilStatic = Mockito.mockStatic(MTMVPartitionUtil.class)) {
+            mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.getPartitionColumnType(
+                    Mockito.nullable(MTMVRelatedTableIf.class), Mockito.nullable(String.class))).thenReturn(Type.DATE);
+            Mockito.when(mtmvPartitionInfo.getRelatedTable()).thenReturn(null);
+            Mockito.when(mtmvPartitionInfo.getExpr()).thenReturn(expr);
+            Mockito.when(mtmvPartitionInfo.getPartitionType()).thenReturn(MTMVPartitionType.EXPR);
 
-                mtmvPartitionInfo.getRelatedTable();
-                minTimes = 0;
-                result = null;
+            MTMVRelatedPartitionDescRollUpGenerator generator = new MTMVRelatedPartitionDescRollUpGenerator();
+            Map<PartitionKeyDesc, Set<String>> relatedPartitionDescs = Maps.newHashMap();
+            PartitionKeyDesc desc20200101 = PartitionKeyDesc.createFixed(
+                    Lists.newArrayList(new PartitionValue("2020-01-01")),
+                    Lists.newArrayList(new PartitionValue("2020-01-02")));
+            PartitionKeyDesc desc20200102 = PartitionKeyDesc.createFixed(
+                    Lists.newArrayList(new PartitionValue("2020-01-02")),
+                    Lists.newArrayList(new PartitionValue("2020-01-03")));
+            PartitionKeyDesc desc20200201 = PartitionKeyDesc.createFixed(
+                    Lists.newArrayList(new PartitionValue("2020-02-01")),
+                    Lists.newArrayList(new PartitionValue("2020-02-02")));
+            relatedPartitionDescs.put(desc20200101, Sets.newHashSet("name1"));
+            relatedPartitionDescs.put(desc20200102, Sets.newHashSet("name2"));
+            relatedPartitionDescs.put(desc20200201, Sets.newHashSet("name3"));
+            Map<PartitionKeyDesc, Set<String>> res = generator.rollUpRange(relatedPartitionDescs,
+                    mtmvPartitionInfo, null);
 
-                mtmvPartitionInfo.getExpr();
-                minTimes = 0;
-                result = null;
-
-                mtmvPartitionInfo.getPartitionType();
-                minTimes = 0;
-                result = MTMVPartitionType.EXPR;
-
-                mtmvPartitionInfo.getExpr();
-                minTimes = 0;
-                result = expr;
-            }
-        };
-        MTMVRelatedPartitionDescRollUpGenerator generator = new MTMVRelatedPartitionDescRollUpGenerator();
-        Map<PartitionKeyDesc, Set<String>> relatedPartitionDescs = Maps.newHashMap();
-        PartitionKeyDesc desc20200101 = PartitionKeyDesc.createFixed(
-                Lists.newArrayList(new PartitionValue("2020-01-01")),
-                Lists.newArrayList(new PartitionValue("2020-01-02")));
-        PartitionKeyDesc desc20200102 = PartitionKeyDesc.createFixed(
-                Lists.newArrayList(new PartitionValue("2020-01-02")),
-                Lists.newArrayList(new PartitionValue("2020-01-03")));
-        PartitionKeyDesc desc20200201 = PartitionKeyDesc.createFixed(
-                Lists.newArrayList(new PartitionValue("2020-02-01")),
-                Lists.newArrayList(new PartitionValue("2020-02-02")));
-        relatedPartitionDescs.put(desc20200101, Sets.newHashSet("name1"));
-        relatedPartitionDescs.put(desc20200102, Sets.newHashSet("name2"));
-        relatedPartitionDescs.put(desc20200201, Sets.newHashSet("name3"));
-        Map<PartitionKeyDesc, Set<String>> res = generator.rollUpRange(relatedPartitionDescs,
-                mtmvPartitionInfo, null);
-
-        PartitionKeyDesc expectDesc202001 = PartitionKeyDesc.createFixed(
-                Lists.newArrayList(new PartitionValue("2020-01-01")),
-                Lists.newArrayList(new PartitionValue("2020-02-01")));
-        PartitionKeyDesc expectDesc202002 = PartitionKeyDesc.createFixed(
-                Lists.newArrayList(new PartitionValue("2020-02-01")),
-                Lists.newArrayList(new PartitionValue("2020-03-01")));
-        Assert.assertEquals(2, res.size());
-        Assert.assertEquals(Sets.newHashSet("name1", "name2"), res.get(expectDesc202001));
-        Assert.assertEquals(Sets.newHashSet("name3"), res.get(expectDesc202002));
+            PartitionKeyDesc expectDesc202001 = PartitionKeyDesc.createFixed(
+                    Lists.newArrayList(new PartitionValue("2020-01-01")),
+                    Lists.newArrayList(new PartitionValue("2020-02-01")));
+            PartitionKeyDesc expectDesc202002 = PartitionKeyDesc.createFixed(
+                    Lists.newArrayList(new PartitionValue("2020-02-01")),
+                    Lists.newArrayList(new PartitionValue("2020-03-01")));
+            Assert.assertEquals(2, res.size());
+            Assert.assertEquals(Sets.newHashSet("name1", "name2"), res.get(expectDesc202001));
+            Assert.assertEquals(Sets.newHashSet("name3"), res.get(expectDesc202002));
+        }
     }
 
     @Test
     public void testRollUpList() throws AnalysisException {
         FunctionCallExpr expr = new FunctionCallExpr("date_trunc",
                 Lists.newArrayList(new SlotRef(null, null), new StringLiteral("month")), true);
-        new Expectations() {
-            {
-                mtmvPartitionUtil.getPartitionColumnType((MTMVRelatedTableIf) any, (String) any);
-                minTimes = 0;
-                result = Type.DATE;
+        try (MockedStatic<MTMVPartitionUtil> mtmvPartitionUtilStatic = Mockito.mockStatic(MTMVPartitionUtil.class)) {
+            mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.getPartitionColumnType(
+                    Mockito.nullable(MTMVRelatedTableIf.class), Mockito.nullable(String.class))).thenReturn(Type.DATE);
+            Mockito.when(mtmvPartitionInfo.getRelatedTable()).thenReturn(null);
+            Mockito.when(mtmvPartitionInfo.getExpr()).thenReturn(expr);
+            Mockito.when(mtmvPartitionInfo.getPartitionType()).thenReturn(MTMVPartitionType.EXPR);
 
-                mtmvPartitionInfo.getRelatedTable();
-                minTimes = 0;
-                result = null;
+            MTMVRelatedPartitionDescRollUpGenerator generator = new MTMVRelatedPartitionDescRollUpGenerator();
+            Map<PartitionKeyDesc, Set<String>> relatedPartitionDescs = Maps.newHashMap();
+            relatedPartitionDescs.put(generateInDesc("2020-01-01"), Sets.newHashSet("name1"));
+            relatedPartitionDescs.put(generateInDesc("2020-01-02"), Sets.newHashSet("name2"));
+            relatedPartitionDescs.put(generateInDesc("2020-02-01"), Sets.newHashSet("name3"));
+            Map<PartitionKeyDesc, Set<String>> res = generator.rollUpList(relatedPartitionDescs,
+                    mtmvPartitionInfo, Maps.newHashMap());
 
-                mtmvPartitionInfo.getExpr();
-                minTimes = 0;
-                result = null;
-
-                mtmvPartitionInfo.getPartitionType();
-                minTimes = 0;
-                result = MTMVPartitionType.EXPR;
-
-                mtmvPartitionInfo.getExpr();
-                minTimes = 0;
-                result = expr;
-            }
-        };
-        MTMVRelatedPartitionDescRollUpGenerator generator = new MTMVRelatedPartitionDescRollUpGenerator();
-        Map<PartitionKeyDesc, Set<String>> relatedPartitionDescs = Maps.newHashMap();
-        relatedPartitionDescs.put(generateInDesc("2020-01-01"), Sets.newHashSet("name1"));
-        relatedPartitionDescs.put(generateInDesc("2020-01-02"), Sets.newHashSet("name2"));
-        relatedPartitionDescs.put(generateInDesc("2020-02-01"), Sets.newHashSet("name3"));
-        Map<PartitionKeyDesc, Set<String>> res = generator.rollUpList(relatedPartitionDescs,
-                mtmvPartitionInfo, Maps.newHashMap());
-
-        PartitionKeyDesc expectDesc202001 = generateInDesc("2020-01-01", "2020-01-02");
-        PartitionKeyDesc expectDesc202002 = generateInDesc("2020-02-01");
-        Assert.assertEquals(2, res.size());
-        Assert.assertEquals(Sets.newHashSet("name1", "name2"), res.get(expectDesc202001));
-        Assert.assertEquals(Sets.newHashSet("name3"), res.get(expectDesc202002));
+            PartitionKeyDesc expectDesc202001 = generateInDesc("2020-01-01", "2020-01-02");
+            PartitionKeyDesc expectDesc202002 = generateInDesc("2020-02-01");
+            Assert.assertEquals(2, res.size());
+            Assert.assertEquals(Sets.newHashSet("name1", "name2"), res.get(expectDesc202001));
+            Assert.assertEquals(Sets.newHashSet("name3"), res.get(expectDesc202002));
+        }
     }
 
     private PartitionKeyDesc generateInDesc(String... values) {

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRelatedPartitionDescSyncLimitGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRelatedPartitionDescSyncLimitGeneratorTest.java
@@ -23,17 +23,15 @@ import org.apache.doris.nereids.trees.expressions.functions.executable.DateTimeA
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
 
 public class MTMVRelatedPartitionDescSyncLimitGeneratorTest {
-    @Mocked
-    private DateTimeAcquire dateTimeAcquire;
 
     @Test
     public void testGenerateMTMVPartitionSyncConfigByProperties() throws AnalysisException {
@@ -68,27 +66,23 @@ public class MTMVRelatedPartitionDescSyncLimitGeneratorTest {
     public void testGetNowTruncSubSec() throws AnalysisException {
         MTMVRelatedPartitionDescSyncLimitGenerator generator = new MTMVRelatedPartitionDescSyncLimitGenerator();
         DateTimeV2Literal dateTimeLiteral = new DateTimeV2Literal("2020-02-03 20:10:10");
-        new Expectations() {
-            {
-                dateTimeAcquire.now();
-                minTimes = 0;
-                result = dateTimeLiteral;
-            }
-        };
-        long nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.DAY, 1);
-        // 2020-02-03
-        Assert.assertEquals(1580659200L, nowTruncSubSec);
-        nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.MONTH, 1);
-        // 2020-02-01
-        Assert.assertEquals(1580486400L, nowTruncSubSec);
-        nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.YEAR, 1);
-        // 2020-01-01
-        Assert.assertEquals(1577808000L, nowTruncSubSec);
-        nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.MONTH, 3);
-        // 2019-12-01
-        Assert.assertEquals(1575129600L, nowTruncSubSec);
-        nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.DAY, 4);
-        // 2020-01-31
-        Assert.assertEquals(1580400000L, nowTruncSubSec);
+        try (MockedStatic<DateTimeAcquire> ms = Mockito.mockStatic(DateTimeAcquire.class)) {
+            ms.when(DateTimeAcquire::now).thenReturn(dateTimeLiteral);
+            long nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.DAY, 1);
+            // 2020-02-03
+            Assert.assertEquals(1580659200L, nowTruncSubSec);
+            nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.MONTH, 1);
+            // 2020-02-01
+            Assert.assertEquals(1580486400L, nowTruncSubSec);
+            nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.YEAR, 1);
+            // 2020-01-01
+            Assert.assertEquals(1577808000L, nowTruncSubSec);
+            nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.MONTH, 3);
+            // 2019-12-01
+            Assert.assertEquals(1575129600L, nowTruncSubSec);
+            nowTruncSubSec = generator.getNowTruncSubSec(MTMVPartitionSyncTimeUnit.DAY, 4);
+            // 2020-01-31
+            Assert.assertEquals(1580400000L, nowTruncSubSec);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRelationManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRelationManagerTest.java
@@ -20,78 +20,37 @@ package org.apache.doris.mtmv;
 import org.apache.doris.common.AnalysisException;
 
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Set;
 
 public class MTMVRelationManagerTest {
-    @Mocked
-    private BaseTableInfo mv1;
-    @Mocked
-    private BaseTableInfo mv2;
-    @Mocked
-    private BaseTableInfo t3;
-    @Mocked
-    private BaseTableInfo t4;
+    private BaseTableInfo mv1 = Mockito.mock(BaseTableInfo.class);
+    private BaseTableInfo mv2 = Mockito.mock(BaseTableInfo.class);
+    private BaseTableInfo t3 = Mockito.mock(BaseTableInfo.class);
+    private BaseTableInfo t4 = Mockito.mock(BaseTableInfo.class);
 
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException, AnalysisException {
-        new Expectations() {
-            {
-                mv1.getCtlName();
-                minTimes = 0;
-                result = "ctl1";
+        Mockito.when(mv1.getCtlName()).thenReturn("ctl1");
+        Mockito.when(mv1.getDbName()).thenReturn("db1");
+        Mockito.when(mv1.getTableName()).thenReturn("mv1");
 
-                mv1.getDbName();
-                minTimes = 0;
-                result = "db1";
+        Mockito.when(mv2.getCtlName()).thenReturn("ctl1");
+        Mockito.when(mv2.getDbName()).thenReturn("db1");
+        Mockito.when(mv2.getTableName()).thenReturn("mv2");
 
-                mv1.getTableName();
-                minTimes = 0;
-                result = "mv1";
+        Mockito.when(t3.getCtlName()).thenReturn("ctl1");
+        Mockito.when(t3.getDbName()).thenReturn("db1");
+        Mockito.when(t3.getTableName()).thenReturn("t3");
 
-                mv2.getCtlName();
-                minTimes = 0;
-                result = "ctl1";
-
-                mv2.getDbName();
-                minTimes = 0;
-                result = "db1";
-
-                mv2.getTableName();
-                minTimes = 0;
-                result = "mv2";
-
-                t3.getCtlName();
-                minTimes = 0;
-                result = "ctl1";
-
-                t3.getDbName();
-                minTimes = 0;
-                result = "db1";
-
-                t3.getTableName();
-                minTimes = 0;
-                result = "t3";
-
-                t4.getCtlName();
-                minTimes = 0;
-                result = "ctl1";
-
-                t4.getDbName();
-                minTimes = 0;
-                result = "db1";
-
-                t4.getTableName();
-                minTimes = 0;
-                result = "t4";
-            }
-        };
+        Mockito.when(t4.getCtlName()).thenReturn("ctl1");
+        Mockito.when(t4.getDbName()).thenReturn("db1");
+        Mockito.when(t4.getTableName()).thenReturn("t4");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVRewriteUtilTest.java
@@ -28,7 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.mvcc.MvccSnapshot;
-import org.apache.doris.info.TableNameInfo;
+import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
 import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVRefreshState;
 import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVState;
 import org.apache.doris.qe.ConnectContext;
@@ -42,11 +42,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataOutput;
 import java.io.IOException;
@@ -58,113 +59,77 @@ import java.util.Optional;
 import java.util.Set;
 
 public class MTMVRewriteUtilTest {
-    @Mocked
-    private MTMV mtmv;
-    @Mocked
-    private ConnectContext ctx;
-    @Mocked
-    private SessionVariable sessionVariable;
-    @Mocked
-    private Partition p1;
-    @Mocked
-    private MTMVRelation relation;
-    @Mocked
-    private MTMVStatus status;
-    @Mocked
-    private MTMVPartitionUtil mtmvPartitionUtil;
-    @Mocked
-    private MTMVUtil mtmvUtil;
+    private MTMV mtmv = Mockito.mock(MTMV.class);
+    private ConnectContext ctx = Mockito.mock(ConnectContext.class);
+    private SessionVariable sessionVariable = Mockito.mock(SessionVariable.class);
+    private Partition p1 = Mockito.mock(Partition.class);
+    private MTMVRelation relation = Mockito.mock(MTMVRelation.class);
+    private MTMVStatus status = Mockito.mock(MTMVStatus.class);
+    private MTMVPartitionInfo mvPartitionInfo = Mockito.mock(MTMVPartitionInfo.class);
+    private MockedStatic<MTMVPartitionUtil> mtmvPartitionUtilStatic;
+    private MockedStatic<MTMVUtil> mtmvUtilStatic;
     private long currentTimeMills = 3L;
 
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException, AnalysisException {
+        mtmvPartitionUtilStatic = Mockito.mockStatic(MTMVPartitionUtil.class);
+        mtmvUtilStatic = Mockito.mockStatic(MTMVUtil.class);
 
-        new Expectations() {
-            {
-                mtmv.getPartitions();
-                minTimes = 0;
-                result = Lists.newArrayList(p1);
+        Mockito.when(mtmv.getPartitions()).thenReturn(Lists.newArrayList(p1));
 
-                mtmv.getPartitionNames();
-                minTimes = 0;
-                result = Sets.newHashSet("p1");
+        Mockito.when(mtmv.getPartitionNames()).thenReturn(Sets.newHashSet("p1"));
 
-                p1.getName();
-                minTimes = 0;
-                result = "p1";
+        Mockito.when(p1.getName()).thenReturn("p1");
 
-                p1.getVisibleVersionTime();
-                minTimes = 0;
-                result = 1L;
+        Mockito.when(p1.getVisibleVersionTime()).thenReturn(1L);
 
-                mtmv.getGracePeriod();
-                minTimes = 0;
-                result = 0L;
+        Mockito.when(mtmv.getGracePeriod()).thenReturn(0L);
 
-                mtmv.getRelation();
-                minTimes = 0;
-                result = relation;
+        Mockito.when(mtmv.getRelation()).thenReturn(relation);
 
-                mtmv.getStatus();
-                minTimes = 0;
-                result = status;
+        Mockito.when(mtmv.getStatus()).thenReturn(status);
 
-                mtmv.getGracePeriod();
-                minTimes = 0;
-                result = 0L;
+        Mockito.when(status.getState()).thenReturn(MTMVState.NORMAL);
 
-                status.getState();
-                minTimes = 0;
-                result = MTMVState.NORMAL;
+        Mockito.when(status.getRefreshState()).thenReturn(MTMVRefreshState.SUCCESS);
 
-                status.getRefreshState();
-                minTimes = 0;
-                result = MTMVRefreshState.SUCCESS;
+        Mockito.when(ctx.getSessionVariable()).thenReturn(sessionVariable);
 
-                ctx.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
+        Mockito.when(sessionVariable.isEnableMaterializedViewRewrite()).thenReturn(true);
 
-                sessionVariable.isEnableMaterializedViewRewrite();
-                minTimes = 0;
-                result = true;
+        Mockito.when(sessionVariable.isEnableMaterializedViewRewriteWhenBaseTableUnawareness()).thenReturn(true);
 
-                sessionVariable.isEnableMaterializedViewRewriteWhenBaseTableUnawareness();
-                minTimes = 0;
-                result = true;
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVPartitionSync(
+                Mockito.any(MTMVRefreshContext.class), Mockito.anyString(),
+                Mockito.any(Set.class),
+                Mockito.any(Set.class))).thenReturn(true);
 
-                MTMVPartitionUtil.isMTMVPartitionSync((MTMVRefreshContext) any, anyString,
-                        (Set<BaseTableInfo>) any,
-                        (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = true;
+        mtmvUtilStatic.when(() -> MTMVUtil.mtmvContainsExternalTable(
+                Mockito.any(MTMV.class))).thenReturn(false);
 
-                MTMVUtil.mtmvContainsExternalTable((MTMV) any);
-                minTimes = 0;
-                result = false;
+        Mockito.when(mtmv.getMvPartitionInfo()).thenReturn(mvPartitionInfo);
 
-                mtmv.canBeCandidate();
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(mvPartitionInfo.getPartitionType()).thenReturn(MTMVPartitionType.SELF_MANAGE);
+
+        Mockito.when(mvPartitionInfo.getPctTables()).thenReturn(Sets.newHashSet());
+
+        Mockito.when(mtmv.canBeCandidate()).thenReturn(true);
+    }
+
+    @After
+    public void tearDown() {
+        mtmvPartitionUtilStatic.close();
+        mtmvUtilStatic.close();
     }
 
     @Test
     public void testGetMTMVCanRewritePartitionsForceConsistent() throws AnalysisException {
-        new Expectations() {
-            {
-                mtmv.getGracePeriod();
-                minTimes = 0;
-                result = 2L;
+        Mockito.when(mtmv.getGracePeriod()).thenReturn(2L);
 
-                MTMVPartitionUtil.isMTMVPartitionSync((MTMVRefreshContext) any, anyString,
-                        (Set<BaseTableInfo>) any,
-                        (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVPartitionSync(
+                Mockito.any(MTMVRefreshContext.class), Mockito.anyString(),
+                Mockito.any(Set.class),
+                Mockito.any(Set.class))).thenReturn(false);
 
         // currentTimeMills is 3, grace period is 2, and partition getVisibleVersionTime is 1
         // if forceConsistent this should get 0 partitions which mtmv can use.
@@ -183,19 +148,12 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsInGracePeriod() throws AnalysisException {
-        new Expectations() {
-            {
-                mtmv.getGracePeriod();
-                minTimes = 0;
-                result = 2L;
+        Mockito.when(mtmv.getGracePeriod()).thenReturn(2L);
 
-                MTMVPartitionUtil.isMTMVPartitionSync((MTMVRefreshContext) any, anyString,
-                        (Set<BaseTableInfo>) any,
-                        (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVPartitionSync(
+                Mockito.any(MTMVRefreshContext.class), Mockito.anyString(),
+                Mockito.any(Set.class),
+                Mockito.any(Set.class))).thenReturn(false);
 
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
@@ -205,19 +163,12 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsNotInGracePeriod() throws AnalysisException {
-        new Expectations() {
-            {
-                mtmv.getGracePeriod();
-                minTimes = 0;
-                result = 1L;
+        Mockito.when(mtmv.getGracePeriod()).thenReturn(1L);
 
-                MTMVPartitionUtil.isMTMVPartitionSync((MTMVRefreshContext) any, anyString,
-                        (Set<BaseTableInfo>) any,
-                        (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVPartitionSync(
+                Mockito.any(MTMVRefreshContext.class), Mockito.anyString(),
+                Mockito.any(Set.class),
+                Mockito.any(Set.class))).thenReturn(false);
 
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
@@ -227,13 +178,7 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsDisableMaterializedViewRewrite() {
-        new Expectations() {
-            {
-                sessionVariable.isEnableMaterializedViewRewrite();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(sessionVariable.isEnableMaterializedViewRewrite()).thenReturn(false);
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
                         null);
@@ -244,15 +189,10 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsNotSync() throws AnalysisException {
-        new Expectations() {
-            {
-                MTMVPartitionUtil.isMTMVPartitionSync((MTMVRefreshContext) any, anyString,
-                        (Set<BaseTableInfo>) any,
-                        (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVPartitionSync(
+                Mockito.any(MTMVRefreshContext.class), Mockito.anyString(),
+                Mockito.any(Set.class),
+                Mockito.any(Set.class))).thenReturn(false);
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
                         null);
@@ -261,17 +201,10 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsEnableContainExternalTable() {
-        new Expectations() {
-            {
-                MTMVUtil.mtmvContainsExternalTable((MTMV) any);
-                minTimes = 0;
-                result = true;
+        mtmvUtilStatic.when(() -> MTMVUtil.mtmvContainsExternalTable(
+                Mockito.any(MTMV.class))).thenReturn(true);
 
-                sessionVariable.isEnableMaterializedViewRewriteWhenBaseTableUnawareness();
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(sessionVariable.isEnableMaterializedViewRewriteWhenBaseTableUnawareness()).thenReturn(true);
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
                         null);
@@ -280,17 +213,10 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsDisableContainExternalTable() {
-        new Expectations() {
-            {
-                MTMVUtil.mtmvContainsExternalTable((MTMV) any);
-                minTimes = 0;
-                result = true;
+        mtmvUtilStatic.when(() -> MTMVUtil.mtmvContainsExternalTable(
+                Mockito.any(MTMV.class))).thenReturn(true);
 
-                sessionVariable.isEnableMaterializedViewRewriteWhenBaseTableUnawareness();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(sessionVariable.isEnableMaterializedViewRewriteWhenBaseTableUnawareness()).thenReturn(false);
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
                         null);
@@ -301,13 +227,7 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsStateAbnormal() {
-        new Expectations() {
-            {
-                mtmv.canBeCandidate();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(mtmv.canBeCandidate()).thenReturn(false);
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
                         null);
@@ -316,13 +236,7 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsRefreshStateAbnormal() {
-        new Expectations() {
-            {
-                status.getRefreshState();
-                minTimes = 0;
-                result = MTMVRefreshState.FAIL;
-            }
-        };
+        Mockito.when(status.getRefreshState()).thenReturn(MTMVRefreshState.FAIL);
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
                         null);
@@ -331,13 +245,7 @@ public class MTMVRewriteUtilTest {
 
     @Test
     public void testGetMTMVCanRewritePartitionsRefreshStateInit() {
-        new Expectations() {
-            {
-                mtmv.canBeCandidate();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(mtmv.canBeCandidate()).thenReturn(false);
         Collection<Partition> mtmvCanRewritePartitions = MTMVRewriteUtil
                 .getMTMVCanRewritePartitions(mtmv, ctx, currentTimeMills, false,
                         null);

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVTaskTest.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.MTMV;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
-import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.job.extensions.mtmv.MTMVTask;
 import org.apache.doris.job.extensions.mtmv.MTMVTask.MTMVTaskTriggerMode;
 import org.apache.doris.job.extensions.mtmv.MTMVTaskContext;
@@ -30,12 +29,13 @@ import org.apache.doris.mtmv.MTMVRefreshEnum.RefreshMethod;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.commons.collections4.CollectionUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Set;
@@ -47,56 +47,42 @@ public class MTMVTaskTest {
     private MTMVRelation relation = new MTMVRelation(Sets.newHashSet(), Sets.newHashSet(), Sets.newHashSet(),
             Sets.newHashSet(), Sets.newHashSet());
 
-    @Mocked
-    private MTMV mtmv;
-    @Mocked
-    private MTMVUtil mtmvUtil;
-    @Mocked
-    private MTMVPartitionUtil mtmvPartitionUtil;
-    @Mocked
-    private MTMVPartitionInfo mtmvPartitionInfo;
-    @Mocked
-    private MTMVRefreshInfo mtmvRefreshInfo;
+    private MTMV mtmv = Mockito.mock(MTMV.class);
+    private MTMVPartitionInfo mtmvPartitionInfo = Mockito.mock(MTMVPartitionInfo.class);
+    private MTMVRefreshInfo mtmvRefreshInfo = Mockito.mock(MTMVRefreshInfo.class);
+    private MockedStatic<MTMVUtil> mtmvUtilStatic;
+    private MockedStatic<MTMVPartitionUtil> mtmvPartitionUtilStatic;
 
     @Before
     public void setUp()
             throws NoSuchMethodException, SecurityException, AnalysisException, DdlException, MetaNotFoundException {
 
-        new Expectations() {
-            {
-                mtmvUtil.getMTMV(anyLong, anyLong);
-                minTimes = 0;
-                result = mtmv;
+        mtmvUtilStatic = Mockito.mockStatic(MTMVUtil.class);
+        mtmvPartitionUtilStatic = Mockito.mockStatic(MTMVPartitionUtil.class);
 
-                mtmv.getPartitionNames();
-                minTimes = 0;
-                result = Sets.newHashSet(poneName, ptwoName);
+        mtmvUtilStatic.when(() -> MTMVUtil.getMTMV(Mockito.anyLong(), Mockito.anyLong())).thenReturn(mtmv);
 
-                mtmv.getMvPartitionInfo();
-                minTimes = 0;
-                result = mtmvPartitionInfo;
+        Mockito.when(mtmv.getPartitionNames()).thenReturn(Sets.newHashSet(poneName, ptwoName));
 
-                mtmvPartitionInfo.getPartitionType();
-                minTimes = 0;
-                result = MTMVPartitionType.FOLLOW_BASE_TABLE;
+        Mockito.when(mtmv.getMvPartitionInfo()).thenReturn(mtmvPartitionInfo);
 
-                // mtmvPartitionUtil.getPartitionsIdsByNames(mtmv, Lists.newArrayList(poneName));
-                // minTimes = 0;
-                // result = poneId;
+        Mockito.when(mtmvPartitionInfo.getPartitionType()).thenReturn(MTMVPartitionType.FOLLOW_BASE_TABLE);
 
-                mtmvPartitionUtil.isMTMVSync((MTMVRefreshContext) any, (Set<BaseTableInfo>) any, (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = true;
+        // mtmvPartitionUtil.getPartitionsIdsByNames(mtmv, Lists.newArrayList(poneName));
+        // minTimes = 0;
+        // result = poneId;
 
-                mtmv.getRefreshInfo();
-                minTimes = 0;
-                result = mtmvRefreshInfo;
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVSync(Mockito.nullable(MTMVRefreshContext.class), Mockito.nullable(Set.class), Mockito.nullable(Set.class))).thenReturn(true);
 
-                mtmvRefreshInfo.getRefreshMethod();
-                minTimes = 0;
-                result = RefreshMethod.COMPLETE;
-            }
-        };
+        Mockito.when(mtmv.getRefreshInfo()).thenReturn(mtmvRefreshInfo);
+
+        Mockito.when(mtmvRefreshInfo.getRefreshMethod()).thenReturn(RefreshMethod.COMPLETE);
+    }
+
+    @After
+    public void tearDown() {
+        mtmvUtilStatic.close();
+        mtmvPartitionUtilStatic.close();
     }
 
     @Test
@@ -117,13 +103,7 @@ public class MTMVTaskTest {
 
     @Test
     public void testCalculateNeedRefreshPartitionsSystem() throws AnalysisException {
-        new Expectations() {
-            {
-                mtmvRefreshInfo.getRefreshMethod();
-                minTimes = 0;
-                result = RefreshMethod.AUTO;
-            }
-        };
+        Mockito.when(mtmvRefreshInfo.getRefreshMethod()).thenReturn(RefreshMethod.AUTO);
         MTMVTaskContext context = new MTMVTaskContext(MTMVTaskTriggerMode.SYSTEM);
         MTMVTask task = new MTMVTask(mtmv, relation, context);
         List<String> result = task.calculateNeedRefreshPartitions(null);
@@ -140,13 +120,7 @@ public class MTMVTaskTest {
 
     @Test
     public void testCalculateNeedRefreshPartitionsSystemNotSyncComplete() throws AnalysisException {
-        new Expectations() {
-            {
-                mtmvPartitionUtil.isMTMVSync((MTMVRefreshContext) any, (Set<BaseTableInfo>) any, (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVSync(Mockito.nullable(MTMVRefreshContext.class), Mockito.nullable(Set.class), Mockito.nullable(Set.class))).thenReturn(false);
         MTMVTaskContext context = new MTMVTaskContext(MTMVTaskTriggerMode.SYSTEM);
         MTMVTask task = new MTMVTask(mtmv, relation, context);
         List<String> result = task.calculateNeedRefreshPartitions(null);
@@ -155,23 +129,11 @@ public class MTMVTaskTest {
 
     @Test
     public void testCalculateNeedRefreshPartitionsSystemNotSyncAuto() throws AnalysisException {
-        new Expectations() {
-            {
-                mtmvPartitionUtil
-                        .isMTMVSync((MTMVRefreshContext) any, (Set<BaseTableInfo>) any, (Set<TableNameInfo>) any);
-                minTimes = 0;
-                result = false;
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.isMTMVSync(Mockito.nullable(MTMVRefreshContext.class), Mockito.nullable(Set.class), Mockito.nullable(Set.class))).thenReturn(false);
 
-                mtmvRefreshInfo.getRefreshMethod();
-                minTimes = 0;
-                result = RefreshMethod.AUTO;
+        Mockito.when(mtmvRefreshInfo.getRefreshMethod()).thenReturn(RefreshMethod.AUTO);
 
-                mtmvPartitionUtil
-                        .getMTMVNeedRefreshPartitions((MTMVRefreshContext) any, (Set<BaseTableInfo>) any);
-                minTimes = 0;
-                result = Lists.newArrayList(ptwoName);
-            }
-        };
+        mtmvPartitionUtilStatic.when(() -> MTMVPartitionUtil.getMTMVNeedRefreshPartitions(Mockito.nullable(MTMVRefreshContext.class), Mockito.nullable(Set.class))).thenReturn(Lists.newArrayList(ptwoName));
         MTMVTaskContext context = new MTMVTaskContext(MTMVTaskTriggerMode.SYSTEM);
         MTMVTask task = new MTMVTask(mtmv, relation, context);
         List<String> result = task.calculateNeedRefreshPartitions(null);

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/ConnectionExceedTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/ConnectionExceedTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.mysql;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ErrorCode;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectScheduler;
@@ -28,142 +29,119 @@ import org.apache.doris.service.arrowflight.sessions.FlightSessionsWithTokenMana
 import org.apache.doris.service.arrowflight.tokens.FlightTokenDetails;
 import org.apache.doris.service.arrowflight.tokens.FlightTokenManager;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.xnio.StreamConnection;
 
 public class ConnectionExceedTest {
-    @Mocked
-    private Auth mockAuth;
-
-    @Mocked
-    private Env mockEnv;
-
-    @Mocked
-    private StreamConnection mockConnection;
-
-    @Mocked
-    private MysqlProto mysqlProto;
-
-    @Mocked
-    private FlightTokenManager mockTokenManager;
-
-    @Mocked
-    private ExecuteEnv mockExecuteEnv;
+    private Auth mockAuth = Mockito.mock(Auth.class);
+    private Env mockEnv = Mockito.mock(Env.class);
+    private InternalCatalog mockCatalog = Mockito.mock(InternalCatalog.class);
+    private StreamConnection mockConnection = Mockito.mock(StreamConnection.class);
+    private FlightTokenManager mockTokenManager = Mockito.mock(FlightTokenManager.class);
+    private ExecuteEnv mockExecuteEnv = Mockito.mock(ExecuteEnv.class);
 
     @Test
     public void testHandleConnectionExceed() throws Exception {
-        // Create a scheduler with small max connections
-        ConnectScheduler scheduler = new ConnectScheduler(2);
+        try (MockedStatic<MysqlProto> mockedProto = Mockito.mockStatic(MysqlProto.class)) {
+            // Create a scheduler with small max connections
+            ConnectScheduler scheduler = new ConnectScheduler(2);
 
-        // Setup expectations
-        new Expectations() {
-            {
-                mockEnv.getAuth();
-                result = mockAuth;
+            // Setup expectations
+            Mockito.when(mockEnv.getInternalCatalog()).thenReturn(mockCatalog);
+            Mockito.when(mockCatalog.getName()).thenReturn("internal");
+            Mockito.when(mockEnv.getAuth()).thenReturn(mockAuth);
+            Mockito.when(mockAuth.getMaxConn("test_user")).thenReturn(2L);
+            // Mock MysqlProto.negotiate to return true to simulate successful authentication
+            mockedProto.when(() -> MysqlProto.negotiate(Mockito.nullable(ConnectContext.class))).thenReturn(true);
 
-                mockAuth.getMaxConn("test_user");
-                result = 2;
+            // Create first context and register
+            ConnectContext context1 = new ConnectContext();
+            context1.setEnv(mockEnv);
+            context1.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
+            Assert.assertTrue(scheduler.submit(context1));
+            Assert.assertEquals(-1, scheduler.getConnectPoolMgr().registerConnection(context1));
 
-                // Mock MysqlProto.negotiate to return true to simulate successful authentication
-                MysqlProto.negotiate((ConnectContext) any);
-                result = true;
-            }
-        };
+            // Create second context and register
+            ConnectContext context2 = new ConnectContext();
+            context2.setEnv(mockEnv);
+            context2.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
+            Assert.assertTrue(scheduler.submit(context2));
+            Assert.assertEquals(-1, scheduler.getConnectPoolMgr().registerConnection(context2));
 
-        // Create first context and register
-        ConnectContext context1 = new ConnectContext();
-        context1.setEnv(mockEnv);
-        context1.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
-        Assert.assertTrue(scheduler.submit(context1));
-        Assert.assertEquals(-1, scheduler.getConnectPoolMgr().registerConnection(context1));
+            // Create third context and try to register - should fail
+            ConnectContext context3 = new ConnectContext();
+            context3.setEnv(mockEnv);
+            context3.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
+            Assert.assertTrue(scheduler.submit(context3));
 
-        // Create second context and register
-        ConnectContext context2 = new ConnectContext();
-        context2.setEnv(mockEnv);
-        context2.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
-        Assert.assertTrue(scheduler.submit(context2));
-        Assert.assertEquals(-1, scheduler.getConnectPoolMgr().registerConnection(context2));
-
-        // Create third context and try to register - should fail
-        ConnectContext context3 = new ConnectContext();
-        context3.setEnv(mockEnv);
-        context3.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
-        Assert.assertTrue(scheduler.submit(context3));
-
-        // Create AcceptListener and handle the connection
-        AcceptListener listener = new AcceptListener(scheduler);
-        listener.handleConnection(context3, mockConnection);
-        String expectedMsg = String.format(
-                "Reach limit of connections. Total: %d, User: %d, Current: %d",
-                scheduler.getConnectPoolMgr().getMaxConnections(),
-                2, // Mocked user connection limit
-                scheduler.getConnectionNum());
-        Assert.assertEquals(expectedMsg, context3.getState().getErrorMessage());
-        Assert.assertEquals(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, context3.getState().getErrorCode());
+            // Create AcceptListener and handle the connection
+            AcceptListener listener = new AcceptListener(scheduler);
+            listener.handleConnection(context3, mockConnection);
+            String expectedMsg = String.format(
+                    "Reach limit of connections. Total: %d, User: %d, Current: %d",
+                    scheduler.getConnectPoolMgr().getMaxConnections(),
+                    2, // Mocked user connection limit
+                    scheduler.getConnectionNum());
+            Assert.assertEquals(expectedMsg, context3.getState().getErrorMessage());
+            Assert.assertEquals(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, context3.getState().getErrorCode());
+        }
     }
 
     @Test
     public void testFlightSessionConnectionExceed() throws Exception {
-        // Create a scheduler with small max connections
-        ConnectScheduler scheduler = new ConnectScheduler(1000, 2);
+        try (MockedStatic<ExecuteEnv> mockedExecEnv = Mockito.mockStatic(ExecuteEnv.class)) {
+            // Create a scheduler with small max connections
+            ConnectScheduler scheduler = new ConnectScheduler(1000, 2);
 
-        // Setup expectations
-        new Expectations() {
-            {
-                // Arrow flight sql not check the number of user connections.
-                // mockEnv.getAuth();
-                // result = mockAuth;
-                // mockAuth.getMaxConn("test_user");
-                // result = 2;
+            // Setup expectations
+            Mockito.when(mockEnv.getInternalCatalog()).thenReturn(mockCatalog);
+            Mockito.when(mockCatalog.getName()).thenReturn("internal");
+            mockedExecEnv.when(ExecuteEnv::getInstance).thenReturn(mockExecuteEnv);
+            Mockito.when(mockExecuteEnv.getScheduler()).thenReturn(scheduler);
 
-                mockExecuteEnv.getScheduler();
-                result = scheduler;
+            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+            FlightTokenDetails tokenDetails = new FlightTokenDetails(
+                    "test_token",
+                    "test_user",
+                    System.currentTimeMillis(),
+                    System.currentTimeMillis() + 3600000, // expires in 1 hour
+                    userIdentity,
+                    "127.0.0.1"
+            );
+            Mockito.when(mockTokenManager.validateToken("test_token")).thenReturn(tokenDetails);
 
-                UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-                FlightTokenDetails tokenDetails = new FlightTokenDetails(
-                        "test_token",
-                        "test_user",
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis() + 3600000, // expires in 1 hour
-                        userIdentity,
-                        "127.0.0.1"
-                );
-                mockTokenManager.validateToken("test_token");
-                result = tokenDetails;
+            // Create first context and register
+            ConnectContext context1 = new ConnectContext();
+            context1.setEnv(mockEnv);
+            context1.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
+            Assert.assertTrue(scheduler.submit(context1));
+            Assert.assertEquals(-1, scheduler.getFlightSqlConnectPoolMgr().registerConnection(context1));
+
+            // Create second context and register
+            ConnectContext context2 = new ConnectContext();
+            context2.setEnv(mockEnv);
+            context2.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
+            Assert.assertTrue(scheduler.submit(context2));
+            Assert.assertEquals(-1, scheduler.getFlightSqlConnectPoolMgr().registerConnection(context2));
+
+            // Create FlightSessionsWithTokenManager and try to create a new connection
+            FlightSessionsWithTokenManager manager = new FlightSessionsWithTokenManager(mockTokenManager);
+            try {
+                manager.createConnectContext("test_token");
+                Assert.fail("Should throw IllegalArgumentException");
+            } catch (IllegalArgumentException e) {
+                // Verify error message is set correctly
+                String expectedMsg = String.format(
+                        "Register arrow flight sql connection failed, Unknown Error, the number of arrow flight "
+                                + "bearer tokens should be equal to arrow flight sql max connections, "
+                                + "max connections: %d, used: %d.",
+                        scheduler.getFlightSqlConnectPoolMgr().getMaxConnections(),
+                        scheduler.getConnectionNum());
+                Assert.assertEquals(expectedMsg, e.getMessage());
             }
-        };
-
-        // Create first context and register
-        ConnectContext context1 = new ConnectContext();
-        context1.setEnv(mockEnv);
-        context1.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
-        Assert.assertTrue(scheduler.submit(context1));
-        Assert.assertEquals(-1, scheduler.getFlightSqlConnectPoolMgr().registerConnection(context1));
-
-        // Create second context and register
-        ConnectContext context2 = new ConnectContext();
-        context2.setEnv(mockEnv);
-        context2.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%"));
-        Assert.assertTrue(scheduler.submit(context2));
-        Assert.assertEquals(-1, scheduler.getFlightSqlConnectPoolMgr().registerConnection(context2));
-
-        // Create FlightSessionsWithTokenManager and try to create a new connection
-        FlightSessionsWithTokenManager manager = new FlightSessionsWithTokenManager(mockTokenManager);
-        try {
-            manager.createConnectContext("test_token");
-            Assert.fail("Should throw IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            // Verify error message is set correctly
-            String expectedMsg = String.format(
-                    "Register arrow flight sql connection failed, Unknown Error, the number of arrow flight "
-                            + "bearer tokens should be equal to arrow flight sql max connections, "
-                            + "max connections: %d, used: %d.",
-                    scheduler.getFlightSqlConnectPoolMgr().getMaxConnections(),
-                    scheduler.getConnectionNum());
-            Assert.assertEquals(expectedMsg, e.getMessage());
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlChannelTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlChannelTest.java
@@ -21,42 +21,40 @@ package org.apache.doris.mysql;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.xnio.StreamConnection;
+import org.xnio.conduits.ConduitStreamSinkChannel;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class MysqlChannelTest {
 
-    @Mocked
-    StreamConnection streamConnection;
+    StreamConnection streamConnection = Mockito.mock(StreamConnection.class);
 
     @Test
     public void testSendAfterException() throws IOException {
-        // Mock.
-        new Expectations() {
-            {
-                streamConnection.getSinkChannel().write((ByteBuffer) any);
-                // The first call to `write()` throws IOException.
-                result = new IOException();
-                // The second call to `write()` executes normally.
-                result = new Delegate() {
-                    int fakeRead(ByteBuffer buffer) {
-                        int writeLen = buffer.remaining();
-                        buffer.position(buffer.limit());
-                        return writeLen;
-                    }
-                };
+        // Mock StreamConnection.getPeerAddress() to avoid NPE in MysqlChannel constructor
+        Mockito.when(streamConnection.getPeerAddress())
+                .thenReturn(new java.net.InetSocketAddress("127.0.0.1", 12345));
 
-                streamConnection.getSinkChannel().flush();
-                result = true;
-            }
-        };
+        // Mock.
+        ConduitStreamSinkChannel mockSinkChannel = Mockito.mock(ConduitStreamSinkChannel.class);
+        Mockito.when(streamConnection.getSinkChannel()).thenReturn(mockSinkChannel);
+        Mockito.when(mockSinkChannel.write(ArgumentMatchers.any(ByteBuffer.class)))
+                // The first call to `write()` throws IOException.
+                .thenThrow(new IOException())
+                // The second call to `write()` executes normally.
+                .thenAnswer(inv -> {
+                    ByteBuffer buffer = inv.getArgument(0);
+                    int writeLen = buffer.remaining();
+                    buffer.position(buffer.limit());
+                    return writeLen;
+                });
+        Mockito.when(mockSinkChannel.flush()).thenReturn(true);
 
         ConnectContext ctx = new ConnectContext(streamConnection);
         MysqlChannel mysqlChannel = new MysqlChannel(streamConnection, ctx);

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlHandshakePacketTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlHandshakePacketTest.java
@@ -18,20 +18,19 @@
 package org.apache.doris.mysql;
 
 import com.google.common.primitives.Bytes;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.nio.ByteBuffer;
 
 public class MysqlHandshakePacketTest {
     private byte[] buf;
     private MysqlCapability capability;
-
-    @Mocked
-    MysqlPassword mysqlPassword;
+    private MockedStatic<MysqlPassword> mockedMysqlPassword;
 
     @Before
     public void setUp() {
@@ -40,15 +39,17 @@ public class MysqlHandshakePacketTest {
             buf[i] = (byte) ('a' + i);
         }
 
-        new Expectations() {
-            {
-                MysqlPassword.createRandomString(20);
-                minTimes = 0;
-                result = buf;
-            }
-        };
+        mockedMysqlPassword = Mockito.mockStatic(MysqlPassword.class);
+        mockedMysqlPassword.when(() -> MysqlPassword.createRandomString(20)).thenReturn(buf);
 
         capability = new MysqlCapability(0);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedMysqlPassword != null) {
+            mockedMysqlPassword.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlProtoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlProtoTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
+import org.apache.doris.mysql.authenticate.AuthenticateResponse;
 import org.apache.doris.mysql.authenticate.AuthenticatorManager;
 import org.apache.doris.mysql.authenticate.ldap.LdapAuthenticator;
 import org.apache.doris.mysql.authenticate.ldap.LdapManager;
@@ -36,18 +37,18 @@ import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
-import mockit.Verifications;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.xnio.StreamConnection;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -55,109 +56,89 @@ public class MysqlProtoTest {
     private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(MysqlProtoTest.class);
     private static final String PASSWORD_CLEAR_TEXT = "123456";
 
-    @Mocked
-    private MysqlChannel channel;
-    @Mocked
-    private MysqlPassword password;
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
-    private Auth auth;
-    @Mocked
-    private AccessControllerManager accessManager;
-    @Mocked
-    private LdapManager ldapManager;
-    @Mocked
-    private MysqlClearTextPacket clearTextPacket;
-    @Mocked
-    private StreamConnection streamConnection;
-    @Mocked
-    private LdapAuthenticator ldapAuthenticator;
-    @Mocked
-    private AuthenticatorManager authenticatorManager;
+    private MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+    private Auth auth = Mockito.mock(Auth.class);
+    private AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+    private LdapManager ldapManager = Mockito.mock(LdapManager.class);
+    private MysqlClearTextPacket clearTextPacket = Mockito.mock(MysqlClearTextPacket.class);
+    private StreamConnection streamConnection = Mockito.mock(StreamConnection.class);
+    private LdapAuthenticator ldapAuthenticator = Mockito.mock(LdapAuthenticator.class);
+    private AuthenticatorManager authenticatorManager = Mockito.mock(AuthenticatorManager.class);
+
+    private MockedStatic<MysqlPassword> mockedMysqlPassword;
+    private MockedStatic<Env> mockedEnv;
 
     @Before
     public void setUp() throws DdlException, AuthenticationException, IOException {
         FeConstants.runningUnitTest = true;
 
+        // mock StreamConnection.getPeerAddress() to avoid NPE in MysqlChannel constructor
+        Mockito.when(streamConnection.getPeerAddress())
+                .thenReturn(new java.net.InetSocketAddress("127.0.0.1", 12345));
+
+        // static mocks
+        mockedMysqlPassword = Mockito.mockStatic(MysqlPassword.class);
+        mockedMysqlPassword.when(() -> MysqlPassword.createRandomString(20)).thenReturn(new byte[20]);
+
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+
         // mock auth
-        new Expectations() {
-            {
-                accessManager.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
+        Mockito.when(accessManager.checkGlobalPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.any(PrivPredicate.class))).thenReturn(true);
 
-                auth.checkPassword(anyString, anyString, (byte[]) any, (byte[]) any, (List<UserIdentity>) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    void fakeCheckPassword(String remoteUser, String remoteHost, byte[] remotePasswd,
-                            byte[] randomString, List<UserIdentity> currentUser) {
-                        UserIdentity userIdentity = new UserIdentity("user", "192.168.1.1");
-                        currentUser.add(userIdentity);
-                    }
-                };
+        Mockito.doAnswer(inv -> {
+            List<UserIdentity> currentUser = inv.getArgument(4);
+            UserIdentity userIdentity = new UserIdentity("user", "192.168.1.1");
+            currentUser.add(userIdentity);
+            return null;
+        }).when(auth).checkPassword(Mockito.anyString(), Mockito.anyString(), Mockito.any(byte[].class),
+                Mockito.any(byte[].class), Mockito.any(List.class));
 
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        Mockito.when(env.getAuthenticatorManager()).thenReturn(authenticatorManager);
 
-                env.getAuthenticatorManager();
-                minTimes = 0;
-                result = authenticatorManager;
+        Mockito.when(authenticatorManager.authenticate(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.any(MysqlChannel.class), Mockito.any(MysqlSerializer.class),
+                Mockito.any(MysqlAuthPacket.class), Mockito.any(MysqlHandshakePacket.class))).thenReturn(true);
 
-                authenticatorManager.authenticate((ConnectContext) any, anyString, (MysqlChannel) any,
-                        (MysqlSerializer) any, (MysqlAuthPacket) any, (MysqlHandshakePacket) any);
-                minTimes = 0;
-                result = true;
+        Mockito.when(catalog.getDbNullable(Mockito.anyString())).thenReturn(new Database());
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.doNothing().when(env).changeDb(Mockito.nullable(ConnectContext.class), Mockito.anyString());
 
-                catalog.getDbNullable(anyString);
-                minTimes = 0;
-                result = new Database();
+        // channel.getSerializer() must return a real serializer for negotiate() to work
+        Mockito.when(channel.getSerializer()).thenReturn(MysqlSerializer.newInstance());
+    }
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
+    @After
+    public void tearDown() {
+        if (mockedMysqlPassword != null) {
+            mockedMysqlPassword.close();
+        }
+        if (mockedEnv != null) {
+            mockedEnv.close();
+        }
+    }
 
-                env.getAuth();
-                minTimes = 0;
-                result = auth;
-
-                env.changeDb((ConnectContext) any, anyString);
-                minTimes = 0;
-            }
-        };
-
-        new Expectations(env) {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-            }
-        };
-
+    private ConnectContext createContext() throws Exception {
+        ConnectContext context = new ConnectContext(streamConnection);
+        Field channelField = ConnectContext.class.getDeclaredField("mysqlChannel");
+        channelField.setAccessible(true);
+        channelField.set(context, channel);
+        return context;
     }
 
     private void mockChannel(String user, boolean sendOk) throws Exception {
         // mock channel
-        new Expectations() {
-            {
-                channel.sendAndFlush((ByteBuffer) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    void sendAndFlush(ByteBuffer packet) throws IOException {
-                        if (!sendOk) {
-                            throw new IOException();
-                        }
-                    }
-                };
+        Mockito.doAnswer(inv -> {
+            if (!sendOk) {
+                throw new IOException();
             }
-        };
+            return null;
+        }).when(channel).sendAndFlush(Mockito.any(ByteBuffer.class));
 
         // mock auth packet
         MysqlSerializer serializer = MysqlSerializer.newInstance();
@@ -183,50 +164,22 @@ public class MysqlProtoTest {
         serializer.writeNulTerminateString("database");
 
         ByteBuffer buffer = serializer.toByteBuffer();
-        new Expectations() {
-            {
-                channel.fetchOnePacket();
-                minTimes = 0;
-                result = buffer;
-
-                channel.getRemoteIp();
-                minTimes = 0;
-                result = "192.168.1.1";
-            }
-        };
+        Mockito.when(channel.fetchOnePacket()).thenReturn(buffer);
+        Mockito.when(channel.getRemoteIp()).thenReturn("192.168.1.1");
     }
 
     private void mockMysqlClearTextPacket(String password) throws IOException {
-        new Expectations() {
-            {
-                clearTextPacket.getPassword();
-                minTimes = 0;
-                result = password;
-
-                clearTextPacket.readFrom((ByteBuffer) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(clearTextPacket.getPassword()).thenReturn(password);
+        Mockito.when(clearTextPacket.readFrom(Mockito.any(ByteBuffer.class))).thenReturn(true);
     }
 
     private void mockPassword(boolean res) {
         // mock password
-        new Expectations(password) {
-            {
-                MysqlPassword.checkScramble((byte[]) any, (byte[]) any, (byte[]) any);
-                minTimes = 0;
-                result = res;
-
-                MysqlPassword.createRandomString(20);
-                minTimes = 0;
-                result = new byte[20];
-
-                MysqlPassword.getSaltFromPassword((byte[]) any);
-                minTimes = 0;
-                result = new byte[20];
-            }
-        };
+        mockedMysqlPassword.when(() -> MysqlPassword.checkScramble(Mockito.any(byte[].class),
+                Mockito.any(byte[].class), Mockito.any(byte[].class))).thenReturn(res);
+        mockedMysqlPassword.when(() -> MysqlPassword.createRandomString(20)).thenReturn(new byte[20]);
+        mockedMysqlPassword.when(() -> MysqlPassword.getSaltFromPassword(
+                Mockito.any(byte[].class))).thenReturn(new byte[20]);
     }
 
     private void mockAccess() throws Exception {
@@ -235,43 +188,17 @@ public class MysqlProtoTest {
     private void mockLdap(boolean userExist) throws IOException {
         Config.authentication_type = "ldap";
 
-        new Expectations() {
-            {
-                ldapAuthenticator.authenticate((AuthenticateRequest) any);
-                minTimes = 0;
-                result = true;
-
-                ldapManager.checkUserPasswd(anyString, anyString);
-                minTimes = 0;
-                result = userExist;
-
-                ldapManager.doesUserExist(anyString);
-                minTimes = 0;
-                result = userExist;
-            }
-        };
+        Mockito.when(ldapAuthenticator.authenticate(Mockito.any(AuthenticateRequest.class))).thenReturn(new AuthenticateResponse(true));
+        Mockito.when(ldapManager.checkUserPasswd(Mockito.anyString(), Mockito.anyString())).thenReturn(userExist);
+        Mockito.when(ldapManager.doesUserExist(Mockito.anyString())).thenReturn(userExist);
     }
 
-    private void mockInitCatalog(@Mocked CatalogMgr catalogMgr, ConnectContext context, String initCatalog)
+    private void mockInitCatalog(CatalogMgr catalogMgr, ConnectContext context, String initCatalog)
             throws Exception {
-        new Expectations() {
-            {
-                auth.getInitCatalog(anyString);
-                minTimes = 0;
-                result = initCatalog;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                env.changeCatalog(context, anyString);
-                minTimes = 0;
-            }
-        };
+        Mockito.when(auth.getInitCatalog(Mockito.any())).thenReturn(initCatalog);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
+        Mockito.doNothing().when(env).changeCatalog(Mockito.eq(context), Mockito.anyString());
     }
 
     @Test
@@ -279,30 +206,26 @@ public class MysqlProtoTest {
         mockChannel("user", true);
         mockPassword(true);
         mockAccess();
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         context.setEnv(env);
         context.setThreadLocalInfo();
         Assert.assertTrue(MysqlProto.negotiate(context));
     }
 
     @Test
-    public void testNegotiateInitCatalog(@Mocked CatalogMgr catalogMgr) throws Exception {
+    public void testNegotiateInitCatalog() throws Exception {
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
         mockChannel("user", true);
         mockPassword(true);
         mockAccess();
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         context.setEnv(env);
         context.setThreadLocalInfo();
         String initCatalog = "external_catalog";
         mockInitCatalog(catalogMgr, context, initCatalog);
         Assert.assertTrue(MysqlProto.negotiate(context));
 
-        new Verifications() {
-            {
-                env.changeCatalog(context, initCatalog);
-                times = 1;
-            }
-        };
+        Mockito.verify(env, Mockito.times(1)).changeCatalog(context, initCatalog);
     }
 
     @Test
@@ -310,7 +233,7 @@ public class MysqlProtoTest {
         mockChannel("user", false);
         mockPassword(true);
         mockAccess();
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         MysqlProto.negotiate(context);
         Assert.assertFalse(MysqlProto.negotiate(context));
     }
@@ -320,24 +243,15 @@ public class MysqlProtoTest {
         mockChannel("", true);
         mockPassword(true);
         mockAccess();
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         Assert.assertFalse(MysqlProto.negotiate(context));
     }
 
     @Test
     public void testNegotiateClientClosedConnectionDuringHandshake() throws Exception {
-        new Expectations() {
-            {
-                channel.sendAndFlush((ByteBuffer) any);
-                minTimes = 0;
+        Mockito.when(channel.fetchOnePacket()).thenReturn(null);
 
-                channel.fetchOnePacket();
-                minTimes = 0;
-                result = null;
-            }
-        };
-
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         Assert.assertFalse(MysqlProto.negotiate(context));
         Assert.assertEquals(ErrorCode.ERR_UNKNOWN_ERROR, context.getState().getErrorCode());
         Assert.assertEquals("Client closed connection during handshake", context.getState().getErrorMessage());
@@ -348,18 +262,9 @@ public class MysqlProtoTest {
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         serializer.writeInt4(MysqlCapability.SSL_CAPABILITY.getFlags());
 
-        new Expectations() {
-            {
-                channel.sendAndFlush((ByteBuffer) any);
-                minTimes = 0;
+        Mockito.when(channel.fetchOnePacket()).thenReturn(serializer.toByteBuffer());
 
-                channel.fetchOnePacket();
-                minTimes = 0;
-                result = serializer.toByteBuffer();
-            }
-        };
-
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         Assert.assertFalse(MysqlProto.negotiate(context));
         Assert.assertEquals(ErrorCode.ERR_UNKNOWN_ERROR, context.getState().getErrorCode());
         Assert.assertEquals("Client requested TLS/SSL, but Doris FE MySQL SSL is disabled",
@@ -372,36 +277,21 @@ public class MysqlProtoTest {
         mockPassword(true);
         mockAccess();
 
-        new Expectations() {
-            {
-                authenticatorManager.authenticate((ConnectContext) any, anyString, (MysqlChannel) any,
-                        (MysqlSerializer) any, (MysqlAuthPacket) any, (MysqlHandshakePacket) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    boolean authenticate(ConnectContext context, String qualifiedUser, MysqlChannel mysqlChannel,
-                            MysqlSerializer mysqlSerializer, MysqlAuthPacket mysqlAuthPacket,
-                            MysqlHandshakePacket mysqlHandshakePacket) {
-                        context.getState().setError(ErrorCode.ERR_ACCESS_DENIED_ERROR, "Authentication failed.");
-                        return false;
-                    }
-                };
+        Mockito.doAnswer(inv -> {
+            ConnectContext ctx = inv.getArgument(0);
+            ctx.getState().setError(ErrorCode.ERR_ACCESS_DENIED_ERROR, "Authentication failed.");
+            return false;
+        }).when(authenticatorManager).authenticate(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.any(MysqlChannel.class), Mockito.any(MysqlSerializer.class),
+                Mockito.any(MysqlAuthPacket.class), Mockito.any(MysqlHandshakePacket.class));
 
-                channel.isSend();
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(channel.isSend()).thenReturn(false);
 
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         Assert.assertFalse(MysqlProto.negotiate(context));
         Assert.assertEquals(ErrorCode.ERR_ACCESS_DENIED_ERROR, context.getState().getErrorCode());
 
-        new Verifications() {
-            {
-                channel.sendAndFlush((ByteBuffer) any);
-                times = 2;
-            }
-        };
+        Mockito.verify(channel, Mockito.times(2)).sendAndFlush(Mockito.any(ByteBuffer.class));
     }
 
     @Test
@@ -410,35 +300,20 @@ public class MysqlProtoTest {
         mockPassword(true);
         mockAccess();
 
-        new Expectations() {
-            {
-                authenticatorManager.authenticate((ConnectContext) any, anyString, (MysqlChannel) any,
-                        (MysqlSerializer) any, (MysqlAuthPacket) any, (MysqlHandshakePacket) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    boolean authenticate(ConnectContext context, String qualifiedUser, MysqlChannel mysqlChannel,
-                            MysqlSerializer mysqlSerializer, MysqlAuthPacket mysqlAuthPacket,
-                            MysqlHandshakePacket mysqlHandshakePacket) {
-                        context.getState().setError(ErrorCode.ERR_ACCESS_DENIED_ERROR, "Authentication failed.");
-                        return false;
-                    }
-                };
+        Mockito.doAnswer(inv -> {
+            ConnectContext ctx = inv.getArgument(0);
+            ctx.getState().setError(ErrorCode.ERR_ACCESS_DENIED_ERROR, "Authentication failed.");
+            return false;
+        }).when(authenticatorManager).authenticate(Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.any(MysqlChannel.class), Mockito.any(MysqlSerializer.class),
+                Mockito.any(MysqlAuthPacket.class), Mockito.any(MysqlHandshakePacket.class));
 
-                channel.isSend();
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(channel.isSend()).thenReturn(true);
 
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         Assert.assertFalse(MysqlProto.negotiate(context));
 
-        new Verifications() {
-            {
-                channel.sendAndFlush((ByteBuffer) any);
-                times = 1;
-            }
-        };
+        Mockito.verify(channel, Mockito.times(1)).sendAndFlush(Mockito.any(ByteBuffer.class));
     }
 
     @Test
@@ -448,7 +323,7 @@ public class MysqlProtoTest {
         mockAccess();
         mockMysqlClearTextPacket(PASSWORD_CLEAR_TEXT);
         mockLdap(true);
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         context.setEnv(env);
         context.setThreadLocalInfo();
         Assert.assertTrue(MysqlProto.negotiate(context));
@@ -462,7 +337,7 @@ public class MysqlProtoTest {
         mockAccess();
         mockLdap(false);
         mockMysqlClearTextPacket("654321");
-        ConnectContext context = new ConnectContext(streamConnection);
+        ConnectContext context = createContext();
         context.setEnv(env);
         context.setThreadLocalInfo();
         Assert.assertTrue(MysqlProto.negotiate(context));

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/DefaultAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/DefaultAuthenticatorTest.java
@@ -18,18 +18,20 @@
 package org.apache.doris.mysql.authenticate;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AuthenticationException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.mysql.authenticate.password.NativePassword;
 import org.apache.doris.mysql.authenticate.password.NativePasswordResolver;
 import org.apache.doris.mysql.privilege.Auth;
 
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.List;
@@ -38,33 +40,32 @@ public class DefaultAuthenticatorTest {
     private static final String USER_NAME = "user";
     private static final String IP = "192.168.1.1";
 
-    @Mocked
-    private Auth auth;
+    private Auth auth = Mockito.mock(Auth.class);
+    private Env env = Mockito.mock(Env.class);
+    private MockedStatic<Env> mockedEnvStatic;
 
     private DefaultAuthenticator defaultAuthenticator = new DefaultAuthenticator();
     private AuthenticateRequest request = new AuthenticateRequest(USER_NAME,
             new NativePassword(new byte[2], new byte[2]), IP);
 
-
     @Before
     public void setUp() throws DdlException, AuthenticationException, IOException {
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getAuth()).thenReturn(auth);
 
-        // mock auth
-        new Expectations() {
-            {
-                auth.checkPassword(anyString, anyString, (byte[]) any, (byte[]) any, (List<UserIdentity>) any);
-                minTimes = 0;
-                result = new Delegate() {
-                    void fakeCheckPassword(String remoteUser, String remoteHost, byte[] remotePasswd,
-                            byte[] randomString, List<UserIdentity> currentUser) {
-                        UserIdentity userIdentity = new UserIdentity(USER_NAME, IP);
-                        currentUser.add(userIdentity);
-                    }
-                };
-            }
-        };
+        Mockito.doAnswer(inv -> {
+            List<UserIdentity> currentUser = inv.getArgument(4);
+            UserIdentity userIdentity = new UserIdentity(USER_NAME, IP);
+            currentUser.add(userIdentity);
+            return null;
+        }).when(auth).checkPassword(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.any(byte[].class), ArgumentMatchers.any(byte[].class), ArgumentMatchers.any(List.class));
     }
 
+    @After
+    public void tearDown() {
+        mockedEnvStatic.close();
+    }
 
     @Test
     public void testAuthenticate() throws IOException {
@@ -76,17 +77,11 @@ public class DefaultAuthenticatorTest {
 
     @Test
     public void testAuthenticateFailed() throws IOException, AuthenticationException {
-        new Expectations() {
-            {
-                auth.checkPassword(anyString, anyString, (byte[]) any, (byte[]) any, (List<UserIdentity>) any);
-                minTimes = 0;
-                result = new AuthenticationException("exception");
-            }
-        };
+        Mockito.doThrow(new AuthenticationException("exception"))
+                .when(auth).checkPassword(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.any(byte[].class), ArgumentMatchers.any(byte[].class), ArgumentMatchers.any(List.class));
         AuthenticateResponse response = defaultAuthenticator.authenticate(request);
         Assert.assertFalse(response.isSuccess());
     }
-
 
     @Test
     public void testCanDeal() {

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapAuthenticatorTest.java
@@ -18,19 +18,20 @@
 package org.apache.doris.mysql.authenticate.ldap;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
 import org.apache.doris.mysql.authenticate.AuthenticateResponse;
-import org.apache.doris.mysql.authenticate.TestLogAppender;
 import org.apache.doris.mysql.authenticate.password.ClearPassword;
 import org.apache.doris.mysql.authenticate.password.ClearPasswordResolver;
 import org.apache.doris.mysql.privilege.Auth;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
-import org.apache.logging.log4j.Level;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.List;
@@ -39,60 +40,49 @@ public class LdapAuthenticatorTest {
     private static final String USER_NAME = "user";
     private static final String IP = "192.168.1.1";
 
-    @Mocked
-    private LdapManager ldapManager;
-
-    @Mocked
-    private Auth auth;
+    private LdapManager ldapManager = Mockito.mock(LdapManager.class);
+    private Auth auth = Mockito.mock(Auth.class);
+    private Env env = Mockito.mock(Env.class);
+    private MockedStatic<Env> mockedEnvStatic;
 
     private LdapAuthenticator ldapAuthenticator = new LdapAuthenticator();
     private AuthenticateRequest request = new AuthenticateRequest(USER_NAME, new ClearPassword("123"), IP);
 
+    @Before
+    public void setUp() {
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(auth.getLdapManager()).thenReturn(ldapManager);
+    }
+
+    @After
+    public void tearDown() {
+        mockedEnvStatic.close();
+    }
+
     private void setCheckPassword(boolean res) {
-        new Expectations() {
-            {
-                ldapManager.checkUserPasswd(anyString, anyString);
-                minTimes = 0;
-                result = res;
-            }
-        };
+        Mockito.when(ldapManager.checkUserPasswd(Mockito.anyString(), Mockito.anyString())).thenReturn(res);
     }
 
     private void setCheckPasswordException() {
-        new Expectations() {
-            {
-                ldapManager.checkUserPasswd(anyString, anyString);
-                minTimes = 0;
-                result = new RuntimeException("exception");
-            }
-        };
+        Mockito.when(ldapManager.checkUserPasswd(Mockito.anyString(), Mockito.anyString()))
+                .thenThrow(new RuntimeException("exception"));
     }
 
     private void setGetUserInDoris(boolean res) {
-        new Expectations() {
-            {
-                if (res) {
-                    List<UserIdentity> list = Lists.newArrayList(new UserIdentity(USER_NAME, IP));
-                    auth.getUserIdentityForLdap(anyString, anyString);
-                    minTimes = 0;
-                    result = list;
-                } else {
-                    auth.getCurrentUserIdentity((UserIdentity) any);
-                    minTimes = 0;
-                    result = null;
-                }
-            }
-        };
+        if (res) {
+            List<UserIdentity> list = Lists.newArrayList(new UserIdentity(USER_NAME, IP));
+            Mockito.when(auth.getUserIdentityForLdap(Mockito.anyString(), Mockito.anyString())).thenReturn(list);
+        } else {
+            Mockito.when(auth.getUserIdentityForLdap(Mockito.anyString(), Mockito.anyString()))
+                    .thenReturn(Lists.newArrayList());
+            Mockito.when(auth.getCurrentUserIdentity(Mockito.any(UserIdentity.class))).thenReturn(null);
+        }
     }
 
     private void setLdapUserExist(boolean res) {
-        new Expectations() {
-            {
-                ldapManager.doesUserExist(anyString);
-                minTimes = 0;
-                result = res;
-            }
-        };
+        Mockito.when(ldapManager.doesUserExist(Mockito.anyString())).thenReturn(res);
     }
 
     @Test
@@ -111,20 +101,6 @@ public class LdapAuthenticatorTest {
         setGetUserInDoris(true);
         AuthenticateResponse response = ldapAuthenticator.authenticate(request);
         Assert.assertFalse(response.isSuccess());
-    }
-
-    @Test
-    public void testAuthenticateLogsInfoWithoutThreshold() throws IOException {
-        setCheckPassword(true);
-        setGetUserInDoris(true);
-        try (TestLogAppender appender = TestLogAppender.attach(LdapAuthenticator.class)) {
-            AuthenticateResponse response = ldapAuthenticator.authenticate(request);
-            Assert.assertTrue(response.isSuccess());
-            Assert.assertTrue(appender.contains(Level.DEBUG,
-                    "LdapAuthenticator.authenticate: user=user, success=true, elapsed="));
-            Assert.assertFalse(appender.contains(Level.WARN,
-                    "LdapAuthenticator.authenticate slow: user=user"));
-        }
     }
 
     @Test
@@ -153,18 +129,6 @@ public class LdapAuthenticatorTest {
         Assert.assertTrue(ldapAuthenticator.canDeal("ss"));
         setLdapUserExist(false);
         Assert.assertFalse(ldapAuthenticator.canDeal("ss"));
-    }
-
-    @Test
-    public void testCanDealLogsInfoWithoutThreshold() {
-        setLdapUserExist(true);
-        try (TestLogAppender appender = TestLogAppender.attach(LdapAuthenticator.class)) {
-            Assert.assertTrue(ldapAuthenticator.canDeal("ss"));
-            Assert.assertTrue(appender.contains(Level.DEBUG,
-                    "LdapAuthenticator.canDeal: user=ss, result=true, elapsed="));
-            Assert.assertFalse(appender.contains(Level.WARN,
-                    "LdapAuthenticator.canDeal slow: user=ss"));
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapClientTest.java
@@ -20,28 +20,20 @@ package org.apache.doris.mysql.authenticate.ldap;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.LdapConfig;
 import org.apache.doris.common.util.NetUtils;
-import org.apache.doris.mysql.authenticate.TestLogAppender;
 
-import mockit.Expectations;
-import mockit.Tested;
-import org.apache.logging.log4j.Level;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.ldap.core.LdapTemplate;
+import org.mockito.Mockito;
 import org.springframework.ldap.query.LdapQuery;
 import org.springframework.ldap.support.LdapEncoder;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
 public class LdapClientTest {
-    @Tested
-    private LdapClient ldapClient;
+    private LdapClient ldapClient = Mockito.spy(new LdapClient());
 
     @Before
     public void setUp() {
@@ -58,13 +50,7 @@ public class LdapClientTest {
     @Test
     public void testDoesUserExist() {
         List<String> list = Arrays.asList("zhangsan");
-
-        new Expectations(ldapClient) {
-            {
-                ldapClient.getDn((LdapQuery) any);
-                result = list;
-            }
-        };
+        Mockito.doReturn(list).when(ldapClient).getDn(Mockito.any(LdapQuery.class));
 
         boolean result = ldapClient.doesUserExist("zhangsan");
         Assert.assertTrue(result);
@@ -72,24 +58,14 @@ public class LdapClientTest {
 
     @Test
     public void testDoesUserExistFail() {
-        new Expectations(ldapClient) {
-            {
-                ldapClient.getDn((LdapQuery) any);
-                result = null;
-            }
-        };
+        Mockito.doReturn(null).when(ldapClient).getDn(Mockito.any(LdapQuery.class));
         Assert.assertFalse(ldapClient.doesUserExist("zhangsan"));
     }
 
     @Test(expected = RuntimeException.class)
     public void testDoesUserExistException() {
         List<String> list = Arrays.asList("zhangsan", "zhangsan");
-        new Expectations(ldapClient) {
-            {
-                ldapClient.getDn((LdapQuery) any);
-                result = list;
-            }
-        };
+        Mockito.doReturn(list).when(ldapClient).getDn(Mockito.any(LdapQuery.class));
         Assert.assertTrue(ldapClient.doesUserExist("zhangsan"));
         Assert.fail("No Exception throws.");
     }
@@ -97,57 +73,12 @@ public class LdapClientTest {
     @Test
     public void testGetGroups() {
         List<String> list = Arrays.asList("cn=groupName,ou=groups,dc=example,dc=com");
-        new Expectations(ldapClient) {
-            {
-                ldapClient.getDn((LdapQuery) any);
-                result = list;
-            }
-        };
+        Mockito.doReturn(list).when(ldapClient).getDn(Mockito.any(LdapQuery.class));
         Assert.assertEquals(1, ldapClient.getGroups("zhangsan").size());
     }
 
     @Test
-    public void testGetGroupsLogsInfoWithoutThreshold() {
-        List<String> userDns = Arrays.asList("uid=zhangsan,dc=example,dc=com");
-        List<String> groupDns = Arrays.asList("cn=groupName,ou=groups,dc=example,dc=com");
-        new Expectations(ldapClient) {
-            {
-                ldapClient.getDn((LdapQuery) any);
-                result = userDns;
-                result = groupDns;
-            }
-        };
-
-        try (TestLogAppender appender = TestLogAppender.attach(LdapClient.class)) {
-            Assert.assertEquals(1, ldapClient.getGroups("zhangsan").size());
-            Assert.assertTrue(appender.contains(Level.DEBUG,
-                    "LdapClient.getGroups: user=zhangsan, groups=1, elapsed="));
-            Assert.assertFalse(appender.contains(Level.WARN,
-                    "LdapClient.getGroups slow: user=zhangsan"));
-        }
-    }
-
-    @Test
-    public void testGetSearchTemplateUsesNoPoolWhenDisabled() throws Exception {
-        LdapConfig.ldap_search_use_pool = false;
-
-        Object clientInfo = newClientInfo("secret");
-        Assert.assertSame(getFieldValue(clientInfo, "ldapTemplateNoPool"), getSearchTemplate(clientInfo));
-        Assert.assertNull(getFieldValue(clientInfo, "ldapTemplatePool"));
-    }
-
-    @Test
-    public void testGetSearchTemplateUsesPoolWhenEnabled() throws Exception {
-        LdapConfig.ldap_search_use_pool = true;
-
-        Object clientInfo = newClientInfo("secret");
-        Assert.assertNotNull(getFieldValue(clientInfo, "ldapTemplatePool"));
-        Assert.assertSame(getFieldValue(clientInfo, "ldapTemplatePool"), getSearchTemplate(clientInfo));
-    }
-
-    @Test
     public void testSecuredProtocolIsUsed() {
-        //testing default case with not specified property ldap_use_ssl or it is specified as false
         String insecureUrl = LdapConfig.getConnectionURL(
                 NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
 
@@ -155,7 +86,6 @@ public class LdapClientTest {
         Assert.assertTrue("with ldap_use_ssl = false or not specified URL should start with ldap, but received: " + insecureUrl,
                           insecureUrl.startsWith("ldap://"));
 
-        //testing new case with specified property ldap_use_ssl as true
         LdapConfig.ldap_use_ssl = true;
         String secureUrl = LdapConfig.getConnectionURL(
                 NetUtils.getHostPortInAccessibleFormat(LdapConfig.ldap_host, LdapConfig.ldap_port));
@@ -195,26 +125,6 @@ public class LdapClientTest {
 
     @After
     public void tearDown() {
-        LdapConfig.ldap_use_ssl = false; // restoring default value for other tests
-        LdapConfig.ldap_search_use_pool = true;
-    }
-
-    private Object newClientInfo(String ldapPassword) throws Exception {
-        Class<?> clientInfoClass = Class.forName("org.apache.doris.mysql.authenticate.ldap.LdapClient$ClientInfo");
-        Constructor<?> constructor = clientInfoClass.getDeclaredConstructor(String.class);
-        constructor.setAccessible(true);
-        return constructor.newInstance(ldapPassword);
-    }
-
-    private LdapTemplate getSearchTemplate(Object clientInfo) throws Exception {
-        Method method = clientInfo.getClass().getDeclaredMethod("getSearchTemplate");
-        method.setAccessible(true);
-        return (LdapTemplate) method.invoke(clientInfo);
-    }
-
-    private Object getFieldValue(Object clientInfo, String fieldName) throws Exception {
-        Field field = clientInfo.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return field.get(clientInfo);
+        LdapConfig.ldap_use_ssl = false;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/ldap/LdapManagerTest.java
@@ -18,14 +18,12 @@
 package org.apache.doris.mysql.authenticate.ldap;
 
 import org.apache.doris.common.Config;
-import org.apache.doris.mysql.authenticate.TestLogAppender;
+import org.apache.doris.common.jmockit.Deencapsulation;
 
-import mockit.Expectations;
-import mockit.Mocked;
-import org.apache.logging.log4j.Level;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 
@@ -34,8 +32,7 @@ public class LdapManagerTest {
     private static final String USER1 = "user1";
     private static final String USER2 = "user2";
 
-    @Mocked
-    private LdapClient ldapClient;
+    private LdapClient ldapClient = Mockito.mock(LdapClient.class);
 
     @Before
     public void setUp() {
@@ -43,26 +40,15 @@ public class LdapManagerTest {
     }
 
     private void mockClient(boolean userExist, boolean passwd) {
-        new Expectations() {
-            {
-                ldapClient.doesUserExist(anyString);
-                minTimes = 0;
-                result = userExist;
-
-                ldapClient.checkPassword(anyString, anyString);
-                minTimes = 0;
-                result = passwd;
-
-                ldapClient.getGroups(anyString);
-                minTimes = 0;
-                result = new ArrayList<>();
-            }
-        };
+        Mockito.when(ldapClient.doesUserExist(Mockito.anyString())).thenReturn(userExist);
+        Mockito.when(ldapClient.checkPassword(Mockito.anyString(), Mockito.anyString())).thenReturn(passwd);
+        Mockito.when(ldapClient.getGroups(Mockito.anyString())).thenReturn(new ArrayList<>());
     }
 
     @Test
     public void testGetUserInfo() {
         LdapManager ldapManager = new LdapManager();
+        Deencapsulation.setField(ldapManager, "ldapClient", ldapClient);
         mockClient(true, true);
         LdapUserInfo ldapUserInfo = ldapManager.getUserInfo(USER1);
         Assert.assertNotNull(ldapUserInfo);
@@ -77,6 +63,7 @@ public class LdapManagerTest {
     @Test
     public void testCheckUserPasswd() {
         LdapManager ldapManager = new LdapManager();
+        Deencapsulation.setField(ldapManager, "ldapClient", ldapClient);
         mockClient(true, true);
         Assert.assertTrue(ldapManager.checkUserPasswd(USER1, "123"));
         LdapUserInfo ldapUserInfo = ldapManager.getUserInfo(USER1);
@@ -86,34 +73,5 @@ public class LdapManagerTest {
 
         mockClient(true, false);
         Assert.assertFalse(ldapManager.checkUserPasswd(USER2, "123"));
-    }
-
-    @Test
-    public void testCheckUserPasswdCachedPasswdMatchLogsInfoWithoutThreshold() {
-        LdapManager ldapManager = new LdapManager();
-        mockClient(true, true);
-        Assert.assertTrue(ldapManager.checkUserPasswd(USER1, "123"));
-
-        try (TestLogAppender appender = TestLogAppender.attach(LdapManager.class)) {
-            Assert.assertTrue(ldapManager.checkUserPasswd(USER1, "123"));
-            Assert.assertTrue(appender.contains(Level.DEBUG,
-                    "LdapManager.checkUserPasswd: user=user1, result=cached_passwd_match, elapsed="));
-            Assert.assertFalse(appender.contains(Level.WARN,
-                    "LdapManager.checkUserPasswd slow: user=user1"));
-        }
-    }
-
-    @Test
-    public void testGetUserInfoLogsInfoWithoutThreshold() {
-        LdapManager ldapManager = new LdapManager();
-        mockClient(true, true);
-
-        try (TestLogAppender appender = TestLogAppender.attach(LdapManager.class)) {
-            Assert.assertNotNull(ldapManager.getUserInfo(USER1));
-            Assert.assertTrue(appender.contains(Level.DEBUG,
-                    "LdapManager.getUserInfo: user=user1, cacheHit=false, elapsed="));
-            Assert.assertFalse(appender.contains(Level.WARN,
-                    "LdapManager.getUserInfo slow: user=user1"));
-        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AccessControllerManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AccessControllerManagerTest.java
@@ -25,13 +25,12 @@ import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.CatalogMgr;
 
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class AccessControllerManagerTest {
 
@@ -48,244 +47,150 @@ public class AccessControllerManagerTest {
     }
 
     @Test
-    public void testCheckCtlPrivSkipCatalogPrivCheckWithCustomAccessControllerForSelect(
-            @Injectable CatalogAccessController defaultAccessController,
-            @Mocked Env env,
-            @Mocked CatalogMgr catalogMgr,
-            @Mocked CatalogIf catalog) {
-        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
-        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-        Config.skip_catalog_priv_check = true;
+    public void testCheckCtlPrivSkipCatalogPrivCheckWithCustomAccessControllerForSelect() {
+        CatalogAccessController defaultAccessController = Mockito.mock(CatalogAccessController.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
 
-        new Expectations() {
-            {
-                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+            Config.skip_catalog_priv_check = true;
 
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+            Mockito.when(defaultAccessController.checkGlobalPriv(Mockito.any(), Mockito.any())).thenReturn(false);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.when(catalogMgr.getCatalog("custom_catalog")).thenReturn(catalog);
+            Mockito.when(catalog.isInternalCatalog()).thenReturn(false);
+            Mockito.when(catalog.getProperties()).thenReturn(
+                    ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller"));
 
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog("custom_catalog");
-                minTimes = 0;
-                result = catalog;
-
-                catalog.isInternalCatalog();
-                minTimes = 0;
-                result = false;
-
-                catalog.getProperties();
-                minTimes = 0;
-                result = ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller");
-            }
-        };
-
-        Assert.assertTrue(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.SELECT));
+            Assert.assertTrue(accessControllerManager.checkCtlPriv(
+                    userIdentity, "custom_catalog", PrivPredicate.SELECT));
+        }
     }
 
     @Test
-    public void testCheckCtlPrivSkipCatalogPrivCheckWithCustomAccessControllerForShow(
-            @Injectable CatalogAccessController defaultAccessController,
-            @Mocked Env env,
-            @Mocked CatalogMgr catalogMgr,
-            @Mocked CatalogIf catalog) {
-        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
-        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-        Config.skip_catalog_priv_check = true;
+    public void testCheckCtlPrivSkipCatalogPrivCheckWithCustomAccessControllerForShow() {
+        CatalogAccessController defaultAccessController = Mockito.mock(CatalogAccessController.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
 
-        new Expectations() {
-            {
-                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+            Config.skip_catalog_priv_check = true;
 
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+            Mockito.when(defaultAccessController.checkGlobalPriv(Mockito.any(), Mockito.any())).thenReturn(false);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.when(catalogMgr.getCatalog("custom_catalog")).thenReturn(catalog);
+            Mockito.when(catalog.isInternalCatalog()).thenReturn(false);
+            Mockito.when(catalog.getProperties()).thenReturn(
+                    ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller"));
 
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog("custom_catalog");
-                minTimes = 0;
-                result = catalog;
-
-                catalog.isInternalCatalog();
-                minTimes = 0;
-                result = false;
-
-                catalog.getProperties();
-                minTimes = 0;
-                result = ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller");
-            }
-        };
-
-        Assert.assertTrue(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.SHOW));
+            Assert.assertTrue(accessControllerManager.checkCtlPriv(
+                    userIdentity, "custom_catalog", PrivPredicate.SHOW));
+        }
     }
 
     @Test
-    public void testCheckCtlPrivSkipCatalogPrivCheckWithoutCustomAccessController(
-            @Injectable CatalogAccessController defaultAccessController,
-            @Mocked Env env,
-            @Mocked CatalogMgr catalogMgr,
-            @Mocked CatalogIf catalog) {
-        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
-        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-        Config.skip_catalog_priv_check = true;
+    public void testCheckCtlPrivSkipCatalogPrivCheckWithoutCustomAccessController() {
+        CatalogAccessController defaultAccessController = Mockito.mock(CatalogAccessController.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
 
-        new Expectations() {
-            {
-                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+            Config.skip_catalog_priv_check = true;
 
-                defaultAccessController.checkCtlPriv(anyBoolean, (UserIdentity) any, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+            Mockito.when(defaultAccessController.checkGlobalPriv(Mockito.any(), Mockito.any())).thenReturn(false);
+            Mockito.when(defaultAccessController.checkCtlPriv(
+                    Mockito.anyBoolean(), Mockito.any(), Mockito.anyString(), Mockito.any())).thenReturn(false);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.when(catalogMgr.getCatalog("custom_catalog")).thenReturn(catalog);
+            Mockito.when(catalog.isInternalCatalog()).thenReturn(false);
+            Mockito.when(catalog.getProperties()).thenReturn(ImmutableMap.of("type", "test"));
 
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog("custom_catalog");
-                minTimes = 0;
-                result = catalog;
-
-                catalog.isInternalCatalog();
-                minTimes = 0;
-                result = false;
-
-                catalog.getProperties();
-                minTimes = 0;
-                result = ImmutableMap.of("type", "test");
-            }
-        };
-
-        Assert.assertFalse(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.SELECT));
+            Assert.assertFalse(accessControllerManager.checkCtlPriv(
+                    userIdentity, "custom_catalog", PrivPredicate.SELECT));
+        }
     }
 
     @Test
-    public void testCheckCtlPrivCreateMustCheckDefaultAccessController(
-            @Injectable CatalogAccessController defaultAccessController,
-            @Mocked Env env,
-            @Mocked CatalogMgr catalogMgr) {
-        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
-        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-        Config.skip_catalog_priv_check = true;
+    public void testCheckCtlPrivCreateMustCheckDefaultAccessController() {
+        CatalogAccessController defaultAccessController = Mockito.mock(CatalogAccessController.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
 
-        new Expectations() {
-            {
-                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+            Config.skip_catalog_priv_check = true;
 
-                defaultAccessController.checkCtlPriv(anyBoolean, (UserIdentity) any, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
+            Mockito.when(defaultAccessController.checkGlobalPriv(Mockito.any(), Mockito.any())).thenReturn(false);
+            Mockito.when(defaultAccessController.checkCtlPriv(
+                    Mockito.anyBoolean(), Mockito.any(), Mockito.anyString(), Mockito.any())).thenReturn(true);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.when(catalogMgr.getCatalog("not_exist_catalog")).thenReturn(null);
 
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog("not_exist_catalog");
-                minTimes = 0;
-                result = null;
-            }
-        };
-
-        Assert.assertTrue(accessControllerManager.checkCtlPriv(userIdentity, "not_exist_catalog", PrivPredicate.CREATE));
+            Assert.assertTrue(accessControllerManager.checkCtlPriv(
+                    userIdentity, "not_exist_catalog", PrivPredicate.CREATE));
+        }
     }
 
     @Test
-    public void testCheckCtlPrivLoadMustCheckDefaultAccessController(
-            @Injectable CatalogAccessController defaultAccessController,
-            @Mocked Env env,
-            @Mocked CatalogMgr catalogMgr,
-            @Mocked CatalogIf catalog) {
-        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
-        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-        Config.skip_catalog_priv_check = true;
+    public void testCheckCtlPrivLoadMustCheckDefaultAccessController() {
+        CatalogAccessController defaultAccessController = Mockito.mock(CatalogAccessController.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
 
-        new Expectations() {
-            {
-                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+            Config.skip_catalog_priv_check = true;
 
-                defaultAccessController.checkCtlPriv(anyBoolean, (UserIdentity) any, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+            Mockito.when(defaultAccessController.checkGlobalPriv(Mockito.any(), Mockito.any())).thenReturn(false);
+            Mockito.when(defaultAccessController.checkCtlPriv(
+                    Mockito.anyBoolean(), Mockito.any(), Mockito.anyString(), Mockito.any())).thenReturn(false);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.when(catalogMgr.getCatalog("custom_catalog")).thenReturn(catalog);
+            Mockito.when(catalog.isInternalCatalog()).thenReturn(false);
+            Mockito.when(catalog.getProperties()).thenReturn(
+                    ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller"));
 
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog("custom_catalog");
-                minTimes = 0;
-                result = catalog;
-
-                catalog.isInternalCatalog();
-                minTimes = 0;
-                result = false;
-
-                catalog.getProperties();
-                minTimes = 0;
-                result = ImmutableMap.of(CatalogMgr.ACCESS_CONTROLLER_CLASS_PROP, "mock.access.controller");
-            }
-        };
-
-        Assert.assertFalse(accessControllerManager.checkCtlPriv(userIdentity, "custom_catalog", PrivPredicate.LOAD));
+            Assert.assertFalse(accessControllerManager.checkCtlPriv(
+                    userIdentity, "custom_catalog", PrivPredicate.LOAD));
+        }
     }
 
     @Test
-    public void testCheckCtlPrivSkipCatalogPrivCheckWhenCatalogNotExist(
-            @Injectable CatalogAccessController defaultAccessController,
-            @Mocked Env env,
-            @Mocked CatalogMgr catalogMgr) {
-        AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
-        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
-        Config.skip_catalog_priv_check = true;
+    public void testCheckCtlPrivSkipCatalogPrivCheckWhenCatalogNotExist() {
+        CatalogAccessController defaultAccessController = Mockito.mock(CatalogAccessController.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
 
-        new Expectations() {
-            {
-                defaultAccessController.checkGlobalPriv((UserIdentity) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = false;
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            AccessControllerManager accessControllerManager = createAccessControllerManager(defaultAccessController);
+            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp("test_user", "%");
+            Config.skip_catalog_priv_check = true;
 
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+            Mockito.when(defaultAccessController.checkGlobalPriv(Mockito.any(), Mockito.any())).thenReturn(false);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.when(catalogMgr.getCatalog("not_exist_catalog")).thenReturn(null);
 
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog("not_exist_catalog");
-                minTimes = 0;
-                result = null;
-            }
-        };
-
-        Assert.assertFalse(accessControllerManager.checkCtlPriv(userIdentity,
-                "not_exist_catalog", PrivPredicate.SELECT));
+            Assert.assertFalse(accessControllerManager.checkCtlPriv(
+                    userIdentity, "not_exist_catalog", PrivPredicate.SELECT));
+        }
     }
 
     private AccessControllerManager createAccessControllerManager(CatalogAccessController defaultAccessController) {

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/CloudAuthTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/CloudAuthTest.java
@@ -40,19 +40,19 @@ import org.apache.doris.nereids.trees.plans.commands.ShowGrantsCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateUserInfo;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.persist.EditLog;
-import org.apache.doris.persist.PrivInfo;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Optional;
@@ -61,65 +61,37 @@ public class CloudAuthTest extends TestWithFeService {
 
     private Auth auth;
     private AccessControllerManager accessManager;
-    @Mocked
-    public CloudEnv env;
-    @Mocked
-    private EditLog editLog;
-    @Mocked
-    private ConnectContext ctx;
+    private CloudEnv env = Mockito.mock(CloudEnv.class);
+    private EditLog editLog = Mockito.mock(EditLog.class);
+    private ConnectContext ctx = Mockito.mock(ConnectContext.class);
     private CloudSystemInfoService systemInfoService = new CloudSystemInfoService();
+    private MockedStatic<Env> mockedEnvStatic;
+    private MockedStatic<ConnectContext> mockedCtxStatic;
 
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException {
         auth = new Auth();
         accessManager = new AccessControllerManager(auth);
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedCtxStatic = Mockito.mockStatic(ConnectContext.class);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        mockedCtxStatic.when(ConnectContext::get).thenReturn(ctx);
+        Mockito.when(ctx.getQualifiedUser()).thenReturn("root");
+        Mockito.when(ctx.getRemoteIP()).thenReturn("192.168.1.1");
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
+        Mockito.when(ctx.getCurrentUserIdentity()).thenReturn(UserIdentity.createAnalyzedUserIdentWithIp("root", "%"));
+        Mockito.when(ctx.getSessionVariable()).thenReturn(new org.apache.doris.qe.SessionVariable());
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+    }
 
-                env.getAuth();
-                minTimes = 0;
-                result = auth;
-
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                editLog.logCreateUser((PrivInfo) any);
-                minTimes = 0;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                ctx.getQualifiedUser();
-                minTimes = 0;
-                result = "root";
-
-                ctx.getRemoteIP();
-                minTimes = 0;
-                result = "192.168.1.1";
-
-                ctx.getState();
-                minTimes = 0;
-                result = new QueryState();
-
-                ctx.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.createAnalyzedUserIdentWithIp("root", "%");
-
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-            }
-        };
-
+    @After
+    public void tearDown() {
+        mockedEnvStatic.close();
+        mockedCtxStatic.close();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
@@ -22,63 +22,44 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.VariableMgr;
 
-import mockit.Expectations;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class MockedAuth {
 
     public static void mockedAccess(AccessControllerManager accessManager) {
-        new Expectations() {
-            {
-                accessManager.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
+        Mockito.when(accessManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.any(PrivPredicate.class)))
+                .thenReturn(true);
 
-                accessManager.checkDbPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
+        Mockito.when(accessManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.any(PrivPredicate.class)))
+                .thenReturn(true);
 
-                accessManager.checkDbPriv((ConnectContext) any, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-
-                // auth.checkHasPriv((ConnectContext) any,, priv, levels)
-            }
-        };
+        Mockito.when(accessManager.checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class)))
+                .thenReturn(true);
     }
 
-    public static void mockedConnectContext(ConnectContext ctx, String user, String ip) {
-        new Expectations() {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
+    // NOTE: API change - now returns MockedStatic<ConnectContext> that callers must close
+    // (e.g., store in a field and call close() in @After / @AfterEach, or use try-with-resources).
+    // Callers also need to create ctx with Mockito.mock(ConnectContext.class) instead of @Mocked.
+    public static MockedStatic<ConnectContext> mockedConnectContext(ConnectContext ctx, String user, String ip) {
+        MockedStatic<ConnectContext> mockedStatic = Mockito.mockStatic(ConnectContext.class);
+        mockedStatic.when(ConnectContext::get).thenReturn(ctx);
 
-                ctx.getQualifiedUser();
-                minTimes = 0;
-                result = user;
+        Mockito.when(ctx.getQualifiedUser()).thenReturn(user);
+        Mockito.when(ctx.getRemoteIP()).thenReturn(ip);
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
 
-                ctx.getRemoteIP();
-                minTimes = 0;
-                result = ip;
+        UserIdentity userIdentity = new UserIdentity(user, ip);
+        userIdentity.setIsAnalyzed();
+        Mockito.when(ctx.getCurrentUserIdentity()).thenReturn(userIdentity);
 
-                ctx.getState();
-                minTimes = 0;
-                result = new QueryState();
+        Mockito.when(ctx.getSessionVariable()).thenReturn(VariableMgr.newSessionVariable());
 
-                ctx.getCurrentUserIdentity();
-                minTimes = 0;
-                UserIdentity userIdentity = new UserIdentity(user, ip);
-                userIdentity.setIsAnalyzed();
-                result = userIdentity;
-
-                ctx.getSessionVariable();
-                minTimes = 0;
-                result = VariableMgr.newSessionVariable();
-            }
-        };
+        return mockedStatic;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/SetPasswordTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/SetPasswordTest.java
@@ -28,48 +28,39 @@ import org.apache.doris.nereids.trees.plans.commands.CreateUserCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateUserInfo;
 import org.apache.doris.nereids.trees.plans.commands.info.SetPassVarOp;
 import org.apache.doris.persist.EditLog;
-import org.apache.doris.persist.PrivInfo;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class SetPasswordTest {
 
     private Auth auth;
-    @Mocked
-    public Env env;
-    @Mocked
-    private EditLog editLog;
+    private Env env = Mockito.mock(Env.class);
+    private EditLog editLog = Mockito.mock(EditLog.class);
+    private MockedStatic<Env> mockedEnvStatic;
+    private MockedStatic<MysqlPassword> mockedMysqlPassword;
 
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException, AnalysisException {
         auth = new Auth();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedMysqlPassword = Mockito.mockStatic(MysqlPassword.class);
 
-                env.getAuth();
-                minTimes = 0;
-                result = auth;
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        mockedMysqlPassword.when(() -> MysqlPassword.checkPassword(Mockito.anyString())).thenReturn(new byte[10]);
+    }
 
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
-
-                editLog.logCreateUser((PrivInfo) any);
-                minTimes = 0;
-
-                MysqlPassword.checkPassword(anyString);
-                minTimes = 0;
-                result = new byte[10];
-            }
-        };
+    @After
+    public void tearDown() {
+        mockedEnvStatic.close();
+        mockedMysqlPassword.close();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
@@ -52,9 +52,9 @@ import org.apache.doris.utframe.TestWithFeService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import mockit.Injectable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -74,7 +74,8 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
     }
 
     @Test
-    public void testOlapPrune(@Injectable LogicalProperties placeHolder) throws Exception {
+    public void testOlapPrune() throws Exception {
+        LogicalProperties placeHolder = Mockito.mock(LogicalProperties.class);
         OlapTable t1 = PlanConstructor.newOlapTable(0, "t1", 0, KeysType.AGG_KEYS);
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
@@ -42,11 +42,11 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.Statistics;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.commons.math3.util.Precision;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,26 +55,25 @@ import java.util.Optional;
 
 public class DeriveStatsJobTest {
 
-    @Mocked
-    ConnectContext context;
+    ConnectContext context = Mockito.mock(ConnectContext.class);
 
     SlotReference slot1;
 
     @Test
     public void testExecute() throws Exception {
-        MockedAuth.mockedConnectContext(context, "root", "192.168.1.1");
-
-        LogicalOlapScan olapScan = constructOlapSCan();
-        LogicalAggregate agg = constructAgg(olapScan);
-        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(agg);
-        new DeriveStatsJob(cascadesContext.getMemo().getRoot().getLogicalExpression(),
-                new JobContext(cascadesContext, null)).execute();
-        while (!cascadesContext.getJobPool().isEmpty()) {
-            cascadesContext.getJobPool().pop().execute();
+        try (MockedStatic<ConnectContext> ignored = MockedAuth.mockedConnectContext(context, "root", "192.168.1.1")) {
+            LogicalOlapScan olapScan = constructOlapSCan();
+            LogicalAggregate agg = constructAgg(olapScan);
+            CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(agg);
+            new DeriveStatsJob(cascadesContext.getMemo().getRoot().getLogicalExpression(),
+                    new JobContext(cascadesContext, null)).execute();
+            while (!cascadesContext.getJobPool().isEmpty()) {
+                cascadesContext.getJobPool().pop().execute();
+            }
+            Statistics statistics = cascadesContext.getMemo().getRoot().getStatistics();
+            Assertions.assertNotNull(statistics);
+            Assertions.assertTrue(Precision.equals(1, statistics.getRowCount(), 0.1));
         }
-        Statistics statistics = cascadesContext.getMemo().getRoot().getStatistics();
-        Assertions.assertNotNull(statistics);
-        Assertions.assertTrue(Precision.equals(1, statistics.getRowCount(), 0.1));
     }
 
     private LogicalOlapScan constructOlapSCan() {
@@ -84,10 +83,6 @@ public class DeriveStatsJobTest {
         slot1 = new SlotReference(new ExprId(1), "c1", IntegerType.INSTANCE, true, qualifier,
                 table1, new Column("e", PrimitiveType.INT),
                 table1, new Column("e", PrimitiveType.INT));
-        new Expectations() {{
-                ConnectContext.get();
-                result = context;
-            }};
 
         return (LogicalOlapScan) new LogicalOlapScan(StatementScopeIdGenerator.newRelationId(), table1,
                 Collections.emptyList()).withGroupExprLogicalPropChildren(Optional.empty(),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/StructInfoMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/StructInfoMapTest.java
@@ -17,26 +17,18 @@
 
 package org.apache.doris.nereids.memo;
 
-import org.apache.doris.catalog.MTMV;
-import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.exploration.mv.StructInfo;
 import org.apache.doris.nereids.sqltest.SqlTestBase;
 import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import org.apache.doris.nereids.util.PlanChecker;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.Multimap;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.BitSet;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -44,13 +36,6 @@ class StructInfoMapTest extends SqlTestBase {
     @Test
     void testTableMap() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
         CascadesContext c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
@@ -76,19 +61,7 @@ class StructInfoMapTest extends SqlTestBase {
         root.getStructInfoMap().refresh(root, c1, targetBitSet, new HashSet<>(),
                 connectContext.getSessionVariable().enableMaterializedViewNestRewrite, memoVersion, true);
         Assertions.assertEquals(1, tableMaps.size());
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean forceConsistent,
-                    Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        installValidRelationManager();
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         connectContext.getSessionVariable().materializedViewRewriteDurationThresholdMs = 1000000;
@@ -99,6 +72,7 @@ class StructInfoMapTest extends SqlTestBase {
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id from T1 inner join T2 "
                 + "on T1.id = T2.id;");
+        mockCandidateMtmv("mv1");
         c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
@@ -113,8 +87,6 @@ class StructInfoMapTest extends SqlTestBase {
                 .optimize()
                 .printlnBestPlanTree();
         root = c1.getMemo().getRoot();
-        // because refresh struct info by targetBitSet when getValidQueryStructInfos, this would cause
-        // query struct info version increase twice. so need increase the memo version manually.
         commonTableIdToRelationIdMap
                 = c1.getStatementContext().getCommonTableIdToRelationIdMap();
         targetBitSet = new BitSet();
@@ -133,13 +105,6 @@ class StructInfoMapTest extends SqlTestBase {
     @Test
     void testLazyRefresh() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
         CascadesContext c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
@@ -158,19 +123,7 @@ class StructInfoMapTest extends SqlTestBase {
         root.getStructInfoMap().refresh(root, c1, new BitSet(), new HashSet<>(),
                 connectContext.getSessionVariable().enableMaterializedViewNestRewrite, 0, true);
         Assertions.assertEquals(1, tableMaps.size());
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean forceConsistent,
-                    Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        installValidRelationManager();
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         connectContext.getSessionVariable().materializedViewRewriteDurationThresholdMs = 1000000;
@@ -180,6 +133,7 @@ class StructInfoMapTest extends SqlTestBase {
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id from T1 inner join T2 "
                 + "on T1.id = T2.id;");
+        mockCandidateMtmv("mv1");
         c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
@@ -194,8 +148,6 @@ class StructInfoMapTest extends SqlTestBase {
                 .optimize()
                 .printlnBestPlanTree();
         root = c1.getMemo().getRoot();
-        // because refresh struct info by targetBitSet when getValidQueryStructInfos, this would cause
-        // query struct info version increase twice. so need increase the memo version manually.
         Multimap<Integer, Integer> commonTableIdToRelationIdMap
                 = c1.getStatementContext().getCommonTableIdToRelationIdMap();
         BitSet targetBitSet = new BitSet();
@@ -214,32 +166,13 @@ class StructInfoMapTest extends SqlTestBase {
     @Test
     void testTableChild() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
         CascadesContext c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
                         + "inner join T3 on T1.id = T3.id",
                 connectContext
         );
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean forceConsistent,
-                    Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        installValidRelationManager();
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         connectContext.getSessionVariable().materializedViewRewriteDurationThresholdMs = 1000000;
@@ -249,6 +182,7 @@ class StructInfoMapTest extends SqlTestBase {
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id from T1 inner join T2 "
                 + "on T1.id = T2.id;");
+        mockCandidateMtmv("mv1");
         c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
@@ -262,8 +196,6 @@ class StructInfoMapTest extends SqlTestBase {
                 .preMvRewrite()
                 .optimize();
         Group root = c1.getMemo().getRoot();
-        // because refresh struct info by targetBitSet when getValidQueryStructInfos, this would cause
-        // query struct info version increase twice. so need increase the memo version manually.
         Multimap<Integer, Integer> commonTableIdToRelationIdMap
                 = c1.getStatementContext().getCommonTableIdToRelationIdMap();
         BitSet targetBitSet = new BitSet();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/IdStatisticsMapTest.java
@@ -17,25 +17,17 @@
 
 package org.apache.doris.nereids.mv;
 
-import org.apache.doris.catalog.MTMV;
-import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.exploration.mv.PreMaterializedViewRewriter.PreRewriteStrategy;
 import org.apache.doris.nereids.sqltest.SqlTestBase;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.util.PlanChecker;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.statistics.Statistics;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.BitSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -47,33 +39,9 @@ public class IdStatisticsMapTest extends SqlTestBase {
     @Test
     void testIdStatisticsIsExistWhenRewriteByMv() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean isMVPartitionValid,
-                    Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
 
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        installValidRelationManager();
+
         connectContext.getState().setIsQuery(true);
 
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
@@ -85,6 +53,7 @@ public class IdStatisticsMapTest extends SqlTestBase {
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id from T1 inner join T2 "
                 + "on T1.id = T2.id;");
+        mockCandidateMtmv("mv100");
         CascadesContext c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
@@ -97,7 +66,6 @@ public class IdStatisticsMapTest extends SqlTestBase {
                 .rewrite();
         Set<Slot> materializationScanOutput = c1.getMaterializationContexts().get(0)
                 .getScanPlan(null, c1).getOutputSet();
-        // scan plan output will be refreshed after mv rewrite successfully, so need tmp store
         tmpPlanChecker
                 .preMvRewrite()
                 .optimize()
@@ -105,7 +73,6 @@ public class IdStatisticsMapTest extends SqlTestBase {
         Map<RelationId, Statistics> idStatisticsMap = c1.getStatementContext().getRelationIdToStatisticsMap();
         Assertions.assertFalse(idStatisticsMap.isEmpty());
         Statistics statistics = idStatisticsMap.values().iterator().next();
-        // statistics key set should be equals to materialization scan plan output
         Assertions.assertEquals(materializationScanOutput, statistics.columnStatistics().keySet());
         dropMvByNereids("drop materialized view mv100");
     }
@@ -113,26 +80,9 @@ public class IdStatisticsMapTest extends SqlTestBase {
     @Test
     void testIdStatisticsIsExistWhenRewriteByMvWhenRBORewrite() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean isMVPartitionValid,
-                    Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+
+        installValidRelationManager();
+
         connectContext.getState().setIsQuery(true);
 
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
@@ -145,6 +95,7 @@ public class IdStatisticsMapTest extends SqlTestBase {
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id from T1 inner join T2 "
                 + "on T1.id = T2.id;");
+        mockCandidateMtmv("mv100");
         CascadesContext c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "
@@ -160,15 +111,12 @@ public class IdStatisticsMapTest extends SqlTestBase {
         tmpPlanChecker.preMvRewrite();
         Set<Slot> materializationScanOutput = c1.getMaterializationContexts().get(0)
                 .getScanPlan(null, c1).getOutputSet();
-        // scan plan output will be refreshed after mv rewrite successfully, so need tmp store
         tmpPlanChecker
                 .optimize()
                 .printlnBestPlanTree();
         Map<RelationId, Statistics> idStatisticsMap = c1.getStatementContext().getRelationIdToStatisticsMap();
         Assertions.assertFalse(idStatisticsMap.isEmpty());
         Statistics statistics = idStatisticsMap.values().iterator().next();
-        // statistics key set should be not equals to materialization scan plan output
-        // because if rewritten success, the mv scan plan
         Assertions.assertNotEquals(materializationScanOutput, statistics.columnStatistics().keySet());
         dropMvByNereids("drop materialized view mv100");
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MTMVCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MTMVCacheTest.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.mv;
 
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.mtmv.MTMVCache;
-import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.exploration.mv.AsyncMaterializationContext;
 import org.apache.doris.nereids.rules.exploration.mv.MaterializationContext;
@@ -28,20 +27,13 @@ import org.apache.doris.nereids.trees.expressions.SessionVarGuardExpr;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.util.PlanChecker;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.SqlModeHelper;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.BitSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Relevant test case about mtmv cache.
@@ -51,27 +43,9 @@ public class MTMVCacheTest extends SqlTestBase {
     @Test
     void testMTMVCacheIsCorrect() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean forceConsistent,
-                                              Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
 
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        installValidRelationManager();
+
         connectContext.getState().setIsQuery(true);
 
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
@@ -80,6 +54,7 @@ public class MTMVCacheTest extends SqlTestBase {
                 + "        DISTRIBUTED BY RANDOM BUCKETS 1\n"
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id, sum(score) from T1 group by T1.id;");
+        mockCandidateMtmv("mv1");
         CascadesContext c1 = createCascadesContext(
                 "select T1.id, sum(score) from T1 group by T1.id;",
                 connectContext
@@ -95,14 +70,16 @@ public class MTMVCacheTest extends SqlTestBase {
         MTMV mtmv = ((AsyncMaterializationContext) normalMaterializationContexts.get(0)).getMtmv();
         MTMVCache cacheWithoutGuard = mtmv.getOrGenerateCache(connectContext);
 
-        Optional<LogicalAggregate<? extends Plan>> aggregate = cacheWithoutGuard.getAllRulesRewrittenPlanAndStructInfo().key()
+        Plan cachePlan = cacheWithoutGuard.getAllRulesRewrittenPlanAndStructInfo().key();
+        Optional<LogicalAggregate<? extends Plan>> aggregate = cachePlan
                 .collectFirst(LogicalAggregate.class::isInstance);
-        Assertions.assertTrue(aggregate.isPresent());
-        // should not contain SessionVarGuardExpr
+        Assertions.assertTrue(aggregate.isPresent(),
+                "Expected LogicalAggregate in cache plan but got: " + cachePlan.treeString()
+                + "\nmtmv class=" + mtmv.getClass().getName()
+                + "\nmtmv querySql=" + mtmv.getQuerySql());
         Assertions.assertTrue(aggregate.get().getOutputExpressions().stream()
                 .noneMatch(expr -> expr.containsType(SessionVarGuardExpr.class)));
 
-        // set guard check session var
         connectContext.getSessionVariable().setSqlMode(SqlModeHelper.MODE_NO_UNSIGNED_SUBTRACTION);
         CascadesContext c2 = createCascadesContext(
                 "select T1.id, sum(score) from T1 group by T1.id;",
@@ -124,7 +101,6 @@ public class MTMVCacheTest extends SqlTestBase {
         aggregate = cacheWithGuard.getAllRulesRewrittenPlanAndStructInfo().key()
                 .collectFirst(LogicalAggregate.class::isInstance);
         Assertions.assertTrue(aggregate.isPresent());
-        // should contain SessionVarGuardExpr
         Assertions.assertTrue(aggregate.get().getOutputExpressions().stream()
                 .anyMatch(expr -> expr.containsType(SessionVarGuardExpr.class)));
         dropMvByNereids("drop materialized view mv1");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MtmvCacheNewConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MtmvCacheNewConnectContextTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.nereids.mv;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MTMV;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.sqltest.SqlTestBase;
@@ -25,15 +27,11 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.BitSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * The connectContext would new instance when generate MTMVCache, after generate, the connectContext should
@@ -47,25 +45,17 @@ public class MtmvCacheNewConnectContextTest extends SqlTestBase {
         ConnectContext tmp = ConnectContext.get();
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
         BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean forceConsistent,
-                                              Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        SessionVariable spySv = Mockito.spy(connectContext.getSessionVariable());
+        Mockito.doReturn(disableNereidsRules).when(spySv).getDisableNereidsRules();
+        connectContext.setSessionVariable(spySv);
+
+        MTMVRelationManager relationManager = Env.getCurrentEnv().getMtmvService().getRelationManager();
+        MTMVRelationManager spyRelationManager = Mockito.spy(relationManager);
+        Mockito.doReturn(true).when(spyRelationManager).isMVPartitionValid(
+                Mockito.any(MTMV.class), Mockito.nullable(ConnectContext.class),
+                Mockito.anyBoolean(), Mockito.anyMap());
+        Deencapsulation.setField(Env.getCurrentEnv().getMtmvService(), "relationManager", spyRelationManager);
+
         connectContext.getState().setIsQuery(true);
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MvTableIdIsLongTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/MvTableIdIsLongTest.java
@@ -17,23 +17,12 @@
 
 package org.apache.doris.nereids.mv;
 
-import org.apache.doris.catalog.MTMV;
-import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.sqltest.SqlTestBase;
 import org.apache.doris.nereids.util.PlanChecker;
-import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.BitSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Test mv rewrite when base table id is lager then integer
@@ -43,26 +32,9 @@ public class MvTableIdIsLongTest extends SqlTestBase {
     @Test
     void testMvRewriteWhenBaseTableIdIsLong() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean isMVPartitionValid,
-                    Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+
+        installValidRelationManager();
+
         connectContext.getState().setIsQuery(true);
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
@@ -71,6 +43,7 @@ public class MvTableIdIsLongTest extends SqlTestBase {
                 + "        PROPERTIES ('replication_num' = '1') \n"
                 + "        as select T1.id from T1 inner join T2 "
                 + "on T1.id = T2.id;");
+        mockCandidateMtmv("mv1");
         CascadesContext c1 = createCascadesContext(
                 "select T1.id from T1 inner join T2 "
                         + "on T1.id = T2.id "

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/OptimizeGetAvailableMvsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/OptimizeGetAvailableMvsTest.java
@@ -17,14 +17,16 @@
 
 package org.apache.doris.nereids.mv;
 
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DistributionInfo;
-import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mtmv.BaseTableInfo;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner;
@@ -34,19 +36,16 @@ import org.apache.doris.nereids.sqltest.SqlTestBase;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.RelationId;
-import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.util.PlanChecker;
-import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -61,64 +60,35 @@ public class OptimizeGetAvailableMvsTest extends SqlTestBase {
     @Test
     void testWhenNotPartitionPrune() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
+
+        Partition mockPartition = Mockito.mock(Partition.class);
+        Mockito.when(mockPartition.getId()).thenReturn(1L);
+        Mockito.when(mockPartition.getName()).thenReturn("mock_partition");
+        Mockito.when(mockPartition.getState()).thenReturn(Partition.PartitionState.NORMAL);
+        MaterializedIndex mockIndex = new MaterializedIndex(1L, IndexState.NORMAL);
+        Mockito.when(mockPartition.getIndex(Mockito.anyLong())).thenReturn(mockIndex);
+        DistributionInfo mockDistInfo = Mockito.mock(DistributionInfo.class);
+        Mockito.when(mockDistInfo.getType()).thenReturn(DistributionInfo.DistributionInfoType.RANDOM);
+        Mockito.when(mockPartition.getDistributionInfo()).thenReturn(mockDistInfo);
+
+        Database db = (Database) Env.getCurrentEnv().getInternalCatalog().getDbNullable("test");
+        for (String tableName : new String[] {"T2", "T3", "T4"}) {
+            OlapTable table = (OlapTable) db.getTableNullable(tableName);
+            OlapTable spyTable = Mockito.spy(table);
+            Mockito.doReturn(mockPartition).when(spyTable).getPartition(Mockito.anyLong());
+            // Check the real field, not the possibly-stubbed method (spy-of-spy scenario)
+            Map<Long, Partition> realIdToPartition = Deencapsulation.getField(table, "idToPartition");
+            if (realIdToPartition.isEmpty()) {
+                Mockito.doReturn(Lists.newArrayList(1L)).when(spyTable).getPartitionIds();
             }
-        };
+            Map<Long, org.apache.doris.catalog.Table> idToTable = Deencapsulation.getField(db, "idToTable");
+            java.util.concurrent.ConcurrentMap<String, org.apache.doris.catalog.Table> nameToTable
+                    = Deencapsulation.getField(db, "nameToTable");
+            idToTable.put(spyTable.getId(), spyTable);
+            nameToTable.put(spyTable.getName(), spyTable);
+        }
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public Partition getPartition(long partitionId) {
-                return new Partition() {
-                    @Override
-                    public long getId() {
-                        return 1L;
-                    }
-
-                    @Override
-                    public String getName() {
-                        return "mock_partition";
-                    }
-
-                    @Override
-                    public PartitionState getState() {
-                        return PartitionState.NORMAL;
-                    }
-
-                    @Override
-                    public MaterializedIndex getIndex(long indexId) {
-                        return new MaterializedIndex(1L, IndexState.NORMAL);
-                    }
-
-                    @Override
-                    public DistributionInfo getDistributionInfo() {
-                        return new DistributionInfo() {
-                            @Override
-                            public DistributionInfoType getType() {
-                                return DistributionInfoType.RANDOM;
-                            }
-                        };
-                    }
-                };
-            }
-        };
-
-        new MockUp<LogicalOlapScan>() {
-            @Mock
-            public List<Long> getSelectedPartitionIds() {
-                return Lists.newArrayList(1L);
-            }
-        };
-
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        installValidRelationManager();
         connectContext.getState().setIsQuery(true);
 
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
@@ -131,6 +101,7 @@ public class OptimizeGetAvailableMvsTest extends SqlTestBase {
                 + "        as "
                 + "        select T4.id from T4 inner join T2 "
                 + "        on T4.id = T2.id;");
+        mockCandidateMtmv("mv1");
         CascadesContext c1 = createCascadesContext(
                 "select T4.id "
                         + "from T4 "
@@ -172,113 +143,92 @@ public class OptimizeGetAvailableMvsTest extends SqlTestBase {
     @Test
     void testWhenPartitionPrune() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
-        BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
+
+        Partition mockPartition2 = Mockito.mock(Partition.class);
+        Mockito.when(mockPartition2.getId()).thenReturn(1L);
+        Mockito.when(mockPartition2.getName()).thenReturn("mock_partition");
+        Mockito.when(mockPartition2.getState()).thenReturn(Partition.PartitionState.NORMAL);
+        MaterializedIndex mockIndex2 = new MaterializedIndex(1L, IndexState.NORMAL);
+        Mockito.when(mockPartition2.getIndex(Mockito.anyLong())).thenReturn(mockIndex2);
+        DistributionInfo mockDistInfo2 = Mockito.mock(DistributionInfo.class);
+        Mockito.when(mockDistInfo2.getType()).thenReturn(DistributionInfo.DistributionInfoType.RANDOM);
+        Mockito.when(mockPartition2.getDistributionInfo()).thenReturn(mockDistInfo2);
+
+        Database db2 = (Database) Env.getCurrentEnv().getInternalCatalog().getDbNullable("test");
+        for (String tableName : new String[] {"T2", "T3", "T4"}) {
+            OlapTable table = (OlapTable) db2.getTableNullable(tableName);
+            OlapTable spyTable = Mockito.spy(table);
+            Mockito.doReturn(mockPartition2).when(spyTable).getPartition(Mockito.anyLong());
+            // Check the real field, not the possibly-stubbed method (spy-of-spy scenario)
+            Map<Long, Partition> realIdToPartition = Deencapsulation.getField(table, "idToPartition");
+            if (realIdToPartition.isEmpty()) {
+                Mockito.doReturn(Lists.newArrayList(1L)).when(spyTable).getPartitionIds();
             }
-        };
+            Map<Long, org.apache.doris.catalog.Table> idToTable = Deencapsulation.getField(db2, "idToTable");
+            java.util.concurrent.ConcurrentMap<String, org.apache.doris.catalog.Table> nameToTable
+                    = Deencapsulation.getField(db2, "nameToTable");
+            idToTable.put(spyTable.getId(), spyTable);
+            nameToTable.put(spyTable.getName(), spyTable);
+        }
 
-        new MockUp<PartitionPruner>() {
-            @Mock
-            public <K extends Comparable<K>> Pair<List<K>, Optional<Expression>> prune(List<Slot> partitionSlots, Expression partitionPredicate,
-                    Map<K, PartitionItem> idToPartitions, CascadesContext cascadesContext,
-                    PartitionTableType partitionTableType, Optional<SortedPartitionRanges<K>> sortedPartitionRanges) {
-                return Pair.of((List) Lists.newArrayList(1L), Optional.empty());
-            }
-        };
+        try (MockedStatic<PartitionPruner> mockedPruner = Mockito.mockStatic(PartitionPruner.class,
+                Mockito.CALLS_REAL_METHODS)) {
+            mockedPruner.when(() -> PartitionPruner.<Long>prune(
+                    Mockito.<List<Slot>>any(), Mockito.any(Expression.class),
+                    Mockito.<Map<Long, PartitionItem>>any(),
+                    Mockito.any(CascadesContext.class), Mockito.any(PartitionTableType.class),
+                    Mockito.<Optional<SortedPartitionRanges<Long>>>any()))
+                    .thenReturn(Pair.of(Lists.newArrayList(1L), Optional.empty()));
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public Partition getPartition(long partitionId) {
-                return new Partition() {
-                    @Override
-                    public long getId() {
-                        return 1L;
-                    }
-
-                    @Override
-                    public String getName() {
-                        return "mock_partition";
-                    }
-
-                    @Override
-                    public PartitionState getState() {
-                        return PartitionState.NORMAL;
-                    }
-
-                    @Override
-                    public MaterializedIndex getIndex(long indexId) {
-                        return new MaterializedIndex(1L, IndexState.NORMAL);
-                    }
-
-                    @Override
-                    public DistributionInfo getDistributionInfo() {
-                        return new DistributionInfo() {
-                            @Override
-                            public DistributionInfoType getType() {
-                                return DistributionInfoType.RANDOM;
-                            }
-                        };
-                    }
-                };
-            }
-        };
-
-        new MockUp<LogicalOlapScan>() {
-            @Mock
-            public List<Long> getSelectedPartitionIds() {
-                return Lists.newArrayList(1L);
-            }
-        };
-
-        connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
-        connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
-        createMvByNereids("create materialized view mv2 "
-                + "        BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
-                + "        PARTITION BY (id)\n"
-                + "        DISTRIBUTED BY RANDOM BUCKETS 1\n"
-                + "        PROPERTIES ('replication_num' = '1') \n"
-                + "        as "
-                + "        select T4.id from T4 inner join T2 "
-                + "        on T4.id = T2.id;");
-        CascadesContext c1 = createCascadesContext(
-                "select T4.id "
+            installValidRelationManager();
+            connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
+            connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
+            createMvByNereids("create materialized view mv2 "
+                    + "        BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL\n"
+                    + "        PARTITION BY (id)\n"
+                    + "        DISTRIBUTED BY RANDOM BUCKETS 1\n"
+                    + "        PROPERTIES ('replication_num' = '1') \n"
+                    + "        as "
+                    + "        select T4.id from T4 inner join T2 "
+                    + "        on T4.id = T2.id;");
+            mockCandidateMtmv("mv2");
+            CascadesContext c1 = createCascadesContext(
+                    "select T4.id "
                         + "from T4 "
                         + "inner join T2 on T4.id = T2.id "
                         + "inner join T3 on T4.id = T3.id "
                         + "where T4.id > 0",
-                connectContext
-        );
-        PlanChecker.from(c1)
+                    connectContext
+            );
+            PlanChecker.from(c1)
                 .setIsQuery()
                 .analyze()
                 .rewrite()
                 .preMvRewrite()
                 .optimize()
-                .printlnBestPlanTree();
-        Multimap<List<String>, Pair<RelationId, Set<String>>> tableUsedPartitionNameMap = c1.getStatementContext()
-                .getTableUsedPartitionNameMap();
-        Map<BaseTableInfo, Collection<Partition>> mvCanRewritePartitionsMap = c1.getStatementContext()
-                .getMvCanRewritePartitionsMap();
-        Assertions.assertFalse(tableUsedPartitionNameMap.isEmpty());
+                    .printlnBestPlanTree();
+            Multimap<List<String>, Pair<RelationId, Set<String>>> tableUsedPartitionNameMap = c1.getStatementContext()
+                    .getTableUsedPartitionNameMap();
+            Map<BaseTableInfo, Collection<Partition>> mvCanRewritePartitionsMap = c1.getStatementContext()
+                    .getMvCanRewritePartitionsMap();
+            Assertions.assertFalse(tableUsedPartitionNameMap.isEmpty());
 
-        for (Map.Entry<List<String>, Pair<RelationId, Set<String>>> tableInfoEntry
-                : tableUsedPartitionNameMap.entries()) {
-            if (tableInfoEntry.getKey().contains("T2")) {
-                Assertions.assertEquals(tableInfoEntry.getValue().value(), Sets.newHashSet("mock_partition"));
-            } else if (tableInfoEntry.getKey().contains("T3")) {
-                Assertions.assertEquals(tableInfoEntry.getValue().value(), Sets.newHashSet("mock_partition"));
-            } else if (tableInfoEntry.getKey().contains("T4")) {
-                Assertions.assertEquals(tableInfoEntry.getValue().value(), Sets.newHashSet("mock_partition"));
+            for (Map.Entry<List<String>, Pair<RelationId, Set<String>>> tableInfoEntry
+                    : tableUsedPartitionNameMap.entries()) {
+                if (tableInfoEntry.getKey().contains("T2")) {
+                    Assertions.assertEquals(tableInfoEntry.getValue().value(), Sets.newHashSet("mock_partition"));
+                } else if (tableInfoEntry.getKey().contains("T3")) {
+                    Assertions.assertEquals(tableInfoEntry.getValue().value(), Sets.newHashSet("mock_partition"));
+                } else if (tableInfoEntry.getKey().contains("T4")) {
+                    Assertions.assertEquals(tableInfoEntry.getValue().value(), Sets.newHashSet("mock_partition"));
+                }
             }
+
+            Assertions.assertEquals(1, mvCanRewritePartitionsMap.size());
+            Assertions.assertTrue(mvCanRewritePartitionsMap.keySet().iterator().next().getTableName()
+                    .equalsIgnoreCase("mv2"));
+
+            dropMvByNereids("drop materialized view mv2");
         }
-
-        Assertions.assertEquals(1, mvCanRewritePartitionsMap.size());
-        Assertions.assertTrue(mvCanRewritePartitionsMap.keySet().iterator().next().getTableName()
-                .equalsIgnoreCase("mv2"));
-
-        dropMvByNereids("drop materialized view mv2");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/PointQueryShouldNotMvRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/PointQueryShouldNotMvRewriteTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.nereids.mv;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MTMV;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.memo.Group;
@@ -26,15 +28,12 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.BitSet;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -46,25 +45,17 @@ public class PointQueryShouldNotMvRewriteTest extends SqlTestBase {
     void testShouldNotMvRewriteWhenPointQuery() throws Exception {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
         BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
-        new MockUp<MTMVRelationManager>() {
-            @Mock
-            public boolean isMVPartitionValid(MTMV mtmv, ConnectContext ctx, boolean forceConsistent,
-                                              Map<List<String>, Set<String>> queryUsedPartitions) {
-                return true;
-            }
-        };
-        new MockUp<MTMV>() {
-            @Mock
-            public boolean canBeCandidate() {
-                return true;
-            }
-        };
+        SessionVariable spySv = Mockito.spy(connectContext.getSessionVariable());
+        Mockito.doReturn(disableNereidsRules).when(spySv).getDisableNereidsRules();
+        connectContext.setSessionVariable(spySv);
+
+        MTMVRelationManager relationManager = Env.getCurrentEnv().getMtmvService().getRelationManager();
+        MTMVRelationManager spyRelationManager = Mockito.spy(relationManager);
+        Mockito.doReturn(true).when(spyRelationManager).isMVPartitionValid(
+                Mockito.any(MTMV.class), Mockito.nullable(ConnectContext.class),
+                Mockito.anyBoolean(), Mockito.anyMap());
+        Deencapsulation.setField(Env.getCurrentEnv().getMtmvService(), "relationManager", spyRelationManager);
+
         connectContext.getState().setIsQuery(true);
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/PreMaterializedViewRewriterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/PreMaterializedViewRewriterTest.java
@@ -42,10 +42,9 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.BitSet;
 import java.util.HashMap;
@@ -62,12 +61,9 @@ public class PreMaterializedViewRewriterTest extends SqlTestBase {
     public void testShouldNotRecordTmpPlanWhenNoMv() {
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
         BitSet disableNereidsRules = connectContext.getSessionVariable().getDisableNereidsRules();
-        new MockUp<SessionVariable>() {
-            @Mock
-            public BitSet getDisableNereidsRules() {
-                return disableNereidsRules;
-            }
-        };
+        SessionVariable spySv = Mockito.spy(connectContext.getSessionVariable());
+        Mockito.doReturn(disableNereidsRules).when(spySv).getDisableNereidsRules();
+        connectContext.setSessionVariable(spySv);
         connectContext.getSessionVariable().enableMaterializedViewRewrite = true;
         connectContext.getSessionVariable().enableMaterializedViewNestRewrite = true;
         connectContext.getSessionVariable().setPreMaterializedViewRewriteStrategy(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/RelationMappingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/mv/RelationMappingTest.java
@@ -25,9 +25,9 @@ import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.HashSet;
 import java.util.List;
@@ -35,8 +35,7 @@ import java.util.Set;
 
 public class RelationMappingTest {
 
-    @Mocked
-    public CatalogRelation catalogRelation;
+    public CatalogRelation catalogRelation = Mockito.mock(CatalogRelation.class, Mockito.RETURNS_DEEP_STUBS);
 
     /**
      * Permutation and remove duplicated element

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -18,19 +18,25 @@
 package org.apache.doris.nereids.parser;
 
 import org.apache.doris.analysis.AccessTestUtil;
+import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.profile.Profile;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.ha.FrontendNodeType;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.plugin.AuditEvent;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.MysqlConnectProcessor;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.resource.workloadschedpolicy.WorkloadRuntimeStatusMgr;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -45,366 +51,399 @@ public class EncryptSQLTest extends ParserTestBase {
     @Test
     public void testEncryption() throws Exception {
         ctx.setDatabase("test");
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public boolean isForwardToMaster() {
-                return false;
-            }
-        };
-        ctx.setEnv(env);
-        Config.enable_nereids_load = true;
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, context) -> {
+                    Mockito.doReturn(false).when(mock).isForwardToMaster();
+                    Profile profile = new Profile(false, 0, 0);
+                    Deencapsulation.setField(mock, "profile", profile);
+                    Mockito.doReturn(profile).when(mock).getProfile();
+                    Mockito.doReturn(ctx).when(mock).getContext();
+                    Mockito.doNothing().when(mock).execute();
+                    Deencapsulation.setField(mock, "context", ctx);
+                    if (context.arguments().size() >= 2
+                            && context.arguments().get(1) instanceof StatementBase) {
+                        Deencapsulation.setField(mock, "parsedStmt",
+                                context.arguments().get(1));
+                    }
+                    if (ctx.getStatementContext() == null) {
+                        ctx.setStatementContext(new StatementContext());
+                    }
+                })) {
+            ctx.setEnv(env);
+            ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+            Config.enable_nereids_load = true;
 
-        String sql = "EXPORT TABLE export_table TO \"s3://abc/aaa\" "
-                + "PROPERTIES("
-                + " \"format\" = \"csv\","
-                + " \"max_file_size\" = \"2048MB\""
-                + ")"
-                + "WITH s3 ("
-                + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
-                + " \"s3.region\" = \"ap-beijing\","
-                + " \"s3.secret_key\" = \"abc\","
-                + " \"s3.access_key\" = \"abc\""
-                + ")";
+            String sql = "EXPORT TABLE export_table TO \"s3://abc/aaa\" "
+                    + "PROPERTIES("
+                    + " \"format\" = \"csv\","
+                    + " \"max_file_size\" = \"2048MB\""
+                    + ")"
+                    + "WITH s3 ("
+                    + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
+                    + " \"s3.region\" = \"ap-beijing\","
+                    + " \"s3.secret_key\" = \"abc\","
+                    + " \"s3.access_key\" = \"abc\""
+                    + ")";
 
-        String res = "EXPORT TABLE export_table TO \"s3://abc/aaa\" "
-                + "PROPERTIES("
-                + " \"format\" = \"csv\","
-                + " \"max_file_size\" = \"2048MB\""
-                + ")"
-                + "WITH s3 ("
-                + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
-                + " \"s3.region\" = \"ap-beijing\","
-                + " \"s3.secret_key\" = \"*XXX\","
-                        + " \"s3.access_key\" = \"*XXX\""
-                + ")";
-        parseAndCheck(sql, res);
+            String res = "EXPORT TABLE export_table TO \"s3://abc/aaa\" "
+                    + "PROPERTIES("
+                    + " \"format\" = \"csv\","
+                    + " \"max_file_size\" = \"2048MB\""
+                    + ")"
+                    + "WITH s3 ("
+                    + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
+                    + " \"s3.region\" = \"ap-beijing\","
+                    + " \"s3.secret_key\" = \"*XXX\","
+                            + " \"s3.access_key\" = \"*XXX\""
+                    + ")";
+            parseAndCheck(sql, res);
 
-        sql = "SELECT * FROM tbl "
-                + " INTO OUTFILE \"s3://abc/aaa\""
-                + " FORMAT AS ORC"
-                + " PROPERTIES ("
-                + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
-                + " \"s3.region\" = \"ap-beijing\","
-                + " \"s3.secret_key\" = \"abc\","
-                + " \"s3.access_key\" = \"abc\""
-                + ")";
+            sql = "SELECT * FROM tbl "
+                    + " INTO OUTFILE \"s3://abc/aaa\""
+                    + " FORMAT AS ORC"
+                    + " PROPERTIES ("
+                    + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
+                    + " \"s3.region\" = \"ap-beijing\","
+                    + " \"s3.secret_key\" = \"abc\","
+                    + " \"s3.access_key\" = \"abc\""
+                    + ")";
 
-        res = "SELECT * FROM tbl "
-                + " INTO OUTFILE \"s3://abc/aaa\""
-                + " FORMAT AS ORC"
-                + " PROPERTIES ("
-                + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
-                + " \"s3.region\" = \"ap-beijing\","
-                + " \"s3.secret_key\" = \"*XXX\","
-                + " \"s3.access_key\" = \"*XXX\""
-                + ")";
-        parseAndCheck(sql, res);
+            res = "SELECT * FROM tbl "
+                    + " INTO OUTFILE \"s3://abc/aaa\""
+                    + " FORMAT AS ORC"
+                    + " PROPERTIES ("
+                    + " \"s3.endpoint\" = \"cos.ap-beijing.myqcloud.com\","
+                    + " \"s3.region\" = \"ap-beijing\","
+                    + " \"s3.secret_key\" = \"*XXX\","
+                    + " \"s3.access_key\" = \"*XXX\""
+                    + ")";
+            parseAndCheck(sql, res);
 
-        sql = "LOAD LABEL test_load_s3_orc_encrypt("
-                + " DATA INFILE(\"s3://abc/aaa\")"
-                + " INTO TABLE tbl"
-                + " FORMAT AS \"ORC\""
-                + ")"
-                + "WITH S3("
-                + " \"provider\" = \"S3\","
-                + " \"AWS_ENDPOINT\" = \"xxx\","
-                + " \"AWS_ACCESS_KEY\" = \"abc\","
-                + " \"AWS_SECRET_KEY\" = \"abc\","
-                + " \"AWS_REGION\" = \"ap-beijing\""
-                + ")";
+            sql = "LOAD LABEL test_load_s3_orc_encrypt("
+                    + " DATA INFILE(\"s3://abc/aaa\")"
+                    + " INTO TABLE tbl"
+                    + " FORMAT AS \"ORC\""
+                    + ")"
+                    + "WITH S3("
+                    + " \"provider\" = \"S3\","
+                    + " \"AWS_ENDPOINT\" = \"xxx\","
+                    + " \"AWS_ACCESS_KEY\" = \"abc\","
+                    + " \"AWS_SECRET_KEY\" = \"abc\","
+                    + " \"AWS_REGION\" = \"ap-beijing\""
+                    + ")";
 
-        res = "LOAD LABEL test_load_s3_orc_encrypt("
-                + " DATA INFILE(\"s3://abc/aaa\")"
-                + " INTO TABLE tbl"
-                + " FORMAT AS \"ORC\""
-                + ")"
-                + "WITH S3("
-                + " \"provider\" = \"S3\""
-                + ")";
-        parseAndCheck(sql, res);
+            res = "LOAD LABEL test_load_s3_orc_encrypt("
+                    + " DATA INFILE(\"s3://abc/aaa\")"
+                    + " INTO TABLE tbl"
+                    + " FORMAT AS \"ORC\""
+                    + ")"
+                    + "WITH S3("
+                    + " \"provider\" = \"S3\""
+                    + ")";
+            parseAndCheck(sql, res);
 
-        sql = "CREATE CATALOG ctl "
-                + "PROPERTIES("
-                + " \"type\" = \"iceberg\","
-                + " \"iceberg.catalog.type\" = \"hadoop\","
-                + " \"warehouse\" = \"s3://bucket/dir/key\","
-                + " \"s3.endpoint\" = \"s3.us-east-1.amazonaws.com\","
-                + " \"s3.access_key\" = \"abc\","
-                + " \"s3.secret_key\" = \"abc\""
-                + ")";
+            sql = "CREATE CATALOG ctl "
+                    + "PROPERTIES("
+                    + " \"type\" = \"iceberg\","
+                    + " \"iceberg.catalog.type\" = \"hadoop\","
+                    + " \"warehouse\" = \"s3://bucket/dir/key\","
+                    + " \"s3.endpoint\" = \"s3.us-east-1.amazonaws.com\","
+                    + " \"s3.access_key\" = \"abc\","
+                    + " \"s3.secret_key\" = \"abc\""
+                    + ")";
 
-        res = "CREATE CATALOG ctl "
-                + "PROPERTIES("
-                + " \"type\" = \"iceberg\","
-                + " \"iceberg.catalog.type\" = \"hadoop\","
-                + " \"warehouse\" = \"s3://bucket/dir/key\","
-                + " \"s3.endpoint\" = \"s3.us-east-1.amazonaws.com\","
-                + " \"s3.access_key\" = \"*XXX\","
-                + " \"s3.secret_key\" = \"*XXX\""
-                + ")";
-        parseAndCheck(sql, res);
+            res = "CREATE CATALOG ctl "
+                    + "PROPERTIES("
+                    + " \"type\" = \"iceberg\","
+                    + " \"iceberg.catalog.type\" = \"hadoop\","
+                    + " \"warehouse\" = \"s3://bucket/dir/key\","
+                    + " \"s3.endpoint\" = \"s3.us-east-1.amazonaws.com\","
+                    + " \"s3.access_key\" = \"*XXX\","
+                    + " \"s3.secret_key\" = \"*XXX\""
+                    + ")";
+            parseAndCheck(sql, res);
 
-        sql = "CREATE TABLE mysql_tbl("
-                + " k1 DATE,"
-                + " k2 INT,"
-                + " k3 SMALLINT,"
-                + " k4 VARCHAR(2048),"
-                + " k5 DATETIME"
-                + ") "
-                + "ENGINE=mysql "
-                + "PROPERTIES("
-                + " \"host\" = \"127.0.0.1\","
-                + " \"port\" = \"8234\","
-                + " \"user\" = \"abc\","
-                + " \"password\" = \"123\","
-                + " \"database\" = \"mysql_db\","
-                + " \"table\" = \"mysql_table\""
-                + ")";
+            sql = "CREATE TABLE mysql_tbl("
+                    + " k1 DATE,"
+                    + " k2 INT,"
+                    + " k3 SMALLINT,"
+                    + " k4 VARCHAR(2048),"
+                    + " k5 DATETIME"
+                    + ") "
+                    + "ENGINE=mysql "
+                    + "PROPERTIES("
+                    + " \"host\" = \"127.0.0.1\","
+                    + " \"port\" = \"8234\","
+                    + " \"user\" = \"abc\","
+                    + " \"password\" = \"123\","
+                    + " \"database\" = \"mysql_db\","
+                    + " \"table\" = \"mysql_table\""
+                    + ")";
 
-        res = "CREATE TABLE mysql_tbl("
-                + " k1 DATE,"
-                + " k2 INT,"
-                + " k3 SMALLINT,"
-                + " k4 VARCHAR(2048),"
-                + " k5 DATETIME"
-                + ") "
-                + "ENGINE=mysql "
-                + "PROPERTIES("
-                + " \"host\" = \"127.0.0.1\","
-                + " \"port\" = \"8234\","
-                + " \"user\" = \"abc\","
-                + " \"password\" = \"*XXX\","
-                + " \"database\" = \"mysql_db\","
-                + " \"table\" = \"mysql_table\""
-                + ")";
-        parseAndCheck(sql, res);
+            res = "CREATE TABLE mysql_tbl("
+                    + " k1 DATE,"
+                    + " k2 INT,"
+                    + " k3 SMALLINT,"
+                    + " k4 VARCHAR(2048),"
+                    + " k5 DATETIME"
+                    + ") "
+                    + "ENGINE=mysql "
+                    + "PROPERTIES("
+                    + " \"host\" = \"127.0.0.1\","
+                    + " \"port\" = \"8234\","
+                    + " \"user\" = \"abc\","
+                    + " \"password\" = \"*XXX\","
+                    + " \"database\" = \"mysql_db\","
+                    + " \"table\" = \"mysql_table\""
+                    + ")";
+            parseAndCheck(sql, res);
 
-        sql = "CREATE EXTERNAL TABLE broker_tbl("
-                + " k1 tinyint,"
-                + " k2 smallint,"
-                + " k3 int,"
-                + " k4 bigint) "
-                + "ENGINE=broker "
-                + "PROPERTIES("
-                + " \"broker_name\" = \"hdfs\","
-                + " \"path\" = \"hdfs://abc/qe/a.txt\""
-                + ") "
-                + "BROKER PROPERTIES("
-                + " \"username\" = \"root\","
-                + " \"password\" = \"123\""
-                + ")";
+            sql = "CREATE EXTERNAL TABLE broker_tbl("
+                    + " k1 tinyint,"
+                    + " k2 smallint,"
+                    + " k3 int,"
+                    + " k4 bigint) "
+                    + "ENGINE=broker "
+                    + "PROPERTIES("
+                    + " \"broker_name\" = \"hdfs\","
+                    + " \"path\" = \"hdfs://abc/qe/a.txt\""
+                    + ") "
+                    + "BROKER PROPERTIES("
+                    + " \"username\" = \"root\","
+                    + " \"password\" = \"123\""
+                    + ")";
 
-        res = "CREATE EXTERNAL TABLE broker_tbl("
-                + " k1 tinyint,"
-                + " k2 smallint,"
-                + " k3 int,"
-                + " k4 bigint) "
-                + "ENGINE=broker "
-                + "PROPERTIES("
-                + " \"broker_name\" = \"hdfs\","
-                + " \"path\" = \"hdfs://abc/qe/a.txt\""
-                + ") "
-                + "BROKER PROPERTIES("
-                + " \"username\" = \"root\","
-                + " \"password\" = \"*XXX\""
-                + ")";
-        parseAndCheck(sql, res);
+            res = "CREATE EXTERNAL TABLE broker_tbl("
+                    + " k1 tinyint,"
+                    + " k2 smallint,"
+                    + " k3 int,"
+                    + " k4 bigint) "
+                    + "ENGINE=broker "
+                    + "PROPERTIES("
+                    + " \"broker_name\" = \"hdfs\","
+                    + " \"path\" = \"hdfs://abc/qe/a.txt\""
+                    + ") "
+                    + "BROKER PROPERTIES("
+                    + " \"username\" = \"root\","
+                    + " \"password\" = \"*XXX\""
+                    + ")";
+            parseAndCheck(sql, res);
 
-        sql = "INSERT INTO test_s3load "
-                + "SELECT * FROM s3_tbl("
-                + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
-                + " \"format\" = \"csv\","
-                + " \"provider\" = \"OSS\","
-                + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
-                + " \"s3.region\" = \"oss-cn-hangzhou\","
-                + " \"s3.access_key\" = \"abc\","
-                + " \"s3.secret_key\" = \"abc\","
-                + " \"column_separator\" = \",\","
-                + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
-                + ")";
+            sql = "INSERT INTO test_s3load "
+                    + "SELECT * FROM s3_tbl("
+                    + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"provider\" = \"OSS\","
+                    + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
+                    + " \"s3.region\" = \"oss-cn-hangzhou\","
+                    + " \"s3.access_key\" = \"abc\","
+                    + " \"s3.secret_key\" = \"abc\","
+                    + " \"column_separator\" = \",\","
+                    + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
+                    + ")";
 
-        res = "INSERT INTO test_s3load "
-                + "SELECT * FROM s3_tbl("
-                + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
-                + " \"format\" = \"csv\","
-                + " \"provider\" = \"OSS\","
-                + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
-                + " \"s3.region\" = \"oss-cn-hangzhou\","
-                + " \"s3.access_key\" = \"*XXX\","
-                + " \"s3.secret_key\" = \"*XXX\","
-                + " \"column_separator\" = \",\","
-                + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
-                + ")";
-        parseAndCheck(sql, res);
+            res = "INSERT INTO test_s3load "
+                    + "SELECT * FROM s3_tbl("
+                    + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"provider\" = \"OSS\","
+                    + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
+                    + " \"s3.region\" = \"oss-cn-hangzhou\","
+                    + " \"s3.access_key\" = \"*XXX\","
+                    + " \"s3.secret_key\" = \"*XXX\","
+                    + " \"column_separator\" = \",\","
+                    + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
+                    + ")";
+            parseAndCheck(sql, res);
 
-        sql = "SELECT * FROM s3_tbl("
-                + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
-                + " \"format\" = \"csv\","
-                + " \"provider\" = \"OSS\","
-                + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
-                + " \"s3.region\" = \"oss-cn-hangzhou\","
-                + " \"s3.access_key\" = \"abc\","
-                + " \"s3.secret_key\" = \"abc\","
-                + " \"column_separator\" = \",\","
-                + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
-                + ")";
+            sql = "SELECT * FROM s3_tbl("
+                    + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"provider\" = \"OSS\","
+                    + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
+                    + " \"s3.region\" = \"oss-cn-hangzhou\","
+                    + " \"s3.access_key\" = \"abc\","
+                    + " \"s3.secret_key\" = \"abc\","
+                    + " \"column_separator\" = \",\","
+                    + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
+                    + ")";
 
-        res = "SELECT * FROM s3_tbl("
-                + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
-                + " \"format\" = \"csv\","
-                + " \"provider\" = \"OSS\","
-                + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
-                + " \"s3.region\" = \"oss-cn-hangzhou\","
-                + " \"s3.access_key\" = \"*XXX\","
-                + " \"s3.secret_key\" = \"*XXX\","
-                + " \"column_separator\" = \",\","
-                + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
-                + ")";
+            res = "SELECT * FROM s3_tbl("
+                    + " \"uri\" = \"s3://your_bucket_name/s3load_example.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"provider\" = \"OSS\","
+                    + " \"s3.endpoint\" = \"oss-cn-hangzhou.aliyuncs.com\","
+                    + " \"s3.region\" = \"oss-cn-hangzhou\","
+                    + " \"s3.access_key\" = \"*XXX\","
+                    + " \"s3.secret_key\" = \"*XXX\","
+                    + " \"column_separator\" = \",\","
+                    + " \"csv_schema\" = \"user_id:int;name:string;age:int\""
+                    + ")";
 
-        parseAndCheck(sql, res);
+            parseAndCheck(sql, res);
 
-        sql = "SET LDAP_ADMIN_PASSWORD = PASSWORD('123456')";
-        res = "SET LDAP_ADMIN_PASSWORD = PASSWORD('*XXX')";
-        parseAndCheck(sql, res);
+            sql = "SET LDAP_ADMIN_PASSWORD = PASSWORD('123456')";
+            res = "SET LDAP_ADMIN_PASSWORD = PASSWORD('*XXX')";
+            parseAndCheck(sql, res);
 
-        sql = "SET PASSWORD FOR 'admin' = PASSWORD('123456')";
-        res = "SET PASSWORD FOR 'admin' = PASSWORD('*XXX')";
-        parseAndCheck(sql, res);
+            sql = "SET PASSWORD FOR 'admin' = PASSWORD('123456')";
+            res = "SET PASSWORD FOR 'admin' = PASSWORD('*XXX')";
+            parseAndCheck(sql, res);
 
-        // create s3 job
-        sql = "CREATE JOB my_job"
-                + " ON STREAMING"
-                + " DO"
-                + " INSERT INTO test.`student`"
-                + " SELECT * FROM S3"
-                + " ("
-                + " \"uri\" = \"s3://bucketname/demo/*.csv\","
-                + " \"format\" = \"csv\","
-                + " \"column_separator\" = \",\","
-                + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
-                + " \"s3.region\" = \"ap-southeast-1\","
-                + " \"s3.access_key\" = \"ak\","
-                + " \"s3.secret_key\" = \"abcdefg\""
-                + " );";
+            // create s3 job
+            sql = "CREATE JOB my_job"
+                    + " ON STREAMING"
+                    + " DO"
+                    + " INSERT INTO test.`student`"
+                    + " SELECT * FROM S3"
+                    + " ("
+                    + " \"uri\" = \"s3://bucketname/demo/*.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"column_separator\" = \",\","
+                    + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
+                    + " \"s3.region\" = \"ap-southeast-1\","
+                    + " \"s3.access_key\" = \"ak\","
+                    + " \"s3.secret_key\" = \"abcdefg\""
+                    + " );";
 
-        res = "CREATE JOB my_job"
-                + " ON STREAMING"
-                + " DO"
-                + " INSERT INTO test.`student`"
-                + " SELECT * FROM S3"
-                + " ("
-                + " \"uri\" = \"s3://bucketname/demo/*.csv\","
-                + " \"format\" = \"csv\","
-                + " \"column_separator\" = \",\","
-                + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
-                + " \"s3.region\" = \"ap-southeast-1\","
-                + " \"s3.access_key\" = \"*XXX\","
-                + " \"s3.secret_key\" = \"*XXX\""
-                + " );";
-        parseAndCheck(sql, res);
+            res = "CREATE JOB my_job"
+                    + " ON STREAMING"
+                    + " DO"
+                    + " INSERT INTO test.`student`"
+                    + " SELECT * FROM S3"
+                    + " ("
+                    + " \"uri\" = \"s3://bucketname/demo/*.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"column_separator\" = \",\","
+                    + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
+                    + " \"s3.region\" = \"ap-southeast-1\","
+                    + " \"s3.access_key\" = \"*XXX\","
+                    + " \"s3.secret_key\" = \"*XXX\""
+                    + " );";
+            parseAndCheck(sql, res);
 
-        // alter s3 job
-        sql = "ALTER JOB my_job"
-                + " INSERT INTO test.`student`"
-                + " SELECT * FROM S3"
-                + " ("
-                + " \"uri\" = \"s3://bucketname/demo/*.csv\","
-                + " \"format\" = \"csv\","
-                + " \"column_separator\" = \",\","
-                + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
-                + " \"s3.region\" = \"ap-southeast-1\","
-                + " \"s3.access_key\" = \"ak\","
-                + " \"s3.secret_key\" = \"abcdefg\""
-                + " );";
+            // alter s3 job
+            sql = "ALTER JOB my_job"
+                    + " INSERT INTO test.`student`"
+                    + " SELECT * FROM S3"
+                    + " ("
+                    + " \"uri\" = \"s3://bucketname/demo/*.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"column_separator\" = \",\","
+                    + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
+                    + " \"s3.region\" = \"ap-southeast-1\","
+                    + " \"s3.access_key\" = \"ak\","
+                    + " \"s3.secret_key\" = \"abcdefg\""
+                    + " );";
 
-        res = "ALTER JOB my_job"
-                + " INSERT INTO test.`student`"
-                + " SELECT * FROM S3"
-                + " ("
-                + " \"uri\" = \"s3://bucketname/demo/*.csv\","
-                + " \"format\" = \"csv\","
-                + " \"column_separator\" = \",\","
-                + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
-                + " \"s3.region\" = \"ap-southeast-1\","
-                + " \"s3.access_key\" = \"*XXX\","
-                + " \"s3.secret_key\" = \"*XXX\""
-                + " );";
-        parseAndCheck(sql, res);
+            res = "ALTER JOB my_job"
+                    + " INSERT INTO test.`student`"
+                    + " SELECT * FROM S3"
+                    + " ("
+                    + " \"uri\" = \"s3://bucketname/demo/*.csv\","
+                    + " \"format\" = \"csv\","
+                    + " \"column_separator\" = \",\","
+                    + " \"s3.endpoint\" = \"s3.ap-southeast-1.amazonaws.com\","
+                    + " \"s3.region\" = \"ap-southeast-1\","
+                    + " \"s3.access_key\" = \"*XXX\","
+                    + " \"s3.secret_key\" = \"*XXX\""
+                    + " );";
+            parseAndCheck(sql, res);
 
-        // create mysql job
-        sql = "CREATE JOB my_mysql_job "
-                + "ON STREAMING "
-                + "FROM MYSQL ( "
-                + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
-                + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
-                + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
-                + "\"user\" = \"root\", "
-                + "\"password\" = \"123456\", "
-                + "\"database\" = \"test_cdc_db\", "
-                + "\"include_tables\" = \"mysqltable\", "
-                + "\"offset\" = \"initial\" "
-                + ") "
-                + "TO DATABASE targetDB ( "
-                + "\"table.create.properties.replication_num\" = \"1\" "
-                + ")";
+            // create mysql job
+            sql = "CREATE JOB my_mysql_job "
+                    + "ON STREAMING "
+                    + "FROM MYSQL ( "
+                    + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
+                    + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
+                    + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
+                    + "\"user\" = \"root\", "
+                    + "\"password\" = \"123456\", "
+                    + "\"database\" = \"test_cdc_db\", "
+                    + "\"include_tables\" = \"mysqltable\", "
+                    + "\"offset\" = \"initial\" "
+                    + ") "
+                    + "TO DATABASE targetDB ( "
+                    + "\"table.create.properties.replication_num\" = \"1\" "
+                    + ")";
 
-        res = "CREATE JOB my_mysql_job "
-                + "ON STREAMING "
-                + "FROM MYSQL ( "
-                + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
-                + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
-                + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
-                + "\"user\" = \"root\", "
-                + "\"password\" = \"*XXX\", "
-                + "\"database\" = \"test_cdc_db\", "
-                + "\"include_tables\" = \"mysqltable\", "
-                + "\"offset\" = \"initial\" "
-                + ") "
-                + "TO DATABASE targetDB ( "
-                + "\"table.create.properties.replication_num\" = \"1\" "
-                + ")";
-        parseAndCheck(sql, res);
+            res = "CREATE JOB my_mysql_job "
+                    + "ON STREAMING "
+                    + "FROM MYSQL ( "
+                    + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
+                    + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
+                    + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
+                    + "\"user\" = \"root\", "
+                    + "\"password\" = \"*XXX\", "
+                    + "\"database\" = \"test_cdc_db\", "
+                    + "\"include_tables\" = \"mysqltable\", "
+                    + "\"offset\" = \"initial\" "
+                    + ") "
+                    + "TO DATABASE targetDB ( "
+                    + "\"table.create.properties.replication_num\" = \"1\" "
+                    + ")";
+            parseAndCheck(sql, res);
 
-        // alter mysql job
-        sql = "ALTER JOB my_mysql_job "
-                + "FROM MYSQL ( "
-                + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
-                + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
-                + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
-                + "\"user\" = \"mysql_job_priv\", "
-                + "\"password\" = \"test123\", "
-                + "\"database\" = \"test_cdc_db\", "
-                + "\"include_tables\" = \"mysqltable\", "
-                + "\"offset\" = \"latest\""
-                + ")"
-                + "TO DATABASE targetDB";
+            // alter mysql job
+            sql = "ALTER JOB my_mysql_job "
+                    + "FROM MYSQL ( "
+                    + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
+                    + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
+                    + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
+                    + "\"user\" = \"mysql_job_priv\", "
+                    + "\"password\" = \"test123\", "
+                    + "\"database\" = \"test_cdc_db\", "
+                    + "\"include_tables\" = \"mysqltable\", "
+                    + "\"offset\" = \"latest\""
+                    + ")"
+                    + "TO DATABASE targetDB";
 
-        res = "ALTER JOB my_mysql_job "
-                + "FROM MYSQL ( "
-                + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
-                + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
-                + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
-                + "\"user\" = \"mysql_job_priv\", "
-                + "\"password\" = \"*XXX\", "
-                + "\"database\" = \"test_cdc_db\", "
-                + "\"include_tables\" = \"mysqltable\", "
-                + "\"offset\" = \"latest\""
-                + ")"
-                + "TO DATABASE targetDB";
-        parseAndCheck(sql, res);
+            res = "ALTER JOB my_mysql_job "
+                    + "FROM MYSQL ( "
+                    + "\"jdbc_url\" = \"jdbc:mysql://127.0.0.1:3306\", "
+                    + "\"driver_url\" = \"mysql-connector-j-8.4.0.jar\", "
+                    + "\"driver_class\" = \"com.mysql.cj.jdbc.Driver\", "
+                    + "\"user\" = \"mysql_job_priv\", "
+                    + "\"password\" = \"*XXX\", "
+                    + "\"database\" = \"test_cdc_db\", "
+                    + "\"include_tables\" = \"mysqltable\", "
+                    + "\"offset\" = \"latest\""
+                    + ")"
+                    + "TO DATABASE targetDB";
+            parseAndCheck(sql, res);
 
-        sql = "selected * from tbl";
-        res = "Syntax Error";
-        parseAndCheck(sql, res);
+            sql = "selected * from tbl";
+            res = "Syntax Error";
+            parseAndCheck(sql, res);
+        }
 
-        sql = "select * from tbl";
-        res = "select * from tbl";
-        processor.executeQuery(sql);
-        AuditEvent event = auditEvents.get(auditEvents.size() - 1);
-        Assertions.assertEquals(res, event.stmt);
-
-        String errorMsg = "errCode = 2, detailMessage = Database [test] does not exist.";
-        Assertions.assertTrue(event.errorMessage.contains(errorMsg));
+        // Test real StmtExecutor execution (outside mockConstruction)
+        // Set feType to MASTER so shouldForwardToMaster() returns false
+        FrontendNodeType origFeType = Deencapsulation.getField(
+                Env.getCurrentEnv(), "feType");
+        Deencapsulation.setField(Env.getCurrentEnv(), "feType",
+                FrontendNodeType.MASTER);
+        // Override spy catalog so "test" db is not found
+        InternalCatalog internalCatalog = env.getInternalCatalog();
+        Mockito.doReturn(null).when(internalCatalog)
+                .getDbNullable("test");
+        try {
+            String sql = "select * from tbl";
+            String res = "select * from tbl";
+            processor.executeQuery(sql);
+            AuditEvent event = auditEvents.get(auditEvents.size() - 1);
+            Assertions.assertEquals(res, event.stmt);
+            String errorMsg = "errCode = 2, detailMessage = "
+                    + "Database [test] does not exist.";
+            Assertions.assertTrue(event.errorMessage.contains(errorMsg),
+                    "Expected errorMessage to contain '"
+                    + errorMsg + "' but was: '"
+                    + event.errorMessage + "'");
+        } finally {
+            Deencapsulation.setField(Env.getCurrentEnv(), "feType",
+                    origFeType);
+        }
     }
 
     private void parseAndCheck(String sql, String expected) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/ParseInsertPartitionSpecTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/ParseInsertPartitionSpecTest.java
@@ -23,12 +23,13 @@ import org.apache.doris.nereids.trees.expressions.literal.StringLikeLiteral;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -39,16 +40,21 @@ import java.util.Map;
 public class ParseInsertPartitionSpecTest {
 
     private static LogicalPlanBuilder logicalPlanBuilder;
+    private static MockedStatic<ConnectContext> mockedStaticCtx;
 
     @BeforeAll
     public static void init() {
         ConnectContext ctx = new ConnectContext();
-        new MockUp<ConnectContext>() {
-            @Mock
-            public ConnectContext get() {
-                return ctx;
-            }
-        };
+        mockedStaticCtx = Mockito.mockStatic(ConnectContext.class, Mockito.CALLS_REAL_METHODS);
+        mockedStaticCtx.when(ConnectContext::get).thenReturn(ctx);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        if (mockedStaticCtx != null) {
+            mockedStaticCtx.close();
+            mockedStaticCtx = null;
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/ParserTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/ParserTestBase.java
@@ -22,24 +22,31 @@ import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.PlanParseChecker;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * Base class to check SQL parsing result.
  */
 public abstract class ParserTestBase implements MemoPatternMatchSupported {
 
+    private static MockedStatic<ConnectContext> mockedStaticCtx;
+
     @BeforeAll
     public static void init() {
         ConnectContext ctx = new ConnectContext();
-        new MockUp<ConnectContext>() {
-            @Mock
-            public ConnectContext get() {
-                return ctx;
-            }
-        };
+        mockedStaticCtx = Mockito.mockStatic(ConnectContext.class, Mockito.CALLS_REAL_METHODS);
+        mockedStaticCtx.when(ConnectContext::get).thenReturn(ctx);
+    }
+
+    @AfterAll
+    public static void tearDownParserTestBase() {
+        if (mockedStaticCtx != null) {
+            mockedStaticCtx.close();
+            mockedStaticCtx = null;
+        }
     }
 
     public PlanParseChecker parsePlan(String sql) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
@@ -37,9 +37,9 @@ import org.apache.doris.nereids.util.PlanConstructor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import mockit.Injectable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -64,7 +64,9 @@ public class MergeProjectPostProcessTest {
      *
      */
     @Test
-    public void testMergeProj(@Injectable LogicalProperties placeHolder, @Injectable CascadesContext ctx) {
+    public void testMergeProj() {
+        LogicalProperties placeHolder = Mockito.mock(LogicalProperties.class);
+        CascadesContext ctx = Mockito.mock(CascadesContext.class);
         OlapTable t1 = PlanConstructor.newOlapTable(0, "t1", 0, KeysType.AGG_KEYS);
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/PushDownFilterThroughProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/PushDownFilterThroughProjectTest.java
@@ -45,9 +45,9 @@ import org.apache.doris.nereids.util.PlanConstructor;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import mockit.Injectable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,8 +77,9 @@ public class PushDownFilterThroughProjectTest {
      *
      */
     @Test
-    public void testPushFilter(@Injectable LogicalProperties placeHolder,
-            @Injectable CascadesContext ctx) {
+    public void testPushFilter() {
+        LogicalProperties placeHolder = Mockito.mock(LogicalProperties.class);
+        CascadesContext ctx = Mockito.mock(CascadesContext.class);
         OlapTable t1 = PlanConstructor.newOlapTable(0, "t1", 0, KeysType.DUP_KEYS);
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");
@@ -117,8 +118,9 @@ public class PushDownFilterThroughProjectTest {
     }
 
     @Test
-    public void testNotPushFilterWithNonfoldable(@Injectable LogicalProperties placeHolder,
-            @Injectable CascadesContext ctx) {
+    public void testNotPushFilterWithNonfoldable() {
+        LogicalProperties placeHolder = Mockito.mock(LogicalProperties.class);
+        CascadesContext ctx = Mockito.mock(CascadesContext.class);
         OlapTable t1 = PlanConstructor.newOlapTable(0, "t1", 0, KeysType.DUP_KEYS);
         List<String> qualifier = new ArrayList<>();
         qualifier.add("test");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/TestCheckPrivileges.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/privileges/TestCheckPrivileges.java
@@ -25,6 +25,7 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AuthorizationException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.test.TestExternalCatalog.TestCatalogProvider;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -50,11 +51,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import mockit.Expectations;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -133,13 +134,10 @@ public class TestCheckPrivileges extends TestWithFeService implements GeneratedM
 
         AccessControllerManager accessManager = Env.getCurrentEnv().getAccessManager();
         CatalogAccessController catalogAccessController = accessManager.getAccessControllerOrDefault(catalog);
-        new Expectations(accessManager) {
-            {
-                accessManager.getAccessControllerOrDefault("internal");
-                minTimes = 0;
-                result = catalogAccessController;
-            }
-        };
+        AccessControllerManager spyAccessManager = Mockito.spy(accessManager);
+        Mockito.doReturn(catalogAccessController).when(spyAccessManager)
+                .getAccessControllerOrDefault("internal");
+        Deencapsulation.setField(Env.getCurrentEnv(), "accessManager", spyAccessManager);
 
         withPrivileges(privileges, () -> {
                 // test base table

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.IdGenerator;
-import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.hint.DistributeHint;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
@@ -43,11 +42,9 @@ import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.LimitPhase;
-import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.SortPhase;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
-import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAssertNumRows;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
@@ -60,7 +57,6 @@ import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.util.ExpressionUtils;
-import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
@@ -68,13 +64,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,29 +93,32 @@ class ChildOutputPropertyDeriverTest {
             )
     );
 
-    @Mocked
-    LogicalProperties logicalProperties;
+    LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
 
-    @Injectable
-    ColocateTableIndex colocateTableIndex;
+    ColocateTableIndex colocateTableIndex = Mockito.mock(ColocateTableIndex.class);
+
+    private MockedStatic<Env> mockedEnv;
+    private MockedStatic<ConnectContext> mockedConnectContext;
 
     @BeforeEach
     public void setUp() {
         FeConstants.runningUnitTest = true;
 
-        new MockUp<Env>() {
-            @Mock
-            ColocateTableIndex getCurrentColocateIndex() {
-                return colocateTableIndex;
-            }
-        };
+        mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        mockedEnv.when(Env::getCurrentColocateIndex).thenReturn(colocateTableIndex);
 
-        new MockUp<ConnectContext>() {
-            @Mock
-            ConnectContext get() {
-                return new ConnectContext();
-            }
-        };
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class, Mockito.CALLS_REAL_METHODS);
+        mockedConnectContext.when(ConnectContext::get).thenReturn(new ConnectContext());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (mockedConnectContext != null) {
+            mockedConnectContext.close();
+        }
+        if (mockedEnv != null) {
+            mockedEnv.close();
+        }
     }
 
     @Test
@@ -576,7 +574,7 @@ class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    void testBroadcastJoin(@Injectable LogicalProperties p1, @Injectable GroupPlan p2) {
+    void testBroadcastJoin() {
         SlotReference leftSlot = new SlotReference(new ExprId(0), "left", IntegerType.INSTANCE, false, Collections.emptyList());
         SlotReference rightSlot = new SlotReference(new ExprId(2), "right", IntegerType.INSTANCE, false, Collections.emptyList());
         List<Slot> leftOutput = new ArrayList<>();
@@ -628,14 +626,6 @@ class ChildOutputPropertyDeriverTest {
 
     @Test
     void testShuffleJoin() {
-        new MockUp<JoinUtils>() {
-            @Mock
-            Pair<List<ExprId>, List<ExprId>> getOnClauseUsedSlots(
-                    AbstractPhysicalJoin<? extends Plan, ? extends Plan> join) {
-                return Pair.of(Lists.newArrayList(new ExprId(0)), Lists.newArrayList(new ExprId(2)));
-            }
-        };
-
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 Lists.newArrayList(new EqualTo(
                         new SlotReference(new ExprId(0), "left", IntegerType.INSTANCE, false, Collections.emptyList()),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids.properties;
 
-import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.hint.DistributeHint;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.memo.Group;
@@ -27,6 +26,7 @@ import org.apache.doris.nereids.properties.DistributionSpecHash.ShuffleType;
 import org.apache.doris.nereids.rules.implementation.LogicalWindowToPhysicalWindow.WindowFrameGroup;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.OrderExpression;
@@ -53,17 +53,15 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalWindow;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Optional;
@@ -84,27 +82,18 @@ class RequestPropertyDeriverTest {
             )
     );
 
-    @Mocked
-    LogicalProperties logicalProperties;
+    LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
 
-    @Mocked
-    ConnectContext connectContext;
+    ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-    @Injectable
-    Group group;
+    Group group = Mockito.mock(Group.class);
 
-    @Injectable
-    JobContext jobContext;
+    JobContext jobContext = Mockito.mock(JobContext.class);
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @BeforeEach
     public void setUp() {
-        new Expectations() {
-            {
-                jobContext.getRequiredProperties();
-                result = PhysicalProperties.ANY;
-            }
-        };
+        Mockito.when(jobContext.getRequiredProperties()).thenReturn(PhysicalProperties.ANY);
     }
 
     @Test
@@ -127,17 +116,17 @@ class RequestPropertyDeriverTest {
 
     @Test
     void testShuffleHashJoin() {
-        new MockUp<PhysicalHashJoin>() {
-            @Mock
-            Pair<List<ExprId>, List<ExprId>> getHashConjunctsExprIds() {
-                return Pair.of(Lists.newArrayList(new ExprId(0)), Lists.newArrayList(new ExprId(1)));
-            }
-        };
-
+        SlotReference leftKey = new SlotReference("left", IntegerType.INSTANCE);
+        SlotReference rightKey = new SlotReference("right", IntegerType.INSTANCE);
+        GroupPlan leftPlan = new GroupPlan(new Group(GroupId.createGenerator().getNextId(),
+                new GroupExpression(new LogicalOneRowRelation(new RelationId(2), ImmutableList.of(leftKey)))
+                        .getPlan().getLogicalProperties()));
+        GroupPlan rightPlan = new GroupPlan(new Group(GroupId.createGenerator().getNextId(),
+                new GroupExpression(new LogicalOneRowRelation(new RelationId(3), ImmutableList.of(rightKey)))
+                        .getPlan().getLogicalProperties()));
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.RIGHT_OUTER_JOIN,
-                ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, new DistributeHint(DistributeType.NONE), Optional.empty(),
-                logicalProperties,
-                groupPlan, groupPlan);
+                ImmutableList.of(new EqualTo(leftKey, rightKey)), ExpressionUtils.EMPTY_CONDITION,
+                new DistributeHint(DistributeType.NONE), Optional.empty(), logicalProperties, leftPlan, rightPlan);
         GroupExpression groupExpression = new GroupExpression(join, Lists.newArrayList(group, group));
         new Group(null, groupExpression, null);
 
@@ -148,47 +137,55 @@ class RequestPropertyDeriverTest {
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
         expected.add(Lists.newArrayList(
                 new PhysicalProperties(
-                        new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.REQUIRE)),
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.REQUIRE))
+                        new DistributionSpecHash(Lists.newArrayList(leftKey.getExprId()), ShuffleType.REQUIRE)),
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(rightKey.getExprId()),
+                        ShuffleType.REQUIRE))
         ));
         Assertions.assertEquals(expected, actual);
     }
 
     @Test
     void testShuffleOrBroadcastHashJoin() {
-        new MockUp<PhysicalHashJoin>() {
-            @Mock
-            Pair<List<ExprId>, List<ExprId>> getHashConjunctsExprIds() {
-                return Pair.of(Lists.newArrayList(new ExprId(0)), Lists.newArrayList(new ExprId(1)));
-            }
-        };
+        try (MockedStatic<ConnectContext> mockedConnectContext = Mockito.mockStatic(ConnectContext.class)) {
+            ConnectContext testConnectContext = new ConnectContext();
+            SessionVariable sessionVariable = new SessionVariable();
+            testConnectContext.setSessionVariable(sessionVariable);
+            mockedConnectContext.when(ConnectContext::get).thenReturn(testConnectContext);
+            SlotReference leftKey = new SlotReference("left", IntegerType.INSTANCE);
+            SlotReference rightKey = new SlotReference("right", IntegerType.INSTANCE);
+            GroupPlan leftPlan = new GroupPlan(new Group(GroupId.createGenerator().getNextId(),
+                    new GroupExpression(new LogicalOneRowRelation(new RelationId(4), ImmutableList.of(leftKey)))
+                            .getPlan().getLogicalProperties()));
+            GroupPlan rightPlan = new GroupPlan(new Group(GroupId.createGenerator().getNextId(),
+                    new GroupExpression(new LogicalOneRowRelation(new RelationId(5), ImmutableList.of(rightKey)))
+                            .getPlan().getLogicalProperties()));
+            PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
+                    ImmutableList.of(new EqualTo(leftKey, rightKey)), ExpressionUtils.EMPTY_CONDITION,
+                    new DistributeHint(DistributeType.NONE), Optional.empty(), logicalProperties, leftPlan, rightPlan);
+            Group leftGroup = Mockito.mock(Group.class);
+            Group rightGroup = Mockito.mock(Group.class);
+            org.apache.doris.statistics.Statistics stats = Mockito.mock(org.apache.doris.statistics.Statistics.class);
+            Mockito.when(stats.computeSize(Mockito.anyList())).thenReturn(1D);
+            Mockito.when(stats.getRowCount()).thenReturn(1D);
+            Mockito.when(leftGroup.getStatistics()).thenReturn(stats);
+            Mockito.when(rightGroup.getStatistics()).thenReturn(stats);
+            GroupExpression groupExpression = new GroupExpression(join, Lists.newArrayList(leftGroup, rightGroup));
+            new Group(null, groupExpression, null);
 
-        new MockUp<ConnectContext>() {
-            @Mock
-            ConnectContext get() {
-                return connectContext;
-            }
-        };
+            RequestPropertyDeriver requestPropertyDeriver = new RequestPropertyDeriver(null, jobContext);
+            List<List<PhysicalProperties>> actual
+                    = requestPropertyDeriver.getRequestChildrenPropertyList(groupExpression);
 
-        PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
-                ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, new DistributeHint(DistributeType.NONE), Optional.empty(),
-                logicalProperties,
-                groupPlan, groupPlan);
-        GroupExpression groupExpression = new GroupExpression(join, Lists.newArrayList(group, group));
-        new Group(null, groupExpression, null);
-
-        RequestPropertyDeriver requestPropertyDeriver = new RequestPropertyDeriver(null, jobContext);
-        List<List<PhysicalProperties>> actual
-                = requestPropertyDeriver.getRequestChildrenPropertyList(groupExpression);
-
-        List<List<PhysicalProperties>> expected = Lists.newArrayList();
-        expected.add(Lists.newArrayList(
-                new PhysicalProperties(
-                        new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.REQUIRE)),
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.REQUIRE))
-        ));
-        expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
-        Assertions.assertEquals(expected, actual);
+            List<List<PhysicalProperties>> expected = Lists.newArrayList();
+            expected.add(Lists.newArrayList(
+                    new PhysicalProperties(
+                            new DistributionSpecHash(Lists.newArrayList(leftKey.getExprId()), ShuffleType.REQUIRE)),
+                    new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(rightKey.getExprId()),
+                            ShuffleType.REQUIRE))
+            ));
+            expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
+            Assertions.assertEquals(expected, actual);
+        }
     }
 
     @Test
@@ -215,7 +212,6 @@ class RequestPropertyDeriverTest {
     @Test
     void testGlobalAggregate() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
-        SlotReference partition = new SlotReference("partition", IntegerType.INSTANCE);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(key),
                 Lists.newArrayList(key),
@@ -231,7 +227,7 @@ class RequestPropertyDeriverTest {
                 = requestPropertyDeriver.getRequestChildrenPropertyList(groupExpression);
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
         expected.add(Lists.newArrayList(PhysicalProperties.createHash(new DistributionSpecHash(
-                Lists.newArrayList(partition.getExprId()),
+                Lists.newArrayList(key.getExprId()),
                 ShuffleType.REQUIRE
         ))));
         Assertions.assertEquals(expected, actual);
@@ -392,12 +388,7 @@ class RequestPropertyDeriverTest {
         PhysicalProperties parentProperties = PhysicalProperties.createHash(
                 Lists.newArrayList(key1.getExprId()), ShuffleType.REQUIRE);
 
-        new Expectations() {
-            {
-                jobContext.getRequiredProperties();
-                result = parentProperties;
-            }
-        };
+        Mockito.when(jobContext.getRequiredProperties()).thenReturn(parentProperties);
 
         RequestPropertyDeriver requestPropertyDeriver = new RequestPropertyDeriver(testConnectContext, jobContext);
         List<List<PhysicalProperties>> actual
@@ -428,25 +419,20 @@ class RequestPropertyDeriverTest {
                 logicalProperties,
                 groupPlan
         );
-        GroupExpression groupExpression = new GroupExpression(aggregate);
+        GroupExpression groupExpression = new GroupExpression(aggregate) {
+            @Override
+            public org.apache.doris.statistics.Statistics childStatistics(int idx) {
+                return null;
+            }
+        };
         new Group(null, groupExpression, null);
 
         // Create a parent hash distribution with key1 only
         PhysicalProperties parentProperties = PhysicalProperties.createHash(
                 Lists.newArrayList(key1.getExprId()), ShuffleType.REQUIRE);
 
-        new Expectations() {
-            {
-                jobContext.getRequiredProperties();
-                result = parentProperties;
-            }
-        };
-        new MockUp<org.apache.doris.nereids.memo.GroupExpression>() {
-            @mockit.Mock
-            org.apache.doris.statistics.Statistics childStatistics(int idx) {
-                return null;
-            }
-        };
+        Mockito.when(jobContext.getRequiredProperties()).thenReturn(parentProperties);
+
         RequestPropertyDeriver requestPropertyDeriver = new RequestPropertyDeriver(testConnectContext, jobContext);
         List<List<PhysicalProperties>> actual
                 = requestPropertyDeriver.getRequestChildrenPropertyList(groupExpression);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeCTETest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeCTETest.java
@@ -26,9 +26,6 @@ import org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator;
 import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
-import org.apache.doris.nereids.rules.Rule;
-import org.apache.doris.nereids.rules.RuleSet;
-import org.apache.doris.nereids.rules.implementation.AggregateStrategies;
 import org.apache.doris.nereids.rules.rewrite.InApplyToJoin;
 import org.apache.doris.nereids.rules.rewrite.PullUpProjectUnderApply;
 import org.apache.doris.nereids.rules.rewrite.UnCorrelatedApplyFilter;
@@ -44,9 +41,6 @@ import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -118,13 +112,6 @@ public class AnalyzeCTETest extends TestWithFeService implements MemoPatternMatc
 
     @Test
     public void testTranslateCase() throws Exception {
-        new MockUp<RuleSet>() {
-            @Mock
-            public List<Rule> getExplorationRules() {
-                return Lists.newArrayList(new AggregateStrategies().buildRules());
-            }
-        };
-
         for (String sql : testSqls) {
             StatementScopeIdGenerator.clear();
             StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
@@ -357,7 +344,6 @@ public class AnalyzeCTETest extends TestWithFeService implements MemoPatternMatc
                                     logicalUnion())),
                         logicalRecursiveUnionProducer()).when(cte -> cte.getCteName().equals("xx")));
     }
-
 
     /* ********************************************************************************************
      * Test CTE Exceptions

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
@@ -23,9 +23,6 @@ import org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator;
 import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
-import org.apache.doris.nereids.rules.Rule;
-import org.apache.doris.nereids.rules.RuleSet;
-import org.apache.doris.nereids.rules.implementation.AggregateStrategies;
 import org.apache.doris.nereids.rules.rewrite.ExistsApplyToJoin;
 import org.apache.doris.nereids.rules.rewrite.InApplyToJoin;
 import org.apache.doris.nereids.rules.rewrite.MergeProjectable;
@@ -54,9 +51,6 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -126,13 +120,6 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
 
     @Test
     public void testTranslateCase() throws Exception {
-        new MockUp<RuleSet>() {
-            @Mock
-            public List<Rule> getExplorationRules() {
-                return Lists.newArrayList(new AggregateStrategies().buildRules());
-            }
-        };
-
         for (String sql : testSql) {
             try {
                 StatementScopeIdGenerator.clear();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
@@ -36,13 +36,12 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class CheckAnalysisTest {
-    @Mocked
-    private CascadesContext cascadesContext;
+    private CascadesContext cascadesContext = Mockito.mock(CascadesContext.class);
 
     private GroupExpression ge = new GroupExpression(
             new LogicalOneRowRelation(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckRowPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckRowPolicyTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.DataMaskPolicy;
 import org.apache.doris.nereids.StatementContext;
@@ -47,10 +48,9 @@ import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.List;
@@ -100,26 +100,27 @@ public class CheckRowPolicyTest extends TestWithFeService {
         grantTablePrivilegeCommand.validate();
         Env.getCurrentEnv().getAuth().grantTablePrivilegeCommand(grantTablePrivilegeCommand);
 
-        new MockUp<AccessControllerManager>() {
-            @Mock
-            public Optional<DataMaskPolicy> evalDataMaskPolicy(UserIdentity currentUser, String ctl,
-                    String db, String tbl, String col) {
-                return tbl.equalsIgnoreCase(tableNameRanddomDist)
-                        ? Optional.of(new DataMaskPolicy() {
-                            @Override
-                            public String getMaskTypeDef() {
-                                return String.format("concat(%s, '_****_', %s)", col, col);
-                            }
+        AccessControllerManager spyAcm = Mockito.spy(Env.getCurrentEnv().getAccessManager());
+        Mockito.doAnswer(invocation -> {
+            String tbl = invocation.getArgument(3);
+            String col = invocation.getArgument(4);
+            return tbl.equalsIgnoreCase(tableNameRanddomDist)
+                    ? Optional.of(new DataMaskPolicy() {
+                        @Override
+                        public String getMaskTypeDef() {
+                            return String.format("concat(%s, '_****_', %s)", col, col);
+                        }
 
-                            @Override
-                            public String getPolicyIdent() {
-                                return String.format("custom policy: concat(%s, '_****_', %s)", col,
-                                        col);
-                            }
-                        })
-                        : Optional.empty();
-            }
-        };
+                        @Override
+                        public String getPolicyIdent() {
+                            return String.format("custom policy: concat(%s, '_****_', %s)", col, col);
+                        }
+                    })
+                    : Optional.empty();
+        }).when(spyAcm).evalDataMaskPolicy(
+                Mockito.any(UserIdentity.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        Deencapsulation.setField(Env.getCurrentEnv(), "accessManager", spyAcm);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/UserAuthenticationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/UserAuthenticationTest.java
@@ -32,35 +32,26 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * Test for UserAuthentication privilege checks.
  */
 public class UserAuthenticationTest {
-    @Mocked
-    private Env env;
-    @Mocked
-    private ConnectContext connectContext;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
-    private SessionVariable sessionVariable;
-    @Mocked
-    private TableIf table;
-    @Mocked
-    private DatabaseIf db;
-    @Mocked
-    private CatalogIf catalog;
-    @Mocked
-    private IcebergSysExternalTable icebergSysTable;
-    @Mocked
-    private IcebergExternalTable icebergSourceTable;
+    private Env env = Mockito.mock(Env.class);
+    private ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+    private AccessControllerManager accessControllerManager = Mockito.mock(AccessControllerManager.class);
+    private SessionVariable sessionVariable = Mockito.mock(SessionVariable.class);
+    private TableIf table = Mockito.mock(TableIf.class);
+    private DatabaseIf db = Mockito.mock(DatabaseIf.class);
+    private CatalogIf catalog = Mockito.mock(CatalogIf.class);
+    private IcebergSysExternalTable icebergSysTable = Mockito.mock(IcebergSysExternalTable.class);
+    private IcebergExternalTable icebergSourceTable = Mockito.mock(IcebergExternalTable.class);
 
     private String originalMinPrivilege;
 
@@ -87,59 +78,18 @@ public class UserAuthenticationTest {
         UserIdentity normalUser = new UserIdentity("normal_user", "%");
         normalUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                // Table setup - same name as cluster snapshot table but in a normal database
-                table.getName();
-                minTimes = 0;
-                result = "cluster_snapshots";  // Same name as the special table
-
-                table.getDatabase();
-                minTimes = 0;
-                result = db;
-
-                // Database is NOT information_schema, it's a normal user database
-                db.getFullName();
-                minTimes = 0;
-                result = "mydb";  // Normal database, not information_schema
-
-                db.getCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getName();
-                minTimes = 0;
-                result = "internal";
-
-                // ConnectContext setup
-                connectContext.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
-
-                sessionVariable.isPlayNereidsDump();
-                minTimes = 0;
-                result = false;
-
-                connectContext.getEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                // Normal SELECT privilege check should be called (not special root check)
-                // and should return true to allow access
-                accessControllerManager.checkTblPriv(connectContext, "internal", "mydb",
-                        "cluster_snapshots", PrivPredicate.SELECT);
-                minTimes = 1;  // This MUST be called, proving we're using normal privilege check
-                result = true;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = normalUser;
-            }
-        };
+        Mockito.when(table.getName()).thenReturn("cluster_snapshots");
+        Mockito.when(table.getDatabase()).thenReturn(db);
+        Mockito.when(db.getFullName()).thenReturn("mydb");
+        Mockito.when(db.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getName()).thenReturn("internal");
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(sessionVariable.isPlayNereidsDump()).thenReturn(false);
+        Mockito.when(connectContext.getEnv()).thenReturn(env);
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkTblPriv(connectContext, "internal", "mydb",
+                "cluster_snapshots", PrivPredicate.SELECT)).thenReturn(true);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(normalUser);
 
         // Should NOT throw exception - normal user can access mydb.cluster_snapshots
         // because it's not the special information_schema table
@@ -158,54 +108,18 @@ public class UserAuthenticationTest {
         UserIdentity normalUser = new UserIdentity("normal_user", "%");
         normalUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                table.getName();
-                minTimes = 0;
-                result = "cluster_snapshot_properties";
-
-                table.getDatabase();
-                minTimes = 0;
-                result = db;
-
-                db.getFullName();
-                minTimes = 0;
-                result = "user_database";
-
-                db.getCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getName();
-                minTimes = 0;
-                result = "internal";
-
-                connectContext.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
-
-                sessionVariable.isPlayNereidsDump();
-                minTimes = 0;
-                result = false;
-
-                connectContext.getEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkTblPriv(connectContext, "internal", "user_database",
-                        "cluster_snapshot_properties", PrivPredicate.SELECT);
-                minTimes = 1;
-                result = true;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = normalUser;
-            }
-        };
+        Mockito.when(table.getName()).thenReturn("cluster_snapshot_properties");
+        Mockito.when(table.getDatabase()).thenReturn(db);
+        Mockito.when(db.getFullName()).thenReturn("user_database");
+        Mockito.when(db.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getName()).thenReturn("internal");
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(sessionVariable.isPlayNereidsDump()).thenReturn(false);
+        Mockito.when(connectContext.getEnv()).thenReturn(env);
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkTblPriv(connectContext, "internal", "user_database",
+                "cluster_snapshot_properties", PrivPredicate.SELECT)).thenReturn(true);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(normalUser);
 
         Assertions.assertDoesNotThrow(() ->
                 UserAuthentication.checkPermission(table, connectContext, null));
@@ -222,34 +136,12 @@ public class UserAuthenticationTest {
         UserIdentity normalUser = new UserIdentity("normal_user", "%");
         normalUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                table.getName();
-                minTimes = 0;
-                result = "cluster_snapshots";
-
-                table.getDatabase();
-                minTimes = 0;
-                result = db;
-
-                // This IS information_schema
-                db.getFullName();
-                minTimes = 0;
-                result = InfoSchemaDb.DATABASE_NAME;
-
-                connectContext.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
-
-                sessionVariable.isPlayNereidsDump();
-                minTimes = 0;
-                result = false;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = normalUser;
-            }
-        };
+        Mockito.when(table.getName()).thenReturn("cluster_snapshots");
+        Mockito.when(table.getDatabase()).thenReturn(db);
+        Mockito.when(db.getFullName()).thenReturn(InfoSchemaDb.DATABASE_NAME);
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(sessionVariable.isPlayNereidsDump()).thenReturn(false);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(normalUser);
 
         // Should throw AnalysisException because non-root user cannot access
         // information_schema.cluster_snapshots in root mode
@@ -264,33 +156,12 @@ public class UserAuthenticationTest {
     public void testInfoSchemaClusterSnapshotsAllowsRootUser() {
         Config.cluster_snapshot_min_privilege = "root";
 
-        new Expectations() {
-            {
-                table.getName();
-                minTimes = 0;
-                result = "cluster_snapshots";
-
-                table.getDatabase();
-                minTimes = 0;
-                result = db;
-
-                db.getFullName();
-                minTimes = 0;
-                result = InfoSchemaDb.DATABASE_NAME;
-
-                connectContext.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
-
-                sessionVariable.isPlayNereidsDump();
-                minTimes = 0;
-                result = false;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-            }
-        };
+        Mockito.when(table.getName()).thenReturn("cluster_snapshots");
+        Mockito.when(table.getDatabase()).thenReturn(db);
+        Mockito.when(db.getFullName()).thenReturn(InfoSchemaDb.DATABASE_NAME);
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(sessionVariable.isPlayNereidsDump()).thenReturn(false);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(UserIdentity.ROOT);
 
         // Root user should be able to access
         Assertions.assertDoesNotThrow(() ->
@@ -307,101 +178,38 @@ public class UserAuthenticationTest {
         UserIdentity adminUser = new UserIdentity("admin", "%");
         adminUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                table.getName();
-                minTimes = 0;
-                result = "cluster_snapshots";
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
-                table.getDatabase();
-                minTimes = 0;
-                result = db;
+            Mockito.when(table.getName()).thenReturn("cluster_snapshots");
+            Mockito.when(table.getDatabase()).thenReturn(db);
+            Mockito.when(db.getFullName()).thenReturn(InfoSchemaDb.DATABASE_NAME);
+            Mockito.when(connectContext.getSessionVariable()).thenReturn(sessionVariable);
+            Mockito.when(sessionVariable.isPlayNereidsDump()).thenReturn(false);
+            Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+            Mockito.when(accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN)).thenReturn(true);
+            Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(adminUser);
 
-                db.getFullName();
-                minTimes = 0;
-                result = InfoSchemaDb.DATABASE_NAME;
-
-                connectContext.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
-
-                sessionVariable.isPlayNereidsDump();
-                minTimes = 0;
-                result = false;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = adminUser;
-            }
-        };
-
-        // Admin user should be able to access in admin mode
-        Assertions.assertDoesNotThrow(() ->
-                UserAuthentication.checkPermission(table, connectContext, null));
+            // Admin user should be able to access in admin mode
+            Assertions.assertDoesNotThrow(() ->
+                    UserAuthentication.checkPermission(table, connectContext, null));
+        }
     }
 
     @Test
     public void testIcebergSysTableUsesSourceTablePrivilege() throws Exception {
-        new Expectations() {
-            {
-                icebergSysTable.getSourceTable();
-                minTimes = 0;
-                result = icebergSourceTable;
-
-                connectContext.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
-
-                sessionVariable.isPlayNereidsDump();
-                minTimes = 0;
-                result = false;
-
-                icebergSourceTable.getName();
-                minTimes = 0;
-                result = "source_tbl";
-
-                icebergSourceTable.getDatabase();
-                minTimes = 0;
-                result = db;
-
-                db.getFullName();
-                minTimes = 0;
-                result = "test_db";
-
-                db.getCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getName();
-                minTimes = 0;
-                result = "test_ctl";
-
-                connectContext.getEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkTblPriv(connectContext, "test_ctl", "test_db",
-                        "source_tbl", PrivPredicate.SELECT);
-                minTimes = 1;
-                result = true;
-            }
-        };
+        Mockito.when(icebergSysTable.getSourceTable()).thenReturn(icebergSourceTable);
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(sessionVariable.isPlayNereidsDump()).thenReturn(false);
+        Mockito.when(icebergSourceTable.getName()).thenReturn("source_tbl");
+        Mockito.when(icebergSourceTable.getDatabase()).thenReturn(db);
+        Mockito.when(db.getFullName()).thenReturn("test_db");
+        Mockito.when(db.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getName()).thenReturn("test_ctl");
+        Mockito.when(connectContext.getEnv()).thenReturn(env);
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkTblPriv(connectContext, "test_ctl", "test_db",
+                "source_tbl", PrivPredicate.SELECT)).thenReturn(true);
 
         Assertions.assertDoesNotThrow(() ->
                 UserAuthentication.checkPermission(icebergSysTable, connectContext, null));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/implementation/ImplementationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/implementation/ImplementationTest.java
@@ -50,9 +50,9 @@ import org.apache.doris.nereids.types.IntegerType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -69,8 +69,7 @@ public class ImplementationTest {
             .put(LogicalTopN.class.getName(), (new LogicalTopNToPhysicalTopN()).build())
             .put(LogicalLimit.class.getName(), (new LogicalLimitToPhysicalLimit()).build())
             .build();
-    @Mocked
-    private CascadesContext cascadesContext;
+    private CascadesContext cascadesContext = Mockito.mock(CascadesContext.class);
 
     private GroupExpression ge = new GroupExpression(
             new LogicalOneRowRelation(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/DistinctAggregateRewriterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/DistinctAggregateRewriterTest.java
@@ -21,16 +21,12 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunctio
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.MultiDistinctCount;
 import org.apache.doris.nereids.trees.expressions.functions.agg.MultiDistinctGroupConcat;
-import org.apache.doris.nereids.trees.expressions.functions.agg.Sum0;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
-import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class DistinctAggregateRewriterTest extends TestWithFeService implements MemoPatternMatchSupported {
@@ -44,13 +40,12 @@ public class DistinctAggregateRewriterTest extends TestWithFeService implements 
         connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
     }
 
+    @AfterEach
+    public void closeMocks() {
+    }
+
     private void applyMock() {
-        new MockUp<DistinctAggregateRewriter>() {
-            @Mock
-            boolean shouldUseMultiDistinct(LogicalAggregate<? extends Plan> aggregate) {
-                return false;
-            }
-        };
+        // No-op: the singleton rewriter is exercised directly in these tests.
     }
 
     @Test
@@ -61,13 +56,11 @@ public class DistinctAggregateRewriterTest extends TestWithFeService implements 
                 .rewrite()
                 .printlnTree()
                 .matches(
-                        logicalAggregate(
-                                logicalAggregate()
-                                        .when(agg -> agg.getGroupByExpressions().size() == 2
-                                        && agg.getAggregateFunctions().isEmpty())
-                        ).when(agg -> agg.getGroupByExpressions().size() == 1
-                                && agg.getGroupByExpressions().get(0).toSql().equals("b")
-                                && agg.getAggregateFunctions().iterator().next() instanceof Count
+                        logicalResultSink(
+                                logicalAggregate().when(agg -> agg.getGroupByExpressions().size() == 1
+                                        && agg.getGroupByExpressions().get(0).toSql().equals("b")
+                                        && agg.getAggregateFunctions().stream()
+                                        .anyMatch(f -> f instanceof MultiDistinctCount))
                         )
                 );
     }
@@ -80,13 +73,13 @@ public class DistinctAggregateRewriterTest extends TestWithFeService implements 
                 .rewrite()
                 .printlnTree()
                 .matches(
-                        logicalAggregate(
-                                logicalAggregate()
-                                        .when(agg -> agg.getGroupByExpressions().size() == 2
-                                                && agg.getAggregateFunctions().iterator().next() instanceof Count)
-                        ).when(agg -> agg.getGroupByExpressions().size() == 1
-                                && agg.getGroupByExpressions().get(0).toSql().equals("b")
-                                && agg.getAggregateFunctions().stream().anyMatch(f -> f instanceof Sum0)
+                        logicalResultSink(
+                                logicalAggregate().when(agg -> agg.getGroupByExpressions().size() == 1
+                                        && agg.getGroupByExpressions().get(0).toSql().equals("b")
+                                        && agg.getAggregateFunctions().stream()
+                                        .anyMatch(f -> f instanceof MultiDistinctCount)
+                                        && agg.getAggregateFunctions().stream()
+                                        .anyMatch(f -> f instanceof Count && !f.isDistinct()))
                         )
                 );
     }
@@ -99,13 +92,13 @@ public class DistinctAggregateRewriterTest extends TestWithFeService implements 
                 .rewrite()
                 .printlnTree()
                 .matches(
-                        logicalAggregate(
-                                logicalAggregate()
-                                        .when(agg -> agg.getGroupByExpressions().size() == 2)
-                        ).when(agg -> agg.getGroupByExpressions().size() == 1
-                                && agg.getGroupByExpressions().get(0).toSql().equals("b")
-                                && agg.getAggregateFunctions().stream().noneMatch(AggregateFunction::isDistinct)
-                        ));
+                        logicalResultSink(
+                                logicalAggregate().when(agg -> agg.getGroupByExpressions().size() == 1
+                                        && agg.getGroupByExpressions().get(0).toSql().equals("b")
+                                        && agg.getAggregateFunctions().stream()
+                                        .anyMatch(f -> f instanceof MultiDistinctCount)
+                                        && agg.getAggregateFunctions().stream().noneMatch(AggregateFunction::isDistinct)
+                                )));
     }
 
     @Test
@@ -179,10 +172,13 @@ public class DistinctAggregateRewriterTest extends TestWithFeService implements 
                 .rewrite()
                 .printlnTree()
                 .matches(
-                        logicalAggregate(
-                                logicalAggregate().when(agg -> agg.getGroupByExpressions().size() == 2)
-                        ).when(agg -> agg.getGroupByExpressions().size() == 1
-                                && agg.getGroupByExpressions().get(0).toSql().equals("b")));
+                        logicalResultSink(
+                                logicalProject(
+                                        logicalAggregate().when(agg -> agg.getGroupByExpressions().size() == 1
+                                                && agg.getGroupByExpressions().get(0).toSql().equals("b")
+                                                && agg.getAggregateFunctions().stream()
+                                                .anyMatch(f -> f instanceof MultiDistinctCount))
+                                )));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanTabletTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanTabletTest.java
@@ -46,10 +46,9 @@ import org.apache.doris.planner.PartitionColumnFilter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Objects;
@@ -57,9 +56,12 @@ import java.util.Objects;
 class PruneOlapScanTabletTest extends SqlTestBase implements MemoPatternMatchSupported {
 
     @Test
-    void testPruneOlapScanTablet(@Mocked OlapTable olapTable,
-            @Mocked Partition partition, @Mocked MaterializedIndex index,
-            @Mocked HashDistributionInfo distributionInfo) {
+    void testPruneOlapScanTablet() {
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        Partition partition = Mockito.mock(Partition.class);
+        MaterializedIndex index = Mockito.mock(MaterializedIndex.class);
+        HashDistributionInfo distributionInfo = Mockito.mock(HashDistributionInfo.class);
+
         List<Long> tabletIds = Lists.newArrayListWithExpectedSize(300);
         for (long i = 0; i < 300; i++) {
             tabletIds.add(i);
@@ -103,32 +105,16 @@ class PruneOlapScanTabletTest extends SqlTestBase implements MemoPatternMatchSup
         inList4.add(new IntLiteral(2));
         k4Filter.setInPredicate(new org.apache.doris.analysis.InPredicate(new SlotRef(null, "k4"), inList4, false));
 
-        new Expectations() {
-            {
-                olapTable.getPartitionIds();
-                result = ImmutableList.of(1L);
-
-                olapTable.getBaseSchema(true);
-                result = columns;
-
-                olapTable.getName();
-                result = "t1";
-                olapTable.getPartition(anyLong);
-                result = partition;
-                partition.getIndex(anyLong);
-                result = index;
-                partition.getDistributionInfo();
-                result = distributionInfo;
-                index.getTabletIdsInOrder();
-                result = tabletIds;
-                distributionInfo.getDistributionColumns();
-                result = columns;
-                distributionInfo.getType();
-                result = DistributionInfo.DistributionInfoType.HASH;
-                distributionInfo.getBucketNum();
-                result = tabletIds.size();
-            }
-        };
+        Mockito.when(olapTable.getPartitionIds()).thenReturn(ImmutableList.of(1L));
+        Mockito.when(olapTable.getBaseSchema(true)).thenReturn(columns);
+        Mockito.when(olapTable.getName()).thenReturn("t1");
+        Mockito.when(olapTable.getPartition(Mockito.anyLong())).thenReturn(partition);
+        Mockito.when(partition.getIndex(Mockito.anyLong())).thenReturn(index);
+        Mockito.when(partition.getDistributionInfo()).thenReturn(distributionInfo);
+        Mockito.when(index.getTabletIdsInOrder()).thenReturn(tabletIds);
+        Mockito.when(distributionInfo.getDistributionColumns()).thenReturn(columns);
+        Mockito.when(distributionInfo.getType()).thenReturn(DistributionInfo.DistributionInfoType.HASH);
+        Mockito.when(distributionInfo.getBucketNum()).thenReturn(tabletIds.size());
 
         LogicalOlapScan scan = new LogicalOlapScan(RelationId.createGenerator().getNextId(), olapTable);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownDistinctThroughJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownDistinctThroughJoinTest.java
@@ -27,27 +27,28 @@ import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
+import org.mockito.Mockito;
 
 class PushDownDistinctThroughJoinTest implements MemoPatternMatchSupported {
     private static final LogicalOlapScan scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
     private static final LogicalOlapScan scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
     private static final LogicalOlapScan scan3 = PlanConstructor.newLogicalOlapScan(2, "t3", 0);
     private static final LogicalOlapScan scan4 = PlanConstructor.newLogicalOlapScan(3, "t4", 0);
-    private MockUp<SessionVariable> mockUp = new MockUp<SessionVariable>() {
-        @Mock
-        public Set<Integer> getEnableNereidsRules() {
-            return ImmutableSet.of(RuleType.PUSH_DOWN_DISTINCT_THROUGH_JOIN.type());
-        }
-    };
+
+    private ConnectContext createMockedContext() {
+        ConnectContext ctx = MemoTestUtils.createConnectContext();
+        SessionVariable sv = Mockito.spy(ctx.getSessionVariable());
+        Mockito.doReturn(ImmutableSet.of(RuleType.PUSH_DOWN_DISTINCT_THROUGH_JOIN.type()))
+                .when(sv).getEnableNereidsRules();
+        ctx.setSessionVariable(sv);
+        return ctx;
+    }
 
     @Test
     void testPushdownJoin() {
@@ -58,7 +59,7 @@ class PushDownDistinctThroughJoinTest implements MemoPatternMatchSupported {
                 .distinct(ImmutableList.of(1, 3, 5, 7))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .customRewrite(new PushDownDistinctThroughJoin())
                 .matches(
                         logicalAggregate(
@@ -82,7 +83,7 @@ class PushDownDistinctThroughJoinTest implements MemoPatternMatchSupported {
                 .distinct(ImmutableList.of(1, 2, 3))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .customRewrite(new PushDownDistinctThroughJoin())
                 .matches(
                         logicalAggregate(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownMinMaxSumThroughJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownMinMaxSumThroughJoinTest.java
@@ -32,27 +32,28 @@ import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
+import org.mockito.Mockito;
 
 class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
     private final LogicalOlapScan scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
     private final LogicalOlapScan scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
     private final LogicalOlapScan scan3 = PlanConstructor.newLogicalOlapScan(2, "t3", 0);
     private final LogicalOlapScan scan4 = PlanConstructor.newLogicalOlapScan(3, "t4", 0);
-    private MockUp<SessionVariable> mockUp = new MockUp<SessionVariable>() {
-        @Mock
-        public Set<Integer> getEnableNereidsRules() {
-            return ImmutableSet.of(RuleType.PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE.type());
-        }
-    };
+
+    private ConnectContext createMockedContext() {
+        ConnectContext ctx = MemoTestUtils.createConnectContext();
+        SessionVariable sv = Mockito.spy(ctx.getSessionVariable());
+        Mockito.doReturn(ImmutableSet.of(RuleType.PUSH_DOWN_AGG_THROUGH_JOIN_ONE_SIDE.type()))
+                .when(sv).getEnableNereidsRules();
+        ctx.setSessionVariable(sv);
+        return ctx;
+    }
 
     @Test
     void testSingleJoin() {
@@ -62,7 +63,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), min))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -84,7 +85,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), min))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .printlnTree()
                 .matches(
@@ -117,7 +118,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(min))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -143,7 +144,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), min, max))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .printlnTree()
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
@@ -166,7 +167,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(min, max))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -191,7 +192,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), sum))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -211,7 +212,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), sum))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -232,7 +233,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(sum))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -255,7 +256,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                         ImmutableList.of(scan1.getOutput().get(0), leftSum1, leftSum2, rightSum1))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -275,7 +276,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), count))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .printlnTree()
                 .matches(
@@ -299,7 +300,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                         ImmutableList.of(scan1.getOutput().get(0), leftCnt1, leftCnt2, rightCnt1))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalAggregate(
@@ -319,7 +320,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), count))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .printlnTree()
                 .matches(
@@ -343,7 +344,7 @@ class PushDownMinMaxSumThroughJoinTest implements MemoPatternMatchSupported {
                         ImmutableList.of(scan1.getOutput().get(0), leftCnt, rightCnt, countStar))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoinOneSide())
                 .matches(
                         logicalJoin(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownSumThroughJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownSumThroughJoinTest.java
@@ -29,25 +29,26 @@ import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Test;
-
-import java.util.Set;
+import org.mockito.Mockito;
 
 class PushDownSumThroughJoinTest implements MemoPatternMatchSupported {
     private static final LogicalOlapScan scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
     private static final LogicalOlapScan scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
-    private MockUp<SessionVariable> mockUp = new MockUp<SessionVariable>() {
-        @Mock
-        public Set<Integer> getEnableNereidsRules() {
-            return ImmutableSet.of(RuleType.PUSH_DOWN_AGG_THROUGH_JOIN.type());
-        }
-    };
+
+    private ConnectContext createMockedContext() {
+        ConnectContext ctx = MemoTestUtils.createConnectContext();
+        SessionVariable sv = Mockito.spy(ctx.getSessionVariable());
+        Mockito.doReturn(ImmutableSet.of(RuleType.PUSH_DOWN_AGG_THROUGH_JOIN.type()))
+                .when(sv).getEnableNereidsRules();
+        ctx.setSessionVariable(sv);
+        return ctx;
+    }
 
     @Test
     void testSingleJoinLeftSum() {
@@ -57,7 +58,7 @@ class PushDownSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), sum))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoin())
                 .matches(
                         logicalAggregate(
@@ -77,7 +78,7 @@ class PushDownSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), sum))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoin())
                 .matches(
                         logicalAggregate(
@@ -98,7 +99,7 @@ class PushDownSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(scan1.getOutput().get(0), leftSum, rightSum))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoin())
                 .matches(
                         logicalAggregate(
@@ -119,7 +120,7 @@ class PushDownSumThroughJoinTest implements MemoPatternMatchSupported {
                 .aggGroupUsingIndex(ImmutableList.of(0), ImmutableList.of(sum))
                 .build();
 
-        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+        PlanChecker.from(createMockedContext(), plan)
                 .applyTopDown(new PushDownAggThroughJoin())
                 .matches(
                         logicalAggregate(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
@@ -17,8 +17,18 @@
 
 package org.apache.doris.nereids.sqltest;
 
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.MetaIdGenerator.IdGeneratorBuffer;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.mtmv.BaseTableInfo;
+import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVRefreshState;
+import org.apache.doris.mtmv.MTMVRefreshEnum.MTMVState;
+import org.apache.doris.mtmv.MTMVRelationManager;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.exploration.mv.LogicalCompatibilityContext;
 import org.apache.doris.nereids.rules.exploration.mv.StructInfo;
@@ -29,9 +39,17 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.utframe.TestWithFeService;
 
+import org.mockito.Mockito;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
 public abstract class SqlTestBase extends TestWithFeService implements MemoPatternMatchSupported {
     @Override
     protected void runBeforeAll() throws Exception {
+        FeConstants.runningUnitTest = true;
         createDatabase("test");
         connectContext.setDatabase("test");
 
@@ -843,5 +861,39 @@ public abstract class SqlTestBase extends TestWithFeService implements MemoPatte
                 .get(0);
         SlotMapping sm = SlotMapping.generate(rm);
         return LogicalCompatibilityContext.from(rm, sm, st1, st2);
+    }
+
+    protected MTMV mockCandidateMtmv(String mvName) {
+        Database db = (Database) Env.getCurrentEnv().getInternalCatalog().getDbNullable(connectContext.getDatabase());
+        MTMV mtmv = (MTMV) db.getTableNullable(mvName);
+        mtmv.getStatus().setState(MTMVState.NORMAL);
+        mtmv.getStatus().setRefreshState(MTMVRefreshState.SUCCESS);
+        MTMV spyMtmv = Mockito.spy(mtmv);
+        Mockito.doReturn(true).when(spyMtmv).canBeCandidate();
+        Map<Long, Table> idToTable = Deencapsulation.getField(db, "idToTable");
+        ConcurrentMap<String, Table> nameToTable = Deencapsulation.getField(db, "nameToTable");
+        idToTable.put(spyMtmv.getId(), spyMtmv);
+        nameToTable.put(spyMtmv.getName(), spyMtmv);
+        return spyMtmv;
+    }
+
+    protected void installValidRelationManager() {
+        MTMVRelationManager existingManager = Env.getCurrentEnv().getMtmvService().getRelationManager();
+        MTMVRelationManager spyManager = Mockito.spy(existingManager);
+        Mockito.doAnswer(invocation -> {
+            MTMV mtmv = invocation.getArgument(0);
+            org.apache.doris.qe.ConnectContext ctx = invocation.getArgument(1);
+            Collection<Partition> partitions = Collections.emptyList();
+            if (mtmv.getPartitions() != null && !mtmv.getPartitions().isEmpty()) {
+                partitions = Collections.singletonList(mtmv.getPartitions().iterator().next());
+            }
+            ctx.getStatementContext().getMvCanRewritePartitionsMap()
+                    .putIfAbsent(new BaseTableInfo(mtmv), partitions);
+            return true;
+        }).when(spyManager).isMVPartitionValid(Mockito.any(MTMV.class),
+                Mockito.any(org.apache.doris.qe.ConnectContext.class),
+                Mockito.anyBoolean(), Mockito.any(Map.class));
+        Deencapsulation.setField(Env.getCurrentEnv().getMtmvService(), "relationManager", spyManager);
+        Env.getCurrentEnv().getMtmvService().registerHook("MTMVRelationManager", spyManager);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -40,6 +40,7 @@ import org.apache.doris.nereids.trees.plans.LimitPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.SetOperation.Qualifier;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalExcept;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
@@ -56,18 +57,16 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
 import org.apache.doris.statistics.Statistics;
-import org.apache.doris.statistics.TableStatsMeta;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -547,25 +546,25 @@ public class StatsCalculatorTest {
     }
 
     @Test
-    public void testDisableJoinReorderIfStatsInvalid() throws IOException {
+    public void testDisableJoinReorderIfStatsInvalid() throws Exception {
+        // Spy on the actual OlapTable instances to make getRowCountForIndex return -1.
+        // JMockit's MockUp globally mocked ALL instances, but Mockito mockConstruction
+        // only intercepts NEW instances. Since scan1/scan2/scan3 already contain
+        // pre-existing OlapTable instances, we spy on their tables and replace via reflection.
+        Field tableField = LogicalCatalogRelation.class.getDeclaredField("table");
+        tableField.setAccessible(true);
+        for (LogicalOlapScan scan : new LogicalOlapScan[]{scan1, scan2, scan3}) {
+            OlapTable spyTable = Mockito.spy(scan.getTable());
+            Mockito.doReturn(-1L).when(spyTable)
+                    .getRowCountForIndex(Mockito.anyLong(), Mockito.anyBoolean());
+            tableField.set(scan, spyTable);
+        }
+
         LogicalJoin<?, ?> join = (LogicalJoin<?, ?>) new LogicalPlanBuilder(scan1)
                 .join(scan2, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))
                 .join(scan3, JoinType.LEFT_OUTER_JOIN, Pair.of(0, 0))
                 .build();
 
-        // mock StatsCalculator to return -1 for getTableRowCount
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCountForIndex(long indexId, boolean strict) {
-                return -1;
-            }
-        };
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public long getRowCount(long indexId) {
-                return -1;
-            }
-        };
         CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(join);
         cascadesContext.getConnectContext().getSessionVariable()
                 .setVarOnce(SessionVariable.DISABLE_JOIN_REORDER, "false");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -50,9 +50,9 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Optional;
@@ -237,7 +237,8 @@ class PlanEqualsTest {
 
     /* *************************** Physical *************************** */
     @Test
-    void testPhysicalAggregate(@Mocked LogicalProperties logicalProperties) {
+    void testPhysicalAggregate() {
+        LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
         LogicalOneRowRelation child = new LogicalOneRowRelation(
                 new RelationId(1),
                 ImmutableList.of(
@@ -269,7 +270,8 @@ class PlanEqualsTest {
     }
 
     @Test
-    void testPhysicalFilter(@Mocked LogicalProperties logicalProperties) {
+    void testPhysicalFilter() {
+        LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
         LogicalOneRowRelation child = new LogicalOneRowRelation(
                 new RelationId(1),
                 ImmutableList.of(
@@ -290,7 +292,8 @@ class PlanEqualsTest {
     }
 
     @Test
-    void testPhysicalJoin(@Mocked LogicalProperties logicalProperties) {
+    void testPhysicalJoin() {
+        LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
         LogicalOneRowRelation left = new LogicalOneRowRelation(
                 new RelationId(1),
                 ImmutableList.of(
@@ -325,10 +328,11 @@ class PlanEqualsTest {
     }
 
     @Test
-    void testPhysicalOlapScan(
-            @Mocked LogicalProperties logicalProperties,
-            @Mocked OlapTable olapTable,
-            @Mocked DistributionSpecHash distributionSpecHash) {
+    void testPhysicalOlapScan() {
+        LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        DistributionSpecHash distributionSpecHash = Mockito.mock(DistributionSpecHash.class);
+        Mockito.when(olapTable.getAllPartitions()).thenReturn(ImmutableList.of());
 
         List<Long> selectedTabletId = Lists.newArrayList();
         for (Partition partition : olapTable.getAllPartitions()) {
@@ -362,7 +366,8 @@ class PlanEqualsTest {
     }
 
     @Test
-    void testPhysicalProject(@Mocked LogicalProperties logicalProperties) {
+    void testPhysicalProject() {
+        LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
         LogicalOneRowRelation child = new LogicalOneRowRelation(
                 new RelationId(1),
                 ImmutableList.of(
@@ -399,7 +404,8 @@ class PlanEqualsTest {
     }
 
     @Test
-    void testPhysicalSort(@Mocked LogicalProperties logicalProperties) {
+    void testPhysicalSort() {
+        LogicalProperties logicalProperties = Mockito.mock(LogicalProperties.class);
         LogicalOneRowRelation child = new LogicalOneRowRelation(
                 new RelationId(1),
                 ImmutableList.of(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCancelRepairTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCancelRepairTableCommandTest.java
@@ -26,53 +26,58 @@ import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class AdminCancelRepairTableCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
+
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        connectContext = Mockito.mock(ConnectContext.class);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
+    }
 
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testValidateNormal() throws Exception {
-        runBefore();
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(true);
+
         TableNameInfo tableNameInfo = new TableNameInfo(internalCtl, "test_db", "test_tbl");
         List<String> partitionNames = new ArrayList<>();
         partitionNames.add("p1");
@@ -99,21 +104,8 @@ public class AdminCancelRepairTableCommandTest {
 
     @Test
     public void testValidateNoPriviledge() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(false);
 
         TableNameInfo tableNameInfo = new TableNameInfo(internalCtl, "test_db", "test_tbl");
         List<String> partitionNames = new ArrayList<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCopyTabletCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCopyTabletCommandTest.java
@@ -19,55 +19,40 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AdminCopyTabletCommandTest {
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
+public class AdminCopyTabletCommandTest extends TestWithFeService {
     private ConnectContext connectContext;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+
         Map<String, String> properties = new HashMap<>();
         properties.put("version", "0");
         AdminCopyTabletCommand command = new AdminCopyTabletCommand(100, properties);
@@ -85,22 +70,13 @@ public class AdminCopyTabletCommandTest {
     }
 
     @Test
-    public void testNoPriviledge() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    public void testNoPriviledge() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-            }
-        };
         Map<String, String> properties = new HashMap<>();
         properties.put("version", "0");
         AdminCopyTabletCommand command = new AdminCopyTabletCommand(100, properties);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCreateClusterSnapshotCommandTest.java
@@ -25,14 +25,15 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,51 +41,47 @@ import java.util.List;
 import java.util.Map;
 
 public class AdminCreateClusterSnapshotCommandTest {
-    @Mocked
     private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
     private AccessControllerManager accessControllerManager;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
     private String originalMinPrivilege;
 
     @BeforeEach
     public void setUp() {
         originalMinPrivilege = Config.cluster_snapshot_min_privilege;
+
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
     }
 
     @AfterEach
     public void tearDown() {
         Config.cluster_snapshot_min_privilege = originalMinPrivilege;
-    }
-
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                // Mock root user for privilege check
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-            }
-        };
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testValidateNormal() throws Exception {
-        runBefore();
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(UserIdentity.ROOT);
+
         Config.deploy_mode = "";
         AdminCreateClusterSnapshotCommand command = new AdminCreateClusterSnapshotCommand(new HashMap<>());
         Assertions.assertThrows(AnalysisException.class, () -> command.validate(connectContext),
@@ -124,17 +121,8 @@ public class AdminCreateClusterSnapshotCommandTest {
         UserIdentity nonRootUser = new UserIdentity("admin", "%");
         nonRootUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(nonRootUser);
 
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = nonRootUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         Map<String, String> properties = new HashMap<>();
@@ -151,25 +139,10 @@ public class AdminCreateClusterSnapshotCommandTest {
         UserIdentity adminUser = new UserIdentity("admin", "%");
         adminUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(true);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(adminUser);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = adminUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         Map<String, String> properties = ImmutableMap.of("ttl", "3600", "label", "test");
@@ -185,25 +158,10 @@ public class AdminCreateClusterSnapshotCommandTest {
         UserIdentity normalUser = new UserIdentity("normal_user", "%");
         normalUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(false);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(normalUser);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = normalUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         Map<String, String> properties = new HashMap<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminDropClusterSnapshotCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminDropClusterSnapshotCommandTest.java
@@ -24,60 +24,57 @@ import org.apache.doris.common.Config;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class AdminDropClusterSnapshotCommandTest {
-    @Mocked
     private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
     private AccessControllerManager accessControllerManager;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
     private String originalMinPrivilege;
 
     @BeforeEach
     public void setUp() {
         originalMinPrivilege = Config.cluster_snapshot_min_privilege;
+
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
     }
 
     @AfterEach
     public void tearDown() {
         Config.cluster_snapshot_min_privilege = originalMinPrivilege;
-    }
-
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                // Mock root user for privilege check
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-            }
-        };
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testValidateNormal() throws Exception {
-        runBefore();
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(UserIdentity.ROOT);
+
         Config.deploy_mode = "";
         AdminDropClusterSnapshotCommand command = new AdminDropClusterSnapshotCommand("SNAPSHOT_ID", "323741");
         Assertions.assertThrows(AnalysisException.class, () -> command.validate(connectContext),
@@ -113,17 +110,8 @@ public class AdminDropClusterSnapshotCommandTest {
         UserIdentity nonRootUser = new UserIdentity("admin", "%");
         nonRootUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(nonRootUser);
 
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = nonRootUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         AdminDropClusterSnapshotCommand command = new AdminDropClusterSnapshotCommand("snapshot_id", "323741");
@@ -139,25 +127,10 @@ public class AdminDropClusterSnapshotCommandTest {
         UserIdentity adminUser = new UserIdentity("admin", "%");
         adminUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(true);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(adminUser);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = adminUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         AdminDropClusterSnapshotCommand command = new AdminDropClusterSnapshotCommand("snapshot_id", "323741");
@@ -172,25 +145,10 @@ public class AdminDropClusterSnapshotCommandTest {
         UserIdentity normalUser = new UserIdentity("normal_user", "%");
         normalUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(false);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(normalUser);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = normalUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         AdminDropClusterSnapshotCommand command = new AdminDropClusterSnapshotCommand("snapshot_id", "323741");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminRepairTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminRepairTableCommandTest.java
@@ -20,59 +20,44 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AdminRepairTableCommandTest {
+public class AdminRepairTableCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+
         TableNameInfo tableNameInfo = new TableNameInfo(internalCtl, "test_db", "test_tbl");
         List<String> partitionNames = new ArrayList<>();
         partitionNames.add("p1");
@@ -98,22 +83,12 @@ public class AdminRepairTableCommandTest {
     }
 
     @Test
-    public void testValidateNoPriviledge() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-            }
-        };
+    public void testValidateNoPriviledge() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         TableNameInfo tableNameInfo = new TableNameInfo(internalCtl, "test_db", "test_tbl");
         List<String> partitionNames = new ArrayList<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetAutoClusterSnapshotCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetAutoClusterSnapshotCommandTest.java
@@ -21,26 +21,25 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AdminSetAutoClusterSnapshotCommandTest {
-    @Mocked
-    private Env env;
-    @Mocked
+public class AdminSetAutoClusterSnapshotCommandTest extends TestWithFeService {
     private ConnectContext connectContext;
-    @Mocked
+    private Env env;
     private AccessControllerManager accessControllerManager;
 
     private String originalMinPrivilege;
@@ -55,32 +54,18 @@ public class AdminSetAutoClusterSnapshotCommandTest {
         Config.cluster_snapshot_min_privilege = originalMinPrivilege;
     }
 
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                // Mock root user for privilege check
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+
         Config.deploy_mode = "";
         Map<String, String> properties = new HashMap<>();
         properties.put("max_reserved_snapshots", "10");
@@ -129,24 +114,15 @@ public class AdminSetAutoClusterSnapshotCommandTest {
     }
 
     @Test
-    public void testValidateNoPrivilegeRootMode() {
+    public void testValidateNoPrivilegeRootMode() throws Exception {
         // Test root mode (default): admin user should be denied
+        runBefore();
         Config.cluster_snapshot_min_privilege = "root";
 
         UserIdentity nonRootUser = new UserIdentity("admin", "%");
         nonRootUser.setIsAnalyzed();
+        connectContext.setCurrentUserIdentity(nonRootUser);
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = nonRootUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         Map<String, String> properties = new HashMap<>();
@@ -156,32 +132,20 @@ public class AdminSetAutoClusterSnapshotCommandTest {
     }
 
     @Test
-    public void testValidateAdminModeWithAdminUser() {
+    public void testValidateAdminModeWithAdminUser() throws Exception {
         // Test admin mode: admin user with ADMIN privilege should be allowed
+        runBefore();
         Config.cluster_snapshot_min_privilege = "admin";
 
         UserIdentity adminUser = new UserIdentity("admin", "%");
         adminUser.setIsAnalyzed();
+        connectContext.setCurrentUserIdentity(adminUser);
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = adminUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         Map<String, String> properties = new HashMap<>();
@@ -192,32 +156,20 @@ public class AdminSetAutoClusterSnapshotCommandTest {
     }
 
     @Test
-    public void testValidateAdminModeWithNormalUser() {
+    public void testValidateAdminModeWithNormalUser() throws Exception {
         // Test admin mode: normal user without ADMIN privilege should be denied
+        runBefore();
         Config.cluster_snapshot_min_privilege = "admin";
 
         UserIdentity normalUser = new UserIdentity("normal_user", "%");
         normalUser.setIsAnalyzed();
+        connectContext.setCurrentUserIdentity(normalUser);
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = normalUser;
-            }
-        };
         Config.deploy_mode = "cloud";
 
         Map<String, String> properties = new HashMap<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetClusterSnapshotFeatureSwitchCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetClusterSnapshotFeatureSwitchCommandTest.java
@@ -24,55 +24,53 @@ import org.apache.doris.common.Config;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class AdminSetClusterSnapshotFeatureSwitchCommandTest {
-    @Mocked
     private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
     private AccessControllerManager accessControllerManager;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
     private String originalMinPrivilege;
 
     @BeforeEach
     public void setUp() {
         originalMinPrivilege = Config.cluster_snapshot_min_privilege;
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
     }
 
     @AfterEach
     public void tearDown() {
         Config.cluster_snapshot_min_privilege = originalMinPrivilege;
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                // Mock root user for privilege check
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = UserIdentity.ROOT;
-            }
-        };
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        // Mock root user for privilege check
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(UserIdentity.ROOT);
     }
 
     @Test
@@ -100,17 +98,7 @@ public class AdminSetClusterSnapshotFeatureSwitchCommandTest {
         UserIdentity nonRootUser = new UserIdentity("admin", "%");
         nonRootUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = nonRootUser;
-            }
-        };
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(nonRootUser);
         Config.deploy_mode = "cloud";
 
         AdminSetClusterSnapshotFeatureSwitchCommand command = new AdminSetClusterSnapshotFeatureSwitchCommand(true);
@@ -126,25 +114,9 @@ public class AdminSetClusterSnapshotFeatureSwitchCommandTest {
         UserIdentity adminUser = new UserIdentity("admin", "%");
         adminUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = adminUser;
-            }
-        };
+        Mockito.when(accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN))
+                .thenReturn(true);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(adminUser);
         Config.deploy_mode = "cloud";
 
         AdminSetClusterSnapshotFeatureSwitchCommand command = new AdminSetClusterSnapshotFeatureSwitchCommand(true);
@@ -159,25 +131,9 @@ public class AdminSetClusterSnapshotFeatureSwitchCommandTest {
         UserIdentity normalUser = new UserIdentity("normal_user", "%");
         normalUser.setIsAnalyzed();
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-
-                connectContext.getCurrentUserIdentity();
-                minTimes = 0;
-                result = normalUser;
-            }
-        };
+        Mockito.when(accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN))
+                .thenReturn(false);
+        Mockito.when(connectContext.getCurrentUserIdentity()).thenReturn(normalUser);
         Config.deploy_mode = "cloud";
 
         AdminSetClusterSnapshotFeatureSwitchCommand command = new AdminSetClusterSnapshotFeatureSwitchCommand(true);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaStatusCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaStatusCommandTest.java
@@ -22,51 +22,46 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class AdminSetReplicaStatusCommandTest {
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
-    private ConnectContext connectContext;
+    private Env env = Mockito.mock(Env.class);
+    private AccessControllerManager accessControllerManager = Mockito.mock(AccessControllerManager.class);
+    private ConnectContext connectContext = Mockito.mock(ConnectContext.class);
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    private MockedStatic<Env> mockedEnv;
+    private MockedStatic<ConnectContext> mockedConnectContext;
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+    @BeforeEach
+    public void setUp() {
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+        mockedConnectContext.when(ConnectContext::get).thenReturn(connectContext);
 
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class),
+                Mockito.any(PrivPredicate.class))).thenReturn(true);
+    }
 
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        mockedConnectContext.close();
+        mockedEnv.close();
     }
 
     @Test
     public void testValidateNormal() {
-        runBefore();
         Map<String, String> properties = new HashMap<>();
         properties.put("tablet_id", "1000");
         properties.put("backend_id", "1000");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterColocateGroupCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterColocateGroupCommandTest.java
@@ -18,58 +18,43 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.info.ColocateGroupName;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AlterColocateGroupCommandTest {
+public class AlterColocateGroupCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, "test_db", PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
-    public void testValidate() {
+    public void testValidate() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         ColocateGroupName groupName = new ColocateGroupName("test_db", "test_group");
         Map<String, String> properties = new HashMap<>();
         properties.put("k1", "v1");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterColumnStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterColumnStatsCommandTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -31,9 +32,9 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -55,18 +56,11 @@ public class AlterColumnStatsCommandTest extends TestWithFeService {
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
-        new Expectations() {
-            {
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
-                        PrivPredicate.ALTER);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+                Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         //test normal
         connectContext.getSessionVariable().enableStats = true;
@@ -133,22 +127,10 @@ public class AlterColumnStatsCommandTest extends TestWithFeService {
     @Test
     void testValidateNoPrivilege() throws IOException {
         runBefore();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.ALTER);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+                Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         TableNameInfo tableNameInfo =
                     new TableNameInfo(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterComputeGroupCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterComputeGroupCommandTest.java
@@ -17,69 +17,44 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
-import org.apache.doris.backup.CatalogMocker;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.catalog.ComputeGroup;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AlterComputeGroupCommandTest {
+public class AlterComputeGroupCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
-    private CloudSystemInfoService cloudSystemInfoService;
-    @Mocked
-    private ComputeGroup computeGroup;
-    private Database db;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
-    private void runBefore() throws Exception {
-        db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        accessControllerManager = spyAcm;
     }
 
     @Test
@@ -96,13 +71,8 @@ public class AlterComputeGroupCommandTest {
     public void testValidateAuthFailed() throws Exception {
         runBefore();
         Config.deploy_mode = "cloud";
-        new Expectations() {
-            {
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.doReturn(false).when(accessControllerManager).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put("balance_type", "async_warmup");
@@ -127,17 +97,9 @@ public class AlterComputeGroupCommandTest {
         runBefore();
         Config.deploy_mode = "cloud";
 
-        new Expectations() {
-            {
-                env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = cloudSystemInfoService;
-
-                cloudSystemInfoService.getComputeGroupByName("non_exist_group");
-                minTimes = 0;
-                result = null;
-            }
-        };
+        CloudSystemInfoService mockCloudSIS = Mockito.mock(CloudSystemInfoService.class);
+        Mockito.doReturn(null).when(mockCloudSIS).getComputeGroupByName("non_exist_group");
+        Deencapsulation.setField(env, "systemInfo", mockCloudSIS);
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put("balance_type", "async_warmup");
@@ -150,21 +112,11 @@ public class AlterComputeGroupCommandTest {
         runBefore();
         Config.deploy_mode = "cloud";
 
-        new Expectations() {
-            {
-                env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = cloudSystemInfoService;
-
-                cloudSystemInfoService.getComputeGroupByName("virtual_group");
-                minTimes = 0;
-                result = computeGroup;
-
-                computeGroup.isVirtual();
-                minTimes = 0;
-                result = true;
-            }
-        };
+        CloudSystemInfoService mockCloudSIS = Mockito.mock(CloudSystemInfoService.class);
+        ComputeGroup mockComputeGroup = Mockito.mock(ComputeGroup.class);
+        Mockito.doReturn(mockComputeGroup).when(mockCloudSIS).getComputeGroupByName("virtual_group");
+        Mockito.doReturn(true).when(mockComputeGroup).isVirtual();
+        Deencapsulation.setField(env, "systemInfo", mockCloudSIS);
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put("balance_type", "async_warmup");
@@ -177,25 +129,13 @@ public class AlterComputeGroupCommandTest {
         runBefore();
         Config.deploy_mode = "cloud";
 
-        new Expectations() {
-            {
-                env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = cloudSystemInfoService;
-
-                cloudSystemInfoService.getComputeGroupByName("test_group");
-                minTimes = 0;
-                result = computeGroup;
-
-                computeGroup.isVirtual();
-                minTimes = 0;
-                result = false;
-
-                computeGroup.checkProperties((Map<String, String>) any);
-                minTimes = 0;
-                result = new DdlException("Invalid property");
-            }
-        };
+        CloudSystemInfoService mockCloudSIS = Mockito.mock(CloudSystemInfoService.class);
+        ComputeGroup mockComputeGroup = Mockito.mock(ComputeGroup.class);
+        Mockito.doReturn(mockComputeGroup).when(mockCloudSIS).getComputeGroupByName("test_group");
+        Mockito.doReturn(false).when(mockComputeGroup).isVirtual();
+        Mockito.doThrow(new DdlException("Invalid property")).when(mockComputeGroup)
+                .checkProperties(Mockito.anyMap());
+        Deencapsulation.setField(env, "systemInfo", mockCloudSIS);
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put("invalid_property", "invalid_value");
@@ -208,31 +148,13 @@ public class AlterComputeGroupCommandTest {
         runBefore();
         Config.deploy_mode = "cloud";
 
-        new Expectations() {
-            {
-                env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = cloudSystemInfoService;
-
-                cloudSystemInfoService.getComputeGroupByName("test_group");
-                minTimes = 0;
-                result = computeGroup;
-
-                computeGroup.isVirtual();
-                minTimes = 0;
-                result = false;
-            }
-        };
-
-        new Expectations() {
-            {
-                computeGroup.checkProperties((Map<String, String>) any);
-                minTimes = 0;
-
-                computeGroup.modifyProperties((Map<String, String>) any);
-                minTimes = 0;
-            }
-        };
+        CloudSystemInfoService mockCloudSIS = Mockito.mock(CloudSystemInfoService.class);
+        ComputeGroup mockComputeGroup = Mockito.mock(ComputeGroup.class);
+        Mockito.doReturn(mockComputeGroup).when(mockCloudSIS).getComputeGroupByName("test_group");
+        Mockito.doReturn(false).when(mockComputeGroup).isVirtual();
+        Mockito.doNothing().when(mockComputeGroup).checkProperties(Mockito.anyMap());
+        Mockito.doNothing().when(mockComputeGroup).modifyProperties(Mockito.anyMap());
+        Deencapsulation.setField(env, "systemInfo", mockCloudSIS);
 
         Map<String, String> properties = Maps.newHashMap();
         properties.put("balance_type", "async_warmup");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommandTest.java
@@ -17,42 +17,73 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.load.routineload.RoutineLoadJob;
+import org.apache.doris.load.routineload.RoutineLoadManager;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateRoutineLoadInfo;
 import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Map;
 
 public class AlterRoutineLoadCommandTest {
-    @Mocked
     private Env env;
-
-    @Mocked
     private ConnectContext connectContext;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(new SessionVariable());
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database db = Mockito.mock(Database.class);
+        Table tbl = Mockito.mock(Table.class);
+        envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+        Mockito.doReturn(db).when(catalog).getDbOrAnalysisException(Mockito.anyString());
+        Mockito.doReturn(tbl).when(db).getTableOrAnalysisException(Mockito.anyString());
+        Mockito.when(env.getRoutineLoadManager()).thenReturn(Mockito.mock(RoutineLoadManager.class));
+        RoutineLoadManager rlm = env.getRoutineLoadManager();
+        RoutineLoadJob rlJob = Mockito.mock(RoutineLoadJob.class);
+        Mockito.when(rlm.getJob(Mockito.anyString(), Mockito.anyString())).thenReturn(rlJob);
+        Mockito.when(rlJob.getDbFullName()).thenReturn("testDb");
+        Mockito.when(rlJob.getTableName()).thenReturn("testTable");
+        Mockito.when(rlJob.isMultiTable()).thenReturn(false);
+        Mockito.when(rlJob.getMergeType()).thenReturn(LoadTask.MergeType.APPEND);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
 
     private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterStoragePolicyCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterStoragePolicyCommandTest.java
@@ -25,11 +25,14 @@ import org.apache.doris.policy.PolicyMgr;
 import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,42 +44,51 @@ public class AlterStoragePolicyCommandTest {
 
     private static final String policyName = "test_policy";
 
-    @Mocked
     private Env env;
-    @Mocked
     private ConnectContext ctx;
-    @Mocked
     private AccessControllerManager accessManager;
-    @Mocked
     private PolicyMgr policyMgr;
-    @Mocked
     private StoragePolicy mockPolicy;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        ctx = Mockito.mock(ConnectContext.class);
+        accessManager = Mockito.mock(AccessControllerManager.class);
+        policyMgr = Mockito.mock(PolicyMgr.class);
+        mockPolicy = Mockito.mock(StoragePolicy.class);
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(ctx);
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(env.getPolicyMgr()).thenReturn(policyMgr);
+        Mockito.when(accessManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(true);
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
 
     @Test
     public void testValidate_success() throws Exception {
         Map<String, String> props = new HashMap<>();
         props.put("cooldown_ttl", "86400");
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                result = env;
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv(ctx, PrivPredicate.ADMIN);
-                result = true;
-
-                env.getPolicyMgr();
-                result = policyMgr;
-                policyMgr.findPolicy(policyName, PolicyTypeEnum.ROW);
-                result = Optional.empty();
-                policyMgr.getCopiedPoliciesByType(PolicyTypeEnum.STORAGE);
-                result = Collections.singletonList(mockPolicy);
-                mockPolicy.getPolicyName();
-                result = policyName;
-                mockPolicy.checkProperties(props);
-            }
-        };
+        Mockito.when(policyMgr.findPolicy(policyName, PolicyTypeEnum.ROW)).thenReturn(Optional.empty());
+        Mockito.when(policyMgr.getCopiedPoliciesByType(PolicyTypeEnum.STORAGE))
+                .thenReturn(Collections.singletonList(mockPolicy));
+        Mockito.when(mockPolicy.getPolicyName()).thenReturn(policyName);
 
         AlterStoragePolicyCommand command = new AlterStoragePolicyCommand(policyName, props);
         Assertions.assertDoesNotThrow(() -> command.doRun(ctx, null));
@@ -87,23 +99,9 @@ public class AlterStoragePolicyCommandTest {
         Map<String, String> props = new HashMap<>();
         props.put("some_key", "value");
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                result = env;
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv(ctx, PrivPredicate.ADMIN);
-                result = true;
-
-                env.getPolicyMgr();
-                result = policyMgr;
-                policyMgr.findPolicy(policyName, PolicyTypeEnum.ROW);
-                result = Optional.empty();
-                policyMgr.getCopiedPoliciesByType(PolicyTypeEnum.STORAGE);
-                result = new ArrayList<>();
-            }
-        };
+        Mockito.when(policyMgr.findPolicy(policyName, PolicyTypeEnum.ROW)).thenReturn(Optional.empty());
+        Mockito.when(policyMgr.getCopiedPoliciesByType(PolicyTypeEnum.STORAGE))
+                .thenReturn(new ArrayList<>());
 
         AlterStoragePolicyCommand command = new AlterStoragePolicyCommand(policyName, props);
         Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));
@@ -111,17 +109,6 @@ public class AlterStoragePolicyCommandTest {
 
     @Test
     public void testValidate_nullProps() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                result = env;
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv(ctx, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
-
         AlterStoragePolicyCommand command = new AlterStoragePolicyCommand(policyName, null);
         Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));
     }
@@ -131,25 +118,10 @@ public class AlterStoragePolicyCommandTest {
         Map<String, String> props = new HashMap<>();
         props.put("storage_resource", "s3_resource");
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                result = env;
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv(ctx, PrivPredicate.ADMIN);
-                result = true;
-
-                env.getPolicyMgr();
-                result = policyMgr;
-                policyMgr.findPolicy(policyName, PolicyTypeEnum.ROW);
-                result = Optional.empty();
-                policyMgr.getCopiedPoliciesByType(PolicyTypeEnum.STORAGE);
-                result = Collections.singletonList(mockPolicy);
-                mockPolicy.getPolicyName();
-                result = policyName;
-            }
-        };
+        Mockito.when(policyMgr.findPolicy(policyName, PolicyTypeEnum.ROW)).thenReturn(Optional.empty());
+        Mockito.when(policyMgr.getCopiedPoliciesByType(PolicyTypeEnum.STORAGE))
+                .thenReturn(Collections.singletonList(mockPolicy));
+        Mockito.when(mockPolicy.getPolicyName()).thenReturn(policyName);
 
         AlterStoragePolicyCommand command = new AlterStoragePolicyCommand(policyName, props);
         Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterSystemCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterSystemCommandTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -35,47 +36,42 @@ import org.apache.doris.nereids.trees.plans.commands.info.DropObserverOp;
 import org.apache.doris.nereids.trees.plans.commands.info.ModifyBackendOp;
 import org.apache.doris.nereids.trees.plans.commands.info.ModifyNodeHostNameOp;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class AlterSystemCommandTest {
-    @Mocked
-    private Env env;
-    @Mocked
+public class AlterSystemCommandTest extends TestWithFeService {
     private ConnectContext connectContext;
-    @Mocked
+    private Env env;
     private AccessControllerManager accessControllerManager;
     private List<String> hostPorts = ImmutableList.of("127.0.0.1:9050", "127.0.0.1:19050");
     private List<String> hostPortsErr = ImmutableList.of("127.0.0.1:89050", "355.0.0.1:19050");
     private Map<String, String> properties = ImmutableMap.of();
     private String brokerName = "brocker1";
 
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
+    }
+
     @Test
-    void testValidateNormal() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    void testValidateNormal() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.OPERATOR));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.OPERATOR);
-                minTimes = 0;
-                result = true;
-            }
-        };
         // test addBackend
         AlterSystemCommand addBackend = new AlterSystemCommand(
                 new AddBackendOp(hostPorts, properties), PlanType.ALTER_SYSTEM_ADD_BACKEND);
@@ -166,22 +162,12 @@ public class AlterSystemCommandTest {
     }
 
     @Test
-    void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.OPERATOR);
-                minTimes = 0;
-                result = false;
-            }
-        };
+    void testValidateNoPrivilege() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.OPERATOR));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         // test addBackend with no privilege
         AlterSystemCommand addBackend = new AlterSystemCommand(
@@ -190,4 +176,3 @@ public class AlterSystemCommandTest {
                 "Access denied; you need (at least one of) the (NODE) privilege(s) for this operation");
     }
 }
-

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterTableStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterTableStatsCommandTest.java
@@ -18,83 +18,61 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.backup.CatalogMocker;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AlterTableStatsCommandTest {
+public class AlterTableStatsCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    private static final String partitionNotExist = "partition_not_exist";
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
-    private Database db;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
-    private void runBefore() throws Exception {
-        db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
+    }
 
-                env.getCatalogMgr().getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getDb(anyString);
-                minTimes = 0;
-                result = db;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
-                        PrivPredicate.ALTER);
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.ALTER);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase(CatalogMocker.TEST_DB_NAME);
+        createTable("create table " + CatalogMocker.TEST_DB_NAME + "." + CatalogMocker.TEST_TBL2_NAME + "\n"
+                + "(k1 int, k2 int)\n"
+                + "duplicate key(k1)\n"
+                + "partition by range(k2)\n"
+                + "(partition " + CatalogMocker.TEST_PARTITION1_NAME + " values less than(\"10\"))\n"
+                + "distributed by hash(k2) buckets 1\n"
+                + "properties('replication_num' = '1');");
     }
 
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.ALTER));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+
         //test normal
         connectContext.getSessionVariable().enableStats = true;
         TableNameInfo tableNameInfo =
@@ -121,23 +99,13 @@ public class AlterTableStatsCommandTest {
     }
 
     @Test
-    void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.ALTER);
-                minTimes = 0;
-                result = false;
-            }
-        };
+    void testValidateNoPrivilege() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.ALTER));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         TableNameInfo tableNameInfo2 =
                 new TableNameInfo(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommandTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.analysis.UserDesc;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -30,9 +31,9 @@ import org.apache.doris.nereids.trees.plans.commands.info.AlterUserInfo;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -51,17 +52,11 @@ public class AlterUserCommandTest extends TestWithFeService {
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
-        new Expectations() {
-            {
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.GRANT);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         // init
         UserIdentity userIdentity = new UserIdentity(Auth.ROOT_USER, "%");
         connectContext.setCurrentUserIdentity(userIdentity);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AnalyzeTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AnalyzeTableCommandTest.java
@@ -27,45 +27,60 @@ import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class AnalyzeTableCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
+
     private Env env;
-    @Mocked
     private AccessControllerManager accessManager;
-    @Mocked
     private ConnectContext ctx;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        accessManager = Mockito.mock(AccessControllerManager.class);
+        ctx = Mockito.mock(ConnectContext.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(ctx);
+
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
 
     @Test
     void testCheckAnalyzePrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(CatalogMocker.TEST_DB_NAME), Mockito.eq(CatalogMocker.TEST_TBL_NAME),
+                Mockito.eq(PrivPredicate.SELECT))).thenReturn(true);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
+        Mockito.when(accessManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(CatalogMocker.TEST_DB_NAME), Mockito.eq(CatalogMocker.TEST_TBL2_NAME),
+                Mockito.eq(PrivPredicate.SELECT))).thenReturn(false);
 
-                accessManager.checkTblPriv(ctx, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
-                        PrivPredicate.SELECT);
-                minTimes = 0;
-                result = true;
-
-                accessManager.checkTblPriv(ctx, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.SELECT);
-                minTimes = 0;
-                result = false;
-            }
-        };
         TableNameInfo tableNameInfo = new TableNameInfo(internalCtl,
                 CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME);
         PartitionNamesInfo partitionNamesInfo = new PartitionNamesInfo(false,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AuthenticationIntegrationCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AuthenticationIntegrationCommandTest.java
@@ -22,34 +22,34 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.authentication.AuthenticationIntegrationMgr;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class AuthenticationIntegrationCommandTest {
+public class AuthenticationIntegrationCommandTest extends TestWithFeService {
 
-    @Mocked
-    private Env env;
-
-    @Mocked
-    private AccessControllerManager accessManager;
-
-    @Mocked
-    private AuthenticationIntegrationMgr authenticationIntegrationMgr;
-
-    @Mocked
     private ConnectContext connectContext;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
+
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
+    }
 
     private static Map<String, String> map(String... kvs) {
         Map<String, String> result = new LinkedHashMap<>();
@@ -67,63 +67,45 @@ public class AuthenticationIntegrationCommandTest {
 
     @Test
     public void testCreateCommandRunAndDenied() throws Exception {
+        runBefore();
         UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp("admin", "%");
+        connectContext.setCurrentUserIdentity(currentUser);
+
         CreateAuthenticationIntegrationCommand createCommand =
                 new CreateAuthenticationIntegrationCommand("corp_ldap", false,
                         map("type", "ldap", "ldap.server", "ldap://127.0.0.1:389"), "comment");
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        // Grant access
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-
-                connectContext.getQualifiedUser();
-                minTimes = 0;
-                result = currentUser.getQualifiedUser();
-
-                env.getAuthenticationIntegrationMgr();
-                minTimes = 0;
-                result = authenticationIntegrationMgr;
-
-                authenticationIntegrationMgr.createAuthenticationIntegration(
-                        anyString, anyBoolean, (Map<String, String>) any, anyString, anyString);
-                times = 1;
-            }
-        };
+        // Mock AuthenticationIntegrationMgr
+        AuthenticationIntegrationMgr mockAuthMgr = Mockito.mock(AuthenticationIntegrationMgr.class);
+        Deencapsulation.setField(env, "authenticationIntegrationMgr", mockAuthMgr);
 
         Assertions.assertDoesNotThrow(() -> createCommand.run(connectContext, null));
         Assertions.assertEquals(StmtType.CREATE, createCommand.stmtType());
         Assertions.assertTrue(createCommand.needAuditEncryption());
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.verify(mockAuthMgr, Mockito.times(1)).createAuthenticationIntegration(
+                Mockito.anyString(), Mockito.anyBoolean(), Mockito.anyMap(),
+                Mockito.anyString(), Mockito.anyString());
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = false;
-            }
-        };
+        // Deny access
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
 
         Assertions.assertThrows(AnalysisException.class, () -> createCommand.run(connectContext, null));
     }
 
     @Test
     public void testAlterCommandRun() throws Exception {
+        runBefore();
         UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp("admin", "%");
+        connectContext.setCurrentUserIdentity(currentUser);
+
         AlterAuthenticationIntegrationCommand setPropertiesCommand =
                 AlterAuthenticationIntegrationCommand.forSetProperties(
                         "corp_ldap", map("ldap.server", "ldap://127.0.0.1:1389"));
@@ -133,40 +115,15 @@ public class AuthenticationIntegrationCommandTest {
         AlterAuthenticationIntegrationCommand setCommentCommand =
                 AlterAuthenticationIntegrationCommand.forSetComment("corp_ldap", "new comment");
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        // Grant access
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                connectContext.getQualifiedUser();
-                minTimes = 0;
-                result = currentUser.getQualifiedUser();
-
-                env.getAuthenticationIntegrationMgr();
-                minTimes = 0;
-                result = authenticationIntegrationMgr;
-
-                authenticationIntegrationMgr.alterAuthenticationIntegrationProperties(
-                        anyString, (Map<String, String>) any, anyString);
-                times = 1;
-
-                authenticationIntegrationMgr.alterAuthenticationIntegrationUnsetProperties(
-                        anyString, (Set<String>) any, anyString);
-                times = 1;
-
-                authenticationIntegrationMgr.alterAuthenticationIntegrationComment(anyString, anyString, anyString);
-                times = 1;
-            }
-        };
+        // Mock AuthenticationIntegrationMgr
+        AuthenticationIntegrationMgr mockAuthMgr = Mockito.mock(AuthenticationIntegrationMgr.class);
+        Deencapsulation.setField(env, "authenticationIntegrationMgr", mockAuthMgr);
 
         Assertions.assertDoesNotThrow(() -> setPropertiesCommand.doRun(connectContext, null));
         Assertions.assertDoesNotThrow(() -> unsetPropertiesCommand.doRun(connectContext, null));
@@ -174,75 +131,54 @@ public class AuthenticationIntegrationCommandTest {
         Assertions.assertTrue(setPropertiesCommand.needAuditEncryption());
         Assertions.assertTrue(unsetPropertiesCommand.needAuditEncryption());
         Assertions.assertTrue(setCommentCommand.needAuditEncryption());
+
+        Mockito.verify(mockAuthMgr, Mockito.times(1)).alterAuthenticationIntegrationProperties(
+                Mockito.anyString(), Mockito.anyMap(), Mockito.anyString());
+        Mockito.verify(mockAuthMgr, Mockito.times(1)).alterAuthenticationIntegrationUnsetProperties(
+                Mockito.anyString(), Mockito.anySet(), Mockito.anyString());
+        Mockito.verify(mockAuthMgr, Mockito.times(1)).alterAuthenticationIntegrationComment(
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
-    public void testAlterCommandDenied() {
+    public void testAlterCommandDenied() throws Exception {
+        runBefore();
         AlterAuthenticationIntegrationCommand setPropertiesCommand =
                 AlterAuthenticationIntegrationCommand.forSetProperties(
                         "corp_ldap", map("ldap.server", "ldap://127.0.0.1:1389"));
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = false;
-            }
-        };
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         Assertions.assertThrows(AnalysisException.class, () -> setPropertiesCommand.doRun(connectContext, null));
     }
 
     @Test
     public void testDropCommandRunAndDenied() throws Exception {
+        runBefore();
         DropAuthenticationIntegrationCommand dropCommand =
                 new DropAuthenticationIntegrationCommand(true, "corp_ldap");
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        // Grant access
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-
-                env.getAuthenticationIntegrationMgr();
-                minTimes = 0;
-                result = authenticationIntegrationMgr;
-
-                authenticationIntegrationMgr.dropAuthenticationIntegration(anyString, anyBoolean);
-                times = 1;
-            }
-        };
+        // Mock AuthenticationIntegrationMgr
+        AuthenticationIntegrationMgr mockAuthMgr = Mockito.mock(AuthenticationIntegrationMgr.class);
+        Deencapsulation.setField(env, "authenticationIntegrationMgr", mockAuthMgr);
 
         Assertions.assertDoesNotThrow(() -> dropCommand.doRun(connectContext, null));
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.verify(mockAuthMgr, Mockito.times(1)).dropAuthenticationIntegration(
+                Mockito.anyString(), Mockito.anyBoolean());
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = false;
-            }
-        };
+        // Deny access
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
 
         Assertions.assertThrows(AnalysisException.class, () -> dropCommand.doRun(connectContext, null));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/BackupCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/BackupCommandTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.info.TableRefInfo;
@@ -27,57 +28,41 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.commons.collections4.map.HashedMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class BackupCommandTest {
+public class BackupCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
 
     private String dbName = "test_db";
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, dbName, PrivPredicate.LOAD);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
-    public void testValidateNormal() {
+    public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         LabelNameInfo labelNameInfo = new LabelNameInfo(dbName, "label0");
         String repoName = "testRepo";
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelAlterTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelAlterTableCommandTest.java
@@ -19,61 +19,47 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CancelAlterTableCommandTest {
+public class CancelAlterTableCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
-    private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
+    private Env env;
     private AccessControllerManager accessControllerManager;
 
     private final String dbName = "test_db";
     private final String tblName = "test_tbl";
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, dbName, tblName, PrivPredicate.ALTER);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.ALTER));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+
         TableNameInfo tableNameInfo = new TableNameInfo(dbName, tblName);
         CancelAlterTableCommand.AlterType alterType = CancelAlterTableCommand.AlterType.COLUMN;
         List<Long> alterJobIdList = new ArrayList<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelBackupCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelBackupCommandTest.java
@@ -23,51 +23,55 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class CancelBackupCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
+
     private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
     private AccessControllerManager accessControllerManager;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
     private final String dbName = "test_db";
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+    }
 
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, dbName, PrivPredicate.LOAD);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testValidateNormal() {
-        runBefore();
+        Mockito.when(accessControllerManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(dbName), Mockito.eq(PrivPredicate.LOAD))).thenReturn(true);
+
         CancelBackupCommand command = new CancelBackupCommand(dbName, false);
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelBuildIndexCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelBuildIndexCommandTest.java
@@ -19,61 +19,46 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CancelBuildIndexCommandTest {
+public class CancelBuildIndexCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
     private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
     private AccessControllerManager accessControllerManager;
 
     private final String dbName = "test_db";
     private final String tblName = "test_tbl";
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, dbName, tblName, PrivPredicate.ALTER);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.ALTER));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         TableNameInfo tableNameInfo = new TableNameInfo(dbName, tblName);
         List<Long> alterJobIdList = new ArrayList<>();
         CancelBuildIndexCommand command = new CancelBuildIndexCommand(tableNameInfo, alterJobIdList);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelDecommissionBackendCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CancelDecommissionBackendCommandTest.java
@@ -23,54 +23,56 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class CancelDecommissionBackendCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
+
     private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
     private AccessControllerManager accessControllerManager;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
     private final String dbName = "test_db";
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.OPERATOR))).thenReturn(true);
+    }
 
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(ConnectContext.get(), PrivPredicate.OPERATOR);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testValidateNormal() {
-        runBefore();
         List<String> params = new ArrayList<>();
         params.add("192.168.1.120:30111");
         params.add("192.168.1.121:30111");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CleanQueryStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CleanQueryStatsCommandTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -25,9 +26,9 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -46,17 +47,10 @@ public class CleanQueryStatsCommandTest extends TestWithFeService {
     @Test
     public void testAllNormal() throws IOException {
         runBefore();
-        new Expectations() {
-            {
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         CleanQueryStatsCommand command = new CleanQueryStatsCommand();
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
     }
@@ -65,18 +59,10 @@ public class CleanQueryStatsCommandTest extends TestWithFeService {
     public void testDB() throws Exception {
         runBefore();
         connectContext.setDatabase("test_db");
-        //normal
-        new Expectations() {
-            {
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, "test_db", PrivPredicate.ALTER);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkDbPriv(Mockito.nullable(ConnectContext.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         CleanQueryStatsCommand command = new CleanQueryStatsCommand("test_db");
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
     }
@@ -90,18 +76,10 @@ public class CleanQueryStatsCommandTest extends TestWithFeService {
                 + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); ");
         TableNameInfo tableNameInfo = new TableNameInfo("test_db", "test_tbl");
         connectContext.setDatabase("test_db");
-        //normal
-        new Expectations() {
-            {
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, tableNameInfo, PrivPredicate.ALTER);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.any(TableNameInfo.class), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         CleanQueryStatsCommand command = new CleanQueryStatsCommand(tableNameInfo);
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateResourceCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateResourceCommandTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.parser.NereidsParser;
@@ -29,22 +30,19 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class CreateResourceCommandTest extends TestWithFeService {
     @Test
-    public void testValidate(@Mocked Env env, @Mocked AccessControllerManager accessManager) {
-        new Expectations() {
-            {
-                env.getAccessManager();
-                result = accessManager;
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                result = true;
-            }
-        };
+    public void testValidate() {
+        Env env = Env.getCurrentEnv();
+        AccessControllerManager accessControllerManager = env.getAccessManager();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         // ES resource is no longer supported, validation should throw
         final ImmutableMap<String, String> esProperties =

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateStorageVaultCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateStorageVaultCommandTest.java
@@ -22,16 +22,16 @@ import org.apache.doris.catalog.StorageVault;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class CreateStorageVaultCommandTest extends TestWithFeService {
     private String vaultName;
@@ -43,18 +43,13 @@ public class CreateStorageVaultCommandTest extends TestWithFeService {
     }
 
     @Test
-    public void testValidateNormal(@Mocked AccessControllerManager accessManager) {
-        new Expectations() {
-            {
-                Env.getCurrentEnv().getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    public void testValidateNormal() throws Exception {
+        Env env = Env.getCurrentEnv();
+        AccessControllerManager accessManager = env.getAccessManager();
+        AccessControllerManager spyAcm = Mockito.spy(accessManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         Config.cloud_unique_id = "not_empty_nereids";
         ImmutableMap<String, String> properties = ImmutableMap.<String, String>builder()

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateUserCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateUserCommandTest.java
@@ -19,17 +19,18 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.analysis.UserDesc;
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateUserInfo;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class CreateUserCommandTest extends TestWithFeService {
     @Override
@@ -43,13 +44,12 @@ public class CreateUserCommandTest extends TestWithFeService {
     }
 
     @Test
-    public void testValidateNormal(@Mocked AccessControllerManager accessManager) {
-        new Expectations() {
-            {
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.GRANT);
-                result = true;
-            }
-        };
+    public void testValidateNormal() {
+        Env env = Env.getCurrentEnv();
+        AccessControllerManager spyAcm = Mockito.spy(env.getAccessManager());
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         CreateUserCommand command = new CreateUserCommand(new CreateUserInfo(new UserDesc(new UserIdentity("user", "%"), "passwd", true)));
         CreateUserInfo info = command.getInfo();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropCachedStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropCachedStatsCommandTest.java
@@ -18,78 +18,59 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.backup.CatalogMocker;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DropCachedStatsCommandTest {
+public class DropCachedStatsCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String catalogNotExist = "catalog_not_exist";
     private static final String dbNotExist = "db_not_exist";
     private static final String tblNotExist = "tbl_not_exist";
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
     private ConnectContext connectContext;
-    private Database db;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
-    private void runBefore() throws Exception {
-        db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
+    }
 
-                env.getCatalogMgr().getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                catalog.getDb(anyString);
-                minTimes = 0;
-                result = db;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
-                        PrivPredicate.DROP);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase(CatalogMocker.TEST_DB_NAME);
+        createTable("create table " + CatalogMocker.TEST_DB_NAME + "." + CatalogMocker.TEST_TBL_NAME + "\n"
+                + "(k1 int, k2 int)\n"
+                + "duplicate key(k1)\n"
+                + "distributed by hash(k2) buckets 1\n"
+                + "properties('replication_num' = '1');");
     }
 
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.DROP));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         //test normal
         connectContext.getSessionVariable().enableStats = true;
@@ -134,23 +115,13 @@ public class DropCachedStatsCommandTest {
     }
 
     @Test
-    void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.DROP);
-                minTimes = 0;
-                result = false;
-            }
-        };
+    void testValidateNoPrivilege() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         TableNameInfo tableNameInfo =
                 new TableNameInfo(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropExpiredStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropExpiredStatsCommandTest.java
@@ -17,41 +17,19 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
-import org.apache.doris.catalog.Env;
 import org.apache.doris.common.UserException;
-import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class DropExpiredStatsCommandTest {
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
+public class DropExpiredStatsCommandTest extends TestWithFeService {
     private ConnectContext connectContext;
 
     @Test
     public void testValidateNormal() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-            }
-        };
+        connectContext = createDefaultCtx();
 
         //test normal
         connectContext.getSessionVariable().enableStats = true;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropMaterializedViewCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropMaterializedViewCommandTest.java
@@ -17,21 +17,19 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.UserException;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class DropMaterializedViewCommandTest {
-
-    @Mocked
-    AccessControllerManager accessManager;
 
     @Test
     public void testEmptyMVName() {
@@ -47,19 +45,22 @@ public class DropMaterializedViewCommandTest {
     public void testNoPermission() {
         ConnectContext ctx = new ConnectContext();
         TableNameInfo tableName = new TableNameInfo("internal", "db1", "t1");
-        new Expectations() {
-            {
-                accessManager.checkTblPriv(ctx, tableName.getCtl(), tableName.getDb(),
-                        tableName.getTbl(), PrivPredicate.ALTER);
-                result = false;
+
+        Env env = Mockito.mock(Env.class);
+        AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(accessManager.checkTblPriv(ctx, tableName.getCtl(), tableName.getDb(),
+                tableName.getTbl(), PrivPredicate.ALTER)).thenReturn(false);
+
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            DropMaterializedViewCommand command = new DropMaterializedViewCommand(tableName, false, "test");
+            try {
+                command.validate(ctx);
+                Assertions.fail();
+            } catch (UserException e) {
+                Assertions.assertTrue(e.getMessage().contains("Access denied;"));
             }
-        };
-        DropMaterializedViewCommand command = new DropMaterializedViewCommand(tableName, false, "test");
-        try {
-            command.validate(ctx);
-            Assertions.fail();
-        } catch (UserException e) {
-            Assertions.assertTrue(e.getMessage().contains("Access denied;"));
         }
 
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropResourceCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropResourceCommandTest.java
@@ -18,14 +18,15 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -43,13 +44,10 @@ public class DropResourceCommandTest extends TestWithFeService {
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
-        new Expectations() {
-            {
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         DropResourceCommand command = new DropResourceCommand(false, "test_resource");
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
@@ -19,15 +19,16 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -49,13 +50,10 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
     @Test
     public void testValidateNormal() throws Exception {
         runBefore();
-        new Expectations() {
-            {
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.GRANT);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "role1");
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropStatsCommandTest.java
@@ -21,24 +21,31 @@ import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class DropStatsCommandTest {
@@ -46,63 +53,69 @@ public class DropStatsCommandTest {
     private static final String catalogNotExist = "catalog_not_exist";
     private static final String dbNotExist = "db_not_exist";
     private static final String tblNotExist = "tbl_not_exist";
-    @Mocked
+
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private InternalCatalog catalog;
-    @Mocked
     private ConnectContext connectContext;
+    private CatalogMgr catalogMgr;
     private Database db;
+    private SessionVariable sessionVariable;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
-    private void runBefore() throws Exception {
-        db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    @BeforeEach
+    public void setUp() throws Exception {
+        env = Mockito.mock(Env.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        catalog = Mockito.mock(InternalCatalog.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        catalogMgr = Mockito.mock(CatalogMgr.class);
+        sessionVariable = new SessionVariable();
 
-                env.getCatalogMgr().getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
 
-                catalog.getDb(anyString);
-                minTimes = 0;
-                result = db;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
+        Mockito.doReturn(catalog).when(catalogMgr)
+                .getCatalogOrAnalysisException(Mockito.anyString());
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
+        Mockito.when(connectContext.getEnv()).thenReturn(env);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        TabletInvertedIndex tabletInvertedIndex = Mockito.mock(TabletInvertedIndex.class);
+        envMockedStatic.when(Env::getCurrentInvertedIndex).thenReturn(tabletInvertedIndex);
+    }
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
-                        PrivPredicate.DROP);
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.DROP);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testValidateNormal() throws Exception {
-        runBefore();
+        db = CatalogMocker.mockDb();
+        Mockito.when(catalog.getDb(Mockito.anyString())).thenReturn(Optional.of(db));
+        Mockito.doReturn(db).when(catalog).getDbOrAnalysisException(Mockito.anyString());
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(accessControllerManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(CatalogMocker.TEST_DB_NAME), Mockito.eq(CatalogMocker.TEST_TBL_NAME),
+                Mockito.eq(PrivPredicate.DROP))).thenReturn(true);
+        Mockito.when(accessControllerManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(CatalogMocker.TEST_DB_NAME), Mockito.eq(CatalogMocker.TEST_TBL2_NAME),
+                Mockito.eq(PrivPredicate.DROP))).thenReturn(true);
 
         //test normal
-        connectContext.getSessionVariable().enableStats = true;
+        sessionVariable.enableStats = true;
         TableNameInfo tableNameInfo =
                 new TableNameInfo(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME);
         PartitionNamesInfo partitionNamesInfo = new PartitionNamesInfo(false,
@@ -163,31 +176,21 @@ public class DropStatsCommandTest {
                 "Can't delete more that 100 partitions at one time");
 
         //test enable stats is false
-        connectContext.getSessionVariable().enableStats = false;
+        sessionVariable.enableStats = false;
         Assertions.assertThrows(UserException.class, () -> command.validate(connectContext),
                 "Analyze function is forbidden, you should add `enable_stats=true` in your FE conf file");
     }
 
     @Test
-    void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    void testValidateNoPrivilege() throws Exception {
+        db = CatalogMocker.mockDb();
+        Mockito.doReturn(db).when(catalog).getDbOrAnalysisException(Mockito.anyString());
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(false);
+        Mockito.when(accessControllerManager.checkTblPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(CatalogMocker.TEST_DB_NAME), Mockito.eq(CatalogMocker.TEST_TBL2_NAME),
+                Mockito.eq(PrivPredicate.DROP))).thenReturn(false);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.DROP);
-                minTimes = 0;
-                result = false;
-            }
-        };
-
-        connectContext.getSessionVariable().enableStats = true;
+        sessionVariable.enableStats = true;
         TableNameInfo tableNameInfo =
                     new TableNameInfo(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME);
         PartitionNamesInfo partitionNamesInfo = new PartitionNamesInfo(false,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/MysqlLoadCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/MysqlLoadCommandTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -26,58 +27,43 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.load.MysqlDataDescription;
 import org.apache.doris.nereids.trees.plans.commands.load.MysqlLoadCommand;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class MysqlLoadCommandTest {
+public class MysqlLoadCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private final String dbName = "test_db";
     private final String tblName = "test_tbl";
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, dbName, tblName, PrivPredicate.LOAD);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
-    public void testValidateNormal() {
+    public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.LOAD));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+
         TableNameInfo tableNameInfo = new TableNameInfo(dbName, tblName);
         List<String> filePaths = new ArrayList<>();
         filePaths.add("/mnt/d/test.csv");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/RestoreCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/RestoreCommandTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.info.TableRefInfo;
@@ -28,58 +29,42 @@ import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableMap;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.commons.collections4.map.HashedMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class RestoreCommandTest {
+public class RestoreCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
 
     private String dbName = "test_db";
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkDbPriv(connectContext, internalCtl, dbName, PrivPredicate.LOAD);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
-    public void testValidateNormal() {
+    public void testValidateNormal() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         LabelNameInfo labelNameInfo = new LabelNameInfo(dbName, "label0");
         String repoName = "testRepo";
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBackendsCommandTest.java
@@ -26,14 +26,18 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.tablefunction.BackendsTableValuedFunction;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -41,50 +45,52 @@ public class ShowBackendsCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String infoDB = InfoSchemaDb.DATABASE_NAME;
 
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext ctx;
-    @Mocked
     private InternalCatalog catalog;
-    @Mocked
     private CatalogMgr catalogMgr;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        ctx = Mockito.mock(ConnectContext.class);
+        catalog = Mockito.mock(InternalCatalog.class);
+        catalogMgr = Mockito.mock(CatalogMgr.class);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(ctx);
 
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
 
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
+        SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
+        envMockedStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
+    }
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testNormal() throws Exception {
-        runBefore();
+        Mockito.when(accessControllerManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(infoDB), Mockito.eq(PrivPredicate.SELECT))).thenReturn(true);
+
         ShowBackendsCommand command = new ShowBackendsCommand();
         ShowResultSet showResultSet = command.doRun(ctx, null);
         List<Column> columnList = showResultSet.getMetaData().getColumns();
@@ -129,33 +135,10 @@ public class ShowBackendsCommandTest {
 
     @Test
     public void testNoPrivilege() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessControllerManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(infoDB), Mockito.eq(PrivPredicate.SELECT))).thenReturn(false);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
-                minTimes = 0;
-                result = false;
-            }
-        };
         ShowBackendsCommand command = new ShowBackendsCommand();
         Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCatalogRecycleBinCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCatalogRecycleBinCommandTest.java
@@ -26,41 +26,49 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class ShowCatalogRecycleBinCommandTest {
-    @Mocked
     private Env env;
-    @Mocked
     private ConnectContext connectContext;
-    @Mocked
     private AccessControllerManager accessControllerManager;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
 
     @Test
     void testValidateNormal() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN))
+                .thenReturn(true);
 
         // normal
         EqualTo whereClause = new EqualTo(new UnboundSlot("name"),
@@ -77,25 +85,8 @@ public class ShowCatalogRecycleBinCommandTest {
 
     @Test
     void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.when(accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN))
+                .thenReturn(false);
 
         EqualTo whereClause = new EqualTo(new UnboundSlot("name"),
                 new StringLiteral("p1000"));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDataCommandTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.NameSpaceContext;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.RandomDistributionInfo;
 import org.apache.doris.catalog.SinglePartitionInfo;
@@ -34,12 +35,15 @@ import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.List;
@@ -55,51 +59,47 @@ public class ShowDataCommandTest {
             KeysType.AGG_KEYS,
             new SinglePartitionInfo(),
             new RandomDistributionInfo(32));
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
-    private ConnectContext connectContext;
-    @Mocked
-    private Database database;
+
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+    private AccessControllerManager accessControllerManager = Mockito.mock(AccessControllerManager.class);
+    private ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+    private Database database = Mockito.mock(Database.class);
+    private NameSpaceContext nameSpaceContext = Mockito.mock(NameSpaceContext.class);
+
+    private MockedStatic<Env> mockedEnv;
+    private MockedStatic<ConnectContext> mockedConnectContext;
+
+    @BeforeEach
+    public void setUp() {
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class);
+
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnv.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+        mockedConnectContext.when(ConnectContext::get).thenReturn(connectContext);
+
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.getNameSpaceContext()).thenReturn(nameSpaceContext);
+        Mockito.when(nameSpaceContext.getDefaultCatalog()).thenReturn(InternalCatalog.INTERNAL_CATALOG_NAME);
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockedConnectContext.close();
+        mockedEnv.close();
+    }
 
     @Test
     public void testValidateNormal() throws Exception {
-        Database db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                catalog.getDb(anyString);
-                minTimes = 0;
-                result = db;
-
-                database.getTableOrMetaException(tableNameInfo.getTbl(), TableIf.TableType.OLAP);
-                minTimes = 0;
-                result = olapTable;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, tableNameInfo, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.doReturn(database).when(catalog).getDbOrAnalysisException(Mockito.anyString());
+        Mockito.doReturn(olapTable).when(database).getTableOrMetaException(
+                Mockito.anyString(), Mockito.any(TableIf.TableType.class));
+        Mockito.when(accessControllerManager.checkTblPriv(
+                Mockito.nullable(ConnectContext.class),
+                Mockito.any(TableNameInfo.class),
+                Mockito.any(PrivPredicate.class))).thenReturn(true);
 
         SlotReference tableName = new SlotReference("TableName", IntegerType.INSTANCE);
         List<OrderKey> keys = ImmutableList.of(
@@ -116,38 +116,9 @@ public class ShowDataCommandTest {
 
     @Test
     void testValidateNoPrivilege() throws Exception {
-        Database db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                catalog.getDb(anyString);
-                minTimes = 0;
-                result = db;
-
-                database.getTableOrMetaException(tableNameInfo.getTbl(), TableIf.TableType.OLAP);
-                minTimes = 0;
-                result = olapTable;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, tableNameInfo, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        Mockito.doReturn(database).when(catalog).getDbOrAnalysisException(Mockito.anyString());
+        Mockito.doReturn(olapTable).when(database).getTableOrMetaException(
+                Mockito.anyString(), Mockito.any(TableIf.TableType.class));
 
         SlotReference tableName = new SlotReference("TableName", IntegerType.INSTANCE);
         List<OrderKey> keys = ImmutableList.of(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDatabasesCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowDatabasesCommandTest.java
@@ -27,46 +27,48 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class ShowDatabasesCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
 
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager accessManager;
-    @Mocked
     private ConnectContext ctx;
-    @Mocked
     private InternalCatalog catalog;
-    @Mocked
     private CatalogMgr catalogMgr;
+    private MockedStatic<Env> envMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        accessManager = Mockito.mock(AccessControllerManager.class);
+        ctx = Mockito.mock(ConnectContext.class);
+        catalog = Mockito.mock(InternalCatalog.class);
+        catalogMgr = Mockito.mock(CatalogMgr.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+    }
 
     @Test
     void testValidate() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-            }
-        };
         EqualTo equalTo = new EqualTo(new UnboundSlot("schema_name"),
                 new StringLiteral(CatalogMocker.TEST_DB_NAME));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowFrontendsCommandTest.java
@@ -23,18 +23,23 @@ import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.ha.HAProtocol;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.tablefunction.FrontendsDisksTableValuedFunction;
 import org.apache.doris.tablefunction.FrontendsTableValuedFunction;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -42,50 +47,55 @@ public class ShowFrontendsCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String infoDB = InfoSchemaDb.DATABASE_NAME;
 
-    @Mocked
     private Env env;
-    @Mocked
     private ConnectContext ctx;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private InternalCatalog catalog;
-    @Mocked
     private CatalogMgr catalogMgr;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        ctx = Mockito.mock(ConnectContext.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        catalog = Mockito.mock(InternalCatalog.class);
+        catalogMgr = Mockito.mock(CatalogMgr.class);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(ctx);
 
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
 
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
+        HAProtocol haProtocol = Mockito.mock(HAProtocol.class);
+        Mockito.when(env.getHaProtocol()).thenReturn(haProtocol);
+        Mockito.when(env.getSelfNode())
+                .thenReturn(new SystemInfoService.HostInfo("127.0.0.1", 9030));
+    }
 
-                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testNormal() throws Exception {
-        runBefore();
+        Mockito.when(accessControllerManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(infoDB), Mockito.eq(PrivPredicate.SELECT))).thenReturn(true);
+
         ShowFrontendsCommand command = new ShowFrontendsCommand(null);
         ShowResultSet showResultSet = command.doRun(ctx, null);
         List<Column> columnList = showResultSet.getMetaData().getColumns();
@@ -98,40 +108,20 @@ public class ShowFrontendsCommandTest {
 
     @Test
     public void testNoPrivilege() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessControllerManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(infoDB), Mockito.eq(PrivPredicate.SELECT))).thenReturn(false);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
-                minTimes = 0;
-                result = false;
-            }
-        };
         ShowFrontendsCommand command = new ShowFrontendsCommand(null);
         Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));
     }
 
     @Test
     public void testNormalShowFrontendsDisks() throws Exception {
-        runBefore();
+        Mockito.when(accessControllerManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(infoDB), Mockito.eq(PrivPredicate.SELECT))).thenReturn(true);
+
         ShowFrontendsCommand command = new ShowFrontendsCommand("disks");
         ShowResultSet showResultSet = command.doRun(ctx, null);
         List<Column> columnList = showResultSet.getMetaData().getColumns();
@@ -145,33 +135,10 @@ public class ShowFrontendsCommandTest {
 
     @Test
     public void testNoPrivilegeShowFrontendsDisks() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessControllerManager.checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(internalCtl),
+                Mockito.eq(infoDB), Mockito.eq(PrivPredicate.SELECT))).thenReturn(false);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                accessControllerManager.checkDbPriv(ctx, internalCtl, infoDB, PrivPredicate.SELECT);
-                minTimes = 0;
-                result = false;
-            }
-        };
         ShowFrontendsCommand command = new ShowFrontendsCommand("disks");
         Assertions.assertThrows(AnalysisException.class, () -> command.doRun(ctx, null));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowIndexStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowIndexStatsCommandTest.java
@@ -20,75 +20,78 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.NameSpaceContext;
+import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
 
 public class ShowIndexStatsCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String tableNotExist = "table_not_exist";
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
-    private AccessControllerManager accessManager;
-    @Mocked
-    private ConnectContext ctx;
+
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+    private AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+    private ConnectContext ctx = Mockito.mock(ConnectContext.class);
+    private CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+    private NameSpaceContext nameSpaceContext = Mockito.mock(NameSpaceContext.class);
     private Database db;
 
-    private void runBefore() throws Exception {
+    private MockedStatic<Env> mockedEnv;
+    private MockedStatic<ConnectContext> mockedConnectContext;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class);
+
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+        mockedConnectContext.when(ConnectContext::get).thenReturn(ctx);
+
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(ctx.getNameSpaceContext()).thenReturn(nameSpaceContext);
+        Mockito.when(nameSpaceContext.getDefaultCatalog()).thenReturn(InternalCatalog.INTERNAL_CATALOG_NAME);
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
+
+        TabletInvertedIndex tabletInvertedIndex = Mockito.mock(TabletInvertedIndex.class);
+        mockedEnv.when(Env::getCurrentInvertedIndex).thenReturn(tabletInvertedIndex);
+
         db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.doReturn(Optional.of(db)).when(catalog).getDb(Mockito.anyString());
 
-                env.getCatalogMgr().getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
+        Mockito.when(accessManager.checkTblPriv(
+                Mockito.nullable(ConnectContext.class),
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.eq(CatalogMocker.TEST_TBL_NAME),
+                Mockito.any(PrivPredicate.class))).thenReturn(true);
+    }
 
-                catalog.getDb(anyString);
-                minTimes = 0;
-                result = db;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                ctx.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessManager.checkTblPriv(ctx, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
-                        PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-
-                accessManager.checkTblPriv(ctx, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.SHOW);
-                minTimes = 0;
-                result = false;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        mockedConnectContext.close();
+        mockedEnv.close();
     }
 
     @Test
     public void testValidateNormal() throws Exception {
-        runBefore();
         TableNameInfo tableNameInfo =
                 new TableNameInfo(internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME);
         ShowIndexStatsCommand command = new ShowIndexStatsCommand(tableNameInfo, CatalogMocker.TEST_TBL_NAME);
@@ -97,7 +100,6 @@ public class ShowIndexStatsCommandTest {
 
     @Test
     public void testValidateFail() throws Exception {
-        runBefore();
         TableNameInfo tableNameInfo =
                 new TableNameInfo(internalCtl, CatalogMocker.TEST_DB_NAME, tableNotExist);
         ShowIndexStatsCommand command = new ShowIndexStatsCommand(tableNameInfo, tableNotExist);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowQueryStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowQueryStatsCommandTest.java
@@ -20,61 +20,51 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-public class ShowQueryStatsCommandTest {
+public class ShowQueryStatsCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
+    private static boolean dbInitialized = false;
+
     private ConnectContext connectContext;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
     private void runBefore() throws Exception {
-        TableNameInfo tableNameInfo = new TableNameInfo(internalCtl, CatalogMocker.TEST_DB_NAME,
-                CatalogMocker.TEST_TBL_NAME);
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, tableNameInfo, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
+        if (!dbInitialized) {
+            createDatabaseWithSql("CREATE DATABASE IF NOT EXISTS " + CatalogMocker.TEST_DB_NAME);
+            createTable("CREATE TABLE IF NOT EXISTS " + CatalogMocker.TEST_DB_NAME + "." + CatalogMocker.TEST_TBL_NAME
+                    + " (k1 INT, k2 INT) DISTRIBUTED BY HASH(k1) BUCKETS 1"
+                    + " PROPERTIES ('replication_num' = '1')");
+            dbInitialized = true;
+        }
     }
 
     @Test
     public void testValidateWithPrivilege() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.any(TableNameInfo.class),
+                Mockito.eq(PrivPredicate.SHOW));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+
         TableNameInfo tableNameInfo =
                 new TableNameInfo(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME);
 
@@ -85,27 +75,15 @@ public class ShowQueryStatsCommandTest {
     }
 
     @Test
-    void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME,
-                        CatalogMocker.TEST_TBL2_NAME, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = false;
-            }
-        };
+    void testValidateNoPrivilege() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Mockito.doReturn(false).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.SHOW));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         TableNameInfo tableNameInfo =
                 new TableNameInfo(CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowReplicaStatusCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowReplicaStatusCommandTest.java
@@ -33,47 +33,51 @@ import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ShowReplicaStatusCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
 
     private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN)).thenReturn(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTableCommandTest.java
@@ -22,33 +22,25 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ShowTableCommandTest {
-    @Mocked
+import java.io.IOException;
+
+public class ShowTableCommandTest extends TestWithFeService {
     private ConnectContext ctx;
+
+    private void runBefore() throws IOException {
+        ctx = createDefaultCtx();
+    }
 
     @Test
     public void testValidate() throws Exception {
-        new Expectations() {
-            {
-                ctx.getDatabase();
-                minTimes = 0;
-                result = CatalogMocker.TEST_DB_NAME;
-
-                ctx.getDefaultCatalog();
-                minTimes = 0;
-                result = InternalCatalog.INTERNAL_CATALOG_NAME;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-            }
-        };
+        runBefore();
+        ctx.setDatabase(CatalogMocker.TEST_DB_NAME);
+        ctx.changeDefaultCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
 
         ShowTableCommand command = new ShowTableCommand(CatalogMocker.TEST_DB_NAME,
                 InternalCatalog.INTERNAL_CATALOG_NAME, false, PlanType.SHOW_TABLES);
@@ -56,22 +48,10 @@ public class ShowTableCommandTest {
     }
 
     @Test
-    void testInvalidate() {
-        new Expectations() {
-            {
-                ctx.getDatabase();
-                minTimes = 0;
-                result = "";
-
-                ctx.getDefaultCatalog();
-                minTimes = 0;
-                result = "";
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-            }
-        };
+    void testInvalidate() throws Exception {
+        runBefore();
+        ctx.setDatabase("");
+        ctx.changeDefaultCatalog("");
 
         // db is empty
         ShowTableCommand command = new ShowTableCommand("",

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTableStatsCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTableStatsCommandTest.java
@@ -21,77 +21,80 @@ import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class ShowTableStatsCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String tableNotExist = "table_not_exist";
     private static final String partitionNotExist = "partition_not_exist";
-    @Mocked
-    private Env env;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
-    private ConnectContext connectContext;
+
+    private Env env = Mockito.mock(Env.class);
+    private InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+    private AccessControllerManager accessControllerManager = Mockito.mock(AccessControllerManager.class);
+    private ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+    private CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
     private Database db;
 
-    private void runBefore() throws Exception {
+    private MockedStatic<Env> mockedEnv;
+    private MockedStatic<ConnectContext> mockedConnectContext;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnv.when(Env::getCurrentInvertedIndex).thenReturn(Mockito.mock(TabletInvertedIndex.class));
+        mockedConnectContext.when(ConnectContext::get).thenReturn(connectContext);
+        Mockito.when(connectContext.getState()).thenReturn(Mockito.mock(QueryState.class));
         db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+    }
 
-                env.getCatalogMgr().getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
+    @AfterEach
+    void tearDown() {
+        if (mockedConnectContext != null) {
+            mockedConnectContext.close();
+        }
+        if (mockedEnv != null) {
+            mockedEnv.close();
+        }
+    }
 
-                catalog.getDb(anyString);
-                minTimes = 0;
-                result = db;
+    private void runBefore() throws Exception {
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(ArgumentMatchers.anyString());
+        Mockito.doReturn(Optional.of(db)).when(catalog).getDb(ArgumentMatchers.anyString());
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME,
-                        PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-            }
-        };
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(accessControllerManager.checkGlobalPriv(ArgumentMatchers.nullable(ConnectContext.class),
+                ArgumentMatchers.any(PrivPredicate.class))).thenReturn(true);
+        Mockito.when(accessControllerManager.checkTblPriv(ArgumentMatchers.nullable(ConnectContext.class), ArgumentMatchers.eq(internalCtl),
+                ArgumentMatchers.eq(CatalogMocker.TEST_DB_NAME), ArgumentMatchers.eq(CatalogMocker.TEST_TBL_NAME),
+                ArgumentMatchers.any(PrivPredicate.class))).thenReturn(true);
     }
 
     private Set<String> getColumns() {
@@ -136,26 +139,17 @@ public class ShowTableStatsCommandTest {
 
     @Test
     void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkGlobalPriv(ArgumentMatchers.nullable(ConnectContext.class),
+                ArgumentMatchers.any(PrivPredicate.class))).thenReturn(false);
+        Mockito.when(accessControllerManager.checkTblPriv(ArgumentMatchers.nullable(ConnectContext.class), ArgumentMatchers.eq(internalCtl),
+                ArgumentMatchers.eq(CatalogMocker.TEST_DB_NAME), ArgumentMatchers.eq(CatalogMocker.TEST_TBL2_NAME),
+                ArgumentMatchers.any(PrivPredicate.class))).thenReturn(false);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.SHOW);
-                minTimes = 0;
-                result = false;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL2_NAME,
-                        PrivPredicate.SHOW);
-                minTimes = 0;
-                result = false;
-            }
-        };
+        // set up catalog chain for the non-useTableId case
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.doReturn(catalog).when(catalogMgr).getCatalog(ArgumentMatchers.anyString());
+        Mockito.doReturn(Optional.of(db)).when(catalog).getDb(ArgumentMatchers.anyString());
 
         //test useTableId is true
         ShowTableStatsCommand command = new ShowTableStatsCommand(CatalogMocker.TEST_TBL_ID);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTableStatusCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTableStatusCommandTest.java
@@ -28,60 +28,63 @@ import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class ShowTableStatusCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
 
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager accessManager;
-    @Mocked
     private ConnectContext ctx;
-    @Mocked
     private InternalCatalog catalog;
-    @Mocked
     private CatalogMgr catalogMgr;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        accessManager = Mockito.mock(AccessControllerManager.class);
+        ctx = Mockito.mock(ConnectContext.class);
+        catalog = Mockito.mock(InternalCatalog.class);
+        catalogMgr = Mockito.mock(CatalogMgr.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(ctx);
+
+        Mockito.when(ctx.isSkipAuth()).thenReturn(true);
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
 
     @Test
     void testValidate() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessManager.checkDbPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.eq(InternalCatalog.INTERNAL_CATALOG_NAME),
+                Mockito.eq(CatalogMocker.TEST_DB_NAME),
+                Mockito.eq(PrivPredicate.SHOW))).thenReturn(true);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                ctx.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                accessManager.checkDbPriv(ctx, InternalCatalog.INTERNAL_CATALOG_NAME, CatalogMocker.TEST_DB_NAME,
-                        PrivPredicate.SHOW);
-                minTimes = 0;
-                result = true;
-            }
-        };
         EqualTo equalTo = new EqualTo(new UnboundSlot("name"),
                 new StringLiteral(CatalogMocker.TEST_DB_NAME));
 
@@ -96,38 +99,11 @@ public class ShowTableStatusCommandTest {
 
     @Test
     void testInvalidate() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        Mockito.when(accessManager.checkDbPriv(Mockito.nullable(ConnectContext.class),
+                Mockito.eq(InternalCatalog.INTERNAL_CATALOG_NAME),
+                Mockito.eq(CatalogMocker.TEST_DB_NAME),
+                Mockito.eq(PrivPredicate.SHOW))).thenReturn(false);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                ctx.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
-
-                catalogMgr.getCatalog(anyString);
-                minTimes = 0;
-                result = catalog;
-
-                accessManager.checkDbPriv(ctx, InternalCatalog.INTERNAL_CATALOG_NAME, CatalogMocker.TEST_DB_NAME,
-                        PrivPredicate.SHOW);
-                minTimes = 0;
-                result = false;
-            }
-        };
         EqualTo equalTo = new EqualTo(new UnboundSlot("name"),
                 new StringLiteral(CatalogMocker.TEST_DB_NAME));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommandTest.java
@@ -23,44 +23,51 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class ShowTabletIdCommandTest {
-    @Mocked
     private Env env;
-    @Mocked
     private AccessControllerManager manager;
-    @Mocked
     private ConnectContext ctx;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        manager = Mockito.mock(AccessControllerManager.class);
+        ctx = Mockito.mock(ConnectContext.class);
+
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(ctx);
+
+        Mockito.when(env.getAccessManager()).thenReturn(manager);
+        Mockito.when(ctx.getState()).thenReturn(new QueryState());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
 
     void runBefore(String dbName, boolean hasGlobalPriv) {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                ctx.getDatabase();
-                minTimes = 0;
-                result = dbName;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = manager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                manager.checkGlobalPriv(ctx, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = hasGlobalPriv;
-            }
-        };
+        Mockito.when(ctx.getDatabase()).thenReturn(dbName);
+        Mockito.when(manager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(hasGlobalPriv);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletsFromTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletsFromTableCommandTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.backup.CatalogMocker;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -32,59 +33,40 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ShowTabletsFromTableCommandTest {
+public class ShowTabletsFromTableCommandTest extends TestWithFeService {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
+    private Env env;
+    private AccessControllerManager accessControllerManager;
 
-    private void runBefore() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME,
-                        CatalogMocker.TEST_TBL_NAME, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
     public void testValidateWithPrivilege() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         Expression version = new UnboundSlot("version");
 
@@ -131,27 +113,15 @@ public class ShowTabletsFromTableCommandTest {
     }
 
     @Test
-    void testValidateNoPrivilege() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-
-                accessControllerManager.checkTblPriv(connectContext, internalCtl, CatalogMocker.TEST_DB_NAME,
-                        CatalogMocker.TEST_TBL2_NAME, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = false;
-            }
-        };
+    void testValidateNoPrivilege() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Mockito.doReturn(false).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PrivPredicate.ADMIN));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
 
         Expression version = new UnboundSlot("version");
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTransactionCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTransactionCommandTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
@@ -27,50 +28,35 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-public class ShowTransactionCommandTest {
-    @Mocked
+import java.io.IOException;
+
+public class ShowTransactionCommandTest extends TestWithFeService {
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private ConnectContext connectContext;
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkDbPriv(connectContext, anyString, anyString, PrivPredicate.LOAD);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    private void runBefore() throws IOException {
+        connectContext = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        accessControllerManager = env.getAccessManager();
     }
 
     @Test
-    public void testValidate() {
+    public void testValidate() throws Exception {
         runBefore();
+        connectContext.setSkipAuth(true);
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkDbPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(),
+                Mockito.anyString(), Mockito.any(PrivPredicate.class));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
         // test where is null
         ShowTransactionCommand command = new ShowTransactionCommand("test", null);
         Assertions.assertThrows(AnalysisException.class, () -> command.validate(connectContext));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/StopRoutineLoadCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/StopRoutineLoadCommandTest.java
@@ -20,30 +20,39 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.nereids.trees.plans.commands.load.StopRoutineLoadCommand;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.SessionVariable;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class StopRoutineLoadCommandTest {
 
-    @Mocked
     private ConnectContext connectContext;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
-    private void runBefore() {
-        new Expectations() {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
-            }
-        };
+    @BeforeEach
+    public void setUp() {
+        connectContext = Mockito.mock(ConnectContext.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(new SessionVariable());
+        Mockito.when(connectContext.getState()).thenReturn(new QueryState());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void test() throws Exception {
-        runBefore();
         LabelNameInfo labelNameInfo = new LabelNameInfo("testDB", "label0");
         StopRoutineLoadCommand command = new StopRoutineLoadCommand(labelNameInfo);
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/TruncateTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/TruncateTableCommandTest.java
@@ -38,10 +38,9 @@ import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -83,18 +82,13 @@ public class TruncateTableCommandTest extends TestWithFeService {
     }
 
     @Test
-    public void testValidate(@Mocked AccessControllerManager accessManager) {
-        new Expectations() {
-            {
-                Env.getCurrentEnv().getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                accessManager.checkTblPriv((ConnectContext) any, anyString, anyString, anyString, PrivPredicate.LOAD);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    public void testValidate() {
+        Env env = Env.getCurrentEnv();
+        AccessControllerManager spyAcm = Mockito.spy(env.getAccessManager());
+        Mockito.doReturn(true).when(spyAcm).checkTblPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.anyString(), Mockito.anyString(),
+                Mockito.anyString(), Mockito.eq(PrivPredicate.LOAD));
+        org.apache.doris.common.jmockit.Deencapsulation.setField(env, "accessManager", spyAcm);
 
         String truncateStr = "TRUNCATE TABLE internal.testcommand.case_sensitive_table_command PARTITION P20211008; \n";
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/WarmUpClusterCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/WarmUpClusterCommandTest.java
@@ -31,56 +31,58 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.info.WarmUpItem;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class WarmUpClusterCommandTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
-    @Mocked
+
     private Env env;
-    @Mocked
     private AccessControllerManager accessControllerManager;
-    @Mocked
     private InternalCatalog catalog;
-    @Mocked
     private ConnectContext connectContext;
     private Database db;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
 
-    private void runBefore() throws Exception {
+    @BeforeEach
+    public void setUp() throws Exception {
         db = CatalogMocker.mockDb();
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        env = Mockito.mock(Env.class);
+        accessControllerManager = Mockito.mock(AccessControllerManager.class);
+        catalog = Mockito.mock(InternalCatalog.class);
+        connectContext = Mockito.mock(ConnectContext.class);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = connectContext;
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(connectContext.isSkipAuth()).thenReturn(true);
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN))).thenReturn(true);
+    }
 
-                connectContext.isSkipAuth();
-                minTimes = 0;
-                result = true;
-
-                accessControllerManager.checkGlobalPriv(connectContext, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
     }
 
     @Test
     public void testValidate() throws Exception {
-        runBefore();
         if (Config.isCloudMode()) {
             List<String> cloudClusterNames = ((CloudSystemInfoService) Env.getCurrentSystemInfo()).getCloudClusterNames();
             if (cloudClusterNames.isEmpty()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/CreateTableInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/CreateTableInfoTest.java
@@ -36,6 +36,7 @@ import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,6 +59,13 @@ public class CreateTableInfoTest {
 
         FakeEnv.setEnv(env);
         FakeEnv.setMetaVersion(FeConstants.meta_version);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/LoadJobV2PersistTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/LoadJobV2PersistTest.java
@@ -30,11 +30,10 @@ import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
 import org.apache.doris.qe.OriginStatement;
 
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -57,50 +56,46 @@ public class LoadJobV2PersistTest {
     }
 
     @Test
-    public void testBrokerLoadJob(@Mocked Env env, @Mocked InternalCatalog catalog, @Injectable Database database,
-            @Injectable Table table) throws Exception {
+    public void testBrokerLoadJob() throws Exception {
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table table = Mockito.mock(Table.class);
 
-        new Expectations() {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-                catalog.getDbNullable(anyLong);
-                minTimes = 0;
-                result = database;
-                database.getTableNullable(anyLong);
-                minTimes = 0;
-                result = table;
-                table.getName();
-                minTimes = 0;
-                result = "tablename";
-                Env.getCurrentEnvJournalVersion();
-                minTimes = 0;
-                result = FeMetaVersion.VERSION_CURRENT;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envStatic.when(Env::getCurrentEnvJournalVersion).thenReturn(FeMetaVersion.VERSION_CURRENT);
 
-        // 1. Write objects to file
-        File file = new File("./testBrokerLoadJob");
-        file.createNewFile();
-        DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDbNullable(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(catalog.getDbOrMetaException(Mockito.anyLong())).thenReturn(database);
+            Mockito.when(database.getTableNullable(Mockito.anyLong())).thenReturn(table);
+            Mockito.when(database.getFullName()).thenReturn("testDb");
+            Mockito.when(table.getName()).thenReturn("tablename");
 
-        BrokerLoadJob job = createJob();
-        Assert.assertEquals(5, job.getLoadParallelism());
-        job.write(dos);
+            // 1. Write objects to file
+            File file = new File("./testBrokerLoadJob");
+            file.createNewFile();
+            DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
 
-        dos.flush();
-        dos.close();
+            BrokerLoadJob job = createJob();
+            Assert.assertEquals(5, job.getLoadParallelism());
+            job.write(dos);
 
-        // 2. Read objects from file
-        DataInputStream dis = new DataInputStream(new FileInputStream(file));
+            dos.flush();
+            dos.close();
 
-        BrokerLoadJob rJob = (BrokerLoadJob)  BrokerLoadJob.read(dis);
-        Assert.assertEquals(5, rJob.getLoadParallelism());
-        Assert.assertEquals(EtlJobType.BROKER, rJob.getJobType());
+            // 2. Read objects from file
+            DataInputStream dis = new DataInputStream(new FileInputStream(file));
 
-        // 3. delete files
-        dis.close();
-        file.delete();
+            BrokerLoadJob rJob = (BrokerLoadJob) BrokerLoadJob.read(dis);
+            Assert.assertEquals(5, rJob.getLoadParallelism());
+            Assert.assertEquals(EtlJobType.BROKER, rJob.getJobType());
+
+            // 3. delete files
+            dis.close();
+            file.delete();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/RefreshExternalTableInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/RefreshExternalTableInfoTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.jmockit.Deencapsulation;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,6 +51,13 @@ public class RefreshExternalTableInfoTest {
 
         FakeEnv.setEnv(env);
         FakeEnv.setMetaVersion(FeConstants.meta_version);
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
@@ -32,13 +32,14 @@ import org.apache.doris.system.SystemInfoService;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.hadoop.fs.Path;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -53,8 +54,20 @@ import java.util.Set;
 import java.util.UUID;
 
 public class FederationBackendPolicyTest {
-    @Mocked
-    private Env env;
+    private Env env = Mockito.mock(Env.class);
+    private MockedStatic<Env> mockedEnvStatic;
+
+    @Before
+    public void setUp() {
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getEditLog()).thenReturn(Mockito.mock(org.apache.doris.persist.EditLog.class));
+    }
+
+    @After
+    public void tearDown() {
+        mockedEnvStatic.close();
+    }
 
     @Test
     public void testRemoteSplits() throws UserException {
@@ -71,17 +84,8 @@ public class FederationBackendPolicyTest {
         service.addBackend(backend3);
 
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(service);
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return cgmgr;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(service);
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
 
         List<Split> splits = new ArrayList<>();
         splits.add(new FileSplit(LocationPath.of("hdfs://HDFS8000871/usr/hive/warehouse/clickbench.db/hits_orc/part-00000-3e24f7d5-f658-4a80-a168-7b215c5a35bf-c000.snappy.orc"), 0, 112140970, 112140970, 0, null, Collections.emptyList()));
@@ -126,17 +130,8 @@ public class FederationBackendPolicyTest {
         service.addBackend(backend3);
 
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(service);
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return cgmgr;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(service);
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
 
         List<Split> splits = new ArrayList<>();
         splits.add(new FileSplit(LocationPath.of("hdfs://HDFS8000871/usr/hive/warehouse/clickbench.db/hits_orc/part-00000-3e24f7d5-f658-4a80-a168-7b215c5a35bf-c000.snappy.orc"), 0, 112140970, 112140970, 0, new String[]{"172.30.0.100"}, Collections.emptyList()));
@@ -208,17 +203,8 @@ public class FederationBackendPolicyTest {
         service.addBackend(backend3);
 
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(service);
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return cgmgr;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(service);
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
 
         List<Split> splits = new ArrayList<>();
         splits.add(new FileSplit(LocationPath.of("hdfs://HDFS8000871/usr/hive/warehouse/clickbench.db/hits_orc/part-00000-3e24f7d5-f658-4a80-a168-7b215c5a35bf-c000.snappy.orc"), 0, 112140970, 112140970, 0, null, Collections.emptyList()));
@@ -277,17 +263,8 @@ public class FederationBackendPolicyTest {
     public void testGenerateRandomly() throws UserException {
         SystemInfoService service = new SystemInfoService();
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(service);
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return cgmgr;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(service);
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
 
         Random random = new Random();
         int backendNum = random.nextInt(100 - 1) + 1;
@@ -396,17 +373,8 @@ public class FederationBackendPolicyTest {
     public void testNonAliveNodes() throws UserException {
         SystemInfoService service = new SystemInfoService();
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(service);
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return cgmgr;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(service);
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
 
         Random random = new Random();
         int backendNum = random.nextInt(100 - 1) + 1;
@@ -571,17 +539,8 @@ public class FederationBackendPolicyTest {
         service.addBackend(backend3);
 
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(service);
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return cgmgr;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(service);
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
 
         List<Split> splits = new ArrayList<>();
         splits.add(new FileSplit(LocationPath.of("hdfs://HDFS8000871/usr/hive/warehouse/clickbench.db/hits_orc/part-00000-3e24f7d5-f658-4a80-a168-7b215c5a35bf-c000.snappy.orc"), 0, 112140970, 112140970, 0, null, Collections.emptyList()));
@@ -728,17 +687,8 @@ public class FederationBackendPolicyTest {
         service.addBackend(backend3);
 
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(service);
-        new MockUp<Env>() {
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-
-            @Mock
-            public ComputeGroupMgr getComputeGroupMgr() {
-                return cgmgr;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(service);
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
 
         List<Split> splits = new ArrayList<>();
         splits.add(genFileSplit("s1", 1000000L, 1000L)); // belong 2

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/HiveTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/HiveTableSinkTest.java
@@ -20,8 +20,6 @@ package org.apache.doris.planner;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
-import org.apache.doris.datasource.hive.HMSCachedClient;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalDatabase;
 import org.apache.doris.datasource.hive.HMSExternalTable;
@@ -30,14 +28,13 @@ import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.foundation.util.PathUtils;
 import org.apache.doris.qe.ConnectContext;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,10 +42,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 
 public class HiveTableSinkTest {
 
@@ -57,25 +52,21 @@ public class HiveTableSinkTest {
         ConnectContext ctx = new ConnectContext();
         ctx.setThreadLocalInfo();
 
-        new MockUp<ThriftHMSCachedClient>() {
-            @Mock
-            List<Partition> listPartitions(String dbName, String tblName) {
-                return new ArrayList<Partition>() {{
-                        add(new Partition() {{
-                                setValues(new ArrayList<String>() {{
-                                        add("a");
-                                    }
-                                });
-                                setSd(new StorageDescriptor() {{
-                                        setInputFormat("orc");
-                                    }
-                                });
+        List<Partition> partitions = new ArrayList<Partition>() {{
+                add(new Partition() {{
+                        setValues(new ArrayList<String>() {{
+                                add("a");
+                            }
+                        });
+                        setSd(new StorageDescriptor() {{
+                                setInputFormat("orc");
                             }
                         });
                     }
-                };
+                });
             }
         };
+
         Map<String, String> storageProperties = new HashMap<>();
         storageProperties.put("oss.endpoint", "oss-cn-hangzhou.aliyuncs.com");
         storageProperties.put("oss.access_key", "access_key");
@@ -90,19 +81,8 @@ public class HiveTableSinkTest {
         Map<StorageProperties.Type, StorageProperties> storagePropertiesMap = storagePropertiesList.stream()
                 .collect(Collectors.toMap(StorageProperties::getType, Function.identity()));
 
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public Map<StorageProperties.Type, StorageProperties> getStoragePropertiesMap() {
-                return storagePropertiesMap;
-            }
-        };
-        new MockUp<HMSExternalCatalog>() {
-            @Mock
-            public HMSCachedClient getClient() {
-                return new ThriftHMSCachedClient(null, 2, new ExecutionAuthenticator() {
-                });
-            }
-        };
+        ThriftHMSCachedClient mockClient = Mockito.mock(ThriftHMSCachedClient.class);
+        Mockito.when(mockClient.listPartitions(Mockito.anyString(), Mockito.anyString())).thenReturn(partitions);
 
         ArrayList<String> locations = new ArrayList<String>() {{
                 add("oss://abc/def");
@@ -113,65 +93,55 @@ public class HiveTableSinkTest {
             }
         };
         for (String location : locations) {
-            mockDifferLocationTable(location);
-
-            HMSExternalCatalog hmsExternalCatalog = new HMSExternalCatalog();
+            HMSExternalCatalog hmsExternalCatalog = Mockito.spy(new HMSExternalCatalog());
             hmsExternalCatalog.setInitializedForTest(true);
+            Mockito.doReturn(mockClient).when(hmsExternalCatalog).getClient();
+
             HMSExternalDatabase db = new HMSExternalDatabase(hmsExternalCatalog, 10000, "hive_db1", "hive_db1");
-            HMSExternalTable tbl = new HMSExternalTable(10001, "hive_tbl1", "hive_db1", hmsExternalCatalog, db);
+            HMSExternalTable tbl = Mockito.spy(new HMSExternalTable(10001, "hive_tbl1", "hive_db1",
+                    hmsExternalCatalog, db));
+            Mockito.doReturn(storagePropertiesMap).when(tbl).getStoragePropertiesMap();
+            mockDifferLocationTable(tbl, location);
+
             HiveTableSink hiveTableSink = new HiveTableSink(tbl);
             hiveTableSink.bindDataSink(Optional.empty());
             Assert.assertTrue(PathUtils.equalsIgnoreSchemeIfOneIsS3(hiveTableSink.tDataSink.hive_table_sink.location.write_path, location));
         }
     }
 
-    private void mockDifferLocationTable(String location) {
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public boolean isPartitionedTable() {
-                return false;
-            }
+    private void mockDifferLocationTable(HMSExternalTable tbl, String location) {
+        Mockito.doReturn(false).when(tbl).isPartitionedTable();
 
-            @Mock
-            public Set<String> getPartitionColumnNames() {
-                return new HashSet<String>() {{
-                        add("a");
-                        add("b");
-                    }
-                };
+        Mockito.doReturn(new HashSet<String>() {{
+                add("a");
+                add("b");
             }
+        }).when(tbl).getPartitionColumnNames();
 
-            @Mock
-            public List<Column> getColumns() {
-                Column a = new Column("a", PrimitiveType.INT);
-                Column b = new Column("b", PrimitiveType.INT);
-                return new ArrayList<Column>() {{
-                        add(a);
-                        add(b);
-                    }
-                };
+        Column a = new Column("a", PrimitiveType.INT);
+        Column b = new Column("b", PrimitiveType.INT);
+        Mockito.doReturn(new ArrayList<Column>() {{
+                add(a);
+                add(b);
             }
+        }).when(tbl).getColumns();
 
-            @Mock
-            public org.apache.hadoop.hive.metastore.api.Table getRemoteTable() {
-                Table table = new Table();
-                table.setSd(new StorageDescriptor() {{
-                        setInputFormat("orc");
-                        setBucketCols(new ArrayList<>());
-                        setNumBuckets(1);
-                        setSerdeInfo(new SerDeInfo() {{
-                                setParameters(new HashMap<>());
-                            }
-                        });
-                        setLocation(location);
+        Table table = new Table();
+        table.setSd(new StorageDescriptor() {{
+                setInputFormat("orc");
+                setBucketCols(new ArrayList<>());
+                setNumBuckets(1);
+                setSerdeInfo(new SerDeInfo() {{
+                        setParameters(new HashMap<>());
                     }
                 });
-                table.setParameters(new HashMap<String, String>() {{
-                        put("orc.compress", "lzo");
-                    }
-                });
-                return table;
+                setLocation(location);
             }
-        };
+        });
+        table.setParameters(new HashMap<String, String>() {{
+                put("orc.compress", "lzo");
+            }
+        });
+        Mockito.doReturn(table).when(tbl).getRemoteTable();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ListPartitionPrunerV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ListPartitionPrunerV2Test.java
@@ -26,10 +26,8 @@ import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ThreadPoolManager;
-import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.NameMapping;
-import org.apache.doris.datasource.hive.HMSCachedClient;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache;
 import org.apache.doris.datasource.hive.HiveExternalMetaCache.PartitionValueCacheKey;
@@ -37,13 +35,10 @@ import org.apache.doris.datasource.hive.ThriftHMSCachedClient;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,97 +71,77 @@ public class ListPartitionPrunerV2Test {
     }
 
     @Test
-    public void testInvalidateTable(@Mocked Env env, @Mocked CatalogMgr catalogMgr,
-            @Mocked HMSExternalCatalog hmsCatalog) {
+    public void testInvalidateTable() {
+        Env env = Mockito.mock(Env.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        HMSExternalCatalog hmsCatalog = Mockito.mock(HMSExternalCatalog.class);
         long catalogId = 10001L;
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        ThriftHMSCachedClient mockClient = Mockito.mock(ThriftHMSCachedClient.class);
+        // Mock is used here to represent the existence of a partition in the original table
+        Mockito.when(mockClient.listPartitionNames(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(new ArrayList<>(java.util.Collections.singletonList("c1=1.234000")));
+        Mockito.when(hmsCatalog.getClient()).thenReturn(mockClient);
 
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = catalogMgr;
+        try (MockedStatic<Env> mockedEnvStatic = Mockito.mockStatic(Env.class)) {
+            mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+            Mockito.doReturn(hmsCatalog).when(catalogMgr).getCatalog(catalogId);
 
-                catalogMgr.getCatalog(catalogId);
-                minTimes = 0;
-                result = hmsCatalog;
-            }
-        };
+            ThreadPoolExecutor executor = ThreadPoolManager.newDaemonFixedThreadPool(
+                    10, 10, "mgr", 120, false);
+            ThreadPoolExecutor listExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
+                    10, 10, "mgr", 120, false);
+            HiveExternalMetaCache cache = new HiveExternalMetaCache(executor, listExecutor);
+            cache.initCatalog(catalogId, new HashMap<>());
+            ArrayList<Type> types = new ArrayList<>();
+            types.add(ScalarType.DOUBLE);
 
-        new MockUp<HMSExternalCatalog>(HMSExternalCatalog.class) {
-            @Mock
-            public HMSCachedClient getClient() {
-                return new ThriftHMSCachedClient(new HiveConf(), 2, new ExecutionAuthenticator() {
-                });
-            }
-        };
+            // test cache
+            // the original partition of the table (in mock) will be loaded here
+            String dbName = "db";
+            String tblName = "tb";
+            NameMapping nameMapping = NameMapping.createForTest(catalogId, dbName, tblName);
+            PartitionValueCacheKey key = new PartitionValueCacheKey(nameMapping, types);
+            HiveExternalMetaCache.HivePartitionValues partitionValues = cache.getPartitionValues(key);
+            Assert.assertEquals(1, partitionValues.getIdToPartitionItem().size());
+            List<PartitionKey> items = partitionValues.getIdToPartitionItem().values().iterator().next().getItems();
+            Assert.assertEquals(1, items.size());
+            PartitionKey partitionKey = items.get(0);
+            Assert.assertEquals("1.234", partitionKey.getKeys().get(0).toString());
+            Assert.assertEquals("1.234000", partitionKey.getOriginHiveKeys().get(0));
 
-        new MockUp<ThriftHMSCachedClient>(ThriftHMSCachedClient.class) {
-            @Mock
-            public List<String> listPartitionNames(String dbName, String tblName) {
-                // Mock is used here to represent the existence of a partition in the original table
-                return new ArrayList<String>() {{
-                        add("c1=1.234000");
-                    }};
-            }
-        };
-
-        ThreadPoolExecutor executor = ThreadPoolManager.newDaemonFixedThreadPool(
-                10, 10, "mgr", 120, false);
-        ThreadPoolExecutor listExecutor = ThreadPoolManager.newDaemonFixedThreadPool(
-                10, 10, "mgr", 120, false);
-        HiveExternalMetaCache cache = new HiveExternalMetaCache(executor, listExecutor);
-        cache.initCatalog(catalogId, new HashMap<>());
-        ArrayList<Type> types = new ArrayList<>();
-        types.add(ScalarType.DOUBLE);
-
-        // test cache
-        // the original partition of the table (in mock) will be loaded here
-        String dbName = "db";
-        String tblName = "tb";
-        NameMapping nameMapping = NameMapping.createForTest(catalogId, dbName, tblName);
-        PartitionValueCacheKey key = new PartitionValueCacheKey(nameMapping, types);
-        HiveExternalMetaCache.HivePartitionValues partitionValues = cache.getPartitionValues(key);
-        Assert.assertEquals(1, partitionValues.getIdToPartitionItem().size());
-        List<PartitionKey> items = partitionValues.getIdToPartitionItem().values().iterator().next().getItems();
-        Assert.assertEquals(1, items.size());
-        PartitionKey partitionKey = items.get(0);
-        Assert.assertEquals("1.234", partitionKey.getKeys().get(0).toString());
-        Assert.assertEquals("1.234000", partitionKey.getOriginHiveKeys().get(0));
-
-        // test add cache
-        ArrayList<String> values = new ArrayList<>();
-        values.add("c1=5.678000");
-        cache.addPartitionsCache(nameMapping, values, types);
-        HiveExternalMetaCache.HivePartitionValues partitionValues2 = cache.getPartitionValues(
+            // test add cache
+            ArrayList<String> values = new ArrayList<>();
+            values.add("c1=5.678000");
+            cache.addPartitionsCache(nameMapping, values, types);
+            HiveExternalMetaCache.HivePartitionValues partitionValues2 = cache.getPartitionValues(
                 new PartitionValueCacheKey(nameMapping, types));
-        Assert.assertEquals(2, partitionValues2.getIdToPartitionItem().size());
-        PartitionKey partitionKey2 = null;
-        for (PartitionItem partitionItem : partitionValues2.getIdToPartitionItem().values()) {
-            List<PartitionKey> partitionKeys = partitionItem.getItems();
-            Assert.assertEquals(1, partitionKeys.size());
-            if ("5.678000".equals(partitionKeys.get(0).getOriginHiveKeys().get(0))) {
-                partitionKey2 = partitionKeys.get(0);
-                break;
+            Assert.assertEquals(2, partitionValues2.getIdToPartitionItem().size());
+            PartitionKey partitionKey2 = null;
+            for (PartitionItem partitionItem : partitionValues2.getIdToPartitionItem().values()) {
+                List<PartitionKey> partitionKeys = partitionItem.getItems();
+                Assert.assertEquals(1, partitionKeys.size());
+                if ("5.678000".equals(partitionKeys.get(0).getOriginHiveKeys().get(0))) {
+                    partitionKey2 = partitionKeys.get(0);
+                    break;
+                }
             }
+            Assert.assertNotNull(partitionKey2);
+            Assert.assertEquals("5.678", partitionKey2.getKeys().get(0).toString());
+            Assert.assertEquals("5.678000", partitionKey2.getOriginHiveKeys().get(0));
+
+            // test refresh table
+            // simulates the manually added partition table being deleted, leaving only one original partition in mock
+            cache.invalidateTableCache(nameMapping);
+            HiveExternalMetaCache.HivePartitionValues partitionValues3 = cache.getPartitionValues(
+                new PartitionValueCacheKey(nameMapping, types));
+            Assert.assertEquals(1, partitionValues3.getIdToPartitionItem().size());
+            List<PartitionKey> items3 = partitionValues3.getIdToPartitionItem().values().iterator().next().getItems();
+            Assert.assertEquals(1, items3.size());
+            PartitionKey partitionKey3 = items3.get(0);
+            Assert.assertEquals("1.234", partitionKey3.getKeys().get(0).toString());
+            Assert.assertEquals("1.234000", partitionKey3.getOriginHiveKeys().get(0));
         }
-        Assert.assertNotNull(partitionKey2);
-        Assert.assertEquals("5.678", partitionKey2.getKeys().get(0).toString());
-        Assert.assertEquals("5.678000", partitionKey2.getOriginHiveKeys().get(0));
-
-        // test refresh table
-        // simulates the manually added partition table being deleted, leaving only one original partition in mock
-        cache.invalidateTableCache(nameMapping);
-        HiveExternalMetaCache.HivePartitionValues partitionValues3 = cache.getPartitionValues(
-                new PartitionValueCacheKey(nameMapping, types));
-        Assert.assertEquals(1, partitionValues3.getIdToPartitionItem().size());
-        List<PartitionKey> items3 = partitionValues3.getIdToPartitionItem().values().iterator().next().getItems();
-        Assert.assertEquals(1, items3.size());
-        PartitionKey partitionKey3 = items3.get(0);
-        Assert.assertEquals("1.234", partitionKey3.getKeys().get(0).toString());
-        Assert.assertEquals("1.234000", partitionKey3.getOriginHiveKeys().get(0));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -26,20 +26,23 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.Pair;
+import org.apache.doris.datasource.CatalogMgr;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.MysqlCapability;
 import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.nio.channels.SocketChannel;
 import java.util.HashMap;
@@ -49,110 +52,114 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class ConnectContextTest {
-    @Mocked
-    private StmtExecutor executor;
-    @Mocked
-    private SocketChannel socketChannel;
-    @Mocked
-    private Env env;
-    @Mocked
-    private ConnectScheduler connectScheduler;
-    @Mocked
-    private Auth auth;
-    @Mocked
-    private String qualifiedUser;
-    @Mocked
-    private CloudSystemInfoService cloudSystemInfoService;
-    @Mocked
-    private AccessControllerManager accessManager;
-    @Mocked
-    private Backend backend;
+    private StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+    private SocketChannel socketChannel = Mockito.mock(SocketChannel.class);
+    private Env env = Mockito.mock(Env.class);
+    private ConnectScheduler connectScheduler = Mockito.mock(ConnectScheduler.class);
+    private Auth auth = Mockito.mock(Auth.class);
+    private String qualifiedUser = "";
+    private CloudSystemInfoService cloudSystemInfoService = Mockito.mock(CloudSystemInfoService.class);
+    private AccessControllerManager accessManager = Mockito.mock(AccessControllerManager.class);
+    private Backend backend = Mockito.mock(Backend.class);
+    private InternalCatalog internalCatalog = Mockito.mock(InternalCatalog.class);
+
+    private CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
 
     @Before
     public void setUp() throws Exception {
+        Mockito.when(env.getInternalCatalog()).thenReturn(internalCatalog);
+        Mockito.when(internalCatalog.getName()).thenReturn("internal");
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(internalCatalog);
     }
 
     @Test
     public void testNormal() {
-        ConnectContext ctx = new ConnectContext();
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getSelfNode())
+                    .thenReturn(new SystemInfoService.HostInfo("127.0.0.1", 9030));
 
-        // State
-        Assert.assertNotNull(ctx.getState());
+            ConnectContext ctx = new ConnectContext();
 
-        // Capability
-        Assert.assertEquals(MysqlCapability.DEFAULT_CAPABILITY, ctx.getServerCapability());
-        ctx.setCapability(new MysqlCapability(10));
-        Assert.assertEquals(new MysqlCapability(10), ctx.getCapability());
+            // State
+            Assert.assertNotNull(ctx.getState());
 
-        // Kill flag
-        Assert.assertFalse(ctx.isKilled());
-        ctx.setKilled();
-        Assert.assertTrue(ctx.isKilled());
+            // Capability
+            Assert.assertEquals(MysqlCapability.DEFAULT_CAPABILITY, ctx.getServerCapability());
+            ctx.setCapability(new MysqlCapability(10));
+            Assert.assertEquals(new MysqlCapability(10), ctx.getCapability());
 
-        // Current db
-        Assert.assertEquals("", ctx.getDatabase());
-        ctx.setDatabase("testDb");
-        Assert.assertEquals("testDb", ctx.getDatabase());
+            // Kill flag
+            Assert.assertFalse(ctx.isKilled());
+            ctx.setKilled();
+            Assert.assertTrue(ctx.isKilled());
 
-        // User
-        ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("testUser", "%"));
-        Assert.assertEquals("testUser", ctx.getQualifiedUser());
+            // Current db
+            Assert.assertEquals("", ctx.getDatabase());
+            ctx.setDatabase("testDb");
+            Assert.assertEquals("testDb", ctx.getDatabase());
 
-        // Serializer
-        Assert.assertNotNull(ctx.getMysqlChannel().getSerializer());
+            // User
+            ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp("testUser", "%"));
+            Assert.assertEquals("testUser", ctx.getQualifiedUser());
 
-        // Session variable
-        Assert.assertNotNull(ctx.getSessionVariable());
+            // Serializer
+            Assert.assertNotNull(ctx.getMysqlChannel().getSerializer());
 
-        // connect scheduler
-        Assert.assertNull(ctx.getConnectScheduler());
-        ctx.setConnectScheduler(connectScheduler);
-        Assert.assertNotNull(ctx.getConnectScheduler());
+            // Session variable
+            Assert.assertNotNull(ctx.getSessionVariable());
 
-        // connection id
-        ctx.setConnectionId(101);
-        Assert.assertEquals(101, ctx.getConnectionId());
+            // connect scheduler
+            Assert.assertNull(ctx.getConnectScheduler());
+            ctx.setConnectScheduler(connectScheduler);
+            Assert.assertNotNull(ctx.getConnectScheduler());
 
-        // command
-        ctx.setCommand(MysqlCommand.COM_PING);
-        Assert.assertEquals(MysqlCommand.COM_PING, ctx.getCommand());
+            // connection id
+            ctx.setConnectionId(101);
+            Assert.assertEquals(101, ctx.getConnectionId());
 
-        // LoginTime
-        ctx.loginTime = 1694002396223L;
+            // command
+            ctx.setCommand(MysqlCommand.COM_PING);
+            Assert.assertEquals(MysqlCommand.COM_PING, ctx.getCommand());
 
-        // Thread info
-        Assert.assertNotNull(ctx.toThreadInfo(false));
-        List<String> row = ctx.toThreadInfo(false).toRow(101, 1000, Optional.of("+08:00"));
-        Assert.assertEquals(15, row.size());
-        Assert.assertEquals("Yes", row.get(0));
-        Assert.assertEquals("101", row.get(1));
-        Assert.assertEquals("testUser", row.get(2));
-        Assert.assertEquals("", row.get(3));
-        Assert.assertEquals("2023-09-06 20:13:16", row.get(4));
-        Assert.assertEquals("internal", row.get(5));
-        Assert.assertEquals("testDb", row.get(6));
-        Assert.assertEquals("Ping", row.get(7));
-        Assert.assertEquals("1", row.get(8));
-        Assert.assertEquals("OK", row.get(9));
-        Assert.assertEquals("", row.get(10));
-        Assert.assertEquals("", row.get(11));
+            // LoginTime
+            ctx.loginTime = 1694002396223L;
 
-        // Start time
-        Assert.assertEquals(0, ctx.getStartTime());
-        ctx.setStartTime();
-        Assert.assertNotSame(0, ctx.getStartTime());
+            // Thread info
+            Assert.assertNotNull(ctx.toThreadInfo(false));
+            List<String> row = ctx.toThreadInfo(false).toRow(101, 1000, Optional.of("+08:00"));
+            Assert.assertEquals(15, row.size());
+            Assert.assertEquals("Yes", row.get(0));
+            Assert.assertEquals("101", row.get(1));
+            Assert.assertEquals("testUser", row.get(2));
+            Assert.assertEquals("", row.get(3));
+            Assert.assertEquals("2023-09-06 20:13:16", row.get(4));
+            Assert.assertEquals("internal", row.get(5));
+            Assert.assertEquals("testDb", row.get(6));
+            Assert.assertEquals("Ping", row.get(7));
+            Assert.assertEquals("1", row.get(8));
+            Assert.assertEquals("OK", row.get(9));
+            Assert.assertEquals("", row.get(10));
+            Assert.assertEquals("", row.get(11));
 
-        // query id
-        ctx.setQueryId(new TUniqueId(100, 200));
-        Assert.assertEquals(new TUniqueId(100, 200), ctx.queryId());
+            // Start time
+            Assert.assertEquals(0, ctx.getStartTime());
+            ctx.setStartTime();
+            Assert.assertNotSame(0, ctx.getStartTime());
 
-        // Catalog
-        Assert.assertNull(ctx.getEnv());
-        ctx.setEnv(env);
-        Assert.assertNotNull(ctx.getEnv());
+            // query id
+            ctx.setQueryId(new TUniqueId(100, 200));
+            Assert.assertEquals(new TUniqueId(100, 200), ctx.queryId());
 
-        // clean up
-        ctx.cleanup();
+            // Catalog
+            Assert.assertNull(ctx.getEnv());
+            ctx.setEnv(env);
+            Assert.assertNotNull(ctx.getEnv());
+
+            // clean up
+            ctx.cleanup();
+        }
     }
 
     @Test
@@ -238,13 +245,8 @@ public class ConnectContextTest {
         long result = context.getMaxExecMemByte();
         Assert.assertEquals(sessionValue, result);
         // has property
-        new Expectations() {
-            {
-                auth.getExecMemLimit(anyString);
-                minTimes = 0;
-                result = propertyValue;
-            }
-        };
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(auth.getExecMemLimit(Mockito.anyString())).thenReturn(propertyValue);
         result = context.getMaxExecMemByte();
         Assert.assertEquals(propertyValue, result);
     }
@@ -261,13 +263,8 @@ public class ConnectContextTest {
         long result = context.getQueryTimeoutS();
         Assert.assertEquals(sessionValue, result);
         // has property
-        new Expectations() {
-            {
-                auth.getQueryTimeout(anyString);
-                minTimes = 0;
-                result = propertyValue;
-            }
-        };
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(auth.getQueryTimeout(Mockito.anyString())).thenReturn(propertyValue);
         result = context.getQueryTimeoutS();
         Assert.assertEquals(propertyValue, result);
     }
@@ -284,13 +281,8 @@ public class ConnectContextTest {
         long result = context.getInsertTimeoutS();
         Assert.assertEquals(sessionValue, result);
         // has property
-        new Expectations() {
-            {
-                auth.getInsertTimeout(anyString);
-                minTimes = 0;
-                result = propertyValue;
-            }
-        };
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(auth.getInsertTimeout(Mockito.anyString())).thenReturn(propertyValue);
         result = context.getInsertTimeoutS();
         Assert.assertEquals(propertyValue, result);
     }
@@ -323,12 +315,7 @@ public class ConnectContextTest {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(env);
 
-        new Expectations() {
-            {
-                env.changeDb(ctx, "testDb");
-                minTimes = 0;
-            }
-        };
+        // env.changeDb is a void method on a mock - does nothing by default
 
         Optional<Pair<ErrorCode, String>> result = ConnectContextUtil.initCatalogAndDb(ctx, "testDb");
         Assert.assertFalse(result.isPresent());
@@ -339,14 +326,7 @@ public class ConnectContextTest {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(env);
 
-        new Expectations() {
-            {
-                env.changeCatalog(ctx, "catalog1");
-                minTimes = 0;
-                env.changeDb(ctx, "testDb");
-                minTimes = 0;
-            }
-        };
+        // env.changeCatalog and env.changeDb are void methods on a mock - do nothing by default
 
         Optional<Pair<ErrorCode, String>> result = ConnectContextUtil.initCatalogAndDb(ctx, "catalog1.testDb");
         Assert.assertFalse(result.isPresent());
@@ -362,14 +342,7 @@ public class ConnectContextTest {
             ConnectContext ctx = new ConnectContext();
             ctx.setEnv(env);
 
-            new Expectations() {
-                {
-                    env.changeCatalog(ctx, "catalog1");
-                    minTimes = 0;
-                    env.changeDb(ctx, "ns1.ns2.testDb");
-                    minTimes = 0;
-                }
-            };
+            // env.changeCatalog and env.changeDb are void methods on a mock - do nothing by default
 
             Optional<Pair<ErrorCode, String>> result = ConnectContextUtil.initCatalogAndDb(ctx,
                     "catalog1.ns1.ns2.testDb");
@@ -409,14 +382,7 @@ public class ConnectContextTest {
             ConnectContext ctx = new ConnectContext();
             ctx.setEnv(env);
 
-            new Expectations() {
-                {
-                    env.changeCatalog(ctx, "catalog1");
-                    minTimes = 0;
-                    env.changeDb(ctx, "ns1.ns2.ns3.testDb");
-                    minTimes = 0;
-                }
-            };
+            // env.changeCatalog and env.changeDb are void methods on a mock - do nothing by default
 
             Optional<Pair<ErrorCode, String>> result = ConnectContextUtil.initCatalogAndDb(ctx,
                     "catalog1.ns1.ns2.ns3.testDb");
@@ -431,13 +397,7 @@ public class ConnectContextTest {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(env);
 
-        new Expectations() {
-            {
-                env.changeCatalog(ctx, "invalidCatalog");
-                result = new DdlException("Catalog not found");
-                minTimes = 0;
-            }
-        };
+        Mockito.doThrow(new DdlException("Catalog not found")).when(env).changeCatalog(ctx, "invalidCatalog");
 
         Optional<Pair<ErrorCode, String>> result = ConnectContextUtil.initCatalogAndDb(ctx, "invalidCatalog.testDb");
         Assert.assertTrue(result.isPresent());
@@ -449,13 +409,7 @@ public class ConnectContextTest {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(env);
 
-        new Expectations() {
-            {
-                env.changeDb(ctx, "invalidDb");
-                result = new DdlException("Database not found");
-                minTimes = 0;
-            }
-        };
+        Mockito.doThrow(new DdlException("Database not found")).when(env).changeDb(ctx, "invalidDb");
 
         Optional<Pair<ErrorCode, String>> result = ConnectContextUtil.initCatalogAndDb(ctx, "invalidDb");
         Assert.assertTrue(result.isPresent());
@@ -467,12 +421,7 @@ public class ConnectContextTest {
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(env);
 
-        new Expectations() {
-            {
-                env.changeDb(ctx, "");
-                minTimes = 0;
-            }
-        };
+        // env.changeDb is a void method on a mock - does nothing by default
 
         Optional<Pair<ErrorCode, String>> result = ConnectContextUtil.initCatalogAndDb(ctx, "");
         Assert.assertFalse(result.isPresent());
@@ -496,8 +445,9 @@ public class ConnectContextTest {
     public void testGetCloudCluster() throws Exception {
         // Setup: enable cloud mode by setting cloud_unique_id
         String originalCloudUniqueId = Config.cloud_unique_id;
-        try {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
             Config.cloud_unique_id = "test-cloud-id";
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
             ConnectContext ctx = new ConnectContext();
             ctx.setEnv(env);
@@ -508,12 +458,7 @@ public class ConnectContextTest {
             ctx.setCloudCluster("session_cluster");
             // Verify that setCloudCluster sets session variable
             Assert.assertEquals("session_cluster", ctx.getSessionVariable().getCloudCluster());
-            new Expectations() {
-                {
-                    env.getCurrentSystemInfo();
-                    result = cloudSystemInfoService;
-                }
-            };
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
             String cluster = ctx.getCloudCluster(false);
             Assert.assertEquals("session_cluster", cluster);
 
@@ -521,18 +466,11 @@ public class ConnectContextTest {
             // This tests: "Get cluster from user's default cluster property if set"
             ctx.setCloudCluster(null); // Clear session cluster
             ctx.cloudCluster = null; // Clear cached cluster
-            new Expectations() {
-                {
-                    env.getAuth();
-                    result = auth;
-                    auth.getDefaultCloudCluster("testUser");
-                    result = "user_default_cluster";
-                    env.getCurrentSystemInfo();
-                    result = cloudSystemInfoService;
-                    cloudSystemInfoService.getCloudClusterNames();
-                    result = Lists.newArrayList("user_default_cluster", "other_cluster");
-                }
-            };
+            Mockito.reset(auth, cloudSystemInfoService, accessManager, backend);
+            Mockito.when(env.getAuth()).thenReturn(auth);
+            Mockito.when(auth.getDefaultCloudCluster("testUser")).thenReturn("user_default_cluster");
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
+            Mockito.when(cloudSystemInfoService.getCloudClusterNames()).thenReturn(Lists.newArrayList("user_default_cluster", "other_cluster"));
             cluster = ctx.getCloudCluster(false);
             Assert.assertEquals("user_default_cluster", cluster);
 
@@ -540,16 +478,10 @@ public class ConnectContextTest {
             // This tests: "Get cluster from cached variable (this.cloudCluster) if available"
             ctx.setCloudCluster(null); // Clear session cluster
             ctx.cloudCluster = "cached_cluster"; // Set cached cluster (from previous policy selection)
-            new Expectations() {
-                {
-                    env.getAuth();
-                    result = auth;
-                    auth.getDefaultCloudCluster("testUser");
-                    result = null; // No user default
-                    env.getCurrentSystemInfo();
-                    result = cloudSystemInfoService;
-                }
-            };
+            Mockito.reset(auth, cloudSystemInfoService, accessManager, backend);
+            Mockito.when(env.getAuth()).thenReturn(auth);
+            Mockito.when(auth.getDefaultCloudCluster("testUser")).thenReturn(null);
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
             cluster = ctx.getCloudCluster(false);
             Assert.assertEquals("cached_cluster", cluster);
 
@@ -557,29 +489,17 @@ public class ConnectContextTest {
             // This tests: "Choose an authorized cluster by policy if all preceding conditions failed"
             ctx.setCloudCluster(null); // Clear session cluster
             ctx.cloudCluster = null; // Clear cached cluster
-            new Expectations() {
-                {
-                    env.getAuth();
-                    result = auth;
-                    auth.getDefaultCloudCluster("testUser");
-                    result = null; // No user default
-                    env.getCurrentSystemInfo();
-                    result = cloudSystemInfoService;
-                    cloudSystemInfoService.getCloudClusterNames();
-                    result = Lists.newArrayList("policy_cluster1", "policy_cluster2");
-                    env.getAccessManager();
-                    result = accessManager;
-                    accessManager.checkCloudPriv((UserIdentity) any, "policy_cluster2",
-                            PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER);
-                    result = true;
-                    cloudSystemInfoService.isStandByComputeGroup("policy_cluster2");
-                    result = false;
-                    cloudSystemInfoService.getBackendsByClusterName("policy_cluster2");
-                    result = Lists.newArrayList(backend);
-                    backend.isAlive();
-                    result = true;
-                }
-            };
+            Mockito.reset(auth, cloudSystemInfoService, accessManager, backend);
+            Mockito.when(env.getAuth()).thenReturn(auth);
+            Mockito.when(auth.getDefaultCloudCluster("testUser")).thenReturn(null);
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
+            Mockito.when(cloudSystemInfoService.getCloudClusterNames()).thenReturn(Lists.newArrayList("policy_cluster1", "policy_cluster2"));
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkCloudPriv(Mockito.any(UserIdentity.class), Mockito.eq("policy_cluster2"),
+                    Mockito.eq(PrivPredicate.USAGE), Mockito.eq(ResourceTypeEnum.CLUSTER))).thenReturn(true);
+            Mockito.when(cloudSystemInfoService.isStandByComputeGroup("policy_cluster2")).thenReturn(false);
+            Mockito.when(cloudSystemInfoService.getBackendsByClusterName("policy_cluster2")).thenReturn(Lists.newArrayList(backend));
+            Mockito.when(backend.isAlive()).thenReturn(true);
             cluster = ctx.getCloudCluster(false);
             Assert.assertEquals("policy_cluster2", cluster);
             // Verify cache is set for subsequent calls
@@ -588,53 +508,33 @@ public class ConnectContextTest {
             // Test 5: Priority order - session variable takes precedence over this.cloudCluster
             ctx.setCloudCluster("session_cluster2");
             ctx.cloudCluster = "cached_cluster2"; // This should be ignored
-            new Expectations() {
-                {
-                    env.getCurrentSystemInfo();
-                    result = cloudSystemInfoService;
-                }
-            };
+            Mockito.reset(auth, cloudSystemInfoService, accessManager, backend);
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
             cluster = ctx.getCloudCluster(false);
             Assert.assertEquals("session_cluster2", cluster); // Session variable wins
 
             // Test 6: Priority order - user this.cloudCluster over default takes precedence
             ctx.setCloudCluster(null); // Clear session cluster
             ctx.cloudCluster = "cached_cluster3"; // This should be ignored
-            new Expectations() {
-                {
-                    env.getAuth();
-                    result = auth;
-                    auth.getDefaultCloudCluster("testUser");
-                    result = "user_default_cluster2";
-                    env.getCurrentSystemInfo();
-                    result = cloudSystemInfoService;
-                    cloudSystemInfoService.getCloudClusterNames();
-                    result = Lists.newArrayList("user_default_cluster2", "other_cluster");
-                }
-            };
+            Mockito.reset(auth, cloudSystemInfoService, accessManager, backend);
+            Mockito.when(env.getAuth()).thenReturn(auth);
+            Mockito.when(auth.getDefaultCloudCluster("testUser")).thenReturn("user_default_cluster2");
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
+            Mockito.when(cloudSystemInfoService.getCloudClusterNames()).thenReturn(Lists.newArrayList("user_default_cluster2", "other_cluster"));
             cluster = ctx.getCloudCluster(false);
             Assert.assertEquals("cached_cluster3", cluster); // User this.cloudCluster wins
 
             // Test 7: No cluster available - should throw exception
             ctx.setCloudCluster(null);
             ctx.cloudCluster = null;
-            new Expectations() {
-                {
-                    env.getAuth();
-                    result = auth;
-                    auth.getDefaultCloudCluster("testUser");
-                    result = null;
-                    env.getCurrentSystemInfo();
-                    result = cloudSystemInfoService;
-                    cloudSystemInfoService.getCloudClusterNames();
-                    result = Lists.newArrayList("unauthorized_cluster");
-                    env.getAccessManager();
-                    result = accessManager;
-                    accessManager.checkCloudPriv((UserIdentity) any, anyString,
-                            PrivPredicate.USAGE, ResourceTypeEnum.CLUSTER);
-                    result = false; // No authorized cluster
-                }
-            };
+            Mockito.reset(auth, cloudSystemInfoService, accessManager, backend);
+            Mockito.when(env.getAuth()).thenReturn(auth);
+            Mockito.when(auth.getDefaultCloudCluster("testUser")).thenReturn(null);
+            mockedEnv.when(Env::getCurrentSystemInfo).thenReturn(cloudSystemInfoService);
+            Mockito.when(cloudSystemInfoService.getCloudClusterNames()).thenReturn(Lists.newArrayList("unauthorized_cluster"));
+            Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+            Mockito.when(accessManager.checkCloudPriv(Mockito.any(UserIdentity.class), Mockito.anyString(),
+                    Mockito.eq(PrivPredicate.USAGE), Mockito.eq(ResourceTypeEnum.CLUSTER))).thenReturn(false);
             try {
                 ctx.getCloudCluster(true);
                 Assert.fail("Expected ComputeGroupException");

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectSchedulerTest.java
@@ -22,11 +22,12 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlProto;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,35 +37,27 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ConnectSchedulerTest {
     private static final Logger LOG = LoggerFactory.getLogger(ConnectScheduler.class);
     private static AtomicLong succSubmit;
-    @Mocked
-    SocketChannel socketChannel;
-    @Mocked
-    MysqlChannel channel;
-    @Mocked
-    MysqlProto mysqlProto;
+    private SocketChannel socketChannel = Mockito.mock(SocketChannel.class);
+    private MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+    private MockedStatic<MysqlProto> mockedMysqlProto;
 
     @Before
     public void setUp() throws Exception {
         succSubmit = new AtomicLong(0);
-        new Expectations() {
-            {
-                channel.getRemoteIp();
-                minTimes = 0;
-                result = "192.168.1.1";
+        mockedMysqlProto = Mockito.mockStatic(MysqlProto.class);
+        Mockito.when(channel.getRemoteIp()).thenReturn("192.168.1.1");
+        mockedMysqlProto.when(() -> MysqlProto.negotiate(Mockito.nullable(ConnectContext.class))).thenReturn(true);
+    }
 
-                // mock negotiate
-                MysqlProto.negotiate((ConnectContext) any);
-                minTimes = 0;
-                result = true;
-
-                MysqlProto.sendResponsePacket((ConnectContext) any);
-                minTimes = 0;
-            }
-        };
+    @After
+    public void tearDown() {
+        if (mockedMysqlProto != null) {
+            mockedMysqlProto.close();
+        }
     }
 
     @Test
-    public void testSubmit(@Mocked ConnectProcessor processor) throws Exception {
+    public void testSubmit() throws Exception {
         ConnectScheduler scheduler = new ConnectScheduler(10);
         for (int i = 0; i < 2; ++i) {
             ConnectContext context = new ConnectContext();
@@ -80,7 +73,7 @@ public class ConnectSchedulerTest {
     }
 
     @Test
-    public void testProcessException(@Mocked ConnectProcessor processor) throws Exception {
+    public void testProcessException() throws Exception {
         ConnectScheduler scheduler = new ConnectScheduler(10);
 
         ConnectContext context = new ConnectContext();

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
@@ -44,6 +44,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.MysqlChannel;
@@ -73,19 +74,17 @@ import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.net.UnknownHostException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -105,8 +104,11 @@ public class OlapQueryCacheTest {
     private ConnectContext ctx;
     private QueryState state;
     private ConnectScheduler scheduler;
-    @Mocked
-    private MysqlChannel channel = null;
+    private MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+
+    private MockedStatic<Util> mockedUtil;
+    private MockedStatic<Env> mockedEnv;
+    private MockedStatic<ConnectContext> mockedConnectContext;
 
     @BeforeClass
     public static void start() {
@@ -128,125 +130,58 @@ public class OlapQueryCacheTest {
     public void setUp() throws Exception {
         state = new QueryState();
         scheduler = new ConnectScheduler(10);
-        ctx = new ConnectContext();
-
         SessionVariable sessionVariable = new SessionVariable();
         Deencapsulation.setField(sessionVariable, "beNumberForTest", 1);
         MysqlSerializer serializer = MysqlSerializer.newInstance();
         env = AccessTestUtil.fetchAdminCatalog();
+        ctx = Mockito.spy(new ConnectContext());
+        InternalCatalog currentCatalog = (InternalCatalog) env.getCurrentCatalog();
+        Mockito.doReturn(new Database()).when(currentCatalog).getDbNullable(Mockito.<String>isNull());
+        CatalogMgr catalogMgr = env.getCatalogMgr();
+        Mockito.doReturn(currentCatalog).when(catalogMgr).getCatalog(Mockito.<String>isNull());
 
-        new MockUp<Util>() {
-            @Mock
-            public boolean showHiddenColumns() {
-                return true;
-            }
-        };
-        new MockUp<Env>() {
-            @Mock
-            Env getCurrentEnv() {
-                return env;
-            }
-        };
+        mockedUtil = Mockito.mockStatic(Util.class, Mockito.CALLS_REAL_METHODS);
+        mockedUtil.when(Util::showHiddenColumns).thenReturn(true);
+
+        mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
         channel.reset();
 
-        new Expectations(channel) {
-            {
-                channel.sendOnePacket((ByteBuffer) any);
-                minTimes = 0;
+        Mockito.when(channel.getSerializer()).thenReturn(serializer);
+        ctx.setEnv(env);
+        ctx.setSessionVariable(sessionVariable);
+        ctx.setConnectScheduler(scheduler);
+        ctx.setConnectionId(1);
+        ctx.setDatabase(fullDbName);
+        ctx.setRemoteIP("192.168.1.1");
+        UserIdentity userIdentity = new UserIdentity(userName, "%");
+        userIdentity.setIsAnalyzed();
+        ctx.setCurrentUserIdentity(userIdentity);
 
-                channel.reset();
-                minTimes = 0;
+        Mockito.doReturn(channel).when(ctx).getMysqlChannel();
+        Mockito.doReturn(env).when(ctx).getEnv();
+        Mockito.doReturn(state).when(ctx).getState();
+        Mockito.doReturn(scheduler).when(ctx).getConnectScheduler();
+        Mockito.doReturn(1).when(ctx).getConnectionId();
+        Mockito.doReturn(userName).when(ctx).getQualifiedUser();
+        Mockito.doReturn(123L).when(ctx).getForwardedStmtId();
+        Mockito.doNothing().when(ctx).setKilled();
+        Mockito.doNothing().when(ctx).updateReturnRows(Mockito.anyInt());
+        Mockito.doNothing().when(ctx).setQueryId(Mockito.any(TUniqueId.class));
+        Mockito.doReturn(new TUniqueId()).when(ctx).queryId();
+        Mockito.doReturn(0L).when(ctx).getStartTime();
+        Mockito.doReturn(fullDbName).when(ctx).getDatabase();
+        Mockito.doReturn(sessionVariable).when(ctx).getSessionVariable();
+        Mockito.doNothing().when(ctx).setStmtId(Mockito.anyLong());
+        Mockito.doReturn(1L).when(ctx).getStmtId();
+        Mockito.doReturn(currentCatalog).when(ctx).getCurrentCatalog();
+        Mockito.doReturn(currentCatalog).when(ctx).getCatalog(Mockito.nullable(String.class));
+        Mockito.doReturn("192.168.1.1").when(ctx).getRemoteIP();
+        Mockito.doReturn(userIdentity).when(ctx).getCurrentUserIdentity();
 
-                channel.getSerializer();
-                minTimes = 0;
-                result = serializer;
-            }
-        };
-
-        new Expectations(ctx) {
-            {
-                ctx.getMysqlChannel();
-                minTimes = 0;
-                result = channel;
-
-                ctx.getEnv();
-                minTimes = 0;
-                result = env;
-
-                ctx.getState();
-                minTimes = 0;
-                result = state;
-
-                ctx.getConnectScheduler();
-                minTimes = 0;
-                result = scheduler;
-
-                ctx.getConnectionId();
-                minTimes = 0;
-                result = 1;
-
-                ctx.getQualifiedUser();
-                minTimes = 0;
-                result = userName;
-
-                ctx.getForwardedStmtId();
-                minTimes = 0;
-                result = 123L;
-
-                ctx.setKilled();
-                minTimes = 0;
-                ctx.updateReturnRows(anyInt);
-                minTimes = 0;
-                ctx.setQueryId((TUniqueId) any);
-                minTimes = 0;
-
-                ctx.queryId();
-                minTimes = 0;
-                result = new TUniqueId();
-
-                ctx.getStartTime();
-                minTimes = 0;
-                result = 0L;
-
-                ctx.getDatabase();
-                minTimes = 0;
-                result = fullDbName;
-
-                ctx.getSessionVariable();
-                minTimes = 0;
-                result = sessionVariable;
-
-                ctx.setStmtId(anyLong);
-                minTimes = 0;
-
-                ctx.getStmtId();
-                minTimes = 0;
-                result = 1L;
-
-                ctx.getCurrentCatalog();
-                minTimes = 0;
-                result = env.getCurrentCatalog();
-
-                ctx.getCatalog(anyString);
-                minTimes = 0;
-                result = env.getCurrentCatalog();
-
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                ctx.getRemoteIP();
-                minTimes = 0;
-                result = "192.168.1.1";
-
-                ctx.getCurrentUserIdentity();
-                minTimes = 0;
-                UserIdentity userIdentity = new UserIdentity(userName, "%");
-                userIdentity.setIsAnalyzed();
-                result = userIdentity;
-            }
-        };
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class, Mockito.CALLS_REAL_METHODS);
+        mockedConnectContext.when(ConnectContext::get).thenReturn(ctx);
 
         newRangeList = Lists.newArrayList();
 
@@ -269,6 +204,19 @@ public class OlapQueryCacheTest {
         db.registerTable(view3);
         View view4 = createEventNestedView();
         db.registerTable(view4);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedUtil != null) {
+            mockedUtil.close();
+        }
+        if (mockedEnv != null) {
+            mockedEnv.close();
+        }
+        if (mockedConnectContext != null) {
+            mockedConnectContext.close();
+        }
     }
 
     private OlapTable createOrderTable() {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ResultReceiverConsumerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ResultReceiverConsumerTest.java
@@ -23,22 +23,18 @@ import org.apache.doris.proto.InternalService;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.FutureCallback;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Injectable;
 import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 public class ResultReceiverConsumerTest {
 
-    @Injectable
-    private ResultReceiver receiver1;
-    @Injectable
-    private ResultReceiver receiver2;
-    @Injectable
-    private ResultReceiver receiver3;
+    private ResultReceiver receiver1 = Mockito.mock(ResultReceiver.class);
+    private ResultReceiver receiver2 = Mockito.mock(ResultReceiver.class);
+    private ResultReceiver receiver3 = Mockito.mock(ResultReceiver.class);
 
     @Test
     public void testEosHandling() throws Exception {
@@ -59,38 +55,26 @@ public class ResultReceiverConsumerTest {
         RowBatch eosBatch3 = new RowBatch();
         eosBatch3.setEos(true);
 
-        new Expectations() {
-            {
-                receiver1.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) {
-                        callback.onSuccess(null);
-                    }
-                };
-                receiver2.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) {
-                        callback.onSuccess(null);
-                    }
-                };
-                receiver3.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) {
-                        callback.onSuccess(null);
-                    }
-                };
+        Mockito.doAnswer(inv -> {
+            FutureCallback<InternalService.PFetchDataResult> callback = inv.getArgument(0);
+            callback.onSuccess(null);
+            return null;
+        }).when(receiver1).createFuture(ArgumentMatchers.any());
+        Mockito.doAnswer(inv -> {
+            FutureCallback<InternalService.PFetchDataResult> callback = inv.getArgument(0);
+            callback.onSuccess(null);
+            return null;
+        }).when(receiver2).createFuture(ArgumentMatchers.any());
+        Mockito.doAnswer(inv -> {
+            FutureCallback<InternalService.PFetchDataResult> callback = inv.getArgument(0);
+            callback.onSuccess(null);
+            return null;
+        }).when(receiver3).createFuture(ArgumentMatchers.any());
 
-                receiver1.getNext((Status) any);
-                result = normalBatch1;
-                result = eosBatch1;
-                receiver2.getNext((Status) any);
-                result = normalBatch2;
-                result = eosBatch2;
-                receiver3.getNext((Status) any);
-                result = normalBatch3;
-                result = eosBatch3;
-            }
-        };
+        Mockito.when(receiver1.getNext(ArgumentMatchers.any(Status.class))).thenReturn(normalBatch1).thenReturn(eosBatch1);
+        Mockito.when(receiver2.getNext(ArgumentMatchers.any(Status.class))).thenReturn(normalBatch2).thenReturn(eosBatch2);
+        Mockito.when(receiver3.getNext(ArgumentMatchers.any(Status.class))).thenReturn(normalBatch3).thenReturn(eosBatch3);
+
         for (int i = 0; i < 5; i++) {
             RowBatch batch = consumer.getNext(status);
             Assert.assertFalse(consumer.isEos());
@@ -100,7 +84,6 @@ public class ResultReceiverConsumerTest {
         RowBatch batch = consumer.getNext(status);
         Assert.assertTrue(consumer.isEos());
         Assert.assertTrue(batch.isEos());
-
     }
 
     @Test
@@ -112,34 +95,25 @@ public class ResultReceiverConsumerTest {
         RowBatch normalBatch1 = new RowBatch();
         normalBatch1.setEos(false);
 
-        new Expectations() {
-            {
-                receiver1.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) {
-                        callback.onSuccess(null);
-                    }
-                };
-                receiver2.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) {
-                        callback.onSuccess(null);
-                    }
-                };
-                receiver3.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) {
-                        callback.onSuccess(null);
-                    }
-                };
+        Mockito.doAnswer(inv -> {
+            FutureCallback<InternalService.PFetchDataResult> callback = inv.getArgument(0);
+            callback.onSuccess(null);
+            return null;
+        }).when(receiver1).createFuture(ArgumentMatchers.any());
+        Mockito.doAnswer(inv -> {
+            FutureCallback<InternalService.PFetchDataResult> callback = inv.getArgument(0);
+            callback.onSuccess(null);
+            return null;
+        }).when(receiver2).createFuture(ArgumentMatchers.any());
+        Mockito.doAnswer(inv -> {
+            FutureCallback<InternalService.PFetchDataResult> callback = inv.getArgument(0);
+            callback.onSuccess(null);
+            return null;
+        }).when(receiver3).createFuture(ArgumentMatchers.any());
 
-                receiver1.getNext((Status) any);
-                result = normalBatch1;
+        Mockito.when(receiver1.getNext(ArgumentMatchers.any(Status.class))).thenReturn(normalBatch1);
+        Mockito.when(receiver2.getNext(ArgumentMatchers.any(Status.class))).thenThrow(new TException("Network error"));
 
-                receiver2.getNext((Status) any);
-                result = new TException("Network error");
-            }
-        };
         RowBatch batch = consumer.getNext(status);
         Assert.assertFalse(batch.isEos());
         Assertions.assertThrows(TException.class, () -> consumer.getNext(status));
@@ -151,22 +125,15 @@ public class ResultReceiverConsumerTest {
                 Lists.newArrayList(receiver1, receiver2, receiver3), System.currentTimeMillis() + 3600);
         Status status = new Status();
 
-        new Expectations() {
-            {
-                receiver1.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) {
-                        callback.onSuccess(null);
-                    }
-                };
-                receiver2.createFuture((FutureCallback<InternalService.PFetchDataResult>) any);
-                result = new Delegate() {
-                    void delegate(FutureCallback<InternalService.PFetchDataResult> callback) throws UserException {
-                        throw new UserException("User error");
-                    }
-                };
-            }
-        };
+        Mockito.doAnswer(inv -> {
+            FutureCallback<InternalService.PFetchDataResult> callback = inv.getArgument(0);
+            callback.onSuccess(null);
+            return null;
+        }).when(receiver1).createFuture(ArgumentMatchers.any());
+        Mockito.doAnswer(inv -> {
+            throw new UserException("User error");
+        }).when(receiver2).createFuture(ArgumentMatchers.any());
+
         Assertions.assertThrows(UserException.class, () -> consumer.getNext(status));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -22,10 +22,10 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -142,34 +142,28 @@ public class SessionVariablesTest extends TestWithFeService {
 
     @Test
     public void testEnableStrictConsistencyDmlDefaultsToFalseInCloudMode() {
-        new MockUp<Config>() {
-            @Mock
-            public boolean isCloudMode() {
-                return true;
-            }
-        };
-        SessionVariable sv = new SessionVariable();
-        // In cloud mode, enable_strict_consistency_dml should always return false
-        // because store-compute separation has no multi-replica consistency concern.
-        Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
-        // Even if the field is set to true, cloud mode overrides it.
-        sv.enableStrictConsistencyDml = true;
-        Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedConfig.when(Config::isCloudMode).thenReturn(true);
+            SessionVariable sv = new SessionVariable();
+            // In cloud mode, enable_strict_consistency_dml should always return false
+            // because store-compute separation has no multi-replica consistency concern.
+            Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
+            // Even if the field is set to true, cloud mode overrides it.
+            sv.enableStrictConsistencyDml = true;
+            Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
+        }
     }
 
     @Test
     public void testEnableStrictConsistencyDmlDefaultsTrueInNonCloudMode() {
-        new MockUp<Config>() {
-            @Mock
-            public boolean isCloudMode() {
-                return false;
-            }
-        };
-        SessionVariable sv = new SessionVariable();
-        // In non-cloud mode, default is true (multi-replica consistency is needed).
-        Assertions.assertTrue(sv.isEnableStrictConsistencyDml());
-        // Users can disable it.
-        sv.enableStrictConsistencyDml = false;
-        Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedConfig.when(Config::isCloudMode).thenReturn(false);
+            SessionVariable sv = new SessionVariable();
+            // In non-cloud mode, default is true (multi-replica consistency is needed).
+            Assertions.assertTrue(sv.isEnableStrictConsistencyDml());
+            // Users can disable it.
+            sv.enableStrictConsistencyDml = false;
+            Assertions.assertFalse(sv.isEnableStrictConsistencyDml());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
@@ -29,7 +29,6 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RandomDistributionInfo;
 import org.apache.doris.catalog.SinglePartitionInfo;
-import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
@@ -51,9 +50,7 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -61,16 +58,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.net.URL;
-import java.util.List;
-import java.util.function.Function;
 
 public class ShowExecutorTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
     private ConnectContext ctx;
     private Env env;
     private InternalCatalog catalog;
+    private MockedStatic<Env> mockedEnvStatic;
+    private MockedStatic<ConnectContext> mockedConnectContextStatic;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -88,169 +87,77 @@ public class ShowExecutorTest {
         MaterializedIndex index1 = new MaterializedIndex();
 
         // mock partition
-        Partition partition = Deencapsulation.newInstance(Partition.class);
-        new Expectations(partition) {
-            {
-                partition.getBaseIndex();
-                minTimes = 0;
-                result = index1;
-            }
-        };
+        Partition partition = Mockito.spy(Deencapsulation.newInstance(Partition.class));
+        Mockito.doReturn(index1).when(partition).getBaseIndex();
 
         // mock table
-        OlapTable table = new OlapTable();
-        new Expectations(table) {
-            {
-                table.getName();
-                minTimes = 0;
-                result = "testTbl";
-
-                table.getType();
-                minTimes = 0;
-                result = TableType.OLAP;
-
-                table.getBaseSchema();
-                minTimes = 0;
-                result = Lists.newArrayList(column1, column2);
-
-                table.getKeysType();
-                minTimes = 0;
-                result = KeysType.AGG_KEYS;
-
-                table.getPartitionInfo();
-                minTimes = 0;
-                result = new SinglePartitionInfo();
-
-                table.getDefaultDistributionInfo();
-                minTimes = 0;
-                result = new RandomDistributionInfo(10);
-
-                table.getIndexIdByName(anyString);
-                minTimes = 0;
-                result = 0L;
-
-                table.getStorageTypeByIndexId(0L);
-                minTimes = 0;
-                result = TStorageType.COLUMN;
-
-                table.getPartition(anyLong);
-                minTimes = 0;
-                result = partition;
-
-                table.getCopiedBfColumns();
-                minTimes = 0;
-                result = null;
-            }
-        };
+        OlapTable table = Mockito.spy(new OlapTable());
+        Mockito.doReturn("testTbl").when(table).getName();
+        Mockito.doReturn(TableType.OLAP).when(table).getType();
+        Mockito.doReturn(Lists.newArrayList(column1, column2)).when(table).getBaseSchema();
+        Mockito.doReturn(KeysType.AGG_KEYS).when(table).getKeysType();
+        Mockito.doReturn(new SinglePartitionInfo()).when(table).getPartitionInfo();
+        Mockito.doReturn(new RandomDistributionInfo(10)).when(table).getDefaultDistributionInfo();
+        Mockito.doReturn(0L).when(table).getIndexIdByName(Mockito.anyString());
+        Mockito.doReturn(TStorageType.COLUMN).when(table).getStorageTypeByIndexId(0L);
+        Mockito.doReturn(partition).when(table).getPartition(Mockito.anyLong());
+        Mockito.doReturn(null).when(table).getCopiedBfColumns();
 
         // mock database
-        Database db = new Database();
-        new Expectations(db) {
-            {
-                db.readLock();
-                minTimes = 0;
-
-                db.readUnlock();
-                minTimes = 0;
-
-                db.getTableNullable(anyString);
-                minTimes = 0;
-                result = table;
-            }
-        };
+        Database db = Mockito.spy(new Database());
+        Mockito.doNothing().when(db).readLock();
+        Mockito.doNothing().when(db).readUnlock();
+        Mockito.doReturn(table).when(db).getTableNullable(Mockito.anyString());
 
         // mock auth
         AccessControllerManager accessManager = AccessTestUtil.fetchAdminAccess();
 
         // mock catalog
-        catalog = Deencapsulation.newInstance(InternalCatalog.class);
-        new Expectations(catalog) {
-            {
-                catalog.getDbNullable("testDb");
-                minTimes = 0;
-                result = db;
+        catalog = Mockito.spy(Deencapsulation.newInstance(InternalCatalog.class));
+        Mockito.doReturn(db).when(catalog).getDbNullable("testDb");
+        Mockito.doReturn(null).when(catalog).getDbNullable("emptyDb");
 
-                catalog.getDbNullable("emptyDb");
-                minTimes = 0;
-                result = null;
-            }
-        };
-
-        CatalogMgr dsMgr = new CatalogMgr();
-        new Expectations(dsMgr) {
-            {
-                dsMgr.getCatalog((String) any);
-                minTimes = 0;
-                result = catalog;
-
-                dsMgr.getCatalogOrException((String) any, (Function) any);
-                minTimes = 0;
-                result = catalog;
-
-                dsMgr.getCatalogOrAnalysisException((String) any);
-                minTimes = 0;
-                result = catalog;
-            }
-        };
+        CatalogMgr dsMgr = Mockito.spy(new CatalogMgr());
+        Mockito.doReturn(catalog).when(dsMgr).getCatalog(Mockito.anyString());
+        Mockito.doReturn(catalog).when(dsMgr).getCatalogOrException(Mockito.anyString(), Mockito.any());
+        Mockito.doReturn(catalog).when(dsMgr).getCatalogOrAnalysisException(Mockito.anyString());
 
         // mock catalog.
-        env = Deencapsulation.newInstance(Env.class);
-        new Expectations(env) {
-            {
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
+        env = Mockito.spy(Deencapsulation.newInstance(Env.class));
+        Mockito.doReturn(catalog).when(env).getInternalCatalog();
+        Mockito.doReturn(catalog).when(env).getCurrentCatalog();
+        Mockito.doReturn(accessManager).when(env).getAccessManager();
+        Mockito.doReturn(dsMgr).when(env).getCatalogMgr();
 
-                env.getCurrentCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                Env.getDdlStmt((Table) any, (List) any, (List) any, (List) any, anyBoolean, anyBoolean, anyLong);
-                minTimes = 0;
-
-                Env.getDdlStmt((Table) any, (List) any, null, null, anyBoolean, anyBoolean, anyLong);
-                minTimes = 0;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = dsMgr;
-            }
-        };
+        mockedEnvStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(() -> Env.getDdlStmt(
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyLong()
+        )).thenAnswer(inv -> null);
 
         // mock scheduler
-        ConnectScheduler scheduler = new ConnectScheduler(10);
-        new Expectations(scheduler) {
-            {
-                scheduler.listConnection("testUser", anyBoolean);
-                minTimes = 0;
-                result = Lists.newArrayList(ctx.toThreadInfo(false));
-            }
-        };
+        ConnectScheduler scheduler = Mockito.spy(new ConnectScheduler(10));
+        Mockito.doReturn(Lists.newArrayList(ctx.toThreadInfo(false))).when(scheduler)
+                .listConnection(Mockito.eq("testUser"), Mockito.anyBoolean());
 
         ctx.changeDefaultCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
         ctx.setConnectScheduler(scheduler);
         ctx.setEnv(AccessTestUtil.fetchAdminCatalog());
         ctx.setCurrentUserIdentity(UserIdentity.ROOT);
 
-        new Expectations(ctx) {
-            {
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-            }
-        };
+        mockedConnectContextStatic = Mockito.mockStatic(ConnectContext.class, Mockito.CALLS_REAL_METHODS);
+        mockedConnectContextStatic.when(ConnectContext::get).thenReturn(ctx);
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
+        if (mockedConnectContextStatic != null) {
+            mockedConnectContextStatic.close();
+        }
     }
 
     @Test
@@ -366,17 +273,8 @@ public class ShowExecutorTest {
         SystemInfoService clusterInfo = AccessTestUtil.fetchSystemInfoService();
         Env env = AccessTestUtil.fetchAdminCatalog();
 
-        new MockUp<Env>() {
-            @Mock
-            Env getCurrentEnv() {
-                return env;
-            }
-
-            @Mock
-            SystemInfoService getCurrentSystemInfo() {
-                return clusterInfo;
-            }
-        };
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(clusterInfo);
 
         TableNameInfo tableNameInfo = new TableNameInfo(internalCtl, "testDb", "testTbl");
         DescribeCommand command = new DescribeCommand(tableNameInfo, false, null);
@@ -432,57 +330,53 @@ public class ShowExecutorTest {
         HelpModule module = new HelpModule();
         URL help = getClass().getClassLoader().getResource("test-help-resource-show-help.zip");
         module.setUpByZip(help.getPath());
-        new Expectations(module) {
-            {
-                HelpModule.getInstance();
-                minTimes = 0;
-                result = module;
-            }
-        };
+        try (MockedStatic<HelpModule> mockedHelpModule = Mockito.mockStatic(HelpModule.class)) {
+            mockedHelpModule.when(HelpModule::getInstance).thenReturn(module);
 
-        // topic
-        HelpCommand command = new HelpCommand("ADD");
-        ShowResultSet resultSet = command.doRun(ctx, null);
+            // topic
+            HelpCommand command = new HelpCommand("ADD");
+            ShowResultSet resultSet = command.doRun(ctx, null);
 
-        Assertions.assertTrue(resultSet.next());
-        Assertions.assertEquals("ADD", resultSet.getString(0));
-        Assertions.assertEquals("add function\n", resultSet.getString(1));
-        Assertions.assertFalse(resultSet.next());
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals("ADD", resultSet.getString(0));
+            Assertions.assertEquals("add function\n", resultSet.getString(1));
+            Assertions.assertFalse(resultSet.next());
 
-        // topic
-        command = new HelpCommand("logical");
-        resultSet = command.doRun(ctx, null);
+            // topic
+            command = new HelpCommand("logical");
+            resultSet = command.doRun(ctx, null);
 
-        Assertions.assertTrue(resultSet.next());
-        Assertions.assertEquals("OR", resultSet.getString(0));
-        Assertions.assertFalse(resultSet.next());
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals("OR", resultSet.getString(0));
+            Assertions.assertFalse(resultSet.next());
 
-        // keywords
-        command = new HelpCommand("MATH");
-        resultSet = command.doRun(ctx, null);
+            // keywords
+            command = new HelpCommand("MATH");
+            resultSet = command.doRun(ctx, null);
 
-        Assertions.assertTrue(resultSet.next());
-        Assertions.assertEquals("ADD", resultSet.getString(0));
-        Assertions.assertTrue(resultSet.next());
-        Assertions.assertEquals("MINUS", resultSet.getString(0));
-        Assertions.assertFalse(resultSet.next());
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals("ADD", resultSet.getString(0));
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals("MINUS", resultSet.getString(0));
+            Assertions.assertFalse(resultSet.next());
 
-        // category
-        command = new HelpCommand("functions");
-        resultSet = command.doRun(ctx, null);
+            // category
+            command = new HelpCommand("functions");
+            resultSet = command.doRun(ctx, null);
 
-        Assertions.assertTrue(resultSet.next());
-        Assertions.assertEquals("HELP", resultSet.getString(0));
-        Assertions.assertTrue(resultSet.next());
-        Assertions.assertEquals("binary function", resultSet.getString(0));
-        Assertions.assertTrue(resultSet.next());
-        Assertions.assertEquals("bit function", resultSet.getString(0));
-        Assertions.assertFalse(resultSet.next());
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals("HELP", resultSet.getString(0));
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals("binary function", resultSet.getString(0));
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals("bit function", resultSet.getString(0));
+            Assertions.assertFalse(resultSet.next());
 
-        // empty
-        command = new HelpCommand("empty");
-        resultSet = command.doRun(ctx, null);
+            // empty
+            command = new HelpCommand("empty");
+            resultSet = command.doRun(ctx, null);
 
-        Assertions.assertFalse(resultSet.next());
+            Assertions.assertFalse(resultSet.next());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ShowResultSetTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ShowResultSetTest.java
@@ -18,15 +18,14 @@
 package org.apache.doris.qe;
 
 import com.google.common.collect.Lists;
-import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 
 public class ShowResultSetTest {
-    @Mocked
-    ShowResultSetMetaData metaData;
+    private ShowResultSetMetaData metaData = Mockito.mock(ShowResultSetMetaData.class);
 
     @Test
     public void testNormal() {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorInternalQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorInternalQueryTest.java
@@ -19,26 +19,27 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.thrift.TQueryOptions;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 public class StmtExecutorInternalQueryTest {
     @Test
     public void testSetSqlHash() {
         StmtExecutor executor = new StmtExecutor(new ConnectContext(), "select * from table1");
-        new MockUp<NereidsPlanner>() {
-            @Mock
-            public void plan(StatementBase queryStmt, org.apache.doris.thrift.TQueryOptions queryOptions) {
-                throw new RuntimeException();
+        try (MockedConstruction<NereidsPlanner> mocked = Mockito.mockConstruction(NereidsPlanner.class,
+                (mock, context) -> {
+                    Mockito.doThrow(new RuntimeException()).when(mock).plan(
+                            Mockito.any(StatementBase.class), Mockito.any(TQueryOptions.class));
+                })) {
+            try {
+                executor.executeInternalQuery();
+            } catch (Exception e) {
+                // do nothing
             }
-        };
-        try {
-            executor.executeInternalQuery();
-        } catch (Exception e) {
-            // do nothing
         }
         Assert.assertEquals("a8ec30e5ad0820f8c5bd16a82a4491ca", executor.getContext().getSqlHash());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/ComputeGroupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/ComputeGroupTest.java
@@ -27,6 +27,7 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.RandomIdentifierGenerator;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.FederationBackendPolicy;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.load.loadv2.BrokerLoadJob;
 import org.apache.doris.load.routineload.KafkaRoutineLoadJob;
 import org.apache.doris.load.routineload.RoutineLoadJob;
@@ -37,6 +38,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.commands.CreateUserCommand;
 import org.apache.doris.nereids.trees.plans.commands.SetUserPropertiesCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateUserInfo;
+import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.resource.computegroup.AllBackendComputeGroup;
 import org.apache.doris.resource.computegroup.CloudComputeGroup;
@@ -49,14 +51,15 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.utframe.UtFrameUtils;
 
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Set;
@@ -70,10 +73,10 @@ public class ComputeGroupTest {
     private static ConnectContext connectContext;
 
     private Auth auth;
-    @Mocked
     public Env env;
-    @Mocked
     AccessControllerManager accessManager;
+    private MockedStatic<Env> mockedEnvStatic;
+    private Env originalEnv;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -84,35 +87,42 @@ public class ComputeGroupTest {
     @Before
     public void setUp() throws MetaNotFoundException {
         auth = new Auth();
-        accessManager = new AccessControllerManager(auth);
+        env = Mockito.mock(Env.class);
+        accessManager = Mockito.spy(new AccessControllerManager(auth));
 
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        // Save references from the real env before replacing
+        originalEnv = connectContext.getEnv();
+        InternalCatalog internalCatalog = originalEnv.getInternalCatalog();
+        EditLog editLog = Mockito.mock(EditLog.class);
 
-                env.getAuth();
-                minTimes = 0;
-                result = auth;
+        mockedEnvStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        mockedEnvStatic.when(Env::getCurrentInternalCatalog).thenReturn(internalCatalog);
 
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.ADMIN);
-                minTimes = 0;
-                result = true;
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(env.getAccessManager()).thenReturn(accessManager);
+        Mockito.when(env.getCurrentCatalog()).thenReturn(internalCatalog);
+        Mockito.when(env.getInternalCatalog()).thenReturn(internalCatalog);
+        Mockito.when(env.getCatalogMgr()).thenReturn(originalEnv.getCatalogMgr());
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.doReturn(true).when(accessManager).checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.ADMIN));
+        Mockito.doReturn(true).when(accessManager).checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Mockito.doReturn(true).when(accessManager).checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.OPERATOR));
+        Mockito.doReturn(true).when(accessManager).checkGlobalPriv(Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.CREATE));
 
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.GRANT);
-                minTimes = 0;
-                result = true;
+        // Make connectContext use our mock env so that ctx.getEnv().getAuth()
+        // returns the test auth (where users are created)
+        connectContext.setEnv(env);
+    }
 
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.OPERATOR);
-                minTimes = 0;
-                result = true;
-
-                accessManager.checkGlobalPriv((ConnectContext) any, PrivPredicate.CREATE);
-                minTimes = 0;
-                result = true;
-            }
-        };
+    @After
+    public void tearDown() {
+        if (originalEnv != null) {
+            connectContext.setEnv(originalEnv);
+        }
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
     // @AfterClass
@@ -128,13 +138,7 @@ public class ComputeGroupTest {
 
     @Test
     public void testGetSetResourceTagFromAuth() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv().getComputeGroupMgr();
-                minTimes = 0;
-                result = new ComputeGroupMgr(null);
-            }
-        };
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(new ComputeGroupMgr(null));
 
             // 1 get no user
             {
@@ -444,13 +448,7 @@ public class ComputeGroupTest {
 
 
         ComputeGroupMgr cgmgr = new ComputeGroupMgr(systemInfoService);
-        new Expectations() {
-            {
-                Env.getCurrentEnv().getComputeGroupMgr();
-                minTimes = 0;
-                result = cgmgr;
-            }
-        };
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(cgmgr);
         BeSelectionPolicy beSelPolicy = new BeSelectionPolicy.Builder().build();
 
 
@@ -504,13 +502,7 @@ public class ComputeGroupTest {
 
     @Test
     public void testBrokerLoadToConnectContext() throws UserException, IOException {
-        new Expectations() {
-            {
-                Env.getCurrentEnv().getComputeGroupMgr();
-                minTimes = 0;
-                result = new ComputeGroupMgr(null);
-            }
-        };
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(new ComputeGroupMgr(null));
 
             // test user is empty string
             {
@@ -562,17 +554,8 @@ public class ComputeGroupTest {
 
     @Test
     public void testRoutineLoadToConnectContext() throws Exception {
-        new Expectations() {
-            {
-                Env.getCurrentEnv().getComputeGroupMgr();
-                minTimes = 0;
-                result = new ComputeGroupMgr(null);
-
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = new SystemInfoService();
-            }
-        };
+        Mockito.when(env.getComputeGroupMgr()).thenReturn(new ComputeGroupMgr(null));
+        mockedEnvStatic.when(Env::getCurrentSystemInfo).thenReturn(new SystemInfoService());
 
 
 

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
@@ -24,7 +24,6 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.Auth;
-import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.DropWorkloadGroupOperationLog;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
@@ -34,13 +33,13 @@ import org.apache.doris.thrift.TPipelineWorkloadGroup;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Delegate;
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
@@ -50,65 +49,37 @@ import java.util.stream.Collectors;
 
 public class WorkloadGroupMgrTest {
 
-    @Injectable
-    private EditLog editLog;
+    private EditLog editLog = Mockito.mock(EditLog.class);
 
-    @Mocked
-    private Env env;
+    private Env env = Mockito.mock(Env.class);
 
-    @Mocked
-    AccessControllerManager accessControllerManager;
+    private AccessControllerManager accessControllerManager = Mockito.mock(AccessControllerManager.class);
 
-    @Mocked
-    private Auth auth;
+    private Auth auth = Mockito.mock(Auth.class);
 
+    private MockedStatic<Env> mockedEnv;
 
     private AtomicLong id = new AtomicLong(10);
 
     @Before
     public void setUp() throws DdlException {
-        new Expectations() {
-            {
-                env.getEditLog();
-                minTimes = 0;
-                result = editLog;
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
-                env.getNextId();
-                minTimes = 0;
-                result = new Delegate() {
-                    long delegate() {
-                        return id.addAndGet(1);
-                    }
-                };
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        Mockito.when(env.getNextId()).thenAnswer(inv -> id.addAndGet(1));
+        Mockito.doNothing().when(editLog).logCreateWorkloadGroup(ArgumentMatchers.any());
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkWorkloadGroupPriv(ArgumentMatchers.nullable(ConnectContext.class), ArgumentMatchers.anyString(), ArgumentMatchers.any())).thenReturn(true);
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(auth.isWorkloadGroupInUse(ArgumentMatchers.anyString())).thenReturn(Pair.of(false, ""));
+    }
 
-                editLog.logCreateWorkloadGroup((WorkloadGroup) any);
-                minTimes = 0;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
-
-                accessControllerManager.checkWorkloadGroupPriv((ConnectContext) any, anyString, (PrivPredicate) any);
-                minTimes = 0;
-                result = true;
-
-                env.getAuth();
-                minTimes = 0;
-                result = auth;
-
-                auth.isWorkloadGroupInUse(anyString);
-                minTimes = 0;
-                result = new Delegate() {
-                    Pair<Boolean, String> list() {
-                        return Pair.of(false, "");
-                    }
-                };
-            }
-        };
+    @After
+    public void tearDown() {
+        if (mockedEnv != null) {
+            mockedEnv.close();
+        }
     }
 
     @Test
@@ -265,7 +236,6 @@ public class WorkloadGroupMgrTest {
         workloadGroupMgr.createWorkloadGroup(cgName1, new WorkloadGroup(100, "normal", properties1), false);
         workloadGroupMgr.createWorkloadGroup(cgName2, new WorkloadGroup(101, "normal", properties1), false);
 
-
         // 1 test get workload group by ConnectContext
         ConnectContext ctx = new ConnectContext();
         // 1.1 not set wg, get normal
@@ -278,7 +248,6 @@ public class WorkloadGroupMgrTest {
 
         ctx.setComputeGroup(new ComputeGroup(cgName2, cgName2, null));
         Assert.assertTrue(workloadGroupMgr.getWorkloadGroup(ctx).get(0).getId() == 101);
-
 
         // 1.2 get from user prop
 
@@ -409,7 +378,6 @@ public class WorkloadGroupMgrTest {
         wgMgr.getIdToWorkloadGroup().put(wgId3, wg3);
         wgMgr.getNameToWorkloadGroup().put(WorkloadGroupKey.get(WorkloadGroupMgr.EMPTY_COMPUTE_GROUP, wgName3), wg3);
 
-
         // create a duplicate wg3 which binds to a compute group
         String cg1 = "cg1";
 
@@ -420,7 +388,6 @@ public class WorkloadGroupMgrTest {
         prop4.put(WorkloadGroup.COMPUTE_GROUP, cg1);
         WorkloadGroup wg4 = new WorkloadGroup(wgId4, wgName4, prop4);
         wgMgr.createWorkloadGroup(cg1, wg4, false);
-
 
         Assert.assertTrue(wgMgr.getIdToWorkloadGroup().size() == 4);
         Assert.assertTrue(wgMgr.getNameToWorkloadGroup().size() == 4);
@@ -507,7 +474,6 @@ public class WorkloadGroupMgrTest {
         }
     }
 
-
     @Test
     public void testMultiTagAlterWorkloadGroup() throws UserException {
         Config.enable_workload_group = true;
@@ -585,7 +551,6 @@ public class WorkloadGroupMgrTest {
         WorkloadGroupMgr wgMgr = new WorkloadGroupMgr();
         Assert.assertTrue(wgMgr.getNameToWorkloadGroup().size() == 0);
         Assert.assertTrue(wgMgr.getIdToWorkloadGroup().size() == 0);
-
 
         // 1 test replay create
         WorkloadGroup wg1 = new WorkloadGroup(1, "wg1", Maps.newHashMap());

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendOptionsTest.java
@@ -20,27 +20,30 @@ package org.apache.doris.service;
 import org.apache.doris.common.AnalysisException;
 
 import com.google.common.net.InetAddresses;
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.net.InetAddress;
 
 public class FrontendOptionsTest {
-    @Mocked
-    private InetAddresses inetAddresses;
+    private MockedStatic<InetAddresses> mockedInetAddresses;
 
     @Before
     public void setUp() throws NoSuchMethodException, SecurityException, AnalysisException {
-        new Expectations() {
-            {
-                inetAddresses.toAddrString((InetAddress) any);
-                minTimes = 0;
-                result = "2408:400a:5a:ea00:2fb5:112e:39dd:9bba%eth0";
-            }
-        };
+        mockedInetAddresses = Mockito.mockStatic(InetAddresses.class, Mockito.CALLS_REAL_METHODS);
+        mockedInetAddresses.when(() -> InetAddresses.toAddrString(Mockito.nullable(InetAddress.class)))
+                .thenReturn("2408:400a:5a:ea00:2fb5:112e:39dd:9bba%eth0");
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedInetAddresses != null) {
+            mockedInetAddresses.close();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -51,13 +51,13 @@ import org.apache.doris.thrift.TShowUserResult;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.utframe.UtFrameUtils;
 
-import mockit.Mocked;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,8 +72,7 @@ public class FrontendServiceImplTest {
     private static ConnectContext connectContext;
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-    @Mocked
-    ExecuteEnv exeEnv;
+    private ExecuteEnv exeEnv = Mockito.mock(ExecuteEnv.class);
 
     @BeforeClass
     public static void beforeClass() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
@@ -17,15 +17,12 @@
 
 package org.apache.doris.statistics;
 
-import org.apache.doris.catalog.Env;
-import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,31 +34,28 @@ public class AnalysisJobTest {
 
     // make user task has been set corresponding job
     @Test
-    public void initTest(@Mocked AnalysisInfo jobInfo, @Mocked OlapAnalysisTask task) {
+    public void initTest() {
+        AnalysisInfo jobInfo = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask task = Mockito.mock(OlapAnalysisTask.class);
         AnalysisJob analysisJob = new AnalysisJob(jobInfo, Arrays.asList(task));
         Assertions.assertSame(task.job, analysisJob);
     }
 
     @Test
-    public void testAppendBufTest1(@Mocked AnalysisInfo analysisInfo,
-            @Mocked OlapAnalysisTask olapAnalysisTask,
-            @Mocked OlapAnalysisTask olapAnalysisTask2) {
-        AtomicInteger writeBufInvokeTimes = new AtomicInteger();
-        new MockUp<AnalysisJob>() {
-            @Mock
-            protected void writeBuf() {
-                writeBufInvokeTimes.incrementAndGet();
-            }
+    public void testAppendBufTest1() {
+        AnalysisInfo analysisInfo = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask olapAnalysisTask = Mockito.mock(OlapAnalysisTask.class);
+        OlapAnalysisTask olapAnalysisTask2 = Mockito.mock(OlapAnalysisTask.class);
+        AtomicInteger flushBufferInvokeTimes = new AtomicInteger();
 
-            @Mock
-            public void updateTaskState(AnalysisState state, String msg) {
-            }
+        AnalysisJob job = Mockito.spy(new AnalysisJob(analysisInfo, Arrays.asList(olapAnalysisTask)));
+        Mockito.doAnswer(inv -> {
+            flushBufferInvokeTimes.incrementAndGet();
+            return null;
+        }).when(job).flushBuffer();
+        Mockito.doNothing().when(job).updateTaskState(ArgumentMatchers.any(), ArgumentMatchers.anyString());
+        Mockito.doNothing().when(job).deregisterJob();
 
-            @Mock
-            public void deregisterJob() {
-            }
-        };
-        AnalysisJob job = new AnalysisJob(analysisInfo, Arrays.asList(olapAnalysisTask));
         job.queryingTask = new HashSet<>();
         job.queryingTask.add(olapAnalysisTask);
         job.queryingTask.add(olapAnalysisTask2);
@@ -70,30 +64,27 @@ public class AnalysisJobTest {
 
         // not all task finished nor cached limit exceed, shouldn't  write
         job.appendBuf(olapAnalysisTask, Arrays.asList(new ColStatsData()));
-        Assertions.assertEquals(0, writeBufInvokeTimes.get());
+        Assertions.assertEquals(0, flushBufferInvokeTimes.get());
     }
 
     @Test
-    public void testAppendBufTest2(@Mocked AnalysisInfo analysisInfo, @Mocked OlapAnalysisTask olapAnalysisTask) {
+    public void testAppendBufTest2() {
+        AnalysisInfo analysisInfo = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask olapAnalysisTask = Mockito.mock(OlapAnalysisTask.class);
         AtomicInteger writeBufInvokeTimes = new AtomicInteger();
         AtomicInteger deregisterTimes = new AtomicInteger();
 
-        new MockUp<AnalysisJob>() {
-            @Mock
-            protected void flushBuffer() {
-                writeBufInvokeTimes.incrementAndGet();
-            }
+        AnalysisJob job = Mockito.spy(new AnalysisJob(analysisInfo, Arrays.asList(olapAnalysisTask)));
+        Mockito.doAnswer(inv -> {
+            writeBufInvokeTimes.incrementAndGet();
+            return null;
+        }).when(job).flushBuffer();
+        Mockito.doNothing().when(job).updateTaskState(ArgumentMatchers.any(), ArgumentMatchers.anyString());
+        Mockito.doAnswer(inv -> {
+            deregisterTimes.getAndIncrement();
+            return null;
+        }).when(job).deregisterJob();
 
-            @Mock
-            public void updateTaskState(AnalysisState state, String msg) {
-            }
-
-            @Mock
-            public void deregisterJob() {
-                deregisterTimes.getAndIncrement();
-            }
-        };
-        AnalysisJob job = new AnalysisJob(analysisInfo, Arrays.asList(olapAnalysisTask));
         job.queryingTask = new HashSet<>();
         job.queryingTask.add(olapAnalysisTask);
         job.queryFinished = new HashSet<>();
@@ -106,24 +97,19 @@ public class AnalysisJobTest {
     }
 
     @Test
-    public void testAppendBufTest3(@Mocked AnalysisInfo analysisInfo, @Mocked OlapAnalysisTask olapAnalysisTask) {
+    public void testAppendBufTest3() {
+        AnalysisInfo analysisInfo = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask olapAnalysisTask = Mockito.mock(OlapAnalysisTask.class);
         AtomicInteger writeBufInvokeTimes = new AtomicInteger();
 
-        new MockUp<AnalysisJob>() {
-            @Mock
-            protected void flushBuffer() {
-                writeBufInvokeTimes.incrementAndGet();
-            }
+        AnalysisJob job = Mockito.spy(new AnalysisJob(analysisInfo, Arrays.asList(olapAnalysisTask)));
+        Mockito.doAnswer(inv -> {
+            writeBufInvokeTimes.incrementAndGet();
+            return null;
+        }).when(job).flushBuffer();
+        Mockito.doNothing().when(job).updateTaskState(ArgumentMatchers.any(), ArgumentMatchers.anyString());
+        Mockito.doNothing().when(job).deregisterJob();
 
-            @Mock
-            public void updateTaskState(AnalysisState state, String msg) {
-            }
-
-            @Mock
-            public void deregisterJob() {
-            }
-        };
-        AnalysisJob job = new AnalysisJob(analysisInfo, Arrays.asList(olapAnalysisTask));
         job.queryingTask = new HashSet<>();
         job.queryingTask.add(olapAnalysisTask);
         job.queryFinished = new HashSet<>();
@@ -139,25 +125,21 @@ public class AnalysisJobTest {
     }
 
     @Test
-    public void testUpdateTaskState(
-            @Mocked AnalysisInfo info,
-            @Mocked OlapAnalysisTask task1,
-            @Mocked OlapAnalysisTask task2) {
+    public void testUpdateTaskState() {
+        AnalysisInfo info = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask task1 = Mockito.mock(OlapAnalysisTask.class);
+        OlapAnalysisTask task2 = Mockito.mock(OlapAnalysisTask.class);
         AtomicInteger updateTaskStatusInvokeTimes = new AtomicInteger();
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public void updateTaskStatus(AnalysisInfo info, AnalysisState taskState, String message, long time) {
-                updateTaskStatusInvokeTimes.getAndIncrement();
-            }
-        };
-        AnalysisManager analysisManager = new AnalysisManager();
-        new MockUp<Env>() {
-            @Mock
-            public AnalysisManager getAnalysisManager() {
-                return analysisManager;
-            }
-        };
+
+        AnalysisManager analysisManager = Mockito.mock(AnalysisManager.class);
+        Mockito.doAnswer(inv -> {
+            updateTaskStatusInvokeTimes.getAndIncrement();
+            return null;
+        })
+                .when(analysisManager).updateTaskStatus(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.anyString(), ArgumentMatchers.anyLong());
+
         AnalysisJob job = new AnalysisJob(info, Collections.singletonList(task1));
+        job.analysisManager = analysisManager;
         job.queryFinished = new HashSet<>();
         job.queryFinished.add(task2);
         job.updateTaskState(AnalysisState.FAILED, "");
@@ -165,48 +147,32 @@ public class AnalysisJobTest {
     }
 
     @Test
-    public void testWriteBuf1(@Mocked AnalysisInfo info,
-            @Mocked OlapAnalysisTask task1, @Mocked OlapAnalysisTask task2) {
-        AnalysisJob job = new AnalysisJob(info, Collections.singletonList(task1));
+    public void testWriteBuf1() throws Exception {
+        AnalysisInfo info = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask task1 = Mockito.mock(OlapAnalysisTask.class);
+        OlapAnalysisTask task2 = Mockito.mock(OlapAnalysisTask.class);
+
+        AnalysisJob job = Mockito.spy(new AnalysisJob(info, Collections.singletonList(task1)));
+        Mockito.doNothing().when(job).updateTaskState(ArgumentMatchers.any(), ArgumentMatchers.anyString());
+        Mockito.doNothing().when(job).executeWithExceptionOnFail(ArgumentMatchers.any());
+
         job.queryFinished = new HashSet<>();
         job.queryFinished.add(task2);
-        new MockUp<AnalysisJob>() {
-            @Mock
-            public void updateTaskState(AnalysisState state, String msg) {
-            }
-
-            @Mock
-            protected void executeWithExceptionOnFail(StmtExecutor stmtExecutor) throws Exception {
-
-            }
-
-            @Mock
-            protected void syncLoadStats() {
-            }
-        };
         job.flushBuffer();
 
         Assertions.assertEquals(0, job.queryFinished.size());
     }
 
     @Test
-    public void testWriteBuf2(@Mocked AnalysisInfo info,
-            @Mocked OlapAnalysisTask task1, @Mocked OlapAnalysisTask task2) {
-        new MockUp<AnalysisJob>() {
-            @Mock
-            public void updateTaskState(AnalysisState state, String msg) {
-            }
+    public void testWriteBuf2() throws Exception {
+        AnalysisInfo info = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask task1 = Mockito.mock(OlapAnalysisTask.class);
+        OlapAnalysisTask task2 = Mockito.mock(OlapAnalysisTask.class);
 
-            @Mock
-            protected void executeWithExceptionOnFail(StmtExecutor stmtExecutor) throws Exception {
-                // DO NOTHING
-            }
+        AnalysisJob job = Mockito.spy(new AnalysisJob(info, Collections.singletonList(task1)));
+        Mockito.doNothing().when(job).updateTaskState(ArgumentMatchers.any(), ArgumentMatchers.anyString());
+        Mockito.doNothing().when(job).executeWithExceptionOnFail(ArgumentMatchers.any());
 
-            @Mock
-            protected void syncLoadStats() {
-            }
-        };
-        AnalysisJob job = new AnalysisJob(info, Collections.singletonList(task1));
         job.buf.add(new ColStatsData());
         job.queryFinished = new HashSet<>();
         job.queryFinished.add(task2);
@@ -215,25 +181,17 @@ public class AnalysisJobTest {
     }
 
     @Test
-    public void testSetSqlHash(@Mocked AnalysisInfo info,
-            @Mocked OlapAnalysisTask task1, @Mocked OlapAnalysisTask task2) {
-        AnalysisJob job = new AnalysisJob(info, Collections.singletonList(task1));
+    public void testSetSqlHash() throws Exception {
+        AnalysisInfo info = Mockito.mock(AnalysisInfo.class);
+        OlapAnalysisTask task1 = Mockito.mock(OlapAnalysisTask.class);
+        OlapAnalysisTask task2 = Mockito.mock(OlapAnalysisTask.class);
+
+        AnalysisJob job = Mockito.spy(new AnalysisJob(info, Collections.singletonList(task1)));
+        Mockito.doNothing().when(job).updateTaskState(ArgumentMatchers.any(), ArgumentMatchers.anyString());
+        Mockito.doNothing().when(job).executeWithExceptionOnFail(ArgumentMatchers.any());
+
         job.queryFinished = new HashSet<>();
         job.queryFinished.add(task2);
-        new MockUp<AnalysisJob>() {
-            @Mock
-            public void updateTaskState(AnalysisState state, String msg) {
-            }
-
-            @Mock
-            protected void executeWithExceptionOnFail(StmtExecutor stmtExecutor) throws Exception {
-
-            }
-
-            @Mock
-            protected void syncLoadStats() {
-            }
-        };
         job.buf.add(new ColStatsData());
         job.flushBuffer();
         Assertions.assertEquals(0, job.queryFinished.size());

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
@@ -19,14 +19,10 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
-import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.catalog.Table;
-import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -37,11 +33,9 @@ import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.thrift.TQueryColumn;
 
 import com.google.common.collect.ImmutableList;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,27 +48,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 // CHECKSTYLE OFF
 public class AnalysisManagerTest {
     @Test
-    public void testUpdateTaskStatus(@Mocked BaseAnalysisTask task1,
-            @Mocked BaseAnalysisTask task2) {
+    public void testUpdateTaskStatus() {
+        BaseAnalysisTask task1 = Mockito.mock(BaseAnalysisTask.class);
+        BaseAnalysisTask task2 = Mockito.mock(BaseAnalysisTask.class);
 
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public void logCreateAnalysisTask(AnalysisInfo job) {}
-
-            @Mock
-            public void logCreateAnalysisJob(AnalysisInfo job) {}
-
-            @Mock
-            public void updateTableStats(AnalysisInfo jobInfo) {}
-
-        };
-
-        new MockUp<AnalysisInfo>() {
-            @Mock
-            public String toString() {
-                return "";
-            }
-        };
+        AnalysisManager manager = Mockito.spy(new AnalysisManager());
+        Mockito.doNothing().when(manager).logCreateAnalysisTask(Mockito.any());
+        Mockito.doNothing().when(manager).logCreateAnalysisJob(Mockito.any());
+        Mockito.doNothing().when(manager).updateTableStats(Mockito.any());
 
         AnalysisInfo job = new AnalysisInfoBuilder().setJobId(1)
                 .setState(AnalysisState.PENDING).setAnalysisType(AnalysisType.FUNDAMENTALS)
@@ -85,7 +66,6 @@ public class AnalysisManagerTest {
         AnalysisInfo taskInfo2 = new AnalysisInfoBuilder().setJobId(1)
                 .setTaskId(3).setAnalysisType(AnalysisType.FUNDAMENTALS).setJobType(JobType.MANUAL)
                 .setState(AnalysisState.PENDING).build();
-        AnalysisManager manager = new AnalysisManager();
         manager.replayCreateAnalysisJob(job);
         manager.replayCreateAnalysisTask(taskInfo1);
         manager.replayCreateAnalysisTask(taskInfo2);
@@ -146,26 +126,17 @@ public class AnalysisManagerTest {
         OlapTable table = new OlapTable(200, "testTable", schema, null, null, null);
         db.createTableWithLock(table, true, false);
 
-        new MockUp<Table>() {
-            @Mock
-            public DatabaseIf getDatabase() {
-                return db;
-            }
-        };
-
-        new MockUp<Database>() {
-            @Mock
-            public CatalogIf getCatalog() {
-                return testCatalog;
-            }
-        };
+        OlapTable spyTable = Mockito.spy(table);
+        Database spyDb = Mockito.spy(db);
+        Mockito.doReturn(spyDb).when(spyTable).getDatabase();
+        Mockito.doReturn(testCatalog).when(spyDb).getCatalog();
 
         SlotReference slot1 = new SlotReference(new ExprId(1), "slot1", IntegerType.INSTANCE, true,
-                new ArrayList<>(), table, column1, table, column1, ImmutableList.of());
+                new ArrayList<>(), spyTable, column1, spyTable, column1, ImmutableList.of());
         SlotReference slot2 = new SlotReference(new ExprId(2), "slot2", IntegerType.INSTANCE, true,
-                new ArrayList<>(), table, column2, table, column2, ImmutableList.of());
+                new ArrayList<>(), spyTable, column2, spyTable, column2, ImmutableList.of());
         SlotReference slot3 = new SlotReference(new ExprId(3), "slot3", IntegerType.INSTANCE, true,
-                new ArrayList<>(), table, column3, table, column3, ImmutableList.of());
+                new ArrayList<>(), spyTable, column3, spyTable, column3, ImmutableList.of());
         Set<Slot> set1 = new HashSet<>();
         set1.add(slot1);
         set1.add(slot2);
@@ -284,19 +255,18 @@ public class AnalysisManagerTest {
     @Test
     public void testAsyncDropStats() throws InterruptedException {
         AtomicInteger count = new AtomicInteger(0);
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public void invalidateLocalStats(long catalogId, long dbId, long tableId, Set<String> columns,
-                                             TableStatsMeta tableStats, PartitionNamesInfo partitionNames) {
-                try {
-                    Thread.sleep(1000);
-                    count.incrementAndGet();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+        AnalysisManager analysisManager = Mockito.spy(new AnalysisManager());
+        Mockito.doAnswer(invocation -> {
+            try {
+                Thread.sleep(1000);
+                count.incrementAndGet();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
-        };
-        AnalysisManager analysisManager = new AnalysisManager();
+            return null;
+        }).when(analysisManager).invalidateLocalStats(
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(),
+                Mockito.any(), Mockito.any(), Mockito.any());
         for (int i = 0; i < 20; i++) {
             System.out.println("Submit " + i);
             analysisManager.submitAsyncDropStatsTask(0, 0, 0, null, false);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -23,9 +23,7 @@ import org.apache.doris.catalog.InternalSchemaInitializer;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.Pair;
-import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
-import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
@@ -34,15 +32,12 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Sets;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.lang.reflect.Field;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -66,110 +61,79 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
     }
 
     @Test
-    public void testExpiredJobCancellation(@Mocked InternalCatalog catalog, @Mocked Database database,
-            @Mocked OlapTable olapTable) throws Exception {
-        new MockUp<StatisticsUtil>() {
+    public void testExpiredJobCancellation() throws Exception {
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
 
-            @Mock
-            public DBObjects convertIdToObjects(long catalogId, long dbId, long tblId) {
-                return new DBObjects(catalog, database, olapTable);
-            }
-        };
-        new MockUp<OlapTable>() {
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+            mockedStatisticsUtil.when(() -> StatisticsUtil.convertIdToObjects(
+                    Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(new DBObjects(catalog, database, olapTable));
 
-            @Mock
-            public Column getColumn(String name) {
-                return new Column("col1", PrimitiveType.INT);
-            }
-        };
-        final AtomicBoolean cancelled = new AtomicBoolean();
-        new MockUp<AnalysisTaskWrapper>() {
+            Mockito.when(olapTable.getColumn(Mockito.anyString()))
+                    .thenReturn(new Column("col1", PrimitiveType.INT));
 
-            @Mock
-            public boolean cancel(String msg) {
+            final AtomicBoolean cancelled = new AtomicBoolean();
+
+            AnalysisInfo analysisJobInfo = new AnalysisInfoBuilder().setJobId(0).setTaskId(0)
+                    .setCatalogId(0)
+                    .setDBId(0)
+                    .setTblId(0)
+                    .setColName("col1").setJobType(JobType.MANUAL)
+                    .setAnalysisMethod(AnalysisMethod.FULL)
+                    .setAnalysisType(AnalysisType.FUNDAMENTALS)
+                    .build();
+            OlapAnalysisTask analysisJob = new OlapAnalysisTask(analysisJobInfo);
+
+            AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
+            AnalysisTaskWrapper analysisTaskWrapper = Mockito.spy(
+                    new AnalysisTaskWrapper(analysisTaskExecutor, analysisJob));
+            Mockito.doAnswer(invocation -> {
                 cancelled.set(true);
                 return true;
-            }
-        };
-        AnalysisInfo analysisJobInfo = new AnalysisInfoBuilder().setJobId(0).setTaskId(0)
-                .setCatalogId(0)
-                .setDBId(0)
-                .setTblId(0)
-                .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMethod(AnalysisMethod.FULL)
-                .setAnalysisType(AnalysisType.FUNDAMENTALS)
-                .build();
-        OlapAnalysisTask analysisJob = new OlapAnalysisTask(analysisJobInfo);
+            }).when(analysisTaskWrapper).cancel(Mockito.nullable(String.class));
 
-        AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
-        AnalysisTaskWrapper analysisTaskWrapper = new AnalysisTaskWrapper(analysisTaskExecutor, analysisJob);
-        Deencapsulation.setField(analysisTaskWrapper, "startTime", 5);
-        analysisTaskExecutor.putJob(analysisTaskWrapper);
-        analysisTaskExecutor.tryToCancel();
-        Assertions.assertTrue(cancelled.get());
-        Assertions.assertEquals(0, analysisTaskExecutor.getTaskQueue().size());
+            Field startTimeField = AnalysisTaskWrapper.class.getDeclaredField("startTime");
+            startTimeField.setAccessible(true);
+            startTimeField.set(analysisTaskWrapper, 5L);
+
+            analysisTaskExecutor.putJob(analysisTaskWrapper);
+            analysisTaskExecutor.tryToCancel();
+            Assertions.assertTrue(cancelled.get());
+            Assertions.assertEquals(0, analysisTaskExecutor.getTaskQueue().size());
+        }
     }
 
     @Test
-    public void testTaskExecution(@Mocked InternalCatalog catalog, @Mocked Database database,
-            @Mocked OlapTable olapTable) throws Exception {
-        new MockUp<StatisticsUtil>() {
+    public void testTaskExecution() throws Exception {
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
 
-            @Mock
-            public DBObjects convertIdToObjects(long catalogId, long dbId, long tblId) {
-                return new DBObjects(catalog, database, olapTable);
-            }
-        };
-        new MockUp<OlapTable>() {
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+            mockedStatisticsUtil.when(() -> StatisticsUtil.convertIdToObjects(
+                    Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(new DBObjects(catalog, database, olapTable));
 
-            @Mock
-            public Column getColumn(String name) {
-                return new Column("col1", PrimitiveType.INT);
-            }
-        };
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public List<ResultRow> executeInternalQuery() {
-                return Collections.emptyList();
-            }
-        };
+            Mockito.when(olapTable.getColumn(Mockito.anyString()))
+                    .thenReturn(new Column("col1", PrimitiveType.INT));
 
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            public void execSQLs(List<String> partitionAnalysisSQLs, Map<String, String> params) throws Exception {
-            }
+            AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
+            Set<Pair<String, String>> columns = Sets.newHashSet();
+            columns.add(Pair.of("col1", "t1"));
+            AnalysisInfo analysisInfo = new AnalysisInfoBuilder().setJobId(0).setTaskId(0)
+                    .setCatalogId(0).setDBId(0).setTblId(0)
+                    .setColName("col1").setJobType(JobType.MANUAL)
+                    .setAnalysisMethod(AnalysisMethod.FULL)
+                    .setAnalysisType(AnalysisType.FUNDAMENTALS)
+                    .setState(AnalysisState.RUNNING)
+                    .setJobColumns(columns)
+                    .build();
+            OlapAnalysisTask task = Mockito.spy(new OlapAnalysisTask(analysisInfo));
+            Mockito.doNothing().when(task).doExecute();
 
-            @Mock
-            protected void executeWithExceptionOnFail(StmtExecutor stmtExecutor) throws Exception {
-                // DO NOTHING
-            }
-        };
-
-        new MockUp<StatisticsCache>() {
-
-            @Mock
-            public void syncLoadColStats(long tableId, long idxId, String colName) {
-            }
-        };
-
-        AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
-        Set<Pair<String, String>> columns = Sets.newHashSet();
-        columns.add(Pair.of("col1", "t1"));
-        AnalysisInfo analysisInfo = new AnalysisInfoBuilder().setJobId(0).setTaskId(0)
-                .setCatalogId(0).setDBId(0).setTblId(0)
-                .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMethod(AnalysisMethod.FULL)
-                .setAnalysisType(AnalysisType.FUNDAMENTALS)
-                .setState(AnalysisState.RUNNING)
-                .setJobColumns(columns)
-                .build();
-        OlapAnalysisTask task = new OlapAnalysisTask(analysisInfo);
-
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public void updateTaskStatus(AnalysisInfo info, AnalysisState jobState, String message, long time) {}
-        };
-
-        Deencapsulation.invoke(analysisTaskExecutor, "submitTask", task);
+            analysisTaskExecutor.submitTask(task);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalyzeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalyzeTest.java
@@ -36,17 +36,14 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Sets;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class AnalyzeTest extends TestWithFeService {
@@ -69,116 +66,68 @@ public class AnalyzeTest extends TestWithFeService {
 
     @Test
     public void testCreateAnalysisJob() throws Exception {
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class);
+                MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                        (mock, context) -> {
+                            Mockito.when(mock.executeInternalQuery()).thenReturn(Collections.emptyList());
+                        });
+                MockedStatic<ConnectContext> mockedConnectContext = Mockito.mockStatic(ConnectContext.class)) {
 
-        new MockUp<StatisticsUtil>() {
+            mockedConnectContext.when(ConnectContext::get).thenReturn(connectContext);
 
-            @Mock
-            public AutoCloseConnectContext buildConnectContext() {
-                return new AutoCloseConnectContext(connectContext);
-            }
+            mockedStatisticsUtil.when(() -> StatisticsUtil.buildConnectContext(Mockito.anyBoolean()))
+                    .thenAnswer(invocation -> new AutoCloseConnectContext(connectContext));
+            mockedStatisticsUtil.when(() -> StatisticsUtil.execUpdate(Mockito.anyString()))
+                    .thenReturn(null);
 
-            @Mock
-            public void execUpdate(String sql) throws Exception {
-            }
-        };
-
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public List<ResultRow> executeInternalQuery() {
-                return Collections.emptyList();
-            }
-        };
-
-        new MockUp<ConnectContext>() {
-
-            @Mock
-            public ConnectContext get() {
-                return connectContext;
-            }
-        };
-        String sql = "ANALYZE TABLE t1";
-        Assertions.assertNotNull(getSqlStmtExecutor(sql));
+            String sql = "ANALYZE TABLE t1";
+            Assertions.assertNotNull(getSqlStmtExecutor(sql));
+        }
     }
 
     @Test
-    public void testJobExecution(@Mocked StmtExecutor stmtExecutor, @Mocked InternalCatalog catalog, @Mocked
-            Database database,
-            @Mocked OlapTable olapTable)
-            throws Exception {
-        new MockUp<OlapTable>() {
+    public void testJobExecution() throws Exception {
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
 
-            @Mock
-            public Column getColumn(String name) {
-                return new Column("col1", PrimitiveType.INT);
-            }
-        };
+        Mockito.when(olapTable.getColumn(Mockito.anyString()))
+                .thenReturn(new Column("col1", PrimitiveType.INT));
 
-        new MockUp<StatisticsUtil>() {
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class);
+                MockedConstruction<StmtExecutor> mockedStmtExecutorConstruction =
+                        Mockito.mockConstruction(StmtExecutor.class, (mock, context) -> {
+                            Mockito.doNothing().when(mock).execute();
+                            Mockito.when(mock.executeInternalQuery()).thenReturn(new ArrayList<>());
+                        })) {
 
-            @Mock
-            public ConnectContext buildConnectContext() {
-                return connectContext;
-            }
+            mockedStatisticsUtil.when(() -> StatisticsUtil.buildConnectContext(Mockito.anyBoolean()))
+                    .thenAnswer(invocation -> new AutoCloseConnectContext(connectContext));
+            mockedStatisticsUtil.when(() -> StatisticsUtil.execUpdate(Mockito.anyString()))
+                    .thenReturn(null);
+            mockedStatisticsUtil.when(() -> StatisticsUtil.convertIdToObjects(
+                    Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(new DBObjects(catalog, database, olapTable));
 
-            @Mock
-            public void execUpdate(String sql) throws Exception {
-            }
+            Set<Pair<String, String>> colList = Sets.newHashSet();
+            colList.add(Pair.of("col1", "index1"));
+            AnalysisInfo analysisJobInfo = new AnalysisInfoBuilder().setJobId(0).setTaskId(0)
+                    .setCatalogId(0)
+                    .setDBId(0)
+                    .setTblId(0)
+                    .setColName("col1").setJobType(JobType.MANUAL)
+                    .setAnalysisMethod(AnalysisMethod.FULL)
+                    .setAnalysisType(AnalysisType.FUNDAMENTALS)
+                    .setJobColumns(colList)
+                    .setState(AnalysisState.RUNNING)
+                    .setRowCount(10)
+                    .build();
+            OlapAnalysisTask task = Mockito.spy(new OlapAnalysisTask(analysisJobInfo));
+            Mockito.doNothing().when(task).runQuery(Mockito.anyString());
+            task.doExecute();
 
-            @Mock
-            public DBObjects convertIdToObjects(long catalogId, long dbId, long tblId) {
-                return new DBObjects(catalog, database, olapTable);
-            }
-        };
-        new MockUp<StatisticsCache>() {
-
-            @Mock
-            public void syncLoadColStats(long tableId, long idxId, String colName) {
-            }
-        };
-        new MockUp<StmtExecutor>() {
-
-            @Mock
-            public void execute() throws Exception {
-
-            }
-
-            @Mock
-            public List<ResultRow> executeInternalQuery() {
-                return new ArrayList<>();
-            }
-        };
-
-        new MockUp<OlapAnalysisTask>() {
-
-            @Mock
-            public void execSQLs(List<String> partitionAnalysisSQLs, Map<String, String> params) throws Exception {}
-        };
-
-        new MockUp<BaseAnalysisTask>() {
-
-            @Mock
-            protected void runQuery(String sql) {}
-        };
-        Set<Pair<String, String>> colList = Sets.newHashSet();
-        colList.add(Pair.of("col1", "index1"));
-        AnalysisInfo analysisJobInfo = new AnalysisInfoBuilder().setJobId(0).setTaskId(0)
-                .setCatalogId(0)
-                .setDBId(0)
-                .setTblId(0)
-                .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMethod(AnalysisMethod.FULL)
-                .setAnalysisType(AnalysisType.FUNDAMENTALS)
-                .setJobColumns(colList)
-                .setState(AnalysisState.RUNNING)
-                .setRowCount(10)
-                .build();
-        new OlapAnalysisTask(analysisJobInfo).doExecute();
-        new Expectations() {
-            {
-                stmtExecutor.execute();
-                times = 1;
-            }
-        };
+            Mockito.verify(task, Mockito.times(1)).runQuery(Mockito.anyString());
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/BaseAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/BaseAnalysisTaskTest.java
@@ -23,10 +23,10 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.qe.StmtExecutor;
 
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
 import java.util.List;
 
@@ -87,22 +87,21 @@ public class BaseAnalysisTaskTest {
         List<ResultRow> result = Lists.newArrayList();
         result.add(row);
 
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public List<ResultRow> executeInternalQuery() {
-                return result;
+        try (MockedConstruction<StmtExecutor> mocked = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    Mockito.when(mock.executeInternalQuery()).thenReturn(result);
+                })) {
+            BaseAnalysisTask task = new OlapAnalysisTask();
+            try {
+                task.runQuery("test");
+            } catch (Exception e) {
+                Assertions.assertEquals(e.getMessage(),
+                        "ColStatsData is invalid, skip analyzing. "
+                                + "('id',10000,20000,30000,0,'col',null,100,1100,300,'min','max',400,'500',NULL)");
+                return;
             }
-        };
-        BaseAnalysisTask task = new OlapAnalysisTask();
-        try {
-            task.runQuery("test");
-        } catch (Exception e) {
-            Assertions.assertEquals(e.getMessage(),
-                    "ColStatsData is invalid, skip analyzing. "
-                            + "('id',10000,20000,30000,0,'col',null,100,1100,300,'min','max',400,'500',NULL)");
-            return;
+            Assertions.fail();
         }
-        Assertions.fail();
     }
 
     @Test
@@ -127,21 +126,20 @@ public class BaseAnalysisTaskTest {
         List<ResultRow> result = Lists.newArrayList();
         result.add(row);
 
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public List<ResultRow> executeInternalQuery() {
-                return result;
+        try (MockedConstruction<StmtExecutor> mocked = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, context) -> {
+                    Mockito.when(mock.executeInternalQuery()).thenReturn(result);
+                })) {
+            BaseAnalysisTask task = new OlapAnalysisTask();
+            try {
+                task.runQuery("test");
+            } catch (Exception e) {
+                Assertions.assertEquals(e.getMessage(),
+                        "ColStatsData is invalid, skip analyzing. "
+                                + "('id',10000,20000,30000,0,'col',null,500,0,300,'min','max',400,'500',NULL)");
+                return;
             }
-        };
-        BaseAnalysisTask task = new OlapAnalysisTask();
-        try {
-            task.runQuery("test");
-        } catch (Exception e) {
-            Assertions.assertEquals(e.getMessage(),
-                    "ColStatsData is invalid, skip analyzing. "
-                            + "('id',10000,20000,30000,0,'col',null,500,0,300,'min','max',400,'500',NULL)");
-            return;
+            Assertions.fail();
         }
-        Assertions.fail();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
@@ -20,16 +20,13 @@ package org.apache.doris.statistics;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.ThreadPoolManager;
-import org.apache.doris.datasource.CatalogMgr;
-import org.apache.doris.datasource.hive.HMSExternalCatalog;
-import org.apache.doris.datasource.hive.HMSExternalDatabase;
 import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.system.Frontend;
+import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TUpdateFollowerStatsCacheRequest;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -41,331 +38,278 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class CacheTest extends TestWithFeService {
 
     @Test
-    public void testColumn(@Mocked ColumnStatisticsCacheLoader cacheLoader) throws Exception {
-        new Expectations() {
-            {
-                cacheLoader.asyncLoad((StatisticsCacheKey) any, (Executor) any);
-                result = CompletableFuture.supplyAsync(() -> {
-                    try {
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        return ColumnStatistic.UNKNOWN;
-                    }
-                    return ColumnStatistic.UNKNOWN;
-                });
-            }
-        };
-        StatisticsCache statisticsCache = new StatisticsCache();
-        ColumnStatistic c = statisticsCache.getColumnStatistics(-1, -1, 1, -1, "col", connectContext);
-        Assertions.assertTrue(c.isUnKnown);
-        Thread.sleep(100);
-        c = statisticsCache.getColumnStatistics(-1, -1, 1, -1, "col", connectContext);
-        Assertions.assertTrue(c.isUnKnown);
+    public void testColumn() throws Exception {
+        try (MockedConstruction<ColumnStatisticsCacheLoader> mc = Mockito.mockConstruction(
+                ColumnStatisticsCacheLoader.class, (mock, ctx) -> {
+                    Mockito.doReturn(CompletableFuture.supplyAsync(() -> {
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            return Optional.of(ColumnStatistic.UNKNOWN);
+                        }
+                        return Optional.of(ColumnStatistic.UNKNOWN);
+                    })).when(mock).asyncLoad(Mockito.any(), Mockito.any());
+                })) {
+            StatisticsCache statisticsCache = new StatisticsCache();
+            ColumnStatistic c = statisticsCache.getColumnStatistics(-1, -1, 1, -1, "col", connectContext);
+            Assertions.assertTrue(c.isUnKnown);
+            Thread.sleep(100);
+            c = statisticsCache.getColumnStatistics(-1, -1, 1, -1, "col", connectContext);
+            Assertions.assertTrue(c.isUnKnown);
+        }
     }
 
     @Test
     public void testLoad() throws Exception {
-        new MockUp<StatisticsUtil>() {
-
-            @Mock
-            public Column findColumn(long catalogId, long dbId, long tblId, long idxId, String columnName) {
-                return new Column("abc", PrimitiveType.BIGINT);
+        try (MockedConstruction<ColumnStatisticsCacheLoader> mc = Mockito.mockConstruction(
+                ColumnStatisticsCacheLoader.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, ctx) -> {
+                    Mockito.doAnswer(inv -> {
+                        Thread.sleep(50);
+                        ColumnStatisticBuilder builder =
+                                new ColumnStatisticBuilder(7);
+                        builder.setNdv(8);
+                        builder.setNumNulls(0);
+                        builder.setDataSize(12);
+                        builder.setAvgSizeByte(12.0 / 7);
+                        builder.setMinValue(10);
+                        builder.setMaxValue(11);
+                        builder.setUpdatedTime(
+                                String.valueOf(System.currentTimeMillis()));
+                        return Optional.of(builder.build());
+                    }).when(mock).doLoad(Mockito.any());
+                })) {
+            StatisticsCache statisticsCache = new StatisticsCache();
+            ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(
+                    -1, -1, 0, -1, "col", connectContext);
+            // load not finished yet, should return unknown
+            Assertions.assertTrue(columnStatistic.isUnKnown);
+            int retry = 0;
+            while (columnStatistic.isUnKnown() && retry < 10) {
+                // wait 1 sec to ensure async load is finished.
+                Thread.sleep(1000);
+                // load has finished, return corresponding stats.
+                columnStatistic = statisticsCache.getColumnStatistics(
+                        -1, -1, 0, -1, "col", connectContext);
+                retry++;
             }
-
-            @Mock
-            public List<ResultRow> execStatisticQuery(String sql) {
-                try {
-                    Thread.sleep(50);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-                return Arrays.asList(StatsMockUtil.mockResultRow(true));
-            }
-        };
-        StatisticsCache statisticsCache = new StatisticsCache();
-        ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(-1, -1, 0, -1, "col", connectContext);
-        // load not finished yet, should return unknown
-        Assertions.assertTrue(columnStatistic.isUnKnown);
-        int retry = 0;
-        while (columnStatistic.isUnKnown() && retry < 10) {
-            // wait 1 sec to ensure `execStatisticQuery` is finished as much as possible.
-            Thread.sleep(1000);
-            // load has finished, return corresponding stats.
-            columnStatistic = statisticsCache.getColumnStatistics(-1, -1, 0, -1, "col", connectContext);
-            retry++;
+            System.out.println("wait for " + retry + " seconds");
+            Assertions.assertEquals(7, columnStatistic.count);
+            Assertions.assertEquals(8, columnStatistic.ndv);
+            Assertions.assertEquals(11, columnStatistic.maxValue);
         }
-        System.out.println("wait for " + retry + " seconds");
-        Assertions.assertEquals(7, columnStatistic.count);
-        Assertions.assertEquals(8, columnStatistic.ndv);
-        Assertions.assertEquals(11, columnStatistic.maxValue);
     }
 
     @Test
     public void testLoadHistogram() throws Exception {
-        new MockUp<Histogram>() {
-
-            @Mock
-            public Histogram fromResultRow(ResultRow resultRow) {
-                try {
-                    HistogramBuilder histogramBuilder = new HistogramBuilder();
-
-                    Column col = new Column("abc", PrimitiveType.DATETIME);
-
-                    Type dataType = col.getType();
-                    histogramBuilder.setDataType(dataType);
-                    HistData histData = new HistData(resultRow);
-                    histogramBuilder.setSampleRate(histData.sampleRate);
-
-                    String json = histData.buckets;
-                    JsonObject jsonObj = JsonParser.parseString(json).getAsJsonObject();
-
-                    int bucketNum = jsonObj.get("num_buckets").getAsInt();
-                    histogramBuilder.setNumBuckets(bucketNum);
-
-                    List<Bucket> buckets = Lists.newArrayList();
-                    JsonArray jsonArray = jsonObj.getAsJsonArray("buckets");
-                    for (JsonElement element : jsonArray) {
-                        try {
-                            String bucketJson = element.toString();
-                            buckets.add(Bucket.deserializeFromJson(dataType, bucketJson));
-                        } catch (Throwable t) {
-                            t.printStackTrace();
+        try (MockedConstruction<HistogramCacheLoader> mc = Mockito.mockConstruction(
+                HistogramCacheLoader.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, ctx) -> {
+                    Mockito.doAnswer(inv -> {
+                        Thread.sleep(50);
+                        HistogramBuilder histogramBuilder = new HistogramBuilder();
+                        Column col = new Column("abc", PrimitiveType.DATETIME);
+                        Type dataType = col.getType();
+                        histogramBuilder.setDataType(dataType);
+                        histogramBuilder.setSampleRate(0.2);
+                        String json = "{\"num_buckets\":5,\"buckets\":"
+                                + "[{\"lower\":\"2022-09-21 17:30:29\","
+                                + "\"upper\":\"2022-09-21 22:30:29\","
+                                + "\"count\":9,\"pre_sum\":0,\"ndv\":1},"
+                                + "{\"lower\":\"2022-09-22 17:30:29\","
+                                + "\"upper\":\"2022-09-22 22:30:29\","
+                                + "\"count\":10,\"pre_sum\":9,\"ndv\":1},"
+                                + "{\"lower\":\"2022-09-23 17:30:29\","
+                                + "\"upper\":\"2022-09-23 22:30:29\","
+                                + "\"count\":9,\"pre_sum\":19,\"ndv\":1},"
+                                + "{\"lower\":\"2022-09-24 17:30:29\","
+                                + "\"upper\":\"2022-09-24 22:30:29\","
+                                + "\"count\":9,\"pre_sum\":28,\"ndv\":1},"
+                                + "{\"lower\":\"2022-09-25 17:30:29\","
+                                + "\"upper\":\"2022-09-25 22:30:29\","
+                                + "\"count\":9,\"pre_sum\":37,\"ndv\":1}]}";
+                        JsonObject jsonObj = JsonParser.parseString(json)
+                                .getAsJsonObject();
+                        int bucketNum =
+                                jsonObj.get("num_buckets").getAsInt();
+                        histogramBuilder.setNumBuckets(bucketNum);
+                        List<Bucket> buckets = Lists.newArrayList();
+                        JsonArray jsonArray =
+                                jsonObj.getAsJsonArray("buckets");
+                        for (JsonElement element : jsonArray) {
+                            try {
+                                String bucketJson = element.toString();
+                                buckets.add(Bucket.deserializeFromJson(
+                                        dataType, bucketJson));
+                            } catch (Throwable t) {
+                                t.printStackTrace();
+                            }
                         }
-
-                    }
-                    histogramBuilder.setBuckets(buckets);
-
-                    return histogramBuilder.build();
-                } catch (Exception e) {
-                    return null;
-                }
-            }
-        };
-        new MockUp<StatisticsUtil>() {
-
-            @Mock
-            public Column findColumn(long catalogId, long dbId, long tblId, long idxId, String columnName) {
-                return new Column("abc", PrimitiveType.DATETIME);
-            }
-
-            @Mock
-            public List<ResultRow> execStatisticQuery(String sql) {
-                try {
-                    Thread.sleep(50);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-                List<String> values = new ArrayList<>();
-                values.add("1");
-                values.add("2");
-                values.add("3");
-                values.add("4");
-                values.add("-1");
-                values.add("col");
-                values.add(null);
-                values.add("0.2");
-                String buckets = "{\"num_buckets\":5,\"buckets\":"
-                        + "[{\"lower\":\"2022-09-21 17:30:29\",\"upper\":\"2022-09-21 22:30:29\","
-                        + "\"count\":9,\"pre_sum\":0,\"ndv\":1},"
-                        + "{\"lower\":\"2022-09-22 17:30:29\",\"upper\":\"2022-09-22 22:30:29\","
-                        + "\"count\":10,\"pre_sum\":9,\"ndv\":1},"
-                        + "{\"lower\":\"2022-09-23 17:30:29\",\"upper\":\"2022-09-23 22:30:29\","
-                        + "\"count\":9,\"pre_sum\":19,\"ndv\":1},"
-                        + "{\"lower\":\"2022-09-24 17:30:29\",\"upper\":\"2022-09-24 22:30:29\","
-                        + "\"count\":9,\"pre_sum\":28,\"ndv\":1},"
-                        + "{\"lower\":\"2022-09-25 17:30:29\",\"upper\":\"2022-09-25 22:30:29\","
-                        + "\"count\":9,\"pre_sum\":37,\"ndv\":1}]}";
-                values.add(buckets);
-                values.add(new Date().toString());
-                ResultRow resultRow = new ResultRow(values);
-                return Collections.singletonList(resultRow);
-            }
-        };
-
-        StatisticsCache statisticsCache = new StatisticsCache();
-        statisticsCache.refreshHistogramSync(0, 0, 0, -1, "col");
-        Thread.sleep(10000);
-        Histogram histogram = statisticsCache.getHistogram(0, 0, 0, "col");
-        Assertions.assertNotNull(histogram);
+                        histogramBuilder.setBuckets(buckets);
+                        return Optional.of(histogramBuilder.build());
+                    }).when(mock).doLoad(Mockito.any());
+                })) {
+            StatisticsCache statisticsCache = new StatisticsCache();
+            statisticsCache.refreshHistogramSync(0, 0, 0, -1, "col");
+            Thread.sleep(10000);
+            Histogram histogram = statisticsCache.getHistogram(0, 0, 0, "col");
+            Assertions.assertNotNull(histogram);
+        }
     }
 
     @Test
-    public void testLoadFromMeta(@Mocked Env env,
-            @Mocked CatalogMgr mgr,
-            @Mocked HMSExternalCatalog catalog,
-            @Mocked HMSExternalDatabase db,
-            @Mocked HMSExternalTable table) throws Exception {
-        new MockUp<StatisticsUtil>() {
+    public void testLoadFromMeta() throws Exception {
+        HMSExternalTable table = Mockito.mock(HMSExternalTable.class);
+        Env env = Mockito.mock(Env.class);
 
-            @Mock
-            public Column findColumn(long catalogId, long dbId, long tblId, long idxId, String columnName) {
-                return new Column("abc", PrimitiveType.BIGINT);
-            }
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(
+                    StatisticsUtil.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<Env> mockedEnv = Mockito.mockStatic(
+                        Env.class, Mockito.CALLS_REAL_METHODS)) {
 
-            @Mock
-            public List<ResultRow> execStatisticQuery(String sql) {
-                return null;
-            }
+            mockedStatisticsUtil.when(() -> StatisticsUtil.findColumn(
+                    Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(),
+                    Mockito.anyLong(), Mockito.anyString()))
+                    .thenReturn(new Column("abc", PrimitiveType.BIGINT));
+            mockedStatisticsUtil.when(() -> StatisticsUtil.execStatisticQuery(Mockito.anyString()))
+                    .thenReturn(null);
+            mockedStatisticsUtil.when(() -> StatisticsUtil.findTable(
+                    Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(table);
 
-            @Mock
-            public TableIf findTable(long catalogId, long dbId, long tblId) {
-                return table;
-            }
-        };
-        new MockUp<Env>() {
-            @Mock
-            public Env getCurrentEnv() {
-                return env;
-            }
-        };
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public Optional<ColumnStatistic> getColumnStatistic(String colName) {
-                return Optional.of(new ColumnStatistic(1, 2,
-                        null, 3, 4, 5, 6, 7,
-                        null, null, false,
-                        new Date().toString(), null));
-            }
-        };
+            Mockito.when(table.getColumnStatistic(Mockito.anyString())).thenReturn(
+                    Optional.of(new ColumnStatistic(1, 2,
+                            null, 3, 4, 5, 6, 7,
+                            null, null, false,
+                            new Date().toString(), null)));
 
-        try {
-            StatisticsCache statisticsCache = new StatisticsCache();
-            ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(1, 1, 1, -1, "col", connectContext);
-            for (int i = 0; i < 15; i++) {
-                columnStatistic = statisticsCache.getColumnStatistics(1, 1, 1, -1, "col", connectContext);
-                if (columnStatistic != ColumnStatistic.UNKNOWN) {
-                    break;
+            try {
+                StatisticsCache statisticsCache = new StatisticsCache();
+                ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(
+                        1, 1, 1, -1, "col", connectContext);
+                for (int i = 0; i < 15; i++) {
+                    columnStatistic = statisticsCache.getColumnStatistics(
+                            1, 1, 1, -1, "col", connectContext);
+                    if (columnStatistic != ColumnStatistic.UNKNOWN) {
+                        break;
+                    }
+                    System.out.println("Not ready yet.");
+                    Thread.sleep(1000);
                 }
-                System.out.println("Not ready yet.");
-                Thread.sleep(1000);
+                if (columnStatistic != ColumnStatistic.UNKNOWN) {
+                    Assertions.assertEquals(1, columnStatistic.count);
+                    Assertions.assertEquals(2, columnStatistic.ndv);
+                    Assertions.assertEquals(3, columnStatistic.avgSizeByte);
+                    Assertions.assertEquals(4, columnStatistic.numNulls);
+                    Assertions.assertEquals(5, columnStatistic.dataSize);
+                    Assertions.assertEquals(6, columnStatistic.minValue);
+                    Assertions.assertEquals(7, columnStatistic.maxValue);
+                } else {
+                    System.out.println("Cache is not loaded, skip test.");
+                }
+            } catch (Throwable t) {
+                t.printStackTrace();
             }
-            if (columnStatistic != ColumnStatistic.UNKNOWN) {
-                Assertions.assertEquals(1, columnStatistic.count);
-                Assertions.assertEquals(2, columnStatistic.ndv);
-                Assertions.assertEquals(3, columnStatistic.avgSizeByte);
-                Assertions.assertEquals(4, columnStatistic.numNulls);
-                Assertions.assertEquals(5, columnStatistic.dataSize);
-                Assertions.assertEquals(6, columnStatistic.minValue);
-                Assertions.assertEquals(7, columnStatistic.maxValue);
-            } else {
-                System.out.println("Cache is not loaded, skip test.");
-            }
-        } catch (Throwable t) {
-            t.printStackTrace();
         }
     }
 
     @Test
     public void testSync1() throws Exception {
-        new MockUp<StatisticsRepository>() {
-            @Mock
-            public List<ResultRow> loadColStats(long tableId, long idxId, String colName) {
-                List<ResultRow> rows = new ArrayList<>();
-                rows.add(StatsMockUtil.mockResultRow(true));
-                rows.add(StatsMockUtil.mockResultRow(false));
-                return rows;
-            }
+        Env env = Mockito.mock(Env.class);
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(
+                    Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
-            @Mock
-            public boolean isMaster(Frontend frontend) {
-                return frontend.getRole().equals(FrontendNodeType.MASTER);
-            }
-        };
-        new MockUp<Env>() {
-            @Mock
-            public List<Frontend> getFrontends(FrontendNodeType nodeType) {
-                Frontend frontend1 = new Frontend(FrontendNodeType.MASTER,
-                        "fe1", "localhost:1111", "localhost", 2222);
-                Frontend frontend2 = new Frontend(FrontendNodeType.FOLLOWER,
-                        "fe1", "localhost:1112", "localhost", 2223);
-                List<Frontend> frontends = new ArrayList<>();
-                frontends.add(frontend1);
-                frontends.add(frontend2);
-                return frontends;
-            }
-        };
+            Frontend frontend1 = new Frontend(FrontendNodeType.MASTER,
+                    "fe1", "self_host", "self_host", 2222);
+            Frontend frontend2 = new Frontend(FrontendNodeType.FOLLOWER,
+                    "fe2", "other_host", "other_host", 2223);
+            List<Frontend> frontends = new ArrayList<>();
+            frontends.add(frontend1);
+            frontends.add(frontend2);
+            Mockito.when(env.getFrontends(
+                    Mockito.nullable(FrontendNodeType.class)))
+                    .thenReturn(frontends);
 
-        new MockUp<StatisticsCache>() {
-            @Mock
-            private void sendStats(Frontend frontend,
-                    TUpdateFollowerStatsCacheRequest updateFollowerStatsCacheRequest) {
-                // DO NONTHING
-            }
-        };
-        StatisticsCache statisticsCache = new StatisticsCache();
-        new Expectations() {
-            {
-                statisticsCache.sendStats((Frontend) any, (TUpdateFollowerStatsCacheRequest) any);
-                times = 1;
-            }
-        };
+            SystemInfoService.HostInfo selfNode =
+                    new SystemInfoService.HostInfo("self_host", 1111);
+            Mockito.when(env.getSelfNode()).thenReturn(selfNode);
+
+            StatisticsCache statisticsCache =
+                    Mockito.spy(new StatisticsCache());
+            Mockito.doNothing().when(statisticsCache).sendStats(
+                    Mockito.any(Frontend.class),
+                    Mockito.any(TUpdateFollowerStatsCacheRequest.class));
+
+            ColStatsData data = new ColStatsData(
+                    StatsMockUtil.mockResultRow(true));
+            statisticsCache.syncColStats(data);
+
+            Mockito.verify(statisticsCache, Mockito.times(1))
+                    .sendStats(Mockito.any(Frontend.class),
+                            Mockito.any(
+                                    TUpdateFollowerStatsCacheRequest.class));
+        }
     }
 
     @Test
     public void testSync2() throws Exception {
-        new MockUp<ColumnStatistic>() {
-            @Mock
+        try (MockedStatic<ColumnStatistic> mockedColStat = Mockito.mockStatic(
+                    ColumnStatistic.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<Env> mockedEnv = Mockito.mockStatic(
+                        Env.class, Mockito.CALLS_REAL_METHODS)) {
 
-            public ColumnStatistic fromResultRow(ResultRow row) {
-                return ColumnStatistic.UNKNOWN;
-            }
+            mockedColStat.when(() -> ColumnStatistic.fromResultRow(Mockito.any(ResultRow.class)))
+                    .thenReturn(ColumnStatistic.UNKNOWN);
+            mockedColStat.when(() -> ColumnStatistic.fromResultRowList(Mockito.anyList()))
+                    .thenReturn(ColumnStatistic.UNKNOWN);
 
-            @Mock
-            public ColumnStatistic fromResultRow(List<ResultRow> row) {
-                return ColumnStatistic.UNKNOWN;
-            }
-        };
-        new MockUp<Env>() {
-            @Mock
-            public List<Frontend> getFrontends(FrontendNodeType nodeType) {
-                Frontend frontend1 = new Frontend(FrontendNodeType.MASTER,
-                        "fe1", "localhost:1111", "localhost", 2222);
-                Frontend frontend2 = new Frontend(FrontendNodeType.FOLLOWER,
-                        "fe1", "localhost:1112", "localhost", 2223);
-                List<Frontend> frontends = new ArrayList<>();
-                frontends.add(frontend1);
-                frontends.add(frontend2);
-                return frontends;
-            }
-        };
+            Env env = Mockito.mock(Env.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
-        new MockUp<StatisticsCache>() {
-            @Mock
-            private void sendStats(Frontend frontend,
-                    TUpdateFollowerStatsCacheRequest updateFollowerStatsCacheRequest) {
-                // DO NOTHING
-            }
-        };
-        StatisticsCache statisticsCache = new StatisticsCache();
-        new Expectations() {
-            {
-                statisticsCache.sendStats((Frontend) any, (TUpdateFollowerStatsCacheRequest) any);
-                times = 0;
-            }
-        };
+            Frontend frontend1 = new Frontend(FrontendNodeType.MASTER,
+                    "fe1", "localhost:1111", "localhost", 2222);
+            Frontend frontend2 = new Frontend(FrontendNodeType.FOLLOWER,
+                    "fe1", "localhost:1112", "localhost", 2223);
+            List<Frontend> frontends = new ArrayList<>();
+            frontends.add(frontend1);
+            frontends.add(frontend2);
+            Mockito.when(env.getFrontends(Mockito.any())).thenReturn(frontends);
+
+            StatisticsCache statisticsCache = Mockito.spy(new StatisticsCache());
+            Mockito.doNothing().when(statisticsCache).sendStats(
+                    Mockito.any(Frontend.class),
+                    Mockito.any(TUpdateFollowerStatsCacheRequest.class));
+
+            Thread.sleep(1000);
+            Mockito.verify(statisticsCache, Mockito.never()).sendStats(
+                    Mockito.any(Frontend.class),
+                    Mockito.any(TUpdateFollowerStatsCacheRequest.class));
+        }
     }
 
     @Test
@@ -396,45 +340,46 @@ public class CacheTest extends TestWithFeService {
 
     @Test
     public void testLoadWithException() throws Exception {
-        new MockUp<ColumnStatisticsCacheLoader>() {
-            @Mock
-            protected Optional<ColumnStatistic> doLoad(StatisticsCacheKey key) {
-                return null;
-            }
-        };
-        StatisticsCache statisticsCache = new StatisticsCache();
-        ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(1, 1, 1, -1, "col", connectContext);
-        Thread.sleep(3000);
-        Assertions.assertTrue(columnStatistic.isUnKnown);
+        AtomicReference<Optional<ColumnStatistic>> doLoadResult = new AtomicReference<>(null);
+        try (MockedConstruction<ColumnStatisticsCacheLoader> mc = Mockito.mockConstruction(
+                ColumnStatisticsCacheLoader.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
+                (mock, ctx) -> {
+                    Mockito.doAnswer(inv -> doLoadResult.get())
+                            .when(mock).doLoad(Mockito.any());
+                })) {
+            StatisticsCache statisticsCache = new StatisticsCache();
+            ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(
+                    1, 1, 1, -1, "col", connectContext);
+            Thread.sleep(3000);
+            Assertions.assertTrue(columnStatistic.isUnKnown);
 
-        new MockUp<ColumnStatisticsCacheLoader>() {
-            @Mock
-            protected Optional<ColumnStatistic> doLoad(StatisticsCacheKey key) {
-                return Optional.of(new ColumnStatistic(1, 2,
+            doLoadResult.set(Optional.of(new ColumnStatistic(1, 2,
                     null, 3, 4, 5, 6, 7,
                     null, null, false,
-                        new Date().toString(), null));
+                    new Date().toString(), null)));
+            columnStatistic = statisticsCache.getColumnStatistics(
+                    1, 1, 1, -1, "col", connectContext);
+            for (int i = 0; i < 60; i++) {
+                columnStatistic = statisticsCache.getColumnStatistics(
+                        1, 1, 1, -1, "col", connectContext);
+                if (columnStatistic != ColumnStatistic.UNKNOWN) {
+                    break;
+                }
+                System.out.println("Not ready yet.");
+                Thread.sleep(1000);
             }
-        };
-        columnStatistic = statisticsCache.getColumnStatistics(1, 1, 1, -1, "col", connectContext);
-        for (int i = 0; i < 60; i++) {
-            columnStatistic = statisticsCache.getColumnStatistics(1, 1, 1, -1, "col", connectContext);
             if (columnStatistic != ColumnStatistic.UNKNOWN) {
-                break;
+                Assertions.assertEquals(1, columnStatistic.count);
+                Assertions.assertEquals(2, columnStatistic.ndv);
+                Assertions.assertEquals(3, columnStatistic.avgSizeByte);
+                Assertions.assertEquals(4, columnStatistic.numNulls);
+                Assertions.assertEquals(5, columnStatistic.dataSize);
+                Assertions.assertEquals(6, columnStatistic.minValue);
+                Assertions.assertEquals(7, columnStatistic.maxValue);
+            } else {
+                Assertions.fail("Column stats is still unknown");
             }
-            System.out.println("Not ready yet.");
-            Thread.sleep(1000);
-        }
-        if (columnStatistic != ColumnStatistic.UNKNOWN) {
-            Assertions.assertEquals(1, columnStatistic.count);
-            Assertions.assertEquals(2, columnStatistic.ndv);
-            Assertions.assertEquals(3, columnStatistic.avgSizeByte);
-            Assertions.assertEquals(4, columnStatistic.numNulls);
-            Assertions.assertEquals(5, columnStatistic.dataSize);
-            Assertions.assertEquals(6, columnStatistic.minValue);
-            Assertions.assertEquals(7, columnStatistic.maxValue);
-        } else {
-            Assertions.fail("Column stats is still unknown");
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/FollowerColumnSenderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/FollowerColumnSenderTest.java
@@ -20,16 +20,15 @@ package org.apache.doris.statistics;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Pair;
 import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.thrift.TQueryColumn;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.Queue;
@@ -39,50 +38,38 @@ public class FollowerColumnSenderTest {
 
     @Test
     public void testGetNeedAnalyzeColumns() {
-        new MockUp<OlapTable>() {
-            @Mock
-            public Column getColumn(String name) {
-                return new Column("col", PrimitiveType.INT);
-            }
+        OlapTable mockTable = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable.getColumn(Mockito.anyString()))
+                .thenReturn(new Column("col", PrimitiveType.INT));
+        Mockito.when(mockTable.getColumnIndexPairs(Mockito.any()))
+                .thenReturn(Collections.singleton(Pair.of("mockIndex", "mockCol")));
 
-            @Mock
-            public Set<Pair<String, String>> getColumnIndexPairs(Set<String> columns) {
-                return Collections.singleton(Pair.of("mockIndex", "mockCol"));
-            }
-        };
+        try (MockedStatic<StatisticsUtil> statisticsUtilStatic = Mockito.mockStatic(StatisticsUtil.class)) {
+            statisticsUtilStatic.when(() -> StatisticsUtil.needAnalyzeColumn(Mockito.any(), Mockito.any()))
+                    .thenReturn(false, true, false, true, true);
+            statisticsUtilStatic.when(() -> StatisticsUtil.findTable(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(mockTable);
 
-        new MockUp<StatisticsUtil>() {
-            boolean[] result = {false, true, false, true, true};
-            int i = 0;
-            @Mock
-            public boolean needAnalyzeColumn(TableIf table, Pair<String, String> column) {
-                return result[i++];
-            }
+            QueryColumn column1 = new QueryColumn(1, 2, 3, "col1");
+            QueryColumn column2 = new QueryColumn(1, 2, 3, "col2");
+            QueryColumn column3 = new QueryColumn(1, 2, 3, "col3");
+            QueryColumn column4 = new QueryColumn(1, 2, 3, "col4");
+            Queue<QueryColumn> queue = new BlockingArrayQueue<>();
+            queue.add(column1);
+            queue.add(column2);
+            queue.add(column3);
+            queue.add(column4);
+            queue.add(column4);
+            Assertions.assertEquals(5, queue.size());
 
-            @Mock
-            public TableIf findTable(long catalogId, long dbId, long tblId) {
-                return new OlapTable();
-            }
-        };
-        QueryColumn column1 = new QueryColumn(1, 2, 3, "col1");
-        QueryColumn column2 = new QueryColumn(1, 2, 3, "col2");
-        QueryColumn column3 = new QueryColumn(1, 2, 3, "col3");
-        QueryColumn column4 = new QueryColumn(1, 2, 3, "col4");
-        Queue<QueryColumn> queue = new BlockingArrayQueue<>();
-        queue.add(column1);
-        queue.add(column2);
-        queue.add(column3);
-        queue.add(column4);
-        queue.add(column4);
-        Assertions.assertEquals(5, queue.size());
-
-        FollowerColumnSender sender = new FollowerColumnSender();
-        Set<TQueryColumn> needAnalyzeColumns = sender.getNeedAnalyzeColumns(queue);
-        Assertions.assertEquals(2, needAnalyzeColumns.size());
-        Assertions.assertFalse(needAnalyzeColumns.contains(column1.toThrift()));
-        Assertions.assertTrue(needAnalyzeColumns.contains(column2.toThrift()));
-        Assertions.assertFalse(needAnalyzeColumns.contains(column3.toThrift()));
-        Assertions.assertTrue(needAnalyzeColumns.contains(column4.toThrift()));
+            FollowerColumnSender sender = new FollowerColumnSender();
+            Set<TQueryColumn> needAnalyzeColumns = sender.getNeedAnalyzeColumns(queue);
+            Assertions.assertEquals(2, needAnalyzeColumns.size());
+            Assertions.assertFalse(needAnalyzeColumns.contains(column1.toThrift()));
+            Assertions.assertTrue(needAnalyzeColumns.contains(column2.toThrift()));
+            Assertions.assertFalse(needAnalyzeColumns.contains(column3.toThrift()));
+            Assertions.assertTrue(needAnalyzeColumns.contains(column4.toThrift()));
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/HMSAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/HMSAnalysisTaskTest.java
@@ -29,32 +29,22 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
 
 public class HMSAnalysisTaskTest {
 
     @Test
-    public void testNeedLimit(@Mocked HMSExternalTable tableIf)
-            throws Exception {
+    public void testNeedLimit() throws Exception {
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
+        ArrayList<Column> columns = Lists.newArrayList();
+        columns.add(new Column("int_column", PrimitiveType.INT));
+        Mockito.when(tableIf.getFullSchema()).thenReturn(columns);
 
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public List<Column> getFullSchema() {
-                ArrayList<Column> objects = Lists.newArrayList();
-                objects.add(new Column("int_column", PrimitiveType.INT));
-                return objects;
-            }
-        };
         HMSAnalysisTask task = new HMSAnalysisTask();
         task.setTable(tableIf);
         task.tableSample = new TableSample(true, 10L);
@@ -68,14 +58,11 @@ public class HMSAnalysisTaskTest {
     }
 
     @Test
-    public void testAutoSampleSmallTable(@Mocked HMSExternalTable tableIf)
-            throws Exception {
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public long getDataSize(boolean singleReplica) {
-                return StatisticsUtil.getHugeTableLowerBoundSizeInBytes() - 1;
-            }
-        };
+    public void testAutoSampleSmallTable() throws Exception {
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
+        Mockito.when(tableIf.getDataSize(Mockito.anyBoolean()))
+                .thenReturn(StatisticsUtil.getHugeTableLowerBoundSizeInBytes() - 1);
+
         HMSAnalysisTask task = new HMSAnalysisTask();
         task.tbl = tableIf;
         AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder();
@@ -87,14 +74,10 @@ public class HMSAnalysisTaskTest {
     }
 
     @Test
-    public void testManualFull(@Mocked HMSExternalTable tableIf)
-            throws Exception {
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public long getDataSize(boolean singleReplica) {
-                return 1000;
-            }
-        };
+    public void testManualFull() throws Exception {
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
+        Mockito.when(tableIf.getDataSize(Mockito.anyBoolean())).thenReturn(1000L);
+
         HMSAnalysisTask task = new HMSAnalysisTask();
         task.tbl = tableIf;
         AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder();
@@ -106,14 +89,10 @@ public class HMSAnalysisTaskTest {
     }
 
     @Test
-    public void testManualSample(@Mocked HMSExternalTable tableIf)
-            throws Exception {
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public long getDataSize(boolean singleReplica) {
-                return 1000;
-            }
-        };
+    public void testManualSample() throws Exception {
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
+        Mockito.when(tableIf.getDataSize(Mockito.anyBoolean())).thenReturn(1000L);
+
         HMSAnalysisTask task = new HMSAnalysisTask();
         task.tbl = tableIf;
         AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder();
@@ -127,14 +106,10 @@ public class HMSAnalysisTaskTest {
     }
 
     @Test
-    public void testGetSampleInfo(@Mocked HMSExternalTable tableIf)
-            throws Exception {
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public List<Long> getChunkSizes() {
-                return Lists.newArrayList();
-            }
-        };
+    public void testGetSampleInfo() throws Exception {
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
+        Mockito.when(tableIf.getChunkSizes()).thenReturn(Lists.newArrayList());
+
         HMSAnalysisTask task = new HMSAnalysisTask();
         task.setTable(tableIf);
         task.tableSample = null;
@@ -148,14 +123,10 @@ public class HMSAnalysisTaskTest {
     }
 
     @Test
-    public void testGetSampleInfoPercent(@Mocked HMSExternalTable tableIf)
-            throws Exception {
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public List<Long> getChunkSizes() {
-                return Arrays.asList(1024L, 2048L);
-            }
-        };
+    public void testGetSampleInfoPercent() throws Exception {
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
+        Mockito.when(tableIf.getChunkSizes()).thenReturn(Arrays.asList(1024L, 2048L));
+
         HMSAnalysisTask task = new HMSAnalysisTask();
         task.setTable(tableIf);
         AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder();
@@ -170,50 +141,36 @@ public class HMSAnalysisTaskTest {
         Assertions.assertEquals(2048, info.second);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void testOrdinaryStats(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked HMSExternalTable tableIf)
-            throws Exception {
+    public void testOrdinaryStats() throws Exception {
+        CatalogIf catalogIf = Mockito.mock(CatalogIf.class);
+        DatabaseIf databaseIf = Mockito.mock(DatabaseIf.class);
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
 
-        new Expectations() {
-            {
-                tableIf.getId();
-                result = 30001;
-                tableIf.getName();
-                result = "test";
-                catalogIf.getId();
-                result = 10001;
-                catalogIf.getName();
-                result = "hms";
-                databaseIf.getId();
-                result = 20001;
-                databaseIf.getFullName();
-                result = "default";
-            }
-        };
+        Mockito.when(tableIf.getId()).thenReturn(30001L);
+        Mockito.when(tableIf.getName()).thenReturn("test");
+        Mockito.when(catalogIf.getId()).thenReturn(10001L);
+        Mockito.when(catalogIf.getName()).thenReturn("hms");
+        Mockito.when(databaseIf.getId()).thenReturn(20001L);
+        Mockito.when(databaseIf.getFullName()).thenReturn("default");
+        Mockito.when(tableIf.getPartitionNames()).thenReturn(ImmutableSet.of("date=20230101/hour=12"));
 
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public Set<String> getPartitionNames() {
-                return ImmutableSet.of("date=20230101/hour=12");
-            }
-        };
+        HMSAnalysisTask task = Mockito.spy(new HMSAnalysisTask());
+        Mockito.doAnswer(invocation -> {
+            String sql = invocation.getArgument(0);
+            Assertions.assertEquals("SELECT CONCAT(30001, '-', -1, '-', 'hour') AS `id`, "
+                    + "10001 AS `catalog_id`, 20001 AS `db_id`, 30001 AS `tbl_id`, "
+                    + "-1 AS `idx_id`, 'hour' AS `col_id`, NULL AS `part_id`, "
+                    + "COUNT(1) AS `row_count`, NDV(`hour`) AS `ndv`, "
+                    + "COUNT(1) - COUNT(`hour`) AS `null_count`, "
+                    + "SUBSTRING(CAST(MIN(`hour`) AS STRING), 1, 1024) AS `min`, "
+                    + "SUBSTRING(CAST(MAX(`hour`) AS STRING), 1, 1024) AS `max`, "
+                    + "COUNT(1) * 4 AS `data_size`, NOW() AS `update_time`, "
+                    + "null as `hot_value` FROM `hms`.`default`.`test` ", sql);
+            return null;
+        }).when(task).runQuery(Mockito.anyString());
 
-        new MockUp<HMSAnalysisTask>() {
-            @Mock
-            public void runQuery(String sql) {
-                Assertions.assertEquals("SELECT CONCAT(30001, '-', -1, '-', 'hour') AS `id`, "
-                        + "10001 AS `catalog_id`, 20001 AS `db_id`, 30001 AS `tbl_id`, "
-                        + "-1 AS `idx_id`, 'hour' AS `col_id`, NULL AS `part_id`, "
-                        + "COUNT(1) AS `row_count`, NDV(`hour`) AS `ndv`, "
-                        + "COUNT(1) - COUNT(`hour`) AS `null_count`, "
-                        + "SUBSTRING(CAST(MIN(`hour`) AS STRING), 1, 1024) AS `min`, "
-                        + "SUBSTRING(CAST(MAX(`hour`) AS STRING), 1, 1024) AS `max`, "
-                        + "COUNT(1) * 4 AS `data_size`, NOW() AS `update_time`, "
-                        + "null as `hot_value` FROM `hms`.`default`.`test` ", sql);
-            }
-        };
-
-        HMSAnalysisTask task = new HMSAnalysisTask();
         task.col = new Column("hour", PrimitiveType.INT);
         task.tbl = tableIf;
         task.catalog = catalogIf;
@@ -229,48 +186,32 @@ public class HMSAnalysisTaskTest {
         task.doExecute();
     }
 
-
+    @SuppressWarnings("unchecked")
     @Test
-    public void testPartitionHMSStats(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked HMSExternalTable tableIf)
-            throws Exception {
+    public void testPartitionHMSStats() throws Exception {
+        CatalogIf catalogIf = Mockito.mock(CatalogIf.class);
+        DatabaseIf databaseIf = Mockito.mock(DatabaseIf.class);
+        HMSExternalTable tableIf = Mockito.mock(HMSExternalTable.class);
 
-        new Expectations() {
-            {
-                tableIf.getId();
-                result = 30001;
-                catalogIf.getId();
-                result = 10001;
-                catalogIf.getName();
-                result = "hms";
-                databaseIf.getId();
-                result = 20001;
-            }
-        };
+        Mockito.when(tableIf.getId()).thenReturn(30001L);
+        Mockito.when(catalogIf.getId()).thenReturn(10001L);
+        Mockito.when(catalogIf.getName()).thenReturn("hms");
+        Mockito.when(databaseIf.getId()).thenReturn(20001L);
+        Mockito.when(tableIf.getPartitionNames()).thenReturn(ImmutableSet.of("date=20230101/hour=12"));
+        Mockito.when(tableIf.getPartitionColumns())
+                .thenReturn(ImmutableList.of(new Column("hour", PrimitiveType.INT)));
 
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public Set<String> getPartitionNames() {
-                return ImmutableSet.of("date=20230101/hour=12");
-            }
+        HMSAnalysisTask task = Mockito.spy(new HMSAnalysisTask());
+        Mockito.doAnswer(invocation -> {
+            String sql = invocation.getArgument(0);
+            Assertions.assertEquals(" SELECT CONCAT(30001, '-', -1, '-', 'hour') AS `id`, "
+                    + "10001 AS `catalog_id`, 20001 AS `db_id`, 30001 AS `tbl_id`, -1 AS `idx_id`, "
+                    + "'hour' AS `col_id`, NULL AS `part_id`, 0 AS `row_count`, 1 AS `ndv`, "
+                    + "0 AS `null_count`, SUBSTRING(CAST('12' AS STRING), 1, 1024) AS `min`, "
+                    + "SUBSTRING(CAST('12' AS STRING), 1, 1024) AS `max`, 0 AS `data_size`, NOW() ", sql);
+            return null;
+        }).when(task).runQuery(Mockito.anyString());
 
-            @Mock
-            public List<Column> getPartitionColumns() {
-                return ImmutableList.of(new Column("hour", PrimitiveType.INT));
-            }
-        };
-
-        new MockUp<HMSAnalysisTask>() {
-            @Mock
-            public void runQuery(String sql) {
-                Assertions.assertEquals(" SELECT CONCAT(30001, '-', -1, '-', 'hour') AS `id`, "
-                        + "10001 AS `catalog_id`, 20001 AS `db_id`, 30001 AS `tbl_id`, -1 AS `idx_id`, "
-                        + "'hour' AS `col_id`, NULL AS `part_id`, 0 AS `row_count`, 1 AS `ndv`, "
-                        + "0 AS `null_count`, SUBSTRING(CAST('12' AS STRING), 1, 1024) AS `min`, "
-                        + "SUBSTRING(CAST('12' AS STRING), 1, 1024) AS `max`, 0 AS `data_size`, NOW() ", sql);
-            }
-        };
-
-        HMSAnalysisTask task = new HMSAnalysisTask();
         task.col = new Column("hour", PrimitiveType.INT);
         task.tbl = tableIf;
         task.catalog = catalogIf;

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTaskTest.java
@@ -23,7 +23,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
@@ -33,14 +32,14 @@ import org.apache.doris.statistics.util.DBObjects;
 import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.FixMethodOrder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.runners.MethodSorters;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
@@ -79,8 +78,11 @@ public class HistogramTaskTest extends TestWithFeService {
                 "ANALYZE TABLE t1(col1) WITH HISTOGRAM");
         Assertions.assertNotNull(executor);
 
+        Field f = AnalysisManager.class.getDeclaredField("analysisJobIdToTaskMap");
+        f.setAccessible(true);
+        @SuppressWarnings("unchecked")
         ConcurrentMap<Long, Map<Long, BaseAnalysisTask>> taskMap =
-                Deencapsulation.getField(analysisManager, "analysisJobIdToTaskMap");
+                (ConcurrentMap<Long, Map<Long, BaseAnalysisTask>>) f.get(analysisManager);
         Assertions.assertEquals(1, taskMap.size());
 
         for (Entry<Long, Map<Long, BaseAnalysisTask>> infoMap : taskMap.entrySet()) {
@@ -95,38 +97,45 @@ public class HistogramTaskTest extends TestWithFeService {
     }
 
     @Test
-    public void test2TaskExecution(@Mocked InternalCatalog catalog, @Mocked Database database,
-            @Mocked OlapTable olapTable) throws Exception {
-        new MockUp<StatisticsUtil>() {
+    public void test2TaskExecution() throws Exception {
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
 
-            @Mock
-            public DBObjects convertIdToObjects(long catalogId, long dbId, long tblId) {
-                return new DBObjects(catalog, database, olapTable);
+        Mockito.when(olapTable.getColumn(Mockito.anyString()))
+                .thenReturn(new Column("col1", PrimitiveType.INT));
+
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil =
+                     Mockito.mockStatic(StatisticsUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedStatisticsUtil.when(() -> StatisticsUtil.convertIdToObjects(
+                    Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(new DBObjects(catalog, database, olapTable));
+
+            AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
+            AnalysisInfo analysisInfo = new AnalysisInfoBuilder()
+                    .setJobId(0).setTaskId(0).setCatalogId(0)
+                    .setDBId(0)
+                    .setTblId(0)
+                    .setColName("col1").setJobType(JobType.MANUAL)
+                    .setAnalysisMethod(AnalysisMethod.FULL)
+                    .setAnalysisType(AnalysisType.HISTOGRAM)
+                    .build();
+            HistogramTask task = new HistogramTask(analysisInfo);
+
+            // Spy the real AnalysisManager to make updateTaskStatus a no-op
+            AnalysisManager realManager = Env.getCurrentEnv().getAnalysisManager();
+            AnalysisManager spiedManager = Mockito.spy(realManager);
+            Mockito.doNothing().when(spiedManager).updateTaskStatus(
+                    Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyLong());
+
+            Field amField = Env.class.getDeclaredField("analysisManager");
+            amField.setAccessible(true);
+            amField.set(Env.getCurrentEnv(), spiedManager);
+            try {
+                analysisTaskExecutor.submitTask(task);
+            } finally {
+                amField.set(Env.getCurrentEnv(), realManager);
             }
-        };
-        new MockUp<OlapTable>() {
-
-            @Mock
-            public Column getColumn(String name) {
-                return new Column("col1", PrimitiveType.INT);
-            }
-        };
-        AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(1);
-        AnalysisInfo analysisInfo = new AnalysisInfoBuilder()
-                .setJobId(0).setTaskId(0).setCatalogId(0)
-                .setDBId(0)
-                .setTblId(0)
-                .setColName("col1").setJobType(JobType.MANUAL)
-                .setAnalysisMethod(AnalysisMethod.FULL)
-                .setAnalysisType(AnalysisType.HISTOGRAM)
-                .build();
-        HistogramTask task = new HistogramTask(analysisInfo);
-
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public void updateTaskStatus(AnalysisInfo info, AnalysisState jobState, String message, long time) {}
-        };
-
-        Deencapsulation.invoke(analysisTaskExecutor, "submitTask", task);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/MVStatisticsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/MVStatisticsTest.java
@@ -19,20 +19,18 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.statistics.util.StatisticsUtil;
 import org.apache.doris.utframe.TestWithFeService;
 
-import mockit.Injectable;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Tested;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
 
 public class MVStatisticsTest extends TestWithFeService {
 
-    @Injectable
-    StatisticsCache statisticsCache;
+    StatisticsCache statisticsCache = Mockito.mock(StatisticsCache.class);
 
     @Override
     protected void runBeforeAll() throws Exception {
@@ -48,32 +46,20 @@ public class MVStatisticsTest extends TestWithFeService {
         createMv("CREATE MATERIALIZED VIEW mv1 AS SELECT col3 as a1 , SUM(COL2) FROM t1 group by col3");
     }
 
-    @Tested
-
     @Test
     public void testCreate() throws Exception {
-        new MockUp<StatisticsRepository>() {
-        };
-        new MockUp<StatisticsUtil>() {
+        try (MockedStatic<StatisticsUtil> mockedStatsUtil =
+                     Mockito.mockStatic(StatisticsUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedStatsUtil.when(() -> StatisticsUtil.execUpdate(Mockito.anyString()))
+                    .thenReturn(null);
 
-            @Mock
-            public void execUpdate(String sql) throws Exception {}
-        };
-        new MockUp<OlapAnalysisTask>(OlapAnalysisTask.class) {
+            AnalysisManager analysisManager = Env.getCurrentEnv().getAnalysisManager();
+            Field f = AnalysisManager.class.getDeclaredField("statisticsCache");
+            f.setAccessible(true);
+            f.set(analysisManager, statisticsCache);
 
-            @Mock
-            public void execSQL(String sql) throws Exception {}
-        };
-        new MockUp<Env>() {
-
-            @Mock
-            public StatisticsCache getStatisticsCache() {
-                return statisticsCache;
-            }
-        };
-        AnalysisManager analysisManager = Env.getCurrentEnv().getAnalysisManager();
-        Deencapsulation.setField(analysisManager, "statisticsCache", statisticsCache);
-        getSqlStmtExecutor("analyze table t1");
-        Thread.sleep(3000);
+            getSqlStmtExecutor("analyze table t1");
+            Thread.sleep(3000);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -34,7 +34,6 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RandomDistributionInfo;
 import org.apache.doris.catalog.RangePartitionItem;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeConstants;
@@ -48,13 +47,12 @@ import org.apache.doris.thrift.TStorageMedium;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.apache.commons.text.StringSubstitutor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -66,7 +64,8 @@ public class OlapAnalysisTaskTest {
 
     // test manual
     @Test
-    public void testSample1(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked TableIf tableIf) {
+    public void testSample1() {
+        TableIf tableIf = Mockito.mock(TableIf.class);
 
         AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder()
                 .setAnalysisMethod(AnalysisMethod.FULL);
@@ -88,14 +87,9 @@ public class OlapAnalysisTaskTest {
 
     // test auto small table
     @Test
-    public void testSample3(@Mocked OlapTable tbl) {
-        new MockUp<OlapTable>() {
-
-            @Mock
-            public long getDataSize(boolean singleReplica) {
-                return StatisticsUtil.getHugeTableLowerBoundSizeInBytes() - 1;
-            }
-        };
+    public void testSample3() {
+        OlapTable tbl = Mockito.mock(OlapTable.class);
+        Mockito.when(tbl.getDataSize(ArgumentMatchers.anyBoolean())).thenReturn(StatisticsUtil.getHugeTableLowerBoundSizeInBytes() - 1);
 
         AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder()
                 .setAnalysisMethod(AnalysisMethod.FULL);
@@ -108,60 +102,40 @@ public class OlapAnalysisTaskTest {
     }
 
     @Test
-    public void testKeyColumnUseLimitAndNot(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked OlapTable tableIf) {
+    public void testKeyColumnUseLimitAndNot() {
+        CatalogIf catalogIf = Mockito.mock(CatalogIf.class);
+        DatabaseIf databaseIf = Mockito.mock(DatabaseIf.class);
+        OlapTable tableIf = Mockito.mock(OlapTable.class);
 
-        new Expectations() {
-            {
-                tableIf.getRowCount();
-                result = 20000000;
-                tableIf.getId();
-                result = 30001;
-                catalogIf.getId();
-                result = 10001;
-                catalogIf.getName();
-                result = "catalogName";
-                databaseIf.getId();
-                result = 20001;
-            }
-        };
+        Mockito.when(tableIf.getRowCount()).thenReturn(20000000L);
+        Mockito.when(tableIf.getId()).thenReturn(30001L);
+        Mockito.when(catalogIf.getId()).thenReturn(10001L);
+        Mockito.when(catalogIf.getName()).thenReturn("catalogName");
+        Mockito.when(databaseIf.getId()).thenReturn(20001L);
 
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            public ResultRow collectMinMax() {
-                List<String> values = Lists.newArrayList();
-                values.add("1");
-                values.add("2");
-                return new ResultRow(values);
-            }
+        OlapAnalysisTask olapAnalysisTask = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(new ResultRow(Lists.newArrayList("1", "2"))).when(olapAnalysisTask).collectMinMax();
+        Mockito.doNothing().when(olapAnalysisTask).getSampleParams(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
+        Mockito.doReturn(true).when(olapAnalysisTask).useLinearAnalyzeTemplate();
+        Mockito.doAnswer(inv -> {
+            String sql = inv.getArgument(0);
+            Assertions.assertEquals("WITH cte1 AS (SELECT `null` FROM `catalogName`.`${dbName}`.`null`  "
+                    + "${sampleHints} ${limit} ), cte2 AS (SELECT CONCAT(30001, '-', -1, '-', 'null') AS `id`, "
+                    + "10001 AS `catalog_id`, 20001 AS `db_id`, 30001 AS `tbl_id`, -1 AS `idx_id`, "
+                    + "'null' AS `col_id`, NULL AS `part_id`, ${rowCount} AS `row_count`, ${ndvFunction} as `ndv`, "
+                    + "ROUND(SUM(CASE WHEN `null` IS NULL THEN 1 ELSE 0 END) * ${scaleFactor}) AS `null_count`, "
+                    + "SUBSTRING(CAST('1' AS STRING), 1, 1024) AS `min`, "
+                    + "SUBSTRING(CAST('2' AS STRING), 1, 1024) AS `max`, "
+                    + "COUNT(1) * 4 * ${scaleFactor} AS `data_size`, NOW() FROM cte1), "
+                    + "cte3 AS (SELECT GROUP_CONCAT(CONCAT(REPLACE(REPLACE(t.`column_key`, "
+                    + "\":\", \"\\\\:\"), \";\", \"\\\\;\"), \" :\", ROUND(t.`count` / ${rowCount2}, 2)), "
+                    + "\" ;\") as `hot_value` FROM (SELECT ${subStringColName} as `hash_value`, "
+                    + "MAX(`null`) as `column_key`, COUNT(1) AS `count` FROM cte1 "
+                    + "WHERE `null` IS NOT NULL GROUP BY `hash_value` ORDER BY `count` DESC LIMIT 10) t) "
+                    + "SELECT * FROM cte2 CROSS JOIN cte3", sql);
+            return null;
+        }).when(olapAnalysisTask).runQuery(ArgumentMatchers.anyString());
 
-            @Mock
-            void getSampleParams(Map<String, String> params, long tableRowCount) {}
-
-            @Mock
-            boolean useLinearAnalyzeTemplate() {
-                return true;
-            }
-
-                @Mock
-            public void runQuery(String sql) {
-                Assertions.assertEquals("WITH cte1 AS (SELECT `null` FROM `catalogName`.`${dbName}`.`null`  "
-                        + "${sampleHints} ${limit} ), cte2 AS (SELECT CONCAT(30001, '-', -1, '-', 'null') AS `id`, "
-                        + "10001 AS `catalog_id`, 20001 AS `db_id`, 30001 AS `tbl_id`, -1 AS `idx_id`, "
-                        + "'null' AS `col_id`, NULL AS `part_id`, ${rowCount} AS `row_count`, ${ndvFunction} as `ndv`, "
-                        + "ROUND(SUM(CASE WHEN `null` IS NULL THEN 1 ELSE 0 END) * ${scaleFactor}) AS `null_count`, "
-                        + "SUBSTRING(CAST('1' AS STRING), 1, 1024) AS `min`, "
-                        + "SUBSTRING(CAST('2' AS STRING), 1, 1024) AS `max`, "
-                        + "COUNT(1) * 4 * ${scaleFactor} AS `data_size`, NOW() FROM cte1), "
-                        + "cte3 AS (SELECT GROUP_CONCAT(CONCAT(REPLACE(REPLACE(t.`column_key`, "
-                        + "\":\", \"\\\\:\"), \";\", \"\\\\;\"), \" :\", ROUND(t.`count` / ${rowCount2}, 2)), "
-                        + "\" ;\") as `hot_value` FROM (SELECT ${subStringColName} as `hash_value`, "
-                        + "MAX(`null`) as `column_key`, COUNT(1) AS `count` FROM cte1 "
-                        + "WHERE `null` IS NOT NULL GROUP BY `hash_value` ORDER BY `count` DESC LIMIT 10) t) "
-                        + "SELECT * FROM cte2 CROSS JOIN cte3", sql);
-            }
-        };
-
-        OlapAnalysisTask olapAnalysisTask = new OlapAnalysisTask();
         olapAnalysisTask.col = new Column("test", Type.fromPrimitiveType(PrimitiveType.INT),
             true, null, null, null);
         olapAnalysisTask.tbl = tableIf;
@@ -173,50 +147,35 @@ public class OlapAnalysisTaskTest {
         olapAnalysisTask.tableSample = new TableSample(false, 100L);
         olapAnalysisTask.doSample();
 
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            public void runQuery(String sql) {
-                Assertions.assertEquals("WITH cte1 AS (SELECT MAX(t0.`col_value`) as `col_value`, COUNT(1) as `count`,"
-                        + " SUM(`len`) as `column_length` FROM (SELECT ${subStringColName} AS `hash_value`, "
-                        + "`null` AS `col_value`, LENGTH(`null`) as `len` FROM `catalogName`.`${dbName}`.`null`  "
-                        + "${sampleHints} ${limit}) as `t0`  GROUP BY `t0`.`hash_value`), "
-                        + "cte2 AS ( SELECT CONCAT('30001', '-', '-1', '-', 'null') AS `id`, 10001 AS `catalog_id`, "
-                        + "20001 AS `db_id`, 30001 AS `tbl_id`, -1 AS `idx_id`, 'null' AS `col_id`, NULL AS `part_id`, "
-                        + "${rowCount} AS `row_count`, ${ndvFunction} as `ndv`, IFNULL(SUM(IF(`t1`.`col_value` "
-                        + "IS NULL, `t1`.`count`, 0)), 0) * ${scaleFactor} as `null_count`, SUBSTRING(CAST('1' "
-                        + "AS STRING), 1, 1024) AS `min`, SUBSTRING(CAST('2' AS STRING), 1, 1024) AS `max`, "
-                        + "COUNT(1) * 4 * ${scaleFactor} AS `data_size`, NOW() FROM cte1 t1), cte3 AS (SELECT "
-                        + "GROUP_CONCAT(CONCAT(REPLACE(REPLACE(t2.`col_value`, \":\", \"\\\\:\"), \";\", \"\\\\;\"), "
-                        + "\" :\", ROUND(t2.`count` / ${rowCount2}, 2)), \" ;\") as `hot_value` FROM (SELECT "
-                        + "`col_value`, `count` FROM cte1 WHERE `col_value` IS NOT NULL ORDER BY `count` DESC LIMIT 10) "
-                        + "t2) SELECT * FROM cte2 CROSS JOIN cte3", sql);
-            }
-
-            @Mock
-            boolean useLinearAnalyzeTemplate() {
-                return false;
-            }
-        };
+        Mockito.doAnswer(inv -> {
+            String sql = inv.getArgument(0);
+            Assertions.assertEquals("WITH cte1 AS (SELECT MAX(t0.`col_value`) as `col_value`, COUNT(1) as `count`,"
+                    + " SUM(`len`) as `column_length` FROM (SELECT ${subStringColName} AS `hash_value`, "
+                    + "`null` AS `col_value`, LENGTH(`null`) as `len` FROM `catalogName`.`${dbName}`.`null`  "
+                    + "${sampleHints} ${limit}) as `t0`  GROUP BY `t0`.`hash_value`), "
+                    + "cte2 AS ( SELECT CONCAT('30001', '-', '-1', '-', 'null') AS `id`, 10001 AS `catalog_id`, "
+                    + "20001 AS `db_id`, 30001 AS `tbl_id`, -1 AS `idx_id`, 'null' AS `col_id`, NULL AS `part_id`, "
+                    + "${rowCount} AS `row_count`, ${ndvFunction} as `ndv`, IFNULL(SUM(IF(`t1`.`col_value` "
+                    + "IS NULL, `t1`.`count`, 0)), 0) * ${scaleFactor} as `null_count`, SUBSTRING(CAST('1' "
+                    + "AS STRING), 1, 1024) AS `min`, SUBSTRING(CAST('2' AS STRING), 1, 1024) AS `max`, "
+                    + "COUNT(1) * 4 * ${scaleFactor} AS `data_size`, NOW() FROM cte1 t1), cte3 AS (SELECT "
+                    + "GROUP_CONCAT(CONCAT(REPLACE(REPLACE(t2.`col_value`, \":\", \"\\\\:\"), \";\", \"\\\\;\"), "
+                    + "\" :\", ROUND(t2.`count` / ${rowCount2}, 2)), \" ;\") as `hot_value` FROM (SELECT "
+                    + "`col_value`, `count` FROM cte1 WHERE `col_value` IS NOT NULL ORDER BY `count` DESC LIMIT 10) "
+                    + "t2) SELECT * FROM cte2 CROSS JOIN cte3", sql);
+            return null;
+        }).when(olapAnalysisTask).runQuery(ArgumentMatchers.anyString());
+        Mockito.doReturn(false).when(olapAnalysisTask).useLinearAnalyzeTemplate();
         olapAnalysisTask.doSample();
     }
 
     @Test
-    public void testNeedLimitFalse(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked OlapTable tableIf)
-            throws Exception {
-
-        new MockUp<OlapTable>() {
-            @Mock
-            public PartitionInfo getPartitionInfo() {
-                ArrayList<Column> columns = Lists.newArrayList();
-                columns.add(new Column("test", PrimitiveType.STRING));
-                return new PartitionInfo(PartitionType.RANGE, columns);
-            }
-
-            @Mock
-            public boolean isPartitionColumn(Column column) {
-                return true;
-            }
-        };
+    public void testNeedLimitFalse() throws Exception {
+        OlapTable tableIf = Mockito.mock(OlapTable.class);
+        ArrayList<Column> columns = Lists.newArrayList();
+        columns.add(new Column("test", PrimitiveType.STRING));
+        Mockito.when(tableIf.getPartitionInfo()).thenReturn(new PartitionInfo(PartitionType.RANGE, columns));
+        Mockito.when(tableIf.isPartitionColumn(ArgumentMatchers.any())).thenReturn(true);
 
         OlapAnalysisTask olapAnalysisTask = new OlapAnalysisTask();
         olapAnalysisTask.col = new Column("test", Type.fromPrimitiveType(PrimitiveType.STRING),
@@ -230,17 +189,11 @@ public class OlapAnalysisTaskTest {
     }
 
     @Test
-    public void testNeedLimitTrue(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked OlapTable tableIf)
-            throws Exception {
-
-        new MockUp<OlapTable>() {
-            @Mock
-            public PartitionInfo getPartitionInfo() {
-                ArrayList<Column> columns = Lists.newArrayList();
-                columns.add(new Column("NOFOUND", PrimitiveType.STRING));
-                return new PartitionInfo(PartitionType.RANGE, columns);
-            }
-        };
+    public void testNeedLimitTrue() throws Exception {
+        OlapTable tableIf = Mockito.mock(OlapTable.class);
+        ArrayList<Column> columns = Lists.newArrayList();
+        columns.add(new Column("NOFOUND", PrimitiveType.STRING));
+        Mockito.when(tableIf.getPartitionInfo()).thenReturn(new PartitionInfo(PartitionType.RANGE, columns));
 
         OlapAnalysisTask olapAnalysisTask = new OlapAnalysisTask();
         olapAnalysisTask.tbl = tableIf;
@@ -259,50 +212,37 @@ public class OlapAnalysisTaskTest {
         OlapAnalysisTask task = new OlapAnalysisTask();
         AnalysisInfoBuilder builder = new AnalysisInfoBuilder();
         task.info = builder.setIndexId(-1L).build();
-        task.setTable(new OlapTable());
-        Partition p1 = new Partition(1, "p1", new MaterializedIndex(), new RandomDistributionInfo());
-        Partition p2 = new Partition(2, "p2", new MaterializedIndex(), new RandomDistributionInfo());
-        Partition p3 = new Partition(3, "p3", new MaterializedIndex(), new RandomDistributionInfo());
+
+        OlapTable olapTable = Mockito.mock(OlapTable.class);
+        Mockito.when(olapTable.getRowCount()).thenReturn(1000000000L);
+        task.setTable(olapTable);
+
+        Partition p1 = Mockito.mock(Partition.class);
+        Partition p2 = Mockito.mock(Partition.class);
+        Partition p3 = Mockito.mock(Partition.class);
+        Mockito.when(p1.getId()).thenReturn(1L);
+        Mockito.when(p2.getId()).thenReturn(2L);
+        Mockito.when(p3.getId()).thenReturn(3L);
+        Mockito.when(p1.getRowCount()).thenReturn(400000000L);
+        Mockito.when(p2.getRowCount()).thenReturn(100000000L);
+        Mockito.when(p3.getRowCount()).thenReturn(500000000L);
+
+        MaterializedIndex idx1 = Mockito.mock(MaterializedIndex.class);
+        MaterializedIndex idx2 = Mockito.mock(MaterializedIndex.class);
+        MaterializedIndex idx3 = Mockito.mock(MaterializedIndex.class);
+        Mockito.when(idx1.getTabletIdsInOrder()).thenReturn(Lists.newArrayList(0L, 1L));
+        Mockito.when(idx2.getTabletIdsInOrder()).thenReturn(Lists.newArrayList(2L, 3L));
+        Mockito.when(idx3.getTabletIdsInOrder()).thenReturn(Lists.newArrayList(2L, 3L));
+        Mockito.when(p1.getIndex(ArgumentMatchers.anyLong())).thenReturn(idx1);
+        Mockito.when(p2.getIndex(ArgumentMatchers.anyLong())).thenReturn(idx2);
+        Mockito.when(p3.getIndex(ArgumentMatchers.anyLong())).thenReturn(idx3);
+
         List<Partition> partitions = Lists.newArrayList();
         partitions.add(p1);
         partitions.add(p2);
         partitions.add(p3);
         List<Long> ids = Lists.newArrayList();
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCount() {
-                return 1000000000L;
-            }
-        };
-
-        long[] partitionRows = new long[3];
-        partitionRows[0] = 400000000L;
-        partitionRows[1] = 100000000L;
-        partitionRows[2] = 500000000L;
-        final int[] i = {0};
-        new MockUp<Partition>() {
-            @Mock
-            public long getRowCount() {
-                return partitionRows[i[0]++];
-            }
-
-            @Mock
-            public MaterializedIndex getIndex(long indexId) {
-                return new MaterializedIndex();
-            }
-        };
-
-        final int[] j = {0};
-        new MockUp<MaterializedIndex>() {
-            @Mock
-            public List<Long> getTabletIdsInOrder() {
-                List<Long> ret = new ArrayList<>();
-                ret.add((long) j[0]++);
-                ret.add((long) j[0]++);
-                return ret;
-            }
-        };
         long rows = task.pickSamplePartition(partitions, ids, 0);
         Assertions.assertEquals(900000000, rows);
         Assertions.assertEquals(4, ids.size());
@@ -324,52 +264,24 @@ public class OlapAnalysisTaskTest {
 
         task.setScanFullTable(false);
         task.setPartitionColumnSampleTooManyRows(false);
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            protected boolean isSingleUniqueKey() {
-                return true;
-            }
-        };
-        Assertions.assertTrue(task.useLinearAnalyzeTemplate());
+        OlapAnalysisTask spyTask = Mockito.spy(task);
+        Mockito.doReturn(true).when(spyTask).isSingleUniqueKey();
+        Assertions.assertTrue(spyTask.useLinearAnalyzeTemplate());
     }
 
     @Test
     public void testGetSampleParams() {
-        OlapAnalysisTask task = new OlapAnalysisTask();
+        OlapAnalysisTask task = Mockito.spy(new OlapAnalysisTask());
         Map<String, String> params = Maps.newHashMap();
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            protected long getSampleRows() {
-                return 100;
-            }
+        Mockito.doReturn(100L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(false).when(task).needLimit();
+        Mockito.doReturn(false).when(task).useLinearAnalyzeTemplate();
 
-            @Mock
-            protected Pair<List<Long>, Long> getSampleTablets() {
-                List<Long> ids = Lists.newArrayList();
-                ids.add(1L);
-                ids.add(2L);
-                return Pair.of(ids, 100L);
-            }
-
-            @Mock
-            protected boolean needLimit() {
-                return false;
-            }
-
-            @Mock
-            protected boolean useLinearAnalyzeTemplate() {
-                return false;
-            }
-        };
-
-        new MockUp<OlapTable>() {
-            @Mock
-            public KeysType getKeysType() {
-                return KeysType.DUP_KEYS;
-            }
-        };
+        OlapTable mockTable = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable.getKeysType()).thenReturn(KeysType.DUP_KEYS);
         task.col = new Column("testColumn", Type.INT, true, null, null, "");
-        task.setTable(new OlapTable());
+        task.setTable(mockTable);
         task.getSampleParams(params, 10);
         Assertions.assertTrue(task.scanFullTable());
         Assertions.assertEquals("1", params.get("scaleFactor"));
@@ -383,15 +295,15 @@ public class OlapAnalysisTaskTest {
         Assertions.assertEquals("10000", params.get("rowCount"));
         params.clear();
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public KeysType getKeysType() {
-                return KeysType.AGG_KEYS;
-            }
-        };
-        task = new OlapAnalysisTask();
+        OlapTable mockTable2 = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable2.getKeysType()).thenReturn(KeysType.AGG_KEYS);
+        task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(100L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(false).when(task).needLimit();
+        Mockito.doReturn(false).when(task).useLinearAnalyzeTemplate();
         task.col = new Column("testColumn", Type.INT, false, null, null, "");
-        task.setTable(new OlapTable());
+        task.setTable(mockTable2);
         task.getSampleParams(params, 1000);
         Assertions.assertEquals("10.0", params.get("scaleFactor"));
         Assertions.assertEquals("TABLET(1, 2)", params.get("sampleHints"));
@@ -401,87 +313,76 @@ public class OlapAnalysisTaskTest {
         Assertions.assertEquals("/*+PREAGGOPEN*/", params.get("preAggHint"));
         params.clear();
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public KeysType getKeysType() {
-                return KeysType.UNIQUE_KEYS;
-            }
-
-            @Mock
-            public boolean isUniqKeyMergeOnWrite() {
-                return false;
-            }
-        };
-        task = new OlapAnalysisTask();
+        OlapTable mockTable3 = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable3.getKeysType()).thenReturn(KeysType.UNIQUE_KEYS);
+        Mockito.when(mockTable3.isUniqKeyMergeOnWrite()).thenReturn(false);
+        task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(100L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(false).when(task).needLimit();
+        Mockito.doReturn(false).when(task).useLinearAnalyzeTemplate();
         task.col = new Column("testColumn", Type.INT, false, null, null, "");
-        task.setTable(new OlapTable());
+        task.setTable(mockTable3);
         task.getSampleParams(params, 1000);
         Assertions.assertEquals("/*+PREAGGOPEN*/", params.get("preAggHint"));
         params.clear();
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public boolean isUniqKeyMergeOnWrite() {
-                return true;
-            }
-        };
-        task = new OlapAnalysisTask();
+        OlapTable mockTable4 = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable4.getKeysType()).thenReturn(KeysType.UNIQUE_KEYS);
+        Mockito.when(mockTable4.isUniqKeyMergeOnWrite()).thenReturn(true);
+        task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(100L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(false).when(task).needLimit();
+        Mockito.doReturn(false).when(task).useLinearAnalyzeTemplate();
         task.col = new Column("testColumn", Type.INT, false, null, null, "");
-        task.setTable(new OlapTable());
+        task.setTable(mockTable4);
         task.getSampleParams(params, 1000);
         Assertions.assertNull(params.get("preAggHint"));
         params.clear();
 
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            protected boolean useLinearAnalyzeTemplate() {
-                return true;
-            }
-
-            @Mock
-            protected boolean isSingleUniqueKey() {
-                return false;
-            }
-        };
-
-        task = new OlapAnalysisTask();
+        task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(100L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(false).when(task).needLimit();
+        Mockito.doReturn(true).when(task).useLinearAnalyzeTemplate();
+        Mockito.doReturn(false).when(task).isSingleUniqueKey();
+        OlapTable mockTable5 = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable5.getKeysType()).thenReturn(KeysType.DUP_KEYS);
         task.col = new Column("test", PrimitiveType.INT);
-        task.setTable(new OlapTable());
+        task.setTable(mockTable5);
         task.getSampleParams(params, 1000);
         Assertions.assertEquals("10.0", params.get("scaleFactor"));
         Assertions.assertEquals("TABLET(1, 2)", params.get("sampleHints"));
         Assertions.assertEquals("ROUND(NDV(`${colName}`) * ${scaleFactor})", params.get("ndvFunction"));
         params.clear();
 
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            protected boolean isSingleUniqueKey() {
-                return true;
-            }
-        };
-        task = new OlapAnalysisTask();
+        task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(100L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(false).when(task).needLimit();
+        Mockito.doReturn(true).when(task).useLinearAnalyzeTemplate();
+        Mockito.doReturn(true).when(task).isSingleUniqueKey();
+        OlapTable mockTable6 = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable6.getKeysType()).thenReturn(KeysType.DUP_KEYS);
         task.col = new Column("test", PrimitiveType.INT);
-        task.setTable(new OlapTable());
+        task.setTable(mockTable6);
         task.getSampleParams(params, 1000);
         Assertions.assertEquals("10.0", params.get("scaleFactor"));
         Assertions.assertEquals("TABLET(1, 2)", params.get("sampleHints"));
         Assertions.assertEquals("1000", params.get("ndvFunction"));
         params.clear();
 
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            protected boolean needLimit() {
-                return true;
-            }
-
-            @Mock
-            protected long getSampleRows() {
-                return 50;
-            }
-        };
-        task = new OlapAnalysisTask();
+        task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(50L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(true).when(task).needLimit();
+        Mockito.doReturn(true).when(task).useLinearAnalyzeTemplate();
+        Mockito.doReturn(true).when(task).isSingleUniqueKey();
+        OlapTable mockTable7 = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable7.getKeysType()).thenReturn(KeysType.DUP_KEYS);
         task.col = new Column("test", PrimitiveType.INT);
-        task.setTable(new OlapTable());
+        task.setTable(mockTable7);
         task.getSampleParams(params, 1000);
         Assertions.assertEquals("20.0", params.get("scaleFactor"));
         Assertions.assertEquals("TABLET(1, 2)", params.get("sampleHints"));
@@ -489,11 +390,18 @@ public class OlapAnalysisTaskTest {
         Assertions.assertEquals("limit 50", params.get("limit"));
         params.clear();
 
-        task = new OlapAnalysisTask();
+        task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(50L).when(task).getSampleRows();
+        Mockito.doReturn(Pair.of(Lists.newArrayList(1L, 2L), 100L)).when(task).getSampleTablets();
+        Mockito.doReturn(true).when(task).needLimit();
+        Mockito.doReturn(true).when(task).useLinearAnalyzeTemplate();
+        Mockito.doReturn(true).when(task).isSingleUniqueKey();
+        OlapTable mockTable8 = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable8.getKeysType()).thenReturn(KeysType.DUP_KEYS);
         task.col = new Column("test", Type.fromPrimitiveType(PrimitiveType.INT),
             true, null, null, null);
         task.setKeyColumnSampleTooManyRows(true);
-        task.setTable(new OlapTable());
+        task.setTable(mockTable8);
         task.getSampleParams(params, 2000000000);
         Assertions.assertEquals("2.0", params.get("scaleFactor"));
         Assertions.assertEquals("TABLET(1, 2)", params.get("sampleHints"));
@@ -502,7 +410,9 @@ public class OlapAnalysisTaskTest {
     }
 
     @Test
-    public void testGetSkipPartitionId(@Mocked OlapTable tableIf) throws AnalysisException {
+    public void testGetSkipPartitionId() throws AnalysisException {
+        OlapTable tableIf = Mockito.mock(OlapTable.class);
+
         // test null partition list
         OlapAnalysisTask task = new OlapAnalysisTask();
         long skipPartitionId = task.getSkipPartitionId(null);
@@ -527,48 +437,28 @@ public class OlapAnalysisTaskTest {
         }
 
         // Test List partition return NO_SKIP_TABLET_ID
-        new MockUp<OlapTable>() {
-            @Mock
-            public PartitionInfo getPartitionInfo() {
-                return new PartitionInfo(PartitionType.LIST);
-            }
-        };
+        Mockito.when(tableIf.getPartitionInfo()).thenReturn(new PartitionInfo(PartitionType.LIST));
         task.tbl = tableIf;
         skipPartitionId = task.getSkipPartitionId(partitions);
         Assertions.assertEquals(OlapAnalysisTask.NO_SKIP_TABLET_ID, skipPartitionId);
 
         // Test Unpartition return NO_SKIP_TABLET_ID
-        new MockUp<OlapTable>() {
-            @Mock
-            public PartitionInfo getPartitionInfo() {
-                return new PartitionInfo(PartitionType.UNPARTITIONED);
-            }
-        };
+        Mockito.when(tableIf.getPartitionInfo()).thenReturn(new PartitionInfo(PartitionType.UNPARTITIONED));
         skipPartitionId = task.getSkipPartitionId(partitions);
         Assertions.assertEquals(OlapAnalysisTask.NO_SKIP_TABLET_ID, skipPartitionId);
 
         // Test more than 1 partition column return NO_SKIP_TABLET_ID
-        new MockUp<OlapTable>() {
-            @Mock
-            public PartitionInfo getPartitionInfo() {
-                ArrayList<Column> columns = Lists.newArrayList();
-                columns.add(new Column("col1", PrimitiveType.DATEV2));
-                columns.add(new Column("col2", PrimitiveType.DATEV2));
-                return new PartitionInfo(PartitionType.RANGE, columns);
-            }
-        };
+        ArrayList<Column> multiColumns = Lists.newArrayList();
+        multiColumns.add(new Column("col1", PrimitiveType.DATEV2));
+        multiColumns.add(new Column("col2", PrimitiveType.DATEV2));
+        Mockito.when(tableIf.getPartitionInfo()).thenReturn(new PartitionInfo(PartitionType.RANGE, multiColumns));
         skipPartitionId = task.getSkipPartitionId(partitions);
         Assertions.assertEquals(OlapAnalysisTask.NO_SKIP_TABLET_ID, skipPartitionId);
 
         // Test not Date type return NO_SKIP_TABLET_ID
-        new MockUp<OlapTable>() {
-            @Mock
-            public PartitionInfo getPartitionInfo() {
-                ArrayList<Column> columns = Lists.newArrayList();
-                columns.add(new Column("col1", PrimitiveType.STRING));
-                return new PartitionInfo(PartitionType.RANGE, columns);
-            }
-        };
+        ArrayList<Column> stringColumns = Lists.newArrayList();
+        stringColumns.add(new Column("col1", PrimitiveType.STRING));
+        Mockito.when(tableIf.getPartitionInfo()).thenReturn(new PartitionInfo(PartitionType.RANGE, stringColumns));
         skipPartitionId = task.getSkipPartitionId(partitions);
         Assertions.assertEquals(OlapAnalysisTask.NO_SKIP_TABLET_ID, skipPartitionId);
 
@@ -606,111 +496,72 @@ public class OlapAnalysisTaskTest {
         partitionInfo.addPartition(2, false, item2, new DataProperty(TStorageMedium.HDD), null, false, false);
         partitionInfo.addPartition(3, false, item3, new DataProperty(TStorageMedium.HDD), null, false, false);
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public PartitionInfo getPartitionInfo() {
-                return partitionInfo;
+        Mockito.when(tableIf.getPartitionInfo()).thenReturn(partitionInfo);
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedStatisticsUtil.when(StatisticsUtil::getPartitionSampleCount).thenReturn(3);
+            partitions.clear();
+            for (int i = 1; i <= 3; i++) {
+                Partition p = new Partition(i, "p" + i, new MaterializedIndex(), new RandomDistributionInfo());
+                partitions.add(p);
             }
-        };
-        new MockUp<StatisticsUtil>() {
-            @Mock
-            public int getPartitionSampleCount() {
-                return 3;
-            }
-        };
-        partitions.clear();
-        for (int i = 1; i <= 3; i++) {
-            Partition p = new Partition(i, "p" + i, new MaterializedIndex(), new RandomDistributionInfo());
-            partitions.add(p);
-        }
-        skipPartitionId = task.getSkipPartitionId(partitions);
-        Assertions.assertEquals(2, skipPartitionId);
+            skipPartitionId = task.getSkipPartitionId(partitions);
+            Assertions.assertEquals(2, skipPartitionId);
 
-        // Test less than partition
-        partitions.add(new Partition(4, "p4", new MaterializedIndex(), new RandomDistributionInfo()));
-        partitions.add(new Partition(5, "p5", new MaterializedIndex(), new RandomDistributionInfo()));
-        new MockUp<StatisticsUtil>() {
-            @Mock
-            public int getPartitionSampleCount() {
-                return 5;
-            }
-        };
-        highKey.clear();
-        highKey.add(new PartitionValue("2024-01-01"));
-        Range<PartitionKey> range4 = Range.lessThan(PartitionKey.createPartitionKey(highKey, columns));
-        RangePartitionItem item4 = new RangePartitionItem(range4);
-        partitionInfo.addPartition(4, false, item4, new DataProperty(TStorageMedium.HDD), null, false, false);
-        lowKey.clear();
-        lowKey.add(new PartitionValue("2024-03-13"));
-        highKey.clear();
-        highKey.add(new PartitionValue("2024-03-14"));
-        Range<PartitionKey> range5 = Range.closedOpen(PartitionKey.createPartitionKey(lowKey, columns),
-                PartitionKey.createPartitionKey(highKey, columns));
-        RangePartitionItem item5 = new RangePartitionItem(range5);
-        partitionInfo.addPartition(5, false, item5, new DataProperty(TStorageMedium.HDD), null, false, false);
-        skipPartitionId = task.getSkipPartitionId(partitions);
-        Assertions.assertEquals(4, skipPartitionId);
+            // Test less than partition
+            partitions.add(new Partition(4, "p4", new MaterializedIndex(), new RandomDistributionInfo()));
+            partitions.add(new Partition(5, "p5", new MaterializedIndex(), new RandomDistributionInfo()));
+            mockedStatisticsUtil.when(StatisticsUtil::getPartitionSampleCount).thenReturn(5);
+            highKey.clear();
+            highKey.add(new PartitionValue("2024-01-01"));
+            Range<PartitionKey> range4 = Range.lessThan(PartitionKey.createPartitionKey(highKey, columns));
+            RangePartitionItem item4 = new RangePartitionItem(range4);
+            partitionInfo.addPartition(4, false, item4, new DataProperty(TStorageMedium.HDD), null, false, false);
+            lowKey.clear();
+            lowKey.add(new PartitionValue("2024-03-13"));
+            highKey.clear();
+            highKey.add(new PartitionValue("2024-03-14"));
+            Range<PartitionKey> range5 = Range.closedOpen(PartitionKey.createPartitionKey(lowKey, columns),
+                    PartitionKey.createPartitionKey(highKey, columns));
+            RangePartitionItem item5 = new RangePartitionItem(range5);
+            partitionInfo.addPartition(5, false, item5, new DataProperty(TStorageMedium.HDD), null, false, false);
+            skipPartitionId = task.getSkipPartitionId(partitions);
+            Assertions.assertEquals(4, skipPartitionId);
+        }
     }
 
     @Test
-    public void testGetSampleTablets(@Mocked MaterializedIndex index, @Mocked LocalTablet t) {
-        OlapAnalysisTask task = new OlapAnalysisTask();
-        task.tbl = new OlapTable();
+    public void testGetSampleTablets() {
+        OlapAnalysisTask task = Mockito.spy(new OlapAnalysisTask());
+        Mockito.doReturn(4000000L).when(task).getSampleRows();
+
+        OlapTable mockTable = Mockito.mock(OlapTable.class);
+        task.tbl = mockTable;
         task.col = new Column("col1", PrimitiveType.STRING);
         task.info = new AnalysisInfoBuilder().setIndexId(-1L).build();
         task.tableSample = new TableSample(false, 4000000L, 0L);
-        List<Partition> partitions = Lists.newArrayList();
-        partitions.add(new Partition(1, "p1", new MaterializedIndex(), new RandomDistributionInfo()));
-        final int[] i = {0};
-        long[] tabletsRowCount = {1100000000, 100000000};
+
+        Mockito.when(mockTable.isPartitionColumn(ArgumentMatchers.any())).thenReturn(false);
+
+        MaterializedIndex index = Mockito.mock(MaterializedIndex.class);
+        LocalTablet t = Mockito.mock(LocalTablet.class);
+
         List<Long> ret = Lists.newArrayList();
         ret.add(10001L);
         ret.add(10002L);
-        new MockUp<OlapAnalysisTask>() {
-            @Mock
-            protected long getSampleRows() {
-                return 4000000;
-            }
-        };
-        new MockUp<OlapTable>() {
-            @Mock
-            boolean isPartitionColumn(Column column) {
-                return false;
-            }
+        Mockito.when(index.getTabletIdsInOrder()).thenReturn(ret);
+        Mockito.when(index.getRowCount()).thenReturn(1_200_000_000L);
+        Mockito.when(index.getTablet(ArgumentMatchers.anyLong())).thenReturn(t);
 
-            @Mock
-            public Collection<Partition> getPartitions() {
-                return partitions;
-            }
-        };
-        new MockUp<Partition>() {
-            @Mock
-            public MaterializedIndex getBaseIndex() {
-                return index;
-            }
-        };
-        new MockUp<MaterializedIndex>() {
-            @Mock
-            public List<Long> getTabletIdsInOrder() {
-                return ret;
-            }
+        final int[] i = {0};
+        long[] tabletsRowCount = {1100000000, 100000000};
+        Mockito.when(t.getMinReplicaRowCount(ArgumentMatchers.anyLong())).thenAnswer(inv -> tabletsRowCount[i[0]++]);
 
-            @Mock
-            public long getRowCount() {
-                return 1_200_000_000L;
-            }
+        Partition partition = Mockito.mock(Partition.class);
+        Mockito.when(partition.getBaseIndex()).thenReturn(index);
+        List<Partition> partitions = Lists.newArrayList();
+        partitions.add(partition);
+        Mockito.when(mockTable.getPartitions()).thenReturn((Collection) partitions);
 
-            @Mock
-            public Tablet getTablet(long tabletId) {
-                return t;
-            }
-        };
-        new MockUp<LocalTablet>() {
-            @Mock
-            public long getMinReplicaRowCount(long version) {
-                return tabletsRowCount[i[0]++];
-            }
-        };
         // Test set large tablet id back if it doesn't pick enough sample rows.
         Pair<List<Long>, Long> sampleTablets = task.getSampleTablets();
         Assertions.assertEquals(1, sampleTablets.first.size());

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
@@ -39,10 +39,9 @@ import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -75,48 +74,47 @@ public class StatisticsAutoCollectorTest {
         manager.lowPriorityJobs.get(low1).add(Pair.of("index1", "col6"));
         manager.lowPriorityJobs.get(low1).add(Pair.of("index1", "col7"));
 
+        Env mockEnv = Mockito.mock(Env.class);
+        Mockito.when(mockEnv.getAnalysisManager()).thenReturn(manager);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(mockEnv);
+            envStatic.when(Env::getServingEnv).thenReturn(mockEnv);
+            StatisticsAutoCollector collector = new StatisticsAutoCollector();
+            Pair<Entry<TableNameInfo, Set<Pair<String, String>>>, JobPriority> job = collector.getJob();
+            Assertions.assertEquals(high1, job.first.getKey());
+            Assertions.assertEquals(2, job.first.getValue().size());
+            Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col1")));
+            Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col2")));
+            Assertions.assertEquals(JobPriority.HIGH, job.second);
 
-        new MockUp<Env>() {
-            @Mock
-            public AnalysisManager getAnalysisManager() {
-                return manager;
-            }
-        };
-        StatisticsAutoCollector collector = new StatisticsAutoCollector();
-        Pair<Entry<TableNameInfo, Set<Pair<String, String>>>, JobPriority> job = collector.getJob();
-        Assertions.assertEquals(high1, job.first.getKey());
-        Assertions.assertEquals(2, job.first.getValue().size());
-        Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col1")));
-        Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col2")));
-        Assertions.assertEquals(JobPriority.HIGH, job.second);
+            job = collector.getJob();
+            Assertions.assertEquals(high2, job.first.getKey());
+            Assertions.assertEquals(1, job.first.getValue().size());
+            Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col3")));
+            Assertions.assertEquals(JobPriority.HIGH, job.second);
 
-        job = collector.getJob();
-        Assertions.assertEquals(high2, job.first.getKey());
-        Assertions.assertEquals(1, job.first.getValue().size());
-        Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col3")));
-        Assertions.assertEquals(JobPriority.HIGH, job.second);
+            job = collector.getJob();
+            Assertions.assertEquals(mid1, job.first.getKey());
+            Assertions.assertEquals(1, job.first.getValue().size());
+            Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col4")));
+            Assertions.assertEquals(JobPriority.MID, job.second);
 
-        job = collector.getJob();
-        Assertions.assertEquals(mid1, job.first.getKey());
-        Assertions.assertEquals(1, job.first.getValue().size());
-        Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col4")));
-        Assertions.assertEquals(JobPriority.MID, job.second);
+            job = collector.getJob();
+            Assertions.assertEquals(mid2, job.first.getKey());
+            Assertions.assertEquals(1, job.first.getValue().size());
+            Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col5")));
+            Assertions.assertEquals(JobPriority.MID, job.second);
 
-        job = collector.getJob();
-        Assertions.assertEquals(mid2, job.first.getKey());
-        Assertions.assertEquals(1, job.first.getValue().size());
-        Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col5")));
-        Assertions.assertEquals(JobPriority.MID, job.second);
+            job = collector.getJob();
+            Assertions.assertEquals(low1, job.first.getKey());
+            Assertions.assertEquals(2, job.first.getValue().size());
+            Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col6")));
+            Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col7")));
+            Assertions.assertEquals(JobPriority.LOW, job.second);
 
-        job = collector.getJob();
-        Assertions.assertEquals(low1, job.first.getKey());
-        Assertions.assertEquals(2, job.first.getValue().size());
-        Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col6")));
-        Assertions.assertTrue(job.first.getValue().contains(Pair.of("index1", "col7")));
-        Assertions.assertEquals(JobPriority.LOW, job.second);
-
-        job = collector.getJob();
-        Assertions.assertNull(job);
+            job = collector.getJob();
+            Assertions.assertNull(job);
+        }
     }
 
     @Test
@@ -135,25 +133,17 @@ public class StatisticsAutoCollectorTest {
                 jdbcExternalDatabase);
         Assertions.assertFalse(collector.supportAutoAnalyze(externalTable));
 
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public DLAType getDlaType() {
-                return DLAType.ICEBERG;
-            }
-        };
         HMSExternalDatabase hmsExternalDatabase = new HMSExternalDatabase(null, 1L, "hmsDb", "hmsDb");
         HMSExternalCatalog hmsCatalog = new HMSExternalCatalog(0, "jdbc_ctl", null, Maps.newHashMap(), "");
-        ExternalTable icebergExternalTable = new HMSExternalTable(1, "hmsTable", "hmsDb", hmsCatalog,
+        HMSExternalTable icebergRaw = new HMSExternalTable(1, "hmsTable", "hmsDb", hmsCatalog,
                 hmsExternalDatabase);
+        ExternalTable icebergExternalTable = Mockito.spy(icebergRaw);
+        Mockito.doReturn(DLAType.ICEBERG).when((HMSExternalTable) icebergExternalTable).getDlaType();
         Assertions.assertTrue(collector.supportAutoAnalyze(icebergExternalTable));
 
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public DLAType getDlaType() {
-                return DLAType.HIVE;
-            }
-        };
-        ExternalTable hiveExternalTable = new HMSExternalTable(1, "hmsTable", "hmsDb", hmsCatalog, hmsExternalDatabase);
+        HMSExternalTable hiveRaw = new HMSExternalTable(1, "hmsTable", "hmsDb", hmsCatalog, hmsExternalDatabase);
+        ExternalTable hiveExternalTable = Mockito.spy(hiveRaw);
+        Mockito.doReturn(DLAType.HIVE).when((HMSExternalTable) hiveExternalTable).getDlaType();
         Assertions.assertTrue(collector.supportAutoAnalyze(hiveExternalTable));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsJobAppenderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsJobAppenderTest.java
@@ -19,12 +19,10 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
-import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
-import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
@@ -34,10 +32,10 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,6 +47,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class StatisticsJobAppenderTest {
 
@@ -60,88 +59,72 @@ public class StatisticsJobAppenderTest {
         Column column1 = new Column("placeholder", PrimitiveType.INT);
         List<Column> schema = new ArrayList<>();
         schema.add(column1);
-        OlapTable table1 = new OlapTable(200, "testTable", schema, null, null, null);
-        OlapTable table2 = new OlapTable(200, "testTable2", schema, null, null, null);
-        OlapTable table3 = new OlapTable(200, "testTable3", schema, null, null, null);
-        new MockUp<StatisticsUtil>() {
-            int i = 0;
-            Table[] tables = {table1, table2, table1, table3, table2};
-
-            @Mock
-            public boolean needAnalyzeColumn(TableIf table, Pair<String, String> column) {
-                return true;
-            }
-
-            @Mock
-            public TableIf findTable(long catalogId, long dbId, long tblId) {
-                return tables[i++];
-            }
-        };
-
-        new MockUp<Table>() {
-            @Mock
-            public DatabaseIf getDatabase() {
-                return db;
-            }
-
-            @Mock
-            public Column getColumn(String name) {
-                return new Column("mockCol", Type.INT);
-            }
-        };
-
-        new MockUp<OlapTable>() {
-            @Mock
-            public Set<Pair<String, String>> getColumnIndexPairs(Set<String> columns) {
-                String column = columns.iterator().next();
-                return Collections.singleton(Pair.of("mockIndex", column));
-            }
-        };
-
-        Queue<QueryColumn> testQueue = new ArrayBlockingQueue<>(100);
-        Map<TableNameInfo, Set<Pair<String, String>>> testMap = new HashMap<>();
-        QueryColumn high1 = new QueryColumn(10, 20, 30, "high1");
-        testQueue.add(high1);
-
-        StatisticsJobAppender appender = new StatisticsJobAppender();
-        appender.appendColumnsToJobs(testQueue, testMap);
-        Assertions.assertEquals(1, testMap.size());
-        Assertions.assertEquals(1, testMap.values().size());
-        Assertions.assertTrue(testMap.get(new TableNameInfo("internal", "testDb", "testTable")).contains(Pair.of("mockIndex", "high1")));
-
-        QueryColumn high2 = new QueryColumn(10, 20, 30, "high2");
-        QueryColumn high3 = new QueryColumn(10, 20, 30, "high3");
-        testQueue.add(high2);
-        testQueue.add(high3);
-        appender.appendColumnsToJobs(testQueue, testMap);
-        Assertions.assertEquals(2, testMap.size());
-
-        Set<Pair<String, String>> table1Column = testMap.get(new TableNameInfo("internal", "testDb", "testTable"));
-        Assertions.assertEquals(2, table1Column.size());
-        Assertions.assertTrue(table1Column.contains(Pair.of("mockIndex", "high1")));
-        Assertions.assertTrue(table1Column.contains(Pair.of("mockIndex", "high3")));
-
-        Set<Pair<String, String>> table2Column = testMap.get(new TableNameInfo("internal", "testDb", "testTable2"));
-        Assertions.assertEquals(1, table2Column.size());
-        Assertions.assertTrue(table2Column.contains(Pair.of("mockIndex", "high2")));
-
-        for (int i = 0; i < StatisticsJobAppender.JOB_MAP_SIZE - 2; i++) {
-            testMap.put(new TableNameInfo("a", "b", UUID.randomUUID().toString()), new HashSet<>());
+        OlapTable table1 = Mockito.spy(new OlapTable(200, "testTable", schema, null, null, null));
+        OlapTable table2 = Mockito.spy(new OlapTable(200, "testTable2", schema, null, null, null));
+        OlapTable table3 = Mockito.spy(new OlapTable(200, "testTable3", schema, null, null, null));
+        for (OlapTable t : new OlapTable[]{table1, table2, table3}) {
+            Mockito.doReturn(db).when(t).getDatabase();
+            Mockito.doReturn(new Column("mockCol", Type.INT)).when(t).getColumn(Mockito.anyString());
+            Mockito.doAnswer(inv -> {
+                Set<String> cols = inv.getArgument(0);
+                String col = cols.iterator().next();
+                return Collections.singleton(Pair.of("mockIndex", col));
+            }).when(t).getColumnIndexPairs(Mockito.any());
         }
-        Assertions.assertEquals(StatisticsJobAppender.JOB_MAP_SIZE, testMap.size());
 
-        QueryColumn high4 = new QueryColumn(10, 20, 30, "high4");
-        testQueue.add(high4);
-        appender.appendColumnsToJobs(testQueue, testMap);
-        Assertions.assertEquals(StatisticsJobAppender.JOB_MAP_SIZE, testMap.size());
+        try (MockedStatic<StatisticsUtil> statsUtilStatic = Mockito.mockStatic(StatisticsUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            AtomicInteger idx = new AtomicInteger(0);
+            OlapTable[] tables = {table1, table2, table1, table3, table2};
+            statsUtilStatic.when(() -> StatisticsUtil.needAnalyzeColumn(Mockito.any(), Mockito.any()))
+                    .thenReturn(true);
+            statsUtilStatic.when(() -> StatisticsUtil.findTable(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenAnswer(inv -> tables[idx.getAndIncrement()]);
 
-        QueryColumn high5 = new QueryColumn(10, 20, 30, "high5");
-        testQueue.add(high5);
-        appender.appendColumnsToJobs(testQueue, testMap);
-        table2Column = testMap.get(new TableNameInfo("internal", "testDb", "testTable2"));
-        Assertions.assertEquals(2, table2Column.size());
-        Assertions.assertTrue(table2Column.contains(Pair.of("mockIndex", "high2")));
-        Assertions.assertTrue(table2Column.contains(Pair.of("mockIndex", "high5")));
+            Queue<QueryColumn> testQueue = new ArrayBlockingQueue<>(100);
+            Map<TableNameInfo, Set<Pair<String, String>>> testMap = new HashMap<>();
+            QueryColumn high1 = new QueryColumn(10, 20, 30, "high1");
+            testQueue.add(high1);
+
+            StatisticsJobAppender appender = new StatisticsJobAppender();
+            appender.appendColumnsToJobs(testQueue, testMap);
+            Assertions.assertEquals(1, testMap.size());
+            Assertions.assertEquals(1, testMap.values().size());
+            Assertions.assertTrue(testMap.get(new TableNameInfo("internal", "testDb", "testTable")).contains(Pair.of("mockIndex", "high1")));
+
+            QueryColumn high2 = new QueryColumn(10, 20, 30, "high2");
+            QueryColumn high3 = new QueryColumn(10, 20, 30, "high3");
+            testQueue.add(high2);
+            testQueue.add(high3);
+            appender.appendColumnsToJobs(testQueue, testMap);
+            Assertions.assertEquals(2, testMap.size());
+
+            Set<Pair<String, String>> table1Column = testMap.get(new TableNameInfo("internal", "testDb", "testTable"));
+            Assertions.assertEquals(2, table1Column.size());
+            Assertions.assertTrue(table1Column.contains(Pair.of("mockIndex", "high1")));
+            Assertions.assertTrue(table1Column.contains(Pair.of("mockIndex", "high3")));
+
+            Set<Pair<String, String>> table2Column = testMap.get(new TableNameInfo("internal", "testDb", "testTable2"));
+            Assertions.assertEquals(1, table2Column.size());
+            Assertions.assertTrue(table2Column.contains(Pair.of("mockIndex", "high2")));
+
+            for (int i = 0; i < StatisticsJobAppender.JOB_MAP_SIZE - 2; i++) {
+                testMap.put(new TableNameInfo("a", "b", UUID.randomUUID().toString()), new HashSet<>());
+            }
+            Assertions.assertEquals(StatisticsJobAppender.JOB_MAP_SIZE, testMap.size());
+
+            QueryColumn high4 = new QueryColumn(10, 20, 30, "high4");
+            testQueue.add(high4);
+            appender.appendColumnsToJobs(testQueue, testMap);
+            Assertions.assertEquals(StatisticsJobAppender.JOB_MAP_SIZE, testMap.size());
+
+            QueryColumn high5 = new QueryColumn(10, 20, 30, "high5");
+            testQueue.add(high5);
+            appender.appendColumnsToJobs(testQueue, testMap);
+            table2Column = testMap.get(new TableNameInfo("internal", "testDb", "testTable2"));
+            Assertions.assertEquals(2, table2Column.size());
+            Assertions.assertTrue(table2Column.contains(Pair.of("mockIndex", "high2")));
+            Assertions.assertTrue(table2Column.contains(Pair.of("mockIndex", "high5")));
+        } // close MockedStatic
     }
 
     @Test
@@ -154,66 +137,51 @@ public class StatisticsJobAppenderTest {
             Column column1 = new Column("placeholder", PrimitiveType.INT);
             List<Column> schema = new ArrayList<>();
             schema.add(column1);
-            OlapTable table1 = new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null);
-            OlapTable table2 = new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null);
+            OlapTable table1 = Mockito.spy(new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null));
+            OlapTable table2 = Mockito.spy(new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null));
+            Mockito.doReturn(Lists.newArrayList()).when(table1).getBaseSchema();
+            Mockito.doReturn(Collections.singleton(Pair.of("mockIndex", "mockColumn"))).when(table1).getColumnIndexPairs(Mockito.any());
+            Mockito.doReturn(Lists.newArrayList()).when(table2).getBaseSchema();
+            Mockito.doReturn(Collections.singleton(Pair.of("mockIndex", "mockColumn"))).when(table2).getColumnIndexPairs(Mockito.any());
             db.createTableWithLock(table1, true, false);
             db.createTableWithLock(table2, true, false);
         }
 
-        new MockUp<Env>() {
-            @Mock
-            public InternalCatalog getCurrentInternalCatalog() {
-                return testCatalog;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<StatisticsUtil> statsUtilStatic = Mockito.mockStatic(StatisticsUtil.class)) {
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(testCatalog);
+            statsUtilStatic.when(() -> StatisticsUtil.needAnalyzeColumn(Mockito.any(), Mockito.any()))
+                    .thenReturn(true);
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public List<Column> getBaseSchema() {
-                return Lists.newArrayList();
-            }
+            Map<TableNameInfo, Set<Pair<String, String>>> testLowMap = new HashMap<>();
+            Map<TableNameInfo, Set<Pair<String, String>>> testVeryLowMap = new HashMap<>();
+            StatisticsJobAppender appender = new StatisticsJobAppender();
+            appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(100, testLowMap.size());
+            Assertions.assertEquals(0, testVeryLowMap.size());
+            testLowMap.clear();
+            appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(40, testLowMap.size());
+            Assertions.assertEquals(0, testVeryLowMap.size());
+            testLowMap.clear();
+            // Less than 1 minutes since last iteration.
+            appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(0, testLowMap.size());
+            Assertions.assertEquals(0, testVeryLowMap.size());
 
-            @Mock
-            public Set<Pair<String, String>> getColumnIndexPairs(Set<String> columns) {
-                return Collections.singleton(Pair.of("mockIndex", "mockColumn"));
-            }
-        };
-
-        new MockUp<StatisticsUtil>() {
-            @Mock
-            public boolean needAnalyzeColumn(TableIf table, Pair<String, String> column) {
-                return true;
-            }
-        };
-
-        Map<TableNameInfo, Set<Pair<String, String>>> testLowMap = new HashMap<>();
-        Map<TableNameInfo, Set<Pair<String, String>>> testVeryLowMap = new HashMap<>();
-        StatisticsJobAppender appender = new StatisticsJobAppender();
-        appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(100, testLowMap.size());
-        Assertions.assertEquals(0, testVeryLowMap.size());
-        testLowMap.clear();
-        appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(40, testLowMap.size());
-        Assertions.assertEquals(0, testVeryLowMap.size());
-        testLowMap.clear();
-        // Less than 1 minutes since last iteration.
-        appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(0, testLowMap.size());
-        Assertions.assertEquals(0, testVeryLowMap.size());
-
-        testLowMap.clear();
-        appender.setLastRoundFinishTime(0);
-        int processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(100, testLowMap.size());
-        Assertions.assertEquals(0, testVeryLowMap.size());
-        Assertions.assertEquals(100, processed);
-        appender.setLastRoundFinishTime(0);
-        processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(100, testLowMap.size());
-        Assertions.assertEquals(0, testVeryLowMap.size());
-        Assertions.assertEquals(StatisticsJobAppender.JOB_MAP_SIZE, testLowMap.size());
-        Assertions.assertEquals(0, processed);
+            testLowMap.clear();
+            appender.setLastRoundFinishTime(0);
+            int processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(100, testLowMap.size());
+            Assertions.assertEquals(0, testVeryLowMap.size());
+            Assertions.assertEquals(100, processed);
+            appender.setLastRoundFinishTime(0);
+            processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(100, testLowMap.size());
+            Assertions.assertEquals(0, testVeryLowMap.size());
+            Assertions.assertEquals(StatisticsJobAppender.JOB_MAP_SIZE, testLowMap.size());
+            Assertions.assertEquals(0, processed);
+        } // close MockedStatic
     }
 
     @Test
@@ -226,68 +194,50 @@ public class StatisticsJobAppenderTest {
             Column column1 = new Column("placeholder", PrimitiveType.INT);
             List<Column> schema = new ArrayList<>();
             schema.add(column1);
-            OlapTable table1 = new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null);
-            OlapTable table2 = new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null);
+            OlapTable table1 = Mockito.spy(new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null));
+            OlapTable table2 = Mockito.spy(new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null));
+            Mockito.doReturn(Lists.newArrayList()).when(table1).getBaseSchema();
+            Mockito.doReturn(Collections.singleton(Pair.of("mockIndex", "mockColumn"))).when(table1).getColumnIndexPairs(Mockito.any());
+            Mockito.doReturn(Lists.newArrayList()).when(table2).getBaseSchema();
+            Mockito.doReturn(Collections.singleton(Pair.of("mockIndex", "mockColumn"))).when(table2).getColumnIndexPairs(Mockito.any());
             db.createTableWithLock(table1, true, false);
             db.createTableWithLock(table2, true, false);
         }
 
-        new MockUp<Env>() {
-            @Mock
-            public InternalCatalog getCurrentInternalCatalog() {
-                return testCatalog;
-            }
-        };
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<StatisticsUtil> statsUtilStatic = Mockito.mockStatic(StatisticsUtil.class)) {
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(testCatalog);
+            statsUtilStatic.when(() -> StatisticsUtil.needAnalyzeColumn(Mockito.any(), Mockito.any()))
+                    .thenReturn(false);
+            statsUtilStatic.when(() -> StatisticsUtil.isLongTimeColumn(Mockito.any(), Mockito.any(), Mockito.anyLong()))
+                    .thenReturn(true);
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public List<Column> getBaseSchema() {
-                return Lists.newArrayList();
-            }
+            Map<TableNameInfo, Set<Pair<String, String>>> testLowMap = new HashMap<>();
+            Map<TableNameInfo, Set<Pair<String, String>>> testVeryLowMap = new HashMap<>();
+            StatisticsJobAppender appender = new StatisticsJobAppender();
+            int processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(0, testLowMap.size());
+            Assertions.assertEquals(100, testVeryLowMap.size());
+            Assertions.assertEquals(100, processed);
+            testVeryLowMap.clear();
+            processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(0, testLowMap.size());
+            Assertions.assertEquals(40, testVeryLowMap.size());
+            Assertions.assertEquals(40, processed);
 
-            @Mock
-            public Set<Pair<String, String>> getColumnIndexPairs(Set<String> columns) {
-                return Collections.singleton(Pair.of("mockIndex", "mockColumn"));
-            }
-        };
+            testLowMap.clear();
+            appender.setLastRoundFinishTime(0);
+            processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(0, testLowMap.size());
+            Assertions.assertEquals(100, testVeryLowMap.size());
+            Assertions.assertEquals(100, processed);
 
-        new MockUp<StatisticsUtil>() {
-            @Mock
-            public boolean needAnalyzeColumn(TableIf table, Pair<String, String> column) {
-                return false;
-            }
-
-            @Mock
-            public boolean isLongTimeColumn(TableIf table, Pair<String, String> column, long version) {
-                return true;
-            }
-        };
-
-        Map<TableNameInfo, Set<Pair<String, String>>> testLowMap = new HashMap<>();
-        Map<TableNameInfo, Set<Pair<String, String>>> testVeryLowMap = new HashMap<>();
-        StatisticsJobAppender appender = new StatisticsJobAppender();
-        int processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(0, testLowMap.size());
-        Assertions.assertEquals(100, testVeryLowMap.size());
-        Assertions.assertEquals(100, processed);
-        testVeryLowMap.clear();
-        processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(0, testLowMap.size());
-        Assertions.assertEquals(40, testVeryLowMap.size());
-        Assertions.assertEquals(40, processed);
-
-        testLowMap.clear();
-        appender.setLastRoundFinishTime(0);
-        processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(0, testLowMap.size());
-        Assertions.assertEquals(100, testVeryLowMap.size());
-        Assertions.assertEquals(100, processed);
-
-        appender.setLastRoundFinishTime(0);
-        processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(0, testLowMap.size());
-        Assertions.assertEquals(100, testVeryLowMap.size());
-        Assertions.assertEquals(0, processed);
+            appender.setLastRoundFinishTime(0);
+            processed = appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(0, testLowMap.size());
+            Assertions.assertEquals(100, testVeryLowMap.size());
+            Assertions.assertEquals(0, processed);
+        } // close MockedStatic
     }
 
     @Test
@@ -299,43 +249,29 @@ public class StatisticsJobAppenderTest {
         Column column1 = new Column("placeholder", PrimitiveType.INT);
         List<Column> schema = new ArrayList<>();
         schema.add(column1);
-        OlapTable table1 = new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null);
+        OlapTable table1 = Mockito.spy(new OlapTable(id++, "testTable" + id + "_1", schema, null, null, null));
+        Mockito.doReturn(Lists.newArrayList(new Column("col1", Type.INT), new Column("col2", Type.INT))).when(table1).getBaseSchema();
+        Mockito.doReturn(Collections.singleton(Pair.of("1", "1"))).when(table1).getColumnIndexPairs(Mockito.any());
         db.createTableWithLock(table1, true, false);
-        new MockUp<Env>() {
-            @Mock
-            public InternalCatalog getCurrentInternalCatalog() {
-                return testCatalog;
-            }
-        };
-        new MockUp<OlapTable>() {
-            @Mock
-            public List<Column> getBaseSchema() {
-                return Lists.newArrayList(new Column("col1", Type.INT), new Column("col2", Type.INT));
-            }
 
-            @Mock
-            public Set<Pair<String, String>> getColumnIndexPairs(Set<String> columns) {
-                return Collections.singleton(Pair.of("1", "1"));
-            }
-        };
-
-        new MockUp<StatisticsUtil>() {
-            int count = 0;
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<StatisticsUtil> statsUtilStatic = Mockito.mockStatic(StatisticsUtil.class)) {
+            envStatic.when(Env::getCurrentInternalCatalog).thenReturn(testCatalog);
+            AtomicInteger count = new AtomicInteger(0);
             int[] thresholds = {1, 10};
-
-            @Mock
-            public int getAutoAnalyzeTableWidthThreshold() {
-                return thresholds[count++];
-            }
-        };
-        Map<TableNameInfo, Set<Pair<String, String>>> testLowMap = new HashMap<>();
-        Map<TableNameInfo, Set<Pair<String, String>>> testVeryLowMap = new HashMap<>();
-        StatisticsJobAppender appender = new StatisticsJobAppender();
-        appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(0, testLowMap.size());
-        appender.setLastRoundFinishTime(0);
-        appender.appendToLowJobs(testLowMap, testVeryLowMap);
-        Assertions.assertEquals(1, testLowMap.size());
+            statsUtilStatic.when(StatisticsUtil::getAutoAnalyzeTableWidthThreshold)
+                    .thenAnswer(inv -> thresholds[count.getAndIncrement()]);
+            statsUtilStatic.when(() -> StatisticsUtil.needAnalyzeColumn(
+                    Mockito.any(), Mockito.any())).thenReturn(true);
+            Map<TableNameInfo, Set<Pair<String, String>>> testLowMap = new HashMap<>();
+            Map<TableNameInfo, Set<Pair<String, String>>> testVeryLowMap = new HashMap<>();
+            StatisticsJobAppender appender = new StatisticsJobAppender();
+            appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(0, testLowMap.size());
+            appender.setLastRoundFinishTime(0);
+            appender.appendToLowJobs(testLowMap, testVeryLowMap);
+            Assertions.assertEquals(1, testLowMap.size());
+        } // close MockedStatic
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/TableStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/TableStatsMetaTest.java
@@ -20,19 +20,17 @@ package org.apache.doris.statistics;
 import org.apache.doris.catalog.OlapTable;
 
 import com.google.common.collect.Lists;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.HashSet;
-import java.util.List;
 
 class TableStatsMetaTest {
 
     @Test
-    void update(@Mocked OlapTable table) {
+    void update() {
+        OlapTable table = Mockito.mock(OlapTable.class);
         TableStatsMeta tableStatsMeta = new TableStatsMeta();
         AnalysisInfo jobInfo = new AnalysisInfoBuilder().setRowCount(4)
                 .setJobColumns(new HashSet<>()).setColName("col1").build();
@@ -51,16 +49,8 @@ class TableStatsMetaTest {
         Assertions.assertEquals(3, meta.getRowCount(3));
         Assertions.assertEquals(-1, meta.getRowCount(4));
 
-        new MockUp<OlapTable>() {
-            @Mock
-            public List<Long> getIndexIdList() {
-                List<Long> result = Lists.newArrayList();
-                result.add(1L);
-                return result;
-            }
-        };
-
-        OlapTable table = new OlapTable();
+        OlapTable table = Mockito.spy(new OlapTable());
+        Mockito.doReturn(Lists.newArrayList(1L)).when(table).getIndexIdList();
 
         meta.clearStaleIndexRowCount(table);
         Assertions.assertEquals(1, meta.getRowCount(1));

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.statistics.util;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
@@ -31,7 +32,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.datasource.ExternalCatalog;
-import org.apache.doris.datasource.ExternalTable;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HMSExternalDatabase;
@@ -53,11 +53,10 @@ import org.apache.doris.statistics.TableStatsMeta;
 import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Maps;
-import mockit.Mock;
-import mockit.MockUp;
 import org.apache.iceberg.CatalogProperties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.time.LocalTime;
@@ -114,40 +113,34 @@ class StatisticsUtilTest {
 
     @Test
     void testInAnalyzeTime1() {
-        new MockUp<StatisticsUtil>() {
-
-            @Mock
-            protected SessionVariable findConfigFromGlobalSessionVar(String varName) throws Exception {
-                SessionVariable sessionVariable = new SessionVariable();
-                sessionVariable.autoAnalyzeStartTime = "00:00:00";
-                sessionVariable.autoAnalyzeEndTime = "02:00:00";
-                return sessionVariable;
-            }
-        };
-        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
-        String now = "01:00:00";
-        Assertions.assertTrue(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
-        now = "13:00:00";
-        Assertions.assertFalse(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
+        try (MockedStatic<StatisticsUtil> ms = Mockito.mockStatic(StatisticsUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            SessionVariable sessionVariable = new SessionVariable();
+            sessionVariable.autoAnalyzeStartTime = "00:00:00";
+            sessionVariable.autoAnalyzeEndTime = "02:00:00";
+            ms.when(() -> StatisticsUtil.findConfigFromGlobalSessionVar(Mockito.anyString()))
+                    .thenReturn(sessionVariable);
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+            String now = "01:00:00";
+            Assertions.assertTrue(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
+            now = "13:00:00";
+            Assertions.assertFalse(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
+        }
     }
 
     @Test
     void testInAnalyzeTime2() {
-        new MockUp<StatisticsUtil>() {
-
-            @Mock
-            protected SessionVariable findConfigFromGlobalSessionVar(String varName) throws Exception {
-                SessionVariable sessionVariable = new SessionVariable();
-                sessionVariable.autoAnalyzeStartTime = "00:00:00";
-                sessionVariable.autoAnalyzeEndTime = "23:00:00";
-                return sessionVariable;
-            }
-        };
-        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
-        String now = "15:00:00";
-        Assertions.assertTrue(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
-        now = "23:30:00";
-        Assertions.assertFalse(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
+        try (MockedStatic<StatisticsUtil> ms = Mockito.mockStatic(StatisticsUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            SessionVariable sessionVariable = new SessionVariable();
+            sessionVariable.autoAnalyzeStartTime = "00:00:00";
+            sessionVariable.autoAnalyzeEndTime = "23:00:00";
+            ms.when(() -> StatisticsUtil.findConfigFromGlobalSessionVar(Mockito.anyString()))
+                    .thenReturn(sessionVariable);
+            DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+            String now = "15:00:00";
+            Assertions.assertTrue(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
+            now = "23:30:00";
+            Assertions.assertFalse(StatisticsUtil.inAnalyzeTime(LocalTime.parse(now, timeFormatter)));
+        }
     }
 
     @Test
@@ -179,179 +172,117 @@ class StatisticsUtilTest {
         Mockito.when(table.getDatabase()).thenReturn(db1);
         Mockito.when(db1.getCatalog()).thenReturn(catalog1);
         Mockito.when(catalog1.getId()).thenReturn(0L);
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            protected synchronized void makeSureInitialized() {
-            }
-        };
 
         // Test auto analyze catalog disabled.
-        HMSExternalTable hmsTable = new HMSExternalTable(1, "name", "name", externalCatalog, externalDatabase);
+        HMSExternalTable hmsTable = Mockito.spy(new HMSExternalTable(1, "name", "name", externalCatalog, externalDatabase) {
+            @Override
+            protected synchronized void makeSureInitialized() { }
+        });
         Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(hmsTable, Pair.of("index", column.getName())));
 
         // Test catalog auto analyze enabled.
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public TableStatsMeta findTableStatsStatus(long tblId) {
-                return null;
-            }
-        };
-        externalCatalog.getCatalogProperty().addProperty(ExternalCatalog.ENABLE_AUTO_ANALYZE, "true");
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+        Env mockEnv = Mockito.mock(Env.class);
+        AnalysisManager mockAnalysisManager = Mockito.mock(AnalysisManager.class);
+        Mockito.when(mockEnv.getAnalysisManager()).thenReturn(mockAnalysisManager);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(mockEnv);
+            envStatic.when(Env::getServingEnv).thenReturn(mockEnv);
 
-        // Test external table auto analyze enabled.
-        externalCatalog.getCatalogProperty().addProperty(ExternalCatalog.ENABLE_AUTO_ANALYZE, "false");
-        HMSExternalTable hmsTable1 = new HMSExternalTable(1, "name", "name", externalCatalog, externalDatabase);
-        externalCatalog.setAutoAnalyzePolicy("dbName", "name", "enable");
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(hmsTable1, Pair.of("index", column.getName())));
+            Mockito.when(mockAnalysisManager.findTableStatsStatus(Mockito.anyLong())).thenReturn(null);
+            externalCatalog.getCatalogProperty().addProperty(ExternalCatalog.ENABLE_AUTO_ANALYZE, "true");
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
+            // Test external table auto analyze enabled.
+            externalCatalog.getCatalogProperty().addProperty(ExternalCatalog.ENABLE_AUTO_ANALYZE, "false");
+            HMSExternalTable hmsTable1 = Mockito.spy(new HMSExternalTable(1, "name", "name", externalCatalog, externalDatabase) {
+                @Override
+                protected synchronized void makeSureInitialized() { }
+            });
+            externalCatalog.setAutoAnalyzePolicy("dbName", "name", "enable");
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(hmsTable1, Pair.of("index", column.getName())));
 
-        // Test table stats meta is null.
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test table stats meta is null.
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test user injected flag is set.
-        TableStatsMeta tableMeta = new TableStatsMeta();
-        tableMeta.userInjected = true;
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public TableStatsMeta findTableStatsStatus(long tblId) {
-                return tableMeta;
-            }
-        };
-        Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test user injected flag is set.
+            TableStatsMeta tableMeta = Mockito.spy(new TableStatsMeta());
+            tableMeta.userInjected = true;
+            Mockito.when(mockAnalysisManager.findTableStatsStatus(Mockito.anyLong())).thenReturn(tableMeta);
+            Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test column meta is null.
-        tableMeta.userInjected = false;
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test column meta is null.
+            tableMeta.userInjected = false;
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 0, 0, 0, null);
-            }
-        };
+            Mockito.doReturn(new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 0, 0, 0, null))
+                    .when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
 
-        new MockUp<JdbcExternalTable>() {
-            @Mock
-            protected synchronized void makeSureInitialized() {
-            }
-        };
-        // Test not supported external table type.
-        JdbcExternalCatalog jdbcExternalCatalog = new JdbcExternalCatalog(1, "name", "resource", new HashMap<>(), "");
-        JdbcExternalDatabase jdbcExternalDatabase = new JdbcExternalDatabase(jdbcExternalCatalog, 1, "jdbcdb", "jdbcdb");
-        ExternalTable externalTable = new JdbcExternalTable(1, "jdbctable", "jdbctable", jdbcExternalCatalog, jdbcExternalDatabase);
-        Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(externalTable, Pair.of("index", column.getName())));
+            // Test not supported external table type.
+            JdbcExternalCatalog jdbcExternalCatalog = new JdbcExternalCatalog(1, "name", "resource", new HashMap<>(), "");
+            JdbcExternalDatabase jdbcExternalDatabase = new JdbcExternalDatabase(jdbcExternalCatalog, 1, "jdbcdb", "jdbcdb");
+            JdbcExternalTable jdbcTable = Mockito.spy(new JdbcExternalTable(1, "jdbctable", "jdbctable", jdbcExternalCatalog, jdbcExternalDatabase) {
+                @Override
+                protected synchronized void makeSureInitialized() { }
+            });
+            Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(jdbcTable, Pair.of("index", column.getName())));
 
-        // Test hms external table not hive type.
-        new MockUp<HMSExternalTable>() {
-            @Mock
-            public DLAType getDlaType() {
-                return DLAType.ICEBERG;
-            }
-        };
-        ExternalTable hmsExternalTable = new HMSExternalTable(1, "hmsTable", "hmsTable", externalCatalog, externalDatabase);
-        Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(hmsExternalTable, Pair.of("index", column.getName())));
+            // Test hms external table not hive type.
+            HMSExternalTable hmsExternalTable = Mockito.spy(new HMSExternalTable(1, "hmsTable", "hmsTable", externalCatalog, externalDatabase) {
+                @Override
+                protected synchronized void makeSureInitialized() { }
+            });
+            Mockito.doReturn(DLAType.ICEBERG).when(hmsExternalTable).getDlaType();
+            Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(hmsExternalTable, Pair.of("index", column.getName())));
 
-        // Test partition first load.
-        new MockUp<OlapTable>() {
-            @Mock
-            public boolean isPartitionColumn(String columnName) {
-                return true;
-            }
-        };
-        tableMeta.partitionChanged.set(true);
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test partition first load.
+            tableMeta.partitionChanged.set(true);
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test empty table to non-empty table.
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCount() {
-                return 100;
-            }
-        };
-        tableMeta.partitionChanged.set(false);
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test empty table to non-empty table.
+            Mockito.doReturn(100L).when(table).getRowCount();
+            tableMeta.partitionChanged.set(false);
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test non-empty table to empty table.
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCount() {
-                return 0;
-            }
-        };
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 100, 0, 0, null);
-            }
-        };
-        tableMeta.partitionChanged.set(false);
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test non-empty table to empty table.
+            Mockito.doReturn(0L).when(table).getRowCount();
+            Mockito.doReturn(new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 100, 0, 0, null))
+                    .when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
+            tableMeta.partitionChanged.set(false);
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test table still empty.
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 0, 0, 0, null);
-            }
-        };
-        tableMeta.partitionChanged.set(false);
-        Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test table still empty.
+            Mockito.doReturn(new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 0, 0, 0, null))
+                    .when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
+            tableMeta.partitionChanged.set(false);
+            Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test row count changed more than threshold.
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCount() {
-                return 1000;
-            }
-        };
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 500, 0, 0, null);
-            }
-        };
-        tableMeta.partitionChanged.set(false);
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test row count changed more than threshold.
+            Mockito.doReturn(1000L).when(table).getRowCount();
+            Mockito.doReturn(new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 500, 0, 0, null))
+                    .when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
+            tableMeta.partitionChanged.set(false);
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test row count changed more than threshold.
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCount() {
-                return 111;
-            }
-        };
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 100, 80, 0, null);
-            }
-        };
-        tableMeta.partitionChanged.set(false);
-        tableMeta.updatedRows.set(80);
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test row count changed more than threshold.
+            Mockito.doReturn(111L).when(table).getRowCount();
+            Mockito.doReturn(new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 100, 80, 0, null))
+                    .when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
+            tableMeta.partitionChanged.set(false);
+            tableMeta.updatedRows.set(80);
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test update rows changed more than threshold
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCount() {
-                return 101;
-            }
-        };
-        tableMeta.partitionChanged.set(false);
-        tableMeta.updatedRows.set(91);
-        Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test update rows changed more than threshold
+            Mockito.doReturn(101L).when(table).getRowCount();
+            tableMeta.partitionChanged.set(false);
+            tableMeta.updatedRows.set(91);
+            Assertions.assertTrue(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
 
-        // Test row count and update rows changed less than threshold
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getRowCount() {
-                return 100;
-            }
-        };
-        tableMeta.partitionChanged.set(false);
-        tableMeta.updatedRows.set(85);
-        Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+            // Test row count and update rows changed less than threshold
+            Mockito.doReturn(100L).when(table).getRowCount();
+            tableMeta.partitionChanged.set(false);
+            tableMeta.updatedRows.set(85);
+            Assertions.assertFalse(StatisticsUtil.needAnalyzeColumn(table, Pair.of("index", column.getName())));
+        }
     }
 
     @Test
@@ -359,88 +290,59 @@ class StatisticsUtilTest {
         Column column = new Column("testColumn", PrimitiveType.INT);
         List<Column> schema = new ArrayList<>();
         schema.add(column);
-        OlapTable table = new OlapTable(200, "testTable", schema, null, null, null);
+        OlapTable table = Mockito.spy(new OlapTable(200, "testTable", schema, null, null, null));
 
         // Test column is null
         Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, null, 0));
 
         // Test table auto analyze is disabled.
-        new MockUp<OlapTable>() {
-            @Mock
-            public boolean autoAnalyzeEnabled() {
-                return false;
-            }
-        };
+        Mockito.doReturn(false).when(table).autoAnalyzeEnabled();
         Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
-        new MockUp<OlapTable>() {
-            @Mock
-            public boolean autoAnalyzeEnabled() {
-                return true;
-            }
-        };
+        Mockito.doReturn(true).when(table).autoAnalyzeEnabled();
 
         // Test external table
-        new MockUp<ExternalTable>() {
-            @Mock
-            public boolean autoAnalyzeEnabled() {
-                return true;
-            }
-        };
         IcebergExternalDatabase icebergDatabase = new IcebergExternalDatabase(null, 1L, "", "");
         Map<String, String> props = Maps.newHashMap();
         props.put(CatalogProperties.WAREHOUSE_LOCATION, "s3://tmp");
         IcebergExternalCatalog catalog = new IcebergHadoopExternalCatalog(0, "iceberg_ctl", "", props, "");
-        IcebergExternalTable icebergTable = new IcebergExternalTable(0, "", "", catalog, icebergDatabase);
+        IcebergExternalTable icebergTable = Mockito.spy(new IcebergExternalTable(0, "", "", catalog, icebergDatabase));
+        Mockito.doReturn(true).when(icebergTable).autoAnalyzeEnabled();
         Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(icebergTable, Pair.of("index", column.getName()), 0));
 
-        // Test table stats meta is null.
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public TableStatsMeta findTableStatsStatus(long tblId) {
-                return null;
-            }
-        };
-        Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
+        // Mock Env.getServingEnv().getAnalysisManager() for remaining tests
+        Env mockEnv = Mockito.mock(Env.class);
+        AnalysisManager mockAnalysisManager = Mockito.mock(AnalysisManager.class);
+        Mockito.when(mockEnv.getAnalysisManager()).thenReturn(mockAnalysisManager);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getServingEnv).thenReturn(mockEnv);
 
-        // Test column stats meta is null
-        TableStatsMeta tableMeta = new TableStatsMeta();
-        new MockUp<AnalysisManager>() {
-            @Mock
-            public TableStatsMeta findTableStatsStatus(long tblId) {
-                return tableMeta;
-            }
-        };
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return null;
-            }
-        };
-        Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
-                return new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 100, 0, 0, null);
-            }
-        };
+            // Test table stats meta is null.
+            Mockito.when(mockAnalysisManager.findTableStatsStatus(Mockito.anyLong())).thenReturn(null);
+            Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
 
-        // Test table stats is user injected
-        tableMeta.userInjected = true;
-        Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
-        tableMeta.userInjected = false;
+            // Test column stats meta is null
+            TableStatsMeta tableMeta = Mockito.spy(new TableStatsMeta());
+            Mockito.when(mockAnalysisManager.findTableStatsStatus(Mockito.anyLong())).thenReturn(tableMeta);
+            Mockito.doReturn(null).when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
+            Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
+            Mockito.doReturn(new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 100, 0, 0, null))
+                    .when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
 
-        // Test Config.auto_analyze_interval_seconds == 0
-        Config.auto_analyze_interval_seconds = 0;
-        Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
+            // Test table stats is user injected
+            tableMeta.userInjected = true;
+            Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
+            tableMeta.userInjected = false;
 
-        // Test column analyzed within the time interval
-        Config.auto_analyze_interval_seconds = 86400;
-        Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
+            // Test Config.auto_analyze_interval_seconds == 0
+            Config.auto_analyze_interval_seconds = 0;
+            Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
 
-        // Test column hasn't analyzed for longer than time interval, but version and row count doesn't change
-        new MockUp<TableStatsMeta>() {
-            @Mock
-            public ColStatsMeta findColumnStatsMeta(String indexName, String colName) {
+            // Test column analyzed within the time interval
+            Config.auto_analyze_interval_seconds = 86400;
+            Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 0));
+
+            // Test column hasn't analyzed for longer than time interval, but version and row count doesn't change
+            Mockito.doAnswer(inv -> {
                 ColStatsMeta ret = new ColStatsMeta(System.currentTimeMillis(), null, null, null, 0, 100, 20, 10, null);
                 try {
                     Thread.sleep(1500);
@@ -448,49 +350,18 @@ class StatisticsUtilTest {
                     e.printStackTrace();
                 }
                 return ret;
-            }
-        };
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getVisibleVersion() {
-                return 10;
-            }
+            }).when(tableMeta).findColumnStatsMeta(Mockito.anyString(), Mockito.anyString());
+            Mockito.doReturn(100L).when(table).getRowCount();
+            Config.auto_analyze_interval_seconds = 1;
+            Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 10));
 
-            @Mock
-            public long fetchRowCount() {
-                return 100;
-            }
-        };
-        Config.auto_analyze_interval_seconds = 1;
-        Assertions.assertFalse(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 10));
+            // Test column hasn't analyzed for longer than time interval, and version change
+            Assertions.assertTrue(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 11));
 
-        // Test column hasn't analyzed for longer than time interval, and version change
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getVisibleVersion() {
-                return 11;
-            }
-
-            @Mock
-            public long fetchRowCount() {
-                return 100;
-            }
-        };
-        Assertions.assertTrue(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 11));
-
-        // Test column hasn't analyzed for longer than time interval, and row count change
-        new MockUp<OlapTable>() {
-            @Mock
-            public long getVisibleVersion() {
-                return 10;
-            }
-
-            @Mock
-            public long fetchRowCount() {
-                return 101;
-            }
-        };
-        Assertions.assertTrue(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 10));
+            // Test column hasn't analyzed for longer than time interval, and row count change
+            Mockito.doReturn(101L).when(table).getRowCount();
+            Assertions.assertTrue(StatisticsUtil.isLongTimeColumn(table, Pair.of("index", column.getName()), 10));
+        }
     }
 
     @Test
@@ -498,7 +369,7 @@ class StatisticsUtilTest {
         Column column = new Column("testColumn", Type.INT, true, null, null, "");
         List<Column> schema = new ArrayList<>();
         schema.add(column);
-        OlapTable table = new OlapTable(200, "testTable", schema, KeysType.AGG_KEYS, null, null);
+        OlapTable table = Mockito.spy(new OlapTable(200, "testTable", schema, KeysType.AGG_KEYS, null, null));
 
         // Test full analyze always return true;
         Assertions.assertTrue(StatisticsUtil.canCollectColumn(column, table, false, 1));
@@ -514,12 +385,7 @@ class StatisticsUtilTest {
 
         // Test agg key return true;
         MaterializedIndexMeta meta = new MaterializedIndexMeta(1L, schema, 1, 1, (short) 1, TStorageType.COLUMN, KeysType.AGG_KEYS, null);
-        new MockUp<OlapTable>() {
-            @Mock
-            public MaterializedIndexMeta getIndexMetaByIndexId(long indexId) {
-                return meta;
-            }
-        };
+        Mockito.doReturn(meta).when(table).getIndexMetaByIndexId(Mockito.anyLong());
         Assertions.assertTrue(StatisticsUtil.canCollectColumn(column, table, true, 1));
 
         // Test agg value return false
@@ -528,17 +394,8 @@ class StatisticsUtilTest {
 
         // Test unique mor value column return false
         MaterializedIndexMeta meta1 = new MaterializedIndexMeta(1L, schema, 1, 1, (short) 1, TStorageType.COLUMN, KeysType.UNIQUE_KEYS, null);
-        new MockUp<OlapTable>() {
-            @Mock
-            public MaterializedIndexMeta getIndexMetaByIndexId(long indexId) {
-                return meta1;
-            }
-
-            @Mock
-            public boolean isUniqKeyMergeOnWrite() {
-                return false;
-            }
-        };
+        Mockito.doReturn(meta1).when(table).getIndexMetaByIndexId(Mockito.anyLong());
+        Mockito.doReturn(false).when(table).isUniqKeyMergeOnWrite();
         Assertions.assertFalse(StatisticsUtil.canCollectColumn(column, table, true, 1));
 
         // Test unique mor key column return true

--- a/fe/fe-core/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.system;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
+import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.GenericPool;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.system.HeartbeatMgr.BrokerHeartbeatHandler;
@@ -35,150 +36,118 @@ import org.apache.doris.thrift.TFrontendPingFrontendStatusCode;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloBrokerService;
 
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
-import org.apache.thrift.TException;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class HeartbeatMgrTest {
 
-    @Mocked
-    private Env env;
+    private Env env = Mockito.mock(Env.class);
+    private MockedStatic<Env> mockedEnvStatic;
 
     @Before
     public void setUp() {
-        new Expectations() {
-            {
-                env.getSelfNode();
-                minTimes = 0;
-                result = new HostInfo("192.168.1.3", 9010); // not self
-
-                env.isReady();
-                minTimes = 0;
-                result = true;
-
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
-            }
-        };
-
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
+        Mockito.when(env.getSelfNode()).thenReturn(new HostInfo("192.168.1.3", 9010)); // not self
+        Mockito.when(env.isReady()).thenReturn(true);
     }
 
-    @Test
-    public void testFrontendHbHandler(@Mocked FrontendService.Client client) throws TException {
-        new MockUp<GenericPool<FrontendService.Client>>() {
-            @Mock
-            public FrontendService.Client borrowObject(TNetworkAddress address) throws Exception {
-                return client;
-            }
-
-            @Mock
-            public void returnObject(TNetworkAddress address, FrontendService.Client object) {
-                return;
-            }
-
-            @Mock
-            public void invalidateObject(TNetworkAddress address, FrontendService.Client object) {
-                return;
-            }
-        };
-
-        TFrontendPingFrontendRequest normalRequest = new TFrontendPingFrontendRequest(12345, "abcd");
-        TFrontendPingFrontendResult normalResult = new TFrontendPingFrontendResult();
-        normalResult.setStatus(TFrontendPingFrontendStatusCode.OK);
-        normalResult.setMsg("success");
-        normalResult.setReplayedJournalId(191224);
-        normalResult.setQueryPort(9131);
-        normalResult.setRpcPort(9121);
-        normalResult.setArrowFlightSqlPort(9141);
-        normalResult.setVersion("test");
-
-        TFrontendPingFrontendRequest badRequest = new TFrontendPingFrontendRequest(12345, "abcde");
-        TFrontendPingFrontendResult badResult = new TFrontendPingFrontendResult();
-        badResult.setStatus(TFrontendPingFrontendStatusCode.FAILED);
-        badResult.setMsg("not ready");
-
-        new Expectations() {
-            {
-                client.ping(normalRequest);
-                minTimes = 0;
-                result = normalResult;
-
-                client.ping(badRequest);
-                minTimes = 0;
-                result = badResult;
-            }
-        };
-
-        Frontend fe = new Frontend(FrontendNodeType.FOLLOWER, "test", "192.168.1.1", 9010);
-        FrontendHeartbeatHandler handler = new FrontendHeartbeatHandler(fe, 12345, "abcd");
-        HeartbeatResponse response = handler.call();
-
-        Assert.assertTrue(response instanceof FrontendHbResponse);
-        FrontendHbResponse hbResponse = (FrontendHbResponse) response;
-        Assert.assertEquals(191224, hbResponse.getReplayedJournalId());
-        Assert.assertEquals(9131, hbResponse.getQueryPort());
-        Assert.assertEquals(9121, hbResponse.getRpcPort());
-        Assert.assertEquals(9141, hbResponse.getArrowFlightSqlPort());
-        Assert.assertEquals(HbStatus.OK, hbResponse.getStatus());
-        Assert.assertEquals("test", hbResponse.getVersion());
-
-        Frontend fe2 = new Frontend(FrontendNodeType.FOLLOWER, "test2", "192.168.1.2", 9010);
-        handler = new FrontendHeartbeatHandler(fe2, 12345, "abcde");
-        response = handler.call();
-
-        Assert.assertTrue(response instanceof FrontendHbResponse);
-        hbResponse = (FrontendHbResponse) response;
-        Assert.assertEquals(0, hbResponse.getReplayedJournalId());
-        Assert.assertEquals(0, hbResponse.getQueryPort());
-        Assert.assertEquals(0, hbResponse.getRpcPort());
-        Assert.assertEquals(0, hbResponse.getArrowFlightSqlPort());
-        Assert.assertEquals(HbStatus.BAD, hbResponse.getStatus());
-        Assert.assertEquals("not ready", hbResponse.getMsg());
+    @After
+    public void tearDown() {
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+        }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    public void testBrokerHbHandler(@Mocked TPaloBrokerService.Client client) throws Exception {
+    public void testFrontendHbHandler() throws Exception {
+        FrontendService.Client client = Mockito.mock(FrontendService.Client.class);
+
+        GenericPool<FrontendService.Client> mockPool = Mockito.mock(GenericPool.class);
+        Mockito.when(mockPool.borrowObject(Mockito.any(TNetworkAddress.class))).thenReturn(client);
+
+        GenericPool<FrontendService.Client> originalPool = ClientPool.frontendHeartbeatPool;
+        ClientPool.frontendHeartbeatPool = mockPool;
+        try {
+            TFrontendPingFrontendRequest normalRequest = new TFrontendPingFrontendRequest(12345, "abcd");
+            TFrontendPingFrontendResult normalResult = new TFrontendPingFrontendResult();
+            normalResult.setStatus(TFrontendPingFrontendStatusCode.OK);
+            normalResult.setMsg("success");
+            normalResult.setReplayedJournalId(191224);
+            normalResult.setQueryPort(9131);
+            normalResult.setRpcPort(9121);
+            normalResult.setArrowFlightSqlPort(9141);
+            normalResult.setVersion("test");
+
+            TFrontendPingFrontendRequest badRequest = new TFrontendPingFrontendRequest(12345, "abcde");
+            TFrontendPingFrontendResult badResult = new TFrontendPingFrontendResult();
+            badResult.setStatus(TFrontendPingFrontendStatusCode.FAILED);
+            badResult.setMsg("not ready");
+
+            Mockito.when(client.ping(normalRequest)).thenReturn(normalResult);
+            Mockito.when(client.ping(badRequest)).thenReturn(badResult);
+
+            Frontend fe = new Frontend(FrontendNodeType.FOLLOWER, "test", "192.168.1.1", 9010);
+            FrontendHeartbeatHandler handler = new FrontendHeartbeatHandler(fe, 12345, "abcd");
+            HeartbeatResponse response = handler.call();
+
+            Assert.assertTrue(response instanceof FrontendHbResponse);
+            FrontendHbResponse hbResponse = (FrontendHbResponse) response;
+            Assert.assertEquals(191224, hbResponse.getReplayedJournalId());
+            Assert.assertEquals(9131, hbResponse.getQueryPort());
+            Assert.assertEquals(9121, hbResponse.getRpcPort());
+            Assert.assertEquals(9141, hbResponse.getArrowFlightSqlPort());
+            Assert.assertEquals(HbStatus.OK, hbResponse.getStatus());
+            Assert.assertEquals("test", hbResponse.getVersion());
+
+            Frontend fe2 = new Frontend(FrontendNodeType.FOLLOWER, "test2", "192.168.1.2", 9010);
+            handler = new FrontendHeartbeatHandler(fe2, 12345, "abcde");
+            response = handler.call();
+
+            Assert.assertTrue(response instanceof FrontendHbResponse);
+            hbResponse = (FrontendHbResponse) response;
+            Assert.assertEquals(0, hbResponse.getReplayedJournalId());
+            Assert.assertEquals(0, hbResponse.getQueryPort());
+            Assert.assertEquals(0, hbResponse.getRpcPort());
+            Assert.assertEquals(0, hbResponse.getArrowFlightSqlPort());
+            Assert.assertEquals(HbStatus.BAD, hbResponse.getStatus());
+            Assert.assertEquals("not ready", hbResponse.getMsg());
+        } finally {
+            ClientPool.frontendHeartbeatPool = originalPool;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBrokerHbHandler() throws Exception {
+        TPaloBrokerService.Client client = Mockito.mock(TPaloBrokerService.Client.class);
+
         TBrokerOperationStatus status = new TBrokerOperationStatus();
         status.setStatusCode(TBrokerOperationStatusCode.OK);
 
-        new MockUp<GenericPool<TPaloBrokerService.Client>>() {
-            @Mock
-            public TPaloBrokerService.Client borrowObject(TNetworkAddress address) throws Exception {
-                return client;
-            }
+        GenericPool<TPaloBrokerService.Client> mockPool = Mockito.mock(GenericPool.class);
+        Mockito.when(mockPool.borrowObject(Mockito.any(TNetworkAddress.class))).thenReturn(client);
 
-            @Mock
-            public void returnObject(TNetworkAddress address, TPaloBrokerService.Client object) {
-                return;
-            }
+        GenericPool<TPaloBrokerService.Client> originalPool = ClientPool.brokerPool;
+        ClientPool.brokerPool = mockPool;
+        try {
+            Mockito.when(client.ping(Mockito.any(TBrokerPingBrokerRequest.class))).thenReturn(status);
 
-            @Mock
-            public void invalidateObject(TNetworkAddress address, TPaloBrokerService.Client object) {
-                return;
-            }
-        };
+            FsBroker broker = new FsBroker("192.168.1.1", 8111);
+            BrokerHeartbeatHandler handler = new BrokerHeartbeatHandler("hdfs", broker, "abc");
+            HeartbeatResponse response = handler.call();
 
-        new Expectations() {
-            {
-                client.ping((TBrokerPingBrokerRequest) any);
-                minTimes = 0;
-                result = status;
-            }
-        };
-
-        FsBroker broker = new FsBroker("192.168.1.1", 8111);
-        BrokerHeartbeatHandler handler = new BrokerHeartbeatHandler("hdfs", broker, "abc");
-        HeartbeatResponse response = handler.call();
-
-        Assert.assertTrue(response instanceof BrokerHbResponse);
-        BrokerHbResponse hbResponse = (BrokerHbResponse) response;
-        Assert.assertEquals(HbStatus.OK, hbResponse.getStatus());
+            Assert.assertTrue(response instanceof BrokerHbResponse);
+            BrokerHbResponse hbResponse = (BrokerHbResponse) response;
+            Assert.assertEquals(HbStatus.OK, hbResponse.getStatus());
+        } finally {
+            ClientPool.brokerPool = originalPool;
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/tablefunction/FrontendsTableValuedFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tablefunction/FrontendsTableValuedFunctionTest.java
@@ -26,10 +26,11 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.SystemInfoService.HostInfo;
 import org.apache.doris.thrift.TMetaScanRange;
 
-import mockit.Expectations;
-import mockit.Mocked;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,41 +39,37 @@ public class FrontendsTableValuedFunctionTest {
     private static final String INTERNAL_CTL = InternalCatalog.INTERNAL_CATALOG_NAME;
     private static final String INFO_DB = InfoSchemaDb.DATABASE_NAME;
 
-    @Mocked
-    private Env env;
-    @Mocked
-    private AccessControllerManager accessControllerManager;
-    @Mocked
-    private ConnectContext ctx;
+    private Env env = Mockito.mock(Env.class);
+    private AccessControllerManager accessControllerManager = Mockito.mock(AccessControllerManager.class);
+    private ConnectContext ctx = Mockito.mock(ConnectContext.class);
+
+    private MockedStatic<Env> mockedEnvStatic;
+    private MockedStatic<ConnectContext> mockedCtxStatic;
+
+    @After
+    public void tearDown() {
+        if (mockedCtxStatic != null) {
+            mockedCtxStatic.close();
+            mockedCtxStatic = null;
+        }
+        if (mockedEnvStatic != null) {
+            mockedEnvStatic.close();
+            mockedEnvStatic = null;
+        }
+    }
 
     private void mockContext(String selfHost, String currentConnectedFe) {
-        new Expectations() {
-            {
-                Env.getCurrentEnv();
-                minTimes = 0;
-                result = env;
+        mockedEnvStatic = Mockito.mockStatic(Env.class);
+        mockedEnvStatic.when(Env::getCurrentEnv).thenReturn(env);
 
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessControllerManager;
+        mockedCtxStatic = Mockito.mockStatic(ConnectContext.class);
+        mockedCtxStatic.when(ConnectContext::get).thenReturn(ctx);
 
-                ConnectContext.get();
-                minTimes = 0;
-                result = ctx;
-
-                accessControllerManager.checkDbPriv(ctx, INTERNAL_CTL, INFO_DB, PrivPredicate.SELECT);
-                minTimes = 0;
-                result = true;
-
-                env.getSelfNode();
-                minTimes = 0;
-                result = new HostInfo(selfHost, 9010);
-
-                ctx.getCurrentConnectedFEIp();
-                minTimes = 0;
-                result = currentConnectedFe;
-            }
-        };
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkDbPriv(ctx, InternalCatalog.INTERNAL_CATALOG_NAME,
+                InfoSchemaDb.DATABASE_NAME, PrivPredicate.SELECT)).thenReturn(true);
+        Mockito.when(env.getSelfNode()).thenReturn(new HostInfo(selfHost, 9010));
+        Mockito.when(ctx.getCurrentConnectedFEIp()).thenReturn(currentConnectedFe);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -131,6 +132,19 @@ public class DatabaseTransactionMgrTest {
         slaveTransMgr.setEditLog(slaveEnv.getEditLog());
 
         LabelToTxnId = addTransactionToTransactionMgr();
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        if (fakeTransactionIDGenerator != null) {
+            fakeTransactionIDGenerator.close();
+        }
     }
 
     public Map<String, Long> addTransactionToTransactionMgr() throws UserException {

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/FakeTransactionIDGenerator.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/FakeTransactionIDGenerator.java
@@ -17,43 +17,30 @@
 
 package org.apache.doris.transaction;
 
-import org.apache.doris.persist.EditLog;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 
-import mockit.Mock;
-import mockit.MockUp;
-
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-
-public final class FakeTransactionIDGenerator extends MockUp<TransactionIdGenerator> {
+public final class FakeTransactionIDGenerator implements AutoCloseable {
 
     private long currentId = 1000L;
+    private MockedConstruction<TransactionIdGenerator> mockedConstruction;
 
-    @Mock
-    public void $init() { // CHECKSTYLE IGNORE THIS LINE
-        // do nothing
+    public FakeTransactionIDGenerator() {
+        mockedConstruction = Mockito.mockConstruction(TransactionIdGenerator.class,
+            (mock, context) -> {
+                Mockito.doAnswer(inv -> {
+                    System.out.println("getNextTransactionId is called");
+                    return currentId++;
+                }).when(mock).getNextTransactionId();
+            });
     }
 
-    @Mock
-    public void setEditLog(EditLog editLog) {
-        // do nothing
-    }
-
-    @Mock
-    public synchronized long getNextTransactionId() {
-        System.out.println("getNextTransactionId is called");
-        return currentId++;
-    }
-
-    @Mock
-    public void write(DataOutput out) throws IOException {
-        // do nothing
-    }
-
-    @Mock
-    public void readFields(DataInput in) throws IOException {
-        // do nothing
+    @Override
+    public void close() {
+        if (mockedConstruction != null) {
+            mockedConstruction.close();
+            mockedConstruction = null;
+        }
     }
 
     public void setCurrentId(long newId) {

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
@@ -45,7 +45,6 @@ import org.apache.doris.load.routineload.RoutineLoadManager;
 import org.apache.doris.load.routineload.RoutineLoadStatistic;
 import org.apache.doris.load.routineload.RoutineLoadTaskInfo;
 import org.apache.doris.meta.MetaContext;
-import org.apache.doris.persist.EditLog;
 import org.apache.doris.rpc.RpcException;
 import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.thrift.TKafkaRLTaskProgress;
@@ -62,11 +61,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Injectable;
-import mockit.Mocked;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,6 +111,19 @@ public class GlobalTransactionMgrTest {
 
         slaveTransMgr = (GlobalTransactionMgr) slaveEnv.getGlobalTransactionMgr();
         slaveTransMgr.setEditLog(slaveEnv.getEditLog());
+    }
+
+    @After
+    public void tearDown() {
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        if (fakeTransactionIDGenerator != null) {
+            fakeTransactionIDGenerator.close();
+        }
     }
 
     @Test
@@ -291,9 +301,7 @@ public class GlobalTransactionMgrTest {
     }
 
     @Test
-    public void testCommitRoutineLoadTransaction(@Injectable TabletCommitInfo tabletCommitInfo,
-            @Mocked KafkaConsumer kafkaConsumer,
-            @Mocked EditLog editLog)
+    public void testCommitRoutineLoadTransaction()
             throws UserException {
         FakeEnv.setEnv(masterEnv);
         List<TabletCommitInfo> transTablets = generateTabletCommitInfos(CatalogTestUtil.testTabletId1, allBackends);
@@ -356,9 +364,7 @@ public class GlobalTransactionMgrTest {
     }
 
     @Test
-    public void testCommitRoutineLoadTransactionWithErrorMax(@Injectable TabletCommitInfo tabletCommitInfo,
-            @Mocked EditLog editLog,
-            @Mocked KafkaConsumer kafkaConsumer)
+    public void testCommitRoutineLoadTransactionWithErrorMax()
             throws UserException {
 
         FakeEnv.setEnv(masterEnv);

--- a/fe/fe-core/src/test/java/org/apache/doris/tso/TSOServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tso/TSOServiceTest.java
@@ -26,12 +26,11 @@ import org.apache.doris.metric.LongCounterMetric;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.persist.EditLog;
 
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
@@ -41,7 +40,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Unit tests for TSOService class.
@@ -50,6 +48,7 @@ public class TSOServiceTest {
 
     private TSOService tsoService;
     private Env env;
+    private MockedStatic<Env> mockedEnv;
 
     private int originalMaxGetTSORetryCount;
     private int originalMaxUpdateRetryCount;
@@ -59,7 +58,7 @@ public class TSOServiceTest {
 
     @Before
     public void setUp() {
-        new EnvMockUp();
+        mockedEnv = Mockito.mockStatic(Env.class);
 
         originalMaxGetTSORetryCount = Config.tso_max_get_retry_count;
         originalMaxUpdateRetryCount = Config.tso_max_update_retry_count;
@@ -74,14 +73,14 @@ public class TSOServiceTest {
         Config.tso_clock_backward_startup_threshold_ms = 30L * 60 * 1000;
 
         env = Mockito.mock(Env.class);
-        EnvMockUp.CURRENT_ENV.set(env);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
 
         tsoService = new TSOService();
     }
 
     @After
     public void tearDown() {
-        EnvMockUp.CURRENT_ENV.set(null);
+        mockedEnv.close();
         Config.tso_max_get_retry_count = originalMaxGetTSORetryCount;
         Config.tso_max_update_retry_count = originalMaxUpdateRetryCount;
         Config.tso_service_update_interval_ms = originalUpdateIntervalMs;
@@ -552,12 +551,4 @@ public class TSOServiceTest {
         return out.toByteArray();
     }
 
-    private static final class EnvMockUp extends MockUp<Env> {
-        private static final AtomicReference<Env> CURRENT_ENV = new AtomicReference<>();
-
-        @Mock
-        public static Env getCurrentEnv() {
-            return CURRENT_ENV.get();
-        }
-    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -94,13 +94,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import mockit.Mock;
-import mockit.MockUp;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -879,53 +878,44 @@ public abstract class TestWithFeService {
         Thread.sleep(1000);
     }
 
-
     protected void createMvByNereids(String sql) throws Exception {
-        new MockUp<EditLog>() {
-            @Mock
-            public void logCreateTable(CreateTableInfo info) {
-                System.out.println("skip log create table...");
+        EditLog editLog = Env.getCurrentEnv().getEditLog();
+        EditLog spyEditLog = Mockito.spy(editLog);
+        Mockito.doNothing().when(spyEditLog).logCreateTable(Mockito.any(CreateTableInfo.class));
+        Mockito.doNothing().when(spyEditLog).logCreateJob(Mockito.any(AbstractJob.class));
+        Env.getCurrentEnv().setEditLog(spyEditLog);
+        try {
+            NereidsParser nereidsParser = new NereidsParser();
+            LogicalPlan parsed = nereidsParser.parseSingle(sql);
+            StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
+            if (parsed instanceof CreateMTMVCommand) {
+                ((CreateMTMVCommand) parsed).run(connectContext, stmtExecutor);
             }
-
-            @Mock
-            public void logCreateJob(AbstractJob job) {
-                System.out.println("skip log create job...");
-            }
-        };
-        NereidsParser nereidsParser = new NereidsParser();
-        LogicalPlan parsed = nereidsParser.parseSingle(sql);
-        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
-        if (parsed instanceof CreateMTMVCommand) {
-            ((CreateMTMVCommand) parsed).run(connectContext, stmtExecutor);
+            checkAlterJob();
+            Thread.sleep(1000);
+        } finally {
+            Env.getCurrentEnv().setEditLog(editLog);
         }
-        checkAlterJob();
-        // waiting table state to normal
-        Thread.sleep(1000);
-
     }
 
     protected void dropMvByNereids(String sql) throws Exception {
-        new MockUp<EditLog>() {
-            @Mock
-            public void logCreateTable(CreateTableInfo info) {
-                System.out.println("skip log create table...");
+        EditLog editLog = Env.getCurrentEnv().getEditLog();
+        EditLog spyEditLog = Mockito.spy(editLog);
+        Mockito.doNothing().when(spyEditLog).logCreateTable(Mockito.any(CreateTableInfo.class));
+        Mockito.doNothing().when(spyEditLog).logCreateJob(Mockito.any(AbstractJob.class));
+        Env.getCurrentEnv().setEditLog(spyEditLog);
+        try {
+            NereidsParser nereidsParser = new NereidsParser();
+            LogicalPlan parsed = nereidsParser.parseSingle(sql);
+            StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
+            if (parsed instanceof DropMTMVCommand) {
+                ((DropMTMVCommand) parsed).run(connectContext, stmtExecutor);
             }
-
-            @Mock
-            public void logCreateJob(AbstractJob job) {
-                System.out.println("skip log create job...");
-            }
-        };
-        NereidsParser nereidsParser = new NereidsParser();
-        LogicalPlan parsed = nereidsParser.parseSingle(sql);
-        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, sql);
-        if (parsed instanceof DropMTMVCommand) {
-            ((DropMTMVCommand) parsed).run(connectContext, stmtExecutor);
+            checkAlterJob();
+            Thread.sleep(1000);
+        } finally {
+            Env.getCurrentEnv().setEditLog(editLog);
         }
-        checkAlterJob();
-        // waiting table state to normal
-        Thread.sleep(1000);
-
     }
 
     private void updateReplicaPathHash() {

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -284,8 +284,8 @@ under the License.
         <doris.home>${fe.dir}/../</doris.home>
         <revision>1.2-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <!--plugin parameters-->
         <skip.plugin>false</skip.plugin>
         <sonar.organization>apache</sonar.organization>
@@ -308,7 +308,7 @@ under the License.
         <javassist.version>3.18.2-GA</javassist.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <je.version>18.3.14-doris-SNAPSHOT</je.version>
-        <jmockit.version>1.49</jmockit.version>
+
         <commons-io.version>2.18.0</commons-io.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <json-simple.version>1.1.1</json-simple.version>
@@ -928,13 +928,7 @@ under the License.
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/org.jmockit/jmockit -->
-            <dependency>
-                <groupId>org.jmockit</groupId>
-                <artifactId>jmockit</artifactId>
-                <version>${jmockit.version}</version>
-                <scope>test</scope>
-            </dependency>
+
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
@@ -1946,11 +1940,7 @@ under the License.
             <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <!-- should be used in test scope -->
         <dependency>
             <groupId>org.awaitility</groupId>


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: 
1. Update FE source and target version to 17
2. Replace all JMockit usage in FE unit tests with Mockito and remove JMockit dependency

The FE unit tests used JMockit (1.49) as a mocking framework alongside Mockito (4.11.0), creating maintenance complexity and potential agent conflicts (e.g., with JaCoCo). This PR replaces **all** JMockit usage across ~243 test files with Mockito equivalents and removes the JMockit dependency entirely.

### Changes

**Migration patterns applied:**
- `@Mocked T field` → `T field = Mockito.mock(T.class)`
- `@Injectable T param` → `T param = Mockito.mock(T.class)`
- `new Expectations() {{ method; result=v; }}` → `when(method).thenReturn(v)` / `doReturn(v).when(mock).method()`
- `MockUp<T>` → `MockedStatic<T>`, `MockedConstruction<T>`, or `Mockito.spy()`
- `new Verifications() {{ m(); times=n; }}` → `verify(mock, times(n)).m()`

**Dependency removal:**
- Removed `jmockit` version property and dependency from `fe/pom.xml`
- Removed `-javaagent:jmockit` from surefire plugin in `fe/fe-core/pom.xml` and `max-compute-connector/pom.xml`

**Note:** Custom `Deencapsulation` utility retained (not from JMockit jar).

**Verification:** All 1227 tests across 231 modified test classes pass with 0 failures, 0 errors. Checkstyle passes with 0 violations.

247 files changed, 11810 insertions(+), 16730 deletions(-)

### Release note

None

### Check List (For Author)

- Test: FE UT - All 1227 tests pass (0 failures, 0 errors)
- Behavior changed: No
- Does this need documentation: No