### PR TITLE
branch-4.0: [fix](fe) Preload paimon jindo for paimon scanner

### DIFF
--- a/fe/be-java-extensions/paimon-scanner/pom.xml
+++ b/fe/be-java-extensions/paimon-scanner/pom.xml
@@ -60,10 +60,6 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-format</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-jindo</artifactId>
-        </dependency>
 
     </dependencies>
 

--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -83,6 +83,11 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-s3</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-jindo</artifactId>
+        </dependency>
         <!-- For Avro and Hudi Scanner PreLoad -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
#62350

  `paimon-scanner` runs under a dedicated scanner classloader, while `preload-extensions` is loaded from the parent classpath with higher priority. Doris currently uses parent-first classloading for
  scanner jars.

  When `paimon-jindo` is packaged only inside `paimon-scanner`, runtime may still resolve `org.apache.paimon.*` classes from the parent classpath first. In this case, the Paimon `FileIO`/
  `ServiceLoader` view seen at runtime is split across different classloaders, and the Jindo file IO loader is not discovered correctly. This can lead to errors like:

  `org.apache.paimon.fs.UnsupportedSchemeException: Could not find a file io implementation for scheme 'oss'`

  This PR removes `paimon-jindo` from `paimon-scanner` and moves it to `preload-extensions`, so the Jindo FileIO implementation is available from the highest-priority parent classpath and stays
  consistent with the Paimon core classes used during scanner execution.

  This keeps the runtime dependency layout aligned with Doris' existing classloading model and avoids scanner-local plugin jars being hidden by parent-first resolution.

(cherry picked from commit be1578ccffca7360712a39fd913dfce0dcca693c)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

