### PR TITLE
[Update](p0) control python version via conf in p0-test

### DIFF
--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -334,3 +334,6 @@ hudiMinioAccessKey="minio"
 hudiMinioSecretKey="minio123"
 
 icebergDlfRestCatalog="'type' = 'iceberg', 'warehouse' = 'new_dlf_iceberg_catalog', 'iceberg.catalog.type' = 'rest', 'iceberg.rest.uri' = 'http://cn-beijing-vpc.dlf.aliyuncs.com/iceberg', 'iceberg.rest.sigv4-enabled' = 'true', 'iceberg.rest.signing-name' = 'DlfNext', 'iceberg.rest.access-key-id' = 'ak', 'iceberg.rest.secret-access-key' = 'sk', 'iceberg.rest.signing-region' = 'cn-beijing', 'iceberg.rest.vended-credentials-enabled' = 'true', 'io-impl' = 'org.apache.iceberg.rest.DlfFileIO', 'fs.oss.support' = 'true'"
+
+// For python UDF test, set the runtime version of python, default: 3.8.10
+// pythonUdfRuntimeVersion = ""

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -140,6 +140,10 @@ class Suite implements GroovyInterceptable {
         return p
     }
 
+    String getPythonUdfRuntimeVersion() {
+        return getConf("pythonUdfRuntimeVersion", "3.8.10")
+    }
+
     void onSuccess(Closure callback) {
         successCallbacks.add(callback)
     }

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_basic.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_basic.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudaf_basic") {
     def pyPath = """${context.file.parent}/udaf_scripts/pyudaf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_aggregation_inline.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_aggregation_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudaf_complex_aggregation_inline") {
     // Test complex aggregation scenarios with Python UDAFs
     // Including: variance, standard deviation, median, percentile, collect_list
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table with statistical data
@@ -68,7 +68,7 @@ suite("test_pythonudaf_complex_aggregation_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "VarianceUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class VarianceUDAF:
@@ -116,7 +116,7 @@ class VarianceUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "StdDevUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import math
@@ -166,7 +166,7 @@ class StdDevUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "MedianUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class MedianUDAF:
@@ -211,7 +211,7 @@ class MedianUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "CollectListUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class CollectListUDAF:
@@ -251,7 +251,7 @@ class CollectListUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "RangeUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class RangeUDAF:
@@ -300,7 +300,7 @@ class RangeUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "GeometricMeanUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import math
@@ -345,7 +345,7 @@ class GeometricMeanUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "WeightedAvgUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class WeightedAvgUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_aggregation_module.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_aggregation_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudaf_complex_aggregation_module") {
     
     def pyPath = """${context.file.parent}/udaf_scripts/pyudaf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_state_objects_inline.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_state_objects_inline.groovy
