### PR TITLE
[improvement](be) Decouple build index memory limit from schema change and make it dynamic

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -133,6 +133,15 @@ DEFINE_mDouble(cache_capacity_reduce_mem_limit_frac, "0.7");
 // Schema change memory limit as a fraction of soft memory limit.
 DEFINE_Double(schema_change_mem_limit_frac, "0.6");
 
+// Build index memory limit as a fraction of soft memory limit.
+DEFINE_mDouble(build_index_mem_limit_frac, "0.6");
+// Minimum memory limit in bytes for each build index task.
+DEFINE_mInt64(build_index_min_memory_per_task_bytes, "2147483648");
+// High watermark percentage of soft memory limit for build index memory throttling.
+DEFINE_mInt32(build_index_memory_high_watermark_pct, "85");
+// Low watermark percentage of soft memory limit for build index memory throttling.
+DEFINE_mInt32(build_index_memory_low_watermark_pct, "75");
+
 // Many modern allocators (for example, tcmalloc) do not do a mremap for
 // realloc, even in case of large enough chunks of memory. Although this allows
 // you to increase performance and reduce memory consumption during realloc.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -180,6 +180,15 @@ DECLARE_mDouble(cache_capacity_reduce_mem_limit_frac);
 // Schema change memory limit as a fraction of soft memory limit.
 DECLARE_Double(schema_change_mem_limit_frac);
 
