### PR TITLE
[fix](filecache) avoid BE crash when finalize misses local cache writer

### DIFF
--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -216,7 +216,13 @@ Status FSFileCacheStorage::finalize(const FileCacheKey& key, const size_t size) 
         std::lock_guard lock(_mtx);
         auto file_writer_map_key = std::make_pair(key.hash, key.offset);
         auto iter = _key_to_writer.find(file_writer_map_key);
-        DCHECK(iter != _key_to_writer.end());
+        if (iter == _key_to_writer.end()) {
+            return Status::InternalError(
+                    "file cache finalize missing writer, hash={}, offset={}, type={}, "
+                    "expiration={}",
+                    key.hash.to_string(), key.offset, cache_type_to_string(key.meta.type),
+                    key.meta.expiration_time);
+        }
         file_writer = std::move(iter->second);
         _key_to_writer.erase(iter);
     }

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -8038,6 +8038,23 @@ TEST_F(BlockFileCacheTest, finalize_partial_block) {
     }
 }
 
+TEST_F(BlockFileCacheTest, fs_file_cache_storage_finalize_missing_writer_returns_error) {
+    FSFileCacheStorage storage;
+    FileCacheKey key;
+    key.hash = io::BlockFileCache::hash("finalize-missing-writer");
+    key.offset = 4096;
+    key.meta.type = io::FileCacheType::NORMAL;
+    key.meta.expiration_time = 0;
+    key.meta.tablet_id = 0;
+
+    auto st = storage.finalize(key, 4096);
+
+    EXPECT_TRUE(st.is<ErrorCode::INTERNAL_ERROR>()) << st;
+    EXPECT_TRUE(st.to_string().find("file cache finalize missing writer") != std::string::npos)
+            << st;
+    EXPECT_TRUE(st.to_string().find("offset=4096") != std::string::npos) << st;
+}
+
 TEST_F(BlockFileCacheTest, set_downloaded_empty_block_branch) {
     FileCacheKey key;
     key.hash = io::BlockFileCache::hash("set_downloaded_empty_block_branch");


### PR DESCRIPTION
## Problem

`FSFileCacheStorage::finalize()` relied on `DCHECK` to assume the writer entry always existed in `_key_to_writer`. In release builds a missing writer entry could still fall through, dereference `end()`, and crash BE.

## Root Cause

When `(hash, offset)` is missing from `_key_to_writer`, the current finalize path moves and erases through an invalid iterator. The target branch already uses the newer `finalize(key, size)` signature, so this PR ports the hardening change to that path.

## Solution

- return `InternalError` immediately when finalize cannot find the writer entry
- include hash, offset, cache type, and expiration time in the error message for diagnosis
- keep the normal finalize path unchanged when the writer exists
- rely on the existing `FileBlock::set_downloaded()` cleanup path to abort the pending cache write and reset block state

## Tests

- `BlockFileCacheTest.fs_file_cache_storage_finalize_missing_writer_returns_error`
- `DORIS_TOOLCHAIN=clang DISABLE_BE_JAVA_EXTENSIONS=ON ENABLE_INJECTION_POINT=ON ENABLE_CACHE_LOCK_DEBUG=0 ENABLE_PCH=0 sh run-be-ut.sh --clean --run --filter=BlockFileCacheTest.fs_file_cache_storage_finalize_missing_writer_returns_error -j 39`
- Source patch: `selectdb/selectdb-core#8321`
