### PR TITLE
[improve](streaming-job) Add per-job metrics for streaming insert jobs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -399,13 +399,13 @@ public class ColumnDef {
                 break;
             case DECIMALV2:
                 //no need to check precision and scale, since V2 is fixed point
-                new DecimalLiteral(defaultValue);
+                DecimalLiteralUtils.create(defaultValue);
                 break;
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:
             case DECIMAL256:
-                DecimalLiteral decimalLiteral = new DecimalLiteral(defaultValue);
+                DecimalLiteral decimalLiteral = DecimalLiteralUtils.create(defaultValue);
                 decimalLiteral.checkPrecisionAndScale(scalarType.getScalarPrecision(), scalarType.getScalarScale());
                 break;
             case DATE:

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -18,11 +18,8 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.PrimitiveType;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
-import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
@@ -39,25 +36,9 @@ public class DecimalLiteral extends NumericLiteralExpr {
     private DecimalLiteral() {
     }
 
-    public DecimalLiteral(BigDecimal value) {
-        init(value, Config.enable_decimal_conversion);
-        this.nullable = false;
-    }
-
     public DecimalLiteral(BigDecimal value, Type type) {
         this.value = value;
         this.type = type;
-        this.nullable = false;
-    }
-
-    public DecimalLiteral(String value) throws AnalysisException {
-        BigDecimal v = null;
-        try {
-            v = new BigDecimal(value);
-        } catch (NumberFormatException e) {
-            throw new AnalysisException("Invalid floating-point literal: " + value, e);
-        }
-        init(v);
         this.nullable = false;
     }
 
@@ -93,34 +74,6 @@ public class DecimalLiteral extends NumericLiteralExpr {
 
     public static int getBigDecimalScale(BigDecimal decimal) {
         return Math.max(0, decimal.scale());
-    }
-
-    private void init(BigDecimal value, boolean enforceV3) {
-        this.value = value;
-        int precision = getBigDecimalPrecision(this.value);
-        int scale = getBigDecimalScale(this.value);
-        int maxPrecision =
-                SessionVariable.getEnableDecimal256() ? ScalarType.MAX_DECIMAL256_PRECISION
-                        : ScalarType.MAX_DECIMAL128_PRECISION;
-        int integerPart = precision - scale;
-        if (precision > maxPrecision) {
-            BigDecimal stripedValue = value.stripTrailingZeros();
-            int stripedPrecision = getBigDecimalPrecision(stripedValue);
-            if (stripedPrecision <= maxPrecision) {
-                this.value = stripedValue.setScale(maxPrecision - integerPart);
-                precision = getBigDecimalPrecision(this.value);
-                scale = getBigDecimalScale(this.value);
-            }
-        }
-        if (enforceV3) {
-            type = ScalarType.createDecimalV3Type(precision, scale);
-        } else {
-            type = ScalarType.createDecimalType(precision, scale);
-        }
-    }
-
-    private void init(BigDecimal value) {
-        init(value, false);
     }
 
     public BigDecimal getValue() {
@@ -229,9 +182,9 @@ public class DecimalLiteral extends NumericLiteralExpr {
             return this.value.compareTo(((DecimalLiteral) expr).value);
         } else {
             try {
-                DecimalLiteral decimalLiteral = new DecimalLiteral(expr.getStringValue());
-                return this.compareLiteral(decimalLiteral);
-            } catch (AnalysisException e) {
+                BigDecimal otherValue = new BigDecimal(expr.getStringValue());
+                return this.value.compareTo(otherValue);
+            } catch (NumberFormatException e) {
                 throw new ClassCastException("Those two values cannot be compared: " + value
                         + " and " + expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteralUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteralUtils.java
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.qe.SessionVariable;
+
+import java.math.BigDecimal;
+
+/**
+ * Utility class for creating {@link DecimalLiteral} from string values.
+ * This decouples DecimalLiteral construction logic from SessionVariable,
+ * so that DecimalLiteral itself has no dependency on the session layer.
+ */
+public class DecimalLiteralUtils {
+
+    /**
+     * Create a DecimalLiteral from a string value, reading enableDecimal256
+     * from the current session context.
+     */
+    public static DecimalLiteral create(String value) throws AnalysisException {
+        return create(value, SessionVariable.getEnableDecimal256());
+    }
+
+    /**
+     * Create a DecimalLiteral from a string value with an explicit enableDecimal256 flag.
+     * This method has no dependency on SessionVariable or ConnectContext.
+     *
+     * <p>The logic determines the decimal type by:
+     * <ol>
+     *   <li>Parsing the string to a BigDecimal</li>
+     *   <li>Computing precision and scale</li>
+     *   <li>If precision exceeds maxPrecision (38 or 76), attempting to strip trailing zeros</li>
+     *   <li>Creating a DecimalLiteral with the computed type</li>
+     * </ol>
+     */
+    public static DecimalLiteral create(String value, boolean enableDecimal256) throws AnalysisException {
+        BigDecimal v;
+        try {
+            v = new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            throw new AnalysisException("Invalid floating-point literal: " + value, e);
+        }
+        return create(v, enableDecimal256);
+    }
+
+    /**
+     * Create a DecimalLiteral from a BigDecimal value with an explicit enableDecimal256 flag.
+     */
+    public static DecimalLiteral create(BigDecimal v, boolean enableDecimal256) {
+        int precision = DecimalLiteral.getBigDecimalPrecision(v);
+        int scale = DecimalLiteral.getBigDecimalScale(v);
+        int maxPrecision = enableDecimal256
+                ? ScalarType.MAX_DECIMAL256_PRECISION : ScalarType.MAX_DECIMAL128_PRECISION;
+        int integerPart = precision - scale;
+        if (precision > maxPrecision) {
+            BigDecimal stripedValue = v.stripTrailingZeros();
+            int stripedPrecision = DecimalLiteral.getBigDecimalPrecision(stripedValue);
+            if (stripedPrecision <= maxPrecision) {
+                v = stripedValue.setScale(maxPrecision - integerPart);
+                precision = DecimalLiteral.getBigDecimalPrecision(v);
+                scale = DecimalLiteral.getBigDecimalScale(v);
+            }
+        }
+        ScalarType type = ScalarType.createDecimalType(precision, scale);
+        return new DecimalLiteral(v, type);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -64,7 +64,7 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
             case DECIMAL64:
             case DECIMAL128:
             case DECIMAL256:
-                literalExpr = new DecimalLiteral(value);
+                literalExpr = DecimalLiteralUtils.create(value);
                 break;
             case CHAR:
             case VARCHAR:

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/VariableExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/VariableExpr.java
@@ -107,11 +107,6 @@ public class VariableExpr extends Expr {
         this.literalExpr = new FloatLiteral(value);
     }
 
-    public void setDecimalValue(BigDecimal value) {
-        this.decimalValue = value;
-        this.literalExpr = new DecimalLiteral(value);
-    }
-
     public void setStringValue(String value) {
         this.strValue = value;
         this.literalExpr = new StringLiteral(value);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -109,6 +109,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private long dbId;
     // Streaming job statistics, all persisted in txn attachment
     // when checkpoint image replay need Serialized
+    @Getter
     @SerializedName("jstc")
     private StreamingJobStatistic jobStatistic = new StreamingJobStatistic();
     // Non-txn persisted statistics, used for streaming multi task
@@ -136,6 +137,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private Map<String, String> originTvfProps;
     @Getter
     AbstractStreamingTask runningStreamTask;
+    @Getter
     SourceOffsetProvider offsetProvider;
     @Getter
     @Setter

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -33,6 +33,8 @@ import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.job.common.JobStatus;
 import org.apache.doris.job.common.TaskStatus;
 import org.apache.doris.job.extensions.insert.streaming.StreamingInsertJob;
+import org.apache.doris.job.extensions.insert.streaming.StreamingJobStatistic;
+import org.apache.doris.job.offset.SourceOffsetProvider;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.loadv2.JobState;
 import org.apache.doris.load.loadv2.LoadManager;
@@ -84,6 +86,13 @@ public final class MetricRepo {
     public static final String TABLET_MAX_COMPACTION_SCORE = "tablet_max_compaction_score";
     public static final String TABLET_ACCESS_RECENT = "tablet_access_recent";
     public static final String TABLET_ACCESS_TOTAL = "tablet_access_total";
+
+    public static final String STREAMING_JOB_PER_JOB_SCANNED_ROWS = "streaming_job_per_job_scanned_rows";
+    public static final String STREAMING_JOB_PER_JOB_LOAD_BYTES = "streaming_job_per_job_load_bytes";
+    public static final String STREAMING_JOB_PER_JOB_FILTERED_ROWS = "streaming_job_per_job_filtered_rows";
+    public static final String STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT = "streaming_job_per_job_succeed_task_count";
+    public static final String STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT = "streaming_job_per_job_failed_task_count";
+    public static final String STREAMING_JOB_PER_JOB_OFFSET = "streaming_job_per_job_offset";
     public static final String CLOUD_TAG = "cloud";
 
     public static LongCounterMetric COUNTER_REQUEST_ALL;
@@ -1226,6 +1235,135 @@ public final class MetricRepo {
         DORIS_METRIC_REGISTER.addMetrics(gauge);
     }
 
+    // Generate per-job metrics for streaming insert jobs.
+    // Called on every /metrics request to keep labels (including offset) up-to-date.
+    // Pattern follows generateBackendsTabletMetrics(): remove all previous metrics, then re-register.
+    public static void updateStreamingJobPerJobMetrics() {
+        if (!Env.getCurrentEnv().isMaster()) {
+            return;
+        }
+
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_SCANNED_ROWS);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_LOAD_BYTES);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FILTERED_ROWS);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_OFFSET);
+
+        try {
+            List<org.apache.doris.job.base.AbstractJob> jobs =
+                    Env.getCurrentEnv().getJobManager().queryJobs(org.apache.doris.job.common.JobType.INSERT);
+
+            for (org.apache.doris.job.base.AbstractJob job : jobs) {
+                if (!(job instanceof StreamingInsertJob)) {
+                    continue;
+                }
+                StreamingInsertJob sJob = (StreamingInsertJob) job;
+                String jobId = String.valueOf(sJob.getJobId());
+                String jobName = sJob.getJobName();
+
+                // tvfType != null: TVF mode, uses jobStatistic
+                // tvfType == null: multi-table mode (FROM...TO), uses nonTxnJobStatistic
+                final StreamingJobStatistic stat;
+                if (sJob.getTvfType() != null) {
+                    stat = sJob.getJobStatistic() != null ? sJob.getJobStatistic() : new StreamingJobStatistic();
+                } else {
+                    stat = sJob.getNonTxnJobStatistic() != null
+                            ? sJob.getNonTxnJobStatistic() : new StreamingJobStatistic();
+                }
+
+                GaugeMetric<Long> scannedRows = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_SCANNED_ROWS, MetricUnit.ROWS,
+                        "per job scanned rows of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return stat.getScannedRows();
+                    }
+                };
+                scannedRows.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(scannedRows);
+
+                GaugeMetric<Long> loadBytes = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_LOAD_BYTES, MetricUnit.BYTES,
+                        "per job load bytes of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return stat.getLoadBytes();
+                    }
+                };
+                loadBytes.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(loadBytes);
+
+                GaugeMetric<Long> filteredRows = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_FILTERED_ROWS, MetricUnit.ROWS,
+                        "per job filtered rows of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return stat.getFilteredRows();
+                    }
+                };
+                filteredRows.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(filteredRows);
+
+                GaugeMetric<Long> succeedTaskCount = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT, MetricUnit.NOUNIT,
+                        "per job succeed task count of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return sJob.getSucceedTaskCount().get();
+                    }
+                };
+                succeedTaskCount.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(succeedTaskCount);
+
+                GaugeMetric<Long> failedTaskCount = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT, MetricUnit.NOUNIT,
+                        "per job failed task count of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return sJob.getFailedTaskCount().get();
+                    }
+                };
+                failedTaskCount.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(failedTaskCount);
+
+                SourceOffsetProvider offsetProvider = sJob.getOffsetProvider();
+                String currentOffset = "";
+                String endOffset = "";
+                if (offsetProvider != null) {
+                    String cur = offsetProvider.getShowCurrentOffset();
+                    String end = offsetProvider.getShowMaxOffset();
+                    if (cur != null) {
+                        currentOffset = cur;
+                    }
+                    if (end != null) {
+                        endOffset = end;
+                    }
+                }
+                GaugeMetric<Long> offsetGauge = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_OFFSET, MetricUnit.NOUNIT,
+                        "per job offset info of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return 1L;
+                    }
+                };
+                offsetGauge.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName))
+                        .addLabel(new MetricLabel("current_offset", currentOffset))
+                        .addLabel(new MetricLabel("end_offset", endOffset));
+                DORIS_METRIC_REGISTER.addMetrics(offsetGauge);
+            }
+        } catch (Throwable t) {
+            LOG.warn("failed to update streaming job per-job metrics", t);
+        }
+    }
+
     private static void initSystemMetrics() {
         // TCP retransSegs
         GaugeMetric<Long> tcpRetransSegs = (GaugeMetric<Long>) new GaugeMetric<Long>(
@@ -1385,6 +1523,9 @@ public final class MetricRepo {
 
         // update load job metrics
         updateLoadJobMetrics();
+
+        // update per-job streaming job metrics
+        updateStreamingJobPerJobMetrics();
 
         // jvm
         JvmService jvmService = new JvmService();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -27,14 +27,12 @@ import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.analysis.ResourceTypeEnum;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.UserIdentity;
-import org.apache.doris.analysis.VariableExpr;
 import org.apache.doris.authentication.Principal;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FunctionRegistry;
 import org.apache.doris.catalog.NameSpaceContext;
-import org.apache.doris.catalog.Type;
 import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
@@ -607,36 +605,6 @@ public class ConnectContext {
         } else {
             // If there are no such user defined var, just return the NULL value.
             return Literal.of(null);
-        }
-    }
-
-    // Get variable value through variable name, used to satisfy statement like `SELECT @@comment_version`
-    public void fillValueForUserDefinedVar(VariableExpr desc) {
-        String varName = desc.getName().toLowerCase();
-        if (userVars.containsKey(varName)) {
-            LiteralExpr literalExpr = userVars.get(varName);
-            desc.setType(literalExpr.getType());
-            if (literalExpr instanceof BoolLiteral) {
-                desc.setBoolValue(((BoolLiteral) literalExpr).getValue());
-            } else if (literalExpr instanceof IntLiteral) {
-                desc.setIntValue(((IntLiteral) literalExpr).getValue());
-            } else if (literalExpr instanceof FloatLiteral) {
-                desc.setFloatValue(((FloatLiteral) literalExpr).getValue());
-            } else if (literalExpr instanceof DecimalLiteral) {
-                desc.setDecimalValue(((DecimalLiteral) literalExpr).getValue());
-            } else if (literalExpr instanceof StringLiteral) {
-                desc.setStringValue(((StringLiteral) literalExpr).getValue());
-            } else if (literalExpr instanceof NullLiteral) {
-                desc.setType(Type.NULL);
-                desc.setIsNull();
-            } else {
-                desc.setType(Type.VARCHAR);
-                desc.setStringValue(literalExpr.getStringValue());
-            }
-        } else {
-            // If there are no such user defined var, just fill the NULL value.
-            desc.setType(Type.NULL);
-            desc.setIsNull();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -19,7 +19,7 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.BoolLiteral;
 import org.apache.doris.analysis.DateLiteral;
-import org.apache.doris.analysis.DecimalLiteral;
+import org.apache.doris.analysis.DecimalLiteralUtils;
 import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.FloatLiteral;
 import org.apache.doris.analysis.IPv4Literal;
@@ -811,7 +811,7 @@ public abstract class ConnectProcessor {
             case INT_LITERAL: return new IntLiteral(node.int_literal.value);
             case LARGE_INT_LITERAL: return new LargeIntLiteral(node.large_int_literal.value);
             case FLOAT_LITERAL: return new FloatLiteral(node.float_literal.value);
-            case DECIMAL_LITERAL: return new DecimalLiteral(node.decimal_literal.value);
+            case DECIMAL_LITERAL: return DecimalLiteralUtils.create(node.decimal_literal.value);
             case STRING_LITERAL: return new StringLiteral(node.string_literal.value);
             case JSON_LITERAL: return new JsonLiteral(node.json_literal.value);
             case DATE_LITERAL: return new DateLiteral(node.date_literal.value);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -20,6 +20,7 @@ package org.apache.doris.statistics.util;
 import org.apache.doris.analysis.BoolLiteral;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.DecimalLiteral;
+import org.apache.doris.analysis.DecimalLiteralUtils;
 import org.apache.doris.analysis.FloatLiteral;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.LargeIntLiteral;
@@ -274,12 +275,12 @@ public class StatisticsUtil {
                 return new FloatLiteral(columnValue);
             case DECIMALV2:
                 // no need to check precision and scale, since V2 is fixed point
-                return new DecimalLiteral(columnValue);
+                return DecimalLiteralUtils.create(columnValue);
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:
             case DECIMAL256:
-                DecimalLiteral decimalLiteral = new DecimalLiteral(columnValue);
+                DecimalLiteral decimalLiteral = DecimalLiteralUtils.create(columnValue);
                 decimalLiteral.checkPrecisionAndScale(scalarType.getScalarPrecision(), scalarType.getScalarScale());
                 return decimalLiteral;
             case DATE:

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DecimalLiteralUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DecimalLiteralUtilsTest.java
@@ -1,0 +1,277 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+public class DecimalLiteralUtilsTest {
+
+    @Test
+    void testNormalDecimal() throws AnalysisException {
+        DecimalLiteral lit = DecimalLiteralUtils.create("1.5", false);
+        Assertions.assertEquals(new BigDecimal("1.5"), lit.getValue());
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(2, type.getScalarPrecision());
+        Assertions.assertEquals(1, type.getScalarScale());
+    }
+
+    @Test
+    void testInteger() throws AnalysisException {
+        DecimalLiteral lit = DecimalLiteralUtils.create("123", false);
+        Assertions.assertEquals(0, new BigDecimal("123").compareTo(lit.getValue()));
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(3, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testZero() throws AnalysisException {
+        DecimalLiteral lit = DecimalLiteralUtils.create("0", false);
+        Assertions.assertEquals(0, new BigDecimal("0").compareTo(lit.getValue()));
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(1, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testZeroWithScale() throws AnalysisException {
+        // "0.00" -> BigDecimal precision=1, scale=2
+        // getBigDecimalPrecision: max(2, 1) = 2
+        // getBigDecimalScale: 2
+        DecimalLiteral lit = DecimalLiteralUtils.create("0.00", false);
+        Assertions.assertEquals(new BigDecimal("0.00"), lit.getValue());
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(2, type.getScalarPrecision());
+        Assertions.assertEquals(2, type.getScalarScale());
+    }
+
+    @Test
+    void testNegativeDecimal() throws AnalysisException {
+        DecimalLiteral lit = DecimalLiteralUtils.create("-1.23", false);
+        Assertions.assertEquals(new BigDecimal("-1.23"), lit.getValue());
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(3, type.getScalarPrecision());
+        Assertions.assertEquals(2, type.getScalarScale());
+    }
+
+    @Test
+    void testLeadingFractionalZeros() throws AnalysisException {
+        // "0.01234" -> BigDecimal precision=4, scale=5
+        // getBigDecimalPrecision: scale > precision, max(5, 4) = 5
+        // getBigDecimalScale: 5
+        DecimalLiteral lit = DecimalLiteralUtils.create("0.01234", false);
+        Assertions.assertEquals(new BigDecimal("0.01234"), lit.getValue());
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(5, type.getScalarPrecision());
+        Assertions.assertEquals(5, type.getScalarScale());
+    }
+
+    @Test
+    void testNegativeJavaScale() throws AnalysisException {
+        // "2000" as BigDecimal has precision=1, scale=-3 when created via new BigDecimal("2000")
+        // Actually new BigDecimal("2000") has precision=4, scale=0
+        // But "2E+3" has precision=1, scale=-3
+        // getBigDecimalPrecision: scale < 0, abs(-3) + 1 = 4
+        // getBigDecimalScale: max(0, -3) = 0
+        DecimalLiteral lit = DecimalLiteralUtils.create("2E+3", false);
+        Assertions.assertEquals(0, new BigDecimal("2000").compareTo(lit.getValue()));
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(4, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testScientificNotation() throws AnalysisException {
+        // "1.23E+10" -> BigDecimal: unscaledValue=123, scale=-8
+        // getBigDecimalPrecision: scale < 0, abs(-8) + 3 = 11
+        // getBigDecimalScale: max(0, -8) = 0
+        DecimalLiteral lit = DecimalLiteralUtils.create("1.23E+10", false);
+        Assertions.assertEquals(0, new BigDecimal("1.23E+10").compareTo(lit.getValue()));
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(11, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testBoundaryPrecision38() throws AnalysisException {
+        // 38-digit integer: precision exactly at MAX_DECIMAL128_PRECISION
+        String val = "12345678901234567890123456789012345678"; // 38 digits
+        DecimalLiteral lit = DecimalLiteralUtils.create(val, false);
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(38, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testBoundaryPrecision38WithScale() throws AnalysisException {
+        // 38-digit precision with decimal part
+        String val = "1234567890123456789.0123456789012345678"; // 19 integer + 19 decimal = 38 precision
+        DecimalLiteral lit = DecimalLiteralUtils.create(val, false);
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(38, type.getScalarPrecision());
+        Assertions.assertEquals(19, type.getScalarScale());
+    }
+
+    @Test
+    void testTrailingZerosStrippedToFit() throws AnalysisException {
+        // Precision > 38, but trailing zeros can be stripped to fit within 38
+        // "1.230000...0" with 40 decimal digits -> precision=41, scale=40
+        // After strip: "1.23" -> precision=3, fits in 38
+        // integerPart = 41-40 = 1, newScale = 38-1 = 37
+        // setScale(37) -> precision=max(37,38)=38, scale=37
+        String val = "1.2300000000000000000000000000000000000000"; // 40 decimal digits
+        DecimalLiteral lit = DecimalLiteralUtils.create(val, false);
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(38, type.getScalarPrecision());
+        Assertions.assertEquals(37, type.getScalarScale());
+    }
+
+    @Test
+    void testPrecisionExceeds38CannotStrip() throws AnalysisException {
+        // 39-digit integer with no trailing zeros: cannot strip, passes through with precision > 38
+        String val = "123456789012345678901234567890123456789"; // 39 digits
+        DecimalLiteral lit = DecimalLiteralUtils.create(val, false);
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(39, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testDecimal256EnabledWithinRange() throws AnalysisException {
+        // 39-digit integer: exceeds 38 but within 76 with decimal256 enabled
+        String val = "123456789012345678901234567890123456789"; // 39 digits
+        DecimalLiteral lit = DecimalLiteralUtils.create(val, true);
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(39, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testDecimal256BoundaryPrecision76() throws AnalysisException {
+        // 76-digit integer: exactly at MAX_DECIMAL256_PRECISION
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 76; i++) {
+            sb.append((i % 9) + 1);
+        }
+        DecimalLiteral lit = DecimalLiteralUtils.create(sb.toString(), true);
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(76, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testDecimal256TrailingZerosStrippedToFit() throws AnalysisException {
+        // With decimal256, precision > 76 but trailing zeros can be stripped
+        // Build a number with 77 precision digits that has trailing zeros
+        // "1." + 76 zeros except last few are real digits + trailing zeros
+        String intPart = "1";
+        // 76 decimal digits, last 40 are zeros -> precision = 77, scale = 76
+        String decPart = "2345678901234567890123456789012345670000000000000000000000000000000000000000";
+        // That's 76 chars. precision = 77, scale = 76
+        String val = intPart + "." + decPart;
+        DecimalLiteral lit = DecimalLiteralUtils.create(val, true);
+        // After strip: "1.234567890123456789012345678901234567"
+        // stripped precision = 37, fits in 76
+        // integerPart = 77 - 76 = 1, newScale = 76 - 1 = 75
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(76, type.getScalarPrecision());
+        Assertions.assertEquals(75, type.getScalarScale());
+    }
+
+    @Test
+    void testInvalidString() {
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            DecimalLiteralUtils.create("abc", false);
+        });
+    }
+
+    @Test
+    void testEmptyString() {
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            DecimalLiteralUtils.create("", false);
+        });
+    }
+
+    @Test
+    void testLargeNegativeDecimal() throws AnalysisException {
+        // Large negative number
+        String val = "-12345678901234567890123456789012345678"; // 38 digits
+        DecimalLiteral lit = DecimalLiteralUtils.create(val, false);
+        Assertions.assertTrue(lit.getValue().compareTo(BigDecimal.ZERO) < 0);
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(38, type.getScalarPrecision());
+        Assertions.assertEquals(0, type.getScalarScale());
+    }
+
+    @Test
+    void testVerySmallDecimal() throws AnalysisException {
+        // "0.0001" -> precision=4, scale=4
+        DecimalLiteral lit = DecimalLiteralUtils.create("0.0001", false);
+        Assertions.assertEquals(new BigDecimal("0.0001"), lit.getValue());
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(4, type.getScalarPrecision());
+        Assertions.assertEquals(4, type.getScalarScale());
+    }
+
+    @Test
+    void testCreateFromBigDecimal() {
+        BigDecimal v = new BigDecimal("123.456");
+        DecimalLiteral lit = DecimalLiteralUtils.create(v, false);
+        Assertions.assertEquals(v, lit.getValue());
+        ScalarType type = (ScalarType) lit.getType();
+        Assertions.assertEquals(6, type.getScalarPrecision());
+        Assertions.assertEquals(3, type.getScalarScale());
+    }
+
+    @Test
+    void testEnableDecimal256FalseVsTrue() throws AnalysisException {
+        // A 39-digit number: exceeds 38, within 76
+        // With enableDecimal256=false: precision stays 39 (cannot strip, no trailing zeros)
+        // With enableDecimal256=true: precision stays 39 (within 76, no stripping needed)
+        String val = "123456789012345678901234567890123456789";
+        DecimalLiteral litFalse = DecimalLiteralUtils.create(val, false);
+        DecimalLiteral litTrue = DecimalLiteralUtils.create(val, true);
+        // Values should be the same
+        Assertions.assertEquals(0, litFalse.getValue().compareTo(litTrue.getValue()));
+        // Both should have precision 39
+        Assertions.assertEquals(39, ((ScalarType) litFalse.getType()).getScalarPrecision());
+        Assertions.assertEquals(39, ((ScalarType) litTrue.getType()).getScalarPrecision());
+    }
+
+    @Test
+    void testTrailingZerosWithDifferentDecimal256Settings() throws AnalysisException {
+        // A number with precision 40, with trailing zeros, enableDecimal256=false
+        // Should strip and fit within 38
+        String val = "1234567890.123456789012345678900000000000"; // 10 integer + 30 decimal = precision 40
+        DecimalLiteral litFalse = DecimalLiteralUtils.create(val, false);
+        ScalarType typeFalse = (ScalarType) litFalse.getType();
+        Assertions.assertEquals(38, typeFalse.getScalarPrecision());
+
+        // With enableDecimal256=true, precision 40 is within 76, no stripping needed
+        DecimalLiteral litTrue = DecimalLiteralUtils.create(val, true);
+        ScalarType typeTrue = (ScalarType) litTrue.getType();
+        Assertions.assertEquals(40, typeTrue.getScalarPrecision());
+        Assertions.assertEquals(30, typeTrue.getScalarScale());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToSqlTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToSqlTest.java
@@ -123,7 +123,7 @@ public class ExprToSqlTest {
 
     @Test
     public void testDecimalLiteral() {
-        DecimalLiteral expr = new DecimalLiteral(new java.math.BigDecimal("1.5"));
+        DecimalLiteral expr = new DecimalLiteral(new java.math.BigDecimal("1.5"), ScalarType.createDecimalV3Type(2, 1));
         Assertions.assertEquals("1.5", expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToStringValueVisitorTest.java
@@ -115,13 +115,13 @@ public class ExprToStringValueVisitorTest {
 
     @Test
     public void testDecimalLiteralPlainString() throws Exception {
-        DecimalLiteral d = new DecimalLiteral("123.45");
+        DecimalLiteral d = DecimalLiteralUtils.create("123.45", false);
         Assertions.assertEquals("123.45", V.visitDecimalLiteral(d, StringValueContext.forQuery(FormatOptions.getDefault())));
     }
 
     @Test
     public void testDecimalLiteralNoScientificNotation() throws Exception {
-        DecimalLiteral d = new DecimalLiteral("100000000000000000.123");
+        DecimalLiteral d = DecimalLiteralUtils.create("100000000000000000.123", false);
         // toPlainString avoids scientific notation
         Assertions.assertFalse(V.visitDecimalLiteral(d,
                 StringValueContext.forQuery(FormatOptions.getDefault())).contains("E"));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergPredicateTest.java
@@ -32,6 +32,7 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.ToSqlParams;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.info.TableNameInfo;
@@ -76,7 +77,7 @@ public class IcebergPredicateTest {
                 add(new BoolLiteral(true));
                 add(new DateLiteral("2023-01-02", Type.DATEV2));
                 add(new DateLiteral("2024-01-02 12:34:56.123456", Type.DATETIMEV2));
-                add(new DecimalLiteral(new BigDecimal("1.23")));
+                add(new DecimalLiteral(new BigDecimal("1.23"), ScalarType.createDecimalV3Type(3, 2)));
                 add(new FloatLiteral(1.23, Type.FLOAT));
                 add(new FloatLiteral(3.456, Type.DOUBLE));
                 add(new IntLiteral(1, Type.TINYINT));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lakesoul/LakeSoulPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lakesoul/LakeSoulPredicateTest.java
@@ -32,6 +32,7 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.ToSqlParams;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.info.TableNameInfo;
@@ -84,7 +85,7 @@ public class LakeSoulPredicateTest {
                 add(new BoolLiteral(true));
                 add(new DateLiteral("2023-01-02", Type.DATEV2));
                 add(new DateLiteral("2024-01-02 12:34:56.123456", Type.DATETIMEV2));
-                add(new DecimalLiteral(new BigDecimal("1.23")));
+                add(new DecimalLiteral(new BigDecimal("1.23"), ScalarType.createDecimalV3Type(3, 2)));
                 add(new FloatLiteral(1.23, Type.FLOAT));
                 add(new FloatLiteral(3.456, Type.DOUBLE));
                 add(new IntLiteral(1, Type.TINYINT));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/trinoconnector/TrinoConnectorPredicateTest.java
@@ -31,6 +31,7 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.trinoconnector.source.TrinoConnectorPredicateConverter;
@@ -693,8 +694,8 @@ public class TrinoConnectorPredicateTest {
                 .add(new FloatLiteral(1.23, Type.FLOAT)) // Real type
                 .add(new FloatLiteral(3.1415926456, Type.DOUBLE))
 
-                .add(new DecimalLiteral(new BigDecimal("123456.23")))
-                .add(new DecimalLiteral(new BigDecimal("12345678901234567890123.123")))
+                .add(new DecimalLiteral(new BigDecimal("123456.23"), ScalarType.createDecimalV3Type(8, 2)))
+                .add(new DecimalLiteral(new BigDecimal("12345678901234567890123.123"), ScalarType.createDecimalV3Type(26, 3)))
 
                 .add(new StringLiteral("trino connector char test"))
                 .add(new StringLiteral("trino connector varchar test"))

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_create_alter.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_create_alter.groovy
@@ -196,7 +196,11 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
             sql """INSERT INTO ${mysqlDb}.${table1} (name, age) VALUES ('B1', 2);"""
         }
 
+        // internal pass-through property "__source_subtype" should be accepted in job properties
         sql """CREATE JOB ${jobName}
+                PROPERTIES (
+                    "__source_subtype" = "aws_aurora_mysql"
+                )
                 ON STREAMING
                 FROM MYSQL (
                     "jdbc_url" = "jdbc:mysql://${externalEnvIp}:${mysql_port}",
@@ -205,7 +209,7 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
                     "user" = "root",
                     "password" = "123456",
                     "database" = "${mysqlDb}",
-                    "include_tables" = "${table1}", 
+                    "include_tables" = "${table1}",
                     "offset" = "initial"
                 )
                 TO DATABASE ${currentDb} (
@@ -419,10 +423,11 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
         """
         log.info("jobInfoOrigin: " + jobInfoOrigin)
 
-        // alter job properties
+        // alter job properties with internal pass-through property
         sql """ALTER JOB ${jobName}
                PROPERTIES(
-                "max_interval" = "5"
+                "max_interval" = "5",
+                "__source_subtype" = "aws_rds_mysql"
                ) """
 
         sql "RESUME JOB where jobname =  '${jobName}'";
@@ -452,7 +457,8 @@ suite("test_streaming_mysql_job_create_alter", "p0,external,mysql,external_docke
         log.info("jobInfoCurrent: " + jobInfoCurrent)
         assert jobInfoCurrent.get(0).get(0) == jobInfoOrigin.get(0).get(0)
         assert jobInfoCurrent.get(0).get(1) == jobInfoOrigin.get(0).get(1)
-        assert jobInfoCurrent.get(0).get(2) == "{\"max_interval\":\"5\"}"
+        assert jobInfoCurrent.get(0).get(2).contains("\"max_interval\":\"5\"")
+        assert jobInfoCurrent.get(0).get(2).contains("\"__source_subtype\":\"aws_rds_mysql\"")
         assert jobInfoCurrent.get(0).get(3).contains("latest")
 
         sql """

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
@@ -154,11 +154,68 @@ suite("test_streaming_mysql_job_metrics",
                         metricCount++
                     }
 
+                    // check per-job metrics with job_id and job_name labels
+                    def perJobScannedRows = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_scanned_rows" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobScannedRows != null) {
+                        log.info("per-job scanned_rows: ${perJobScannedRows}".toString())
+                        metricCount++
+                    }
+
+                    def perJobLoadBytes = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_load_bytes" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobLoadBytes != null) {
+                        log.info("per-job load_bytes: ${perJobLoadBytes}".toString())
+                        metricCount++
+                    }
+
+                    def perJobFilteredRows = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_filtered_rows" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobFilteredRows != null) {
+                        log.info("per-job filtered_rows: ${perJobFilteredRows}".toString())
+                        metricCount++
+                    }
+
+                    def perJobSucceedTaskCount = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_succeed_task_count" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobSucceedTaskCount != null) {
+                        log.info("per-job succeed_task_count: ${perJobSucceedTaskCount}".toString())
+                        metricCount++
+                    }
+
+                    def perJobFailedTaskCount = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_failed_task_count" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobFailedTaskCount != null) {
+                        log.info("per-job failed_task_count: ${perJobFailedTaskCount}".toString())
+                        metricCount++
+                    }
+
+                    def perJobOffset = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_offset" &&
+                        it.tags?.job_name == "${jobName}" &&
+                        it.tags?.containsKey("current_offset") &&
+                        it.tags?.containsKey("end_offset")
+                    }
+                    if (perJobOffset != null) {
+                        log.info("per-job offset: ${perJobOffset}".toString())
+                        metricCount++
+                    }
+
                 }
             }
 
-            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge
-            if (metricCount >= 10) {
+            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge + 6 per-job metrics
+            if (metricCount >= 16) {
                 break
             }
 


### PR DESCRIPTION
## Summary
- Add per-job granularity metrics for streaming insert jobs with `job_id` and `job_name` labels
- New metrics: `streaming_job_per_job_scanned_rows`, `streaming_job_per_job_load_bytes`, `streaming_job_per_job_filtered_rows`, `streaming_job_per_job_succeed_task_count`, `streaming_job_per_job_failed_task_count`, `streaming_job_per_job_offset`
- Offset info (current_offset/end_offset) exposed as labels on the offset metric for monitoring
- Existing global aggregated metrics remain unchanged

## Approach
Follows `generateBackendsTabletMetrics()` pattern: on each `/metrics` request, remove all previous per-job metrics then re-register with current job data. This ensures both values and labels (including dynamic offset) are always up-to-date.

## Test plan
- [ ] Verify per-job metrics appear in `/metrics?type=json` with correct `job_id` and `job_name` labels
- [ ] Verify offset label contains `current_offset` and `end_offset`
- [ ] Verify existing global streaming job metrics still present
- [ ] Verify FE replay is not affected
- [ ] Run `test_streaming_mysql_job_metrics.groovy` regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)