### PR TITLE
[fix](compile) Remove stale compile_check includes from schema_role_mappings_scanner

### DIFF
--- a/be/src/information_schema/schema_role_mappings_scanner.cpp
+++ b/be/src/information_schema/schema_role_mappings_scanner.cpp
@@ -29,7 +29,6 @@
 #include "util/thrift_rpc_helper.h"
 
 namespace doris {
-#include "common/compile_check_begin.h"
 
 std::vector<SchemaScanner::ColumnDesc> SchemaRoleMappingsScanner::_s_tbls_columns = {
         {"NAME", TYPE_VARCHAR, sizeof(StringRef), true},
@@ -141,5 +140,4 @@ Status SchemaRoleMappingsScanner::get_next_block_internal(Block* block, bool* eo
     return Status::OK();
 }
 
-#include "common/compile_check_end.h"
 } // namespace doris


### PR DESCRIPTION
## Summary
- Remove stale `#include "common/compile_check_begin.h"` and `#include "common/compile_check_end.h"` from `schema_role_mappings_scanner.cpp`
- These headers were deleted globally in #62300, but `schema_role_mappings_scanner.cpp` (added by #62077) still referenced them, causing a compile failure on master

## Root Cause
PR #62077 and PR #62300 were prepared independently. #62077 added a new file with the compile_check includes, while #62300 deleted those headers. After both merged, master fails to compile with:
```
fatal error: 'common/compile_check_begin.h' file not found
```

## Test plan
- [ ] Verify master compiles successfully after this change

---
🤖 *Generated by [ThinkOps](https://github.com/dataroaring/ThinkOps) — autonomous agent pipeline*