### PR TITLE
[fix](be) Add missing SCOPED_ATTACH_TASK in download and move_dir callbacks

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1333,12 +1333,14 @@ void download_callback(StorageEngine& engine, ExecEnv* env, const TAgentTaskRequ
     if (download_request.__isset.remote_tablet_snapshots) {
         std::unique_ptr<SnapshotLoader> loader = std::make_unique<SnapshotLoader>(
                 engine, env, download_request.job_id, req.signature);
+        SCOPED_ATTACH_TASK(loader->resource_ctx());
         status = loader->remote_http_download(download_request.remote_tablet_snapshots,
                                               &downloaded_tablet_ids);
     } else {
         std::unique_ptr<SnapshotLoader> loader = std::make_unique<SnapshotLoader>(
                 engine, env, download_request.job_id, req.signature, download_request.broker_addr,
                 download_request.broker_prop);
+        SCOPED_ATTACH_TASK(loader->resource_ctx());
         status = loader->init(download_request.__isset.storage_backend
                                       ? download_request.storage_backend
                                       : TStorageBackendType::type::BROKER,
@@ -1386,6 +1388,7 @@ void download_callback(CloudStorageEngine& engine, ExecEnv* env, const TAgentTas
         std::unique_ptr<CloudSnapshotLoader> loader = std::make_unique<CloudSnapshotLoader>(
                 engine, env, download_request.job_id, req.signature, download_request.broker_addr,
                 download_request.broker_prop);
+        SCOPED_ATTACH_TASK(loader->resource_ctx());
         status = loader->init(download_request.__isset.storage_backend
                                       ? download_request.storage_backend
                                       : TStorageBackendType::type::BROKER,
@@ -1539,6 +1542,7 @@ void move_dir_callback(StorageEngine& engine, ExecEnv* env, const TAgentTaskRequ
         status = Status::InvalidArgument("Could not find tablet");
     } else {
         SnapshotLoader loader(engine, env, move_dir_req.job_id, move_dir_req.tablet_id);
+        SCOPED_ATTACH_TASK(loader.resource_ctx());
         status = loader.move(move_dir_req.src, tablet, true);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #xxx

Problem Summary:
  download_callback() and move_dir_callback() in task_worker_pool.cpp use
  SnapshotLoader/CloudSnapshotLoader to perform HDFS downloads and file
  moves, but do not attach the MemTracker to the thread context via
  SCOPED_ATTACH_TASK. This causes memory orphan check failures when these
  callbacks allocate memory through HDFS operations, as the allocations
  are not tracked by any MemTrackerLimiter.

  The parallel upload_callback() already has SCOPED_ATTACH_TASK correctly.

### Release note
  Fix: Add SCOPED_ATTACH_TASK(loader->resource_ctx()) in all four missing
  locations:
  - download_callback(StorageEngine&): remote_http_download branch
  - download_callback(StorageEngine&): broker download branch
  - download_callback(CloudStorageEngine&): cloud download branch
  - move_dir_callback(StorageEngine&): local move branch

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