@@ -25,7 +25,7 @@ suite("test_pythonudaf_complex_state_objects_inline") {
     // 5. Named tuples
     // 6. Mixed complex structures
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_state_objects_module.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_complex_state_objects_module.groovy
@@ -22,7 +22,7 @@ suite("test_pythonudaf_complex_state_objects_module") {
     
     def pyPath = """${context.file.parent}/udaf_scripts/pyudaf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_concurrent.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_concurrent.groovy
@@ -18,6 +18,7 @@
 suite("test_pythonudaf_concurrent") {
     // Test multiple Python UDAFs executing concurrently in the same SQL query
     // This is the key test case to verify the fix for multi-UDAF state management
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table
@@ -58,7 +59,7 @@ suite("test_pythonudaf_concurrent") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumUDAF:
@@ -89,7 +90,7 @@ class SumUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "CountUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class CountUDAF:
@@ -120,7 +121,7 @@ class CountUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "AvgUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class AvgUDAF:
@@ -157,7 +158,7 @@ class AvgUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "MaxUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class MaxUDAF:
@@ -191,7 +192,7 @@ class MaxUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "MinUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class MinUDAF:
@@ -225,7 +226,7 @@ class MinUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumDoubleUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumDoubleUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_data_types.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_data_types.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudaf_data_types") {
     // Test Python UDAFs with various data types
     // Including: TINYINT, SMALLINT, INT, BIGINT, FLOAT, DOUBLE, DECIMAL, STRING, DATE, DATETIME
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table with various data types
@@ -64,7 +64,7 @@ suite("test_pythonudaf_data_types") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumTinyIntUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumTinyIntUDAF:
@@ -99,7 +99,7 @@ class SumTinyIntUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumSmallIntUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumSmallIntUDAF:
@@ -134,7 +134,7 @@ class SumSmallIntUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumBigIntUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumBigIntUDAF:
@@ -169,7 +169,7 @@ class SumBigIntUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumFloatUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumFloatUDAF:
@@ -204,7 +204,7 @@ class SumFloatUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumDecimalUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumDecimalUDAF:
@@ -239,7 +239,7 @@ class SumDecimalUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "ConcatStrUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class ConcatStrUDAF:
@@ -277,7 +277,7 @@ class ConcatStrUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "CountTrueUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class CountTrueUDAF:
@@ -327,7 +327,7 @@ class CountTrueUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "IntToDoubleSumUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class IntToDoubleSumUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_drop.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_drop.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite('test_pythonudaf_drop') {
-    def runtime_version = '3.8.10'
+    def runtime_version = getPythonUdfRuntimeVersion()
     def zipA = """${context.file.parent}/udaf_scripts/python_udaf_drop_a/python_udaf_drop_test.zip"""
     def zipB = """${context.file.parent}/udaf_scripts/python_udaf_drop_b/python_udaf_drop_test.zip"""
 

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_edge_cases.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_edge_cases.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudaf_edge_cases") {
     // Test Python UDAFs with edge cases and boundary values
     // Including: very large numbers, very small numbers, negative numbers, zero, duplicates
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table with edge cases
@@ -65,7 +65,7 @@ suite("test_pythonudaf_edge_cases") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumLargeUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumLargeUDAF:
@@ -103,7 +103,7 @@ class SumLargeUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "MinValUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class MinValUDAF:
@@ -141,7 +141,7 @@ class MinValUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "MaxValUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class MaxValUDAF:
@@ -179,7 +179,7 @@ class MaxValUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "CountDistinctUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class CountDistinctUDAF:
@@ -218,7 +218,7 @@ class CountDistinctUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "ProductUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class ProductUDAF:
@@ -261,7 +261,7 @@ class ProductUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "AbsSumUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class AbsSumUDAF:
@@ -299,7 +299,7 @@ class AbsSumUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SafeAvgUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SafeAvgUDAF:
@@ -343,7 +343,7 @@ class SafeAvgUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SignSummaryUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SignSummaryUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_forbidden_module.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_forbidden_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudaf_forbidden_module") {
 
     def pyPath = """${context.file.parent}/udaf_scripts/python_udaf_forbidden_module.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def forbiddenCases = [
         [name: "os", function: "py_forbidden_os_udaf", symbol: "os.ForbiddenUDAF"],
         [name: "pathlib", function: "py_forbidden_pathlib_udaf", symbol: "pathlib.ForbiddenUDAF"],

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_inline.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_inline.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudaf_inline") {
     // Test Python UDAF using Inline mode
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table
@@ -55,7 +55,7 @@ suite("test_pythonudaf_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumUDAF:
@@ -101,7 +101,7 @@ class SumUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "AvgUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class AvgUDAF:
@@ -151,7 +151,7 @@ class AvgUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "CountUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class CountUDAF:
@@ -195,7 +195,7 @@ class CountUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "MaxUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class MaxUDAF:
@@ -289,7 +289,7 @@ class MaxUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_inline_simple.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_inline_simple.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudaf_inline_simple") {
     // Simplest Python UDAF test using inline mode
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_nested_query.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_nested_query.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudaf_nested_query") {
     // Test Python UDAFs in complex nested queries, subqueries, CTEs, and JOINs
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create orders table
@@ -87,7 +87,7 @@ suite("test_pythonudaf_nested_query") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "TotalRevenueUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class TotalRevenueUDAF:
@@ -118,7 +118,7 @@ class TotalRevenueUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "OrderCountUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class OrderCountUDAF:
@@ -149,7 +149,7 @@ class OrderCountUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "AvgOrderValueUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class AvgOrderValueUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_null_handling.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_null_handling.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudaf_null_handling") {
     // Test NULL handling in Python UDAFs
     // This is critical for data quality and edge cases
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table with NULLs
@@ -63,7 +63,7 @@ suite("test_pythonudaf_null_handling") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "CountNonNullUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class CountNonNullUDAF:
@@ -100,7 +100,7 @@ class CountNonNullUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "SumNullUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class SumNullUDAF:
@@ -141,7 +141,7 @@ class SumNullUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "FirstNonNullUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class FirstNonNullUDAF:
@@ -179,7 +179,7 @@ class FirstNonNullUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "CountNullUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class CountNullUDAF:
@@ -216,7 +216,7 @@ class CountNullUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "AvgCoalesceUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class AvgCoalesceUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_pkg_isolation.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_pkg_isolation.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite('test_pythonudaf_pkg_isolation') {
-    def runtime_version = '3.8.10'
+    def runtime_version = getPythonUdfRuntimeVersion()
     def zipA = """${context.file.parent}/udaf_scripts/python_udaf_pkg_a/python_udaf_pkg_test.zip"""
     def zipB = """${context.file.parent}/udaf_scripts/python_udaf_pkg_b/python_udaf_pkg_test.zip"""
 

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_simple.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_simple.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudaf_simple") {
     def pyPath = """${context.file.parent}/udaf_scripts/pyudaf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     def tableName = "test_pythonudaf_simple"

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_window_advanced_inline.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_window_advanced_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudaf_window_advanced_inline") {
     // Advanced window function tests with Python UDAFs
     // Including: moving averages, percentiles, custom analytics
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create time series data for advanced analytics
@@ -68,7 +68,7 @@ suite("test_pythonudaf_window_advanced_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "MovingAvgUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class MovingAvgUDAF:
@@ -104,7 +104,7 @@ class MovingAvgUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "WindowStdDevUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import math
@@ -144,7 +144,7 @@ class WindowStdDevUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "LastValueUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class LastValueUDAF:
@@ -178,7 +178,7 @@ class LastValueUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "WindowMinUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class WindowMinUDAF:
@@ -211,7 +211,7 @@ class WindowMinUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "WindowMaxUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class WindowMaxUDAF:
@@ -430,7 +430,7 @@ class WindowMaxUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "Percentile50UDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class Percentile50UDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_window_advanced_module.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_window_advanced_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudaf_window_advanced_module") {
     
     def pyPath = """${context.file.parent}/udaf_scripts/pyudaf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudaf_p0/test_pythonudaf_window_functions.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudaf_window_functions.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudaf_window_functions") {
     // Test Python UDAFs with window functions (OVER clause)
     // This tests PARTITION BY, ORDER BY, and frame specifications
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create sales data table for window function tests
@@ -72,7 +72,7 @@ suite("test_pythonudaf_window_functions") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "RunningSumUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class RunningSumUDAF:
@@ -105,7 +105,7 @@ class RunningSumUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "RunningCountUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class RunningCountUDAF:
@@ -138,7 +138,7 @@ class RunningCountUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "RunningAvgUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class RunningAvgUDAF:
@@ -408,7 +408,7 @@ class RunningAvgUDAF:
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "WindowFirstUDAF",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 class WindowFirstUDAF:

--- a/regression-test/suites/pythonudaf_p0/test_pythonudf_udaf_mixed.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudf_udaf_mixed.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudf_udaf_mixed") {
     // Test mixing Python scalar UDFs and aggregate UDAFs in the same query
     // This verifies that UDFs and UDAFs can coexist and work correctly together
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table

--- a/regression-test/suites/pythonudaf_p0/test_pythonudwf_comprehensive.groovy
+++ b/regression-test/suites/pythonudaf_p0/test_pythonudwf_comprehensive.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudwf_comprehensive") {
     // Comprehensive test suite for Python User-Defined Window Functions (UDWF)
     // Tests cover: PARTITION BY, ORDER BY, frame specifications, edge cases, and complex scenarios
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================

--- a/regression-test/suites/pythonudf_complex_p0/test_python_udaf_complex.groovy
+++ b/regression-test/suites/pythonudf_complex_p0/test_python_udaf_complex.groovy
@@ -21,7 +21,7 @@ suite("test_python_udaf_complex") {
 
     def pyPath = """${context.file.parent}/py_udf_complex_scripts/py_udf_complex.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
 
     try {

--- a/regression-test/suites/pythonudf_complex_p0/test_python_udf_business_logic.groovy
+++ b/regression-test/suites/pythonudf_complex_p0/test_python_udf_business_logic.groovy
@@ -21,7 +21,7 @@ suite("test_python_udf_business_logic") {
 
     def pyPath = """${context.file.parent}/py_udf_complex_scripts/py_udf_complex.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
 
     try {

--- a/regression-test/suites/pythonudf_complex_p0/test_python_udf_external_api.groovy
+++ b/regression-test/suites/pythonudf_complex_p0/test_python_udf_external_api.groovy
@@ -22,7 +22,7 @@ suite("test_python_udf_external_api") {
 
     def pyPath = """${context.file.parent}/py_udf_complex_scripts/py_udf_complex.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
 
     try {
         // Test 1-5: JSONPlaceholder FIXED responses - qt_ tests

--- a/regression-test/suites/pythonudf_complex_p0/test_python_udf_nlp_chinese.groovy
+++ b/regression-test/suites/pythonudf_complex_p0/test_python_udf_nlp_chinese.groovy
@@ -21,7 +21,7 @@ suite("test_python_udf_nlp_chinese") {
 
     def pyPath = """${context.file.parent}/py_udf_complex_scripts/py_udf_complex.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
 
     try {

--- a/regression-test/suites/pythonudf_complex_p0/test_python_udtf_complex.groovy
+++ b/regression-test/suites/pythonudf_complex_p0/test_python_udtf_complex.groovy
@@ -21,7 +21,7 @@ suite("test_python_udtf_complex") {
 
     def pyPath = """${context.file.parent}/py_udf_complex_scripts/py_udf_complex.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
 
     try {

--- a/regression-test/suites/pythonudf_p0/sanity/test_pythonudf_assertequal.groovy
+++ b/regression-test/suites/pythonudf_p0/sanity/test_pythonudf_assertequal.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_assertequal") {
     def pyPath = """${context.file.parent}/../udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS test_pythonudf_assertequal """

--- a/regression-test/suites/pythonudf_p0/sanity/test_pythonudf_assertlessthan.groovy
+++ b/regression-test/suites/pythonudf_p0/sanity/test_pythonudf_assertlessthan.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudf_assertlessthan") {
     def tableName = "test_pythonudf_assertlessthan"
     def pyPath = """${context.file.parent}/../udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS test_pythonudf_assertlessthan """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_aggregate.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_aggregate.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_pythonudf_aggregate") {
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
 
     try {
         // Test 1: Create simple aggregate function (although Python UDF is mainly for scalar functions)

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_always_nullable.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_always_nullable.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_always_nullable") {
     // Test different configurations of always_nullable parameter
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     try {
         // Test 1: always_nullable = true (default value)
         sql """ DROP FUNCTION IF EXISTS py_nullable_true(INT); """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_array.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_array.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_array") {
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS test_pythonudf_array """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_base_data_type.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_base_data_type.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_base_data_type") {
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
 
     // TEST INLINE CASE

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_boolean.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_boolean.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_boolean") {
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS test_pythonudf_boolean """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_complex_data_type.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_complex_data_type.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_complex_data_type") {
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
 
     // TEST ARRAY INLINE CASE

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_concurrent.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_concurrent.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_concurrent") {
     // Test multiple Python UDFs executing concurrently in the same SQL query
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_data_types.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_data_types.groovy
@@ -17,7 +17,7 @@
 
 suite("test_pythonudf_data_types") {
     // Test various data types supported by Python UDF
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Test 1: TINYINT type

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_drop.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_drop.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_pythonudf_drop") {
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def zipA = """${context.file.parent}/udf_scripts/python_udf_drop_a/python_udf_drop_test.zip"""
     def zipB = """${context.file.parent}/udf_scripts/python_udf_drop_b/python_udf_drop_test.zip"""
 

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_error_handling.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_error_handling.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_error_handling") {
     // Test error handling and exception cases for Python UDF
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     try {
         // Test 1: Division by zero error handling
         sql """ DROP FUNCTION IF EXISTS py_safe_divide(DOUBLE, DOUBLE); """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_file_protocol.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_file_protocol.groovy
@@ -20,7 +20,7 @@ suite("test_pythonudf_file_protocol") {
     
     def zipPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(zipPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${zipPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_float.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_float.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_float") {
     def pyPath   = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS test_pythonudf_float """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_forbidden_module.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_forbidden_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudf_forbidden_module") {
 
     def pyPath = """${context.file.parent}/udf_scripts/python_udf_forbidden_module.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def forbiddenCases = [
         [name: "threading", function: "py_forbidden_threading", symbol: "threading.evaluate"],
         [name: "json", function: "py_forbidden_json", symbol: "json.evaluate"],

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_global_function.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_global_function.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_global_function") {
     // Test creating global Python UDF with GLOBAL keyword
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     try {
         // Test 1: Create GLOBAL function
         sql """ DROP GLOBAL FUNCTION IF EXISTS py_global_multiply(INT, INT); """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_inline_complex.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_inline_complex.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_inline_complex") {
     // Test complex Python UDF using Inline mode
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     try {
         // Test 1: Array processing
         sql """ DROP FUNCTION IF EXISTS py_array_sum(ARRAY<INT>); """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_inline_scalar.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_inline_scalar.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_inline_basic") {
     // Test basic Python UDF using Inline mode
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     try {
         // Test 1: Simple integer addition
         sql """ DROP FUNCTION IF EXISTS py_add(INT, INT); """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_inline_vector.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_inline_vector.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_inline_vector") {
     // Test vectorized Python UDF using Inline mode with pandas.Series
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     try {
         // Create test table
         sql """ DROP TABLE IF EXISTS vector_udf_test_table; """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_int.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_int.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_int") {
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS test_pythonudf_int """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_ip.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_ip.groovy
@@ -17,7 +17,7 @@
 
 suite("test_pythonudf_ip") {
     def tableName = "test_pythonudf_ip_table"
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
 
     sql """ DROP TABLE IF EXISTS ${tableName} """
     sql """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_map.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_map.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_map") {
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         try_sql("DROP FUNCTION IF EXISTS udfii(Map<INT, INT>);")

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_mixed_params.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_mixed_params.groovy
@@ -24,7 +24,7 @@ suite("test_pythonudf_mixed_params") {
     //   - pd.Series parameters (process entire column)
     //   - scalar parameters (single value like int, float, str)
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_module.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_module.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_module") {
     def pyPath = """${context.file.parent}/udf_scripts/python_udf_module_test.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP FUNCTION IF EXISTS python_udf_ltv_score(BIGINT, BIGINT, DOUBLE); """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_module_advanced.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_module_advanced.groovy
@@ -20,7 +20,7 @@ suite("test_pythonudf_module_advanced") {
     
     def zipPath = """${context.file.parent}/udf_scripts/python_udf_module_test.zip"""
     scp_udf_file_to_all_be(zipPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${zipPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_module_scalar.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_module_scalar.groovy
@@ -20,7 +20,7 @@ suite("test_pythonudf_module_scalar") {
     
     def pyPath = """${context.file.parent}/udf_scripts/python_udf_scalar_ops.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     log.info("Python module path: ${pyPath}".toString())
     

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_module_vector.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_module_vector.groovy
@@ -20,7 +20,7 @@ suite("test_pythonudf_module_vector") {
     
     def pyPath = """${context.file.parent}/udf_scripts/python_udf_vector_ops.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     log.info("Python module path: ${pyPath}".toString())
     

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_multiline_inline.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_multiline_inline.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_multiline_inline") {
     // Test complex multi-line inline Python code
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     try {
         // Test 1: Inline code with helper functions
         sql """ DROP FUNCTION IF EXISTS py_complex_calculation(INT, INT); """

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_pkg_isolation.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_pkg_isolation.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_pythonudf_pkg_isolation") {
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def zipA = """${context.file.parent}/udf_scripts/python_udf_pkg_a/python_udf_pkg_test.zip"""
     def zipB = """${context.file.parent}/udf_scripts/python_udf_pkg_b/python_udf_pkg_test.zip"""
 

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_ret_map.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_ret_map.groovy
@@ -18,7 +18,7 @@
 suite("test_pythonudf_ret_map") {
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         try_sql("DROP FUNCTION IF EXISTS retii(map<int,int>);")

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_schema_check.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_schema_check.groovy
@@ -20,7 +20,7 @@ suite("test_pythonudf_schema_check") {
     // Users can specify compatible types instead of exact matching types
     // For example: TINYINT can be used where INT is expected
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // Create test table with various integer types

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_string.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_string.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudf_string") {
     def tableName = "test_pythonudf_string"
     def pyPath = """${context.file.parent}/udf_scripts/pyudf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python Zip path: ${pyPath}".toString())
     try {
         sql """ DROP TABLE IF EXISTS test_pythonudf_string """

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_basic_inline.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_basic_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudtf_basic_inline") {
     // Basic Python UDTF tests following Snowflake syntax
     // UDTF (User-Defined Table Function) returns table (multiple rows) from scalar/table input
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================
@@ -34,7 +34,7 @@ suite("test_pythonudtf_basic_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "split_string_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def split_string_udtf(input_str):
@@ -79,7 +79,7 @@ def split_string_udtf(input_str):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "generate_series_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def generate_series_udtf(start, end):
@@ -131,7 +131,7 @@ def generate_series_udtf(start, end):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "running_sum_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def running_sum_udtf(value):
@@ -180,7 +180,7 @@ def running_sum_udtf(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "explode_json_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import json
@@ -230,7 +230,7 @@ def explode_json_udtf(json_str):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "top_n_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def top_n_udtf(value, n):
@@ -282,7 +282,7 @@ def top_n_udtf(value, n):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "duplicate_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def duplicate_udtf(text, n):
@@ -326,7 +326,7 @@ def duplicate_udtf(text, n):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "filter_positive_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def filter_positive_udtf(value):
@@ -370,7 +370,7 @@ def filter_positive_udtf(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "cartesian_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def cartesian_udtf(list1, list2):
@@ -419,7 +419,7 @@ def cartesian_udtf(list1, list2):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "filter_negative_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def filter_negative_udtf(value):
@@ -513,7 +513,7 @@ def filter_negative_udtf(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "nullable_processor_udtf",
-            "runtime_version" = "3.8.10",
+            "runtime_version" = "${runtime_version}",
             "always_nullable" = "true"
         )
         AS \$\$
@@ -562,7 +562,7 @@ def nullable_processor_udtf(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "non_nullable_processor_udtf",
-            "runtime_version" = "3.8.10",
+            "runtime_version" = "${runtime_version}",
             "always_nullable" = "false"
         )
         AS \$\$
@@ -644,7 +644,7 @@ def non_nullable_processor_udtf(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "default_nullable_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def default_nullable_udtf(text):
@@ -690,7 +690,7 @@ def default_nullable_udtf(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "nullable_explode_udtf",
-            "runtime_version" = "3.8.10",
+            "runtime_version" = "${runtime_version}",
             "always_nullable" = "true"
         )
         AS \$\$
@@ -747,7 +747,7 @@ def nullable_explode_udtf(csv_string):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "scalar_int_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def scalar_int_udtf(start, end):
@@ -773,7 +773,7 @@ def scalar_int_udtf(start, end):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "scalar_string_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def scalar_string_udtf(text):
@@ -799,7 +799,7 @@ def scalar_string_udtf(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "mixed_style_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def mixed_style_udtf(n):
@@ -829,7 +829,7 @@ def mixed_style_udtf(n):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "return_scalar_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def return_scalar_udtf(text):
@@ -853,7 +853,7 @@ def return_scalar_udtf(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "multi_field_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def multi_field_udtf(n):
@@ -884,7 +884,7 @@ def multi_field_udtf(n):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_value_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_value_udtf(value):
@@ -939,7 +939,7 @@ def process_value_udtf(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "split_words_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def split_words_udtf(text):
@@ -996,7 +996,7 @@ def split_words_udtf(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "expand_range_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def expand_range_udtf(n):
@@ -1052,7 +1052,7 @@ def expand_range_udtf(n):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "parse_csv_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def parse_csv_udtf(csv_line):
@@ -1212,7 +1212,7 @@ def parse_csv_udtf(csv_line):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "largeint_expand_udtf",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def largeint_expand_udtf(val):

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_basic_module.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_basic_module.groovy
@@ -20,7 +20,7 @@ suite("test_pythonudtf_basic_module") {
     
     def pyPath = """${context.file.parent}/udtf_scripts/pyudtf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_data_types_inline.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_data_types_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudtf_data_types_inline") {
     // Test Python UDTF with Various Data Types
     // Coverage: Basic types, numeric types, date/time types, complex types
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================
@@ -32,7 +32,7 @@ suite("test_pythonudtf_data_types_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_tinyint",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_tinyint(v):
@@ -74,7 +74,7 @@ def process_tinyint(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_smallint",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_smallint(v):
@@ -116,7 +116,7 @@ def process_smallint(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_bigint",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_bigint(v):
@@ -158,7 +158,7 @@ def process_bigint(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_float",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_float(v):
@@ -200,7 +200,7 @@ def process_float(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_double",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import math
@@ -244,7 +244,7 @@ def process_double(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_boolean",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_boolean(v):
@@ -286,7 +286,7 @@ def process_boolean(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_string",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_string(v):
@@ -328,7 +328,7 @@ def process_string(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_date",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_date(v):
@@ -371,7 +371,7 @@ def process_date(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_datetime",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_datetime(v):
@@ -417,7 +417,7 @@ def process_datetime(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_array_int",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_array_int(arr):
@@ -464,7 +464,7 @@ def process_array_int(arr):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_array_string",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_array_string(arr):
@@ -510,7 +510,7 @@ def process_array_string(arr):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_struct",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_struct(person):
@@ -560,7 +560,7 @@ def process_struct(person):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_multi_types",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_multi_types(num, text):
@@ -603,7 +603,7 @@ def process_multi_types(num, text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_decimal",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 from decimal import Decimal
@@ -651,7 +651,7 @@ def process_decimal(v):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_map_string",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_map_string(map_str):
@@ -700,7 +700,7 @@ def process_map_string(map_str):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_nested_array",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_nested_array(nested_str):
@@ -752,7 +752,7 @@ def process_nested_array(nested_str):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_array_structs",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_array_structs(data):
@@ -801,7 +801,7 @@ def process_array_structs(data):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_struct_array",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_struct_array(data):
@@ -845,7 +845,7 @@ def process_struct_array(data):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "extract_json_fields",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import json
@@ -895,7 +895,7 @@ def extract_json_fields(json_str):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_complex_struct",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_complex_struct(data):

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_data_types_module.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_data_types_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudtf_data_types_module") {
     
     def pyPath = """${context.file.parent}/udtf_scripts/pyudtf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_drop.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_drop.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_pythonudtf_drop") {
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def zipA = """${context.file.parent}/udtf_scripts/python_udtf_drop_a/python_udtf_drop_test.zip"""
     def zipB = """${context.file.parent}/udtf_scripts/python_udtf_drop_b/python_udtf_drop_test.zip"""
 

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_edge_cases_inline.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_edge_cases_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudtf_edge_cases_inline") {
     // Test Python UDTF Edge Cases and Boundary Conditions
     // Coverage: NULL handling, extreme cases, special values
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================
@@ -34,7 +34,7 @@ suite("test_pythonudtf_edge_cases_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "handle_null_int",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def handle_null_int(value):
@@ -76,7 +76,7 @@ def handle_null_int(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "handle_null_string",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def handle_null_string(value):
@@ -120,7 +120,7 @@ def handle_null_string(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "handle_empty_array",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def handle_empty_array(arr):
@@ -167,7 +167,7 @@ def handle_empty_array(arr):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "handle_null_struct",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def handle_null_struct(person):
@@ -231,7 +231,7 @@ def handle_null_struct(person):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_empty_table",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_empty_table(value):
@@ -268,7 +268,7 @@ def process_empty_table(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_single_row",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_single_row(value):
@@ -309,7 +309,7 @@ def process_single_row(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_long_string",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_long_string(text):
@@ -354,7 +354,7 @@ def process_long_string(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_large_array",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_large_array(arr):
@@ -400,7 +400,7 @@ def process_large_array(arr):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "output_explosion",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def output_explosion(n):
@@ -446,7 +446,7 @@ def output_explosion(n):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_special_numbers",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_special_numbers(value):
@@ -504,7 +504,7 @@ def process_special_numbers(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_special_doubles",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import math
@@ -566,7 +566,7 @@ def process_special_doubles(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_special_strings",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_special_strings(text):
@@ -627,7 +627,7 @@ def process_special_strings(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_boundary_dates",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_boundary_dates(dt):

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_edge_cases_module.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_edge_cases_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudtf_edge_cases_module") {
     
     def pyPath = """${context.file.parent}/udtf_scripts/pyudtf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_exceptions_inline.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_exceptions_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudtf_exceptions_inline") {
     // Test Python UDTF Exception Handling
     // Coverage: Runtime errors, type errors, logic errors, edge cases
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================
@@ -34,7 +34,7 @@ suite("test_pythonudtf_exceptions_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "safe_divide",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def safe_divide(a, b):
@@ -85,7 +85,7 @@ def safe_divide(a, b):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "check_overflow",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def check_overflow(value):
@@ -145,7 +145,7 @@ def check_overflow(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "parse_number",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def parse_number(text):
@@ -197,7 +197,7 @@ def parse_number(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "check_type",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def check_type(value):
@@ -252,7 +252,7 @@ def check_type(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "safe_array_access",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def safe_array_access(arr, position):
@@ -304,7 +304,7 @@ def safe_array_access(arr, position):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "compute_stats",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def compute_stats(arr):
@@ -359,7 +359,7 @@ def compute_stats(arr):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "access_struct_fields",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def access_struct_fields(person):
@@ -416,7 +416,7 @@ def access_struct_fields(person):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "slice_string",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def slice_string(text, start, end):
@@ -477,7 +477,7 @@ def slice_string(text, start, end):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "check_text_encoding",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def check_text_encoding(text):
@@ -532,7 +532,7 @@ def check_text_encoding(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "process_conditional",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def process_conditional(value):
@@ -589,7 +589,7 @@ def process_conditional(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "conditional_yield",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def conditional_yield(value):
@@ -640,7 +640,7 @@ def conditional_yield(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "classify_number_range",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 import math
@@ -702,7 +702,7 @@ def classify_number_range(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "validate_date",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def validate_date(dt):

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_exceptions_module.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_exceptions_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudtf_exceptions_module") {
     
     def pyPath = """${context.file.parent}/udtf_scripts/pyudtf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_forbidden_module.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_forbidden_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudtf_forbidden_module") {
 
     def pyPath = """${context.file.parent}/udtf_scripts/python_udtf_forbidden_module.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def forbiddenCases = [
         [name: "importlib", function: "py_forbidden_importlib_udtf", symbol: "importlib.forbidden_udtf"],
         [name: "inspect", function: "py_forbidden_inspect_udtf", symbol: "inspect.forbidden_udtf"],

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_io_patterns_inline.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_io_patterns_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudtf_io_patterns_inline") {
     // Test Python UDTF Input/Output Patterns
     // Testing different cardinality patterns: 1-to-1, 1-to-N, 1-to-0, N-to-M
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================
@@ -33,7 +33,7 @@ suite("test_pythonudtf_io_patterns_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "one_to_one",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def one_to_one(value):
@@ -77,7 +77,7 @@ def one_to_one(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "one_to_many",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def one_to_many(n):
@@ -122,7 +122,7 @@ def one_to_many(n):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "one_to_zero",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def one_to_zero(value):
@@ -167,7 +167,7 @@ def one_to_zero(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "one_to_variable",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def one_to_variable(text):
@@ -223,7 +223,7 @@ def one_to_variable(text):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "aggregate_pattern",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def aggregate_pattern(value):
@@ -275,7 +275,7 @@ def aggregate_pattern(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "explosive",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def explosive(all_rows, all_cols):
@@ -322,7 +322,7 @@ def explosive(all_rows, all_cols):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "conditional",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def conditional(value):
@@ -376,7 +376,7 @@ def conditional(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "all_or_nothing",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def all_or_nothing(text, min_length):
@@ -429,7 +429,7 @@ def all_or_nothing(text, min_length):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "empty_input",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def empty_input(value):
@@ -469,7 +469,7 @@ def empty_input(value):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "batch_process",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def batch_process(value):

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_io_patterns_module.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_io_patterns_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudtf_io_patterns_module") {
     
     def pyPath = """${context.file.parent}/udtf_scripts/pyudtf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_pkg_isolation.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_pkg_isolation.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_pythonudtf_pkg_isolation") {
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def zipA = """${context.file.parent}/udtf_scripts/python_udtf_pkg_a/python_udtf_pkg_test.zip"""
     def zipB = """${context.file.parent}/udtf_scripts/python_udtf_pkg_b/python_udtf_pkg_test.zip"""
 

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_sql_integration_inline.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_sql_integration_inline.groovy
@@ -19,7 +19,7 @@ suite("test_pythonudtf_sql_integration_inline") {
     // Test Python UDTF Integration with SQL Operations
     // Coverage: WHERE, JOIN, GROUP BY, ORDER BY, LIMIT, Subqueries, CTEs
     
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     
     try {
         // ========================================
@@ -34,7 +34,7 @@ suite("test_pythonudtf_sql_integration_inline") {
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "split_with_position",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def split_with_position(text, delimiter):
@@ -54,7 +54,7 @@ def split_with_position(text, delimiter):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "generate_range",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def generate_range(start, end):
@@ -73,7 +73,7 @@ def generate_range(start, end):
         PROPERTIES (
             "type" = "PYTHON_UDF",
             "symbol" = "explode_with_index",
-            "runtime_version" = "3.8.10"
+            "runtime_version" = "${runtime_version}"
         )
         AS \$\$
 def explode_with_index(arr):

--- a/regression-test/suites/pythonudtf_p0/test_pythonudtf_sql_integration_module.groovy
+++ b/regression-test/suites/pythonudtf_p0/test_pythonudtf_sql_integration_module.groovy
@@ -21,7 +21,7 @@ suite("test_pythonudtf_sql_integration_module") {
     
     def pyPath = """${context.file.parent}/udtf_scripts/pyudtf.zip"""
     scp_udf_file_to_all_be(pyPath)
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     log.info("Python zip path: ${pyPath}".toString())
     
     try {

--- a/regression-test/suites/query_p0/show/test_nereids_show_functions.groovy
+++ b/regression-test/suites/query_p0/show/test_nereids_show_functions.groovy
@@ -97,7 +97,7 @@ suite("test_nereids_show_functions") {
     assertTrue(res11[0][4].contains("NULLABLE_MODE="))
     assertTrue(res11[0][4].contains("ALIAS_OF="))
 
-    def runtime_version = "3.8.10"
+    def runtime_version = getPythonUdfRuntimeVersion()
     def suitePath = context.file.parent + "/../.."
 
     sql """ DROP FUNCTION IF EXISTS py_add(int, int) """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Newer versions of Conda can no longer keep Python pinned to `3.8.10` while remaining compatible with several required test dependencies (e.g. pyarrow, pandas) from conda-forge.(will automatically upgrade to `3.8.19`)

To ensure the test environment can be successfully created and remains stable, This PR allows controlling the Python UDF version in p0 by modifying the `pythonUdfRuntimeVersion` in `regression_conf.groovy`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

