### PR TITLE
[improvement](fe) Extend StringEmptyToLengthRule to handle non-SlotReference string expressions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/StringEmptyToLengthRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/StringEmptyToLengthRule.java
@@ -23,7 +23,6 @@ import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Not;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Length;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -41,13 +40,15 @@ import java.util.List;
  *   <li>{@code str_col = ''}   → {@code length(str_col) = 0}</li>
  *   <li>{@code str_col <> ''}  → {@code length(str_col) != 0}
  *       (represented as {@code NOT(length(str_col) = 0)})</li>
+ *   <li>{@code element_at(struct_col, 'f3') = ''} → {@code length(element_at(struct_col, 'f3')) = 0}</li>
  * </ul>
  *
  * This is a semantics-preserving rewrite: for any non-NULL string, {@code s = ''} is equivalent
  * to {@code length(s) = 0}; for NULL, both sides evaluate to NULL.
  *
- * Only applies when the compared expression is a direct {@link SlotReference} of string-like type,
- * so that the resulting {@code length(slot)} call can benefit from OFFSET-only column reading.
+ * Applies when the compared expression is a non-literal expression of string-like type (e.g. a
+ * {@code SlotReference}, a {@code StructElement} field access, etc.), so that the resulting
+ * {@code length(expr)} call can benefit from OFFSET-only column reading.
  */
 public class StringEmptyToLengthRule implements ExpressionPatternRuleFactory {
     public static final StringEmptyToLengthRule INSTANCE = new StringEmptyToLengthRule();
@@ -78,8 +79,8 @@ public class StringEmptyToLengthRule implements ExpressionPatternRuleFactory {
     }
 
     /**
-     * If {@code equalTo} compares a string-typed SlotReference against an empty-string literal,
-     * rewrites it to {@code length(slot) = 0}.  Returns the original expression unchanged otherwise.
+     * If {@code equalTo} compares a string-typed expression against an empty-string literal,
+     * rewrites it to {@code length(expr) = 0}.  Returns the original expression unchanged otherwise.
      */
     private static Expression rewriteEqualToEmpty(EqualTo equalTo) {
         if (ConnectContext.get().getStatementContext().isDelete()) {
@@ -88,21 +89,21 @@ public class StringEmptyToLengthRule implements ExpressionPatternRuleFactory {
         Expression left = equalTo.left();
         Expression right = equalTo.right();
 
-        SlotReference slot = null;
-        if (isStringSlot(left) && isEmptyStringLiteral(right)) {
-            slot = (SlotReference) left;
-        } else if (isStringSlot(right) && isEmptyStringLiteral(left)) {
-            slot = (SlotReference) right;
+        Expression stringExpr = null;
+        if (isStringExpression(left) && isEmptyStringLiteral(right)) {
+            stringExpr = left;
+        } else if (isStringExpression(right) && isEmptyStringLiteral(left)) {
+            stringExpr = right;
         }
 
-        if (slot == null) {
+        if (stringExpr == null) {
             return equalTo;
         }
-        return new EqualTo(new Length(slot), new IntegerLiteral(0));
+        return new EqualTo(new Length(stringExpr), new IntegerLiteral(0));
     }
 
-    private static boolean isStringSlot(Expression expr) {
-        return expr instanceof SlotReference && expr.getDataType().isStringLikeType();
+    private static boolean isStringExpression(Expression expr) {
+        return !(expr instanceof Literal) && expr.getDataType().isStringLikeType();
     }
 
     private static boolean isEmptyStringLiteral(Expression expr) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/StringEmptyToLengthRuleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/StringEmptyToLengthRuleTest.java
@@ -24,10 +24,13 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Length;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.StructElement;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.StringType;
+import org.apache.doris.nereids.types.StructField;
+import org.apache.doris.nereids.types.StructType;
 import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.collect.ImmutableList;
@@ -137,5 +140,55 @@ public class StringEmptyToLengthRuleTest extends ExpressionRewriteTestHelper {
         // NOT(str_col = 'abc') — non-empty literal, must not be rewritten
         SlotReference slot = new SlotReference("str_col", StringType.INSTANCE, true);
         assertRuleNoRewrite(new Not(new EqualTo(slot, new VarcharLiteral("abc"))));
+    }
+
+    // ─── Struct element (non-SlotReference expression) cases ─────────────────────
+
+    @Test
+    public void testStructElementEqualEmptyRewrite() {
+        // struct_element(struct_col, 'f3') = '' → length(struct_element(struct_col, 'f3')) = 0
+        SlotReference structSlot = new SlotReference("struct_col",
+                new StructType(ImmutableList.of(
+                        new StructField("f1", IntegerType.INSTANCE, true, ""),
+                        new StructField("f3", StringType.INSTANCE, true, "")
+                )), true);
+        StructElement structElement = new StructElement(structSlot, new VarcharLiteral("f3"));
+        VarcharLiteral empty = new VarcharLiteral("");
+        assertRuleRewrite(
+                new EqualTo(structElement, empty),
+                new EqualTo(new Length(structElement), new IntegerLiteral(0))
+        );
+    }
+
+    @Test
+    public void testStructElementReversedOperandsRewrite() {
+        // '' = struct_element(struct_col, 'f3') → length(struct_element(struct_col, 'f3')) = 0
+        SlotReference structSlot = new SlotReference("struct_col",
+                new StructType(ImmutableList.of(
+                        new StructField("f1", IntegerType.INSTANCE, true, ""),
+                        new StructField("f3", StringType.INSTANCE, true, "")
+                )), true);
+        StructElement structElement = new StructElement(structSlot, new VarcharLiteral("f3"));
+        VarcharLiteral empty = new VarcharLiteral("");
+        assertRuleRewrite(
+                new EqualTo(empty, structElement),
+                new EqualTo(new Length(structElement), new IntegerLiteral(0))
+        );
+    }
+
+    @Test
+    public void testNotStructElementEqualEmptyRewrite() {
+        // NOT(struct_element(struct_col, 'f3') = '') → NOT(length(struct_element(struct_col, 'f3')) = 0)
+        SlotReference structSlot = new SlotReference("struct_col",
+                new StructType(ImmutableList.of(
+                        new StructField("f1", IntegerType.INSTANCE, true, ""),
+                        new StructField("f3", StringType.INSTANCE, true, "")
+                )), true);
+        StructElement structElement = new StructElement(structSlot, new VarcharLiteral("f3"));
+        VarcharLiteral empty = new VarcharLiteral("");
+        assertRuleRewrite(
+                new Not(new EqualTo(structElement, empty)),
+                new Not(new EqualTo(new Length(structElement), new IntegerLiteral(0)))
+        );
     }
 }

--- a/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
+++ b/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
@@ -299,6 +299,27 @@ suite("string_length_column_pruning") {
         notContains "type=bigint"
     }
 
+    // ─── Struct field empty-string rewrite cases ────────────────────────────────
+
+    // element_at(struct_col, 'f3') = '' rewrites to length(element_at(struct_col, 'f3')) = 0
+    // → OFFSET optimization applies to the struct string field
+    explain {
+        sql "select 1 from slcp_str_tbl where element_at(struct_col, 'f3') = ''"
+        contains "length"
+        contains "nested columns"
+        contains "OFFSET"
+        notContains "type=bigint"
+    }
+
+    // element_at(struct_col, 'f3') <> '' rewrites to length(element_at(struct_col, 'f3')) != 0
+    explain {
+        sql "select 1 from slcp_str_tbl where element_at(struct_col, 'f3') <> ''"
+        contains "length"
+        contains "nested columns"
+        contains "OFFSET"
+        notContains "type=bigint"
+    }
+
     // Struct field also projected directly → field access is full, not OFFSET-only
     // The struct's nested-columns entry still appears (partial struct pruning),
     // but the pruned field type must remain text (not bigint).


### PR DESCRIPTION
…

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: StringEmptyToLengthRule only rewrites `str_col = ''` to `length(str_col) = 0` when the non-literal side is a direct SlotReference. This means expressions like `element_at(struct_col, 'f3') = ''` (which becomes `struct_element(struct_col, 'f3') = ''` after analysis) are not rewritten, preventing the OFFSET-only column reading optimization from applying to struct string fields.

### Release note

StringEmptyToLengthRule now rewrites any string-typed expression compared against an empty string literal, not just direct column references. This enables the OFFSET optimization for struct field access patterns like `element_at(struct_col, 'f3') = ''`.

### Check List (For Author)

- Test: Unit Test + Regression test
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

