### PR TITLE
[refactor](desc) decouple SlotDescriptor from TupleDescriptor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
@@ -51,7 +51,7 @@ public class DescriptorTable {
     }
 
     public SlotDescriptor addSlotDescriptor(TupleDescriptor d) {
-        SlotDescriptor result = new SlotDescriptor(slotIdGenerator.getNextId(), d);
+        SlotDescriptor result = new SlotDescriptor(slotIdGenerator.getNextId(), d.getId());
         d.addSlot(result);
         slotDescs.put(result.getId(), result);
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToThriftVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprToThriftVisitor.java
@@ -290,7 +290,7 @@ public class ExprToThriftVisitor extends ExprVisitor<Void, TExprNode> {
     @Override
     public Void visitSlotRef(SlotRef expr, TExprNode msg) {
         msg.node_type = TExprNodeType.SLOT_REF;
-        msg.slot_ref = new TSlotRef(expr.getDesc().getId().asInt(), expr.getDesc().getParent().getId().asInt());
+        msg.slot_ref = new TSlotRef(expr.getDesc().getId().asInt(), expr.getDesc().getParentId().asInt());
         msg.slot_ref.setColUniqueId(expr.getDesc().getUniqueId());
         msg.slot_ref.setIsVirtualSlot(expr.getDesc().getVirtualColumn() != null);
         msg.setLabel(expr.getLabel());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class SlotDescriptor {
     private static final Logger LOG = LogManager.getLogger(SlotDescriptor.class);
     private final SlotId id;
-    private final TupleDescriptor parent;
+    private final TupleId parentId;
     private Type type;
     private Column column;  // underlying column, if there is one
 
@@ -66,20 +66,10 @@ public class SlotDescriptor {
     private List<TColumnAccessPath> displayAllAccessPaths;
     private List<TColumnAccessPath> displayPredicateAccessPaths;
 
-    public SlotDescriptor(SlotId id, TupleDescriptor parent) {
-
+    public SlotDescriptor(SlotId id, TupleId parentId) {
         this.id = id;
-        this.parent = parent;
+        this.parentId = parentId;
         this.isNullable = true;
-    }
-
-    public SlotDescriptor(SlotId id, TupleDescriptor parent, SlotDescriptor src) {
-        this.id = id;
-        this.parent = parent;
-        this.column = src.column;
-        this.isNullable = src.isNullable;
-        this.type = src.type;
-        this.sourceExprs.add(new SlotRef(src));
     }
 
     public SlotId getId() {
@@ -126,8 +116,8 @@ public class SlotDescriptor {
         this.displayPredicateAccessPaths = displayPredicateAccessPaths;
     }
 
-    public TupleDescriptor getParent() {
-        return parent;
+    public TupleId getParentId() {
+        return parentId;
     }
 
     public Type getType() {
@@ -203,7 +193,7 @@ public class SlotDescriptor {
         // Non-nullable slots will have 0 for the byte offset and -1 for the bit mask
         String colName = materializedColumnName != null ? materializedColumnName :
                                      ((column != null) ? column.getNonShadowName() : "");
-        TSlotDescriptor tSlotDescriptor = new TSlotDescriptor(id.asInt(), parent.getId().asInt(), type.toThrift(), -1,
+        TSlotDescriptor tSlotDescriptor = new TSlotDescriptor(id.asInt(), parentId.asInt(), type.toThrift(), -1,
                 0, 0, getIsNullable() ? 0 : -1, colName, -1,
                 true);
         tSlotDescriptor.setIsAutoIncrement(isAutoInc);
@@ -265,7 +255,7 @@ public class SlotDescriptor {
 
     public String debugString() {
         String typeStr = (type == null ? "null" : type.toString());
-        String parentTupleId = (parent == null) ? "null" : parent.getId().toString();
+        String parentTupleId = (parentId == null) ? "null" : parentId.toString();
         return MoreObjects.toStringHelper(this).add("id", id.asInt()).add("parent", parentTupleId).add("col", caption)
                 .add("type", typeStr).add("nullable", getIsNullable())
                 .add("isAutoIncrement", isAutoInc).add("subColPath", subColPath)

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -80,7 +80,7 @@ public class SlotRef extends Expr {
         // tuple id and slot id is meaningless here, nereids just use type and nullable
         // to build the TAggregateExpr.param_types
         TupleDescriptor tupleDescriptor = new TupleDescriptor(new TupleId(-1));
-        desc = new SlotDescriptor(new SlotId(-1), tupleDescriptor);
+        desc = new SlotDescriptor(new SlotId(-1), tupleDescriptor.getId());
         tupleDescriptor.addSlot(desc);
         desc.setIsNullable(nullable);
         this.nullable = nullable;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -136,7 +136,7 @@ public class RuntimeFilterTranslator {
                     targetExpr = new CastExpr(src.getType(), targetExpr, Cast.castNullable(src.isNullable(),
                             DataType.fromCatalogType(src.getType()), DataType.fromCatalogType(targetExpr.getType())));
                 }
-                TupleId targetTupleId = targetSlotRef.getDesc().getParent().getId();
+                TupleId targetTupleId = targetSlotRef.getDesc().getParentId();
                 SlotId targetSlotId = targetSlotRef.getSlotId();
                 scanNodeList.add(scanNode);
                 targetExprList.add(targetExpr);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToSqlTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprToSqlTest.java
@@ -294,7 +294,7 @@ public class ExprToSqlTest {
         // isNereids=true, isQuery=false, sessionVariable set, desc set
         // → Nereids plan-printing path: label + "[#<slotId>]"
         TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(0));
-        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(3), tupleDesc);
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(3), tupleDesc.getId());
         slotDesc.setLabel("`col`");
         SlotRef expr = new SlotRef(null, "col");
         expr.setDesc(slotDesc);
@@ -307,7 +307,7 @@ public class ExprToSqlTest {
     public void testSlotRefLabelNereidsIsQuery() {
         // isNereids=true, isQuery=true → query execution path, slot-id suffix suppressed
         TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(0));
-        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(5), tupleDesc);
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(5), tupleDesc.getId());
         slotDesc.setLabel("`score`");
         SlotRef expr = new SlotRef(null, "score");
         expr.setDesc(slotDesc);
@@ -320,7 +320,7 @@ public class ExprToSqlTest {
     public void testSlotRefLabelNotNereids() {
         // isNereids=false → non-Nereids path, no slot-id suffix regardless of desc
         TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(0));
-        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(7), tupleDesc);
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(7), tupleDesc.getId());
         slotDesc.setLabel("`price`");
         SlotRef expr = new SlotRef(null, "price");
         expr.setDesc(slotDesc);
@@ -349,7 +349,7 @@ public class ExprToSqlTest {
     public void testSlotRefDescWithSourceExprs() {
         // label=null, desc has sourceExprs → "<slot N> expr visitor result"
         TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(0));
-        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(2), tupleDesc);
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(2), tupleDesc.getId());
         slotDesc.setSourceExpr(new IntLiteral(42L));
 
         SlotRef expr = new SlotRef(null, "x");
@@ -369,7 +369,7 @@ public class ExprToSqlTest {
     public void testSlotRefDescNoSourceExprs() {
         // label=null, desc has no sourceExprs → "<slot N>"
         TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(0));
-        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(4), tupleDesc);
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(4), tupleDesc.getId());
 
         SlotRef expr = new SlotRef(null, "x");
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/PlanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/PlanNodeTest.java
@@ -74,7 +74,7 @@ public class PlanNodeTest {
 
     private static SlotDescriptor createColumnSlot(TupleDescriptor tupleDescriptor, int slotId,
             String columnName) {
-        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(slotId), tupleDescriptor);
+        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(slotId), tupleDescriptor.getId());
         slotDescriptor.setColumn(new Column(columnName, Type.BIGINT));
         slotDescriptor.setLabel(columnName);
         tupleDescriptor.addSlot(slotDescriptor);
@@ -83,7 +83,7 @@ public class PlanNodeTest {
 
     private static SlotDescriptor createExprSlot(TupleDescriptor tupleDescriptor, int slotId,
             String label) {
-        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(slotId), tupleDescriptor);
+        SlotDescriptor slotDescriptor = new SlotDescriptor(new SlotId(slotId), tupleDescriptor.getId());
         slotDescriptor.setType(Type.BIGINT);
         slotDescriptor.setLabel(label);
         tupleDescriptor.addSlot(slotDescriptor);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

use TupleID in SlotDescriptor to avoid import TupleDescriptor in it.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

