### PR TITLE
[fix](cloud) Deduplicate pending one-shot warm up jobs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
@@ -969,9 +969,13 @@ public class CacheHotspotManager extends MasterDaemon {
             try {
                 CloudWarmUpJob existingPendingJob = findExistingPendingOnceJob(oncePendingJobKey);
                 if (existingPendingJob != null) {
-                    LOG.info("reuse existing pending warm up job {} for key {}",
-                            existingPendingJob.getJobId(), oncePendingJobKey);
-                    return existingPendingJob.getJobId();
+                    long existingJobId = existingPendingJob.getJobId();
+                    if (stmt.isWarmUpWithTable()) {
+                        throw new AnalysisException("Table warm up job already has a pending job, job id: "
+                                + existingJobId + ". Please retry later.");
+                    }
+                    LOG.info("reuse existing pending warm up job {} for key {}", existingJobId, oncePendingJobKey);
+                    return existingJobId;
                 }
                 return createJobInternal(stmt);
             } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
@@ -67,6 +67,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -82,6 +83,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class CacheHotspotManager extends MasterDaemon {
     public static final int MAX_SHOW_ENTRIES = 2000;
@@ -108,6 +110,8 @@ public class CacheHotspotManager extends MasterDaemon {
     private ConcurrentMap<Long, CloudWarmUpJob> activeCloudWarmUpJobs = Maps.newConcurrentMap();
 
     private ConcurrentMap<Long, CloudWarmUpJob> runnableCloudWarmUpJobs = Maps.newConcurrentMap();
+
+    private final ConcurrentMap<OncePendingJobKey, ReentrantLock> oncePendingCreateLocks = Maps.newConcurrentMap();
 
     private final ThreadPoolExecutor cloudWarmUpThreadPool = ThreadPoolManager.newDaemonCacheThreadPool(
             Config.max_active_cloud_warm_up_job, "cloud-warm-up-pool", true);
@@ -148,9 +152,153 @@ public class CacheHotspotManager extends MasterDaemon {
         }
     }
 
+    private static class OncePendingJobKey {
+        private final JobType jobType;
+        private final String srcName;
+        private final String dstName;
+        private final List<String> normalizedTables;
+        private final boolean force;
+
+        OncePendingJobKey(JobType jobType, String srcName, String dstName,
+                List<String> normalizedTables, boolean force) {
+            this.jobType = jobType;
+            this.srcName = normalizeNullableName(srcName);
+            this.dstName = normalizeNullableName(dstName);
+            this.normalizedTables = normalizedTables.isEmpty()
+                    ? Collections.emptyList()
+                    : Collections.unmodifiableList(new ArrayList<>(normalizedTables));
+            this.force = force;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof OncePendingJobKey)) {
+                return false;
+            }
+            OncePendingJobKey jobKey = (OncePendingJobKey) o;
+            return force == jobKey.force
+                    && jobType == jobKey.jobType
+                    && Objects.equals(srcName, jobKey.srcName)
+                    && Objects.equals(dstName, jobKey.dstName)
+                    && Objects.equals(normalizedTables, jobKey.normalizedTables);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(jobType, srcName, dstName, normalizedTables, force);
+        }
+
+        @Override
+        public String toString() {
+            return "OncePendingWarmUpJob{"
+                    + "jobType=" + jobType
+                    + ", src='" + srcName + '\''
+                    + ", dst='" + dstName + '\''
+                    + ", tables=" + normalizedTables
+                    + ", force=" + force
+                    + '}';
+        }
+    }
+
     // Tracks long-running jobs (event-driven and periodic).
     // Ensures only one active job exists per <source, destination, sync_mode> tuple.
     private Set<JobKey> repeatJobDetectionSet = ConcurrentHashMap.newKeySet();
