### PR TITLE
[fix](fe) Fix no_use_cbo_rule hint being silently ignored in EliminateLogicalSelectHint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/EliminateLogicalSelectHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/EliminateLogicalSelectHint.java
@@ -66,7 +66,8 @@ public class EliminateLogicalSelectHint extends OneRewriteRuleFactory {
                 } else if (hintName.equalsIgnoreCase("LEADING")) {
                     extractLeading((SelectHintLeading) hint, ctx.cascadesContext,
                             ctx.statementContext, selectHintPlan);
-                } else if (hintName.equalsIgnoreCase("USE_CBO_RULE")) {
+                } else if (hintName.equalsIgnoreCase("USE_CBO_RULE")
+                        || hintName.equalsIgnoreCase("NO_USE_CBO_RULE")) {
                     extractRule((SelectHintUseCboRule) hint, ctx.statementContext);
                 } else if (hintName.equalsIgnoreCase("USE_MV")) {
                     extractMv((SelectHintUseMv) hint, ConnectContext.get().getStatementContext());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/EliminateLogicalSelectHintTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/EliminateLogicalSelectHintTest.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.nereids.hint.Hint;
+import org.apache.doris.nereids.hint.UseCboRuleHint;
+import org.apache.doris.nereids.sqltest.SqlTestBase;
+import org.apache.doris.nereids.util.PlanChecker;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for EliminateLogicalSelectHint, verifying that no_use_cbo_rule hints are correctly
+ * propagated into the statement context after analysis.
+ */
+public class EliminateLogicalSelectHintTest extends SqlTestBase {
+
+    @Test
+    public void testNoUseCboRuleHintIsRecognized() {
+        String sql = "SELECT /*+ no_use_cbo_rule(INFER_SET_OPERATOR_DISTINCT) */ * FROM T1";
+        PlanChecker checker = PlanChecker.from(connectContext).analyze(sql);
+
+        List<Hint> hints = checker.getCascadesContext().getStatementContext().getHints();
+        List<UseCboRuleHint> cboHints = hints.stream()
+                .filter(h -> h instanceof UseCboRuleHint)
+                .map(h -> (UseCboRuleHint) h)
+                .collect(Collectors.toList());
+
+        Assertions.assertFalse(cboHints.isEmpty(),
+                "no_use_cbo_rule hint should be added to statementContext hints");
+        Assertions.assertTrue(cboHints.stream().anyMatch(UseCboRuleHint::isNotUseCboRule),
+                "hint should have isNotUseCboRule=true");
+        Assertions.assertTrue(
+                cboHints.stream().anyMatch(h -> h.getHintName().equalsIgnoreCase("INFER_SET_OPERATOR_DISTINCT")),
+                "hint should carry the rule name INFER_SET_OPERATOR_DISTINCT");
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
When a query uses the `/*+ no_use_cbo_rule(RULE_NAME) */` hint, the hint was silently ignored. The root cause was that `EliminateLogicalSelectHint#build` only handled the `USE_CBO_RULE` hint name but had no branch for `NO_USE_CBO_RULE`. As a result, the hint fell into the else branch which just logged a warning and skipped it, so the CBO rule was never disabled.

**Fix:** add `NO_USE_CBO_RULE` to the existing `USE_CBO_RULE` condition so both hint names are routed to `extractRule()`, which already handles both cases via the `isNotUseCboRule` flag on `SelectHintUseCboRule`.

Example query that was broken before this fix:
```sql
explain physical plan
SELECT /*+ no_use_cbo_rule(INFER_SET_OPERATOR_DISTINCT)*/ ka, kb, kc 
FROM t1 INTERSECT SELECT ka, kb, kc FROM t2
```

### Release note

Fix: `no_use_cbo_rule` hint now correctly disables the specified CBO rewrite rule instead of being silently ignored.

### Check List (For Author)

- Test: FE unit test added (`EliminateLogicalSelectHintTest`)
    - Unit Test
- Behavior changed: Yes — `no_use_cbo_rule` hint now takes effect
- Does this need documentation: No