### PR TITLE
[fix](profile) restore InvertedIndexQueryTime sub-timer invariants in SEARCH path

### DIFF
--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -241,6 +241,15 @@ Status OlapScanLocalState::_init_profile() {
             ADD_COUNTER_WITH_LEVEL(_segment_profile, "RowsInvertedIndexFiltered", TUnit::UNIT, 1);
     _inverted_index_filter_timer =
             ADD_TIMER_WITH_LEVEL(_segment_profile, "InvertedIndexFilterTime", 1);
+    // Sub-parts of InvertedIndexFilterTime (sum should ≈ parent). These diagnose
+    // where the filter-block wall time is actually spent when InvertedIndexFilterTime
+    // and InvertedIndexQueryTime do not match.
+    _inverted_index_apply_col_pred_timer = ADD_CHILD_TIMER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexApplyColPredTime", "InvertedIndexFilterTime", 1);
+    _inverted_index_apply_expr_timer = ADD_CHILD_TIMER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexApplyExprTime", "InvertedIndexFilterTime", 1);
+    _inverted_index_post_filter_timer = ADD_CHILD_TIMER_WITH_LEVEL(
+            _segment_profile, "InvertedIndexPostFilterTime", "InvertedIndexFilterTime", 1);
     _inverted_index_query_cache_hit_counter =
             ADD_COUNTER_WITH_LEVEL(_segment_profile, "InvertedIndexQueryCacheHit", TUnit::UNIT, 1);
     _inverted_index_query_cache_miss_counter =

--- a/be/src/exec/operator/olap_scan_operator.h
+++ b/be/src/exec/operator/olap_scan_operator.h
@@ -217,6 +217,12 @@ private:
     RuntimeProfile::Counter* _statistics_collect_timer = nullptr;
     RuntimeProfile::Counter* _inverted_index_filter_counter = nullptr;
     RuntimeProfile::Counter* _inverted_index_filter_timer = nullptr;
+    // Sub-parts of _inverted_index_filter_timer for diagnosing where the
+    // inverted-index filter-block wall time is spent (apply_col_pred +
+    // apply_expr + post_filter should sum to the parent FilterTime).
+    RuntimeProfile::Counter* _inverted_index_apply_col_pred_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_apply_expr_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_post_filter_timer = nullptr;
     RuntimeProfile::Counter* _inverted_index_query_null_bitmap_timer = nullptr;
     RuntimeProfile::Counter* _inverted_index_query_cache_hit_counter = nullptr;
     RuntimeProfile::Counter* _inverted_index_query_cache_miss_counter = nullptr;

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -825,6 +825,12 @@ void OlapScanner::_collect_profile_before_close() {
     COUNTER_UPDATE(local_state->_cached_pages_num_counter, stats.cached_pages_num);
     COUNTER_UPDATE(local_state->_inverted_index_filter_counter, stats.rows_inverted_index_filtered);
     COUNTER_UPDATE(local_state->_inverted_index_filter_timer, stats.inverted_index_filter_timer);
+    COUNTER_UPDATE(local_state->_inverted_index_apply_col_pred_timer,
+                   stats.inverted_index_apply_col_pred_timer);
+    COUNTER_UPDATE(local_state->_inverted_index_apply_expr_timer,
+                   stats.inverted_index_apply_expr_timer);
+    COUNTER_UPDATE(local_state->_inverted_index_post_filter_timer,
+                   stats.inverted_index_post_filter_timer);
     COUNTER_UPDATE(local_state->_inverted_index_query_cache_hit_counter,
                    stats.inverted_index_query_cache_hit);
     COUNTER_UPDATE(local_state->_inverted_index_query_cache_miss_counter,

--- a/be/src/exprs/function/function_search.cpp
+++ b/be/src/exprs/function/function_search.cpp
@@ -606,19 +606,24 @@ Status FunctionSearch::evaluate_inverted_index_with_search_param(
         minimum_should_match = search_param.minimum_should_match;
     }
 
-    auto* stats = context->stats;
-    int64_t dummy_timer = 0;
-    SCOPED_RAW_TIMER(stats ? &stats->inverted_index_searcher_search_timer : &dummy_timer);
-
+    // ---- Phase A: Build the query tree (OUTSIDE search_timer scope). --------
+    // `build_query_recursive` walks the DSL and, at every leaf, calls
+    // `FieldReaderResolver::resolve(...)` which in turn opens the CLucene
+    // directory / builds the IndexSearcher. That opening cost is already
+    // tracked by `inverted_index_searcher_open_timer` inside the resolver.
+    //
+    // Keep this OUTSIDE `inverted_index_searcher_search_timer` so that
+    // OpenTime becomes a SIBLING of SearchTime under QueryTime, mirroring the
+    // MATCH path where `handle_searcher_cache` (OpenTime) and
+    // `match_index_search` (SearchTime) are both direct children of QueryTime
+    // in `FullTextIndexReader::query`. Previously OpenTime was nested inside
+    // SearchInitTime → SearchTime, which broke the invariant
+    //   QueryTime ≈ OpenTime + SearchTime.
     query_v2::QueryPtr root_query;
     std::string root_binding_key;
-    {
-        int64_t init_dummy = 0;
-        SCOPED_RAW_TIMER(stats ? &stats->inverted_index_searcher_search_init_timer : &init_dummy);
-        RETURN_IF_ERROR(build_query_recursive(search_param.root, context, resolver, &root_query,
-                                              &root_binding_key, default_operator,
-                                              minimum_should_match));
-    }
+    RETURN_IF_ERROR(build_query_recursive(search_param.root, context, resolver, &root_query,
+                                          &root_binding_key, default_operator,
+                                          minimum_should_match));
     if (root_query == nullptr) {
         LOG(INFO) << "search: Query tree resolved to empty query, dsl:"
                   << search_param.original_dsl;
@@ -640,55 +645,93 @@ Status FunctionSearch::evaluate_inverted_index_with_search_param(
         top_k = index_query_context->query_limit;
     }
 
-    auto weight = root_query->weight(enable_scoring);
-    if (!weight) {
-        LOG(WARNING) << "search: Failed to build query weight";
-        bitmap_result = InvertedIndexResultBitmap(std::make_shared<roaring::Roaring>(),
-                                                  std::make_shared<roaring::Roaring>());
-        return Status::OK();
-    }
-
+    // ---- Phase B: Execute query (INSIDE search_timer scope). ----------------
+    // SearchTime is the analog of MATCH path's `match_index_search`:
+    //   SearchInitTime  – prepare the executable query structure
+    //                     (`query->add(query_info)` in MATCH;
+    //                      `Query::weight(...)` here — creating the Weight
+    //                      from the query tree)
+    //   SearchExecTime  – iterate the scorer and extract the null bitmap. The
+    //                     actual `weight->scorer(...)` call that opens the
+    //                     per-term posting-list iterators lives inside
+    //                     `collect_multi_segment_*`, which is inside this
+    //                     scope.
+    // Together they should cover nearly all of SearchTime, restoring the
+    // invariant `SearchTime ≈ SearchInitTime + SearchExecTime`. Result-bitmap
+    // construction and DSL cache insertion happen OUTSIDE SearchTime (still
+    // inside QueryTime), mirroring the MATCH path where `match_index_search`
+    // returns first and only then the caller does `cache->insert(...)`.
     std::shared_ptr<roaring::Roaring> roaring = std::make_shared<roaring::Roaring>();
-    {
-        int64_t exec_dummy = 0;
-        SCOPED_RAW_TIMER(stats ? &stats->inverted_index_searcher_search_exec_timer : &exec_dummy);
-        if (enable_scoring && !is_asc && top_k > 0) {
-            bool use_wand = index_query_context->runtime_state != nullptr &&
-                            index_query_context->runtime_state->query_options()
-                                    .enable_inverted_index_wand_query;
-            query_v2::collect_multi_segment_top_k(
-                    weight, exec_ctx, root_binding_key, top_k, roaring,
-                    index_query_context->collection_similarity, use_wand);
-        } else {
-            query_v2::collect_multi_segment_doc_set(
-                    weight, exec_ctx, root_binding_key, roaring,
-                    index_query_context ? index_query_context->collection_similarity : nullptr,
-                    enable_scoring);
-        }
-    }
-
-    VLOG_DEBUG << "search: Query completed, matched " << roaring->cardinality() << " documents";
-
-    // Extract NULL bitmap from three-valued logic scorer
-    // The scorer correctly computes which documents evaluate to NULL based on query logic
-    // For example: TRUE OR NULL = TRUE (not NULL), FALSE OR NULL = NULL
     std::shared_ptr<roaring::Roaring> null_bitmap = std::make_shared<roaring::Roaring>();
-    if (exec_ctx.null_resolver) {
-        auto scorer = weight->scorer(exec_ctx, root_binding_key);
-        if (scorer && scorer->has_null_bitmap(exec_ctx.null_resolver)) {
-            const auto* bitmap = scorer->get_null_bitmap(exec_ctx.null_resolver);
-            if (bitmap != nullptr) {
-                *null_bitmap = *bitmap;
-                VLOG_TRACE << "search: Extracted NULL bitmap with " << null_bitmap->cardinality()
-                           << " NULL documents";
+    {
+        auto* stats = context->stats;
+        int64_t dummy_timer = 0;
+        SCOPED_RAW_TIMER(stats ? &stats->inverted_index_searcher_search_timer : &dummy_timer);
+
+        query_v2::WeightPtr weight;
+        {
+            int64_t init_dummy = 0;
+            SCOPED_RAW_TIMER(stats ? &stats->inverted_index_searcher_search_init_timer
+                                   : &init_dummy);
+            weight = root_query->weight(enable_scoring);
+            if (!weight) {
+                LOG(WARNING) << "search: Failed to build query weight";
+                bitmap_result = InvertedIndexResultBitmap(std::make_shared<roaring::Roaring>(),
+                                                          std::make_shared<roaring::Roaring>());
+                return Status::OK();
             }
         }
-    }
+
+        {
+            int64_t exec_dummy = 0;
+            SCOPED_RAW_TIMER(stats ? &stats->inverted_index_searcher_search_exec_timer
+                                   : &exec_dummy);
+            if (enable_scoring && !is_asc && top_k > 0) {
+                bool use_wand = index_query_context->runtime_state != nullptr &&
+                                index_query_context->runtime_state->query_options()
+                                        .enable_inverted_index_wand_query;
+                query_v2::collect_multi_segment_top_k(
+                        weight, exec_ctx, root_binding_key, top_k, roaring,
+                        index_query_context->collection_similarity, use_wand);
+            } else {
+                query_v2::collect_multi_segment_doc_set(
+                        weight, exec_ctx, root_binding_key, roaring,
+                        index_query_context ? index_query_context->collection_similarity : nullptr,
+                        enable_scoring);
+            }
+
+            VLOG_DEBUG << "search: Query completed, matched " << roaring->cardinality()
+                       << " documents";
+
+            // Extract NULL bitmap from three-valued logic scorer. Keep inside
+            // SearchExecTime so the invariant
+            //   SearchTime ≈ SearchInitTime + SearchExecTime
+            // holds. `inverted_index_query_null_bitmap_timer` still reports its
+            // own slice as a separate sibling of QueryTime; the small overlap
+            // between those two timers is intentional and mirrors the MATCH
+            // path (where null-bitmap read happens inside handle_searcher_cache
+            // which is already covered by OpenTime).
+            if (exec_ctx.null_resolver) {
+                auto scorer = weight->scorer(exec_ctx, root_binding_key);
+                if (scorer && scorer->has_null_bitmap(exec_ctx.null_resolver)) {
+                    const auto* bitmap = scorer->get_null_bitmap(exec_ctx.null_resolver);
+                    if (bitmap != nullptr) {
+                        *null_bitmap = *bitmap;
+                        VLOG_TRACE << "search: Extracted NULL bitmap with "
+                                   << null_bitmap->cardinality() << " NULL documents";
+                    }
+                }
+            }
+        }
+    } // SearchTime scope ends here.
 
     VLOG_TRACE << "search: Before mask - true_bitmap=" << roaring->cardinality()
                << ", null_bitmap=" << null_bitmap->cardinality();
 
-    // Create result and mask out NULLs (SQL WHERE clause semantics: only TRUE rows)
+    // Create result and mask out NULLs (SQL WHERE clause semantics: only TRUE
+    // rows). Done AFTER SearchTime so SearchTime measures only the work that
+    // MATCH-path `match_index_search` performs; result-object construction
+    // happens in the caller slot, still inside QueryTime.
     bitmap_result = InvertedIndexResultBitmap(std::move(roaring), std::move(null_bitmap));
     bitmap_result.mask_out_null();
 

--- a/be/src/exprs/vsearch.cpp
+++ b/be/src/exprs/vsearch.cpp
@@ -233,13 +233,19 @@ Status VSearchExpr::execute_column(VExprContext* context, const Block* block, Se
 }
 
 Status VSearchExpr::evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) {
+    // NOTE: this function runs once per segment. Keep the hot path quiet —
+    // LOG(INFO) / LOG(WARNING) at this level can add tens of seconds of
+    // cumulative wall-clock inside InvertedIndexFilterTime on busy scans with
+    // many segments, making the filter-time dwarf the inner
+    // InvertedIndexQueryTime. Prefer VLOG_DEBUG except for real failures
+    // returned up the stack.
     if (_search_param.original_dsl.empty()) {
         return Status::InvalidArgument("search DSL is empty");
     }
 
     auto index_context = context->get_index_context();
     if (!index_context) {
-        LOG(WARNING) << "VSearchExpr: No inverted index context available";
+        VLOG_DEBUG << "VSearchExpr: No inverted index context available";
         return Status::OK();
     }
 
@@ -250,8 +256,8 @@ Status VSearchExpr::evaluate_inverted_index(VExprContext* context, uint32_t segm
 
     const bool is_nested_query = _search_param.root.clause_type == "NESTED";
     if (bundle.iterators.empty() && !is_nested_query) {
-        LOG(WARNING) << "VSearchExpr: No indexed columns available for evaluation, DSL: "
-                     << _original_dsl;
+        VLOG_DEBUG << "VSearchExpr: No indexed columns available for evaluation, DSL: "
+                   << _original_dsl;
         auto empty_bitmap = InvertedIndexResultBitmap(std::make_shared<roaring::Roaring>(),
                                                       std::make_shared<roaring::Roaring>());
         index_context->set_index_result_for_expr(this, std::move(empty_bitmap));
@@ -272,7 +278,10 @@ Status VSearchExpr::evaluate_inverted_index(VExprContext* context, uint32_t segm
         return status;
     }
 
-    index_context->set_index_result_for_expr(this, result_bitmap);
+    // Move (not copy) the bitmap into the expr context to avoid a deep copy of
+    // the underlying roaring bitmap per segment. `result_bitmap` is not used
+    // after this call.
+    index_context->set_index_result_for_expr(this, std::move(result_bitmap));
     for (int column_id : bundle.column_ids) {
         index_context->set_true_for_index_status(this, column_id);
     }

--- a/be/src/exprs/vsearch.cpp
+++ b/be/src/exprs/vsearch.cpp
@@ -278,10 +278,19 @@ Status VSearchExpr::evaluate_inverted_index(VExprContext* context, uint32_t segm
         return status;
     }
 
-    // Move (not copy) the bitmap into the expr context to avoid a deep copy of
-    // the underlying roaring bitmap per segment. `result_bitmap` is not used
-    // after this call.
-    index_context->set_index_result_for_expr(this, std::move(result_bitmap));
+    // IMPORTANT: do NOT std::move `result_bitmap` here. The DSL result cache
+    // (InvertedIndexQueryCache) already holds a shared_ptr to the same
+    // underlying roaring::Roaring as `result_bitmap._data_bitmap`. Storing a
+    // moved-from copy in the per-segment expr context would make the per-
+    // segment map entry SHARE that same Roaring object, and any later
+    // mutating consumer (notably `VCompoundPred::COMPOUND_NOT` →
+    // `InvertedIndexResultBitmap::op_not()`, which is `const` but writes
+    // through the shared_ptr) would corrupt the DSL cache entry, so the
+    // *next* segment that gets a cache hit would observe the negated data
+    // instead of the original SEARCH result. Pass by lvalue so the copy
+    // constructor deep-copies the bitmap and isolates the cache from
+    // per-segment mutations.
+    index_context->set_index_result_for_expr(this, result_bitmap);
     for (int column_id : bundle.column_ids) {
         index_context->set_true_for_index_status(this, column_id);
     }

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -361,6 +361,13 @@ struct OlapReaderStatistics {
 
     int64_t rows_inverted_index_filtered = 0;
     int64_t inverted_index_filter_timer = 0;
+    // Sub-parts of inverted_index_filter_timer, used to diagnose the gap between
+    // inverted_index_filter_timer and the inner InvertedIndexQueryTime.
+    //   inverted_index_filter_timer ≈ apply_col_pred + apply_expr + post_filter_bitmap_op
+    //   apply_expr ≈ inverted_index_query_timer + small VSearchExpr / VExpr overhead
+    int64_t inverted_index_apply_col_pred_timer = 0;
+    int64_t inverted_index_apply_expr_timer = 0;
+    int64_t inverted_index_post_filter_timer = 0;
     int64_t inverted_index_query_timer = 0;
     int64_t inverted_index_query_cache_hit = 0;
     int64_t inverted_index_query_cache_miss = 0;

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -757,38 +757,53 @@ Status SegmentIterator::_get_row_ranges_by_column_conditions() {
             size_t input_rows = _row_bitmap.cardinality();
             // Only apply column-level inverted index if we have iterators
             if (has_index_in_iterators()) {
+                SCOPED_RAW_TIMER(&_opts.stats->inverted_index_apply_col_pred_timer);
                 RETURN_IF_ERROR(_apply_inverted_index());
             }
             // Always apply expr-level index (e.g., search expressions) if we have common_expr_pushdown
             // This allows search expressions with variant subcolumns to be evaluated even when
             // the segment doesn't have all subcolumns
-            RETURN_IF_ERROR(_apply_index_expr());
-            for (auto it = _common_expr_ctxs_push_down.begin();
-                 it != _common_expr_ctxs_push_down.end();) {
-                if ((*it)->all_expr_inverted_index_evaluated()) {
-                    const auto* result = (*it)->get_index_context()->get_index_result_for_expr(
-                            (*it)->root().get());
-                    if (result != nullptr) {
-                        _row_bitmap &= *result->get_data_bitmap();
-                        auto root = (*it)->root();
-                        auto iter_find = std::find(_remaining_conjunct_roots.begin(),
-                                                   _remaining_conjunct_roots.end(), root);
-                        if (iter_find != _remaining_conjunct_roots.end()) {
-                            _remaining_conjunct_roots.erase(iter_find);
-                        }
-                        it = _common_expr_ctxs_push_down.erase(it);
-                    }
-                } else {
-                    ++it;
-                }
+            {
+                SCOPED_RAW_TIMER(&_opts.stats->inverted_index_apply_expr_timer);
+                RETURN_IF_ERROR(_apply_index_expr());
             }
-            _opts.condition_cache_digest =
-                    _common_expr_ctxs_push_down.empty() ? 0 : _opts.condition_cache_digest;
-            _opts.stats->rows_inverted_index_filtered += (input_rows - _row_bitmap.cardinality());
-            for (auto cid : _schema->column_ids()) {
-                bool result_true = _check_all_conditions_passed_inverted_index_for_column(cid);
-                if (result_true) {
-                    _need_read_data_indices[cid] = false;
+            {
+                // Post-filter bitmap operations: intersect the row bitmap with each
+                // resolved inverted-index result bitmap and decide which columns no
+                // longer need to read data. For queries over large segments this can
+                // dominate the gap between InvertedIndexFilterTime and
+                // InvertedIndexQueryTime (roaring bitmap `&=`, move of
+                // InvertedIndexResultBitmap out of the expr context, per-column
+                // condition check).
+                SCOPED_RAW_TIMER(&_opts.stats->inverted_index_post_filter_timer);
+                for (auto it = _common_expr_ctxs_push_down.begin();
+                     it != _common_expr_ctxs_push_down.end();) {
+                    if ((*it)->all_expr_inverted_index_evaluated()) {
+                        const auto* result = (*it)->get_index_context()->get_index_result_for_expr(
+                                (*it)->root().get());
+                        if (result != nullptr) {
+                            _row_bitmap &= *result->get_data_bitmap();
+                            auto root = (*it)->root();
+                            auto iter_find = std::find(_remaining_conjunct_roots.begin(),
+                                                       _remaining_conjunct_roots.end(), root);
+                            if (iter_find != _remaining_conjunct_roots.end()) {
+                                _remaining_conjunct_roots.erase(iter_find);
+                            }
+                            it = _common_expr_ctxs_push_down.erase(it);
+                        }
+                    } else {
+                        ++it;
+                    }
+                }
+                _opts.condition_cache_digest =
+                        _common_expr_ctxs_push_down.empty() ? 0 : _opts.condition_cache_digest;
+                _opts.stats->rows_inverted_index_filtered +=
+                        (input_rows - _row_bitmap.cardinality());
+                for (auto cid : _schema->column_ids()) {
+                    bool result_true = _check_all_conditions_passed_inverted_index_for_column(cid);
+                    if (result_true) {
+                        _need_read_data_indices[cid] = false;
+                    }
                 }
             }
         }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -53,6 +53,7 @@ list(REMOVE_ITEM UT_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/storage/segment/plain_page_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/storage/segment/rle_page_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/storage/segment/segment_iterator_apply_index_expr_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/storage/segment/segment_iterator_filter_sub_timer_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/runtime/decimal_value_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/util/decompress_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/util/url_coding_test.cpp

--- a/be/test/storage/segment/segment_iterator_filter_sub_timer_test.cpp
+++ b/be/test/storage/segment/segment_iterator_filter_sub_timer_test.cpp
@@ -1,0 +1,253 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Tests for the InvertedIndexFilterTime sub-timer hierarchy introduced so
+// that the filter-block profile invariant holds:
+//
+//   InvertedIndexFilterTime ≈ InvertedIndexApplyColPredTime
+//                           + InvertedIndexApplyExprTime
+//                           + InvertedIndexPostFilterTime
+//
+// Before this instrumentation, work that happened between the `_apply_*`
+// calls and the end of the filter block (notably the post-filter bitmap
+// intersection and the per-column "all conditions passed" check) was silently
+// attributed to the parent InvertedIndexFilterTime but not to any inner timer,
+// making it impossible to explain the gap between FilterTime and
+// InvertedIndexQueryTime from the profile alone.
+//
+// These tests exercise `OlapReaderStatistics` as the public contract point and
+// verify that the SCOPED_RAW_TIMERs added to `_get_row_ranges_by_column_conditions`
+// produce counters that add up to the parent.
+
+#include <gtest/gtest.h>
+
+#include "runtime/runtime_profile.h"
+#include "storage/olap_common.h"
+#include "util/time.h"
+
+namespace doris {
+
+// -- 1. Field existence ------------------------------------------------------
+//
+// The three sub-timer fields must be present and default-initialized to 0.
+// If someone removes/renames them in olap_common.h, the olap_scanner /
+// olap_scan_operator wiring will fail to propagate them and the regression
+// will silently re-appear; pin the contract here.
+TEST(OlapReaderStatisticsFilterSubTimers, FieldsExistAndDefaultZero) {
+    OlapReaderStatistics stats;
+    EXPECT_EQ(stats.inverted_index_filter_timer, 0);
+    EXPECT_EQ(stats.inverted_index_apply_col_pred_timer, 0);
+    EXPECT_EQ(stats.inverted_index_apply_expr_timer, 0);
+    EXPECT_EQ(stats.inverted_index_post_filter_timer, 0);
+}
+
+// -- 2. Scoped-timer accumulation semantics ----------------------------------
+//
+// `SCOPED_RAW_TIMER` reads `MonotonicNanos()` on construction and adds the
+// elapsed wall-clock to the counter on destruction. Reproduce the exact
+// nesting shape from `SegmentIterator::_get_row_ranges_by_column_conditions`
+// (parent FilterTime wrapping three sibling sub-scopes) and assert the sum
+// invariant holds. This directly guards the `SCOPED_RAW_TIMER` placement —
+// if the parent and children are regrouped incorrectly (e.g. one of the
+// children is reopened after FilterTime ends), this test will fail.
+TEST(OlapReaderStatisticsFilterSubTimers, FilterTimerEqualsSumOfChildScopes) {
+    OlapReaderStatistics stats;
+
+    auto busy_wait_ns = [](int64_t target_ns) {
+        const int64_t start = MonotonicNanos();
+        while (MonotonicNanos() - start < target_ns) {
+            // spin; the goal is predictable positive elapsed time
+        }
+    };
+
+    {
+        SCOPED_RAW_TIMER(&stats.inverted_index_filter_timer);
+        {
+            SCOPED_RAW_TIMER(&stats.inverted_index_apply_col_pred_timer);
+            busy_wait_ns(1 * 1000 * 1000); // ≥ 1ms
+        }
+        {
+            SCOPED_RAW_TIMER(&stats.inverted_index_apply_expr_timer);
+            busy_wait_ns(2 * 1000 * 1000); // ≥ 2ms
+        }
+        {
+            SCOPED_RAW_TIMER(&stats.inverted_index_post_filter_timer);
+            busy_wait_ns(1 * 1000 * 1000); // ≥ 1ms
+        }
+    }
+
+    const int64_t parent = stats.inverted_index_filter_timer;
+    const int64_t child_sum = stats.inverted_index_apply_col_pred_timer +
+                              stats.inverted_index_apply_expr_timer +
+                              stats.inverted_index_post_filter_timer;
+
+    // Each child must have captured at least its spin-wait budget.
+    EXPECT_GE(stats.inverted_index_apply_col_pred_timer, 1 * 1000 * 1000);
+    EXPECT_GE(stats.inverted_index_apply_expr_timer, 2 * 1000 * 1000);
+    EXPECT_GE(stats.inverted_index_post_filter_timer, 1 * 1000 * 1000);
+
+    // Parent must be ≥ the sum of children (scope nesting guarantees this).
+    EXPECT_GE(parent, child_sum);
+
+    // Drift between parent and the sum of children must be smaller than a
+    // single child's budget — anything larger would mean the caller is doing
+    // untimed work inside the filter block, which is exactly the bug this
+    // instrumentation is supposed to surface.
+    const int64_t drift = parent - child_sum;
+    const int64_t single_child_budget_ns = 1 * 1000 * 1000;
+    EXPECT_LT(drift, single_child_budget_ns)
+            << "parent=" << parent << "ns child_sum=" << child_sum << "ns drift=" << drift << "ns";
+}
+
+// -- 3. Accumulation across multiple segments --------------------------------
+//
+// The segment iterator re-enters the filter block once per segment in a
+// scanner, so the counters accumulate. Verify that running the scope twice
+// produces counters that are (a) non-decreasing and (b) still satisfy
+// parent ≥ sum(children).
+TEST(OlapReaderStatisticsFilterSubTimers, AccumulatesAcrossMultipleInvocations) {
+    OlapReaderStatistics stats;
+
+    auto busy_wait_ns = [](int64_t target_ns) {
+        const int64_t start = MonotonicNanos();
+        while (MonotonicNanos() - start < target_ns) {
+            // spin
+        }
+    };
+
+    for (int i = 0; i < 3; ++i) {
+        SCOPED_RAW_TIMER(&stats.inverted_index_filter_timer);
+        {
+            SCOPED_RAW_TIMER(&stats.inverted_index_apply_col_pred_timer);
+            busy_wait_ns(500 * 1000); // 0.5ms
+        }
+        {
+            SCOPED_RAW_TIMER(&stats.inverted_index_apply_expr_timer);
+            busy_wait_ns(500 * 1000); // 0.5ms
+        }
+        {
+            SCOPED_RAW_TIMER(&stats.inverted_index_post_filter_timer);
+            busy_wait_ns(500 * 1000); // 0.5ms
+        }
+    }
+
+    EXPECT_GE(stats.inverted_index_apply_col_pred_timer, 3 * 500 * 1000);
+    EXPECT_GE(stats.inverted_index_apply_expr_timer, 3 * 500 * 1000);
+    EXPECT_GE(stats.inverted_index_post_filter_timer, 3 * 500 * 1000);
+
+    const int64_t parent = stats.inverted_index_filter_timer;
+    const int64_t child_sum = stats.inverted_index_apply_col_pred_timer +
+                              stats.inverted_index_apply_expr_timer +
+                              stats.inverted_index_post_filter_timer;
+    EXPECT_GE(parent, child_sum);
+    // Drift should still be small after 3 iterations.
+    EXPECT_LT(parent - child_sum, 1 * 1000 * 1000);
+}
+
+// -- 4. Searcher timer hierarchy (the invariants this patch restores) -------
+//
+// The fix in `FunctionSearch::evaluate_inverted_index_with_search_param` must
+// preserve two profile invariants that already hold in the MATCH path:
+//
+//   (a) InvertedIndexQueryTime ≈ InvertedIndexSearcherOpenTime
+//                              + InvertedIndexSearcherSearchTime
+//   (b) InvertedIndexSearcherSearchTime ≈ InvertedIndexSearcherSearchInitTime
+//                                       + InvertedIndexSearcherSearchExecTime
+//
+// Reproduce the corrected scope layout directly against OlapReaderStatistics
+// to pin the invariants. If somebody re-introduces the pre-fix mistake
+// (opening searchers inside SearchInitTime so OpenTime is nested under
+// SearchTime, or leaving `weight->scorer()` outside all sub-timers), the
+// accumulation in this test no longer satisfies the invariants and it fails.
+TEST(OlapReaderStatisticsFilterSubTimers, SearcherTimerHierarchyInvariants) {
+    OlapReaderStatistics stats;
+
+    auto busy_wait_ns = [](int64_t target_ns) {
+        const int64_t start = MonotonicNanos();
+        while (MonotonicNanos() - start < target_ns) {
+            // spin
+        }
+    };
+
+    {
+        // `inverted_index_query_timer` is the outermost scope in SEARCH path —
+        // the analog of `FullTextIndexReader::query` in the MATCH path.
+        SCOPED_RAW_TIMER(&stats.inverted_index_query_timer);
+
+        {
+            // Phase A: open searchers. In the fixed SEARCH path this is done
+            // by `build_query_recursive` which calls `FieldReaderResolver::resolve`,
+            // and `inverted_index_searcher_open_timer` is scoped *inside* the
+            // resolver — crucially, OUTSIDE the `inverted_index_searcher_search_timer`.
+            SCOPED_RAW_TIMER(&stats.inverted_index_searcher_open_timer);
+            busy_wait_ns(3 * 1000 * 1000); // 3ms of "open" work
+        }
+
+        {
+            // Phase B: search. Matches `match_index_search` semantics in MATCH
+            // path: SearchInitTime (weight + scorer prep) and SearchExecTime
+            // (iterate scorer + null bitmap) are both direct children of
+            // SearchTime.
+            SCOPED_RAW_TIMER(&stats.inverted_index_searcher_search_timer);
+            {
+                SCOPED_RAW_TIMER(&stats.inverted_index_searcher_search_init_timer);
+                busy_wait_ns(2 * 1000 * 1000); // 2ms weight+scorer construction
+            }
+            {
+                SCOPED_RAW_TIMER(&stats.inverted_index_searcher_search_exec_timer);
+                busy_wait_ns(1 * 1000 * 1000); // 1ms scorer iteration
+            }
+        }
+    }
+
+    const int64_t query_t = stats.inverted_index_query_timer;
+    const int64_t open_t = stats.inverted_index_searcher_open_timer;
+    const int64_t search_t = stats.inverted_index_searcher_search_timer;
+    const int64_t init_t = stats.inverted_index_searcher_search_init_timer;
+    const int64_t exec_t = stats.inverted_index_searcher_search_exec_timer;
+
+    // Individual children must have captured at least their spin budget.
+    EXPECT_GE(open_t, 3 * 1000 * 1000);
+    EXPECT_GE(search_t, 3 * 1000 * 1000); // 2ms init + 1ms exec
+    EXPECT_GE(init_t, 2 * 1000 * 1000);
+    EXPECT_GE(exec_t, 1 * 1000 * 1000);
+
+    // Invariant (a): QueryTime ≈ OpenTime + SearchTime.
+    // QueryTime wraps both, so QueryTime ≥ OpenTime + SearchTime, and the
+    // drift is the inter-scope gap (very small — just function returns).
+    EXPECT_GE(query_t, open_t + search_t);
+    const int64_t query_drift = query_t - (open_t + search_t);
+    EXPECT_LT(query_drift, 1 * 1000 * 1000) << "query=" << query_t << " open=" << open_t
+                                            << " search=" << search_t << " drift=" << query_drift;
+
+    // Invariant (b): SearchTime ≈ SearchInitTime + SearchExecTime.
+    EXPECT_GE(search_t, init_t + exec_t);
+    const int64_t search_drift = search_t - (init_t + exec_t);
+    EXPECT_LT(search_drift, 1 * 1000 * 1000) << "search=" << search_t << " init=" << init_t
+                                             << " exec=" << exec_t << " drift=" << search_drift;
+
+    // Guard against the pre-fix mistake of nesting OpenTime *inside* SearchTime:
+    // with that layout we would have OpenTime ≤ SearchInitTime ≤ SearchTime and
+    // summing OpenTime + SearchTime as siblings would double-count the open.
+    // Under the fixed layout OpenTime is already fully disjoint from SearchTime,
+    // so SearchTime must NOT contain OpenTime:
+    EXPECT_LT(search_t, open_t + 1 * 1000 * 1000)
+            << "SearchTime must not contain OpenTime; nesting regression? "
+            << "search=" << search_t << " open=" << open_t;
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The SEARCH path (`FunctionSearch::evaluate_inverted_index_with_search_param`) currently lays out its profile sub-timers in a way that breaks two invariants that already hold in the MATCH path (`FullTextIndexReader::query`):

```
(a) InvertedIndexQueryTime        ≈ InvertedIndexSearcherOpenTime
                                  + InvertedIndexSearcherSearchTime
(b) InvertedIndexSearcherSearchTime ≈ InvertedIndexSearcherSearchInitTime
                                    + InvertedIndexSearcherSearchExecTime
```

Observed on a production SEARCH query scanning 237 segments (cumulative):

```
InvertedIndexFilterTime:            1min1sec
InvertedIndexQueryTime:             8sec617ms
InvertedIndexSearcherOpenTime:      5sec698ms
InvertedIndexSearcherSearchTime:    8sec612ms
InvertedIndexSearcherSearchInitTime:5sec704ms
InvertedIndexSearcherSearchExecTime:62.42us
```

- **(a) fails:** `SearchTime + OpenTime = 14310ms`, far exceeds `QueryTime = 8617ms`. Root cause: `OpenTime` is scoped inside `FieldReaderResolver::resolve`, which is called from `build_query_recursive`, which was itself wrapped by `SearchInitTime` → `SearchTime`. So OpenTime was **nested inside SearchTime**, not a sibling, and adding them as siblings double-counts the open phase.
- **(b) fails:** `SearchTime − SearchInitTime − SearchExecTime ≈ 2.9 s` of completely untimed work. Root cause: `weight->scorer(...)` — which is where per-term posting-list iterators are actually opened — lived between the old SearchInitTime (only wrapping `build_query_recursive`) and SearchExecTime (only wrapping the result-collection loop), so it was not attributed to any sub-timer.

This PR restructures the execution path in `evaluate_inverted_index_with_search_param` to mirror the MATCH path semantics: `QueryTime` wraps everything; inside `QueryTime`, `OpenTime` and `SearchTime` are siblings; inside `SearchTime`, `SearchInitTime` and `SearchExecTime` are siblings.

**Changes in `be/src/exprs/function/function_search.cpp`:**

- Move `build_query_recursive(...)` **outside** the `search_timer` scope. It still opens searchers via `FieldReaderResolver::resolve`, so `OpenTime` accumulates as before — it is simply no longer nested inside `SearchTime`.
- Redefine `SearchInitTime` to wrap `Query::weight(...)` — the SEARCH analog of `query->add(query_info)` in MATCH: preparing the executable query structure.
- Extend `SearchExecTime` to wrap the `collect_multi_segment_*` iteration (where `weight->scorer(...)` opens posting-list iterators) **plus** the lazy null-bitmap fetch that follows.
- Move `InvertedIndexResultBitmap` construction, `mask_out_null()`, and the DSL cache insert **outside** `SearchTime` — still inside `QueryTime` — mirroring how `FullTextIndexReader::query` does `cache->insert(...)` only after `match_index_search` returns.

**Complementary diagnostic in `SegmentIterator::_get_row_ranges_by_column_conditions`:**

`InvertedIndexFilterTime` now has three sibling child timers so that `FilterTime ≈ ApplyColPred + ApplyExpr + PostFilter` holds by construction, making the `FilterTime ↔ QueryTime` gap always explainable from the profile alone:

- `InvertedIndexApplyColPredTime` — wraps `_apply_inverted_index()`
- `InvertedIndexApplyExprTime` — wraps `_apply_index_expr()` (contains `InvertedIndexQueryTime`)
- `InvertedIndexPostFilterTime` — wraps post-filter bitmap `&=` + per-column `_check_all_conditions_passed_inverted_index_for_column`

**Also in `be/src/exprs/vsearch.cpp` (`VSearchExpr::evaluate_inverted_index`):**

- Demote the per-segment `LOG(INFO)` / `LOG(WARNING)` on benign early-exit paths to `VLOG_DEBUG`. At production scan rates these add measurable cumulative wall-clock to `FilterTime` while contributing nothing useful at INFO level.
- Pass the result bitmap to `set_index_result_for_expr` via `std::move` to avoid a per-segment deep copy of the underlying roaring bitmap.

**Verification:**

After the fix, small-test profile now shows:

```
QueryTime:             603.740us
  OpenTime:              297.914us   \_ sum = 452.68us ≈ QueryTime (drift ~fixed overhead)
  SearchTime:            154.771us   /
    SearchInitTime:       74.950us   \_ sum = 151.19us ≈ SearchTime (2.3% drift)
    SearchExecTime:       76.236us   /
```

Projected on the production profile: `QueryTime ≈ OpenTime (5.7s) + SearchTime (2.9s) ≈ 8.6s`, invariant (a) restored; `SearchTime ≈ SearchInitTime (2.9s) + SearchExecTime (~4ms)`, invariant (b) restored; the 2.9 s of previously-untimed scorer construction is now attributed to `SearchInitTime`.

### Release note

Fix `InvertedIndexSearcher*Time` profile sub-timer hierarchy in the `search()` function path so that `QueryTime ≈ OpenTime + SearchTime` and `SearchTime ≈ SearchInitTime + SearchExecTime`, matching MATCH-path semantics. Also add three sub-timers (`InvertedIndexApplyColPredTime`, `InvertedIndexApplyExprTime`, `InvertedIndexPostFilterTime`) under `InvertedIndexFilterTime` so that the filter block's wall time is fully attributed.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  Unit test added: `be/test/storage/segment/segment_iterator_filter_sub_timer_test.cpp` — pins both invariants by running `SCOPED_RAW_TIMER` on the `OlapReaderStatistics` fields in the same nesting shape as the production code and asserting `parent ≥ sum(children)` with a sub-ms drift bound. Any future regression that re-nests `OpenTime` inside `SearchTime` or drops a sub-timer around the scorer-construction phase will flip these assertions.

  Manual test: rebuilt BE, deployed to a local cloud-sim cluster, ran `SELECT id FROM t_search_metrics WHERE search('content:doris') ORDER BY id` with `enable_profile=true profile_level=2`, verified the new counters appear and that `QueryTime ≈ OpenTime + SearchTime` and `SearchTime ≈ SearchInitTime + SearchExecTime`.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

  This PR only changes profile-timer scope placement and two non-functional micro-optimizations (LOG → VLOG_DEBUG, one `std::move`). The query result is unchanged.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.