+
+    private static String normalizeNullableName(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static String normalizeTableKey(Triple<String, String, String> tableTriple) {
+        String dbName = normalizeNullableName(tableTriple.getLeft());
+        String tableName = normalizeNullableName(tableTriple.getMiddle());
+        String partitionName = normalizeNullableName(tableTriple.getRight());
+        if (partitionName.isEmpty()) {
+            return dbName + "." + tableName;
+        }
+        return dbName + "." + tableName + "." + partitionName;
+    }
+
+    private static List<String> normalizeTables(List<Triple<String, String, String>> tables) {
+        if (tables == null || tables.isEmpty()) {
+            return Collections.emptyList();
+        }
+        HashSet<String> normalizedTables = new HashSet<>();
+        for (Triple<String, String, String> table : tables) {
+            normalizedTables.add(normalizeTableKey(table));
+        }
+        List<String> sortedTables = new ArrayList<>(normalizedTables);
+        Collections.sort(sortedTables);
+        return sortedTables;
+    }
+
+    private boolean isClusterOnceCommand(WarmUpClusterCommand command) {
+        Map<String, String> properties = command.getProperties();
+        if (properties == null) {
+            return true;
+        }
+        String syncMode = properties.get("sync_mode");
+        return !"periodic".equals(syncMode) && !"event_driven".equals(syncMode);
+    }
+
+    private OncePendingJobKey buildOncePendingJobKey(WarmUpClusterCommand command) {
+        if (command.isWarmUpWithTable()) {
+            return new OncePendingJobKey(JobType.TABLE, "", command.getDstCluster(),
+                    normalizeTables(command.getTables()), command.isForce());
+        }
+        if (!isClusterOnceCommand(command)) {
+            return null;
+        }
+        return new OncePendingJobKey(JobType.CLUSTER, command.getSrcCluster(),
+                command.getDstCluster(), Collections.emptyList(), false);
+    }
+
+    private OncePendingJobKey buildOncePendingJobKey(CloudWarmUpJob job) {
+        if (!job.isOnce()) {
+            return null;
+        }
+        if (job.getJobType() == JobType.TABLE) {
+            return new OncePendingJobKey(JobType.TABLE, "", job.getDstClusterName(),
+                    normalizeTables(job.tables), job.force);
+        }
+        if (job.getJobType() == JobType.CLUSTER) {
+            return new OncePendingJobKey(JobType.CLUSTER, job.getSrcClusterName(),
+                    job.getDstClusterName(), Collections.emptyList(), false);
+        }
+        return null;
+    }
+
+    private CloudWarmUpJob findExistingPendingOnceJob(OncePendingJobKey key) {
+        CloudWarmUpJob selectedJob = null;
+        for (CloudWarmUpJob job : cloudWarmUpJobs.values()) {
+            if (job.getJobState() != JobState.PENDING || !job.isOnce()) {
+                continue;
+            }
+            OncePendingJobKey existingKey = buildOncePendingJobKey(job);
+            if (!key.equals(existingKey)) {
+                continue;
+            }
+            if (selectedJob == null
+                    || job.getCreateTimeMs() < selectedJob.getCreateTimeMs()
+                    || (job.getCreateTimeMs() == selectedJob.getCreateTimeMs()
+                        && job.getJobId() < selectedJob.getJobId())) {
+                selectedJob = job;
+            }
+        }
+        return selectedJob;
+    }
+
+    private ReentrantLock getOncePendingCreateLock(OncePendingJobKey key) {
+        ReentrantLock lock = oncePendingCreateLocks.get(key);
+        if (lock != null) {
+            return lock;
+        }
+        ReentrantLock newLock = new ReentrantLock();
+        ReentrantLock existingLock = oncePendingCreateLocks.putIfAbsent(key, newLock);
+        return existingLock == null ? newLock : existingLock;
+    }
 
     private void registerJobForRepeatDetection(CloudWarmUpJob job, boolean replay) throws AnalysisException {
         if (job.isDone()) {
@@ -781,6 +929,26 @@ public class CacheHotspotManager extends MasterDaemon {
     }
 
     public long createJob(WarmUpClusterCommand stmt) throws AnalysisException {
+        OncePendingJobKey oncePendingJobKey = buildOncePendingJobKey(stmt);
+        if (oncePendingJobKey != null) {
+            ReentrantLock createLock = getOncePendingCreateLock(oncePendingJobKey);
+            createLock.lock();
+            try {
+                CloudWarmUpJob existingPendingJob = findExistingPendingOnceJob(oncePendingJobKey);
+                if (existingPendingJob != null) {
+                    LOG.info("reuse existing pending warm up job {} for key {}",
+                            existingPendingJob.getJobId(), oncePendingJobKey);
+                    return existingPendingJob.getJobId();
+                }
+                return createJobInternal(stmt);
+            } finally {
+                createLock.unlock();
+            }
+        }
+        return createJobInternal(stmt);
+    }
+
+    private long createJobInternal(WarmUpClusterCommand stmt) throws AnalysisException {
         long jobId = Env.getCurrentEnv().getNextId();
         CloudWarmUpJob warmUpJob;
         if (stmt.isWarmUpWithTable()) {
@@ -800,6 +968,9 @@ public class CacheHotspotManager extends MasterDaemon {
                     .setJobType(JobType.CLUSTER);
 
             Map<String, String> properties = stmt.getProperties();
+            if (properties == null) {
+                properties = Collections.emptyMap();
+            }
             if ("periodic".equals(properties.get("sync_mode"))) {
                 String syncIntervalSecStr = properties.get("sync_interval_sec");
                 if (syncIntervalSecStr == null) {
@@ -831,7 +1002,6 @@ public class CacheHotspotManager extends MasterDaemon {
             }
             warmUpJob = builder.build();
         }
-
         addCloudWarmUpJob(warmUpJob);
 
         Env.getCurrentEnv().getEditLog().logModifyCloudWarmUpJob(warmUpJob);

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/CacheHotspotManager.java
@@ -52,6 +52,7 @@ import org.apache.doris.thrift.THotTableMessage;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TStatusCode;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
@@ -111,7 +112,8 @@ public class CacheHotspotManager extends MasterDaemon {
 
     private ConcurrentMap<Long, CloudWarmUpJob> runnableCloudWarmUpJobs = Maps.newConcurrentMap();
 
-    private final ConcurrentMap<OncePendingJobKey, ReentrantLock> oncePendingCreateLocks = Maps.newConcurrentMap();
+    private final ConcurrentMap<OncePendingJobKey, RefCountedPendingCreateLock> oncePendingCreateLocks
+            = Maps.newConcurrentMap();
 
     private final ThreadPoolExecutor cloudWarmUpThreadPool = ThreadPoolManager.newDaemonCacheThreadPool(
             Config.max_active_cloud_warm_up_job, "cloud-warm-up-pool", true);
@@ -203,6 +205,30 @@ public class CacheHotspotManager extends MasterDaemon {
         }
     }
 
+    private static class RefCountedPendingCreateLock {
+        private final ReentrantLock lock = new ReentrantLock();
+
+        // Tracks holders and waiters that retained the entry before locking.
+        private volatile int refCount = 1;
+
+        void retain() {
+            ++refCount;
+        }
+
+        int release() {
+            Preconditions.checkState(refCount > 0, "once pending create lock ref count underflow");
+            return --refCount;
+        }
+
+        void lock() {
+            lock.lock();
+        }
+
+        void unlock() {
+            lock.unlock();
+        }
+    }
+
     // Tracks long-running jobs (event-driven and periodic).
     // Ensures only one active job exists per <source, destination, sync_mode> tuple.
     private Set<JobKey> repeatJobDetectionSet = ConcurrentHashMap.newKeySet();
@@ -290,14 +316,21 @@ public class CacheHotspotManager extends MasterDaemon {
         return selectedJob;
     }
 
-    private ReentrantLock getOncePendingCreateLock(OncePendingJobKey key) {
-        ReentrantLock lock = oncePendingCreateLocks.get(key);
-        if (lock != null) {
-            return lock;
-        }
-        ReentrantLock newLock = new ReentrantLock();
-        ReentrantLock existingLock = oncePendingCreateLocks.putIfAbsent(key, newLock);
-        return existingLock == null ? newLock : existingLock;
+    private RefCountedPendingCreateLock retainOncePendingCreateLock(OncePendingJobKey key) {
+        return oncePendingCreateLocks.compute(key, (ignored, existingLock) -> {
+            if (existingLock == null) {
+                return new RefCountedPendingCreateLock();
+            }
+            existingLock.retain();
+            return existingLock;
+        });
+    }
+
+    private void releaseOncePendingCreateLock(OncePendingJobKey key, RefCountedPendingCreateLock lock) {
+        oncePendingCreateLocks.compute(key, (ignored, existingLock) -> {
+            Preconditions.checkState(existingLock == lock, "unexpected once pending create lock entry");
+            return existingLock.release() == 0 ? null : existingLock;
+        });
     }
 
     private void registerJobForRepeatDetection(CloudWarmUpJob job, boolean replay) throws AnalysisException {
@@ -931,7 +964,7 @@ public class CacheHotspotManager extends MasterDaemon {
     public long createJob(WarmUpClusterCommand stmt) throws AnalysisException {
         OncePendingJobKey oncePendingJobKey = buildOncePendingJobKey(stmt);
         if (oncePendingJobKey != null) {
-            ReentrantLock createLock = getOncePendingCreateLock(oncePendingJobKey);
+            RefCountedPendingCreateLock createLock = retainOncePendingCreateLock(oncePendingJobKey);
             createLock.lock();
             try {
                 CloudWarmUpJob existingPendingJob = findExistingPendingOnceJob(oncePendingJobKey);
@@ -943,6 +976,7 @@ public class CacheHotspotManager extends MasterDaemon {
                 return createJobInternal(stmt);
             } finally {
                 createLock.unlock();
+                releaseOncePendingCreateLock(oncePendingJobKey, createLock);
             }
         }
         return createJobInternal(stmt);

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
@@ -147,29 +147,32 @@ public class CacheHotspotManagerTest {
     }
 
     @Test
-    public void testCreateTableOnceJobDedupesPendingOrderDifference() throws AnalysisException {
+    public void testCreateTableOnceJobRejectsPendingDuplicateOrderDifference() throws AnalysisException {
         long firstJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
                 Triple.of("db1", "tbl1", ""),
                 Triple.of("db2", "tbl2", "p1")));
-        long reusedJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
+        AnalysisException exception = Assert.assertThrows(AnalysisException.class, () ->
+                cacheHotspotManager.createJob(newTableStmt("dst", false,
                 Triple.of("db2", "tbl2", "p1"),
-                Triple.of("db1", "tbl1", "")));
+                Triple.of("db1", "tbl1", ""))));
 
-        Assert.assertEquals(firstJobId, reusedJobId);
+        Assert.assertTrue(exception.getMessage().contains("already has a pending job"));
+        Assert.assertTrue(exception.getMessage().contains("job id: " + firstJobId));
         Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
         Mockito.verify(env, Mockito.times(1)).getNextId();
         Mockito.verify(editLog, Mockito.times(1)).logModifyCloudWarmUpJob(Mockito.any(CloudWarmUpJob.class));
     }
 
     @Test
-    public void testCreateTableOnceJobDedupesDuplicateTableEntries() throws AnalysisException {
+    public void testCreateTableOnceJobRejectsPendingDuplicateTableEntries() throws AnalysisException {
         long firstJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
                 Triple.of("db1", "tbl1", ""),
                 Triple.of("db1", "tbl1", "")));
-        long reusedJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
-                Triple.of("db1", "tbl1", "")));
+        AnalysisException exception = Assert.assertThrows(AnalysisException.class, () ->
+                cacheHotspotManager.createJob(newTableStmt("dst", false, Triple.of("db1", "tbl1", ""))));
 
-        Assert.assertEquals(firstJobId, reusedJobId);
+        Assert.assertTrue(exception.getMessage().contains("already has a pending job"));
+        Assert.assertTrue(exception.getMessage().contains("job id: " + firstJobId));
         Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
     }
 
@@ -291,11 +294,11 @@ public class CacheHotspotManagerTest {
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
-            Future<Long> firstCreate = executor.submit(() -> cacheHotspotManager.createJob(
+            Future<Long> firstCreate = executor.submit(() -> createJobWithThreadLocalEnv(
                     newClusterStmt("dst", "src", false)));
             Assert.assertTrue(firstCreateEntered.await(5, TimeUnit.SECONDS));
 
-            Future<Long> secondCreate = executor.submit(() -> cacheHotspotManager.createJob(
+            Future<Long> secondCreate = executor.submit(() -> createJobWithThreadLocalEnv(
                     newClusterStmt("dst", "src", false)));
             waitForOncePendingCreateLockRefCount(2, 5000L);
 
@@ -391,6 +394,13 @@ public class CacheHotspotManagerTest {
 
     private int getOncePendingCreateLockCount() throws Exception {
         return getOncePendingCreateLocks().size();
+    }
+
+    private long createJobWithThreadLocalEnv(WarmUpClusterCommand command) throws AnalysisException {
+        try (MockedStatic<Env> threadLocalEnvMock = Mockito.mockStatic(Env.class)) {
+            threadLocalEnvMock.when(Env::getCurrentEnv).thenReturn(env);
+            return cacheHotspotManager.createJob(command);
+        }
     }
 
     private int getOnlyOncePendingCreateLockRefCount() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
@@ -44,12 +44,19 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CacheHotspotManagerTest {
@@ -246,6 +253,67 @@ public class CacheHotspotManagerTest {
     }
 
     @Test
+    public void testCreateTableOnceJobRemovesLockEntryWhenCreateFails() throws Exception {
+        boolean previousRunningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = false;
+        cacheHotspotManager = new CacheHotspotManager(cloudSystemInfoService) {
+            @Override
+            public Map<Long, List<Tablet>> warmUpNewClusterByTable(long jobId, String dstClusterName,
+                    List<Triple<String, String, String>> tables, boolean isForce) {
+                throw new RuntimeException("mock create failure");
+            }
+        };
+
+        try {
+            RuntimeException exception = Assert.assertThrows(RuntimeException.class, () ->
+                    cacheHotspotManager.createJob(newTableStmt("dst", false, Triple.of("db1", "tbl1", ""))));
+
+            Assert.assertEquals("mock create failure", exception.getMessage());
+            Assert.assertEquals(0, getOncePendingCreateLockCount());
+            Assert.assertEquals(0, cacheHotspotManager.getCloudWarmUpJobs().size());
+        } finally {
+            FeConstants.runningUnitTest = previousRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testConcurrentCreateClusterOnceJobReleasesRefCountedLockAfterWaiterCompletes() throws Exception {
+        CountDownLatch firstCreateEntered = new CountDownLatch(1);
+        CountDownLatch allowFirstCreateToContinue = new CountDownLatch(1);
+        AtomicInteger getNextIdCalls = new AtomicInteger();
+        Mockito.when(env.getNextId()).thenAnswer(invocation -> {
+            if (getNextIdCalls.incrementAndGet() == 1) {
+                firstCreateEntered.countDown();
+                Assert.assertTrue(allowFirstCreateToContinue.await(5, TimeUnit.SECONDS));
+            }
+            return nextJobId.getAndIncrement();
+        });
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Long> firstCreate = executor.submit(() -> cacheHotspotManager.createJob(
+                    newClusterStmt("dst", "src", false)));
+            Assert.assertTrue(firstCreateEntered.await(5, TimeUnit.SECONDS));
+
+            Future<Long> secondCreate = executor.submit(() -> cacheHotspotManager.createJob(
+                    newClusterStmt("dst", "src", false)));
+            waitForOncePendingCreateLockRefCount(2, 5000L);
+
+            allowFirstCreateToContinue.countDown();
+
+            long firstJobId = firstCreate.get(5, TimeUnit.SECONDS);
+            long secondJobId = secondCreate.get(5, TimeUnit.SECONDS);
+            Assert.assertEquals(firstJobId, secondJobId);
+            Assert.assertEquals(1, getNextIdCalls.get());
+            Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
+            Assert.assertEquals(0, getOncePendingCreateLockCount());
+        } finally {
+            allowFirstCreateToContinue.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     public void testCreatePeriodicJobUnaffected() throws AnalysisException {
         WarmUpClusterCommand periodicStmt = newClusterStmt("dst", "src", false, periodicProperties(60));
         long firstJobId = cacheHotspotManager.createJob(periodicStmt);
@@ -319,5 +387,36 @@ public class CacheHotspotManagerTest {
         job.setJobState(jobState);
         job.setCreateTimeMs(createTimeMs);
         return job;
+    }
+
+    private int getOncePendingCreateLockCount() throws Exception {
+        return getOncePendingCreateLocks().size();
+    }
+
+    private int getOnlyOncePendingCreateLockRefCount() throws Exception {
+        Map<?, ?> locks = getOncePendingCreateLocks();
+        Assert.assertEquals(1, locks.size());
+        Object lockEntry = locks.values().iterator().next();
+        Field refCountField = lockEntry.getClass().getDeclaredField("refCount");
+        refCountField.setAccessible(true);
+        return refCountField.getInt(lockEntry);
+    }
+
+    private Map<?, ?> getOncePendingCreateLocks() throws Exception {
+        Field locksField = CacheHotspotManager.class.getDeclaredField("oncePendingCreateLocks");
+        locksField.setAccessible(true);
+        return (Map<?, ?>) locksField.get(cacheHotspotManager);
+    }
+
+    private void waitForOncePendingCreateLockRefCount(int expectedRefCount, long timeoutMs) throws Exception {
+        long deadlineMs = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadlineMs) {
+            if (getOncePendingCreateLockCount() == 1
+                    && getOnlyOncePendingCreateLockRefCount() == expectedRefCount) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        Assert.fail("Timed out waiting for once pending create lock ref count " + expectedRefCount);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/cache/CacheHotspotManagerTest.java
@@ -17,30 +17,70 @@
 
 package org.apache.doris.cloud.cache;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.cloud.CacheHotspotManager;
+import org.apache.doris.cloud.CloudWarmUpJob;
+import org.apache.doris.cloud.CloudWarmUpJob.JobState;
+import org.apache.doris.cloud.CloudWarmUpJob.JobType;
+import org.apache.doris.cloud.CloudWarmUpJob.SyncEvent;
+import org.apache.doris.cloud.CloudWarmUpJob.SyncMode;
 import org.apache.doris.cloud.catalog.CloudTablet;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Triple;
+import org.apache.doris.nereids.trees.plans.commands.WarmUpClusterCommand;
+import org.apache.doris.persist.EditLog;
 import org.apache.doris.system.Backend;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class CacheHotspotManagerTest {
     private CacheHotspotManager cacheHotspotManager;
     private CloudSystemInfoService cloudSystemInfoService;
-    private Partition partition;
+    private boolean originalRunningUnitTest;
+    private AtomicLong nextJobId;
+    private Env env;
+    private EditLog editLog;
+    private MockedStatic<Env> envMockedStatic;
+
+    @Before
+    public void setUp() {
+        originalRunningUnitTest = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = true;
+        nextJobId = new AtomicLong(1000L);
+        env = Mockito.mock(Env.class);
+        editLog = Mockito.mock(EditLog.class);
+        Mockito.when(env.getNextId()).thenAnswer(invocation -> nextJobId.getAndIncrement());
+        Mockito.when(env.getEditLog()).thenReturn(editLog);
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        cloudSystemInfoService = new CloudSystemInfoService();
+        cacheHotspotManager = new CacheHotspotManager(cloudSystemInfoService);
+    }
+
+    @After
+    public void tearDown() {
+        envMockedStatic.close();
+        FeConstants.runningUnitTest = originalRunningUnitTest;
+    }
 
     @Test
     public void testWarmUpNewClusterByTable() {
@@ -84,22 +124,200 @@ public class CacheHotspotManagerTest {
             }
         });
 
-        // Setup mock data
         long jobId = 1L;
         String dstClusterName = "test_cluster";
         List<Triple<String, String, String>> tables = new ArrayList<>();
         tables.add(Triple.of("test_db", "test_table", ""));
 
-        // force = true
         Map<Long, List<Tablet>> result = cacheHotspotManager.warmUpNewClusterByTable(
                 jobId, dstClusterName, tables, true);
-        Assert.assertEquals(result.size(), 1);
-        Assert.assertEquals(result.get(11L).get(0).getId(), 1001L);
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(1001L, result.get(11L).get(0).getId());
 
-        // force = false
-        RuntimeException exception = Assert.assertThrows(RuntimeException.class, () -> {
-            cacheHotspotManager.warmUpNewClusterByTable(jobId, dstClusterName, tables, false);
-        });
+        RuntimeException exception = Assert.assertThrows(RuntimeException.class, () ->
+                cacheHotspotManager.warmUpNewClusterByTable(jobId, dstClusterName, tables, false));
         Assert.assertEquals("The cluster " + dstClusterName + " cache size is not enough", exception.getMessage());
+    }
+
+    @Test
+    public void testCreateTableOnceJobDedupesPendingOrderDifference() throws AnalysisException {
+        long firstJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
+                Triple.of("db1", "tbl1", ""),
+                Triple.of("db2", "tbl2", "p1")));
+        long reusedJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
+                Triple.of("db2", "tbl2", "p1"),
+                Triple.of("db1", "tbl1", "")));
+
+        Assert.assertEquals(firstJobId, reusedJobId);
+        Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
+        Mockito.verify(env, Mockito.times(1)).getNextId();
+        Mockito.verify(editLog, Mockito.times(1)).logModifyCloudWarmUpJob(Mockito.any(CloudWarmUpJob.class));
+    }
+
+    @Test
+    public void testCreateTableOnceJobDedupesDuplicateTableEntries() throws AnalysisException {
+        long firstJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
+                Triple.of("db1", "tbl1", ""),
+                Triple.of("db1", "tbl1", "")));
+        long reusedJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
+                Triple.of("db1", "tbl1", "")));
+
+        Assert.assertEquals(firstJobId, reusedJobId);
+        Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    @Test
+    public void testCreateTableOnceJobDoesNotDedupDifferentForce() throws AnalysisException {
+        long forceFalseJobId = cacheHotspotManager.createJob(newTableStmt("dst", false,
+                Triple.of("db1", "tbl1", "")));
+        long forceTrueJobId = cacheHotspotManager.createJob(newTableStmt("dst", true,
+                Triple.of("db1", "tbl1", "")));
+
+        Assert.assertNotEquals(forceFalseJobId, forceTrueJobId);
+        Assert.assertEquals(2, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    @Test
+    public void testCreateClusterOnceJobDedupesPendingJob() throws AnalysisException {
+        long firstJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", false));
+        long reusedJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", false));
+
+        Assert.assertEquals(firstJobId, reusedJobId);
+        Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    @Test
+    public void testCreateClusterOnceJobDedupesRegardlessOfForceFlag() throws AnalysisException {
+        long firstJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", false));
+        long reusedJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", true));
+
+        Assert.assertEquals(firstJobId, reusedJobId);
+        Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    @Test
+    public void testCreateClusterOnceJobAllowsNewPendingWhenOnlyRunningExists() throws AnalysisException {
+        CloudWarmUpJob runningJob = newClusterJob(10L, "src", "dst", SyncMode.ONCE, JobState.RUNNING, 100L);
+        cacheHotspotManager.addCloudWarmUpJob(runningJob);
+
+        long newJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", false));
+
+        Assert.assertNotEquals(runningJob.getJobId(), newJobId);
+        Assert.assertEquals(2, cacheHotspotManager.getCloudWarmUpJobs().size());
+        Assert.assertEquals(JobState.PENDING, cacheHotspotManager.getCloudWarmUpJob(newJobId).getJobState());
+    }
+
+    @Test
+    public void testCreateClusterOnceJobReusesPendingWhenRunningAndPendingExist() throws AnalysisException {
+        CloudWarmUpJob runningJob = newClusterJob(10L, "src", "dst", SyncMode.ONCE, JobState.RUNNING, 100L);
+        CloudWarmUpJob pendingJob = newClusterJob(11L, "src", "dst", SyncMode.ONCE, JobState.PENDING, 200L);
+        cacheHotspotManager.addCloudWarmUpJob(runningJob);
+        cacheHotspotManager.addCloudWarmUpJob(pendingJob);
+
+        long reusedJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", false));
+
+        Assert.assertEquals(pendingJob.getJobId(), reusedJobId);
+        Assert.assertEquals(2, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    @Test
+    public void testCreateOnceJobIgnoresFinishedHistory() throws AnalysisException {
+        CloudWarmUpJob finishedJob = newClusterJob(10L, "src", "dst", SyncMode.ONCE, JobState.FINISHED, 100L);
+        cacheHotspotManager.addCloudWarmUpJob(finishedJob);
+
+        long newJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", false));
+
+        Assert.assertNotEquals(finishedJob.getJobId(), newJobId);
+        Assert.assertEquals(2, cacheHotspotManager.getCloudWarmUpJobs().size());
+        Assert.assertEquals(JobState.PENDING, cacheHotspotManager.getCloudWarmUpJob(newJobId).getJobState());
+    }
+
+    @Test
+    public void testCreateClusterOnceJobReusesOldestHistoricalPendingDuplicateAfterReplay() throws Exception {
+        CloudWarmUpJob newerPendingJob = newClusterJob(20L, "src", "dst", SyncMode.ONCE, JobState.PENDING, 200L);
+        CloudWarmUpJob olderPendingJob = newClusterJob(30L, "src", "dst", SyncMode.ONCE, JobState.PENDING, 100L);
+        cacheHotspotManager.replayCloudWarmUpJob(newerPendingJob);
+        cacheHotspotManager.replayCloudWarmUpJob(olderPendingJob);
+
+        long reusedJobId = cacheHotspotManager.createJob(newClusterStmt("dst", "src", false));
+
+        Assert.assertEquals(olderPendingJob.getJobId(), reusedJobId);
+        Assert.assertEquals(2, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    @Test
+    public void testCreatePeriodicJobUnaffected() throws AnalysisException {
+        WarmUpClusterCommand periodicStmt = newClusterStmt("dst", "src", false, periodicProperties(60));
+        long firstJobId = cacheHotspotManager.createJob(periodicStmt);
+        AnalysisException exception = Assert.assertThrows(AnalysisException.class, () ->
+                cacheHotspotManager.createJob(newClusterStmt("dst", "src", false, periodicProperties(60))));
+
+        Assert.assertEquals(1000L, firstJobId);
+        Assert.assertTrue(exception.getMessage().contains("already has a runnable job"));
+        Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    @Test
+    public void testCreateEventDrivenJobUnaffected() throws AnalysisException {
+        WarmUpClusterCommand eventDrivenStmt = newClusterStmt("dst", "src", false, eventDrivenProperties("load"));
+        long firstJobId = cacheHotspotManager.createJob(eventDrivenStmt);
+        AnalysisException exception = Assert.assertThrows(AnalysisException.class, () ->
+                cacheHotspotManager.createJob(newClusterStmt("dst", "src", false, eventDrivenProperties("load"))));
+
+        Assert.assertEquals(1000L, firstJobId);
+        Assert.assertTrue(exception.getMessage().contains("already has a runnable job"));
+        Assert.assertEquals(1, cacheHotspotManager.getCloudWarmUpJobs().size());
+    }
+
+    private WarmUpClusterCommand newTableStmt(String dstClusterName, boolean force,
+            Triple<String, String, String>... tables) {
+        WarmUpClusterCommand stmt = new WarmUpClusterCommand(new ArrayList<>(),
+                null, dstClusterName, force, true);
+        for (Triple<String, String, String> table : tables) {
+            stmt.getTables().add(table);
+        }
+        return stmt;
+    }
+
+    private WarmUpClusterCommand newClusterStmt(String dstClusterName, String srcClusterName, boolean force) {
+        return newClusterStmt(dstClusterName, srcClusterName, force, new HashMap<>());
+    }
+
+    private WarmUpClusterCommand newClusterStmt(String dstClusterName, String srcClusterName,
+            boolean force, Map<String, String> properties) {
+        return new WarmUpClusterCommand(null, srcClusterName, dstClusterName, force, false, properties);
+    }
+
+    private Map<String, String> periodicProperties(long syncIntervalSec) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("sync_mode", "periodic");
+        properties.put("sync_interval_sec", String.valueOf(syncIntervalSec));
+        return properties;
+    }
+
+    private Map<String, String> eventDrivenProperties(String syncEvent) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("sync_mode", "event_driven");
+        properties.put("sync_event", syncEvent);
+        return properties;
+    }
+
+    private CloudWarmUpJob newClusterJob(long jobId, String srcClusterName, String dstClusterName,
+            SyncMode syncMode, JobState jobState, long createTimeMs) {
+        CloudWarmUpJob.Builder builder = new CloudWarmUpJob.Builder()
+                .setJobId(jobId)
+                .setSrcClusterName(srcClusterName)
+                .setDstClusterName(dstClusterName)
+                .setJobType(JobType.CLUSTER)
+                .setSyncMode(syncMode);
+        if (syncMode == SyncMode.PERIODIC) {
+            builder.setSyncInterval(60L);
+        } else if (syncMode == SyncMode.EVENT_DRIVEN) {
+            builder.setSyncEvent(SyncEvent.LOAD);
+        }
+        CloudWarmUpJob job = builder.build();
+        job.setJobState(jobState);
+        job.setCreateTimeMs(createTimeMs);
+        return job;
     }
 }


### PR DESCRIPTION
Proposed changes
Issue Number: N/A

Deduplicate equivalent PENDING one-shot TABLE warm up jobs by destination cluster, normalized table set, and force flag.
Deduplicate equivalent PENDING one-shot CLUSTER warm up jobs by source/destination cluster pair.
Reuse the oldest matching pending job and return its job id instead of appending another pending duplicate.
Keep RUNNING jobs out of deduplication and preserve the existing PERIODIC / EVENT_DRIVEN behavior.
Add unit tests for table/cluster deduplication, replay handling, and regression coverage.
Test:

Not run in this backport branch per request.