### PR TITLE
[fix](cdc) close snapshot readers on re-prepare and harden REST error handling

### DIFF
--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/controller/ClientController.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/controller/ClientController.java
@@ -105,15 +105,25 @@ public class ClientController {
     @RequestMapping(path = "/api/fetchEndOffset", method = RequestMethod.POST)
     public Object fetchEndOffset(@RequestBody JobBaseConfig jobConfig) {
         LOG.info("Fetching end offset for job {}", jobConfig.getJobId());
-        SourceReader reader = Env.getCurrentEnv().getReader(jobConfig);
-        return RestResponse.success(reader.getEndOffset(jobConfig));
+        try {
+            SourceReader reader = Env.getCurrentEnv().getReader(jobConfig);
+            return RestResponse.success(reader.getEndOffset(jobConfig));
+        } catch (Exception ex) {
+            LOG.error("Failed to fetch end offset, jobId={}", jobConfig.getJobId(), ex);
+            return RestResponse.internalError(ExceptionUtils.getRootCauseMessage(ex));
+        }
     }
 
     /** compare datasource Binlog Offset */
     @RequestMapping(path = "/api/compareOffset", method = RequestMethod.POST)
     public Object compareOffset(@RequestBody CompareOffsetRequest compareOffsetRequest) {
-        SourceReader reader = Env.getCurrentEnv().getReader(compareOffsetRequest);
-        return RestResponse.success(reader.compareOffset(compareOffsetRequest));
+        try {
+            SourceReader reader = Env.getCurrentEnv().getReader(compareOffsetRequest);
+            return RestResponse.success(reader.compareOffset(compareOffsetRequest));
+        } catch (Exception ex) {
+            LOG.error("Failed to compare offset, jobId={}", compareOffsetRequest.getJobId(), ex);
+            return RestResponse.internalError(ExceptionUtils.getRootCauseMessage(ex));
+        }
     }
 
     /** Close job */

--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/JdbcIncrementalSourceReader.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/JdbcIncrementalSourceReader.java
@@ -261,7 +261,21 @@ public abstract class JdbcIncrementalSourceReader extends AbstractCdcSourceReade
             activePollFutures = null;
         }
 
-        // Clear previous contexts
+        // Close previous readers before clearing to avoid JDBC connection leak
+        if (!this.snapshotReaderContexts.isEmpty()) {
+            LOG.info(
+                    "Closing {} previous snapshot readers before preparing new splits",
+                    snapshotReaderContexts.size());
+            for (SnapshotReaderContext<
+                            org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit,
+                            Fetcher<SourceRecords, SourceSplitBase>,
+                            SnapshotSplitState>
+                    context : snapshotReaderContexts) {
+                if (context.getReader() != null) {
+                    closeReaderInternal(context.getReader());
+                }
+            }
+        }
         this.snapshotReaderContexts.clear();
         this.completedSplitIds.clear();
 

--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/mysql/MySqlSourceReader.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/source/reader/mysql/MySqlSourceReader.java
@@ -272,7 +272,19 @@ public class MySqlSourceReader extends AbstractCdcSourceReader {
             activePollFutures = null;
         }
 
-        // Clear previous contexts
+        // Close previous readers before clearing to avoid JDBC connection leak
+        if (!this.snapshotReaderContexts.isEmpty()) {
+            LOG.info(
+                    "Closing {} previous snapshot readers before preparing new splits",
+                    snapshotReaderContexts.size());
+            for (SnapshotReaderContext<
+                            MySqlSnapshotSplit, SnapshotSplitReader, MySqlSnapshotSplitState>
+                    context : snapshotReaderContexts) {
+                if (context.getReader() != null) {
+                    context.getReader().close();
+                }
+            }
+        }
         this.snapshotReaderContexts.clear();
         this.completedSplitIds.clear();
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

This PR fixes two independent issues in the `cdc_client` module:

1. **JDBC connection leak on snapshot re-prepare** (`JdbcIncrementalSourceReader`, `MySqlSourceReader`)
   `prepareSnapshotSplits` used to call `snapshotReaderContexts.clear()` directly, dropping references to the previous snapshot split readers without closing them. Each reader owns a JDBC connection (plus a Debezium queue), so every re-prepare leaked connections until the upstream database hit its connection limit. The fix closes every previous reader before clearing the context list.

2. **Unhandled exceptions in REST endpoints** (`ClientController`)
   `/api/fetchEndOffset` and `/api/compareOffset` propagated any exception from the underlying `SourceReader` as an unhandled 500 with no useful body. They are now wrapped in try/catch, logged with the `jobId`, and return `RestResponse.internalError(rootCauseMessage)` so the caller gets an actionable error.

### Release note

Fix JDBC connection leak in cdc_client snapshot reader re-prepare, and return structured error responses from `fetchEndOffset` / `compareOffset` instead of unhandled 500s.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] Previous test can cover this change.

- Behavior changed:
    - [x] Yes.
      - `fetchEndOffset` / `compareOffset` no longer throw unhandled exceptions; failures now return `internalError` with the root cause message.
      - Previous snapshot split readers are closed before being dropped on re-prepare.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label