### PR TITLE
[fix](cloud) Add predecessor instance id

### DIFF
--- a/cloud/src/resource-manager/resource_manager.cpp
+++ b/cloud/src/resource-manager/resource_manager.cpp
@@ -1414,18 +1414,19 @@ std::pair<MetaServiceCode, std::string> ResourceManager::refresh_instance(
 void ResourceManager::refresh_instance(const std::string& instance_id,
                                        const InstanceInfoPB& instance) {
     bool is_successor_instance = instance.has_original_instance_id();
-    std::string source_instance_id = is_successor_instance ? instance.source_instance_id() : "";
+    std::string predecessor_instance_id =
+            is_successor_instance ? instance.predecessor_instance_id() : "";
 
     std::lock_guard l(mtx_);
     for (auto i = node_info_.begin(); i != node_info_.end();) {
-        // erase all nodes not belong to this instance_id
-        if (i->second.instance_id != instance_id &&
-            // ... or, if is_successor_instance, erase nodes belong to source_instance_id
-            (!is_successor_instance || i->second.instance_id != source_instance_id)) {
+        // erase all nodes belong to this instance_id
+        if (i->second.instance_id == instance_id ||
+            // ... or, if is_successor_instance, erase nodes belong to predecessor_instance_id
+            (is_successor_instance && i->second.instance_id == predecessor_instance_id)) {
+            i = node_info_.erase(i);
+        } else {
             ++i;
-            continue;
         }
-        i = node_info_.erase(i);
     }
 
     // If successor_instance_id is set, it means this instance has a successor instance,

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -129,7 +129,7 @@ message InstanceInfoPB {
     // For snapshot
     optional MultiVersionStatus multi_version_status = 110;
     optional SnapshotSwitchStatus snapshot_switch_status = 111;
-    optional string source_instance_id = 112;   // The instance cloned from.
+    optional string source_instance_id = 112;   // The instance cloned from (the snapshot instance id).
     optional string source_snapshot_id = 113;   // The snapshot cloned from.
 
     // Inherited from which instance (only used during rollback, the earliest instance id).
@@ -147,6 +147,11 @@ message InstanceInfoPB {
     optional int64 snapshot_retained_data_size = 121;
     optional int64 snapshot_billable_data_size = 122;
     optional SnapshotCompactStatus snapshot_compact_status = 123;
+
+    // The instance that is being rolled back, only used during rollback.
+    // It is not always same as source_instance_id, because the source instance may inherit from another
+    // instance during rollback, and the predecessor instance is the real instance which to execute the rollback.
+    optional string predecessor_instance_id = 124;
 }
 
 message StagePB {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

When a rollback exists, the predecessor instance is not the same as the source instance. This change separates the two semantics into distinct fields for clarity.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

