### PR TITLE
[fix](fe) Force copy-dependencies on cache hits

### DIFF
--- a/fe/.mvn/maven-build-cache-config.xml
+++ b/fe/.mvn/maven-build-cache-config.xml
@@ -57,6 +57,18 @@ under the License.
                         <execId>validate</execId>
                     </execIds>
                 </execution>
+                <!-- dependency:copy-dependencies writes JARs to target/lib/ which the build
+                     scripts later copy into the output directory. The cache extension only
+                     restores the primary JAR artifact on a hit, not the target/lib/ tree.
+                     When combined with a clean build, target/lib/ is
+                     deleted by the clean phase and never recreated, causing "cp: cannot stat
+                     target/lib/*" failures. Force this goal to always run so that the lib
+                     directory is always populated regardless of cache state. -->
+                <execution artifactId="maven-dependency-plugin">
+                    <execIds>
+                        <execId>copy-dependencies</execId>
+                    </execIds>
+                </execution>
             </executions>
         </runAlways>
     </executionControl>


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: FE builds that hit the Maven build cache can skip `maven-dependency-plugin:copy-dependencies`, leaving `target/lib` empty after a clean build. When `build.sh` later copies frontend libraries into `output`, it can fail with `cp: cannot stat target/lib/*`.

### Release note

None

### Check List (For Author)

- Test: `./build.sh --fe -j48`
    - Manual test
- Behavior changed: Yes (cached FE builds now always repopulate `target/lib`)
- Does this need documentation: No
