### PR TITLE
[refine](exec) remove unnecessary materialize_block_inplace calls

### DIFF
--- a/be/src/exec/exchange/vdata_stream_recvr.cpp
+++ b/be/src/exec/exchange/vdata_stream_recvr.cpp
@@ -28,7 +28,6 @@
 
 #include "common/logging.h"
 #include "core/block/block.h"
-#include "core/block/materialize_block.h"
 #include "exec/exchange/vdata_stream_mgr.h"
 #include "exec/operator/exchange_sink_operator.h"
 #include "exec/operator/exchange_source_operator.h"
@@ -297,7 +296,6 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
                     nblock->get_by_position(i).column->clone_resized(rows);
         }
     }
-    materialize_block_inplace(*nblock);
 
     auto block_mem_size = nblock->allocated_bytes();
     {

--- a/be/src/exec/operator/multi_cast_data_stream_source.cpp
+++ b/be/src/exec/operator/multi_cast_data_stream_source.cpp
@@ -19,7 +19,6 @@
 
 #include "common/status.h"
 #include "core/block/block.h"
-#include "core/block/materialize_block.h"
 #include "exec/operator/multi_cast_data_streamer.h"
 #include "exec/operator/operator.h"
 
@@ -112,7 +111,6 @@ Status MultiCastDataStreamerSourceOperatorX::get_block(RuntimeState* state, Bloc
         SCOPED_TIMER(local_state._materialize_data_timer);
         RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(
                 local_state._output_expr_contexts, *output_block, block, true));
-        materialize_block_inplace(*block);
     }
     return Status::OK();
 }

--- a/be/src/exec/operator/set_sink_operator.cpp
+++ b/be/src/exec/operator/set_sink_operator.cpp
@@ -19,7 +19,6 @@
 
 #include <memory>
 
-#include "core/block/materialize_block.h"
 #include "exec/common/hash_table/hash_table_set_build.h"
 #include "exec/operator/operator.h"
 
@@ -118,7 +117,6 @@ Status SetSinkOperatorX<is_intersect>::_process_build_block(
         return Status::OK();
     }
 
-    materialize_block_inplace(block);
     // Dispose the overflow of ColumnString
     for (auto& data : block) {
         data.column = std::move(*data.column).mutate()->convert_column_if_overflow();


### PR DESCRIPTION
### What problem does this PR solve?
Remove three redundant `materialize_block_inplace` calls where const column handling is already covered by downstream logic.

**1. `set_sink_operator.cpp`**
`_extract_build_column` already checks `is_column_const()` and calls `convert_to_full_column_if_const()` for each expression result column. The preceding `materialize_block_inplace` on the raw input block is redundant.

**2. `vdata_stream_recvr.cpp`**
In the local exchange path, blocks are enqueued and consumed by downstream operators that handle const columns themselves. `ColumnConst::allocated_bytes()` correctly reports actual allocated memory, so memory tracking remains accurate without materialization.

**3. `multi_cast_data_stream_source.cpp`**
The output block enters the pipeline and is processed by downstream operators, which handle const columns through their own expression evaluation. No need to materialize here.



### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

