### PR TITLE
[fix](fe) Fix struct field slot type in NestedColumnPruning for OFFSET-only access

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
@@ -666,8 +666,7 @@ public class NestedColumnPruning implements CustomRewriter {
                 return Optional.of(type);
             } else if (isStringOffsetOnly) {
                 // Only the offset array is accessed (e.g. length(str_col)).
-                // The slot type stays unchanged (varchar); the access path tells BE to skip char data.
-                return Optional.empty();
+                return Optional.of(type);
             } else if (!accessPartialChild) {
                 return Optional.empty();
             }

--- a/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
+++ b/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
@@ -69,7 +69,7 @@ suite("string_length_column_pruning") {
         contains "OFFSET"
         notContains "type=bigint"
     }
-    //sql "select length(struct_element(struct_col, 'f3')) from slcp_str_tbl"
+    sql "select length(struct_element(struct_col, 'f3')) from slcp_str_tbl"
     // length() in both SELECT and WHERE: predicate must remain length(str_col) > 1,
     // never be rewritten to CAST(str_col AS int) > 1. Slot type must stay varchar.
     explain {


### PR DESCRIPTION
Problem Summary: When using struct_element() to access a string field inside a struct (e.g., length(struct_element(struct_col, 'f3'))), the NestedColumnPruning rule incorrectly returned Optional.empty() for the slot type, causing the slot type to become nullable and lose its original type information.

The fix changes the return value from Optional.empty() to Optional.of(type) when the column is accessed in OFFSET-only mode (e.g., length()), ensuring the slot type remains the original type (e.g., varchar).

Release note: None

Test: Added test case in string_length_column_pruning.groovy


