### PR TITLE
[improve](streaming-job) Add RETRYING state to distinguish normal jobs from retrying ones

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1872,6 +1872,11 @@ public class Config extends ConfigBase {
                     + "old records will be discarded."})
     public static int max_streaming_task_show_count = 100;
 
+    @ConfField(masterOnly = true, mutable = true, description = {
+            "Max auto resume retry count for streaming jobs. "
+                    + "After exceeding, transitions to PAUSED and requires manual intervention."})
+    public static int streaming_job_max_auto_resume_count = 10;
+
     /* job test config */
     /**
      * If set to true, we will allow the interval unit to be set to second, when creating a recurring job.

--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -108,8 +108,6 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
     @SerializedName(value = "ctc")
     protected AtomicLong canceledTaskCount = new AtomicLong(0);
 
-    @Getter
-    @Setter
     @SerializedName(value = "ltst")
     protected long lastTaskSuccessTime;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -333,7 +333,8 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         if (newJobStatus.equals(JobStatus.FINISHED)) {
             this.finishTimeMs = System.currentTimeMillis();
         }
-        if (JobStatus.PAUSED.equals(newJobStatus) || JobStatus.STOPPED.equals(newJobStatus)) {
+        if (JobStatus.PAUSED.equals(newJobStatus) || JobStatus.STOPPED.equals(newJobStatus)
+                || JobStatus.RETRYING.equals(newJobStatus)) {
             cancelAllTasks(JobStatus.STOPPED.equals(newJobStatus) ? false : true);
         }
         jobStatus = newJobStatus;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/AbstractJob.java
@@ -108,6 +108,11 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
     @SerializedName(value = "ctc")
     protected AtomicLong canceledTaskCount = new AtomicLong(0);
 
+    @Getter
+    @Setter
+    @SerializedName(value = "ltst")
+    protected long lastTaskSuccessTime;
+
     public AbstractJob() {
     }
 
@@ -313,8 +318,15 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
         if (newJobStatus.equals(JobStatus.PENDING) && jobStatus.equals(JobStatus.STOPPED)) {
             throw new IllegalArgumentException(errorMsg);
         }
+        // RETRYING can only come from RUNNING (task failed with resumable error)
+        if (newJobStatus.equals(JobStatus.RETRYING) && !jobStatus.equals(JobStatus.RUNNING)) {
+            throw new IllegalArgumentException(errorMsg);
+        }
+        // RUNNING can come from PAUSED, PENDING, or RETRYING
         if (newJobStatus.equals(JobStatus.RUNNING)
-                && (!jobStatus.equals(JobStatus.PAUSED) && !jobStatus.equals(JobStatus.PENDING))) {
+                && (!jobStatus.equals(JobStatus.PAUSED)
+                    && !jobStatus.equals(JobStatus.PENDING)
+                    && !jobStatus.equals(JobStatus.RETRYING))) {
             throw new IllegalArgumentException(errorMsg);
         }
         if (newJobStatus.equals(JobStatus.PAUSED) && jobStatus.equals(JobStatus.STOPPED)) {
@@ -363,6 +375,7 @@ public abstract class AbstractJob<T extends AbstractTask, C> implements Job<T, C
     @Override
     public void onTaskSuccess(T task) throws JobException {
         succeedTaskCount.incrementAndGet();
+        lastTaskSuccessTime = System.currentTimeMillis();
         updateJobStatusIfEnd(true, task.getTaskType());
         runningTasks.remove(task);
         logUpdateOperation();

--- a/fe/fe-core/src/main/java/org/apache/doris/job/common/JobStatus.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/common/JobStatus.java
@@ -35,6 +35,13 @@ public enum JobStatus {
      */
     PAUSED,
     /**
+     * When the task execution encounters a resumable exception,
+     * the retrying state will be triggered.
+     * The system will auto-resume with exponential backoff.
+     * After exceeding max retry count, transitions to PAUSED.
+     */
+    RETRYING,
+    /**
      * When the task is manually stopped, the stop state will be triggered.
      * The stop state cannot be resumed
      */
@@ -46,6 +53,6 @@ public enum JobStatus {
 
 
     public static boolean isRunning(JobStatus status) {
-        return PENDING.equals(status) || RUNNING.equals(status);
+        return PENDING.equals(status) || RUNNING.equals(status) || RETRYING.equals(status);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/InsertJob.java
@@ -105,6 +105,8 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
             .add(new Column("LoadStatistic", ScalarType.createStringType()))
             .add(new Column("ErrorMsg", ScalarType.createStringType()))
             .add(new Column("JobRuntimeMsg", ScalarType.createStringType()))
+            .add(new Column("LastTaskSuccessTime", ScalarType.createStringType()))
+            .add(new Column("RetryInfo", ScalarType.createStringType()))
             .build();
 
     public static final ShowResultSetMetaData TASK_META_DATA =
@@ -568,6 +570,9 @@ public class InsertJob extends AbstractJob<InsertTask, Map<Object, Object>> impl
         trow.addToColumnValue(new TCell().setStringVal(
                 loadStatistic == null ? FeConstants.null_string : loadStatistic.toJson()));
         trow.addToColumnValue(new TCell().setStringVal(failMsg == null ? FeConstants.null_string : failMsg.getMsg()));
+        trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
+        trow.addToColumnValue(new TCell().setStringVal(lastTaskSuccessTime > 0
+                ? TimeUtils.longToTimeString(lastTaskSuccessTime) : FeConstants.null_string));
         trow.addToColumnValue(new TCell().setStringVal(FeConstants.null_string));
         return trow;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -440,13 +440,24 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         this.setJobRuntimeMsg("");
     }
 
-    public boolean isResumableFailure(FailureReason reason) {
+    private boolean isResumableFailure(FailureReason reason) {
         if (reason == null) {
             return true;
         }
         return reason.getCode() != InternalErrorCode.MANUAL_PAUSE_ERR
                 && reason.getCode() != InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR
                 && reason.getCode() != InternalErrorCode.CANNOT_RESUME_ERR;
+    }
+
+    /**
+     * Transition to RETRYING for resumable errors, or PAUSED for non-resumable errors.
+     */
+    public void updateStatusOnFailure() throws JobException {
+        if (isResumableFailure(failureReason)) {
+            updateJobStatus(JobStatus.RETRYING);
+        } else {
+            updateJobStatus(JobStatus.PAUSED);
+        }
     }
 
     @Override
@@ -584,11 +595,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
                                 "Failed to fetch meta, " + ex.getMessage()));
                 // If fetching meta fails with a resumable error, the job enters RETRYING
                 // and auto resume will automatically wake it up.
