### PR TITLE
[config] Change default value of max_bucket_num_per_partition to 768

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2587,7 +2587,7 @@ public class Config extends ConfigBase {
                     + "2. For auto-bucket feature (Dynamic Partition): "
                     + "bucket number will be capped at autobucket_max_buckets automatically. "
                     + "Set to 0 or negative value to disable this limit for user-specified buckets."})
-    public static int max_bucket_num_per_partition = autobucket_max_buckets;
+    public static int max_bucket_num_per_partition = 768;
 
     @ConfField(description = {"Maximum number of connections for the Arrow Flight Server per FE."})
     public static int arrow_flight_max_connections = 4096;


### PR DESCRIPTION
follow up #61576

## Summary
Increase the default value of `max_bucket_num_per_partition` from 128 to 768 to support larger partition bucket configurations by the benchmarks

## Changes
- Modified `Config.java` to change the default value of `max_bucket_num_per_partition` from `autobucket_max_buckets` (128) to 768

## Testing
- FE unit tests passed locally