### PR TITLE
[opt](mv) simplify get base column names' way

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -241,7 +241,7 @@ public class MaterializedViewHandler extends AlterHandler {
             // Step2: create mv job
             RollupJobV2 rollupJobV2 =
                     createMaterializedViewJob(null, mvIndexName, baseIndexName, mvColumns,
-                            createMvCommand.getWhereClauseItemColumn(olapTable),
+                            createMvCommand.getWhereClauseItemColumn(),
                             createMvCommand.getProperties(), olapTable, db, baseIndexId,
                             createMvCommand.getMVKeysType(), createMvCommand.getOriginStatement(),
                             sessionVariables);
@@ -594,7 +594,7 @@ public class MaterializedViewHandler extends AlterHandler {
                                 "The mvItem[" + mvColumnItem.getName() + "] require slot because it is value column");
                     }
                 }
-                newMVColumns.add(mvColumnItem.toMVColumn(olapTable, sessionVariables));
+                newMVColumns.add(mvColumnItem.toMVColumn(sessionVariables));
             }
         } else {
             for (MVColumnItem mvColumnItem : mvColumnItemList) {
@@ -603,7 +603,7 @@ public class MaterializedViewHandler extends AlterHandler {
                     throw new DdlException("Base columns is null");
                 }
 
-                newMVColumns.add(mvColumnItem.toMVColumn(olapTable, sessionVariables));
+                newMVColumns.add(mvColumnItem.toMVColumn(sessionVariables));
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -36,10 +36,8 @@ import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -290,19 +288,6 @@ public abstract class Expr extends TreeNode<Expr> implements Cloneable {
             }
         }
         return true;
-    }
-
-    public Map<Long, Set<String>> getTableIdToColumnNames() {
-        Map<Long, Set<String>> tableIdToColumnNames = new HashMap<Long, Set<String>>();
-        getTableIdToColumnNames(tableIdToColumnNames);
-        return tableIdToColumnNames;
-    }
-
-    public void getTableIdToColumnNames(Map<Long, Set<String>> tableIdToColumnNames) {
-        Preconditions.checkState(tableIdToColumnNames != null);
-        for (Expr child : children) {
-            child.getTableIdToColumnNames(tableIdToColumnNames);
-        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/MVColumnItem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/MVColumnItem.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
@@ -27,6 +26,7 @@ import org.apache.doris.common.DdlException;
 
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -36,31 +36,22 @@ import java.util.Set;
  * It just a intermediate variable between semantic analysis and final handler.
  */
 public class MVColumnItem {
-    private String name;
+    private final String name;
     // the origin type of slot ref
     private Type type;
     private boolean isKey;
     private AggregateType aggregationType;
     private boolean isAggregationTypeImplicit;
-    private Expr defineExpr;
-    private Set<String> baseColumnNames;
+    private final Expr defineExpr;
+    private final Set<String> baseColumnNames;
 
     public MVColumnItem(String name, Type type, AggregateType aggregateType, Expr defineExpr) {
         this.name = name;
         this.type = type;
         this.aggregationType = aggregateType;
         this.isAggregationTypeImplicit = false;
-        this.defineExpr = defineExpr;
-
-        Map<Long, Set<String>> tableIdToColumnNames = defineExpr.getTableIdToColumnNames();
-
-        if (tableIdToColumnNames.size() == 1) {
-            for (Map.Entry<Long, Set<String>> entry : tableIdToColumnNames.entrySet()) {
-                baseColumnNames = entry.getValue();
-            }
-        } else {
-            baseColumnNames = new HashSet<>();
-        }
+        this.defineExpr = Objects.requireNonNull(defineExpr, "defineExpr is null");
+        baseColumnNames = extractBaseColumnNames(defineExpr);
     }
 
     public MVColumnItem(Expr defineExpr) throws AnalysisException {
@@ -70,23 +61,14 @@ public class MVColumnItem {
     public MVColumnItem(String name, Expr defineExpr) {
         this.name = name;
         this.isAggregationTypeImplicit = false;
-        this.defineExpr = defineExpr;
+        this.defineExpr = Objects.requireNonNull(defineExpr, "defineExpr is null");
 
         this.type = defineExpr.getType();
         if (this.type instanceof ScalarType && this.type.isStringType()) {
             this.type = new ScalarType(type.getPrimitiveType());
             ((ScalarType) this.type).setMaxLength();
         }
-
-        Map<Long, Set<String>> tableIdToColumnNames = defineExpr.getTableIdToColumnNames();
-
-        if (tableIdToColumnNames.size() == 1) {
-            for (Map.Entry<Long, Set<String>> entry : tableIdToColumnNames.entrySet()) {
-                baseColumnNames = entry.getValue();
-            }
-        } else {
-            baseColumnNames = new HashSet<>();
-        }
+        baseColumnNames = extractBaseColumnNames(defineExpr);
     }
 
     public String getName() {
@@ -126,32 +108,29 @@ public class MVColumnItem {
         return baseColumnNames;
     }
 
-    public Column toMVColumn(OlapTable olapTable, Map<String, String> sessionVars) throws DdlException {
-        Column baseColumn = olapTable.getBaseColumn(name);
+    public Column toMVColumn(Map<String, String> sessionVars) throws DdlException {
         Column result;
-        if (baseColumn == null && defineExpr == null) {
-            // Some mtmv column have name diffrent with base column
-            baseColumn = olapTable.getBaseColumn(baseColumnNames.iterator().next());
+        if (type == null) {
+            throw new DdlException("MVColumnItem type is null");
         }
-        if (baseColumn != null) {
-            result = new Column(baseColumn);
-            if (result.getType() == null) {
-                throw new DdlException("base column's type is null, column=" + result.getName());
-            }
-            result.setIsKey(isKey);
-        } else {
-            if (type == null) {
-                throw new DdlException("MVColumnItem type is null");
-            }
-            result = new Column(name, type, isKey, aggregationType, null, "");
-            if (defineExpr != null) {
-                result.setIsAllowNull(defineExpr.isNullable());
-            }
-        }
+        result = new Column(name, type, isKey, aggregationType, null, "");
+        result.setIsAllowNull(defineExpr.isNullable());
         result.setName(name);
         result.setAggregationType(aggregationType, isAggregationTypeImplicit);
         result.setDefineExpr(defineExpr);
         result.setSessionVariables(sessionVars);
+        return result;
+    }
+
+    private Set<String> extractBaseColumnNames(Expr defineExpr) {
+        Set<String> result = new HashSet<>();
+        Set<SlotRef> slotRefs = new HashSet<>();
+        defineExpr.collect(SlotRef.class, slotRefs);
+        for (SlotRef slotRef : slotRefs) {
+            if (slotRef.getCol() != null) {
+                result.add(slotRef.getCol());
+            }
+        }
         return result;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -31,9 +31,6 @@ import com.google.gson.annotations.SerializedName;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 public class SlotRef extends Expr {
     @SerializedName("tn")
@@ -234,31 +231,6 @@ public class SlotRef extends Expr {
     @Override
     public boolean isBound(SlotId slotId) {
         return desc.getId().equals(slotId);
-    }
-
-    @Override
-    public void getTableIdToColumnNames(Map<Long, Set<String>> tableIdToColumnNames) {
-        if (desc == null) {
-            return;
-        }
-
-        if (col == null) {
-            for (Expr expr : desc.getSourceExprs()) {
-                expr.getTableIdToColumnNames(tableIdToColumnNames);
-            }
-        } else {
-            if (desc.getParent().getTable() == null) {
-                // Maybe this column comes from inline view.
-                return;
-            }
-            Long tableId = desc.getParent().getTable().getId();
-            Set<String> columnNames = tableIdToColumnNames.get(tableId);
-            if (columnNames == null) {
-                columnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-                tableIdToColumnNames.put(tableId, columnNames);
-            }
-            columnNames.add(desc.getColumn().getName());
-        }
     }
 
     public void setLabel(String label) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/VirtualSlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/VirtualSlotRef.java
@@ -17,9 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import java.util.Map;
-import java.util.Set;
-
 /**
  * It like a SlotRef except that it is not a real column exist in table.
  */
@@ -28,10 +25,6 @@ public class VirtualSlotRef extends SlotRef {
 
     protected VirtualSlotRef(VirtualSlotRef other) {
         super(other);
-    }
-
-    @Override
-    public void getTableIdToColumnNames(Map<Long, Set<String>> tableIdToColumnNames) {
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
@@ -172,13 +172,13 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
     }
 
     /**getWhereClauseItemColumn*/
-    public Column getWhereClauseItemColumn(OlapTable olapTable) throws DdlException {
+    public Column getWhereClauseItemColumn() throws DdlException {
         if (whereClauseItem == null) {
             return null;
         }
         // sessionVars is null because in BindSink, the where clause guard expr
         // can directly use the session var in materialized view metadata.
-        return whereClauseItem.toMVColumn(olapTable, null);
+        return whereClauseItem.toMVColumn(null);
     }
 
     public MVColumnItem getWhereClauseItem() {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/MaterializedViewHandlerTest.java
@@ -220,8 +220,6 @@ public class MaterializedViewHandlerTest {
         List<MVColumnItem> list = Lists.newArrayList(mvColumnItem);
         new Expectations() {
             {
-                olapTable.getBaseColumn(columnName1);
-                result = null;
                 olapTable.hasMaterializedIndex(mvName);
                 result = false;
                 createMaterializedViewCommand.getMVName();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

try to simplify MvColumnItem get base column names' way.
The target is not rely on tuple descriptor anymore.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