-                if (isResumableFailure(this.getFailureReason())) {
-                    this.updateJobStatus(JobStatus.RETRYING);
-                } else {
-                    this.updateJobStatus(JobStatus.PAUSED);
-                }
+                this.updateStatusOnFailure();
 
                 if (MetricRepo.isInit) {
                     MetricRepo.COUNTER_STREAMING_JOB_GET_META_FAIL_COUNT.increase(1L);
@@ -653,11 +660,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         } finally {
             writeUnlock();
         }
-        if (isResumableFailure(failureReason)) {
-            updateJobStatus(JobStatus.RETRYING);
-        } else {
-            updateJobStatus(JobStatus.PAUSED);
-        }
+        updateStatusOnFailure();
     }
 
     public void onStreamTaskSuccess(AbstractStreamingTask task) throws JobException {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -126,11 +126,6 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     @Getter
     @Setter
     protected long autoResumeCount;
-
-    public long getMaxAutoResumeCount() {
-        return Config.streaming_job_max_auto_resume_count;
-    }
-
     @Getter
     @SerializedName("props")
     private Map<String, String> properties;
@@ -339,6 +334,10 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         if (lock.writeLock().isHeldByCurrentThread()) {
             lock.writeLock().unlock();
         }
+    }
+
+    public long getMaxAutoResumeCount() {
+        return Config.streaming_job_max_auto_resume_count;
     }
 
     private UnboundTVFRelation getCurrentTvf() {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -122,11 +122,9 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     protected volatile FailureReason failureReason;
     @Getter
     @Setter
-    @SerializedName("lart")
     protected long latestAutoResumeTimestamp;
     @Getter
     @Setter
-    @SerializedName("arc")
     protected long autoResumeCount;
     public long getMaxAutoResumeCount() {
         return Config.streaming_job_max_auto_resume_count;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -1190,10 +1190,6 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
 
     @Override
     public void gsonPostProcess() throws IOException {
-        // Defensive: unknown enum values (e.g. from newer FE version) deserialize as null
-        if (getJobStatus() == null) {
-            setJobStatus(JobStatus.PENDING);
-        }
         if (offsetProvider == null) {
             if (tvfType != null) {
                 offsetProvider = SourceOffsetProviderFactory.createSourceOffsetProvider(tvfType);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -126,9 +126,11 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     @Getter
     @Setter
     protected long autoResumeCount;
+
     public long getMaxAutoResumeCount() {
         return Config.streaming_job_max_auto_resume_count;
     }
+
     @Getter
     @SerializedName("props")
     private Map<String, String> properties;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -122,10 +122,15 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     protected volatile FailureReason failureReason;
     @Getter
     @Setter
+    @SerializedName("lart")
     protected long latestAutoResumeTimestamp;
     @Getter
     @Setter
+    @SerializedName("arc")
     protected long autoResumeCount;
+    public long getMaxAutoResumeCount() {
+        return Config.streaming_job_max_auto_resume_count;
+    }
     @Getter
     @SerializedName("props")
     private Map<String, String> properties;
@@ -414,13 +419,18 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         lock.writeLock().lock();
         try {
             super.updateJobStatus(status);
-            if (JobStatus.PAUSED.equals(getJobStatus())) {
+            if (JobStatus.PAUSED.equals(getJobStatus()) || JobStatus.RETRYING.equals(getJobStatus())) {
                 clearRunningStreamTask(status);
             }
             if (isFinalStatus()) {
                 Env.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(getJobId());
             }
             log.info("Streaming insert job {} update status to {}", getJobId(), getJobStatus());
+            // RUNNING and RETRYING are transient runtime states, do not persist to editlog.
+            // On FE restart, job must go through PENDING to re-initialize (fetch meta, create task).
+            if (!JobStatus.RUNNING.equals(status) && !JobStatus.RETRYING.equals(status)) {
+                logUpdateOperation();
+            }
         } finally {
             lock.writeLock().unlock();
         }
@@ -430,6 +440,15 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         this.setFailureReason(reason);
         // Currently, only delayMsg is present here, which needs to be cleared when the status changes.
         this.setJobRuntimeMsg("");
+    }
+
+    public boolean isResumableFailure(FailureReason reason) {
+        if (reason == null) {
+            return true;
+        }
+        return reason.getCode() != InternalErrorCode.MANUAL_PAUSE_ERR
+                && reason.getCode() != InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR
+                && reason.getCode() != InternalErrorCode.CANNOT_RESUME_ERR;
     }
 
     @Override
@@ -565,9 +584,13 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
                 this.setFailureReason(
                         new FailureReason(InternalErrorCode.GET_REMOTE_DATA_ERROR,
                                 "Failed to fetch meta, " + ex.getMessage()));
-                // If fetching meta fails, the job is paused
+                // If fetching meta fails with a resumable error, the job enters RETRYING
                 // and auto resume will automatically wake it up.
-                this.updateJobStatus(JobStatus.PAUSED);
+                if (isResumableFailure(this.getFailureReason())) {
+                    this.updateJobStatus(JobStatus.RETRYING);
+                } else {
+                    this.updateJobStatus(JobStatus.PAUSED);
+                }
 
                 if (MetricRepo.isInit) {
                     MetricRepo.COUNTER_STREAMING_JOB_GET_META_FAIL_COUNT.increase(1L);
@@ -586,7 +609,8 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         readLock();
         try {
             return (getJobStatus().equals(JobStatus.RUNNING)
-                    || getJobStatus().equals(JobStatus.PENDING));
+                    || getJobStatus().equals(JobStatus.PENDING)
+                    || getJobStatus().equals(JobStatus.RETRYING));
         } finally {
             readUnlock();
         }
@@ -631,13 +655,18 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         } finally {
             writeUnlock();
         }
-        updateJobStatus(JobStatus.PAUSED);
+        if (isResumableFailure(failureReason)) {
+            updateJobStatus(JobStatus.RETRYING);
+        } else {
+            updateJobStatus(JobStatus.PAUSED);
+        }
     }
 
     public void onStreamTaskSuccess(AbstractStreamingTask task) throws JobException {
         try {
             resetFailureInfo(null);
             succeedTaskCount.incrementAndGet();
+            lastTaskSuccessTime = System.currentTimeMillis();
             //update metric
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_STREAMING_JOB_TASK_EXECUTE_COUNT.increase(1L);
@@ -747,8 +776,9 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
      * @param replayJob
      */
     public void replayOnUpdated(StreamingInsertJob replayJob) {
-        if (!JobStatus.RUNNING.equals(replayJob.getJobStatus())) {
-            // No need to restore in the running state, as scheduling relies on pending states.
+        if (!JobStatus.RUNNING.equals(replayJob.getJobStatus())
+                && !JobStatus.RETRYING.equals(replayJob.getJobStatus())) {
+            // No need to restore in the running/retrying state, as scheduling relies on pending states.
             // insert TVF does not persist the running state.
             // streaming multi task persists the running state when commitOffset() is called.
             setJobStatus(replayJob.getJobStatus());
@@ -868,6 +898,15 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
                 ? "" : failureReason.getMsg()));
         trow.addToColumnValue(new TCell().setStringVal(jobRuntimeMsg == null
                 ? "" : jobRuntimeMsg));
+        trow.addToColumnValue(new TCell().setStringVal(lastTaskSuccessTime > 0
+                ? TimeUtils.longToTimeString(lastTaskSuccessTime) : ""));
+        if (autoResumeCount > 0) {
+            Map<String, Object> retryInfo = new HashMap<>();
+            retryInfo.put("retryCount", autoResumeCount);
+            trow.addToColumnValue(new TCell().setStringVal(GsonUtils.GSON.toJson(retryInfo)));
+        } else {
+            trow.addToColumnValue(new TCell().setStringVal(""));
+        }
         return trow;
     }
 
@@ -1149,6 +1188,10 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
 
     @Override
     public void gsonPostProcess() throws IOException {
+        // Defensive: unknown enum values (e.g. from newer FE version) deserialize as null
+        if (getJobStatus() == null) {
+            setJobStatus(JobStatus.PENDING);
+        }
         if (offsetProvider == null) {
             if (tvfType != null) {
                 offsetProvider = SourceOffsetProviderFactory.createSourceOffsetProvider(tvfType);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
@@ -29,7 +29,7 @@ import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class StreamingJobSchedulerTask extends AbstractTask {
-    private static final long BACK_OFF_BASIC_TIME_SEC = 10L;
+    private static final long BACK_OFF_BASIC_TIME_SEC = 30L;
     private static final long MAX_BACK_OFF_TIME_SEC = 60 * 5;
     private StreamingInsertJob streamingInsertJob;
 
@@ -43,11 +43,14 @@ public class StreamingJobSchedulerTask extends AbstractTask {
             case PENDING:
                 handlePendingState();
                 break;
+            case RETRYING:
+                handleRetryingState();
+                break;
             case RUNNING:
                 handleRunningState();
                 break;
             case PAUSED:
-                autoResumeHandler();
+                // PAUSED means "needs manual intervention", no auto-resume
                 break;
             default:
                 break;
@@ -74,8 +77,12 @@ public class StreamingJobSchedulerTask extends AbstractTask {
         }
         streamingInsertJob.createStreamingTask();
         streamingInsertJob.setSampleStartTime(System.currentTimeMillis());
+        // Only reset autoResumeCount on user-initiated start (PENDING),
+        // not on system auto-resume (RETRYING)
+        if (JobStatus.PENDING.equals(streamingInsertJob.getJobStatus())) {
+            streamingInsertJob.setAutoResumeCount(0);
+        }
         streamingInsertJob.updateJobStatus(JobStatus.RUNNING);
-        streamingInsertJob.setAutoResumeCount(0);
     }
 
     private void handleRunningState() throws JobException {
@@ -83,27 +90,31 @@ public class StreamingJobSchedulerTask extends AbstractTask {
         streamingInsertJob.fetchMeta();
     }
 
-    private void autoResumeHandler() throws JobException {
-        final FailureReason failureReason = streamingInsertJob.getFailureReason();
+    private void handleRetryingState() throws JobException {
         final long latestAutoResumeTimestamp = streamingInsertJob.getLatestAutoResumeTimestamp();
         final long autoResumeCount = streamingInsertJob.getAutoResumeCount();
+        final long maxAutoResumeCount = streamingInsertJob.getMaxAutoResumeCount();
         final long current = System.currentTimeMillis();
 
-        if (failureReason != null
-                && failureReason.getCode() != InternalErrorCode.MANUAL_PAUSE_ERR
-                && failureReason.getCode() != InternalErrorCode.TOO_MANY_FAILURE_ROWS_ERR
-                && failureReason.getCode() != InternalErrorCode.CANNOT_RESUME_ERR) {
-            long autoResumeIntervalTimeSec = autoResumeCount < 5
-                        ? Math.min((long) Math.pow(2, autoResumeCount) * BACK_OFF_BASIC_TIME_SEC,
-                                MAX_BACK_OFF_TIME_SEC) : MAX_BACK_OFF_TIME_SEC;
-            if (current - latestAutoResumeTimestamp > autoResumeIntervalTimeSec * 1000L) {
-                streamingInsertJob.setLatestAutoResumeTimestamp(current);
-                if (autoResumeCount < Long.MAX_VALUE) {
-                    streamingInsertJob.setAutoResumeCount(autoResumeCount + 1);
-                }
-                streamingInsertJob.updateJobStatus(JobStatus.PENDING);
-                return;
-            }
+        // Exceeded max retry count, give up and transition to PAUSED
+        if (autoResumeCount >= maxAutoResumeCount) {
+            String lastError = streamingInsertJob.getFailureReason() != null
+                    ? streamingInsertJob.getFailureReason().getMsg() : "unknown";
+            streamingInsertJob.setFailureReason(new FailureReason(
+                    InternalErrorCode.CANNOT_RESUME_ERR,
+                    "Auto resume failed after " + autoResumeCount
+                            + " attempts. Last error: " + lastError));
+            streamingInsertJob.updateJobStatus(JobStatus.PAUSED);
+            return;
+        }
+
+        long autoResumeIntervalTimeSec = Math.min(
+                (long) Math.pow(2, autoResumeCount) * BACK_OFF_BASIC_TIME_SEC,
+                MAX_BACK_OFF_TIME_SEC);
+        if (current - latestAutoResumeTimestamp > autoResumeIntervalTimeSec * 1000L) {
+            streamingInsertJob.setLatestAutoResumeTimestamp(current);
+            streamingInsertJob.setAutoResumeCount(autoResumeCount + 1);
+            handlePendingState();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
@@ -29,7 +29,7 @@ import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class StreamingJobSchedulerTask extends AbstractTask {
-    private static final long BACK_OFF_BASIC_TIME_SEC = 30L;
+    private static final long BACK_OFF_BASIC_TIME_SEC = 15L;
     private static final long MAX_BACK_OFF_TIME_SEC = 60 * 5;
     private StreamingInsertJob streamingInsertJob;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -23,7 +23,6 @@ import org.apache.doris.common.CustomThreadFactory;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.job.common.FailureReason;
-
 import org.apache.doris.job.exception.JobException;
 import org.apache.doris.job.extensions.insert.streaming.AbstractStreamingTask;
 import org.apache.doris.job.extensions.insert.streaming.StreamingInsertJob;

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -94,9 +94,13 @@ public class StreamingTaskScheduler extends MasterDaemon {
                             (StreamingInsertJob) Env.getCurrentEnv().getJobManager().getJob(task.getJobId());
                     job.setFailureReason(new FailureReason(e.getMessage()));
                     try {
-                        job.updateJobStatus(JobStatus.PAUSED);
+                        if (job.isResumableFailure(job.getFailureReason())) {
+                            job.updateJobStatus(JobStatus.RETRYING);
+                        } else {
+                            job.updateJobStatus(JobStatus.PAUSED);
+                        }
                     } catch (JobException ex) {
-                        log.warn("Failed to pause job {} after task {} scheduling failed",
+                        log.warn("Failed to update job {} status after task {} scheduling failed",
                                 task.getJobId(), task.getTaskId(), ex);
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/scheduler/StreamingTaskScheduler.java
@@ -23,7 +23,7 @@ import org.apache.doris.common.CustomThreadFactory;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.job.common.FailureReason;
-import org.apache.doris.job.common.JobStatus;
+
 import org.apache.doris.job.exception.JobException;
 import org.apache.doris.job.extensions.insert.streaming.AbstractStreamingTask;
 import org.apache.doris.job.extensions.insert.streaming.StreamingInsertJob;
@@ -94,11 +94,7 @@ public class StreamingTaskScheduler extends MasterDaemon {
                             (StreamingInsertJob) Env.getCurrentEnv().getJobManager().getJob(task.getJobId());
                     job.setFailureReason(new FailureReason(e.getMessage()));
                     try {
-                        if (job.isResumableFailure(job.getFailureReason())) {
-                            job.updateJobStatus(JobStatus.RETRYING);
-                        } else {
-                            job.updateJobStatus(JobStatus.PAUSED);
-                        }
+                        job.updateStatusOnFailure();
                     } catch (JobException ex) {
                         log.warn("Failed to update job {} status after task {} scheduling failed",
                                 task.getJobId(), task.getTaskId(), ex);

--- a/fe/fe-core/src/test/java/org/apache/doris/job/base/AbstractJobStatusTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/base/AbstractJobStatusTest.java
@@ -209,6 +209,74 @@ class AbstractJobStatusTest {
         Assertions.assertEquals(JobStatus.STOPPED, job.getJobStatus());
     }
 
+    /**
+     * Test retrying status
+     */
+    @Test
+    void testRetryingFromRunning() throws Exception {
+        DummyJob job = new DummyJob(JobStatus.PENDING);
+        job.updateJobStatus(JobStatus.RUNNING);
+        job.updateJobStatus(JobStatus.RETRYING);
+        Assertions.assertEquals(JobStatus.RETRYING, job.getJobStatus());
+    }
+
+    @Test
+    void testRetryingFromPausedIsInvalid() {
+        DummyJob job = new DummyJob(JobStatus.PAUSED);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> job.updateJobStatus(JobStatus.RETRYING));
+    }
+
+    @Test
+    void testRetryingFromStoppedIsInvalid() {
+        DummyJob job = new DummyJob(JobStatus.STOPPED);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> job.updateJobStatus(JobStatus.RETRYING));
+    }
+
+    @Test
+    void testRetryingFromPendingIsInvalid() {
+        DummyJob job = new DummyJob(JobStatus.PENDING);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> job.updateJobStatus(JobStatus.RETRYING));
+    }
+
+    @Test
+    void testRunningFromRetrying() throws Exception {
+        DummyJob job = new DummyJob(JobStatus.PENDING);
+        job.updateJobStatus(JobStatus.RUNNING);
+        job.updateJobStatus(JobStatus.RETRYING);
+        job.updateJobStatus(JobStatus.RUNNING);
+        Assertions.assertEquals(JobStatus.RUNNING, job.getJobStatus());
+    }
+
+    @Test
+    void testPausedFromRetrying() throws Exception {
+        DummyJob job = new DummyJob(JobStatus.PENDING);
+        job.updateJobStatus(JobStatus.RUNNING);
+        job.updateJobStatus(JobStatus.RETRYING);
+        job.updateJobStatus(JobStatus.PAUSED);
+        Assertions.assertEquals(JobStatus.PAUSED, job.getJobStatus());
+    }
+
+    @Test
+    void testStopFromRetrying() throws Exception {
+        DummyJob job = new DummyJob(JobStatus.PENDING);
+        job.updateJobStatus(JobStatus.RUNNING);
+        job.updateJobStatus(JobStatus.RETRYING);
+        job.updateJobStatus(JobStatus.STOPPED);
+        Assertions.assertEquals(JobStatus.STOPPED, job.getJobStatus());
+    }
+
+    @Test
+    void testFinishedFromRetrying() throws Exception {
+        DummyJob job = new DummyJob(JobStatus.PENDING);
+        job.updateJobStatus(JobStatus.RUNNING);
+        job.updateJobStatus(JobStatus.RETRYING);
+        job.updateJobStatus(JobStatus.FINISHED);
+        Assertions.assertEquals(JobStatus.FINISHED, job.getJobStatus());
+    }
+
     @Test
     void testFinishSetsFinishTime() throws Exception {
         DummyJob job = new DummyJob(JobStatus.RUNNING);

--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/controller/ClientController.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/controller/ClientController.java
@@ -105,15 +105,25 @@ public class ClientController {
     @RequestMapping(path = "/api/fetchEndOffset", method = RequestMethod.POST)
     public Object fetchEndOffset(@RequestBody JobBaseConfig jobConfig) {
         LOG.info("Fetching end offset for job {}", jobConfig.getJobId());
-        SourceReader reader = Env.getCurrentEnv().getReader(jobConfig);
-        return RestResponse.success(reader.getEndOffset(jobConfig));
+        try {
+            SourceReader reader = Env.getCurrentEnv().getReader(jobConfig);
+            return RestResponse.success(reader.getEndOffset(jobConfig));
+        } catch (Exception ex) {
+            LOG.error("Failed to fetch end offset, jobId={}", jobConfig.getJobId(), ex);
+            return RestResponse.internalError(ExceptionUtils.getRootCauseMessage(ex));
+        }
     }
 
     /** compare datasource Binlog Offset */
     @RequestMapping(path = "/api/compareOffset", method = RequestMethod.POST)
     public Object compareOffset(@RequestBody CompareOffsetRequest compareOffsetRequest) {
-        SourceReader reader = Env.getCurrentEnv().getReader(compareOffsetRequest);
-        return RestResponse.success(reader.compareOffset(compareOffsetRequest));
+        try {
+            SourceReader reader = Env.getCurrentEnv().getReader(compareOffsetRequest);
+            return RestResponse.success(reader.compareOffset(compareOffsetRequest));
+        } catch (Exception ex) {
+            LOG.error("Failed to compare offset, jobId={}", compareOffsetRequest.getJobId(), ex);
+            return RestResponse.internalError(ExceptionUtils.getRootCauseMessage(ex));
+        }
     }
 
     /** Close job */

--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/JdbcIncrementalSourceReader.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/JdbcIncrementalSourceReader.java
@@ -261,7 +261,21 @@ public abstract class JdbcIncrementalSourceReader extends AbstractCdcSourceReade
             activePollFutures = null;
         }
 
-        // Clear previous contexts
+        // Close previous readers before clearing to avoid JDBC connection leak
+        if (!this.snapshotReaderContexts.isEmpty()) {
+            LOG.info(
+                    "Closing {} previous snapshot readers before preparing new splits",
+                    snapshotReaderContexts.size());
+            for (SnapshotReaderContext<
+                            org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit,
+                            Fetcher<SourceRecords, SourceSplitBase>,
+                            SnapshotSplitState>
+                    context : snapshotReaderContexts) {
+                if (context.getReader() != null) {
+                    closeReaderInternal(context.getReader());
+                }
+            }
+        }
         this.snapshotReaderContexts.clear();
         this.completedSplitIds.clear();
 

--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/mysql/MySqlSourceReader.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/mysql/MySqlSourceReader.java
@@ -272,7 +272,19 @@ public class MySqlSourceReader extends AbstractCdcSourceReader {
             activePollFutures = null;
         }
 
-        // Clear previous contexts
+        // Close previous readers before clearing to avoid JDBC connection leak
+        if (!this.snapshotReaderContexts.isEmpty()) {
+            LOG.info(
+                    "Closing {} previous snapshot readers before preparing new splits",
+                    snapshotReaderContexts.size());
+            for (SnapshotReaderContext<
+                            MySqlSnapshotSplit, SnapshotSplitReader, MySqlSnapshotSplitState>
+                    context : snapshotReaderContexts) {
+                if (context.getReader() != null) {
+                    context.getReader().close();
+                }
+            }
+        }
         this.snapshotReaderContexts.clear();
         this.completedSplitIds.clear();
 

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_priv.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_priv.groovy
@@ -180,7 +180,7 @@ suite("test_streaming_mysql_job_priv", "p0,external,mysql,external_docker,extern
                        def jobStatus = sql """ select status, ErrorMsg from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
                        log.info("jobStatus: " + jobStatus)
                        // check job status
-                       jobStatus.size() == 1 && 'PAUSED' == jobStatus.get(0).get(0)
+                       jobStatus.size() == 1 && 'RETRYING' == jobStatus.get(0).get(0)
                    }
            )
        } catch (Exception ex){

--- a/regression-test/suites/job_p0/streaming_job/cdc/tvf/test_streaming_job_cdc_stream_postgres_latest_alter_cred.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/tvf/test_streaming_job_cdc_stream_postgres_latest_alter_cred.groovy
@@ -173,7 +173,7 @@ suite("test_streaming_job_cdc_stream_postgres_latest_alter_cred",
             Awaitility.await().atMost(120, SECONDS).pollInterval(2, SECONDS).until({
                 def s = sql """select status from jobs("type"="insert") where Name='${jobName}'"""
                 log.info("status after wrong cred resume: " + s)
-                s.size() == 1 && s.get(0).get(0) == "PAUSED"
+                s.size() == 1 && s.get(0).get(0) == "RETRYING"
             })
         } catch (Exception ex) {
             log.info("job: " + (sql """select * from jobs("type"="insert") where Name='${jobName}'"""))
@@ -186,6 +186,12 @@ suite("test_streaming_job_cdc_stream_postgres_latest_alter_cred",
                 "ErrorMsg should be non-empty when wrong credentials are used"
 
         // ── Scenario C: ALTER back to correct credentials and recover ─────────────────
+        // Pause the job first since it's currently in RETRYING state
+        sql """PAUSE JOB where jobname = '${jobName}'"""
+        Awaitility.await().atMost(30, SECONDS).pollInterval(1, SECONDS).until({
+            def s = sql """select status from jobs("type"="insert") where Name='${jobName}'"""
+            s.size() == 1 && s.get(0).get(0) == "PAUSED"
+        })
         sql """
             ALTER JOB ${jobName}
             INSERT INTO ${currentDb}.${dorisTable} (name, age)

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_alter_aksk.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_alter_aksk.groovy
@@ -101,15 +101,15 @@ suite("test_streaming_insert_job_alter_aksk") {
         )
     """
 
-    // Step 5: resume the job and wait for it to pause again due to fetchMeta failure
+    // Step 5: resume the job and wait for it to enter RETRYING due to fetchMeta failure
     sql """RESUME JOB where jobname = '${jobName}'"""
     try {
         Awaitility.await().atMost(300, SECONDS)
                 .pollInterval(1, SECONDS).until(
                 {
                     def r = sql """select status from jobs("type"="insert") where Name='${jobName}' and ExecuteType='STREAMING'"""
-                    log.info("check job status paused after altering to wrong aksk: " + r)
-                    r.size() == 1 && 'PAUSED' == r.get(0).get(0)
+                    log.info("check job status retrying after altering to wrong aksk: " + r)
+                    r.size() == 1 && 'RETRYING' == r.get(0).get(0)
                 }
         )
     } catch (Exception ex) {

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_task_retry.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_task_retry.groovy
@@ -67,7 +67,7 @@ suite("test_streaming_insert_job_task_retry", 'nonConcurrent') {
                 {
                     def jobStatus = sql """ select Status,FailedTaskCount from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
                     log.info("jobStatus: " + jobStatus)
-                    jobStatus.size() == 1 && 'PAUSED' == jobStatus.get(0).get(0) && '1' == jobStatus.get(0).get(1)
+                    jobStatus.size() == 1 && 'RETRYING' == jobStatus.get(0).get(0) && '1' == jobStatus.get(0).get(1)
                 }
         )
     } catch (Exception ex){

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_job_max_retry.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_job_max_retry.groovy
@@ -20,11 +20,11 @@ import org.awaitility.Awaitility
 
 import static java.util.concurrent.TimeUnit.SECONDS
 
-// Verify that when fetchRemoteMeta receives a failed GlobListResult (e.g. S3 auth error),
-// the streaming job is correctly RETRYING rather than hanging indefinitely.
-suite("test_streaming_insert_job_fetch_meta_error", "nonConcurrent") {
-    def tableName = "test_streaming_insert_job_fetch_meta_error_tbl"
-    def jobName = "test_streaming_insert_job_fetch_meta_error_job"
+// Verify that after exceeding max auto resume count, the streaming job
+// transitions from RETRYING to PAUSED with CANNOT_RESUME_ERR.
+suite("test_streaming_job_max_retry", "nonConcurrent") {
+    def tableName = "test_streaming_job_max_retry_tbl"
+    def jobName = "test_streaming_job_max_retry_job"
 
     sql """drop table if exists `${tableName}` force"""
     sql """
@@ -43,7 +43,10 @@ suite("test_streaming_insert_job_fetch_meta_error", "nonConcurrent") {
         PROPERTIES ("replication_allocation" = "tag.location.default: 1");
     """
 
-    GetDebugPoint().enableDebugPointForAllFEs("S3SourceOffsetProvider.fetchRemoteMeta.error")
+    // Set max retry count to 2 for faster testing
+    sql "ADMIN SET FRONTEND CONFIG ('streaming_job_max_auto_resume_count' = '2')"
+
+    GetDebugPoint().enableDebugPointForAllFEs('StreamingJob.scheduleTask.exception')
     try {
         sql """
            CREATE JOB ${jobName}
@@ -61,6 +64,7 @@ suite("test_streaming_insert_job_fetch_meta_error", "nonConcurrent") {
             );
         """
 
+        // First, job should enter RETRYING state
         try {
             Awaitility.await().atMost(120, SECONDS)
                     .pollInterval(2, SECONDS).until(
@@ -72,25 +76,34 @@ suite("test_streaming_insert_job_fetch_meta_error", "nonConcurrent") {
             )
         } catch (Exception ex) {
             def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
-            def showtask = sql """select * from tasks("type"="insert") where JobName='${jobName}'"""
             log.info("show job: " + showjob)
-            log.info("show task: " + showtask)
             throw ex
         }
 
+        // Then, after exceeding max retry count, job should transition to PAUSED
+        try {
+            Awaitility.await().atMost(300, SECONDS)
+                    .pollInterval(2, SECONDS).until(
+                    {
+                        def jobRes = sql """ select Status from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                        log.info("jobRes waiting for PAUSED: " + jobRes)
+                        jobRes.size() == 1 && 'PAUSED'.equals(jobRes.get(0).get(0))
+                    }
+            )
+        } catch (Exception ex) {
+            def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
+            log.info("show job: " + showjob)
+            throw ex
+        }
+
+        // Verify error message indicates max retry exceeded
         def jobStatus = sql """select Status, ErrorMsg from jobs("type"="insert") where Name='${jobName}'"""
-        assert jobStatus.get(0).get(0) == "RETRYING"
-        assert jobStatus.get(0).get(1).contains("Failed to list S3 files")
-
-        sql """
-            DROP JOB IF EXISTS where jobname = '${jobName}'
-        """
-
-        def jobCountRsp = sql """select count(1) from jobs("type"="insert") where Name='${jobName}'"""
-        assert jobCountRsp.get(0).get(0) == 0
+        assert jobStatus.get(0).get(0) == "PAUSED"
+        assert jobStatus.get(0).get(1).contains("Auto resume failed after")
 
     } finally {
-        GetDebugPoint().disableDebugPointForAllFEs("S3SourceOffsetProvider.fetchRemoteMeta.error")
+        GetDebugPoint().disableDebugPointForAllFEs('StreamingJob.scheduleTask.exception')
+        sql "ADMIN SET FRONTEND CONFIG ('streaming_job_max_auto_resume_count' = '10')"
         sql """DROP JOB IF EXISTS where jobname = '${jobName}'"""
     }
 }

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_job_max_retry.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_job_max_retry.groovy
@@ -43,8 +43,8 @@ suite("test_streaming_job_max_retry", "nonConcurrent") {
         PROPERTIES ("replication_allocation" = "tag.location.default: 1");
     """
 
-    // Set max retry count to 2 for faster testing
-    sql "ADMIN SET FRONTEND CONFIG ('streaming_job_max_auto_resume_count' = '2')"
+    // Set max retry count to 4 for faster testing
+    sql "ADMIN SET FRONTEND CONFIG ('streaming_job_max_auto_resume_count' = '4')"
 
     GetDebugPoint().enableDebugPointForAllFEs('StreamingJob.scheduleTask.exception')
     try {

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_job_retry_info.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_job_retry_info.groovy
@@ -85,19 +85,18 @@ suite("test_streaming_job_retry_info", "nonConcurrent") {
         // case2: Inject failure, verify RetryInfo is populated
         GetDebugPoint().enableDebugPointForAllBEs("FlushToken.submit_flush_error")
         try {
+            // Wait until RetryInfo is populated (autoResumeCount increments after backoff)
             Awaitility.await().atMost(120, SECONDS)
                     .pollInterval(2, SECONDS).until(
                     {
                         def jobRes = sql """ select Status, RetryInfo from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
-                        log.info("jobRes waiting for RETRYING: " + jobRes)
-                        jobRes.size() == 1 && 'RETRYING'.equals(jobRes.get(0).get(0))
+                        log.info("jobRes waiting for RetryInfo: " + jobRes)
+                        jobRes.size() == 1 && jobRes.get(0).get(1) != null && jobRes.get(0).get(1).contains("retryCount")
                     }
             )
 
-            // Verify RetryInfo contains retryCount
             def retryInfo = sql """select RetryInfo from jobs("type"="insert") where Name='${jobName}'"""
             log.info("retryInfo: " + retryInfo)
-            assert retryInfo.get(0).get(0) != null && retryInfo.get(0).get(0) != "" : "RetryInfo should be set during RETRYING"
             assert retryInfo.get(0).get(0).contains("retryCount") : "RetryInfo should contain retryCount"
         } finally {
             GetDebugPoint().disableDebugPointForAllBEs("FlushToken.submit_flush_error")

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_job_retry_info.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_job_retry_info.groovy
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+// Verify that RetryInfo and LastTaskSuccessTime TVF columns are populated correctly.
+// 1. After a successful task, LastTaskSuccessTime should be set.
+// 2. After failures and retries, RetryInfo should contain retryCount.
+// 3. After manual resume, retryCount should be reset to 0.
+suite("test_streaming_job_retry_info", "nonConcurrent") {
+    def tableName = "test_streaming_job_retry_info_tbl"
+    def jobName = "test_streaming_job_retry_info_job"
+
+    sql """drop table if exists `${tableName}` force"""
+    sql """
+        DROP JOB IF EXISTS where jobname = '${jobName}'
+    """
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            `c1` int NULL,
+            `c2` string NULL,
+            `c3` int  NULL,
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`c1`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`c1`) BUCKETS 3
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+
+    // case1: Verify LastTaskSuccessTime is set after successful task
+    sql """
+       CREATE JOB ${jobName}
+       PROPERTIES(
+           "s3.max_batch_files" = "1"
+       )
+       ON STREAMING DO INSERT INTO ${tableName}
+       SELECT * FROM S3
+        (
+            "uri" = "s3://${s3BucketName}/regression/load/data/example_[0-1].csv",
+            "format" = "csv",
+            "provider" = "${getS3Provider()}",
+            "column_separator" = ",",
+            "s3.endpoint" = "${getS3Endpoint()}",
+            "s3.region" = "${getS3Region()}",
+            "s3.access_key" = "${getS3AK()}",
+            "s3.secret_key" = "${getS3SK()}"
+        );
+    """
+
+    try {
+        // Wait for at least one successful task
+        Awaitility.await().atMost(120, SECONDS)
+                .pollInterval(2, SECONDS).until(
+                {
+                    def jobRes = sql """ select SucceedTaskCount from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                    log.info("jobRes: " + jobRes)
+                    jobRes.size() == 1 && '0' < jobRes.get(0).get(0)
+                }
+        )
+
+        // Verify LastTaskSuccessTime is set and RetryInfo is empty
+        def jobInfo = sql """select LastTaskSuccessTime, RetryInfo from jobs("type"="insert") where Name='${jobName}'"""
+        log.info("jobInfo after success: " + jobInfo)
+        assert jobInfo.get(0).get(0) != null && jobInfo.get(0).get(0) != "" : "LastTaskSuccessTime should be set after successful task"
+        assert jobInfo.get(0).get(1) == null || jobInfo.get(0).get(1) == "" : "RetryInfo should be empty when no retries"
+
+        // case2: Inject failure, verify RetryInfo is populated
+        GetDebugPoint().enableDebugPointForAllBEs("FlushToken.submit_flush_error")
+        try {
+            Awaitility.await().atMost(120, SECONDS)
+                    .pollInterval(2, SECONDS).until(
+                    {
+                        def jobRes = sql """ select Status, RetryInfo from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                        log.info("jobRes waiting for RETRYING: " + jobRes)
+                        jobRes.size() == 1 && 'RETRYING'.equals(jobRes.get(0).get(0))
+                    }
+            )
+
+            // Verify RetryInfo contains retryCount
+            def retryInfo = sql """select RetryInfo from jobs("type"="insert") where Name='${jobName}'"""
+            log.info("retryInfo: " + retryInfo)
+            assert retryInfo.get(0).get(0) != null && retryInfo.get(0).get(0) != "" : "RetryInfo should be set during RETRYING"
+            assert retryInfo.get(0).get(0).contains("retryCount") : "RetryInfo should contain retryCount"
+        } finally {
+            GetDebugPoint().disableDebugPointForAllBEs("FlushToken.submit_flush_error")
+        }
+
+        // case3: Manual resume should reset retryCount
+        sql """
+            PAUSE JOB where jobname = '${jobName}'
+        """
+        def pausedStatus = sql """select Status from jobs("type"="insert") where Name='${jobName}'"""
+        assert pausedStatus.get(0).get(0) == "PAUSED"
+
+        sql """
+            RESUME JOB where jobname = '${jobName}'
+        """
+
+        // Wait for job to run successfully again
+        Awaitility.await().atMost(120, SECONDS)
+                .pollInterval(2, SECONDS).until(
+                {
+                    def jobRes = sql """ select Status, SucceedTaskCount from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                    log.info("jobRes after resume: " + jobRes)
+                    jobRes.size() == 1 && 'RUNNING'.equals(jobRes.get(0).get(0))
+                }
+        )
+
+        // Verify RetryInfo is empty after manual resume
+        def jobInfoAfterResume = sql """select RetryInfo from jobs("type"="insert") where Name='${jobName}'"""
+        log.info("jobInfo after resume: " + jobInfoAfterResume)
+        assert jobInfoAfterResume.get(0).get(0) == null || jobInfoAfterResume.get(0).get(0) == "" : "RetryInfo should be empty after manual resume"
+
+    } catch (Exception ex) {
+        def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
+        log.info("show job: " + showjob)
+        throw ex
+    } finally {
+        sql """DROP JOB IF EXISTS where jobname = '${jobName}'"""
+    }
+}

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_job_schedule_task_error.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_job_schedule_task_error.groovy
@@ -66,7 +66,7 @@ suite("test_streaming_job_schedule_task_error", 'nonConcurrent') {
                         def jobRes = sql """ select Status, errorMsg from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
                         // check job status and succeed task count larger than 2
                         log.info("jobRes: " + jobRes)
-                        jobRes.size() == 1 && 'PAUSED'.equals(jobRes.get(0).get(0))
+                        jobRes.size() == 1 && 'RETRYING'.equals(jobRes.get(0).get(0))
                     }
             )
         } catch (Exception ex){


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

Currently, StreamingInsertJob uses `PAUSED` state for both manual pause and automatic retry scenarios. Users cannot distinguish between:
- A job that was manually paused (needs no action)
- A job that encountered a transient error and is auto-recovering
- A job that has been continuously failing and retrying

This PR introduces a new `RETRYING` state to purify the semantics:
- **PAUSED** = needs manual intervention (manual pause, non-resumable errors, max retries exceeded)
- **RETRYING** = system is auto-recovering with exponential backoff

#### Key Changes

**New RETRYING State:**
- `RUNNING → RETRYING`: when task fails with a resumable error
- `RETRYING → RUNNING`: when backoff expires and createTask succeeds
- `RETRYING → PAUSED`: when max retry count exceeded or non-resumable error
- RETRYING is a runtime-only state, **not persisted to editlog** for backward compatibility

**Max Retry Limit:**
- New config `streaming_job_max_auto_resume_count` (default 10, mutable)
- After exceeding the limit, job transitions to PAUSED with `CANNOT_RESUME_ERR`
- Error message: "Auto resume failed after N attempts. Last error: ..."

**Backoff Interval:**
- Base time increased from 10s to 30s for better observability
- Progression: 30s → 60s → 120s → 240s → 300s (cap)

**New TVF Columns:**
- `LastTaskSuccessTime`: timestamp of the last successful task completion
- `RetryInfo`: JSON containing `retryCount` (e.g. `{"retryCount": 3}`), empty when count is 0

**Compatibility:**
- RETRYING never appears in editlog, so old FE never encounters unknown enum during rolling upgrade
- `gsonPostProcess` adds null fallback: if an unknown enum deserializes as null, defaults to PENDING
- `replayOnUpdated` skips RETRYING (same as RUNNING) — FE restart goes through PENDING for proper initialization

### Release note

Add RETRYING state to streaming insert job to distinguish auto-recovering jobs from manually paused ones. New TVF columns `LastTaskSuccessTime` and `RetryInfo` provide retry visibility. New config `streaming_job_max_auto_resume_count` limits auto-resume attempts.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes.
      - Resumable task failures now transition to `RETRYING` instead of `PAUSED`
      - `PAUSED` state no longer triggers auto-resume; only `RETRYING` does
      - Backoff base time changed from 10s to 30s
      - Two new columns added to insert job TVF: `LastTaskSuccessTime`, `RetryInfo`

- Does this need documentation?
    - [x] Yes. <!-- TODO: add docs PR -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label