### PR TITLE
branch-4.1:[fix](maxcompute) avoid block_id collisions in rotated large writes.

### DIFF
--- a/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
+++ b/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
@@ -42,7 +42,8 @@ Status VMCTableWriter::init_properties(ObjectPool* pool) {
 
 Status VMCTableWriter::open(RuntimeState* state, RuntimeProfile* profile) {
     _state = state;
-    _next_block_id.store(state->per_fragment_instance_idx() * BLOCK_ID_STRIDE);
+    _next_block_id.store(static_cast<int64_t>(state->per_fragment_instance_idx())
+                         << BLOCK_ID_INSTANCE_SHIFT);
 
     LOG(INFO) << "VMCTableWriter::open"
               << ", fragment_instance_id=" << print_id(state->fragment_instance_id())

--- a/be/src/exec/sink/writer/maxcompute/vmc_table_writer.h
+++ b/be/src/exec/sink/writer/maxcompute/vmc_table_writer.h
@@ -82,11 +82,14 @@ private:
     // Write output expr contexts (after removing partition columns)
     VExprContextSPtrs _write_output_vexpr_ctxs;
 
-    // Atomic block_id counter: each partition writer gets a unique block_id
-    // Initialized with offset based on per_fragment_instance_idx to avoid collisions
-    // across pipeline instances sharing the same write session.
+    // Atomic block_id counter: each partition writer gets a unique block_id.
+    // Reserve the low 32 bits for the per-instance sequence so rotated
+    // block ids can grow without overlapping other fragment instances in
+    // the same write session. per_fragment_instance_idx is an int, and
+    // shifting it by 32 is the largest safe value that still keeps the
+    // computed block_id in the positive int64_t range.
     std::atomic<int64_t> _next_block_id {0};
-    static constexpr int64_t BLOCK_ID_STRIDE = 100;
+    static constexpr int64_t BLOCK_ID_INSTANCE_SHIFT = 32;
 
     size_t _row_count = 0;
     int64_t _send_data_ns = 0;


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
This fixes an intermittent MaxCompute write failure introduced by PR #61245 and backported to branch-4.1 by PR #61745.

Large-data writes rotate the MaxCompute writer and consume additional blockIds, but the previous BE allocation strategy still used a small per-instance block id range. Under large inserts, one fragment instance could exhaust that range and overlap with another instance in the
  same write session.

This change fixes the issue by encoding `per_fragment_instance_idx` in the high bits of `block_id` and reserving the low 32 bits for the per-instance sequence. As a result, rotated block ids remain unique across fragment instances and no longer collide during large MaxCompute writes.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