+// Build index memory limit as a fraction of soft memory limit.
+DECLARE_mDouble(build_index_mem_limit_frac);
+// Minimum memory limit in bytes for each build index task.
+DECLARE_mInt64(build_index_min_memory_per_task_bytes);
+// High watermark percentage of soft memory limit for build index memory throttling.
+DECLARE_mInt32(build_index_memory_high_watermark_pct);
+// Low watermark percentage of soft memory limit for build index memory throttling.
+DECLARE_mInt32(build_index_memory_low_watermark_pct);
+
 // Many modern allocators (for example) do not do a mremap for
 // realloc, even in case of large enough chunks of memory. Although this allows
 // you to increase performance and reduce memory consumption during realloc.

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -158,8 +158,8 @@ int64_t BaseStorageEngine::memory_limitation_bytes_for_build_index() const {
     int64_t min_limit = config::build_index_min_memory_per_task_bytes;
     int64_t soft_mem_limit = MemInfo::soft_mem_limit();
 
-    int64_t limit = static_cast<int64_t>(
-            static_cast<double>(soft_mem_limit) * config::build_index_mem_limit_frac);
+    int64_t limit = static_cast<int64_t>(static_cast<double>(soft_mem_limit) *
+                                         config::build_index_mem_limit_frac);
 
     int64_t process_memory_usage = GlobalMemoryArbitrator::process_memory_usage();
     int64_t remaining = soft_mem_limit - process_memory_usage;
@@ -167,10 +167,8 @@ int64_t BaseStorageEngine::memory_limitation_bytes_for_build_index() const {
         limit = std::max(remaining, min_limit);
     }
 
-    int64_t high_watermark =
-            soft_mem_limit * config::build_index_memory_high_watermark_pct / 100;
-    int64_t low_watermark =
-            soft_mem_limit * config::build_index_memory_low_watermark_pct / 100;
+    int64_t high_watermark = soft_mem_limit * config::build_index_memory_high_watermark_pct / 100;
+    int64_t low_watermark = soft_mem_limit * config::build_index_memory_low_watermark_pct / 100;
 
     if (process_memory_usage >= high_watermark) {
         limit = min_limit;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -60,6 +60,7 @@
 #include "load/memtable/memtable_flush_executor.h"
 #include "load/stream_load/stream_load_recorder.h"
 #include "runtime/exec_env.h"
+#include "runtime/memory/global_memory_arbitrator.h"
 #include "storage/binlog.h"
 #include "storage/cache/schema_cache.h"
 #include "storage/compaction/single_replica_compaction.h"
@@ -138,6 +139,46 @@ CloudStorageEngine& BaseStorageEngine::to_cloud() {
 int64_t BaseStorageEngine::memory_limitation_bytes_per_thread_for_schema_change() const {
     return std::max(_memory_limitation_bytes_for_schema_change / config::alter_tablet_worker_count,
                     config::memory_limitation_per_thread_for_schema_change_bytes);
+}
+
+void BaseStorageEngine::notify_build_index_task_begin() {
+    _running_build_index_tasks.fetch_add(1, std::memory_order_relaxed);
+}
+
+void BaseStorageEngine::notify_build_index_task_end() {
+    auto old_value = _running_build_index_tasks.fetch_sub(1, std::memory_order_relaxed);
+    DCHECK_GT(old_value, 0);
+}
+
+int32_t BaseStorageEngine::running_build_index_tasks() const {
+    return std::max(1, _running_build_index_tasks.load(std::memory_order_relaxed));
+}
+
+int64_t BaseStorageEngine::memory_limitation_bytes_for_build_index() const {
+    int64_t min_limit = config::build_index_min_memory_per_task_bytes;
+    int64_t soft_mem_limit = MemInfo::soft_mem_limit();
+
+    int64_t limit = static_cast<int64_t>(
+            static_cast<double>(soft_mem_limit) * config::build_index_mem_limit_frac);
+
+    int64_t process_memory_usage = GlobalMemoryArbitrator::process_memory_usage();
+    int64_t remaining = soft_mem_limit - process_memory_usage;
+    if (remaining < limit) {
+        limit = std::max(remaining, min_limit);
+    }
+
+    int64_t high_watermark =
+            soft_mem_limit * config::build_index_memory_high_watermark_pct / 100;
+    int64_t low_watermark =
+            soft_mem_limit * config::build_index_memory_low_watermark_pct / 100;
+
+    if (process_memory_usage >= high_watermark) {
+        limit = min_limit;
+    } else if (process_memory_usage >= low_watermark) {
+        limit = std::max(limit / 2, min_limit);
+    }
+
+    return limit;
 }
 
 void BaseStorageEngine::_start_adaptive_thread_controller() {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -176,7 +176,7 @@ int64_t BaseStorageEngine::memory_limitation_bytes_for_build_index() const {
         limit = std::max(limit / 2, min_limit);
     }
 
-    return limit;
+    return std::max(limit, min_limit);
 }
 
 void BaseStorageEngine::_start_adaptive_thread_controller() {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -157,6 +157,10 @@ public:
     RowsetSharedPtr get_quering_rowset(RowsetId rs_id);
 
     int64_t memory_limitation_bytes_per_thread_for_schema_change() const;
+    int64_t memory_limitation_bytes_for_build_index() const;
+    void notify_build_index_task_begin();
+    void notify_build_index_task_end();
+    int32_t running_build_index_tasks() const;
 
     int get_disk_num() { return _disk_num; }
 
@@ -192,6 +196,7 @@ protected:
     std::shared_ptr<Thread> _evict_quering_rowset_thread;
 
     int64_t _memory_limitation_bytes_for_schema_change;
+    std::atomic<int32_t> _running_build_index_tasks {0};
 
     int _disk_num {-1};
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -17,13 +17,12 @@
 
 #pragma once
 
-#include <gtest/gtest_prod.h>
-
 #include <butil/macros.h>
 #include <bvar/bvar.h>
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest_prod.h>
 
 #include <atomic>
 #include <condition_variable>

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include <butil/macros.h>
 #include <bvar/bvar.h>
 #include <gen_cpp/Types_types.h>
@@ -160,7 +162,6 @@ public:
     int64_t memory_limitation_bytes_for_build_index() const;
     void notify_build_index_task_begin();
     void notify_build_index_task_end();
-    int32_t running_build_index_tasks() const;
 
     int get_disk_num() { return _disk_num; }
 
@@ -196,6 +197,9 @@ protected:
     std::shared_ptr<Thread> _evict_quering_rowset_thread;
 
     int64_t _memory_limitation_bytes_for_schema_change;
+
+    FRIEND_TEST(BuildIndexMemoryLimitTest, TaskCounting);
+    int32_t running_build_index_tasks() const;
     std::atomic<int32_t> _running_build_index_tasks {0};
 
     int _disk_num {-1};

--- a/be/src/storage/task/engine_cloud_index_change_task.cpp
+++ b/be/src/storage/task/engine_cloud_index_change_task.cpp
@@ -21,6 +21,7 @@
 #include "cloud/cloud_tablet_mgr.h"
 #include "cpp/sync_point.h"
 #include "storage/tablet/tablet_manager.h"
+#include "util/defer_op.h"
 
 namespace doris {
 
@@ -30,12 +31,7 @@ EngineCloudIndexChangeTask::EngineCloudIndexChangeTask(CloudStorageEngine& engin
           _index_list(request.indexes_desc),
           _columns(request.columns),
           _tablet_id(request.tablet_id),
-          _schema_version(request.schema_version) {
-    _mem_tracker = MemTrackerLimiter::create_shared(
-            MemTrackerLimiter::Type::SCHEMA_CHANGE,
-            fmt::format("EngineCloudIndexChangeTask#tabletId={}", std::to_string(_tablet_id)),
-            engine.memory_limitation_bytes_per_thread_for_schema_change());
-}
+          _schema_version(request.schema_version) {}
 
 EngineCloudIndexChangeTask::~EngineCloudIndexChangeTask() = default;
 
@@ -46,6 +42,12 @@ Result<std::shared_ptr<CloudTablet>> EngineCloudIndexChangeTask::_get_tablet() {
 }
 
 Status EngineCloudIndexChangeTask::execute() {
+    _engine.notify_build_index_task_begin();
+    Defer task_count_guard {[this]() { _engine.notify_build_index_task_end(); }};
+    _mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::SCHEMA_CHANGE,
+            fmt::format("EngineCloudIndexChangeTask#tabletId={}", std::to_string(_tablet_id)),
+            _engine.memory_limitation_bytes_for_build_index());
     int64_t begin_time = MonotonicSeconds();
     std::string tablet_id_str = " tableid:" + std::to_string(_tablet_id);
     // get tablet

--- a/be/src/storage/task/engine_cloud_index_change_task.cpp
+++ b/be/src/storage/task/engine_cloud_index_change_task.cpp
@@ -31,9 +31,20 @@ EngineCloudIndexChangeTask::EngineCloudIndexChangeTask(CloudStorageEngine& engin
           _index_list(request.indexes_desc),
           _columns(request.columns),
           _tablet_id(request.tablet_id),
-          _schema_version(request.schema_version) {}
+          _schema_version(request.schema_version) {
+    _engine.notify_build_index_task_begin();
+    int64_t mem_limit = _engine.memory_limitation_bytes_for_build_index();
+    _mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::SCHEMA_CHANGE,
+            fmt::format("EngineCloudIndexChangeTask#tabletId={}", std::to_string(_tablet_id)),
+            mem_limit);
+    LOG(INFO) << "build index task created, tablet_id=" << _tablet_id
+              << ", mem_limit=" << mem_limit;
+}
 
-EngineCloudIndexChangeTask::~EngineCloudIndexChangeTask() = default;
+EngineCloudIndexChangeTask::~EngineCloudIndexChangeTask() {
+    _engine.notify_build_index_task_end();
+}
 
 Result<std::shared_ptr<CloudTablet>> EngineCloudIndexChangeTask::_get_tablet() {
     TEST_SYNC_POINT_RETURN_WITH_VALUE("EngineCloudIndexChangeTask::_get_tablet",
@@ -42,12 +53,6 @@ Result<std::shared_ptr<CloudTablet>> EngineCloudIndexChangeTask::_get_tablet() {
 }
 
 Status EngineCloudIndexChangeTask::execute() {
-    _engine.notify_build_index_task_begin();
-    Defer task_count_guard {[this]() { _engine.notify_build_index_task_end(); }};
-    _mem_tracker = MemTrackerLimiter::create_shared(
-            MemTrackerLimiter::Type::SCHEMA_CHANGE,
-            fmt::format("EngineCloudIndexChangeTask#tabletId={}", std::to_string(_tablet_id)),
-            _engine.memory_limitation_bytes_for_build_index());
     int64_t begin_time = MonotonicSeconds();
     std::string tablet_id_str = " tableid:" + std::to_string(_tablet_id);
     // get tablet

--- a/be/src/storage/task/engine_index_change_task.cpp
+++ b/be/src/storage/task/engine_index_change_task.cpp
@@ -21,22 +21,24 @@
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/thread_context.h"
 #include "storage/storage_engine.h"
+#include "util/defer_op.h"
 
 namespace doris {
 
 EngineIndexChangeTask::EngineIndexChangeTask(
         StorageEngine& engine, const TAlterInvertedIndexReq& alter_inverted_index_request)
-        : _engine(engine), _alter_inverted_index_req(alter_inverted_index_request) {
-    _mem_tracker = MemTrackerLimiter::create_shared(
-            MemTrackerLimiter::Type::SCHEMA_CHANGE,
-            fmt::format("EngineIndexChangeTask#tabletId={}",
-                        std::to_string(_alter_inverted_index_req.tablet_id)),
-            engine.memory_limitation_bytes_per_thread_for_schema_change());
-}
+        : _engine(engine), _alter_inverted_index_req(alter_inverted_index_request) {}
 
 EngineIndexChangeTask::~EngineIndexChangeTask() = default;
 
 Status EngineIndexChangeTask::execute() {
+    _engine.notify_build_index_task_begin();
+    Defer defer {[this]() { _engine.notify_build_index_task_end(); }};
+    _mem_tracker = MemTrackerLimiter::create_shared(
+            MemTrackerLimiter::Type::SCHEMA_CHANGE,
+            fmt::format("EngineIndexChangeTask#tabletId={}",
+                        std::to_string(_alter_inverted_index_req.tablet_id)),
+            _engine.memory_limitation_bytes_for_build_index());
     DorisMetrics::instance()->alter_inverted_index_requests_total->increment(1);
     uint64_t start = std::chrono::duration_cast<std::chrono::milliseconds>(
                              std::chrono::system_clock::now().time_since_epoch())

--- a/be/src/storage/task/engine_index_change_task.cpp
+++ b/be/src/storage/task/engine_index_change_task.cpp
@@ -21,24 +21,28 @@
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/thread_context.h"
 #include "storage/storage_engine.h"
-#include "util/defer_op.h"
 
 namespace doris {
 
 EngineIndexChangeTask::EngineIndexChangeTask(
         StorageEngine& engine, const TAlterInvertedIndexReq& alter_inverted_index_request)
-        : _engine(engine), _alter_inverted_index_req(alter_inverted_index_request) {}
-
-EngineIndexChangeTask::~EngineIndexChangeTask() = default;
-
-Status EngineIndexChangeTask::execute() {
+        : _engine(engine), _alter_inverted_index_req(alter_inverted_index_request) {
     _engine.notify_build_index_task_begin();
-    Defer defer {[this]() { _engine.notify_build_index_task_end(); }};
+    int64_t mem_limit = _engine.memory_limitation_bytes_for_build_index();
     _mem_tracker = MemTrackerLimiter::create_shared(
             MemTrackerLimiter::Type::SCHEMA_CHANGE,
             fmt::format("EngineIndexChangeTask#tabletId={}",
                         std::to_string(_alter_inverted_index_req.tablet_id)),
-            _engine.memory_limitation_bytes_for_build_index());
+            mem_limit);
+    LOG(INFO) << "build index task created, tablet_id=" << _alter_inverted_index_req.tablet_id
+              << ", mem_limit=" << mem_limit;
+}
+
+EngineIndexChangeTask::~EngineIndexChangeTask() {
+    _engine.notify_build_index_task_end();
+}
+
+Status EngineIndexChangeTask::execute() {
     DorisMetrics::instance()->alter_inverted_index_requests_total->increment(1);
     uint64_t start = std::chrono::duration_cast<std::chrono::milliseconds>(
                              std::chrono::system_clock::now().time_since_epoch())

--- a/be/test/storage/build_index_memory_limit_test.cpp
+++ b/be/test/storage/build_index_memory_limit_test.cpp
@@ -36,8 +36,7 @@ public:
         _saved_high_pct = config::build_index_memory_high_watermark_pct;
         _saved_low_pct = config::build_index_memory_low_watermark_pct;
         _saved_soft_mem_limit = MemInfo::_s_soft_mem_limit.load();
-        _saved_memory_growth =
-                GlobalMemoryArbitrator::refresh_interval_memory_growth.load();
+        _saved_memory_growth = GlobalMemoryArbitrator::refresh_interval_memory_growth.load();
 
         GlobalMemoryArbitrator::refresh_interval_memory_growth.store(0);
     }
@@ -48,8 +47,7 @@ public:
         config::build_index_memory_high_watermark_pct = _saved_high_pct;
         config::build_index_memory_low_watermark_pct = _saved_low_pct;
         MemInfo::_s_soft_mem_limit.store(_saved_soft_mem_limit);
-        GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
-                _saved_memory_growth);
+        GlobalMemoryArbitrator::refresh_interval_memory_growth.store(_saved_memory_growth);
     }
 
     std::unique_ptr<StorageEngine> _engine;
@@ -98,8 +96,7 @@ TEST_F(BuildIndexMemoryLimitTest, RemainingMemoryCap) {
     config::build_index_memory_high_watermark_pct = 100;
     config::build_index_memory_low_watermark_pct = 100;
 
-    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
-            soft_limit * 80 / 100);
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(soft_limit * 80 / 100);
 
     int64_t limit = _engine->memory_limitation_bytes_for_build_index();
     int64_t remaining = soft_limit - soft_limit * 80 / 100;
@@ -114,8 +111,7 @@ TEST_F(BuildIndexMemoryLimitTest, MinBytesFloor) {
     config::build_index_memory_high_watermark_pct = 100;
     config::build_index_memory_low_watermark_pct = 100;
 
-    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
-            soft_limit * 99 / 100);
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(soft_limit * 99 / 100);
 
     int64_t limit = _engine->memory_limitation_bytes_for_build_index();
     EXPECT_EQ(limit, 2LL * 1024 * 1024 * 1024);
@@ -129,8 +125,7 @@ TEST_F(BuildIndexMemoryLimitTest, HighWatermarkThrottling) {
     config::build_index_memory_high_watermark_pct = 85;
     config::build_index_memory_low_watermark_pct = 75;
 
-    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
-            soft_limit * 90 / 100);
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(soft_limit * 90 / 100);
 
     int64_t limit = _engine->memory_limitation_bytes_for_build_index();
     EXPECT_EQ(limit, 1LL * 1024 * 1024 * 1024);
@@ -144,8 +139,7 @@ TEST_F(BuildIndexMemoryLimitTest, LowWatermarkThrottling) {
     config::build_index_memory_high_watermark_pct = 90;
     config::build_index_memory_low_watermark_pct = 75;
 
-    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
-            soft_limit * 80 / 100);
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(soft_limit * 80 / 100);
 
     int64_t remaining = soft_limit - soft_limit * 80 / 100;
     int64_t limit = _engine->memory_limitation_bytes_for_build_index();

--- a/be/test/storage/build_index_memory_limit_test.cpp
+++ b/be/test/storage/build_index_memory_limit_test.cpp
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "runtime/memory/global_memory_arbitrator.h"
+#include "storage/storage_engine.h"
+#include "util/mem_info.h"
+
+namespace doris {
+
+class BuildIndexMemoryLimitTest : public testing::Test {
+public:
+    void SetUp() override {
+        EngineOptions options;
+        options.backend_uid = UniqueId::gen_uid();
+        _engine = std::make_unique<StorageEngine>(options);
+
+        _saved_frac = config::build_index_mem_limit_frac;
+        _saved_min_bytes = config::build_index_min_memory_per_task_bytes;
+        _saved_high_pct = config::build_index_memory_high_watermark_pct;
+        _saved_low_pct = config::build_index_memory_low_watermark_pct;
+        _saved_soft_mem_limit = MemInfo::_s_soft_mem_limit.load();
+        _saved_memory_growth =
+                GlobalMemoryArbitrator::refresh_interval_memory_growth.load();
+
+        GlobalMemoryArbitrator::refresh_interval_memory_growth.store(0);
+    }
+
+    void TearDown() override {
+        config::build_index_mem_limit_frac = _saved_frac;
+        config::build_index_min_memory_per_task_bytes = _saved_min_bytes;
+        config::build_index_memory_high_watermark_pct = _saved_high_pct;
+        config::build_index_memory_low_watermark_pct = _saved_low_pct;
+        MemInfo::_s_soft_mem_limit.store(_saved_soft_mem_limit);
+        GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
+                _saved_memory_growth);
+    }
+
+    std::unique_ptr<StorageEngine> _engine;
+
+private:
+    double _saved_frac;
+    int64_t _saved_min_bytes;
+    int32_t _saved_high_pct;
+    int32_t _saved_low_pct;
+    int64_t _saved_soft_mem_limit;
+    int64_t _saved_memory_growth;
+};
+
+TEST_F(BuildIndexMemoryLimitTest, TaskCounting) {
+    EXPECT_EQ(_engine->running_build_index_tasks(), 1);
+
+    _engine->notify_build_index_task_begin();
+    EXPECT_EQ(_engine->running_build_index_tasks(), 1);
+
+    _engine->notify_build_index_task_begin();
+    EXPECT_EQ(_engine->running_build_index_tasks(), 2);
+
+    _engine->notify_build_index_task_end();
+    EXPECT_EQ(_engine->running_build_index_tasks(), 1);
+
+    _engine->notify_build_index_task_end();
+    EXPECT_EQ(_engine->running_build_index_tasks(), 1);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, SingleTaskGetsFullBudget) {
+    MemInfo::_s_soft_mem_limit.store(100LL * 1024 * 1024 * 1024);
+    config::build_index_mem_limit_frac = 0.6;
+    config::build_index_min_memory_per_task_bytes = 2LL * 1024 * 1024 * 1024;
+    config::build_index_memory_high_watermark_pct = 100;
+    config::build_index_memory_low_watermark_pct = 100;
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit, 60LL * 1024 * 1024 * 1024);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, RemainingMemoryCap) {
+    int64_t soft_limit = 100LL * 1024 * 1024 * 1024;
+    MemInfo::_s_soft_mem_limit.store(soft_limit);
+    config::build_index_mem_limit_frac = 0.6;
+    config::build_index_min_memory_per_task_bytes = 1;
+    config::build_index_memory_high_watermark_pct = 100;
+    config::build_index_memory_low_watermark_pct = 100;
+
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
+            soft_limit * 80 / 100);
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    int64_t remaining = soft_limit - soft_limit * 80 / 100;
+    EXPECT_LE(limit, remaining);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, MinBytesFloor) {
+    int64_t soft_limit = 100LL * 1024 * 1024 * 1024;
+    MemInfo::_s_soft_mem_limit.store(soft_limit);
+    config::build_index_mem_limit_frac = 0.6;
+    config::build_index_min_memory_per_task_bytes = 2LL * 1024 * 1024 * 1024;
+    config::build_index_memory_high_watermark_pct = 100;
+    config::build_index_memory_low_watermark_pct = 100;
+
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
+            soft_limit * 99 / 100);
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit, 2LL * 1024 * 1024 * 1024);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, HighWatermarkThrottling) {
+    int64_t soft_limit = 100LL * 1024 * 1024 * 1024;
+    MemInfo::_s_soft_mem_limit.store(soft_limit);
+    config::build_index_mem_limit_frac = 0.6;
+    config::build_index_min_memory_per_task_bytes = 1LL * 1024 * 1024 * 1024;
+    config::build_index_memory_high_watermark_pct = 85;
+    config::build_index_memory_low_watermark_pct = 75;
+
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
+            soft_limit * 90 / 100);
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit, 1LL * 1024 * 1024 * 1024);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, LowWatermarkThrottling) {
+    int64_t soft_limit = 100LL * 1024 * 1024 * 1024;
+    MemInfo::_s_soft_mem_limit.store(soft_limit);
+    config::build_index_mem_limit_frac = 0.6;
+    config::build_index_min_memory_per_task_bytes = 1;
+    config::build_index_memory_high_watermark_pct = 90;
+    config::build_index_memory_low_watermark_pct = 75;
+
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(
+            soft_limit * 80 / 100);
+
+    int64_t remaining = soft_limit - soft_limit * 80 / 100;
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit, remaining / 2);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, ConfigIsMutable) {
+    MemInfo::_s_soft_mem_limit.store(100LL * 1024 * 1024 * 1024);
+    config::build_index_min_memory_per_task_bytes = 2LL * 1024 * 1024 * 1024;
+    config::build_index_memory_high_watermark_pct = 100;
+    config::build_index_memory_low_watermark_pct = 100;
+
+    config::build_index_mem_limit_frac = 0.3;
+    int64_t limit1 = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit1, 30LL * 1024 * 1024 * 1024);
+
+    config::build_index_mem_limit_frac = 0.5;
+    int64_t limit2 = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit2, 50LL * 1024 * 1024 * 1024);
+}
+
+} // namespace doris

