### PR TITLE
[fix](regression) fix MissingPropertyException in test_query_stmt

### DIFF
--- a/regression-test/suites/http_rest_api/post/test_query_stmt.groovy
+++ b/regression-test/suites/http_rest_api/post/test_query_stmt.groovy
@@ -152,7 +152,7 @@ suite("test_query_stmt") {
     assertEquals(obj.msg, SUCCESS_MSG)
     assertEquals(obj.code, SUCCESS_CODE)
     // we can only check the number is correctly
-    assertEquals(obj.data.data.size, 3)
+    assertEquals(obj.data.data.size(), 3)
 
     url = "/api/query_schema/default_cluster/" + context.config.defaultDb
     def stmt5 = " select * from ${tableName}"


### PR DESCRIPTION
## Problem

`assertEquals(obj.data.data.size, 3)` uses `.size` without parentheses on a JSON-parsed `ArrayList<ArrayList<Integer>>`. In newer Groovy versions this triggers GPath spreading, mapping `.size` across each row element (which are `Integer`s). Since `Integer` has no `size` property:

```
groovy.lang.MissingPropertyException: No such property: size for class: java.lang.Integer
```

## Fix

```groovy
// Before
assertEquals(obj.data.data.size, 3)

// After
assertEquals(obj.data.data.size(), 3)
```

Root cause: case issue — same GPath `.size` vs `.size()` pattern as apache/doris#62454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)