### PR TITLE
[fix](test) Fix wrong split count assertion in test_hive_compress_type_large_data

### DIFF
--- a/regression-test/suites/external_table_p2/hive/test_hive_compress_type_large_data.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_compress_type_large_data.groovy
@@ -44,15 +44,18 @@ suite("test_hive_compress_type_large_data", "p2,external") {
         );"""
         sql """use `${catalog_name}`.`multi_catalog`"""
 
-        // table test_compress_partitioned has mixed compressed files and larger data volume.
+        // table test_compress_partitioned has 16 files across 8 partitions (734MB total).
+        // With count pushdown, needSplit depends on totalFileNum vs parallelNum * backendNum.
+        // When needSplit=false: each file = 1 split = 16 splits.
+        // When needSplit=true and file_split_size=0: splits by dynamic size = 28 splits.
+        // When needSplit=true and file_split_size=8MB: splits by 8MB = 82 splits.
+        def needSplit = (backendNum > 1) && (16 < parallelExecInstanceNum * backendNum)
+
         sql """set file_split_size=0"""
-        def expectedSplitNum = 16
-        if (backendNum > 1) {
-            expectedSplitNum = (16 < parallelExecInstanceNum * backendNum) ? 28 : 16
-        }
+        def expectedSplitNum1 = needSplit ? 28 : 16
         explain {
             sql("select count(*) from test_compress_partitioned")
-            contains "inputSplitNum=${expectedSplitNum}, totalFileSize=734675596, scanRanges=${expectedSplitNum}"
+            contains "inputSplitNum=${expectedSplitNum1}, totalFileSize=734675596, scanRanges=${expectedSplitNum1}"
             contains "partition=8/8"
         }
 
@@ -64,9 +67,10 @@ suite("test_hive_compress_type_large_data", "p2,external") {
         assertEquals(15, countWatchId1[0][0])
 
         sql """set file_split_size=8388608"""
+        def expectedSplitNum2 = needSplit ? 82 : 16
         explain {
             sql("select count(*) from test_compress_partitioned")
-            contains "inputSplitNum=16, totalFileSize=734675596, scanRanges=16"
+            contains "inputSplitNum=${expectedSplitNum2}, totalFileSize=734675596, scanRanges=${expectedSplitNum2}"
             contains "partition=8/8"
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

`test_hive_compress_type_large_data` fails because the second explain block hardcodes `inputSplitNum=16` for `file_split_size=8MB`, but on multi-BE clusters where `parallelExecInstanceNum * backendNum > 16`, count pushdown sets `needSplit=true`, causing files to be split by 8MB and producing 82 splits instead of 16.

The first explain block already used dynamic logic to handle this case, but the second block did not. Fix: apply the same dynamic expectedSplitNum logic to both explain blocks.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

