### PR TITLE
[chore](dep)Upgrade Hadoop version from 3.4.2 to 3.5.0

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -391,7 +391,7 @@ under the License.
         <httpcore.version>4.4.15</httpcore.version>
         <aws-java-sdk.version>1.12.669</aws-java-sdk.version>
         <mariadb-java-client.version>3.0.9</mariadb-java-client.version>
-        <hadoop.version>3.4.2</hadoop.version>
+        <hadoop.version>3.5.0</hadoop.version>
         <re2j.version>1.8</re2j.version>
         <hadoop.thirdparty.guava.version>1.2.0</hadoop.thirdparty.guava.version>
         <hadoop.thirdparty.protobuf_3_25.version>1.5.0</hadoop.thirdparty.protobuf_3_25.version>


### PR DESCRIPTION

  This branch upgrades `hadoop.version` to `3.5.0`, but keeps `awssdk.version` at `2.29.52`. That combination is not compatible. Hadoop 3.5.0's upstream BOM expects AWS SDK v2 `2.35.4`, and `hadoop-
  aws` in 3.5.0 uses `ChecksumAlgorithm.CRC64_NVME` in `ChecksumSupport`. That enum value does not exist in AWS SDK v2 `2.29.52`, which explains the `NoSuchFieldError: CRC64_NVME` during S3A
  initialization.

  However, I do not think we should move the AWS SDK version right now. We already have compatibility concerns on newer AWS SDK v2 versions, for example:
  https://github.com/aws/aws-sdk-java-v2/issues/5805

  Given that, I suggest we do not proceed with the Hadoop 3.5.0 upgrade in this PR for now.