### PR TITLE
[opt](nereids) scale num_nulls in col stats when partition pruned

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -433,14 +433,6 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
         return getColumnStatistic(catalogRelation.getTable(), slot.getName(), idxId);
     }
 
-    /**
-     * if get partition col stats failed, then return table level col stats
-     */
-    private ColumnStatistic getColumnStatsFromPartitionCacheOrTableCache(
-            OlapTableStatistics olapTableStats, SlotReference slot, List<String> partitionNames) {
-        return getColumnStatistic(olapTableStats, slot.getName(), partitionNames);
-    }
-
     private double getSelectedPartitionRowCount(OlapScan olapScan, double tableRowCount) {
         // the number of partitions whose row count is not available
         double unknownPartitionCount = 0;
@@ -629,8 +621,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             for (SlotReference slot : visibleOutputSlots) {
                 ColumnStatistic cache;
                 if (enablePartitionStatics) {
-                    cache = getColumnStatsFromPartitionCacheOrTableCache(
-                            olapTableStats, slot, selectedPartitionNames);
+                    cache = getColumnStatistic(olapTableStats, slot.getName(), selectedPartitionNames);
                 } else {
                     cache = olapTableStats.getColumnStatistics(slot.getName(), connectContext);
                 }
@@ -639,7 +630,10 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 }
                 ColumnStatisticBuilder colStatsBuilder = new ColumnStatisticBuilder(cache,
                         selectedPartitionsRowCount);
-                colStatsBuilder.normalizeAvgSizeByte(slot);
+                colStatsBuilder.normalizeAvgSizeByte(slot.getDataType());
+                //scale null_num
+                double scale = tableRowCount == 0 ? 1 : selectedPartitionsRowCount / tableRowCount;
+                colStatsBuilder.setNumNulls(colStatsBuilder.getNumNulls() * scale);
                 builder.putColumnStatistics(slot, colStatsBuilder.build());
             }
             checkIfUnknownStatsUsedAsKey(builder);
@@ -649,7 +643,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             for (SlotReference slot : visibleOutputSlots) {
                 ColumnStatistic cache = olapTableStats.getColumnStatistics(slot.getName(), connectContext);
                 ColumnStatisticBuilder colStatsBuilder = new ColumnStatisticBuilder(cache, tableRowCount);
-                colStatsBuilder.normalizeAvgSizeByte(slot);
+                colStatsBuilder.normalizeAvgSizeByte(slot.getDataType());
                 builder.putColumnStatistics(slot, colStatsBuilder.build());
             }
             checkIfUnknownStatsUsedAsKey(builder);
@@ -1288,6 +1282,10 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
         return columnStatistics;
     }
 
+    /**
+     * - partition pruned: try to get partition col stats, if failed, then fall back to table level col stats
+     * - no partition pruned: get table level col stats
+     */
     private ColumnStatistic getColumnStatistic(
             OlapTableStatistics olapTableStatistics, String colName, List<String> partitionNames) {
         if (connectContext != null && connectContext.getState().isPlanWithUnKnownColumnStats()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
@@ -20,6 +20,7 @@ package org.apache.doris.statistics;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 
 import java.util.Map;
@@ -203,17 +204,17 @@ public class ColumnStatisticBuilder {
         return colStats;
     }
 
-    public void normalizeAvgSizeByte(SlotReference slot) {
+    public void normalizeAvgSizeByte(DataType dataType) {
         if (isUnknown) {
             return;
         }
         if (avgSizeByte > 0) {
             return;
         }
-        avgSizeByte = slot.getDataType().toCatalogDataType().getSlotSize();
+        avgSizeByte = dataType.toCatalogDataType().getSlotSize();
         // When defining SQL schemas, users often tend to set the length of string \
         // fields much longer than actually needed for storage.
-        if (slot.getDataType() instanceof CharacterType) {
+        if (dataType instanceof CharacterType) {
             avgSizeByte = Math.min(avgSizeByte, CharacterType.DEFAULT_WIDTH);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
@@ -18,7 +18,6 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.analysis.LiteralExpr;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;

--- a/regression-test/suites/statistics/test_scale_num_nulls.groovy
+++ b/regression-test/suites/statistics/test_scale_num_nulls.groovy
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_scale_num_nulls") {
+    // For an OlapTable, when only a subset of partitions is selected, 
+    // the num_nulls value in column statistics needs to be scaled proportionally.
+    sql """
+        drop table if exists ptable;
+        CREATE TABLE `ptable` (
+        `id` int NULL,
+        `val` int NULL,
+        `d` date NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        PARTITION BY RANGE(`d`)
+        (PARTITION p201701 VALUES [('2017-01-01'), ('2017-02-01')),
+        PARTITION p201702 VALUES [('2017-02-01'), ('2017-03-01')),
+        PARTITION p201703 VALUES [('2017-03-01'), ('2017-04-01')))
+        DISTRIBUTED BY HASH(`id`) BUCKETS 16
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "min_load_replica_num" = "-1",
+        "is_being_synced" = "false",
+        "storage_medium" = "hdd",
+        "storage_format" = "V2",
+        "inverted_index_storage_format" = "V3",
+        "light_schema_change" = "true",
+        "disable_auto_compaction" = "false",
+        "enable_single_replica_compaction" = "false",
+        "group_commit_interval_ms" = "10000",
+        "group_commit_data_bytes" = "134217728"
+        ); 
+
+        insert into ptable values 
+        (1, null, '2017-01-01'), (11,2, '2017-01-01'), (111,2, '2017-01-01'), (1111,2, '2017-01-01'), 
+        (2, null, '2017-02-01'), (22,2, '2017-02-01'), (222,2, '2017-02-01'), (2222,2, '2017-02-01'),
+        (3, null, '2017-03-01'), (33,2, '2017-03-01'), (333,2, '2017-03-01'), (333,2, '2017-03-01');
+
+        analyze table ptable with sync;
+        """
+        def colStats = sql "show column stats ptable";
+        def memo = sql "explain memo plan select * from ptable where d='2017-01-01'"
+        // check numNulls=1.0000 for column val, which is scaled from 3 to 1 according to the partition pruning result.
+        assertTrue(memo.toString().contains("val#1 -> ndv=1.0000, min=2.000000(2), max=2.000000(2), count=4.0000, numNulls=1.0000"),
+            "numNulls should be 1.0000, but is " + memo.toString() + "\n column stats: \n" + colStats.toString());
+}
+


### PR DESCRIPTION


### What problem does this PR solve?
For an OlapTable, when only a subset of partitions is selected, the num_nulls value in column statistics needs to be scaled proportionally.
Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

