### PR TITLE
[fix](metrics)The BE disk metrics value is empty when use LVM

### DIFF
--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -35,6 +35,8 @@
 #include <iterator>
 #include <memory>
 #include <utility>
+#include <dirent.h>
+#include <fstream>
 
 #include "common/cast_set.h"
 #include "io/fs/local_file_system.h"
@@ -166,6 +168,56 @@ std::string DiskInfo::debug_string() {
     return stream.str();
 }
 
+std::set<std::string> DiskInfo::get_lvm_physical_disks(const std::string dm_name) {
+    set<std::string> disks;
+    // find slaves dir
+    std::string slaves_dir = "/sys/block/" + dm_name + "/slaves/";
+    DIR* dir = opendir(slaves_dir.c_str());
+    if (!dir) {
+        return disks;
+    }
+ 
+    dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        std::string slave_name = entry->d_name;
+        if (slave_name == "." || slave_name == "..") {
+            continue;
+        }
+ 
+        // If the subdirectory is still of the LVM type, recursive processing is performed.
+        if (slave_name.find("dm-") == 0) {
+            auto sub_disks = get_lvm_physical_disks(slave_name);
+            disks.insert(sub_disks.begin(), sub_disks.end());
+            continue;
+        }
+ 
+        // if it is, get parent device.
+        std::string partition_path = "/sys/class/block/" + slave_name + "/partition";
+        std::ifstream pf(partition_path);
+        if (pf.good()) {
+            std::string current_link = "/sys/class/block/" + slave_name;
+            char current_path[256];
+            ssize_t len = readlink(current_link.c_str(), current_path, sizeof(current_path)-1);
+ 
+            string parent_path_str = "";
+            parent_path_str.append("/sys/class/block/").append(current_path).append("/..");
+            char parent_path[parent_path_str.length() + 1];
+            strcpy(parent_path, parent_path_str.c_str());
+            if (len != -1) {
+                std::string parent_str(parent_path);
+                size_t pos = parent_str.find_last_of('/');
+                std::string parent_dev = (pos != std::string::npos) ? parent_str.substr(pos+1) : parent_str;
+                disks.insert(parent_dev);
+            }
+        } else {
+            disks.insert(slave_name);
+        }
+        pf.close();
+    }
+    closedir(dir);
+    return disks;
+}
+
 Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths,
                                   std::set<std::string>* devices) {
     std::vector<std::string> real_paths;
@@ -208,7 +260,29 @@ Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths,
                 strncmp(path.c_str(), mount_path, mount_size) != 0) {
                 continue;
             }
