### PR TITLE
[doc](be) Add allocator-aware memory review guidance

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -101,6 +101,7 @@ After checking all the above items with code. Use the remaining parts of this sk
 #### 1.3.3 Memory Safety (High Priority)
 
 - [ ] **Reservation**: `try_reserve()` before large allocations, with guaranteed release on every exit path
+- [ ] **Allocator-aware ownership**: In BE code, for memory-owning containers or buffers that should be tracked by Doris memory accounting, prefer allocator-aware types from `be/src/core/custom_allocator.h` such as `DorisVector`, `DorisMap`, and `DorisUniqueBufferPtr` instead of `std::vector`, `std::map`, and `std::unique_ptr`
 - [ ] **Ownership**: See `be/src/runtime/AGENTS.md` for cache-handle, shared_ptr-cycle, and factory-creator rules
 
 #### 1.3.4 Data Correctness (High Priority)

--- a/be/src/core/AGENTS.md
+++ b/be/src/core/AGENTS.md
@@ -1,5 +1,13 @@
 # BE Core Module — Review Guide
 
+## Allocator-Aware Containers
+
+Types in `be/src/core/custom_allocator.h` exist to route owned memory through Doris allocation and tracking paths.
+
+### Checkpoints
+
+- [ ] For BE-owned buffers or containers whose memory should be tracked, prefer `DorisVector`, `DorisMap`, `DorisUniqueBufferPtr`, and related allocator-aware wrappers instead of the corresponding standard library ownership types
+
 ## COW Column Semantics
 
 Vectorized columns (`IColumn`) use intrusive-reference-counted copy-on-write.

--- a/be/src/runtime/AGENTS.md
+++ b/be/src/runtime/AGENTS.md
@@ -11,6 +11,7 @@ Two levels: `MemTrackerLimiter` (heavyweight, with limits) and `MemTracker` (lig
 - [ ] Temporary limiter switching uses `SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER`, not manual save/restore?
 - [ ] Thread-pool callbacks attach at callback entry, not deeper in the call chain?
 - [ ] Large allocations use `try_reserve()` with `DEFER_RELEASE_RESERVED()` for balanced accounting on every exit?
+- [ ] For BE-owned buffers or containers whose memory should be tracked by Doris accounting, prefer allocator-aware types from `be/src/core/custom_allocator.h` such as `DorisVector`, `DorisMap`, and `DorisUniqueBufferPtr` instead of the corresponding standard library ownership types
 - [ ] Code reachable from `ThreadMemTrackerMgr::consume` avoids operations that may allocate recursively?
 
 ## Object Lifecycle


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary: Review guidance did not explicitly require allocator-aware Doris container and buffer types for BE-owned memory that should be tracked by Doris accounting. This adds that rule to the code-review skill and the BE core/runtime module guides.

### Release note

None

### Check List (For Author)

- Test: No need to test (documentation-only change)
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

