### PR TITLE
[improve](StreamingJob) Add lag method for CDC data sources

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
@@ -102,6 +102,7 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
             .add(new Column("Properties", ScalarType.createStringType()))
             .add(new Column("CurrentOffset", ScalarType.createStringType()))
             .add(new Column("EndOffset", ScalarType.createStringType()))
+            .add(new Column("Lag", ScalarType.createStringType()))
             .add(new Column("LoadStatistic", ScalarType.createStringType()))
             .add(new Column("ErrorMsg", ScalarType.createStringType()))
             .add(new Column("JobRuntimeMsg", ScalarType.createStringType()))

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
@@ -102,10 +102,10 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
             .add(new Column("Properties", ScalarType.createStringType()))
             .add(new Column("CurrentOffset", ScalarType.createStringType()))
             .add(new Column("EndOffset", ScalarType.createStringType()))
-            .add(new Column("Lag", ScalarType.createStringType()))
             .add(new Column("LoadStatistic", ScalarType.createStringType()))
             .add(new Column("ErrorMsg", ScalarType.createStringType()))
             .add(new Column("JobRuntimeMsg", ScalarType.createStringType()))
+            .add(new Column("Lag", ScalarType.createStringType()))
             .build();
 
     public static final ShowResultSetMetaData TASK_META_DATA =
@@ -569,6 +569,7 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
         trow.addToColumnValue(new TCell().setStringVal(
                 loadStatistic == null ? FeConstants.null_string : loadStatistic.toJson()));
         trow.addToColumnValue(new TCell().setStringVal(failMsg == null ? FeConstants.null_string : failMsg.getMsg()));
+        trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
         trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
         return trow;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -857,6 +857,8 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         } else {
             trow.addToColumnValue(new TCell().setStringVal(""));
         }
+        trow.addToColumnValue(new TCell().setStringVal(
+                offsetProvider != null ? offsetProvider.getLag() : ""));
         if (tvfType != null) {
             trow.addToColumnValue(new TCell().setStringVal(
                     jobStatistic == null ? "" : jobStatistic.toJson()));

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -857,8 +857,6 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         } else {
             trow.addToColumnValue(new TCell().setStringVal(""));
         }
-        trow.addToColumnValue(new TCell().setStringVal(
-                offsetProvider != null ? offsetProvider.getLag() : ""));
         if (tvfType != null) {
             trow.addToColumnValue(new TCell().setStringVal(
                     jobStatistic == null ? "" : jobStatistic.toJson()));
@@ -870,6 +868,8 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
                 ? "" : failureReason.getMsg()));
         trow.addToColumnValue(new TCell().setStringVal(jobRuntimeMsg == null
                 ? "" : jobRuntimeMsg));
+        trow.addToColumnValue(new TCell().setStringVal(
+                offsetProvider != null ? offsetProvider.getLag() : ""));
         return trow;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/SourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/SourceOffsetProvider.java
@@ -159,5 +159,15 @@ public interface SourceOffsetProvider {
         return false;
     }
 
+    /**
+     * Get the lag of the data source in seconds.
+     * For CDC sources, lag = (now - last consumed event timestamp) in seconds.
+     *
+     * @return lag in seconds as string, empty string if not applicable
+     */
+    default String getLag() {
+        return "";
+    }
+
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
@@ -569,6 +569,40 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
     }
 
     @Override
