### PR TITLE
[enhance](insert) support observe insert by show load when loading

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/InsertLoadJob.java
@@ -53,8 +53,10 @@ public class InsertLoadJob extends LoadJob {
         super(EtlJobType.INSERT);
     }
 
-    public InsertLoadJob(long dbId, String label, long jobId) {
+    public InsertLoadJob(long dbId, String label, long jobId, long tableId, String dbName, String tableName,
+            UserIdentity userInfo) {
         super(EtlJobType.INSERT, dbId, label, jobId);
+        initializeRunningJob(tableId, dbName, tableName, userInfo);
     }
 
     public InsertLoadJob(String label, long transactionId, long dbId, long tableId,
@@ -90,6 +92,12 @@ public class InsertLoadJob extends LoadJob {
         this.authorizationInfo = gatherAuthInfo();
         this.loadingStatus.setTrackingUrl(trackingUrl);
         this.loadingStatus.setFirstErrorMsg(firstErrorMsg);
+        this.userInfo = userInfo;
+    }
+
+    private void initializeRunningJob(long tableId, String dbName, String tableName, UserIdentity userInfo) {
+        this.tableId = tableId;
+        this.authorizationInfo = new AuthorizationInfo(dbName, Sets.newHashSet(tableName));
         this.userInfo = userInfo;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -99,7 +99,8 @@ public abstract class AbstractInsertExecutor {
             Optional<InsertCommandContext> insertCtx, boolean emptyInsert, long jobId) {
         this.ctx = ctx;
         this.database = table.getDatabase();
-        this.insertLoadJob = new InsertLoadJob(database.getId(), labelName, jobId);
+        this.insertLoadJob = new InsertLoadJob(database.getId(), labelName, jobId, table.getId(),
+                database.getFullName(), table.getName(), ctx.getCurrentUserIdentity());
         // Do not add load job if job id is -1.
         if (jobId != -1) {
             ctx.getEnv().getLoadManager().addLoadJob(insertLoadJob);


### PR DESCRIPTION
Support observe insert by show load when loading:
```
*************************** 97. row ***************************
         JobId: 1775813665622
         Label: label_6a5633eadd64c2a_a4a02ef7c3e02cde
         State: PENDING
      Progress: 0%
          Type: INSERT
       EtlInfo: NULL
      TaskInfo: cluster:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: NULL
    CreateTime: 2026-04-10 17:43:34
  EtlStartTime: NULL
 EtlFinishTime: NULL
 LoadStartTime: NULL
LoadFinishTime: NULL
           URL: NULL
    JobDetails: {"ScannedRows":87629968,"LoadBytes":14283684784,"FileNumber":0,"FileSize":0,"TaskNumber":1,"Unfinished backends":[],"All backends":[1775813653513,1775813653511,1775813653509]}
 TransactionId: 0
  ErrorTablets: {}
          User: root
       Comment: 
 FirstErrorMsg:
```
