### PR TITLE
[refactor](fe) Extract toThrift from descriptor classes into DescriptorToThriftConverter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnAccessPath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnAccessPath.java
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Java equivalent of the Thrift {@code TColumnAccessPath} struct.
+ * Merges {@code TDataAccessPath} and {@code TMetaAccessPath} into a single class
+ * since both are structurally identical ({@code List<String> path}).
+ * The {@link ColumnAccessPathType} discriminates between data and metadata access.
+ *
+ * <p>This class is immutable and implements {@link Comparable} so it can be used
+ * in sorted collections such as {@code TreeSet}.
+ */
+public final class ColumnAccessPath implements Comparable<ColumnAccessPath> {
+    private final ColumnAccessPathType type;
+    private final List<String> path;
+
+    public ColumnAccessPath(ColumnAccessPathType type, List<String> path) {
+        this.type = Objects.requireNonNull(type, "type must not be null");
+        this.path = Collections.unmodifiableList(new ArrayList<>(
+                Objects.requireNonNull(path, "path must not be null")));
+    }
+
+    /** Creates a DATA access path. */
+    public static ColumnAccessPath data(List<String> path) {
+        return new ColumnAccessPath(ColumnAccessPathType.DATA, path);
+    }
+
+    /** Creates a META access path. */
+    public static ColumnAccessPath meta(List<String> path) {
+        return new ColumnAccessPath(ColumnAccessPathType.META, path);
+    }
+
+    public ColumnAccessPathType getType() {
+        return type;
+    }
+
+    public List<String> getPath() {
+        return path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ColumnAccessPath)) {
+            return false;
+        }
+        ColumnAccessPath that = (ColumnAccessPath) o;
+        return type == that.type && Objects.equals(path, that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, path);
+    }
+
+    @Override
+    public int compareTo(ColumnAccessPath other) {
+        int cmp = type.compareTo(other.type);
+        if (cmp != 0) {
+            return cmp;
+        }
+        int minLen = Math.min(path.size(), other.path.size());
+        for (int i = 0; i < minLen; i++) {
+            cmp = path.get(i).compareTo(other.path.get(i));
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return Integer.compare(path.size(), other.path.size());
+    }
+
+    @Override
+    public String toString() {
+        return type + ":" + String.join(".", path);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnAccessPathType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnAccessPathType.java
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+/**
+ * Java equivalent of the Thrift {@code TAccessPathType} enum.
+ * Represents whether a column access path reads data or metadata.
+ */
+public enum ColumnAccessPathType {
+    DATA,
+    META
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
@@ -20,14 +20,13 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.thrift.TDescriptorTable;
 
 import com.google.common.collect.Maps;
 
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Repository for tuple (and slot) descriptors.
@@ -61,33 +60,16 @@ public class DescriptorTable {
         return tupleDescs.get(id);
     }
 
-    public TDescriptorTable toThrift() {
-        if (thriftDescTable != null) {
-            return thriftDescTable;
-        }
+    public TDescriptorTable getThriftDescTable() {
+        return thriftDescTable;
+    }
 
-        TDescriptorTable result = new TDescriptorTable();
-        Map<Long, TableIf> referencedTbls = Maps.newHashMap();
-        for (TupleDescriptor tupleD : tupleDescs.values()) {
-            // inline view of a non-constant select has a non-materialized tuple descriptor
-            // in the descriptor table just for type checking, which we need to skip
-            result.addToTupleDescriptors(tupleD.toThrift());
-            // an inline view of a constant select has a materialized tuple
-            // but its table has no id
-            if (tupleD.getTable() != null
-                    && tupleD.getTable().getId() >= 0) {
-                referencedTbls.put(tupleD.getTable().getId(), tupleD.getTable());
-            }
-            for (SlotDescriptor slotD : tupleD.getSlots()) {
-                result.addToSlotDescriptors(slotD.toThrift());
-            }
-        }
+    void setThriftDescTable(TDescriptorTable thriftDescTable) {
+        this.thriftDescTable = thriftDescTable;
+    }
 
-        for (TableIf tbl : referencedTbls.values()) {
-            result.addToTableDescriptors(tbl.toThrift());
-        }
-        thriftDescTable = result;
-        return result;
+    public Collection<TupleDescriptor> getTupleDescs() {
+        return tupleDescs.values();
     }
 
     public String getExplainString() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
@@ -21,7 +21,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.IdGenerator;
-import org.apache.doris.thrift.TDescriptorTable;
 
 import com.google.common.collect.Maps;
 
@@ -38,7 +37,6 @@ public class DescriptorTable {
     private final IdGenerator<TupleId> tupleIdGenerator = TupleId.createGenerator();
     private final IdGenerator<SlotId> slotIdGenerator = SlotId.createGenerator();
     private final HashMap<SlotId, SlotDescriptor> slotDescs = Maps.newHashMap();
-    private TDescriptorTable thriftDescTable = null; // serialized version of this
 
     public DescriptorTable() {
     }
@@ -58,14 +56,6 @@ public class DescriptorTable {
 
     public TupleDescriptor getTupleDesc(TupleId id) {
         return tupleDescs.get(id);
-    }
-
-    public TDescriptorTable getThriftDescTable() {
-        return thriftDescTable;
-    }
-
-    void setThriftDescTable(TDescriptorTable thriftDescTable) {
-        this.thriftDescTable = thriftDescTable;
     }
 
     public Collection<TupleDescriptor> getTupleDescs() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorToThriftConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorToThriftConverter.java
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.thrift.TDescriptorTable;
+import org.apache.doris.thrift.TSlotDescriptor;
+import org.apache.doris.thrift.TTupleDescriptor;
+
+import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+/**
+ * Converts {@link SlotDescriptor}, {@link TupleDescriptor}, and {@link DescriptorTable}
+ * to their Thrift representations.
+ */
+public final class DescriptorToThriftConverter {
+    private static final Logger LOG = LogManager.getLogger(DescriptorToThriftConverter.class);
+
+    private DescriptorToThriftConverter() {
+    }
+
+    /**
+     * Converts a {@link SlotDescriptor} to its Thrift representation.
+     */
+    public static TSlotDescriptor toThrift(SlotDescriptor slotDesc) {
+        String materializedColumnName = slotDesc.getMaterializedColumnName();
+        Column column = slotDesc.getColumn();
+        String colName = materializedColumnName != null ? materializedColumnName :
+                                     ((column != null) ? column.getNonShadowName() : "");
+        TSlotDescriptor tSlotDescriptor = new TSlotDescriptor(slotDesc.getId().asInt(),
+                slotDesc.getParentId().asInt(), slotDesc.getType().toThrift(), -1,
+                0, 0, slotDesc.getIsNullable() ? 0 : -1, colName, -1,
+                true);
+        tSlotDescriptor.setIsAutoIncrement(slotDesc.isAutoInc());
+        if (column != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("column name:{}, column unique id:{}", column.getNonShadowName(), column.getUniqueId());
+            }
+            tSlotDescriptor.setColUniqueId(column.getUniqueId());
+            tSlotDescriptor.setPrimitiveType(column.getDataType().toThrift());
+            tSlotDescriptor.setIsKey(column.isKey());
+            tSlotDescriptor.setColDefaultValue(column.getDefaultValue());
+        }
+        if (slotDesc.getSubColLables() != null) {
+            tSlotDescriptor.setColumnPaths(slotDesc.getSubColLables());
+        }
+        if (slotDesc.getVirtualColumn() != null) {
+            tSlotDescriptor.setVirtualColumnExpr(ExprToThriftVisitor.treeToThrift(slotDesc.getVirtualColumn()));
+        }
+        if (slotDesc.getAllAccessPaths() != null) {
+            tSlotDescriptor.setAllAccessPaths(slotDesc.getAllAccessPaths());
+        }
+        if (slotDesc.getPredicateAccessPaths() != null) {
+            tSlotDescriptor.setPredicateAccessPaths(slotDesc.getPredicateAccessPaths());
+        }
+        return tSlotDescriptor;
+    }
+
+    /**
+     * Converts a {@link TupleDescriptor} to its Thrift representation.
+     */
+    public static TTupleDescriptor toThrift(TupleDescriptor tupleDesc) {
+        TTupleDescriptor tTupleDesc = new TTupleDescriptor(tupleDesc.getId().asInt(), 0, 0);
+        if (tupleDesc.getTable() != null && tupleDesc.getTable().getId() >= 0) {
+            tTupleDesc.setTableId((int) tupleDesc.getTable().getId());
+        }
+        return tTupleDesc;
+    }
+
+    /**
+     * Converts a {@link DescriptorTable} to its Thrift representation.
+     * Uses caching: if a cached Thrift descriptor table exists, returns it directly.
+     */
+    public static TDescriptorTable toThrift(DescriptorTable descTable) {
+        if (descTable.getThriftDescTable() != null) {
+            return descTable.getThriftDescTable();
+        }
+
+        TDescriptorTable result = new TDescriptorTable();
+        Map<Long, TableIf> referencedTbls = Maps.newHashMap();
+        for (TupleDescriptor tupleD : descTable.getTupleDescs()) {
+            result.addToTupleDescriptors(toThrift(tupleD));
+            if (tupleD.getTable() != null && tupleD.getTable().getId() >= 0) {
+                referencedTbls.put(tupleD.getTable().getId(), tupleD.getTable());
+            }
+            for (SlotDescriptor slotD : tupleD.getSlots()) {
+                result.addToSlotDescriptors(toThrift(slotD));
+            }
+        }
+
+        for (TableIf tbl : referencedTbls.values()) {
+            result.addToTableDescriptors(tbl.toThrift());
+        }
+        descTable.setThriftDescTable(result);
+        return result;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorToThriftConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorToThriftConverter.java
@@ -19,7 +19,11 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.thrift.TAccessPathType;
+import org.apache.doris.thrift.TColumnAccessPath;
+import org.apache.doris.thrift.TDataAccessPath;
 import org.apache.doris.thrift.TDescriptorTable;
+import org.apache.doris.thrift.TMetaAccessPath;
 import org.apache.doris.thrift.TSlotDescriptor;
 import org.apache.doris.thrift.TTupleDescriptor;
 
@@ -27,6 +31,8 @@ import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -68,12 +74,37 @@ public final class DescriptorToThriftConverter {
             tSlotDescriptor.setVirtualColumnExpr(ExprToThriftVisitor.treeToThrift(slotDesc.getVirtualColumn()));
         }
         if (slotDesc.getAllAccessPaths() != null) {
-            tSlotDescriptor.setAllAccessPaths(slotDesc.getAllAccessPaths());
+            tSlotDescriptor.setAllAccessPaths(toThrift(slotDesc.getAllAccessPaths()));
         }
         if (slotDesc.getPredicateAccessPaths() != null) {
-            tSlotDescriptor.setPredicateAccessPaths(slotDesc.getPredicateAccessPaths());
+            tSlotDescriptor.setPredicateAccessPaths(toThrift(slotDesc.getPredicateAccessPaths()));
         }
         return tSlotDescriptor;
+    }
+
+    /**
+     * Converts a {@link ColumnAccessPath} to its Thrift representation.
+     */
+    public static TColumnAccessPath toThrift(ColumnAccessPath accessPath) {
+        TColumnAccessPath result = new TColumnAccessPath(
+                accessPath.getType() == ColumnAccessPathType.DATA ? TAccessPathType.DATA : TAccessPathType.META);
+        if (accessPath.getType() == ColumnAccessPathType.DATA) {
+            result.setDataAccessPath(new TDataAccessPath(accessPath.getPath()));
+        } else {
+            result.setMetaAccessPath(new TMetaAccessPath(accessPath.getPath()));
+        }
+        return result;
+    }
+
+    /**
+     * Converts a list of {@link ColumnAccessPath} to Thrift representations.
+     */
+    public static List<TColumnAccessPath> toThrift(List<ColumnAccessPath> accessPaths) {
+        List<TColumnAccessPath> result = new ArrayList<>(accessPaths.size());
+        for (ColumnAccessPath accessPath : accessPaths) {
+            result.add(toThrift(accessPath));
+        }
+        return result;
     }
 
     /**
@@ -89,13 +120,8 @@ public final class DescriptorToThriftConverter {
 
     /**
      * Converts a {@link DescriptorTable} to its Thrift representation.
-     * Uses caching: if a cached Thrift descriptor table exists, returns it directly.
      */
     public static TDescriptorTable toThrift(DescriptorTable descTable) {
-        if (descTable.getThriftDescTable() != null) {
-            return descTable.getThriftDescTable();
-        }
-
         TDescriptorTable result = new TDescriptorTable();
         Map<Long, TableIf> referencedTbls = Maps.newHashMap();
         for (TupleDescriptor tupleD : descTable.getTupleDescs()) {
@@ -111,7 +137,6 @@ public final class DescriptorToThriftConverter {
         for (TableIf tbl : referencedTbls.values()) {
             result.addToTableDescriptors(tbl.toThrift());
         }
-        descTable.setThriftDescTable(result);
         return result;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -22,7 +22,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
-import org.apache.doris.thrift.TColumnAccessPath;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
@@ -57,10 +56,10 @@ public class SlotDescriptor {
 
     private boolean isAutoInc = false;
     private Expr virtualColumn = null;
-    private List<TColumnAccessPath> allAccessPaths;
-    private List<TColumnAccessPath> predicateAccessPaths;
-    private List<TColumnAccessPath> displayAllAccessPaths;
-    private List<TColumnAccessPath> displayPredicateAccessPaths;
+    private List<ColumnAccessPath> allAccessPaths;
+    private List<ColumnAccessPath> predicateAccessPaths;
+    private List<ColumnAccessPath> displayAllAccessPaths;
+    private List<ColumnAccessPath> displayPredicateAccessPaths;
 
     public SlotDescriptor(SlotId id, TupleId parentId) {
         this.id = id;
@@ -80,35 +79,35 @@ public class SlotDescriptor {
         return this.subColPath;
     }
 
-    public List<TColumnAccessPath> getAllAccessPaths() {
+    public List<ColumnAccessPath> getAllAccessPaths() {
         return allAccessPaths;
     }
 
-    public void setAllAccessPaths(List<TColumnAccessPath> allAccessPaths) {
+    public void setAllAccessPaths(List<ColumnAccessPath> allAccessPaths) {
         this.allAccessPaths = allAccessPaths;
     }
 
-    public List<TColumnAccessPath> getPredicateAccessPaths() {
+    public List<ColumnAccessPath> getPredicateAccessPaths() {
         return predicateAccessPaths;
     }
 
-    public void setPredicateAccessPaths(List<TColumnAccessPath> predicateAccessPaths) {
+    public void setPredicateAccessPaths(List<ColumnAccessPath> predicateAccessPaths) {
         this.predicateAccessPaths = predicateAccessPaths;
     }
 
-    public List<TColumnAccessPath> getDisplayAllAccessPaths() {
+    public List<ColumnAccessPath> getDisplayAllAccessPaths() {
         return displayAllAccessPaths;
     }
 
-    public void setDisplayAllAccessPaths(List<TColumnAccessPath> displayAllAccessPaths) {
+    public void setDisplayAllAccessPaths(List<ColumnAccessPath> displayAllAccessPaths) {
         this.displayAllAccessPaths = displayAllAccessPaths;
     }
 
-    public List<TColumnAccessPath> getDisplayPredicateAccessPaths() {
+    public List<ColumnAccessPath> getDisplayPredicateAccessPaths() {
         return displayPredicateAccessPaths;
     }
 
-    public void setDisplayPredicateAccessPaths(List<TColumnAccessPath> displayPredicateAccessPaths) {
+    public void setDisplayPredicateAccessPaths(List<ColumnAccessPath> displayPredicateAccessPaths) {
         this.displayPredicateAccessPaths = displayPredicateAccessPaths;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -23,18 +23,14 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.thrift.TColumnAccessPath;
-import org.apache.doris.thrift.TSlotDescriptor;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
 
 public class SlotDescriptor {
-    private static final Logger LOG = LogManager.getLogger(SlotDescriptor.class);
     private final SlotId id;
     private final TupleId parentId;
     private Type type;
@@ -158,6 +154,10 @@ public class SlotDescriptor {
         this.materializedColumnName = name;
     }
 
+    public String getMaterializedColumnName() {
+        return materializedColumnName;
+    }
+
     public String getLabel() {
         return label;
     }
@@ -187,38 +187,6 @@ public class SlotDescriptor {
 
     public void setVirtualColumn(Expr virtualColumn) {
         this.virtualColumn = virtualColumn;
-    }
-
-    public TSlotDescriptor toThrift() {
-        // Non-nullable slots will have 0 for the byte offset and -1 for the bit mask
-        String colName = materializedColumnName != null ? materializedColumnName :
-                                     ((column != null) ? column.getNonShadowName() : "");
-        TSlotDescriptor tSlotDescriptor = new TSlotDescriptor(id.asInt(), parentId.asInt(), type.toThrift(), -1,
-                0, 0, getIsNullable() ? 0 : -1, colName, -1,
-                true);
-        tSlotDescriptor.setIsAutoIncrement(isAutoInc);
-        if (column != null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("column name:{}, column unique id:{}", column.getNonShadowName(), column.getUniqueId());
-            }
-            tSlotDescriptor.setColUniqueId(column.getUniqueId());
-            tSlotDescriptor.setPrimitiveType(column.getDataType().toThrift());
-            tSlotDescriptor.setIsKey(column.isKey());
-            tSlotDescriptor.setColDefaultValue(column.getDefaultValue());
-        }
-        if (subColPath != null) {
-            tSlotDescriptor.setColumnPaths(subColPath);
-        }
-        if (virtualColumn != null) {
-            tSlotDescriptor.setVirtualColumnExpr(ExprToThriftVisitor.treeToThrift(virtualColumn));
-        }
-        if (allAccessPaths != null) {
-            tSlotDescriptor.setAllAccessPaths(allAccessPaths);
-        }
-        if (predicateAccessPaths != null) {
-            tSlotDescriptor.setPredicateAccessPaths(predicateAccessPaths);
-        }
-        return tSlotDescriptor;
     }
 
     private String normalizeCaption(String caption) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -21,7 +21,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.thrift.TTupleDescriptor;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
@@ -95,14 +94,6 @@ public class TupleDescriptor {
 
     public void setTable(TableIf tbl) {
         table = tbl;
-    }
-
-    public TTupleDescriptor toThrift() {
-        TTupleDescriptor tTupleDesc = new TTupleDescriptor(id.asInt(), 0, 0);
-        if (table != null && table.getId() >= 0) {
-            tTupleDesc.setTableId((int) table.getId());
-        }
-        return tTupleDesc;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.httpv2.rest;
 
+import org.apache.doris.analysis.DescriptorToThriftConverter;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
@@ -297,7 +298,7 @@ public class TableQueryPlanAction extends RestBaseController {
             tPlanFragment.output_sink = tDataSink;
 
             tQueryPlanInfo.plan_fragment = tPlanFragment;
-            tQueryPlanInfo.desc_tbl = planner.getDescTable().toThrift();
+            tQueryPlanInfo.desc_tbl = DescriptorToThriftConverter.toThrift(planner.getDescTable());
             // set query_id
             tQueryPlanInfo.query_id = queryId;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsStreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsStreamLoadPlanner.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.load;
 
 import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.analysis.DescriptorTable;
+import org.apache.doris.analysis.DescriptorToThriftConverter;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
@@ -273,7 +274,7 @@ public class NereidsStreamLoadPlanner {
         params.setProtocolVersion(PaloInternalServiceVersion.V1);
         params.setFragment(fragment.toThrift());
 
-        params.setDescTbl(descriptorTable.toThrift());
+        params.setDescTbl(DescriptorToThriftConverter.toThrift(descriptorTable));
         params.setCoord(new TNetworkAddress(FrontendOptions.getLocalHostAddress(), Config.rpc_port));
         params.setCurrentConnectFe(new TNetworkAddress(FrontendOptions.getLocalHostAddress(), Config.rpc_port));
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.analysis.ColumnAccessPathType;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.rules.rewrite.AccessPathExpressionCollector.CollectorContext;
 import org.apache.doris.nereids.rules.rewrite.NestedColumnPruning.DataTypeAccessTree;
@@ -61,7 +62,6 @@ import org.apache.doris.nereids.types.StructField;
 import org.apache.doris.nereids.types.StructType;
 import org.apache.doris.nereids.types.VariantType;
 import org.apache.doris.nereids.util.Utils;
-import org.apache.doris.thrift.TAccessPathType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -121,7 +121,7 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
             path.addAll(context.accessPathBuilder.getPathList());
             int slotId = slotReference.getExprId().asInt();
             slotToAccessPaths.put(slotId, new CollectAccessPathResult(
-                    path, context.bottomFilter, TAccessPathType.DATA));
+                    path, context.bottomFilter, ColumnAccessPathType.DATA));
             return null;
         }
         if (dataType instanceof NestedColumnPrunable) {
@@ -138,13 +138,13 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
                 context.accessPathBuilder.addPrefix(slotReference.getName());
                 ImmutableList<String> path = ImmutableList.copyOf(context.accessPathBuilder.accessPath);
                 slotToAccessPaths.put(slotId,
-                        new CollectAccessPathResult(path, context.bottomFilter, TAccessPathType.DATA));
+                        new CollectAccessPathResult(path, context.bottomFilter, ColumnAccessPathType.DATA));
             } else {
                 // Direct access to the string column → record a DATA path so that any
                 // concurrent offset-only path for the same slot is suppressed.
                 List<String> path = ImmutableList.of(slotReference.getName());
                 slotToAccessPaths.put(slotId,
-                        new CollectAccessPathResult(path, context.bottomFilter, TAccessPathType.DATA));
+                        new CollectAccessPathResult(path, context.bottomFilter, ColumnAccessPathType.DATA));
             }
         }
         return null;
@@ -224,8 +224,10 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
                 && cast.child().getDataType() instanceof NestedColumnPrunable
                 && !mapTypeIsChanged(cast.child().getDataType(), cast.getDataType(), false)) {
 
-            DataTypeAccessTree castTree = DataTypeAccessTree.of(cast.getDataType(), TAccessPathType.DATA);
-            DataTypeAccessTree originTree = DataTypeAccessTree.of(cast.child().getDataType(), TAccessPathType.DATA);
+            DataTypeAccessTree castTree = DataTypeAccessTree.of(
+                    cast.getDataType(), ColumnAccessPathType.DATA);
+            DataTypeAccessTree originTree = DataTypeAccessTree.of(
+                    cast.child().getDataType(), ColumnAccessPathType.DATA);
 
             List<String> replacePath = new ArrayList<>(context.accessPathBuilder.getPathList());
             if (originTree.replacePathByAnotherTree(castTree, replacePath, 0)) {
@@ -494,7 +496,7 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
     // @Override
     // public Void visitIsNull(IsNull isNull, CollectorContext context) {
     //     if (context.accessPathBuilder.isEmpty()) {
-    //         context.setType(TAccessPathType.META);
+    //         context.setType(ColumnAccessPathType.META);
     //         return continueCollectAccessPath(isNull.child(), context);
     //     }
     //     return visit(isNull, context);
@@ -528,20 +530,20 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
         private StatementContext statementContext;
         private AccessPathBuilder accessPathBuilder;
         private boolean bottomFilter;
-        private TAccessPathType type;
+        private ColumnAccessPathType type;
 
         public CollectorContext(StatementContext statementContext, boolean bottomFilter) {
             this.statementContext = statementContext;
             this.accessPathBuilder = new AccessPathBuilder();
             this.bottomFilter = bottomFilter;
-            this.type = TAccessPathType.DATA;
+            this.type = ColumnAccessPathType.DATA;
         }
 
-        public TAccessPathType getType() {
+        public ColumnAccessPathType getType() {
             return type;
         }
 
-        public void setType(TAccessPathType type) {
+        public void setType(ColumnAccessPathType type) {
             this.type = type;
         }
 
@@ -596,15 +598,15 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
     public static class CollectAccessPathResult {
         private final List<String> path;
         private final boolean isPredicate;
-        private final TAccessPathType type;
+        private final ColumnAccessPathType type;
 
-        public CollectAccessPathResult(List<String> path, boolean isPredicate, TAccessPathType type) {
+        public CollectAccessPathResult(List<String> path, boolean isPredicate, ColumnAccessPathType type) {
             this.path = path;
             this.isPredicate = isPredicate;
             this.type = type;
         }
 
-        public TAccessPathType getType() {
+        public ColumnAccessPathType getType() {
             return type;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathInfo.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.analysis.ColumnAccessPath;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.thrift.TColumnAccessPath;
 
 import java.util.List;
 
@@ -37,11 +37,11 @@ public class AccessPathInfo {
     // e.g. select element_at(s, 'name') from tbl where element_at(s, 'id') = 1
     //      the allAccessPaths is: ["s.name", "s.id"]
     //      the predicateAccessPaths is: ["s.id"]
-    private List<TColumnAccessPath> allAccessPaths;
-    private List<TColumnAccessPath> predicateAccessPaths;
+    private List<ColumnAccessPath> allAccessPaths;
+    private List<ColumnAccessPath> predicateAccessPaths;
 
-    public AccessPathInfo(DataType prunedType, List<TColumnAccessPath> allAccessPaths,
-            List<TColumnAccessPath> predicateAccessPaths) {
+    public AccessPathInfo(DataType prunedType, List<ColumnAccessPath> allAccessPaths,
+            List<ColumnAccessPath> predicateAccessPaths) {
         this.prunedType = prunedType;
         this.allAccessPaths = allAccessPaths;
         this.predicateAccessPaths = predicateAccessPaths;
@@ -55,19 +55,19 @@ public class AccessPathInfo {
         this.prunedType = prunedType;
     }
 
-    public List<TColumnAccessPath> getAllAccessPaths() {
+    public List<ColumnAccessPath> getAllAccessPaths() {
         return allAccessPaths;
     }
 
-    public void setAllAccessPaths(List<TColumnAccessPath> allAccessPaths) {
+    public void setAllAccessPaths(List<ColumnAccessPath> allAccessPaths) {
         this.allAccessPaths = allAccessPaths;
     }
 
-    public List<TColumnAccessPath> getPredicateAccessPaths() {
+    public List<ColumnAccessPath> getPredicateAccessPaths() {
         return predicateAccessPaths;
     }
 
-    public void setPredicateAccessPaths(List<TColumnAccessPath> predicateAccessPaths) {
+    public void setPredicateAccessPaths(List<ColumnAccessPath> predicateAccessPaths) {
         this.predicateAccessPaths = predicateAccessPaths;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.analysis.ColumnAccessPath;
+import org.apache.doris.analysis.ColumnAccessPathType;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -37,10 +39,6 @@ import org.apache.doris.nereids.types.StructField;
 import org.apache.doris.nereids.types.StructType;
 import org.apache.doris.nereids.types.VariantType;
 import org.apache.doris.qe.SessionVariable;
-import org.apache.doris.thrift.TAccessPathType;
-import org.apache.doris.thrift.TColumnAccessPath;
-import org.apache.doris.thrift.TDataAccessPath;
-import org.apache.doris.thrift.TMetaAccessPath;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -172,12 +170,12 @@ public class NestedColumnPruning implements CustomRewriter {
         Map<Slot, DataTypeAccessTree> slotIdToPredicateAccessTree = new LinkedHashMap<>();
         Map<Slot, DataType> variantSlots = new LinkedHashMap<>();
 
-        Comparator<Pair<TAccessPathType, List<String>>> pathComparator = Comparator.comparing(
+        Comparator<Pair<ColumnAccessPathType, List<String>>> pathComparator = Comparator.comparing(
                 l -> StringUtils.join(l.second, "."));
 
-        Multimap<Integer, Pair<TAccessPathType, List<String>>> allAccessPaths = TreeMultimap.create(
+        Multimap<Integer, Pair<ColumnAccessPathType, List<String>>> allAccessPaths = TreeMultimap.create(
                 Comparator.naturalOrder(), pathComparator);
-        Multimap<Integer, Pair<TAccessPathType, List<String>>> predicateAccessPaths = TreeMultimap.create(
+        Multimap<Integer, Pair<ColumnAccessPathType, List<String>>> predicateAccessPaths = TreeMultimap.create(
                 Comparator.naturalOrder(), pathComparator);
 
         // first: build access data type tree
@@ -188,7 +186,7 @@ public class NestedColumnPruning implements CustomRewriter {
                 variantSlots.put(slot, slot.getDataType());
                 for (CollectAccessPathResult collectAccessPathResult : collectAccessPathResults) {
                     List<String> path = collectAccessPathResult.getPath();
-                    TAccessPathType pathType = collectAccessPathResult.getType();
+                    ColumnAccessPathType pathType = collectAccessPathResult.getType();
                     allAccessPaths.put(slot.getExprId().asInt(), Pair.of(pathType, path));
                     if (collectAccessPathResult.isPredicate()) {
                         predicateAccessPaths.put(
@@ -200,7 +198,7 @@ public class NestedColumnPruning implements CustomRewriter {
             }
             for (CollectAccessPathResult collectAccessPathResult : collectAccessPathResults) {
                 List<String> path = collectAccessPathResult.getPath();
-                TAccessPathType pathType = collectAccessPathResult.getType();
+                ColumnAccessPathType pathType = collectAccessPathResult.getType();
                 DataTypeAccessTree allAccessTree = slotIdToAllAccessTree.computeIfAbsent(
                         slot, i -> DataTypeAccessTree.ofRoot(slot, pathType)
                 );
@@ -229,7 +227,7 @@ public class NestedColumnPruning implements CustomRewriter {
                 if (accessTree.hasStringOffsetOnlyAccess()) {
                     // Offset-only access (e.g. length(str_col)): type stays varchar,
                     // but we must still send the access path to BE so it skips the char data.
-                    List<TColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
+                    List<ColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
                     result.put(slot.getExprId().asInt(),
                             new AccessPathInfo(slot.getDataType(), allPaths, new ArrayList<>()));
                 }
@@ -241,7 +239,7 @@ public class NestedColumnPruning implements CustomRewriter {
                     && accessTree.hasStringOffsetOnlyAccess()) {
                 // Offset-only access (e.g. length(arr_col) / length(map_col)): type stays unchanged,
                 // but we must send the OFFSET access path to BE so it skips element/key-value data.
-                List<TColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
+                List<ColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
                 result.put(slot.getExprId().asInt(),
                         new AccessPathInfo(slot.getDataType(), allPaths, new ArrayList<>()));
                 continue;
@@ -252,17 +250,12 @@ public class NestedColumnPruning implements CustomRewriter {
                 // Emit [col, KEYS] and [col, VALUES, OFFSET] directly instead of the collected
                 // [col, *, OFFSET] path which the BE cannot interpret for split key/value access.
                 String colName = slot.getName().toLowerCase();
-                TDataAccessPath keysDataPath = new TDataAccessPath();
-                keysDataPath.setPath(
+                ColumnAccessPath keysColumnPath = ColumnAccessPath.data(
                         new ArrayList<>(ImmutableList.of(colName, AccessPathInfo.ACCESS_MAP_KEYS)));
-                TColumnAccessPath keysColumnPath = new TColumnAccessPath(TAccessPathType.DATA);
-                keysColumnPath.setDataAccessPath(keysDataPath);
 
-                TDataAccessPath valsOffsetDataPath = new TDataAccessPath();
-                valsOffsetDataPath.setPath(new ArrayList<>(ImmutableList.of(
-                        colName, AccessPathInfo.ACCESS_MAP_VALUES, AccessPathInfo.ACCESS_STRING_OFFSET)));
-                TColumnAccessPath valsOffsetColumnPath = new TColumnAccessPath(TAccessPathType.DATA);
-                valsOffsetColumnPath.setDataAccessPath(valsOffsetDataPath);
+                ColumnAccessPath valsOffsetColumnPath = ColumnAccessPath.data(
+                        new ArrayList<>(ImmutableList.of(colName, AccessPathInfo.ACCESS_MAP_VALUES,
+                                AccessPathInfo.ACCESS_STRING_OFFSET)));
 
                 result.put(slot.getExprId().asInt(), new AccessPathInfo(
                         slot.getDataType(),
@@ -293,14 +286,14 @@ public class NestedColumnPruning implements CustomRewriter {
                     });
                 }
             }
-            List<TColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
+            List<ColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
             result.put(slot.getExprId().asInt(),
                     new AccessPathInfo(prunedDataType, allPaths, new ArrayList<>()));
         }
 
         for (Entry<Slot, DataType> kv : variantSlots.entrySet()) {
             Slot slot = kv.getKey();
-            List<TColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
+            List<ColumnAccessPath> allPaths = buildColumnAccessPaths(slot, allAccessPaths);
             result.put(slot.getExprId().asInt(),
                     new AccessPathInfo(slot.getDataType(), allPaths, new ArrayList<>()));
         }
@@ -309,7 +302,7 @@ public class NestedColumnPruning implements CustomRewriter {
         for (Entry<Slot, DataTypeAccessTree> kv : slotIdToPredicateAccessTree.entrySet()) {
             Slot slot = kv.getKey();
 
-            List<TColumnAccessPath> predicatePaths =
+            List<ColumnAccessPath> predicatePaths =
                     buildColumnAccessPaths(slot, predicateAccessPaths);
             AccessPathInfo accessPathInfo = result.get(slot.getExprId().asInt());
             if (accessPathInfo != null) {
@@ -319,7 +312,7 @@ public class NestedColumnPruning implements CustomRewriter {
 
         for (Entry<Slot, DataType> kv : variantSlots.entrySet()) {
             Slot slot = kv.getKey();
-            List<TColumnAccessPath> predicatePaths =
+            List<ColumnAccessPath> predicatePaths =
                     buildColumnAccessPaths(slot, predicateAccessPaths);
             AccessPathInfo accessPathInfo = result.get(slot.getExprId().asInt());
             if (accessPathInfo != null) {
@@ -330,48 +323,30 @@ public class NestedColumnPruning implements CustomRewriter {
         return result;
     }
 
-    private static List<TColumnAccessPath> buildColumnAccessPaths(
-            Slot slot, Multimap<Integer, Pair<TAccessPathType, List<String>>> accessPaths) {
-        List<TColumnAccessPath> paths = new ArrayList<>();
+    private static List<ColumnAccessPath> buildColumnAccessPaths(
+            Slot slot, Multimap<Integer, Pair<ColumnAccessPathType, List<String>>> accessPaths) {
+        List<ColumnAccessPath> paths = new ArrayList<>();
         boolean accessWholeColumn = false;
-        TAccessPathType accessWholeColumnType = TAccessPathType.META;
-        for (Pair<TAccessPathType, List<String>> pathInfo : accessPaths.get(slot.getExprId().asInt())) {
+        ColumnAccessPathType accessWholeColumnType = ColumnAccessPathType.META;
+        for (Pair<ColumnAccessPathType, List<String>> pathInfo : accessPaths.get(slot.getExprId().asInt())) {
             if (pathInfo == null) {
                 throw new AnalysisException("This is a bug, please report this");
             }
-            if (pathInfo.first == TAccessPathType.DATA) {
-                TDataAccessPath dataAccessPath = new TDataAccessPath();
-                dataAccessPath.setPath(new ArrayList<>(pathInfo.second));
-                TColumnAccessPath accessPath = new TColumnAccessPath(TAccessPathType.DATA);
-                accessPath.setDataAccessPath(dataAccessPath);
-                paths.add(accessPath);
-            } else {
-                TMetaAccessPath dataAccessPath = new TMetaAccessPath();
-                dataAccessPath.setPath(new ArrayList<>(pathInfo.second));
-                TColumnAccessPath accessPath = new TColumnAccessPath(TAccessPathType.META);
-                accessPath.setMetaAccessPath(dataAccessPath);
-                paths.add(accessPath);
-            }
+            paths.add(new ColumnAccessPath(pathInfo.first, new ArrayList<>(pathInfo.second)));
             // only retain access the whole root
             if (pathInfo.second.size() == 1) {
                 accessWholeColumn = true;
-                if (pathInfo.first == TAccessPathType.DATA) {
-                    accessWholeColumnType = TAccessPathType.DATA;
+                if (pathInfo.first == ColumnAccessPathType.DATA) {
+                    accessWholeColumnType = ColumnAccessPathType.DATA;
                 }
             } else {
-                accessWholeColumnType = TAccessPathType.DATA;
+                accessWholeColumnType = ColumnAccessPathType.DATA;
             }
         }
         if (accessWholeColumn) {
-            TColumnAccessPath accessPath = new TColumnAccessPath(accessWholeColumnType);
             SlotReference slotReference = (SlotReference) slot;
             String wholeColumnName = slotReference.getOriginalColumn().get().getName();
-            if (accessWholeColumnType == TAccessPathType.DATA) {
-                accessPath.setDataAccessPath(new TDataAccessPath(ImmutableList.of(wholeColumnName)));
-            } else {
-                accessPath.setMetaAccessPath(new TMetaAccessPath(ImmutableList.of(wholeColumnName)));
-            }
-            return ImmutableList.of(accessPath);
+            return ImmutableList.of(new ColumnAccessPath(accessWholeColumnType, ImmutableList.of(wholeColumnName)));
         }
         return paths;
     }
@@ -392,16 +367,16 @@ public class NestedColumnPruning implements CustomRewriter {
         private boolean isStringOffsetOnly;
         // for the future, only access the meta of the column,
         // e.g. `is not null` can only access the column's offset, not need to read the data
-        private TAccessPathType pathType;
+        private ColumnAccessPathType pathType;
         // the children of the column, for example, column s is `struct<a:int, b:int>`,
         // then node 's' has two children: 'a' and 'b', and the key is the column name
         private Map<String, DataTypeAccessTree> children = new LinkedHashMap<>();
 
-        public DataTypeAccessTree(DataType type, TAccessPathType pathType) {
+        public DataTypeAccessTree(DataType type, ColumnAccessPathType pathType) {
             this(false, type, pathType);
         }
 
-        public DataTypeAccessTree(boolean isRoot, DataType type, TAccessPathType pathType) {
+        public DataTypeAccessTree(boolean isRoot, DataType type, ColumnAccessPathType pathType) {
             this.isRoot = isRoot;
             this.type = type;
             this.pathType = pathType;
@@ -423,7 +398,7 @@ public class NestedColumnPruning implements CustomRewriter {
             return accessAll;
         }
 
-        public TAccessPathType getPathType() {
+        public ColumnAccessPathType getPathType() {
             return pathType;
         }
 
@@ -579,7 +554,7 @@ public class NestedColumnPruning implements CustomRewriter {
         }
 
         /** setAccessByPath */
-        public void setAccessByPath(List<String> path, int accessIndex, TAccessPathType pathType) {
+        public void setAccessByPath(List<String> path, int accessIndex, ColumnAccessPathType pathType) {
             if (accessIndex >= path.size()) {
                 accessAll = true;
                 return;
@@ -587,8 +562,8 @@ public class NestedColumnPruning implements CustomRewriter {
                 accessPartialChild = true;
             }
 
-            if (pathType == TAccessPathType.DATA) {
-                this.pathType = TAccessPathType.DATA;
+            if (pathType == ColumnAccessPathType.DATA) {
+                this.pathType = ColumnAccessPathType.DATA;
             }
 
             if (this.type.isStructType()) {
@@ -659,7 +634,7 @@ public class NestedColumnPruning implements CustomRewriter {
             throw new AnalysisException("unsupported data type: " + this.type);
         }
 
-        public static DataTypeAccessTree ofRoot(Slot slot, TAccessPathType pathType) {
+        public static DataTypeAccessTree ofRoot(Slot slot, ColumnAccessPathType pathType) {
             DataTypeAccessTree child = of(slot.getDataType(), pathType);
             DataTypeAccessTree root = new DataTypeAccessTree(true, NullType.INSTANCE, pathType);
             root.children.put(slot.getName().toLowerCase(), child);
@@ -667,7 +642,7 @@ public class NestedColumnPruning implements CustomRewriter {
         }
 
         /** of */
-        public static DataTypeAccessTree of(DataType type, TAccessPathType pathType) {
+        public static DataTypeAccessTree of(DataType type, ColumnAccessPathType pathType) {
             DataTypeAccessTree root = new DataTypeAccessTree(type, pathType);
             if (type instanceof StructType) {
                 StructType structType = (StructType) type;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SlotTypeReplacer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SlotTypeReplacer.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.analysis.ColumnAccessPath;
+import org.apache.doris.analysis.ColumnAccessPathType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
@@ -65,10 +67,6 @@ import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.NestedColumnPrunable;
 import org.apache.doris.nereids.types.StructType;
 import org.apache.doris.nereids.util.MoreFieldsThread;
-import org.apache.doris.thrift.TAccessPathType;
-import org.apache.doris.thrift.TColumnAccessPath;
-import org.apache.doris.thrift.TDataAccessPath;
-import org.apache.doris.thrift.TMetaAccessPath;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
@@ -420,13 +418,13 @@ public class SlotTypeReplacer extends DefaultPlanRewriter<Void> {
                         continue;
                     }
                     SlotReference slotReference = (SlotReference) slot;
-                    Optional<List<TColumnAccessPath>> allAccessPaths = slotReference.getAllAccessPaths();
+                    Optional<List<ColumnAccessPath>> allAccessPaths = slotReference.getAllAccessPaths();
                     if (!allAccessPaths.isPresent() || !slotReference.getOriginalColumn().isPresent()) {
                         continue;
                     }
-                    List<TColumnAccessPath> allAccessPathsWithId
+                    List<ColumnAccessPath> allAccessPathsWithId
                             = replaceIcebergAccessPathToId(allAccessPaths.get(), slotReference);
-                    List<TColumnAccessPath> predicateAccessPathsWithId = replaceIcebergAccessPathToId(
+                    List<ColumnAccessPath> predicateAccessPathsWithId = replaceIcebergAccessPathToId(
                             slotReference.getPredicateAccessPaths().get(), slotReference);
                     replaceSlots.set(i, ((SlotReference) slot).withAccessPaths(
                             allAccessPathsWithId,
@@ -645,38 +643,28 @@ public class SlotTypeReplacer extends DefaultPlanRewriter<Void> {
         DataType newType = cast.getDataType();
         if (cast.getDataType() instanceof NestedColumnPrunable
                 && newChild.getDataType() instanceof NestedColumnPrunable) {
-            DataTypeAccessTree originTree = DataTypeAccessTree.of(cast.child().getDataType(), TAccessPathType.DATA);
-            DataTypeAccessTree prunedTree = DataTypeAccessTree.of(newChild.getDataType(), TAccessPathType.DATA);
-            DataTypeAccessTree castTree = DataTypeAccessTree.of(cast.getDataType(), TAccessPathType.DATA);
+            DataTypeAccessTree originTree = DataTypeAccessTree.of(
+                    cast.child().getDataType(), ColumnAccessPathType.DATA);
+            DataTypeAccessTree prunedTree = DataTypeAccessTree.of(
+                    newChild.getDataType(), ColumnAccessPathType.DATA);
+            DataTypeAccessTree castTree = DataTypeAccessTree.of(
+                    cast.getDataType(), ColumnAccessPathType.DATA);
             newType = prunedTree.pruneCastType(originTree, castTree);
         }
 
         return new Cast(newChild, newType);
     }
 
-    private List<TColumnAccessPath> replaceIcebergAccessPathToId(
-            List<TColumnAccessPath> originAccessPaths, SlotReference slotReference) {
+    private List<ColumnAccessPath> replaceIcebergAccessPathToId(
+            List<ColumnAccessPath> originAccessPaths, SlotReference slotReference) {
         Column column = slotReference.getOriginalColumn().get();
-        List<TColumnAccessPath> replacedAccessPaths = new ArrayList<>();
-        for (TColumnAccessPath accessPath : originAccessPaths) {
-            List<String> icebergColumnAccessPath = new ArrayList<>();
-            if (accessPath.type == TAccessPathType.DATA) {
-                icebergColumnAccessPath.addAll(accessPath.data_access_path.path);
-                replaceIcebergAccessPathToId(
-                        icebergColumnAccessPath, 0, slotReference.getDataType(), column
-                );
-                TColumnAccessPath newAccessPath = new TColumnAccessPath(TAccessPathType.DATA);
-                newAccessPath.data_access_path = new TDataAccessPath(icebergColumnAccessPath);
-                replacedAccessPaths.add(newAccessPath);
-            } else {
-                icebergColumnAccessPath.addAll(accessPath.meta_access_path.path);
-                replaceIcebergAccessPathToId(
-                        icebergColumnAccessPath, 0, slotReference.getDataType(), column
-                );
-                TColumnAccessPath newAccessPath = new TColumnAccessPath(TAccessPathType.META);
-                newAccessPath.meta_access_path = new TMetaAccessPath(icebergColumnAccessPath);
-                replacedAccessPaths.add(newAccessPath);
-            }
+        List<ColumnAccessPath> replacedAccessPaths = new ArrayList<>();
+        for (ColumnAccessPath accessPath : originAccessPaths) {
+            List<String> icebergColumnAccessPath = new ArrayList<>(accessPath.getPath());
+            replaceIcebergAccessPathToId(
+                    icebergColumnAccessPath, 0, slotReference.getDataType(), column
+            );
+            replacedAccessPaths.add(new ColumnAccessPath(accessPath.getType(), icebergColumnAccessPath));
         }
         return replacedAccessPaths;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions;
 
+import org.apache.doris.analysis.ColumnAccessPath;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Pair;
@@ -24,7 +25,6 @@ import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.util.Utils;
-import org.apache.doris.thrift.TColumnAccessPath;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -57,10 +57,10 @@ public class SlotReference extends Slot {
     // that need return original table and name for view not its original table if u query a view
     private final TableIf oneLevelTable;
     private final Column oneLevelColumn;
-    private final Optional<List<TColumnAccessPath>> allAccessPaths;
-    private final Optional<List<TColumnAccessPath>> predicateAccessPaths;
-    private final Optional<List<TColumnAccessPath>> displayAllAccessPaths;
-    private final Optional<List<TColumnAccessPath>> displayPredicateAccessPaths;
+    private final Optional<List<ColumnAccessPath>> allAccessPaths;
+    private final Optional<List<ColumnAccessPath>> predicateAccessPaths;
+    private final Optional<List<ColumnAccessPath>> displayAllAccessPaths;
+    private final Optional<List<ColumnAccessPath>> displayPredicateAccessPaths;
 
     public SlotReference(String name, DataType dataType) {
         this(StatementScopeIdGenerator.newExprId(), name, dataType, true, ImmutableList.of(),
@@ -121,9 +121,9 @@ public class SlotReference extends Slot {
             List<String> qualifier, @Nullable TableIf originalTable, @Nullable Column originalColumn,
             @Nullable TableIf oneLevelTable, Column oneLevelColumn,
             List<String> subPath, Optional<Pair<Integer, Integer>> indexInSql,
-            Optional<List<TColumnAccessPath>> allAccessPaths, Optional<List<TColumnAccessPath>> predicateAccessPaths,
-            Optional<List<TColumnAccessPath>> displayAllAccessPaths,
-            Optional<List<TColumnAccessPath>> displayPredicateAccessPaths) {
+            Optional<List<ColumnAccessPath>> allAccessPaths, Optional<List<ColumnAccessPath>> predicateAccessPaths,
+            Optional<List<ColumnAccessPath>> displayAllAccessPaths,
+            Optional<List<ColumnAccessPath>> displayPredicateAccessPaths) {
         super(indexInSql);
         this.exprId = exprId;
         this.name = name;
@@ -365,7 +365,7 @@ public class SlotReference extends Slot {
     }
 
     public SlotReference withAccessPaths(
-            List<TColumnAccessPath> allAccessPaths, List<TColumnAccessPath> predicateAccessPaths) {
+            List<ColumnAccessPath> allAccessPaths, List<ColumnAccessPath> predicateAccessPaths) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
                 subPath, indexInSqlString, Optional.of(allAccessPaths), Optional.of(predicateAccessPaths),
@@ -373,27 +373,27 @@ public class SlotReference extends Slot {
     }
 
     public SlotReference withAccessPaths(
-            List<TColumnAccessPath> allAccessPaths, List<TColumnAccessPath> predicateAccessPaths,
-            List<TColumnAccessPath> displayAllAccessPaths, List<TColumnAccessPath> displayPredicateAccessPaths) {
+            List<ColumnAccessPath> allAccessPaths, List<ColumnAccessPath> predicateAccessPaths,
+            List<ColumnAccessPath> displayAllAccessPaths, List<ColumnAccessPath> displayPredicateAccessPaths) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier,
                 originalTable, originalColumn, oneLevelTable, oneLevelColumn,
                 subPath, indexInSqlString, Optional.of(allAccessPaths), Optional.of(predicateAccessPaths),
                 Optional.of(displayAllAccessPaths), Optional.of(displayPredicateAccessPaths));
     }
 
-    public Optional<List<TColumnAccessPath>> getAllAccessPaths() {
+    public Optional<List<ColumnAccessPath>> getAllAccessPaths() {
         return allAccessPaths;
     }
 
-    public Optional<List<TColumnAccessPath>> getPredicateAccessPaths() {
+    public Optional<List<ColumnAccessPath>> getPredicateAccessPaths() {
         return predicateAccessPaths;
     }
 
-    public Optional<List<TColumnAccessPath>> getDisplayAllAccessPaths() {
+    public Optional<List<ColumnAccessPath>> getDisplayAllAccessPaths() {
         return displayAllAccessPaths;
     }
 
-    public Optional<List<TColumnAccessPath>> getDisplayPredicateAccessPaths() {
+    public Optional<List<ColumnAccessPath>> getDisplayPredicateAccessPaths() {
         return displayPredicateAccessPaths;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.analysis.DescriptorToThriftConverter;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprToSqlVisitor;
 import org.apache.doris.analysis.ExprToThriftVisitor;
@@ -400,9 +401,9 @@ public class OlapTableSink extends DataSink {
         schemaParam.setVersion(table.getIndexMetaByIndexId(table.getBaseIndexId()).getSchemaVersion());
         schemaParam.setIsStrictMode(isStrictMode);
 
-        schemaParam.tuple_desc = tupleDescriptor.toThrift();
+        schemaParam.tuple_desc = DescriptorToThriftConverter.toThrift(tupleDescriptor);
         for (SlotDescriptor slotDesc : tupleDescriptor.getSlots()) {
-            schemaParam.addToSlotDescs(slotDesc.toThrift());
+            schemaParam.addToSlotDescs(DescriptorToThriftConverter.toThrift(slotDesc));
         }
 
         for (Map.Entry<Long, MaterializedIndexMeta> pair : table.getIndexIdToMeta().entrySet()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -20,6 +20,7 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.analysis.ColumnAccessPath;
 import org.apache.doris.analysis.CompoundPredicate;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprSubstitutionMap;
@@ -39,8 +40,6 @@ import org.apache.doris.datasource.iceberg.source.IcebergScanNode;
 import org.apache.doris.planner.normalize.ExprNormalizeVisitor;
 import org.apache.doris.planner.normalize.Normalizer;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.thrift.TAccessPathType;
-import org.apache.doris.thrift.TColumnAccessPath;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TExpr;
 import org.apache.doris.thrift.TNormalizedPlanNode;
@@ -863,13 +862,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
                 } else {
                     displayAllAccessPathsString = slot.getDisplayAllAccessPaths()
                             .stream()
-                            .map(a -> {
-                                if (a.type == TAccessPathType.DATA) {
-                                    return StringUtils.join(a.data_access_path.path, ".");
-                                } else {
-                                    return StringUtils.join(a.meta_access_path.path, ".");
-                                }
-                            })
+                            .map(a -> StringUtils.join(a.getPath(), "."))
                             .collect(Collectors.joining(", "));
                 }
             }
@@ -885,13 +878,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
                 } else {
                     displayPredicateAccessPathsString = slot.getPredicateAccessPaths()
                             .stream()
-                            .map(a -> {
-                                if (a.type == TAccessPathType.DATA) {
-                                    return StringUtils.join(a.data_access_path.path, ".");
-                                } else {
-                                    return StringUtils.join(a.meta_access_path.path, ".");
-                                }
-                            })
+                            .map(a -> StringUtils.join(a.getPath(), "."))
                             .collect(Collectors.joining(", "));
                 }
             }
@@ -924,15 +911,13 @@ public abstract class PlanNode extends TreeNode<PlanNode> {
     }
 
     private String mergeIcebergAccessPathsWithId(
-            List<TColumnAccessPath> accessPaths, List<TColumnAccessPath> displayAccessPaths) {
+            List<ColumnAccessPath> accessPaths, List<ColumnAccessPath> displayAccessPaths) {
         List<String> mergeDisplayAccessPaths = Lists.newArrayList();
         for (int i = 0; i < displayAccessPaths.size(); i++) {
-            TColumnAccessPath displayAccessPath = displayAccessPaths.get(i);
-            TColumnAccessPath idAccessPath = accessPaths.get(i);
-            List<String> nameAccessPathStrings = displayAccessPath.type == TAccessPathType.DATA
-                    ? displayAccessPath.data_access_path.path : displayAccessPath.meta_access_path.path;
-            List<String> idAccessPathStrings = idAccessPath.type == TAccessPathType.DATA
-                    ? idAccessPath.data_access_path.path : idAccessPath.meta_access_path.path;
+            ColumnAccessPath displayAccessPath = displayAccessPaths.get(i);
+            ColumnAccessPath idAccessPath = accessPaths.get(i);
+            List<String> nameAccessPathStrings = displayAccessPath.getPath();
+            List<String> idAccessPathStrings = idAccessPath.getPath();
 
             List<String> mergedPath = new ArrayList<>();
             for (int j = 0; j < idAccessPathStrings.size(); j++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -18,6 +18,7 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.analysis.DescriptorTable;
+import org.apache.doris.analysis.DescriptorToThriftConverter;
 import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.catalog.AIResource;
 import org.apache.doris.catalog.Env;
@@ -338,7 +339,7 @@ public class Coordinator implements CoordInterface {
         this.queryId = context.queryId();
         this.fragments = planner.getFragments();
         this.scanNodes = planner.getScanNodes();
-        this.descTable = planner.getDescTable().toThrift();
+        this.descTable = DescriptorToThriftConverter.toThrift(planner.getDescTable());
 
         this.returnedAllResults = false;
         this.enableShareHashTableForBroadcastJoin = context.getSessionVariable().enableShareHashTableForBroadcastJoin;
@@ -380,7 +381,7 @@ public class Coordinator implements CoordInterface {
             List<ScanNode> scanNodes, String timezone, boolean loadZeroTolerance, boolean enableProfile) {
         this.jobId = jobId;
         this.queryId = queryId;
-        this.descTable = descTable.toThrift();
+        this.descTable = DescriptorToThriftConverter.toThrift(descTable);
         this.fragments = fragments;
         this.scanNodes = scanNodes;
         this.queryOptions = new TQueryOptions();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordinatorContext.java
@@ -18,6 +18,7 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.analysis.DescriptorTable;
+import org.apache.doris.analysis.DescriptorToThriftConverter;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Status;
@@ -277,7 +278,7 @@ public class CoordinatorContext {
         ConnectContext connectContext = planner.getCascadesContext().getConnectContext();
         TQueryOptions queryOptions = initQueryOptions(connectContext);
         TQueryGlobals queryGlobals = createQueryGlobals(connectContext);
-        TDescriptorTable descriptorTable = planner.getDescTable().toThrift();
+        TDescriptorTable descriptorTable = DescriptorToThriftConverter.toThrift(planner.getDescTable());
 
         ExecutionProfile executionProfile = new ExecutionProfile(
                 connectContext.queryId,
@@ -323,7 +324,7 @@ public class CoordinatorContext {
         );
 
         return new CoordinatorContext(coordinator, jobId, fragments, distributedPlans,
-                scanNodes, queryId, queryOptions, queryGlobals, descTable.toThrift(),
+                scanNodes, queryId, queryOptions, queryGlobals, DescriptorToThriftConverter.toThrift(descTable),
                 executionProfile);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShortCircuitQueryContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShortCircuitQueryContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.DescriptorToThriftConverter;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprToThriftVisitor;
 import org.apache.doris.analysis.Queriable;
@@ -83,7 +84,7 @@ public class ShortCircuitQueryContext {
     public ShortCircuitQueryContext(Planner planner, Queriable analzyedQuery) throws TException {
         this.planner = planner;
         this.serializedDescTable = ByteString.copyFrom(
-                new TSerializer().serialize(planner.getDescTable().toThrift()));
+                new TSerializer().serialize(DescriptorToThriftConverter.toThrift(planner.getDescTable())));
         TQueryOptions options = planner.getQueryOptions() != null ? planner.getQueryOptions() : new TQueryOptions();
         this.serializedQueryOptions = ByteString.copyFrom(
                 new TSerializer().serialize(options));

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AlterReplicaTask.java
@@ -19,6 +19,7 @@ package org.apache.doris.task;
 
 import org.apache.doris.alter.AlterJobV2;
 import org.apache.doris.analysis.DescriptorTable;
+import org.apache.doris.analysis.DescriptorToThriftConverter;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprToThriftVisitor;
 import org.apache.doris.analysis.SlotRef;
@@ -175,7 +176,7 @@ public class AlterReplicaTask extends AgentTask {
                 req.addToMaterializedViewParams(mvParam);
             }
         }
-        req.setDescTbl(descTable.toThrift());
+        req.setDescTbl(DescriptorToThriftConverter.toThrift(descTable));
 
         if (baseSchemaColumns != null) {
             Object value = objectPool.get(baseSchemaColumns);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DescriptorToThriftConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DescriptorToThriftConverterTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.thrift.TAccessPathType;
 import org.apache.doris.thrift.TColumnAccessPath;
 import org.apache.doris.thrift.TDescriptorTable;
 import org.apache.doris.thrift.TSlotDescriptor;
@@ -118,8 +119,11 @@ public class DescriptorToThriftConverterTest {
     public void testSlotDescriptorWithAccessPaths() {
         SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(7), new TupleId(0));
         slotDesc.setType(Type.INT);
-        List<TColumnAccessPath> allPaths = Arrays.asList(new TColumnAccessPath(), new TColumnAccessPath());
-        List<TColumnAccessPath> predPaths = Arrays.asList(new TColumnAccessPath());
+        List<ColumnAccessPath> allPaths = Arrays.asList(
+                ColumnAccessPath.data(Arrays.asList("a", "b")),
+                ColumnAccessPath.meta(Arrays.asList("c")));
+        List<ColumnAccessPath> predPaths = Arrays.asList(
+                ColumnAccessPath.data(Arrays.asList("x")));
         slotDesc.setAllAccessPaths(allPaths);
         slotDesc.setPredicateAccessPaths(predPaths);
 
@@ -151,8 +155,10 @@ public class DescriptorToThriftConverterTest {
         slotDesc.setAutoInc(true);
         slotDesc.setMaterializedColumnName("mat_col");
         slotDesc.setSubColLables(Arrays.asList("x", "y"));
-        List<TColumnAccessPath> allPaths = Arrays.asList(new TColumnAccessPath());
-        List<TColumnAccessPath> predPaths = Arrays.asList(new TColumnAccessPath());
+        List<ColumnAccessPath> allPaths = Arrays.asList(
+                ColumnAccessPath.data(Arrays.asList("a")));
+        List<ColumnAccessPath> predPaths = Arrays.asList(
+                ColumnAccessPath.meta(Arrays.asList("b")));
         slotDesc.setAllAccessPaths(allPaths);
         slotDesc.setPredicateAccessPaths(predPaths);
 
@@ -239,7 +245,7 @@ public class DescriptorToThriftConverterTest {
     }
 
     @Test
-    public void testDescriptorTableCaching() {
+    public void testDescriptorTableReturnsNewInstanceEachCall() {
         DescriptorTable descTable = new DescriptorTable();
         TupleDescriptor tuple = descTable.createTupleDescriptor();
         SlotDescriptor slot = descTable.addSlotDescriptor(tuple);
@@ -248,7 +254,8 @@ public class DescriptorToThriftConverterTest {
         TDescriptorTable first = DescriptorToThriftConverter.toThrift(descTable);
         TDescriptorTable second = DescriptorToThriftConverter.toThrift(descTable);
 
-        Assertions.assertSame(first, second);
+        Assertions.assertNotSame(first, second);
+        Assertions.assertEquals(first, second);
     }
 
     @Test
@@ -272,5 +279,80 @@ public class DescriptorToThriftConverterTest {
         Assertions.assertNotNull(result.getTableDescriptors());
         Assertions.assertEquals(1, result.getTableDescriptors().size());
         Mockito.verify(mockTable).toThrift();
+    }
+
+    // ==================== ColumnAccessPath conversion tests ====================
+
+    @Test
+    public void testColumnAccessPathDataToThrift() {
+        ColumnAccessPath accessPath = ColumnAccessPath.data(Arrays.asList("col1", "field1"));
+
+        TColumnAccessPath result = DescriptorToThriftConverter.toThrift(accessPath);
+
+        Assertions.assertEquals(TAccessPathType.DATA, result.getType());
+        Assertions.assertTrue(result.isSetDataAccessPath());
+        Assertions.assertFalse(result.isSetMetaAccessPath());
+        Assertions.assertEquals(Arrays.asList("col1", "field1"), result.getDataAccessPath().getPath());
+    }
+
+    @Test
+    public void testColumnAccessPathMetaToThrift() {
+        ColumnAccessPath accessPath = ColumnAccessPath.meta(Arrays.asList("col2", "field2"));
+
+        TColumnAccessPath result = DescriptorToThriftConverter.toThrift(accessPath);
+
+        Assertions.assertEquals(TAccessPathType.META, result.getType());
+        Assertions.assertFalse(result.isSetDataAccessPath());
+        Assertions.assertTrue(result.isSetMetaAccessPath());
+        Assertions.assertEquals(Arrays.asList("col2", "field2"), result.getMetaAccessPath().getPath());
+    }
+
+    @Test
+    public void testColumnAccessPathListToThrift() {
+        List<ColumnAccessPath> paths = Arrays.asList(
+                ColumnAccessPath.data(Arrays.asList("a", "b")),
+                ColumnAccessPath.meta(Arrays.asList("c")),
+                ColumnAccessPath.data(Arrays.asList("d", "e", "f")));
+
+        List<TColumnAccessPath> results = DescriptorToThriftConverter.toThrift(paths);
+
+        Assertions.assertEquals(3, results.size());
+        Assertions.assertEquals(TAccessPathType.DATA, results.get(0).getType());
+        Assertions.assertEquals(Arrays.asList("a", "b"), results.get(0).getDataAccessPath().getPath());
+        Assertions.assertEquals(TAccessPathType.META, results.get(1).getType());
+        Assertions.assertEquals(Arrays.asList("c"), results.get(1).getMetaAccessPath().getPath());
+        Assertions.assertEquals(TAccessPathType.DATA, results.get(2).getType());
+        Assertions.assertEquals(Arrays.asList("d", "e", "f"), results.get(2).getDataAccessPath().getPath());
+    }
+
+    @Test
+    public void testColumnAccessPathEmptyPathToThrift() {
+        ColumnAccessPath accessPath = ColumnAccessPath.data(Arrays.asList());
+
+        TColumnAccessPath result = DescriptorToThriftConverter.toThrift(accessPath);
+
+        Assertions.assertEquals(TAccessPathType.DATA, result.getType());
+        Assertions.assertTrue(result.isSetDataAccessPath());
+        Assertions.assertEquals(Arrays.asList(), result.getDataAccessPath().getPath());
+    }
+
+    @Test
+    public void testSlotDescriptorAccessPathsRoundTrip() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(20), new TupleId(0));
+        slotDesc.setType(Type.INT);
+        List<ColumnAccessPath> allPaths = Arrays.asList(
+                ColumnAccessPath.data(Arrays.asList("x", "y")),
+                ColumnAccessPath.meta(Arrays.asList("z")));
+        slotDesc.setAllAccessPaths(allPaths);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertEquals(2, result.getAllAccessPaths().size());
+        TColumnAccessPath first = result.getAllAccessPaths().get(0);
+        Assertions.assertEquals(TAccessPathType.DATA, first.getType());
+        Assertions.assertEquals(Arrays.asList("x", "y"), first.getDataAccessPath().getPath());
+        TColumnAccessPath second = result.getAllAccessPaths().get(1);
+        Assertions.assertEquals(TAccessPathType.META, second.getType());
+        Assertions.assertEquals(Arrays.asList("z"), second.getMetaAccessPath().getPath());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DescriptorToThriftConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DescriptorToThriftConverterTest.java
@@ -1,0 +1,276 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.thrift.TColumnAccessPath;
+import org.apache.doris.thrift.TDescriptorTable;
+import org.apache.doris.thrift.TSlotDescriptor;
+import org.apache.doris.thrift.TTableDescriptor;
+import org.apache.doris.thrift.TTupleDescriptor;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DescriptorToThriftConverterTest {
+
+    // ==================== SlotDescriptor tests ====================
+
+    @Test
+    public void testSlotDescriptorBasic() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(1), new TupleId(0));
+        slotDesc.setType(Type.INT);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertEquals(1, result.getId());
+        Assertions.assertEquals(0, result.getParent());
+        Assertions.assertEquals(Type.INT.toThrift(), result.getSlotType());
+        Assertions.assertEquals(0, result.getNullIndicatorBit());
+        Assertions.assertEquals("", result.getColName());
+    }
+
+    @Test
+    public void testSlotDescriptorWithColumn() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(2), new TupleId(1));
+        Column column = new Column("col_name", Type.INT);
+        slotDesc.setColumn(column);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertTrue(result.isSetColUniqueId());
+        Assertions.assertTrue(result.isSetPrimitiveType());
+        Assertions.assertTrue(result.isSetIsKey());
+        Assertions.assertEquals(column.getUniqueId(), result.getColUniqueId());
+        Assertions.assertEquals(column.getDataType().toThrift(), result.getPrimitiveType());
+        Assertions.assertEquals(column.isKey(), result.isIsKey());
+    }
+
+    @Test
+    public void testSlotDescriptorWithMaterializedColumnName() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(3), new TupleId(0));
+        Column column = new Column("original_name", Type.INT);
+        slotDesc.setColumn(column);
+        slotDesc.setMaterializedColumnName("materialized_name");
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertEquals("materialized_name", result.getColName());
+    }
+
+    @Test
+    public void testSlotDescriptorNonNullable() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(4), new TupleId(0));
+        slotDesc.setType(Type.INT);
+        slotDesc.setIsNullable(false);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertEquals(-1, result.getNullIndicatorBit());
+    }
+
+    @Test
+    public void testSlotDescriptorWithAutoIncrement() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(5), new TupleId(0));
+        slotDesc.setType(Type.INT);
+        slotDesc.setAutoInc(true);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertTrue(result.isIsAutoIncrement());
+    }
+
+    @Test
+    public void testSlotDescriptorWithSubColPath() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(6), new TupleId(0));
+        slotDesc.setType(Type.INT);
+        List<String> subColPath = Arrays.asList("a", "b", "c");
+        slotDesc.setSubColLables(subColPath);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertTrue(result.isSetColumnPaths());
+        Assertions.assertEquals(subColPath, result.getColumnPaths());
+    }
+
+    @Test
+    public void testSlotDescriptorWithAccessPaths() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(7), new TupleId(0));
+        slotDesc.setType(Type.INT);
+        List<TColumnAccessPath> allPaths = Arrays.asList(new TColumnAccessPath(), new TColumnAccessPath());
+        List<TColumnAccessPath> predPaths = Arrays.asList(new TColumnAccessPath());
+        slotDesc.setAllAccessPaths(allPaths);
+        slotDesc.setPredicateAccessPaths(predPaths);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertTrue(result.isSetAllAccessPaths());
+        Assertions.assertEquals(2, result.getAllAccessPaths().size());
+        Assertions.assertTrue(result.isSetPredicateAccessPaths());
+        Assertions.assertEquals(1, result.getPredicateAccessPaths().size());
+    }
+
+    @Test
+    public void testSlotDescriptorWithDefaultValue() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(8), new TupleId(0));
+        Column column = new Column("col_with_default", Type.INT, true, null, "42", "");
+        slotDesc.setColumn(column);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertTrue(result.isSetColDefaultValue());
+        Assertions.assertEquals("42", result.getColDefaultValue());
+    }
+
+    @Test
+    public void testSlotDescriptorWithAllFields() {
+        SlotDescriptor slotDesc = new SlotDescriptor(new SlotId(10), new TupleId(2));
+        Column column = new Column("test_col", Type.INT);
+        slotDesc.setColumn(column);
+        slotDesc.setAutoInc(true);
+        slotDesc.setMaterializedColumnName("mat_col");
+        slotDesc.setSubColLables(Arrays.asList("x", "y"));
+        List<TColumnAccessPath> allPaths = Arrays.asList(new TColumnAccessPath());
+        List<TColumnAccessPath> predPaths = Arrays.asList(new TColumnAccessPath());
+        slotDesc.setAllAccessPaths(allPaths);
+        slotDesc.setPredicateAccessPaths(predPaths);
+
+        TSlotDescriptor result = DescriptorToThriftConverter.toThrift(slotDesc);
+
+        Assertions.assertEquals(10, result.getId());
+        Assertions.assertEquals(2, result.getParent());
+        Assertions.assertEquals("mat_col", result.getColName());
+        Assertions.assertTrue(result.isIsAutoIncrement());
+        Assertions.assertEquals(Arrays.asList("x", "y"), result.getColumnPaths());
+        Assertions.assertEquals(1, result.getAllAccessPaths().size());
+        Assertions.assertEquals(1, result.getPredicateAccessPaths().size());
+    }
+
+    // ==================== TupleDescriptor tests ====================
+
+    @Test
+    public void testTupleDescriptorBasic() {
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(5));
+
+        TTupleDescriptor result = DescriptorToThriftConverter.toThrift(tupleDesc);
+
+        Assertions.assertEquals(5, result.getId());
+        Assertions.assertEquals(0, result.getByteSize());
+        Assertions.assertEquals(0, result.getNumNullBytes());
+        Assertions.assertFalse(result.isSetTableId());
+    }
+
+    @Test
+    public void testTupleDescriptorWithTable() {
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(6));
+        TableIf mockTable = Mockito.mock(TableIf.class);
+        Mockito.when(mockTable.getId()).thenReturn(12345L);
+        tupleDesc.setTable(mockTable);
+
+        TTupleDescriptor result = DescriptorToThriftConverter.toThrift(tupleDesc);
+
+        Assertions.assertTrue(result.isSetTableId());
+        Assertions.assertEquals(12345, result.getTableId());
+    }
+
+    @Test
+    public void testTupleDescriptorWithNegativeTableId() {
+        TupleDescriptor tupleDesc = new TupleDescriptor(new TupleId(7));
+        TableIf mockTable = Mockito.mock(TableIf.class);
+        Mockito.when(mockTable.getId()).thenReturn(-1L);
+        tupleDesc.setTable(mockTable);
+
+        TTupleDescriptor result = DescriptorToThriftConverter.toThrift(tupleDesc);
+
+        Assertions.assertFalse(result.isSetTableId());
+    }
+
+    // ==================== DescriptorTable tests ====================
+
+    @Test
+    public void testDescriptorTableEmpty() {
+        DescriptorTable descTable = new DescriptorTable();
+
+        TDescriptorTable result = DescriptorToThriftConverter.toThrift(descTable);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.getTupleDescriptors() == null || result.getTupleDescriptors().isEmpty());
+        Assertions.assertTrue(result.getSlotDescriptors() == null || result.getSlotDescriptors().isEmpty());
+    }
+
+    @Test
+    public void testDescriptorTableWithTuplesAndSlots() {
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tuple1 = descTable.createTupleDescriptor();
+        SlotDescriptor slot1 = descTable.addSlotDescriptor(tuple1);
+        slot1.setType(Type.INT);
+        SlotDescriptor slot2 = descTable.addSlotDescriptor(tuple1);
+        slot2.setType(Type.STRING);
+
+        TupleDescriptor tuple2 = descTable.createTupleDescriptor();
+        SlotDescriptor slot3 = descTable.addSlotDescriptor(tuple2);
+        slot3.setType(Type.DOUBLE);
+
+        TDescriptorTable result = DescriptorToThriftConverter.toThrift(descTable);
+
+        Assertions.assertEquals(2, result.getTupleDescriptors().size());
+        Assertions.assertEquals(3, result.getSlotDescriptors().size());
+    }
+
+    @Test
+    public void testDescriptorTableCaching() {
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tuple = descTable.createTupleDescriptor();
+        SlotDescriptor slot = descTable.addSlotDescriptor(tuple);
+        slot.setType(Type.INT);
+
+        TDescriptorTable first = DescriptorToThriftConverter.toThrift(descTable);
+        TDescriptorTable second = DescriptorToThriftConverter.toThrift(descTable);
+
+        Assertions.assertSame(first, second);
+    }
+
+    @Test
+    public void testDescriptorTableWithReferencedTable() {
+        DescriptorTable descTable = new DescriptorTable();
+        TupleDescriptor tuple = descTable.createTupleDescriptor();
+        SlotDescriptor slot = descTable.addSlotDescriptor(tuple);
+        slot.setType(Type.INT);
+
+        TableIf mockTable = Mockito.mock(TableIf.class);
+        Mockito.when(mockTable.getId()).thenReturn(100L);
+        TTableDescriptor tTableDesc = new TTableDescriptor();
+        Mockito.when(mockTable.toThrift()).thenReturn(tTableDesc);
+        tuple.setTable(mockTable);
+
+        TDescriptorTable result = DescriptorToThriftConverter.toThrift(descTable);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(1, result.getTupleDescriptors().size());
+        Assertions.assertEquals(100, result.getTupleDescriptors().get(0).getTableId());
+        Assertions.assertNotNull(result.getTableDescriptors());
+        Assertions.assertEquals(1, result.getTableDescriptors().size());
+        Mockito.verify(mockTable).toThrift();
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.analysis.ColumnAccessPath;
+import org.apache.doris.analysis.ColumnAccessPathType;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.Pair;
@@ -45,10 +47,6 @@ import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanFragment;
-import org.apache.doris.thrift.TAccessPathType;
-import org.apache.doris.thrift.TColumnAccessPath;
-import org.apache.doris.thrift.TDataAccessPath;
-import org.apache.doris.thrift.TMetaAccessPath;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
@@ -1057,9 +1055,9 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     private void setAccessPathsAndAssertType(SlotReference slot, List<List<String>> paths, String expectedType) {
         DataType columnType = DataType.fromCatalogType(slot.getOriginalColumn().get().getType());
         SlotReference originColumnTypeSlot = new SlotReference(slot.getName(), columnType);
-        DataTypeAccessTree tree = DataTypeAccessTree.ofRoot(originColumnTypeSlot, TAccessPathType.DATA);
+        DataTypeAccessTree tree = DataTypeAccessTree.ofRoot(originColumnTypeSlot, ColumnAccessPathType.DATA);
         for (List<String> path : paths) {
-            tree.setAccessByPath(path, 0, TAccessPathType.DATA);
+            tree.setAccessByPath(path, 0, ColumnAccessPathType.DATA);
         }
         DataType dataType = tree.pruneDataType().get();
         Assertions.assertEquals(expectedType, dataType.toSql());
@@ -1079,7 +1077,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
         List<Pair<SlotReference, DataTypeAccessTree>> trees = new ArrayList<>();
         for (Slot slot : output) {
             if (slot.getDataType() instanceof NestedColumnPrunable) {
-                DataTypeAccessTree dataTypeAccessTree = DataTypeAccessTree.ofRoot(slot, TAccessPathType.DATA);
+                DataTypeAccessTree dataTypeAccessTree = DataTypeAccessTree.ofRoot(slot, ColumnAccessPathType.DATA);
                 trees.add(Pair.of((SlotReference) slot, dataTypeAccessTree));
             }
         }
@@ -1087,28 +1085,28 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     }
 
     private void assertColumn(String sql, String expectType,
-            List<TColumnAccessPath> expectAllAccessPaths,
-            List<TColumnAccessPath> expectPredicateAccessPaths) throws Exception {
+            List<ColumnAccessPath> expectAllAccessPaths,
+            List<ColumnAccessPath> expectPredicateAccessPaths) throws Exception {
         assertColumns(sql, expectType == null ? null : ImmutableList.of(Triple.of(expectType, expectAllAccessPaths, expectPredicateAccessPaths)));
     }
 
-    private void assertAllAccessPathsContain(String sql, List<TColumnAccessPath> expectContainAllAccessPaths,
-            List<TColumnAccessPath> expectNotContainAllAccessPaths) throws Exception {
+    private void assertAllAccessPathsContain(String sql, List<ColumnAccessPath> expectContainAllAccessPaths,
+            List<ColumnAccessPath> expectNotContainAllAccessPaths) throws Exception {
         Pair<PhysicalPlan, List<SlotDescriptor>> result = collectComplexSlots(sql);
-        TreeSet<TColumnAccessPath> allAccessPaths = new TreeSet<>();
+        TreeSet<ColumnAccessPath> allAccessPaths = new TreeSet<>();
         for (SlotDescriptor slotDescriptor : result.second) {
             allAccessPaths.addAll(slotDescriptor.getAllAccessPaths());
         }
-        for (TColumnAccessPath accessPath : expectContainAllAccessPaths) {
+        for (ColumnAccessPath accessPath : expectContainAllAccessPaths) {
             Assertions.assertTrue(allAccessPaths.contains(accessPath));
         }
-        for (TColumnAccessPath accessPath : expectNotContainAllAccessPaths) {
+        for (ColumnAccessPath accessPath : expectNotContainAllAccessPaths) {
             Assertions.assertFalse(allAccessPaths.contains(accessPath));
         }
     }
 
     private void assertColumns(String sql,
-            List<Triple<String, List<TColumnAccessPath>, List<TColumnAccessPath>>> expectResults) throws Exception {
+            List<Triple<String, List<ColumnAccessPath>, List<ColumnAccessPath>>> expectResults) throws Exception {
         Pair<PhysicalPlan, List<SlotDescriptor>> result = collectComplexSlots(sql);
         PhysicalPlan physicalPlan = result.first;
         List<SlotDescriptor> slotDescriptors = result.second;
@@ -1119,20 +1117,20 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
 
         Assertions.assertEquals(expectResults.size(), slotDescriptors.size());
         int slotIndex = 0;
-        for (Triple<String, List<TColumnAccessPath>, List<TColumnAccessPath>> expectResult : expectResults) {
+        for (Triple<String, List<ColumnAccessPath>, List<ColumnAccessPath>> expectResult : expectResults) {
             String expectType = expectResult.left;
-            List<TColumnAccessPath> expectAllAccessPaths = expectResult.middle;
-            List<TColumnAccessPath> expectPredicateAccessPaths = expectResult.right;
+            List<ColumnAccessPath> expectAllAccessPaths = expectResult.middle;
+            List<ColumnAccessPath> expectPredicateAccessPaths = expectResult.right;
             SlotDescriptor slotDescriptor = slotDescriptors.get(slotIndex++);
             Assertions.assertEquals(expectType, slotDescriptor.getType().toString());
 
-            TreeSet<TColumnAccessPath> expectAllAccessPathSet = new TreeSet<>(expectAllAccessPaths);
-            TreeSet<TColumnAccessPath> actualAllAccessPaths
+            TreeSet<ColumnAccessPath> expectAllAccessPathSet = new TreeSet<>(expectAllAccessPaths);
+            TreeSet<ColumnAccessPath> actualAllAccessPaths
                     = new TreeSet<>(slotDescriptor.getAllAccessPaths());
             Assertions.assertEquals(expectAllAccessPathSet, actualAllAccessPaths);
 
-            TreeSet<TColumnAccessPath> expectPredicateAccessPathSet = new TreeSet<>(expectPredicateAccessPaths);
-            TreeSet<TColumnAccessPath> actualPredicateAccessPaths
+            TreeSet<ColumnAccessPath> expectPredicateAccessPathSet = new TreeSet<>(expectPredicateAccessPaths);
+            TreeSet<ColumnAccessPath> actualPredicateAccessPaths
                     = new TreeSet<>(slotDescriptor.getPredicateAccessPaths());
             Assertions.assertEquals(expectPredicateAccessPathSet, actualPredicateAccessPaths);
 
@@ -1235,7 +1233,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     //  * @param expectAllPaths   expected access paths when {@code expectOptimized} is true
     //  */
     // private void assertStringColumn(String sql, String columnName,
-    //         boolean expectOptimized, List<TColumnAccessPath> expectAllPaths) {
+    //         boolean expectOptimized, List<ColumnAccessPath> expectAllPaths) {
     //     Plan rewritePlan = PlanChecker.from(connectContext)
     //             .analyze(sql)
     //             .rewrite()
@@ -1256,7 +1254,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     //         if (expectOptimized) {
     //             Assertions.assertEquals(BigIntType.INSTANCE, slotRef.getDataType(),
     //                     "Slot '" + columnName + "' should be BigIntType after offset-only optimization");
-    //             Optional<List<TColumnAccessPath>> allPaths = slotRef.getAllAccessPaths();
+    //             Optional<List<ColumnAccessPath>> allPaths = slotRef.getAllAccessPaths();
     //             Assertions.assertTrue(allPaths.isPresent() && !allPaths.get().isEmpty(),
     //                     "Slot '" + columnName + "' should have access paths set");
     //             Assertions.assertEquals(
@@ -1291,16 +1289,12 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
         return Pair.of(physicalPlan, complexSlots);
     }
 
-    private TColumnAccessPath path(String... path) {
-        TColumnAccessPath accessPath = new TColumnAccessPath(TAccessPathType.DATA);
-        accessPath.data_access_path = new TDataAccessPath(ImmutableList.copyOf(path));
-        return accessPath;
+    private ColumnAccessPath path(String... path) {
+        return ColumnAccessPath.data(ImmutableList.copyOf(path));
     }
 
-    private TColumnAccessPath metaPath(String... path) {
-        TColumnAccessPath accessPath = new TColumnAccessPath(TAccessPathType.META);
-        accessPath.meta_access_path = new TMetaAccessPath(ImmutableList.copyOf(path));
-        return accessPath;
+    private ColumnAccessPath metaPath(String... path) {
+        return ColumnAccessPath.meta(ImmutableList.copyOf(path));
     }
 
     private void assertVariantSubColumnSlots(String sql, List<List<String>> expectedSubColPaths) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/VariantPruningLogicTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/VariantPruningLogicTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.analysis.ColumnAccessPath;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.Pair;
@@ -25,9 +26,6 @@ import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanFragment;
-import org.apache.doris.thrift.TAccessPathType;
-import org.apache.doris.thrift.TColumnAccessPath;
-import org.apache.doris.thrift.TDataAccessPath;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
@@ -205,39 +203,37 @@ public class VariantPruningLogicTest extends TestWithFeService {
         Assertions.assertEquals(expectedSubColPathSet, actualSubColPaths);
     }
 
-    private void assertPredicateAccessPathsEqual(String sql, List<TColumnAccessPath> expected) throws Exception {
+    private void assertPredicateAccessPathsEqual(String sql, List<ColumnAccessPath> expected) throws Exception {
         Pair<PhysicalPlan, List<SlotDescriptor>> result = collectVariantSlots(sql);
-        TreeSet<TColumnAccessPath> actualSet = new TreeSet<>();
+        TreeSet<ColumnAccessPath> actualSet = new TreeSet<>();
         for (SlotDescriptor slotDescriptor : result.second) {
-            List<TColumnAccessPath> predicate = slotDescriptor.getPredicateAccessPaths();
+            List<ColumnAccessPath> predicate = slotDescriptor.getPredicateAccessPaths();
             if (predicate != null) {
                 actualSet.addAll(predicate);
             }
         }
 
-        TreeSet<TColumnAccessPath> expectedSet = new TreeSet<>(expected);
+        TreeSet<ColumnAccessPath> expectedSet = new TreeSet<>(expected);
         Assertions.assertEquals(expectedSet, actualSet);
     }
 
     private void assertAllAccessPathsContain(
-            String sql, List<TColumnAccessPath> expectedContain, List<TColumnAccessPath> expectedNotContain)
+            String sql, List<ColumnAccessPath> expectedContain, List<ColumnAccessPath> expectedNotContain)
             throws Exception {
         Pair<PhysicalPlan, List<SlotDescriptor>> result = collectVariantSlots(sql);
-        TreeSet<TColumnAccessPath> allAccessPaths = new TreeSet<>();
+        TreeSet<ColumnAccessPath> allAccessPaths = new TreeSet<>();
         for (SlotDescriptor slotDescriptor : result.second) {
             allAccessPaths.addAll(slotDescriptor.getAllAccessPaths());
         }
-        for (TColumnAccessPath accessPath : expectedContain) {
+        for (ColumnAccessPath accessPath : expectedContain) {
             Assertions.assertTrue(allAccessPaths.contains(accessPath));
         }
-        for (TColumnAccessPath accessPath : expectedNotContain) {
+        for (ColumnAccessPath accessPath : expectedNotContain) {
             Assertions.assertFalse(allAccessPaths.contains(accessPath));
         }
     }
 
-    private TColumnAccessPath path(String... path) {
-        TColumnAccessPath accessPath = new TColumnAccessPath(TAccessPathType.DATA);
-        accessPath.data_access_path = new TDataAccessPath(ImmutableList.copyOf(path));
-        return accessPath;
+    private ColumnAccessPath path(String... path) {
+        return ColumnAccessPath.data(ImmutableList.copyOf(path));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
The `toThrift()` methods on `SlotDescriptor`, `TupleDescriptor`, and `DescriptorTable` mix serialization logic with domain model classes. Following the same pattern as `FunctionToThriftConverter`, this PR extracts all three `toThrift()` methods into a new `DescriptorToThriftConverter` utility class, keeping the domain classes focused on their core responsibilities.

**Changes:**
- Created `DescriptorToThriftConverter` as a `final` utility class with private constructor and 3 static `toThrift` overloads
- Created `DescriptorToThriftConverterTest` with 17 unit tests covering all code paths
- Updated all 11 call sites across 7 files to use `DescriptorToThriftConverter.toThrift()`
- Removed `toThrift()` from `SlotDescriptor`, `TupleDescriptor`, and `DescriptorTable`
- Added necessary getters: `getMaterializedColumnName()`, `getThriftDescTable()`, `getTupleDescs()`
- Cleaned up unused imports (`TSlotDescriptor`, `TTupleDescriptor`, `TableIf`, `Logger/LogManager`)

### Release note

None

### Check List (For Author)

- Test: Unit Test (DescriptorToThriftConverterTest with 17 test cases)
- Behavior changed: No
- Does this need documentation: No