### PR TITLE
[test](regression) Shorten generated HMS and DLF identifiers in catalog case

### DIFF
--- a/regression-test/suites/external_table_p2/refactor_catalog_param/hive_on_hms_and_dlf.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/hive_on_hms_and_dlf.groovy
@@ -19,6 +19,16 @@ import java.util.concurrent.ThreadLocalRandom
 
 suite("hive_on_hms_and_dlf", "p2,external") {
 
+    // Keep generated identifiers under the FE 64-character limit for long prefixes.
+    def buildDbName = { String prefix ->
+        def suffix = String.format("_db%d%03d", System.currentTimeMillis(), ThreadLocalRandom.current().nextInt(1000))
+        return prefix.take(64 - suffix.length()) + suffix
+    }
+
+    def buildTableName = { String prefix, String suffix ->
+        def randomSuffix = String.format("%03d", ThreadLocalRandom.current().nextInt(1000))
+        return prefix.take(64 - randomSuffix.length() - suffix.length()) + randomSuffix + suffix
+    }
 
     def testQueryAndInsert = { String catalogProperties, String prefix, String dbLocation ->
 
@@ -35,7 +45,7 @@ suite("hive_on_hms_and_dlf", "p2,external") {
             switch ${catalog_name};
         """
 
-        def db_name = prefix + "_db" + System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000)
+        def db_name = buildDbName(prefix)
         sql """
             DROP DATABASE IF EXISTS ${db_name} FORCE;
         """
@@ -53,7 +63,7 @@ suite("hive_on_hms_and_dlf", "p2,external") {
         sql """
             use ${db_name};
         """
-        def table_name = prefix + ThreadLocalRandom.current().nextInt(1000) + "_table"
+        def table_name = buildTableName(prefix, "_table")
         sql """
             CREATE TABLE ${table_name} (
             user_id            BIGINT      COMMENT "user id",
@@ -98,7 +108,7 @@ suite("hive_on_hms_and_dlf", "p2,external") {
             switch ${catalog_name};
         """
 
-        def db_name = prefix + "_db" + System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000)
+        def db_name = buildDbName(prefix)
         sql """
             DROP DATABASE IF EXISTS ${db_name} FORCE;
         """
@@ -116,7 +126,7 @@ suite("hive_on_hms_and_dlf", "p2,external") {
             use ${db_name};
         """
 
-        def table_name = prefix + ThreadLocalRandom.current().nextInt(1000) + "_partition_table"
+        def table_name = buildTableName(prefix, "_partition_table")
 
         // Create partitioned table
         sql """
@@ -198,7 +208,7 @@ suite("hive_on_hms_and_dlf", "p2,external") {
             switch ${catalog_name};
         """
 
-        def db_name = prefix + "_db" + System.currentTimeMillis() + ThreadLocalRandom.current().nextInt(1000)
+        def db_name = buildDbName(prefix)
         sql """
             DROP DATABASE IF EXISTS ${db_name} FORCE;
         """
@@ -216,7 +226,7 @@ suite("hive_on_hms_and_dlf", "p2,external") {
             use ${db_name};
         """
 
-        def table_name = prefix + ThreadLocalRandom.current().nextInt(1000) + "_overwrite_table"
+        def table_name = buildTableName(prefix, "_overwrite_table")
 
         // Create non-partitioned table for insert overwrite test
         sql """


### PR DESCRIPTION
…

### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Keep dynamically generated database and table names in hive_on_hms_and_dlf.groovy within the FE 64-character identifier limit for long prefixes so the external HMS and DLF regression case does not fail on identifier validation.

### Release note

None

### Check List (For Author)

- Test: No need to test (updated only regression case identifier generation and verified generated name lengths locally)
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

