### PR TITLE
[fix](regression) fix MissingPropertyException in plugins_create_table_nested_type

### DIFF
--- a/regression-test/plugins/plugins_create_table_nested_type.groovy
+++ b/regression-test/plugins/plugins_create_table_nested_type.groovy
@@ -133,9 +133,9 @@ Suite.metaClass.get_create_table_with_nested_type { int depth, String tb_name ->
     }
 
     backtrack();
-    for (int i = 0; i < res.size; i++) {
+    for (int i = 0; i < res.size(); i++) {
         def date_type_str = ""
-        for (int j = 0; j < res[i].size; j++) {
+        for (int j = 0; j < res[i].size(); j++) {
             date_type_str += res[i][j] + " "
         }
         logger.info(date_type_str)


### PR DESCRIPTION
## Problem

`plugins_create_table_nested_type.groovy` uses `res.size` and `res[i].size` (without parentheses) to iterate over lists. In newer Groovy versions, accessing `.size` on a collection without `()` triggers **GPath spreading**, which maps the property access across each element instead of calling `size()` on the collection itself.

Since `res` is `List<List<Integer>>`, `res.size` returns a `List<Integer>` (the sizes of each inner list). When the loop then tries `res[i].size` on a `List<Integer>`, Groovy spreads again to each `Integer` element, which has no `size` property — resulting in:

```
groovy.lang.MissingPropertyException: No such property: size for class: java.lang.Integer
```

## Fix

Replace `.size` with `.size()` (explicit method call) to always get the collection size as an `int`:

```groovy
// Before
for (int i = 0; i < res.size; i++) {
    for (int j = 0; j < res[i].size; j++) {

// After  
for (int i = 0; i < res.size(); i++) {
    for (int j = 0; j < res[i].size(); j++) {
```

## Root Cause

Case issue — Groovy GPath property spread vs. explicit method call on collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)