+    public String getLag() {
+        if (currentOffset == null || currentOffset.snapshotSplit()) {
+            return "";
+        }
+        BinlogSplit binlogSplit = (BinlogSplit) currentOffset.getSplits().get(0);
+        Map<String, String> offsetMap = binlogSplit.getStartingOffset();
+        if (MapUtils.isEmpty(offsetMap)) {
+            return "";
+        }
+        long eventTimeMs = extractEventTimeMs(offsetMap);
+        if (eventTimeMs <= 0) {
+            return "";
+        }
+        long lagSec = (System.currentTimeMillis() - eventTimeMs) / 1000;
+        return String.valueOf(Math.max(lagSec, 0));
+    }
+
+    /**
+     * Extract event timestamp in milliseconds from binlog offset map.
+     * MySQL: ts_sec (seconds), PostgreSQL: ts_usec (microseconds).
+     */
+    protected long extractEventTimeMs(Map<String, String> offsetMap) {
+        String tsSec = offsetMap.get("ts_sec");
+        if (tsSec != null) {
+            return Long.parseLong(tsSec) * 1000;
+        }
+        String tsUsec = offsetMap.get("ts_usec");
+        if (tsUsec != null) {
+            return Long.parseLong(tsUsec) / 1000;
+        }
+        return -1;
+    }
+
+    @Override
     public void onTaskCommitted(long scannedRows, long loadBytes) {
         if (scannedRows == 0 && loadBytes == 0) {
             hasMoreData = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
@@ -573,6 +573,10 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         if (currentOffset == null || currentOffset.snapshotSplit()) {
             return "";
         }
+        // Source is idle (last task consumed no data), report zero lag
+        if (!hasMoreData) {
+            return "0";
+        }
         BinlogSplit binlogSplit = (BinlogSplit) currentOffset.getSplits().get(0);
         Map<String, String> offsetMap = binlogSplit.getStartingOffset();
         if (MapUtils.isEmpty(offsetMap)) {
@@ -580,7 +584,7 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         }
         long eventTimeMs = extractEventTimeMs(offsetMap);
         if (eventTimeMs <= 0) {
-            return "";
+            return "0";
         }
         long lagSec = (System.currentTimeMillis() - eventTimeMs) / 1000;
         return String.valueOf(Math.max(lagSec, 0));

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
@@ -280,7 +280,8 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
                     // snapshot to binlog phase
                     return true;
                 }
-                return compareOffset(endBinlogOffset, new HashMap<>(binlogSplit.getStartingOffset()));
+                hasMoreData = compareOffset(endBinlogOffset, new HashMap<>(binlogSplit.getStartingOffset()));
+                return hasMoreData;
             } else {
                 // snapshot means has data to consume
                 return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
@@ -591,13 +591,17 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
      * MySQL: ts_sec (seconds), PostgreSQL: ts_usec (microseconds).
      */
     protected long extractEventTimeMs(Map<String, String> offsetMap) {
-        String tsSec = offsetMap.get("ts_sec");
-        if (tsSec != null) {
-            return Long.parseLong(tsSec) * 1000;
-        }
-        String tsUsec = offsetMap.get("ts_usec");
-        if (tsUsec != null) {
-            return Long.parseLong(tsUsec) / 1000;
+        try {
+            String tsSec = offsetMap.get("ts_sec");
+            if (tsSec != null) {
+                return Long.parseLong(tsSec) * 1000;
+            }
+            String tsUsec = offsetMap.get("ts_usec");
+            if (tsUsec != null) {
+                return Long.parseLong(tsUsec) / 1000;
+            }
+        } catch (NumberFormatException e) {
+            log.warn("Failed to parse event timestamp from offset: {}", offsetMap, e);
         }
         return -1;
     }

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_lag.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_lag.groovy
@@ -49,9 +49,6 @@ suite("test_streaming_mysql_job_lag",
         }
 
         sql """CREATE JOB ${jobName}
-                PROPERTIES(
-                    "max_interval" = "1"
-                )
                 ON STREAMING
                 FROM MYSQL (
                     "jdbc_url" = "jdbc:mysql://${externalEnvIp}:${mysql_port}",

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_lag.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_lag.groovy
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+suite("test_streaming_mysql_job_lag",
+      "p0,external,mysql,external_docker,external_docker_mysql,nondatalake") {
+
+    def jobName = "test_streaming_mysql_job_lag"
+    def currentDb = (sql "select database()")[0][0]
+    def mysqlDb = "test_cdc_db"
+    def mysqlTable = "user_info_lag"
+
+    sql """DROP JOB IF EXISTS where jobname = '${jobName}'"""
+
+    String enabled = context.config.otherConfigs.get("enableJdbcTest")
+    if (enabled != null && enabled.equalsIgnoreCase("true")) {
+        String mysql_port = context.config.otherConfigs.get("mysql_57_port")
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String s3_endpoint = getS3Endpoint()
+        String bucket = getS3BucketName()
+        String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.4.0.jar"
+
+        connect("root", "123456", "jdbc:mysql://${externalEnvIp}:${mysql_port}") {
+            sql """CREATE DATABASE IF NOT EXISTS ${mysqlDb}"""
+            sql """DROP TABLE IF EXISTS ${mysqlDb}.${mysqlTable}"""
+            sql """CREATE TABLE ${mysqlDb}.${mysqlTable} (
+                      `name` varchar(200) NOT NULL,
+                      `age` int DEFAULT NULL,
+                      PRIMARY KEY (`name`)
+                   ) ENGINE=InnoDB"""
+            sql """INSERT INTO ${mysqlDb}.${mysqlTable} (name, age) VALUES ('Alice', 10)"""
+        }
+
+        sql """CREATE JOB ${jobName}
+                ON STREAMING
+                FROM MYSQL (
+                    "jdbc_url" = "jdbc:mysql://${externalEnvIp}:${mysql_port}",
+                    "driver_url" = "${driver_url}",
+                    "driver_class" = "com.mysql.cj.jdbc.Driver",
+                    "user" = "root",
+                    "password" = "123456",
+                    "database" = "${mysqlDb}",
+                    "include_tables" = "${mysqlTable}",
+                    "offset" = "initial"
+                )
+                TO DATABASE ${currentDb} (
+                    "table.create.properties.replication_num" = "1"
+                )
+            """
+
+        try {
+            // wait for snapshot + enter binlog phase, need at least 2 succeed tasks
+            Awaitility.await().atMost(300, SECONDS)
+                    .pollInterval(1, SECONDS).until({
+                        def jobInfo = sql """
+                            select SucceedTaskCount, Status
+                            from jobs("type"="insert")
+                            where Name = '${jobName}' and ExecuteType='STREAMING'
+                        """
+                        log.info("lag job status: " + jobInfo)
+                        jobInfo.size() == 1 &&
+                                Integer.parseInt(jobInfo[0][0] as String) >= 2 &&
+                                (jobInfo[0][1] as String) == "RUNNING"
+                    })
+
+            // insert incremental data to trigger binlog consumption
+            connect("root", "123456", "jdbc:mysql://${externalEnvIp}:${mysql_port}") {
+                sql """INSERT INTO ${mysqlDb}.${mysqlTable} (name, age) VALUES ('Bob', 20)"""
+            }
+
+            sleep(60000) // wait for cdc incremental data
+
+            // verify lag column has a non-empty numeric value
+            def lagInfo = sql """
+                select Lag from jobs("type"="insert")
+                where Name = '${jobName}' and ExecuteType='STREAMING'
+            """
+            log.info("lag info: " + lagInfo)
+            assert lagInfo.size() == 1
+            def lagValue = lagInfo[0][0] as String
+            assert lagValue != null && lagValue != "" : "Lag should not be empty in binlog phase"
+            assert lagValue.isNumber() : "Lag should be a numeric value, but got: ${lagValue}"
+            log.info("lag value in seconds: " + lagValue)
+        } catch (Exception ex) {
+            def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
+            def showtask = sql """select * from tasks("type"="insert") where JobName='${jobName}'"""
+            log.info("lag show job: " + showjob)
+            log.info("lag show task: " + showtask)
+            throw ex
+        }
+
+        sql """DROP JOB IF EXISTS where jobname = '${jobName}'"""
+        def jobCountRsp = sql """select count(1) from jobs("type"="insert") where Name = '${jobName}'"""
+        assert jobCountRsp.get(0).get(0) == 0
+    }
+}

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_lag.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_lag.groovy
@@ -58,7 +58,7 @@ suite("test_streaming_mysql_job_lag",
                     "password" = "123456",
                     "database" = "${mysqlDb}",
                     "include_tables" = "${mysqlTable}",
-                    "offset" = "initial"
+                    "offset" = "latest"
                 )
                 TO DATABASE ${currentDb} (
                     "table.create.properties.replication_num" = "1"
@@ -66,26 +66,18 @@ suite("test_streaming_mysql_job_lag",
             """
 
         try {
-            // wait for snapshot + enter binlog phase, need at least 2 succeed tasks
-            Awaitility.await().atMost(300, SECONDS)
-                    .pollInterval(1, SECONDS).until({
-                        def jobInfo = sql """
-                            select SucceedTaskCount, Status
-                            from jobs("type"="insert")
-                            where Name = '${jobName}' and ExecuteType='STREAMING'
-                        """
-                        log.info("lag job status: " + jobInfo)
-                        jobInfo.size() == 1 &&
-                                Integer.parseInt(jobInfo[0][0] as String) >= 2 &&
-                                (jobInfo[0][1] as String) == "RUNNING"
-                    })
-
             // insert incremental data to trigger binlog consumption
             connect("root", "123456", "jdbc:mysql://${externalEnvIp}:${mysql_port}") {
                 sql """INSERT INTO ${mysqlDb}.${mysqlTable} (name, age) VALUES ('Bob', 20)"""
             }
 
-            sleep(60000) // wait for cdc incremental data
+            // wait for binlog data consumed
+            Awaitility.await().atMost(300, SECONDS)
+                    .pollInterval(1, SECONDS).until({
+                        def cnt = sql """ select SucceedTaskCount from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                        log.info("SucceedTaskCount: " + cnt)
+                        cnt.size() == 1 && Integer.parseInt(cnt[0][0] as String) >= 1
+                    })
 
             // verify lag column has a non-empty numeric value
             def lagInfo = sql """

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_postgres_job_lag.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_postgres_job_lag.groovy
@@ -19,33 +19,35 @@ import org.awaitility.Awaitility
 
 import static java.util.concurrent.TimeUnit.SECONDS
 
-suite("test_streaming_mysql_job_lag",
-      "p0,external,mysql,external_docker,external_docker_mysql,nondatalake") {
+suite("test_streaming_postgres_job_lag",
+      "p0,external,pg,external_docker,external_docker_pg,nondatalake") {
 
-    def jobName = "test_streaming_mysql_job_lag"
+    def jobName = "test_streaming_postgres_job_lag"
     def currentDb = (sql "select database()")[0][0]
-    def mysqlDb = "test_cdc_db"
-    def mysqlTable = "user_info_lag"
+    def pgDB = "postgres"
+    def pgSchema = "cdc_test"
+    def pgUser = "postgres"
+    def pgPassword = "123456"
+    def pgTable = "user_info_pg_lag"
 
     sql """DROP JOB IF EXISTS where jobname = '${jobName}'"""
 
     String enabled = context.config.otherConfigs.get("enableJdbcTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
-        String mysql_port = context.config.otherConfigs.get("mysql_57_port")
+        String pg_port = context.config.otherConfigs.get("pg_14_port")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String s3_endpoint = getS3Endpoint()
         String bucket = getS3BucketName()
-        String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-j-8.4.0.jar"
+        String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/postgresql-42.5.0.jar"
 
-        connect("root", "123456", "jdbc:mysql://${externalEnvIp}:${mysql_port}") {
-            sql """CREATE DATABASE IF NOT EXISTS ${mysqlDb}"""
-            sql """DROP TABLE IF EXISTS ${mysqlDb}.${mysqlTable}"""
-            sql """CREATE TABLE ${mysqlDb}.${mysqlTable} (
-                      `name` varchar(200) NOT NULL,
-                      `age` int DEFAULT NULL,
-                      PRIMARY KEY (`name`)
-                   ) ENGINE=InnoDB"""
-            sql """INSERT INTO ${mysqlDb}.${mysqlTable} (name, age) VALUES ('Alice', 10)"""
+        connect("${pgUser}", "${pgPassword}", "jdbc:postgresql://${externalEnvIp}:${pg_port}/${pgDB}") {
+            sql """DROP TABLE IF EXISTS ${pgDB}.${pgSchema}.${pgTable}"""
+            sql """CREATE TABLE ${pgDB}.${pgSchema}.${pgTable} (
+                      "name" varchar(200),
+                      "age" int2,
+                      PRIMARY KEY ("name")
+                   )"""
+            sql """INSERT INTO ${pgDB}.${pgSchema}.${pgTable} (name, age) VALUES ('Alice', 10)"""
         }
 
         sql """CREATE JOB ${jobName}
@@ -53,14 +55,15 @@ suite("test_streaming_mysql_job_lag",
                     "max_interval" = "1"
                 )
                 ON STREAMING
-                FROM MYSQL (
-                    "jdbc_url" = "jdbc:mysql://${externalEnvIp}:${mysql_port}",
+                FROM POSTGRES (
+                    "jdbc_url" = "jdbc:postgresql://${externalEnvIp}:${pg_port}/${pgDB}",
                     "driver_url" = "${driver_url}",
-                    "driver_class" = "com.mysql.cj.jdbc.Driver",
-                    "user" = "root",
-                    "password" = "123456",
-                    "database" = "${mysqlDb}",
-                    "include_tables" = "${mysqlTable}",
+                    "driver_class" = "org.postgresql.Driver",
+                    "user" = "${pgUser}",
+                    "password" = "${pgPassword}",
+                    "database" = "${pgDB}",
+                    "schema" = "${pgSchema}",
+                    "include_tables" = "${pgTable}",
                     "offset" = "latest"
                 )
                 TO DATABASE ${currentDb} (
@@ -69,9 +72,9 @@ suite("test_streaming_mysql_job_lag",
             """
 
         try {
-            // insert incremental data to trigger binlog consumption
-            connect("root", "123456", "jdbc:mysql://${externalEnvIp}:${mysql_port}") {
-                sql """INSERT INTO ${mysqlDb}.${mysqlTable} (name, age) VALUES ('Bob', 20)"""
+            // insert incremental data to trigger WAL consumption
+            connect("${pgUser}", "${pgPassword}", "jdbc:postgresql://${externalEnvIp}:${pg_port}/${pgDB}") {
+                sql """INSERT INTO ${pgDB}.${pgSchema}.${pgTable} (name, age) VALUES ('Bob', 20)"""
             }
 
             // wait for binlog data consumed and lag is available

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_postgres_job_lag.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_postgres_job_lag.groovy
@@ -51,9 +51,6 @@ suite("test_streaming_postgres_job_lag",
         }
 
         sql """CREATE JOB ${jobName}
-                PROPERTIES(
-                    "max_interval" = "1"
-                )
                 ON STREAMING
                 FROM POSTGRES (
                     "jdbc_url" = "jdbc:postgresql://${externalEnvIp}:${pg_port}/${pgDB}",


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Add lag calculation for StreamingInsertJob CDC data sources (MySQL/PostgreSQL) to support monitoring delay visualization on the frontend.

Currently, StreamingInsertJob exposes `CurrentOffset` and `EndOffset` but has no lag metric. Users cannot easily determine how far behind the CDC consumer is from the source database, which is essential for monitoring and alerting.

### How is this PR implemented?

- Add `getLag()` default method to `SourceOffsetProvider` interface
- Implement `getLag()` in `JdbcSourceOffsetProvider` for MySQL and PostgreSQL
- Add `Lag` column to `InsertJob.SCHEMA` for `SHOW JOBS` / `jobs()` TVF output
- Fill `Lag` column in `StreamingInsertJob.getTvfInfo()`
- Sync `compareOffset` result to `hasMoreData` in `hasMoreDataToConsume()` for accurate idle detection

#### Lag Calculation

The lag value represents **end-to-end delay in seconds**: how long ago the last consumed binlog/WAL event was produced on the source database.

```
lag = (System.currentTimeMillis() - eventTimestamp) / 1000
```

- **MySQL**: event timestamp is extracted from `ts_sec` in the binlog offset (seconds precision, from Debezium/Flink CDC `BinlogOffset`)
- **PostgreSQL**: event timestamp is extracted from `ts_usec` in the WAL offset (microsecond precision, from Debezium `SourceInfo.TIMESTAMP_USEC_KEY`)
- **S3**: not applicable, returns empty string
- **Snapshot phase**: not applicable, returns empty string (only binlog/incremental phase has lag)

#### Idle Source Handling

When the source database has no new data:
- `hasMoreData` is set to `false` via two paths:
  1. `onTaskCommitted(scannedRows=0, loadBytes=0)` — last task consumed no data
  2. `hasMoreDataToConsume()` → `compareOffset()` returns `false` — current offset has caught up with end offset
- `getLag()` checks `hasMoreData` and returns `"0"` when idle, preventing lag from growing indefinitely while the source is quiet
- Source health issues (connection failures, etc.) are reported via `Status` and `ErrorMsg` columns, not via lag

#### Edge Cases

- `ts_sec=0` or `ts_usec=0` (invalid timestamp): returns `"0"` instead of empty string
- `NumberFormatException` in timestamp parsing: caught and logged, returns `"-1"` from `extractEventTimeMs`, `getLag()` returns `"0"`

### Release note

Add lag column for StreamingInsertJob CDC data sources (MySQL/PostgreSQL). Lag represents the time delay in seconds between the source database event timestamp and the current Doris system time. When the source is idle (no new data), lag reports 0.

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. Added a new `Lag` column (at the end) to the `jobs("type"="insert")` TVF output. Synced `compareOffset` result to `hasMoreData` in `hasMoreDataToConsume()`.

- Does this need documentation?
    - [ ] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label