### PR TITLE
[refine](function) enforce `final` on CRTP aggregate function derived classes to enable compiler devirtualization

### DIFF
--- a/be/src/exprs/aggregate/aggregate_function.h
+++ b/be/src/exprs/aggregate/aggregate_function.h
@@ -303,12 +303,33 @@ protected:
     int version {};
 };
 
+/// Marker base for aggregate function classes that intentionally form an inheritance
+/// hierarchy (e.g. AggregateStateUnion -> AggregateStateMerge, or
+/// AggregateFunctionForEach -> AggregateFunctionForEachV2) and therefore cannot be
+/// marked 'final'. Classes that inherit this marker are exempt from the
+/// static_assert in IAggregateFunctionHelper.
+struct AggregateFunctionNonFinalBase {};
+
 /// Implement method to obtain an address of 'add' function.
 template <typename Derived>
 class IAggregateFunctionHelper : public IAggregateFunction {
 public:
     IAggregateFunctionHelper(const DataTypes& argument_types_)
-            : IAggregateFunction(argument_types_) {}
+            : IAggregateFunction(argument_types_) {
+        // The static_assert is placed in the constructor body (not at class scope) because
+        // at class-scope instantiation time Derived is still an incomplete type, whereas
+        // the constructor body is instantiated lazily when a concrete object is constructed,
+        // at which point Derived is fully defined.
+        //
+        // Classes that form deliberate inheritance hierarchies must inherit
+        // AggregateFunctionNonFinalBase to opt out of this check.
+        static_assert(
+                std::is_final_v<Derived> ||
+                        std::is_base_of_v<AggregateFunctionNonFinalBase, Derived>,
+                "Derived must be marked 'final' to ensure correct CRTP devirtualization. "
+                "If the class intentionally has subclasses, inherit AggregateFunctionNonFinalBase "
+                "to opt out of this check.");
+    }
 
     void destroy_vec(AggregateDataPtr __restrict place,
                      const size_t num_rows) const noexcept override {

--- a/be/src/exprs/aggregate/aggregate_function.h
+++ b/be/src/exprs/aggregate/aggregate_function.h
@@ -316,17 +316,26 @@ class IAggregateFunctionHelper : public IAggregateFunction {
 public:
     IAggregateFunctionHelper(const DataTypes& argument_types_)
             : IAggregateFunction(argument_types_) {
-        // The static_assert is placed in the constructor body (not at class scope) because
-        // at class-scope instantiation time Derived is still an incomplete type, whereas
-        // the constructor body is instantiated lazily when a concrete object is constructed,
-        // at which point Derived is fully defined.
+        // NOTE: This static_assert is placed in the constructor body (not at class scope)
+        // because at class-scope instantiation time Derived is still an incomplete type,
+        // whereas the constructor body is instantiated lazily when a concrete object is
+        // constructed, at which point Derived is fully defined.
         //
-        // Classes that form deliberate inheritance hierarchies must inherit
-        // AggregateFunctionNonFinalBase to opt out of this check.
+        // Marking Derived as 'final' is an *optimization hint*, not a correctness
+        // requirement. add() is virtual in IAggregateFunction, so subclasses always
+        // dispatch correctly through the vtable regardless. However, when Derived is
+        // final, the compiler can see that assert_cast<const Derived*>(this)->add(...)
+        // inside add_batch() / add_batch_single_place() etc. has no further overrides,
+        // allowing it to devirtualize (and potentially inline) the add() call -- which
+        // is critical for hot aggregation paths.
+        //
+        // Classes that intentionally form inheritance hierarchies (and therefore accept
+        // the vtable overhead) must inherit AggregateFunctionNonFinalBase to opt out.
         static_assert(
                 std::is_final_v<Derived> ||
                         std::is_base_of_v<AggregateFunctionNonFinalBase, Derived>,
-                "Derived must be marked 'final' to ensure correct CRTP devirtualization. "
+                "Derived should be marked 'final' to allow the compiler to devirtualize "
+                "add() calls inside add_batch() and related hot paths. "
                 "If the class intentionally has subclasses, inherit AggregateFunctionNonFinalBase "
                 "to opt out of this check.");
     }

--- a/be/src/exprs/aggregate/aggregate_function_array_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_array_agg.h
@@ -278,7 +278,7 @@ struct AggregateFunctionArrayAggData<T> {
 //ShowNull is just used to support array_agg because array_agg needs to display NULL
 //todo: Supports order by sorting for array_agg
 template <typename Data>
-class AggregateFunctionArrayAgg
+class AggregateFunctionArrayAgg final
         : public IAggregateFunctionDataHelper<Data, AggregateFunctionArrayAgg<Data>, true>,
           UnaryExpression,
           NotNullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_binary.h
+++ b/be/src/exprs/aggregate/aggregate_function_binary.h
@@ -41,7 +41,7 @@ struct StatFunc {
 };
 
 template <typename StatFunc>
-struct AggregateFunctionBinary
+struct AggregateFunctionBinary final
         : public IAggregateFunctionDataHelper<typename StatFunc::Data,
                                               AggregateFunctionBinary<StatFunc>>,
           MultiExpression,

--- a/be/src/exprs/aggregate/aggregate_function_collect.h
+++ b/be/src/exprs/aggregate/aggregate_function_collect.h
@@ -393,7 +393,7 @@ struct AggregateFunctionCollectListData<T, HasLimit> {
 };
 
 template <typename Data, bool HasLimit>
-class AggregateFunctionCollect
+class AggregateFunctionCollect final
         : public IAggregateFunctionDataHelper<Data, AggregateFunctionCollect<Data, HasLimit>, true>,
           VarargsExpression,
           NotNullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_covar.h
+++ b/be/src/exprs/aggregate/aggregate_function_covar.h
@@ -137,7 +137,7 @@ struct SampData : BaseData<T> {
 };
 
 template <typename Data>
-class AggregateFunctionSampCovariance
+class AggregateFunctionSampCovariance final
         : public IAggregateFunctionDataHelper<Data, AggregateFunctionSampCovariance<Data>>,
           MultiExpression,
           NullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_distinct.h
+++ b/be/src/exprs/aggregate/aggregate_function_distinct.h
@@ -260,7 +260,7 @@ struct AggregateFunctionDistinctMultipleGenericData
   * Adding -Distinct suffix to aggregate function
 **/
 template <template <bool stable> typename Data, bool stable = false>
-class AggregateFunctionDistinct
+class AggregateFunctionDistinct final
         : public IAggregateFunctionDataHelper<Data<stable>,
                                               AggregateFunctionDistinct<Data, stable>>,
           VarargsExpression,

--- a/be/src/exprs/aggregate/aggregate_function_foreach.h
+++ b/be/src/exprs/aggregate/aggregate_function_foreach.h
@@ -51,7 +51,8 @@ struct AggregateFunctionForEachData {
   *
   * TODO Allow variable number of arguments.
   */
-class AggregateFunctionForEach : public IAggregateFunctionDataHelper<AggregateFunctionForEachData,
+class AggregateFunctionForEach : public AggregateFunctionNonFinalBase,
+                                 public IAggregateFunctionDataHelper<AggregateFunctionForEachData,
                                                                      AggregateFunctionForEach>,
                                  VarargsExpression,
                                  NullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_foreachv2.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_foreachv2.cpp
@@ -35,7 +35,7 @@ namespace doris {
 // because we may have already assumed that the array's elements are always nullable types, and many places have such checks.
 // V1 code is kept to ensure compatibility during upgrades and downgrades.
 // V2 code differs from V1 only in the return type and insert_into logic; all other logic is exactly the same.
-class AggregateFunctionForEachV2 : public AggregateFunctionForEach {
+class AggregateFunctionForEachV2 final : public AggregateFunctionForEach {
 public:
     constexpr static auto AGG_FOREACH_SUFFIX = "_foreachv2";
     AggregateFunctionForEachV2(AggregateFunctionPtr nested_function_, const DataTypes& arguments)

--- a/be/src/exprs/aggregate/aggregate_function_group_array_set_op.h
+++ b/be/src/exprs/aggregate/aggregate_function_group_array_set_op.h
@@ -405,7 +405,7 @@ struct GroupArrayStringUnionData : public GroupArraySetOpStringBaseData {
 
 /// Puts all values to the hybrid set. Returns an array of unique values
 template <typename ImplData>
-class AggregateFunctionGroupArraySetOp
+class AggregateFunctionGroupArraySetOp final
         : public IAggregateFunctionDataHelper<ImplData, AggregateFunctionGroupArraySetOp<ImplData>>,
           UnaryExpression,
           NotNullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_hll_union_agg.h
+++ b/be/src/exprs/aggregate/aggregate_function_hll_union_agg.h
@@ -100,7 +100,7 @@ struct AggregateFunctionHLLUnionAggImpl : Data {
 };
 
 template <typename Data>
-class AggregateFunctionHLLUnion
+class AggregateFunctionHLLUnion final
         : public IAggregateFunctionDataHelper<Data, AggregateFunctionHLLUnion<Data>>,
           UnaryExpression,
           NullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_percentile.h
+++ b/be/src/exprs/aggregate/aggregate_function_percentile.h
@@ -154,42 +154,40 @@ struct PercentileApproxState {
     float compressions = 10000;
 };
 
-class AggregateFunctionPercentileApprox
-        : public IAggregateFunctionDataHelper<PercentileApproxState,
-                                              AggregateFunctionPercentileApprox> {
+template <typename Derived>
+class AggregateFunctionPercentileApproxBase
+        : public IAggregateFunctionDataHelper<PercentileApproxState, Derived> {
 public:
-    AggregateFunctionPercentileApprox(const DataTypes& argument_types_)
-            : IAggregateFunctionDataHelper<PercentileApproxState,
-                                           AggregateFunctionPercentileApprox>(argument_types_) {}
+    AggregateFunctionPercentileApproxBase(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<PercentileApproxState, Derived>(argument_types_) {}
 
     String get_name() const override { return "percentile_approx"; }
 
-    void reset(AggregateDataPtr __restrict place) const override {
-        AggregateFunctionPercentileApprox::data(place).reset();
-    }
+    void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
                Arena&) const override {
-        AggregateFunctionPercentileApprox::data(place).merge(
-                AggregateFunctionPercentileApprox::data(rhs));
+        this->data(place).merge(this->data(rhs));
     }
 
     void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
-        AggregateFunctionPercentileApprox::data(place).write(buf);
+        this->data(place).write(buf);
     }
 
     void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
                      Arena&) const override {
-        AggregateFunctionPercentileApprox::data(place).read(buf);
+        this->data(place).read(buf);
     }
 };
 
-class AggregateFunctionPercentileApproxTwoParams final : public AggregateFunctionPercentileApprox,
-                                                         public MultiExpression,
-                                                         public NullableAggregateFunction {
+class AggregateFunctionPercentileApproxTwoParams final
+        : public AggregateFunctionPercentileApproxBase<AggregateFunctionPercentileApproxTwoParams>,
+          public MultiExpression,
+          public NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxTwoParams(const DataTypes& argument_types_)
-            : AggregateFunctionPercentileApprox(argument_types_) {}
+            : AggregateFunctionPercentileApproxBase<AggregateFunctionPercentileApproxTwoParams>(
+                      argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
         const auto& sources =
@@ -204,7 +202,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         auto& col = assert_cast<ColumnFloat64&>(to);
-        double result = AggregateFunctionPercentileApprox::data(place).get();
+        double result = this->data(place).get();
 
         if (std::isnan(result)) {
             col.insert_default();
@@ -214,12 +212,15 @@ public:
     }
 };
 
-class AggregateFunctionPercentileApproxThreeParams final : public AggregateFunctionPercentileApprox,
-                                                           public MultiExpression,
-                                                           public NullableAggregateFunction {
+class AggregateFunctionPercentileApproxThreeParams final
+        : public AggregateFunctionPercentileApproxBase<
+                  AggregateFunctionPercentileApproxThreeParams>,
+          public MultiExpression,
+          public NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxThreeParams(const DataTypes& argument_types_)
-            : AggregateFunctionPercentileApprox(argument_types_) {}
+            : AggregateFunctionPercentileApproxBase<AggregateFunctionPercentileApproxThreeParams>(
+                      argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
         const auto& sources =
@@ -238,7 +239,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         auto& col = assert_cast<ColumnFloat64&>(to);
-        double result = AggregateFunctionPercentileApprox::data(place).get();
+        double result = this->data(place).get();
 
         if (std::isnan(result)) {
             col.insert_default();
@@ -249,12 +250,14 @@ public:
 };
 
 class AggregateFunctionPercentileApproxWeightedThreeParams final
-        : public AggregateFunctionPercentileApprox,
+        : public AggregateFunctionPercentileApproxBase<
+                  AggregateFunctionPercentileApproxWeightedThreeParams>,
           MultiExpression,
           NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxWeightedThreeParams(const DataTypes& argument_types_)
-            : AggregateFunctionPercentileApprox(argument_types_) {}
+            : AggregateFunctionPercentileApproxBase<
+                      AggregateFunctionPercentileApproxWeightedThreeParams>(argument_types_) {}
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
@@ -274,7 +277,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         auto& col = assert_cast<ColumnFloat64&>(to);
-        double result = AggregateFunctionPercentileApprox::data(place).get();
+        double result = this->data(place).get();
 
         if (std::isnan(result)) {
             col.insert_default();
@@ -285,12 +288,14 @@ public:
 };
 
 class AggregateFunctionPercentileApproxWeightedFourParams final
-        : public AggregateFunctionPercentileApprox,
+        : public AggregateFunctionPercentileApproxBase<
+                  AggregateFunctionPercentileApproxWeightedFourParams>,
           MultiExpression,
           NullableAggregateFunction {
 public:
     AggregateFunctionPercentileApproxWeightedFourParams(const DataTypes& argument_types_)
-            : AggregateFunctionPercentileApprox(argument_types_) {}
+            : AggregateFunctionPercentileApproxBase<
+                      AggregateFunctionPercentileApproxWeightedFourParams>(argument_types_) {}
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
         const auto& sources =
@@ -312,7 +317,7 @@ public:
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         auto& col = assert_cast<ColumnFloat64&>(to);
-        double result = AggregateFunctionPercentileApprox::data(place).get();
+        double result = this->data(place).get();
 
         if (std::isnan(result)) {
             col.insert_default();

--- a/be/src/exprs/aggregate/aggregate_function_retention.h
+++ b/be/src/exprs/aggregate/aggregate_function_retention.h
@@ -105,7 +105,7 @@ struct RetentionState {
     }
 };
 
-class AggregateFunctionRetention
+class AggregateFunctionRetention final
         : public IAggregateFunctionDataHelper<RetentionState, AggregateFunctionRetention>,
           VarargsExpression,
           NullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_sort.h
+++ b/be/src/exprs/aggregate/aggregate_function_sort.h
@@ -114,7 +114,7 @@ struct AggregateFunctionSortData {
 };
 
 template <typename Data>
-class AggregateFunctionSort
+class AggregateFunctionSort final
         : public IAggregateFunctionDataHelper<Data, AggregateFunctionSort<Data>> {
 private:
     static constexpr auto prefix_size = sizeof(Data);

--- a/be/src/exprs/aggregate/aggregate_function_state_union.h
+++ b/be/src/exprs/aggregate/aggregate_function_state_union.h
@@ -25,7 +25,8 @@
 namespace doris {
 const static std::string AGG_UNION_SUFFIX = "_union";
 
-class AggregateStateUnion : public IAggregateFunctionHelper<AggregateStateUnion> {
+class AggregateStateUnion : public AggregateFunctionNonFinalBase,
+                            public IAggregateFunctionHelper<AggregateStateUnion> {
 public:
     AggregateStateUnion(AggregateFunctionPtr function, const DataTypes& argument_types_,
                         DataTypePtr return_type)

--- a/be/src/exprs/aggregate/aggregate_function_statistic.h
+++ b/be/src/exprs/aggregate/aggregate_function_statistic.h
@@ -55,7 +55,7 @@ struct StatFuncOneArg {
 };
 
 template <typename StatFunc, bool NullableInput>
-class AggregateFunctionVarianceSimple
+class AggregateFunctionVarianceSimple final
         : public IAggregateFunctionDataHelper<
                   typename StatFunc::Data,
                   AggregateFunctionVarianceSimple<StatFunc, NullableInput>> {

--- a/be/src/exprs/aggregate/aggregate_function_stddev.h
+++ b/be/src/exprs/aggregate/aggregate_function_stddev.h
@@ -175,7 +175,7 @@ struct StddevSampName {
 };
 
 template <typename Data>
-class AggregateFunctionSampVariance
+class AggregateFunctionSampVariance final
         : public IAggregateFunctionDataHelper<Data, AggregateFunctionSampVariance<Data>>,
           UnaryExpression,
           NullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_topn.h
+++ b/be/src/exprs/aggregate/aggregate_function_topn.h
@@ -295,14 +295,12 @@ struct AggregateFunctionTopNImplWeight {
 };
 
 //base function
-template <typename Impl>
+template <typename Impl, typename Derived>
 class AggregateFunctionTopNBase
-        : public IAggregateFunctionDataHelper<typename Impl::Data,
-                                              AggregateFunctionTopNBase<Impl>> {
+        : public IAggregateFunctionDataHelper<typename Impl::Data, Derived> {
 public:
     AggregateFunctionTopNBase(const DataTypes& argument_types_)
-            : IAggregateFunctionDataHelper<typename Impl::Data, AggregateFunctionTopNBase<Impl>>(
-                      argument_types_) {}
+            : IAggregateFunctionDataHelper<typename Impl::Data, Derived>(argument_types_) {}
 
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
@@ -328,12 +326,13 @@ public:
 
 //topn function return string
 template <typename Impl>
-class AggregateFunctionTopN final : public AggregateFunctionTopNBase<Impl>,
-                                    MultiExpression,
-                                    NullableAggregateFunction {
+class AggregateFunctionTopN final
+        : public AggregateFunctionTopNBase<Impl, AggregateFunctionTopN<Impl>>,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionTopN(const DataTypes& argument_types_)
-            : AggregateFunctionTopNBase<Impl>(argument_types_) {}
+            : AggregateFunctionTopNBase<Impl, AggregateFunctionTopN<Impl>>(argument_types_) {}
 
     String get_name() const override { return "topn"; }
 
@@ -347,12 +346,13 @@ public:
 
 //topn function return array
 template <typename Impl>
-class AggregateFunctionTopNArray final : public AggregateFunctionTopNBase<Impl>,
-                                         MultiExpression,
-                                         NullableAggregateFunction {
+class AggregateFunctionTopNArray final
+        : public AggregateFunctionTopNBase<Impl, AggregateFunctionTopNArray<Impl>>,
+          MultiExpression,
+          NullableAggregateFunction {
 public:
     AggregateFunctionTopNArray(const DataTypes& argument_types_)
-            : AggregateFunctionTopNBase<Impl>(argument_types_),
+            : AggregateFunctionTopNBase<Impl, AggregateFunctionTopNArray<Impl>>(argument_types_),
               _argument_type(argument_types_[0]) {}
 
     String get_name() const override { return Impl::get_name(); }

--- a/be/src/exprs/aggregate/aggregate_function_window_funnel.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel.h
@@ -341,7 +341,7 @@ struct WindowFunnelState {
     }
 };
 
-class AggregateFunctionWindowFunnel
+class AggregateFunctionWindowFunnel final
         : public IAggregateFunctionDataHelper<WindowFunnelState, AggregateFunctionWindowFunnel>,
           MultiExpression,
           NullableAggregateFunction {

--- a/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
@@ -616,7 +616,7 @@ private:
     }
 };
 
-class AggregateFunctionWindowFunnelV2
+class AggregateFunctionWindowFunnelV2 final
         : public IAggregateFunctionDataHelper<WindowFunnelStateV2, AggregateFunctionWindowFunnelV2>,
           MultiExpression,
           NullableAggregateFunction {


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: N/A

Problem Summary:

`IAggregateFunctionHelper<Derived>` implements hot aggregate paths such as `add_batch()` and `add_batch_single_place()` by calling `assert_cast<const Derived*>(this)->add(...)`. Because `add()` is declared `virtual` in `IAggregateFunction`, the compiler cannot devirtualize this call unless it can prove that `Derived` has no further overrides — which requires `Derived` to be marked `final`.

This PR enforces this via a `static_assert` in the `IAggregateFunctionHelper` constructor. Note that `final` here is a **performance hint only** — correctness is not affected, since `add()` remains virtual and subclasses always dispatch correctly through the vtable regardless. Marking `Derived` as `final` allows the compiler to devirtualize (and potentially inline) the `add()` call inside hot aggregation paths.

Changes:

1. Add a `static_assert` in the `IAggregateFunctionHelper` constructor asserting `std::is_final_v<Derived>`, so that missing `final` is caught at compile time.
2. Introduce `AggregateFunctionNonFinalBase` as an opt-out marker for classes that intentionally form inheritance hierarchies (e.g. `AggregateStateUnion → AggregateStateMerge`, `AggregateFunctionForEach → AggregateFunctionForEachV2`).
3. Mark all concrete aggregate function classes `final` across `be/src/exprs/aggregate/`.
4. Refactor `AggregateFunctionTopNBase` to accept a `Derived` template parameter so that `AggregateFunctionTopN` and `AggregateFunctionTopNArray` can each be marked `final`.
5. Refactor `AggregateFunctionPercentileApprox` into `AggregateFunctionPercentileApproxBase<Derived>` so the four concrete specializations can each be marked `final`.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

