### PR TITLE
[improve](streaming-job) Add per-job metrics for streaming insert jobs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -137,7 +137,6 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private Map<String, String> originTvfProps;
     @Getter
     AbstractStreamingTask runningStreamTask;
-    @Getter
     SourceOffsetProvider offsetProvider;
     @Getter
     @Setter

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -109,6 +109,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private long dbId;
     // Streaming job statistics, all persisted in txn attachment
     // when checkpoint image replay need Serialized
+    @Getter
     @SerializedName("jstc")
     private StreamingJobStatistic jobStatistic = new StreamingJobStatistic();
     // Non-txn persisted statistics, used for streaming multi task
@@ -136,6 +137,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private Map<String, String> originTvfProps;
     @Getter
     AbstractStreamingTask runningStreamTask;
+    @Getter
     SourceOffsetProvider offsetProvider;
     @Getter
     @Setter

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -1339,10 +1339,10 @@ public final class MetricRepo {
                     String cur = offsetProvider.getShowCurrentOffset();
                     String end = offsetProvider.getShowMaxOffset();
                     if (cur != null) {
-                        currentOffset = cur;
+                        currentOffset = cur.replace("\\", "\\\\").replace("\"", "\\\"");
                     }
                     if (end != null) {
-                        endOffset = end;
+                        endOffset = end.replace("\\", "\\\\").replace("\"", "\\\"");
                     }
                 }
                 GaugeMetric<Long> offsetGauge = new GaugeMetric<Long>(

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -33,6 +33,8 @@ import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.job.common.JobStatus;
 import org.apache.doris.job.common.TaskStatus;
 import org.apache.doris.job.extensions.insert.streaming.StreamingInsertJob;
+import org.apache.doris.job.extensions.insert.streaming.StreamingJobStatistic;
+import org.apache.doris.job.offset.SourceOffsetProvider;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.loadv2.JobState;
 import org.apache.doris.load.loadv2.LoadManager;
@@ -84,6 +86,13 @@ public final class MetricRepo {
     public static final String TABLET_MAX_COMPACTION_SCORE = "tablet_max_compaction_score";
     public static final String TABLET_ACCESS_RECENT = "tablet_access_recent";
     public static final String TABLET_ACCESS_TOTAL = "tablet_access_total";
+
+    public static final String STREAMING_JOB_PER_JOB_SCANNED_ROWS = "streaming_job_per_job_scanned_rows";
+    public static final String STREAMING_JOB_PER_JOB_LOAD_BYTES = "streaming_job_per_job_load_bytes";
+    public static final String STREAMING_JOB_PER_JOB_FILTERED_ROWS = "streaming_job_per_job_filtered_rows";
+    public static final String STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT = "streaming_job_per_job_succeed_task_count";
+    public static final String STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT = "streaming_job_per_job_failed_task_count";
+    public static final String STREAMING_JOB_PER_JOB_OFFSET = "streaming_job_per_job_offset";
     public static final String CLOUD_TAG = "cloud";
 
     public static LongCounterMetric COUNTER_REQUEST_ALL;
@@ -1226,6 +1235,135 @@ public final class MetricRepo {
         DORIS_METRIC_REGISTER.addMetrics(gauge);
     }
 
+    // Generate per-job metrics for streaming insert jobs.
+    // Called on every /metrics request to keep labels (including offset) up-to-date.
+    // Pattern follows generateBackendsTabletMetrics(): remove all previous metrics, then re-register.
+    public static void updateStreamingJobPerJobMetrics() {
+        if (!Env.getCurrentEnv().isMaster()) {
+            return;
+        }
+
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_SCANNED_ROWS);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_LOAD_BYTES);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FILTERED_ROWS);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_OFFSET);
+
+        try {
+            List<org.apache.doris.job.base.AbstractJob> jobs =
+                    Env.getCurrentEnv().getJobManager().queryJobs(org.apache.doris.job.common.JobType.INSERT);
+
+            for (org.apache.doris.job.base.AbstractJob job : jobs) {
+                if (!(job instanceof StreamingInsertJob)) {
+                    continue;
+                }
+                StreamingInsertJob sJob = (StreamingInsertJob) job;
+                String jobId = String.valueOf(sJob.getJobId());
+                String jobName = sJob.getJobName();
+
+                // tvfType != null: TVF mode, uses jobStatistic
+                // tvfType == null: multi-table mode (FROM...TO), uses nonTxnJobStatistic
+                final StreamingJobStatistic stat;
+                if (sJob.getTvfType() != null) {
+                    stat = sJob.getJobStatistic() != null ? sJob.getJobStatistic() : new StreamingJobStatistic();
+                } else {
+                    stat = sJob.getNonTxnJobStatistic() != null
+                            ? sJob.getNonTxnJobStatistic() : new StreamingJobStatistic();
+                }
+
+                GaugeMetric<Long> scannedRows = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_SCANNED_ROWS, MetricUnit.ROWS,
+                        "per job scanned rows of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return stat.getScannedRows();
+                    }
+                };
+                scannedRows.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(scannedRows);
+
+                GaugeMetric<Long> loadBytes = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_LOAD_BYTES, MetricUnit.BYTES,
+                        "per job load bytes of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return stat.getLoadBytes();
+                    }
+                };
+                loadBytes.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(loadBytes);
+
+                GaugeMetric<Long> filteredRows = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_FILTERED_ROWS, MetricUnit.ROWS,
+                        "per job filtered rows of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return stat.getFilteredRows();
+                    }
+                };
+                filteredRows.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(filteredRows);
+
+                GaugeMetric<Long> succeedTaskCount = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT, MetricUnit.NOUNIT,
+                        "per job succeed task count of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return sJob.getSucceedTaskCount().get();
+                    }
+                };
+                succeedTaskCount.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(succeedTaskCount);
+
+                GaugeMetric<Long> failedTaskCount = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT, MetricUnit.NOUNIT,
+                        "per job failed task count of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return sJob.getFailedTaskCount().get();
+                    }
+                };
+                failedTaskCount.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(failedTaskCount);
+
+                SourceOffsetProvider offsetProvider = sJob.getOffsetProvider();
+                String currentOffset = "";
+                String endOffset = "";
+                if (offsetProvider != null) {
+                    String cur = offsetProvider.getShowCurrentOffset();
+                    String end = offsetProvider.getShowMaxOffset();
+                    if (cur != null) {
+                        currentOffset = cur;
+                    }
+                    if (end != null) {
+                        endOffset = end;
+                    }
+                }
+                GaugeMetric<Long> offsetGauge = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_OFFSET, MetricUnit.NOUNIT,
+                        "per job offset info of streaming job") {
+                    @Override
+                    public Long getValue() {
+                        return 1L;
+                    }
+                };
+                offsetGauge.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName))
+                        .addLabel(new MetricLabel("current_offset", currentOffset))
+                        .addLabel(new MetricLabel("end_offset", endOffset));
+                DORIS_METRIC_REGISTER.addMetrics(offsetGauge);
+            }
+        } catch (Throwable t) {
+            LOG.warn("failed to update streaming job per-job metrics", t);
+        }
+    }
+
     private static void initSystemMetrics() {
         // TCP retransSegs
         GaugeMetric<Long> tcpRetransSegs = (GaugeMetric<Long>) new GaugeMetric<Long>(
@@ -1385,6 +1523,9 @@ public final class MetricRepo {
 
         // update load job metrics
         updateLoadJobMetrics();
+
+        // update per-job streaming job metrics
+        updateStreamingJobPerJobMetrics();
 
         // jvm
         JvmService jvmService = new JvmService();

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -34,7 +34,6 @@ import org.apache.doris.job.common.JobStatus;
 import org.apache.doris.job.common.TaskStatus;
 import org.apache.doris.job.extensions.insert.streaming.StreamingInsertJob;
 import org.apache.doris.job.extensions.insert.streaming.StreamingJobStatistic;
-import org.apache.doris.job.offset.SourceOffsetProvider;
 import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.loadv2.JobState;
 import org.apache.doris.load.loadv2.LoadManager;
@@ -92,7 +91,6 @@ public final class MetricRepo {
     public static final String STREAMING_JOB_PER_JOB_FILTERED_ROWS = "streaming_job_per_job_filtered_rows";
     public static final String STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT = "streaming_job_per_job_succeed_task_count";
     public static final String STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT = "streaming_job_per_job_failed_task_count";
-    public static final String STREAMING_JOB_PER_JOB_OFFSET = "streaming_job_per_job_offset";
     public static final String CLOUD_TAG = "cloud";
 
     public static LongCounterMetric COUNTER_REQUEST_ALL;
@@ -1248,7 +1246,6 @@ public final class MetricRepo {
         DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FILTERED_ROWS);
         DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT);
         DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT);
-        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_OFFSET);
 
         try {
             List<org.apache.doris.job.base.AbstractJob> jobs =
@@ -1331,33 +1328,6 @@ public final class MetricRepo {
                 failedTaskCount.addLabel(new MetricLabel("job_id", jobId))
                         .addLabel(new MetricLabel("job_name", jobName));
                 DORIS_METRIC_REGISTER.addMetrics(failedTaskCount);
-
-                SourceOffsetProvider offsetProvider = sJob.getOffsetProvider();
-                String currentOffset = "";
-                String endOffset = "";
-                if (offsetProvider != null) {
-                    String cur = offsetProvider.getShowCurrentOffset();
-                    String end = offsetProvider.getShowMaxOffset();
-                    if (cur != null) {
-                        currentOffset = cur.replace("\\", "\\\\").replace("\"", "\\\"");
-                    }
-                    if (end != null) {
-                        endOffset = end.replace("\\", "\\\\").replace("\"", "\\\"");
-                    }
-                }
-                GaugeMetric<Long> offsetGauge = new GaugeMetric<Long>(
-                        STREAMING_JOB_PER_JOB_OFFSET, MetricUnit.NOUNIT,
-                        "per job offset info of streaming job") {
-                    @Override
-                    public Long getValue() {
-                        return 1L;
-                    }
-                };
-                offsetGauge.addLabel(new MetricLabel("job_id", jobId))
-                        .addLabel(new MetricLabel("job_name", jobName))
-                        .addLabel(new MetricLabel("current_offset", currentOffset))
-                        .addLabel(new MetricLabel("end_offset", endOffset));
-                DORIS_METRIC_REGISTER.addMetrics(offsetGauge);
             }
         } catch (Throwable t) {
             LOG.warn("failed to update streaming job per-job metrics", t);

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
@@ -154,11 +154,68 @@ suite("test_streaming_mysql_job_metrics",
                         metricCount++
                     }
 
+                    // check per-job metrics with job_id and job_name labels
+                    def perJobScannedRows = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_scanned_rows" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobScannedRows != null) {
+                        log.info("per-job scanned_rows: ${perJobScannedRows}".toString())
+                        metricCount++
+                    }
+
+                    def perJobLoadBytes = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_load_bytes" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobLoadBytes != null) {
+                        log.info("per-job load_bytes: ${perJobLoadBytes}".toString())
+                        metricCount++
+                    }
+
+                    def perJobFilteredRows = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_filtered_rows" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobFilteredRows != null) {
+                        log.info("per-job filtered_rows: ${perJobFilteredRows}".toString())
+                        metricCount++
+                    }
+
+                    def perJobSucceedTaskCount = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_succeed_task_count" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobSucceedTaskCount != null) {
+                        log.info("per-job succeed_task_count: ${perJobSucceedTaskCount}".toString())
+                        metricCount++
+                    }
+
+                    def perJobFailedTaskCount = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_failed_task_count" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobFailedTaskCount != null) {
+                        log.info("per-job failed_task_count: ${perJobFailedTaskCount}".toString())
+                        metricCount++
+                    }
+
+                    def perJobOffset = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_offset" &&
+                        it.tags?.job_name == "${jobName}" &&
+                        it.tags?.containsKey("current_offset") &&
+                        it.tags?.containsKey("end_offset")
+                    }
+                    if (perJobOffset != null) {
+                        log.info("per-job offset: ${perJobOffset}".toString())
+                        metricCount++
+                    }
+
                 }
             }
 