-            std::string dev(basename(dev_path));
+            std::string dev;
+            std::string dev_path_str(dev_path);
+            char real_dm_path_char[PATH_MAX];
+            // is lvm disk type
+            if (dev_path_str.find("/dev/mapper/") == 0 && realpath(dev_path, real_dm_path_char)) {
+                std::string real_dm_path(real_dm_path_char);
+                size_t pos = real_dm_path.find_last_of('/');
+                if (pos == std::string::npos) {
+                    LOG(WARNING) << "real dm path [" << real_dm_path << "] dont contains /.";
+                    continue;
+                }
+                std::string dm_name = real_dm_path.substr(pos + 1);
+                std::set<std::string> disk_devs = get_lvm_physical_disks(dm_name);
+                if (disk_devs.size() != 1) {
+                    LOG(WARNING) << "more than one disk device is found in " << dm_name << "." << "size: " << disk_devs.size();
+                    if (disk_devs.size() == 0) {
+                        continue;
+                    }
+                }
+                dev = *(disk_devs.begin());
+            } else {
+                dev = basename(dev_path);
+            }
             boost::trim_right_if(dev, boost::is_any_of("0123456789"));
             if (_s_disk_name_to_disk_id.find(dev) != std::end(_s_disk_name_to_disk_id)) {
                 max_mount_size = mount_size;

--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -197,7 +197,7 @@ std::set<std::string> DiskInfo::get_lvm_physical_disks(const std::string dm_name
         if (pf.good()) {
             std::string current_link = "/sys/class/block/" + slave_name;
             char current_path[256];
-            ssize_t len = readlink(current_link.c_str(), current_path, sizeof(current_path)-1);
+            ssize_t len = readlink(current_link.c_str(), current_path, sizeof(current_path) - 1);
  
             string parent_path_str = "";
             parent_path_str.append("/sys/class/block/").append(current_path).append("/..");
@@ -206,7 +206,8 @@ std::set<std::string> DiskInfo::get_lvm_physical_disks(const std::string dm_name
             if (len != -1) {
                 std::string parent_str(parent_path);
                 size_t pos = parent_str.find_last_of('/');
-                std::string parent_dev = (pos != std::string::npos) ? parent_str.substr(pos+1) : parent_str;
+                std::string parent_dev = 
+                        (pos != std::string::npos) ? parent_str.substr(pos+1) : parent_str;
                 disks.insert(parent_dev);
             }
         } else {
@@ -274,7 +275,8 @@ Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths,
                 std::string dm_name = real_dm_path.substr(pos + 1);
                 std::set<std::string> disk_devs = get_lvm_physical_disks(dm_name);
                 if (disk_devs.size() != 1) {
-                    LOG(WARNING) << "more than one disk device is found in " << dm_name << "." << "size: " << disk_devs.size();
+                    LOG(WARNING) << "more than one disk device is found in " << dm_name << "."
+                                 << "size: " << disk_devs.size();
                     if (disk_devs.size() == 0) {
                         continue;
                     }

--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -207,7 +207,7 @@ std::set<std::string> DiskInfo::get_lvm_physical_disks(const std::string dm_name
                 std::string parent_str(parent_path);
                 size_t pos = parent_str.find_last_of('/');
                 std::string parent_dev = 
-                        (pos != std::string::npos) ? parent_str.substr(pos+1) : parent_str;
+                        (pos != std::string::npos) ? parent_str.substr(pos + 1) : parent_str;
                 disks.insert(parent_dev);
             }
         } else {

--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -19,6 +19,7 @@
 
 // IWYU pragma: no_include <bthread/errno.h>
 #include <absl/strings/str_split.h>
+#include <dirent.h>
 #include <errno.h> // IWYU pragma: keep
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,8 +36,6 @@
 #include <iterator>
 #include <memory>
 #include <utility>
-#include <dirent.h>
-#include <fstream>
 
 #include "common/cast_set.h"
 #include "io/fs/local_file_system.h"
@@ -176,21 +175,21 @@ std::set<std::string> DiskInfo::get_lvm_physical_disks(const std::string dm_name
     if (!dir) {
         return disks;
     }
- 
+
     dirent* entry;
     while ((entry = readdir(dir)) != nullptr) {
         std::string slave_name = entry->d_name;
         if (slave_name == "." || slave_name == "..") {
             continue;
         }
- 
+
         // If the subdirectory is still of the LVM type, recursive processing is performed.
         if (slave_name.find("dm-") == 0) {
             auto sub_disks = get_lvm_physical_disks(slave_name);
             disks.insert(sub_disks.begin(), sub_disks.end());
             continue;
         }
- 
+
         // if it is, get parent device.
         std::string partition_path = "/sys/class/block/" + slave_name + "/partition";
         std::ifstream pf(partition_path);
@@ -198,7 +197,6 @@ std::set<std::string> DiskInfo::get_lvm_physical_disks(const std::string dm_name
             std::string current_link = "/sys/class/block/" + slave_name;
             char current_path[256];
             ssize_t len = readlink(current_link.c_str(), current_path, sizeof(current_path) - 1);
- 
             string parent_path_str = "";
             parent_path_str.append("/sys/class/block/").append(current_path).append("/..");
             char parent_path[parent_path_str.length() + 1];

--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -206,7 +206,7 @@ std::set<std::string> DiskInfo::get_lvm_physical_disks(const std::string dm_name
             if (len != -1) {
                 std::string parent_str(parent_path);
                 size_t pos = parent_str.find_last_of('/');
-                std::string parent_dev = 
+                std::string parent_dev =
                         (pos != std::string::npos) ? parent_str.substr(pos + 1) : parent_str;
                 disks.insert(parent_dev);
             }

--- a/be/src/util/disk_info.h
+++ b/be/src/util/disk_info.h
@@ -70,6 +70,7 @@ public:
     // get disk devices of given path
     static Status get_disk_devices(const std::vector<std::string>& paths,
                                    std::set<std::string>* devices);
+    static std::set<std::string> get_lvm_physical_disks(std::string dev_path);
 
 private:
     static bool _s_initialized;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62365

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

