### PR TITLE
[fix](test) Fix flaky assertion in test_export_max_file_size

### DIFF
--- a/regression-test/suites/export_p2/test_export_max_file_size.groovy
+++ b/regression-test/suites/export_p2/test_export_max_file_size.groovy
@@ -135,7 +135,9 @@ suite("test_export_max_file_size", "p2,external") {
             def outfile_info = waiting_export.call(uuid)
             def json = parseJson(outfile_info)
             assert json instanceof List
-            assertEquals("25", json.fileNumber[0][0])
+            def fileNum = Integer.parseInt(json.fileNumber[0][0])
+            assertTrue(fileNum > 1, "Export with max_file_size should produce multiple files, but got ${fileNum}")
+
             def outfile_url = json.url[0][0]
 
             qt_sql_count """ 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

`test_export_max_file_size` fails intermittently with file count mismatch (e.g., expected 25, got 23). The test uses random data via rand() which produces variable-width CSV rows (especially float/double columns), causing the total exported data size to fluctuate between runs. With max_file_size=5MB, this leads to different file counts each time.

Fix: Replace exact assertEquals("25", fileNumber) with assertTrue(fileNum > 1) to verify that file splitting occurs without depending on an exact count. Data correctness is already verified by subsequent load-back and comparison.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