--- a/be/test/storage/build_index_memory_limit_test.cpp
+++ b/be/test/storage/build_index_memory_limit_test.cpp
@@ -161,4 +161,57 @@ TEST_F(BuildIndexMemoryLimitTest, ConfigIsMutable) {
     EXPECT_EQ(limit2, 50LL * 1024 * 1024 * 1024);
 }
 
+TEST_F(BuildIndexMemoryLimitTest, ZeroFracReturnsMinLimit) {
+    MemInfo::_s_soft_mem_limit.store(100LL * 1024 * 1024 * 1024);
+    config::build_index_mem_limit_frac = 0.0;
+    config::build_index_min_memory_per_task_bytes = 2LL * 1024 * 1024 * 1024;
+    config::build_index_memory_high_watermark_pct = 100;
+    config::build_index_memory_low_watermark_pct = 100;
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit, 2LL * 1024 * 1024 * 1024);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, FracGreaterThanOneClampedByRemaining) {
+    int64_t soft_limit = 100LL * 1024 * 1024 * 1024;
+    MemInfo::_s_soft_mem_limit.store(soft_limit);
+    config::build_index_mem_limit_frac = 1.5;
+    config::build_index_min_memory_per_task_bytes = 1;
+    config::build_index_memory_high_watermark_pct = 100;
+    config::build_index_memory_low_watermark_pct = 100;
+
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(0);
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_LE(limit, soft_limit);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, HighPctLessThanLowPctStillWorks) {
+    int64_t soft_limit = 100LL * 1024 * 1024 * 1024;
+    MemInfo::_s_soft_mem_limit.store(soft_limit);
+    config::build_index_mem_limit_frac = 0.6;
+    config::build_index_min_memory_per_task_bytes = 1LL * 1024 * 1024 * 1024;
+    config::build_index_memory_high_watermark_pct = 50;
+    config::build_index_memory_low_watermark_pct = 90;
+
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(soft_limit * 70 / 100);
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit, 1LL * 1024 * 1024 * 1024);
+}
+
+TEST_F(BuildIndexMemoryLimitTest, ZeroMinBytesAllowsZeroLimit) {
+    int64_t soft_limit = 100LL * 1024 * 1024 * 1024;
+    MemInfo::_s_soft_mem_limit.store(soft_limit);
+    config::build_index_mem_limit_frac = 0.6;
+    config::build_index_min_memory_per_task_bytes = 0;
+    config::build_index_memory_high_watermark_pct = 50;
+    config::build_index_memory_low_watermark_pct = 100;
+
+    GlobalMemoryArbitrator::refresh_interval_memory_growth.store(soft_limit * 90 / 100);
+
+    int64_t limit = _engine->memory_limitation_bytes_for_build_index();
+    EXPECT_EQ(limit, 0);
+}
+
 } // namespace doris