-            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge
-            if (metricCount >= 10) {
+            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge + 6 per-job metrics
+            if (metricCount >= 16) {
                 break
             }
 

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
@@ -200,22 +200,12 @@ suite("test_streaming_mysql_job_metrics",
                         metricCount++
                     }
 
-                    def perJobOffset = result.find {
-                        it.tags?.metric == "doris_fe_streaming_job_per_job_offset" &&
-                        it.tags?.job_name == "${jobName}" &&
-                        it.tags?.containsKey("current_offset") &&
-                        it.tags?.containsKey("end_offset")
-                    }
-                    if (perJobOffset != null) {
-                        log.info("per-job offset: ${perJobOffset}".toString())
-                        metricCount++
-                    }
 
                 }
             }
 
-            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge + 6 per-job metrics
-            if (metricCount >= 16) {
+            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge + 5 per-job metrics
+            if (metricCount >= 15) {
                 break
             }
 


### PR DESCRIPTION
## Summary
- Add per-job granularity metrics for streaming insert jobs with `job_id` and `job_name` labels
- New metrics: `streaming_job_per_job_scanned_rows`, `streaming_job_per_job_load_bytes`, `streaming_job_per_job_filtered_rows`, `streaming_job_per_job_succeed_task_count`, `streaming_job_per_job_failed_task_count`
- Existing global aggregated metrics remain unchanged
- Follow-up to #60493

## Approach
Follows `generateBackendsTabletMetrics()` pattern: on each `/metrics` request, remove all previous per-job metrics then re-register with current job data. This ensures values are always up-to-date and stale jobs are cleaned up automatically.

Offset info is intentionally excluded from metric labels to avoid Prometheus series churn and serialization issues. Offset can be viewed via `SHOW STREAMING JOBS` or `jobs("type"="insert")` TVF.

## Test plan
- [ ] Verify per-job metrics appear in `/metrics?type=json` with correct `job_id` and `job_name` labels
- [ ] Verify existing global streaming job metrics still present
- [ ] Verify FE replay is not affected
- [ ] Run `test_streaming_mysql_job_metrics.groovy` regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)