### PR TITLE
[chore](expr) decouple Expr from unnecessary class

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -102,11 +102,9 @@ public class ArithmeticExpr extends Expr {
     @Override
     public String toString() {
         if (children.size() == 1) {
-            return op.toString() + " " + getChild(0).accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE);
+            return op.toString() + " " + getChild(0);
         } else {
-            return "(" + getChild(0).accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE)
-                    + " " + op.toString()
-                    + " " + getChild(1).accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE) + ")";
+            return "(" + getChild(0) + " " + op.toString() + " " + getChild(1) + ")";
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToThriftVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToThriftVisitor.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.thrift.TAggregateExpr;
 import org.apache.doris.thrift.TBoolLiteral;
 import org.apache.doris.thrift.TCaseExpr;
 import org.apache.doris.thrift.TColumnRef;
@@ -493,7 +494,7 @@ public class ExprToThriftVisitor extends ExprVisitor<Void, TExprNode> {
             if (aggParams == null) {
                 aggParams = expr.getFnParams();
             }
-            msg.setAggExpr(aggParams.createTAggregateExpr(expr.isMergeAggFn()));
+            msg.setAggExpr(createTAggregateExprFromFunctionParams(aggParams, expr.isMergeAggFn()));
         } else {
             msg.node_type = TExprNodeType.FUNCTION_CALL;
         }
@@ -502,6 +503,20 @@ public class ExprToThriftVisitor extends ExprVisitor<Void, TExprNode> {
             msg.setShortCircuitEvaluation(ConnectContext.get().getSessionVariable().isShortCircuitEvaluation());
         }
         return null;
+    }
+
+    public TAggregateExpr createTAggregateExprFromFunctionParams(FunctionParams functionParams, boolean isMergeAggFn) {
+        List<TTypeDesc> paramTypes = new ArrayList<>();
+        if (functionParams.exprs() != null) {
+            for (Expr expr : functionParams.exprs()) {
+                TTypeDesc desc = expr.getType().toThrift();
+                desc.setIsNullable(expr.isNullable());
+                paramTypes.add(desc);
+            }
+        }
+        TAggregateExpr aggExpr = new TAggregateExpr(isMergeAggFn);
+        aggExpr.setParamTypes(paramTypes);
+        return aggExpr;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionParams.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionParams.java
@@ -20,13 +20,9 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.thrift.TAggregateExpr;
-import org.apache.doris.thrift.TTypeDesc;
-
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -72,20 +68,6 @@ public class FunctionParams {
             return FunctionParams.createStarParam();
         }
         return new FunctionParams(isDistinct(), children);
-    }
-
-    public TAggregateExpr createTAggregateExpr(boolean isMergeAggFn) {
-        List<TTypeDesc> paramTypes = new ArrayList<>();
-        if (exprs != null) {
-            for (Expr expr : exprs) {
-                TTypeDesc desc = expr.getType().toThrift();
-                desc.setIsNullable(expr.isNullable());
-                paramTypes.add(desc);
-            }
-        }
-        TAggregateExpr aggExpr = new TAggregateExpr(isMergeAggFn);
-        aggExpr.setParamTypes(paramTypes);
-        return aggExpr;
     }
 
     public boolean isStar() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OrderByElement.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OrderByElement.java
@@ -75,13 +75,14 @@ public class OrderByElement {
         return result;
     }
 
-    public String toSql() {
+    @Override
+    public String toString() {
         StringBuilder strBuilder = new StringBuilder();
-        strBuilder.append(expr.accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
+        strBuilder.append(expr);
         strBuilder.append(isAsc ? " ASC" : " DESC");
 
         // When ASC and NULLS LAST or DESC and NULLS FIRST, we do not print NULLS FIRST/LAST
-        // because it is the default behavior and we want to avoid printing NULLS FIRST/LAST
+        // because it is the default behavior. we want to avoid printing NULLS FIRST/LAST
         // whenever possible as it is incompatible with Hive (SQL compatibility with Hive is
         // important for views).
         if (nullsFirstParam != null) {
@@ -95,11 +96,6 @@ public class OrderByElement {
         }
 
         return strBuilder.toString();
-    }
-
-    @Override
-    public String toString() {
-        return toSql();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticEvalNode.java
@@ -126,7 +126,7 @@ public class AnalyticEvalNode extends PlanNode {
             strings.clear();
 
             for (OrderByElement element : orderByElements) {
-                strings.add(element.toSql());
+                strings.add(orderByElementToSql(element));
             }
 
             output.append(Joiner.on(", ").join(strings));
@@ -144,6 +144,29 @@ public class AnalyticEvalNode extends PlanNode {
         }
 
         return output.toString();
+    }
+
+
+    private String orderByElementToSql(OrderByElement orderByElement) {
+        StringBuilder strBuilder = new StringBuilder();
+        strBuilder.append(orderByElement.getExpr().accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE));
+        strBuilder.append(orderByElement.getIsAsc() ? " ASC" : " DESC");
+
+        // When ASC and NULLS LAST or DESC and NULLS FIRST, we do not print NULLS FIRST/LAST
+        // because it is the default behavior and we want to avoid printing NULLS FIRST/LAST
+        // whenever possible as it is incompatible with Hive (SQL compatibility with Hive is
+        // important for views).
+        if (orderByElement.getNullsFirstParam() != null) {
+            if (orderByElement.getIsAsc() && orderByElement.getNullsFirstParam()) {
+                // If ascending, nulls are last by default, so only add if nulls first.
+                strBuilder.append(" NULLS FIRST");
+            } else if (!orderByElement.getIsAsc() && !orderByElement.getNullsFirstParam()) {
+                // If descending, nulls are first by default, so only add if nulls last.
+                strBuilder.append(" NULLS LAST");
+            }
+        }
+
+        return strBuilder.toString();
     }
 
     /**


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

1. ArithmeticExpr toString should not rely ExprToSqlVisitor
2. move FunctionParams toThrift into ExprToThriftVisitor
3. move OrderByElement toSql into AnalyticEvalNode

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