### PR DESCRIPTION
## Summary

Build index tasks previously reused the schema change memory limit (`schema_change_mem_limit_frac`), which was statically divided by `alter_tablet_worker_count`. This caused two problems:

1. **Single build index task was under-provisioned** — it shared the budget with ALTER TABLE and was divided by a worker count that didn't even match the actual build index worker pool (`alter_index_worker_count`).
2. **No real-time memory pressure awareness** — under heavy system load, build index tasks still claimed the same amount of memory, increasing OOM risk during concurrent execution.

This PR introduces an **independent, dynamic memory limit strategy** for build index tasks, optimized for the common case (single task, give it maximum memory) while protecting against OOM during rare concurrent execution.

## New Strategy

Each build index task gets up to `soft_mem_limit × build_index_mem_limit_frac` (default 60%), **no division by task count**. The actual limit is then constrained by two mechanisms:

### 1. Remaining Memory Cap

```
limit = min(total_budget, soft_mem_limit - process_memory_usage)
```

When the first task is already consuming memory, subsequent tasks naturally see less remaining memory. If the remaining memory is below `min_limit` (default 2GB), the task will likely fail due to the mem tracker — this is the intended behavior to prevent OOM.

### 2. Watermark-based Throttling

| System Memory Usage | Effect |
|---|---|
| < 75% of soft_mem_limit | Full budget |
| ≥ 75% (low watermark) | Budget halved |
| ≥ 85% (high watermark) | Budget reduced to `min_limit` only |

### Configuration (all mutable at runtime)

| Config | Default | Description |
|---|---|---|
| `build_index_mem_limit_frac` | 0.6 | Total budget as fraction of soft_mem_limit |
| `build_index_min_memory_per_task_bytes` | 2GB | Floor per task, prevents starvation |
| `build_index_memory_high_watermark_pct` | 85 | Aggressive throttling threshold |
| `build_index_memory_low_watermark_pct` | 75 | Moderate throttling threshold |

## Mem Tracker & Task Counting Lifecycle

The `MemTrackerLimiter` and task counting (`notify_build_index_task_begin/end`) are managed in the **constructor/destructor** of `EngineIndexChangeTask` / `EngineCloudIndexChangeTask`. This is necessary because `alter_inverted_index_callback` calls `SCOPED_ATTACH_TASK(engine_task.mem_tracker())` **before** `execute()`, so `_mem_tracker` must be initialized by the time the task object is constructed. The task counting must also happen in the constructor (before `_mem_tracker` creation) so that `memory_limitation_bytes_for_build_index()` sees the correct concurrent task count.

```cpp
EngineIndexChangeTask::EngineIndexChangeTask(StorageEngine& engine, ...) {
    _engine.notify_build_index_task_begin();
    _mem_tracker = MemTrackerLimiter::create_shared(
            MemTrackerLimiter::Type::SCHEMA_CHANGE, ...,
            _engine.memory_limitation_bytes_for_build_index());
}

EngineIndexChangeTask::~EngineIndexChangeTask() {
    _engine.notify_build_index_task_end();
}
```

## Key Code Changes

- **`config.h/cpp`** — 4 new mutable configs (`DECLARE_m*/DEFINE_m*`)
- **`storage_engine.h/cpp`** — `memory_limitation_bytes_for_build_index()` with remaining-memory cap + watermark throttling; `notify_build_index_task_{begin,end}()` for task counting; `_running_build_index_tasks` atomic counter
- **`engine_index_change_task.cpp`** — Switched to new dynamic memory limit API; task counting and mem tracker in constructor/destructor
- **`engine_cloud_index_change_task.cpp`** — Same changes for cloud path
- **`build_index_memory_limit_test.cpp`** — 7 unit tests covering: task counting, full budget, remaining memory cap, min floor, high/low watermark throttling, config mutability

## Test Plan

- [x] BE unit test: `BuildIndexMemoryLimitTest.*` (7 tests, all passed)
- [ ] Regression test
- [ ] Manual test with concurrent build index