### PR TITLE
[improvement](be) Persist rowset key bounds for non-MoW rowsets

### DIFF
--- a/be/src/cloud/cloud_snapshot_mgr.cpp
+++ b/be/src/cloud/cloud_snapshot_mgr.cpp
@@ -275,6 +275,9 @@ Status CloudSnapshotMgr::_create_rowset_meta(
     for (const auto& key_bound : source_meta_pb.segments_key_bounds()) {
         *new_rowset_meta_pb->add_segments_key_bounds() = key_bound;
     }
+    if (source_meta_pb.has_rowset_key_bounds()) {
+        new_rowset_meta_pb->mutable_rowset_key_bounds()->CopyFrom(source_meta_pb.rowset_key_bounds());
+    }
     if (source_meta_pb.has_delete_predicate()) {
         DeletePredicatePB* new_delete_condition = new_rowset_meta_pb->mutable_delete_predicate();
         *new_delete_condition = source_meta_pb.delete_predicate();

--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -71,6 +71,9 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in) 
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
     out->mutable_segments_key_bounds()->CopyFrom(in.segments_key_bounds());
+    if (in.has_rowset_key_bounds()) {
+        out->mutable_rowset_key_bounds()->CopyFrom(in.rowset_key_bounds());
+    }
     if (in.has_tablet_schema()) {
         doris_tablet_schema_to_cloud(out->mutable_tablet_schema(), in.tablet_schema());
     }
@@ -151,6 +154,9 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in) {
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
     out->mutable_segments_key_bounds()->Swap(in.mutable_segments_key_bounds());
+    if (in.has_rowset_key_bounds()) {
+        out->mutable_rowset_key_bounds()->Swap(in.mutable_rowset_key_bounds());
+    }
     if (in.has_tablet_schema()) {
         doris_tablet_schema_to_cloud(out->mutable_tablet_schema(),
                                      std::move(*in.mutable_tablet_schema()));
@@ -245,6 +251,9 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in) 
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
     out->mutable_segments_key_bounds()->CopyFrom(in.segments_key_bounds());
+    if (in.has_rowset_key_bounds()) {
+        out->mutable_rowset_key_bounds()->CopyFrom(in.rowset_key_bounds());
+    }
     if (in.has_tablet_schema()) {
         cloud_tablet_schema_to_doris(out->mutable_tablet_schema(), in.tablet_schema());
     }
@@ -325,6 +334,9 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in) {
     out->set_resource_id(in.resource_id());
     out->set_newest_write_timestamp(in.newest_write_timestamp());
     out->mutable_segments_key_bounds()->Swap(in.mutable_segments_key_bounds());
+    if (in.has_rowset_key_bounds()) {
+        out->mutable_rowset_key_bounds()->Swap(in.mutable_rowset_key_bounds());
+    }
     if (in.has_tablet_schema()) {
         cloud_tablet_schema_to_doris(out->mutable_tablet_schema(),
                                      std::move(*in.mutable_tablet_schema()));

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1715,6 +1715,9 @@ DEFINE_mBool(enable_fetch_rowsets_from_peer_replicas, "false");
 DEFINE_mInt32(segments_key_bounds_truncation_threshold, "36");
 // ATTENTION: for test only, use random segments key bounds truncation threshold every time
 DEFINE_mBool(random_segments_key_bounds_truncation, "false");
+// persist rowset-level key bounds instead of per-segment key bounds for non-MoW rowsets.
+// rollback compatibility requires disabling this config before downgrade.
+DEFINE_mBool(enable_rowset_key_bounds_for_non_mow, "true");
 // p0, daily, rqg, external
 DEFINE_String(fuzzy_test_type, "");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1771,6 +1771,9 @@ DECLARE_mBool(enable_fetch_rowsets_from_peer_replicas);
 DECLARE_mInt32(segments_key_bounds_truncation_threshold);
 // ATTENTION: for test only, use random segments key bounds truncation threshold every time
 DECLARE_mBool(random_segments_key_bounds_truncation);
+// persist rowset-level key bounds instead of per-segment key bounds for non-MoW rowsets.
+// rollback compatibility requires disabling this config before downgrade.
+DECLARE_mBool(enable_rowset_key_bounds_for_non_mow);
 
 DECLARE_mBool(enable_auto_clone_on_compaction_missing_version);
 

--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -31,6 +31,7 @@
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <numeric>
+#include <optional>
 #include <ostream>
 #include <set>
 #include <shared_mutex>
@@ -420,6 +421,7 @@ Status CompactionMixin::do_compact_ordered_rowsets() {
     auto seg_id = 0;
     bool segments_key_bounds_truncated {false};
     std::vector<KeyBoundsPB> segment_key_bounds;
+    std::optional<KeyBoundsPB> rowset_key_bounds;
     std::vector<uint32_t> num_segment_rows;
     for (auto rowset : _input_rowsets) {
         RETURN_IF_ERROR(rowset->link_files_to(tablet()->tablet_path(),
@@ -429,6 +431,18 @@ Status CompactionMixin::do_compact_ordered_rowsets() {
         std::vector<KeyBoundsPB> key_bounds;
         RETURN_IF_ERROR(rowset->get_segments_key_bounds(&key_bounds));
         segment_key_bounds.insert(segment_key_bounds.end(), key_bounds.begin(), key_bounds.end());
+        std::string first_key;
+        bool has_first_key = rowset->first_key(&first_key);
+        std::string last_key;
+        bool has_last_key = rowset->last_key(&last_key);
+        DCHECK_EQ(has_first_key, has_last_key);
+        if (has_first_key) {
+            if (!rowset_key_bounds.has_value()) {
+                rowset_key_bounds.emplace();
+                rowset_key_bounds->set_min_key(first_key);
+            }
+            rowset_key_bounds->set_max_key(last_key);
+        }
         std::vector<uint32_t> input_segment_rows;
         rowset->get_num_segment_rows(&input_segment_rows);
         num_segment_rows.insert(num_segment_rows.end(), input_segment_rows.begin(),
@@ -445,7 +459,11 @@ Status CompactionMixin::do_compact_ordered_rowsets() {
     rowset_meta->set_segments_overlap(NONOVERLAPPING);
     rowset_meta->set_rowset_state(VISIBLE);
     rowset_meta->set_segments_key_bounds_truncated(segments_key_bounds_truncated);
-    rowset_meta->set_segments_key_bounds(segment_key_bounds);
+    if (!segment_key_bounds.empty()) {
+        rowset_meta->set_segments_key_bounds(segment_key_bounds);
+    } else if (rowset_key_bounds.has_value()) {
+        rowset_meta->set_rowset_key_bounds(rowset_key_bounds.value());
+    }
     rowset_meta->set_num_segment_rows(num_segment_rows);
 
     _output_rowset = _output_rs_writer->manual_build(rowset_meta);

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -94,9 +94,14 @@ void build_rowset_meta_with_spec_field(RowsetMeta& rowset_meta,
     rowset_meta.set_rowset_state(spec_rowset_meta.rowset_state());
     rowset_meta.set_segments_key_bounds_truncated(
             spec_rowset_meta.is_segments_key_bounds_truncated());
+    if (spec_rowset_meta.has_rowset_key_bounds()) {
+        rowset_meta.set_rowset_key_bounds(spec_rowset_meta.rowset_key_bounds());
+    }
     std::vector<KeyBoundsPB> segments_key_bounds;
     spec_rowset_meta.get_segments_key_bounds(&segments_key_bounds);
-    rowset_meta.set_segments_key_bounds(segments_key_bounds);
+    if (!segments_key_bounds.empty()) {
+        rowset_meta.set_segments_key_bounds(segments_key_bounds);
+    }
     std::vector<uint32_t> num_segment_rows;
     spec_rowset_meta.get_num_segment_rows(&num_segment_rows);
     rowset_meta.set_num_segment_rows(num_segment_rows);
@@ -781,7 +786,21 @@ Status BaseBetaRowsetWriter::add_rowset(RowsetSharedPtr rowset) {
     // append key_bounds to current rowset
     RETURN_IF_ERROR(rowset->get_segments_key_bounds(&_segments_encoded_key_bounds));
     rowset->get_num_segment_rows(&_segment_num_rows);
-    _segments_key_bounds_truncated = rowset->rowset_meta()->is_segments_key_bounds_truncated();
+    _segments_key_bounds_truncated =
+            _segments_key_bounds_truncated.value_or(false) ||
+            rowset->rowset_meta()->is_segments_key_bounds_truncated();
+    std::string first_key;
+    bool has_first_key = rowset->first_key(&first_key);
+    std::string last_key;
+    bool has_last_key = rowset->last_key(&last_key);
+    DCHECK_EQ(has_first_key, has_last_key);
+    if (has_first_key) {
+        if (!_rowset_key_bounds.has_value()) {
+            _rowset_key_bounds.emplace();
+            _rowset_key_bounds->set_min_key(first_key);
+        }
+        _rowset_key_bounds->set_max_key(last_key);
+    }
 
     // TODO update zonemap
     if (rowset->rowset_meta()->has_delete_predicate()) {
@@ -1019,7 +1038,19 @@ Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool ch
                                      _total_index_size);
     rowset_meta->set_data_disk_size(total_data_size + _total_data_size);
     rowset_meta->set_index_disk_size(total_index_size + _total_index_size);
-    rowset_meta->set_segments_key_bounds(segments_encoded_key_bounds);
+    if (!segments_encoded_key_bounds.empty()) {
+        if (_context.enable_unique_key_merge_on_write ||
+            !config::enable_rowset_key_bounds_for_non_mow) {
+            rowset_meta->set_segments_key_bounds(segments_encoded_key_bounds);
+        } else {
+            KeyBoundsPB rowset_key_bounds;
+            rowset_key_bounds.set_min_key(segments_encoded_key_bounds.front().min_key());
+            rowset_key_bounds.set_max_key(segments_encoded_key_bounds.back().max_key());
+            rowset_meta->set_rowset_key_bounds(rowset_key_bounds);
+        }
+    } else if (_rowset_key_bounds.has_value()) {
+        rowset_meta->set_rowset_key_bounds(_rowset_key_bounds.value());
+    }
     // TODO write zonemap to meta
     rowset_meta->set_empty((num_rows_written + _num_rows_written) == 0);
     rowset_meta->set_creation_time(time(nullptr));

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -238,6 +238,7 @@ protected:
     // for unique key table with merge-on-write
     std::vector<KeyBoundsPB> _segments_encoded_key_bounds;
     std::optional<bool> _segments_key_bounds_truncated;
+    std::optional<KeyBoundsPB> _rowset_key_bounds;
 
     // counters and statistics maintained during add_rowset
     std::atomic<int64_t> _num_rows_written;

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -48,8 +48,6 @@
 
 namespace doris {
 
-#include "common/compile_check_begin.h"
-
 namespace {
 
 int32_t get_segments_key_bounds_truncation_threshold() {
@@ -456,7 +454,5 @@ bool operator==(const RowsetMeta& a, const RowsetMeta& b) {
         return false;
     return true;
 }
-
-#include "common/compile_check_end.h"
 
 } // namespace doris

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -48,6 +48,46 @@
 
 namespace doris {
 
+#include "common/compile_check_begin.h"
+
+namespace {
+
+int32_t get_segments_key_bounds_truncation_threshold() {
+    int32_t truncation_threshold = config::segments_key_bounds_truncation_threshold;
+    if (config::random_segments_key_bounds_truncation) {
+        std::mt19937 generator(std::random_device {}());
+        std::uniform_int_distribution<int> distribution(-10, 40);
+        truncation_threshold = distribution(generator);
+    }
+    return truncation_threshold;
+}
+
+bool truncate_key_bounds(KeyBoundsPB* key_bounds, int32_t truncation_threshold) {
+    bool truncated = false;
+    if (truncation_threshold <= 0) {
+        return truncated;
+    }
+    if (key_bounds->min_key().size() > truncation_threshold) {
+        truncated = true;
+        key_bounds->mutable_min_key()->resize(truncation_threshold);
+    }
+    if (key_bounds->max_key().size() > truncation_threshold) {
+        truncated = true;
+        key_bounds->mutable_max_key()->resize(truncation_threshold);
+    }
+    return truncated;
+}
+
+KeyBoundsPB build_rowset_key_bounds(const std::vector<KeyBoundsPB>& segments_key_bounds) {
+    DCHECK(!segments_key_bounds.empty());
+    KeyBoundsPB rowset_key_bounds;
+    rowset_key_bounds.set_min_key(segments_key_bounds.front().min_key());
+    rowset_key_bounds.set_max_key(segments_key_bounds.back().max_key());
+    return rowset_key_bounds;
+}
+
+} // namespace
+
 RowsetMeta::~RowsetMeta() {
     if (_handle) {
         TabletSchemaCache::instance()->release(_handle);
@@ -289,29 +329,31 @@ int64_t RowsetMeta::segment_file_size(int seg_id) const {
                    : -1;
 }
 
+void RowsetMeta::set_rowset_key_bounds(const KeyBoundsPB& rowset_key_bounds) {
+    *_rowset_meta_pb.mutable_rowset_key_bounds() = rowset_key_bounds;
+    bool really_do_truncation = truncate_key_bounds(_rowset_meta_pb.mutable_rowset_key_bounds(),
+                                                    get_segments_key_bounds_truncation_threshold());
+    set_segments_key_bounds_truncated(really_do_truncation || is_segments_key_bounds_truncated());
+}
+
 void RowsetMeta::set_segments_key_bounds(const std::vector<KeyBoundsPB>& segments_key_bounds) {
+    if (!segments_key_bounds.empty()) {
+        *_rowset_meta_pb.mutable_rowset_key_bounds() = build_rowset_key_bounds(segments_key_bounds);
+    }
     for (const KeyBoundsPB& key_bounds : segments_key_bounds) {
         KeyBoundsPB* new_key_bounds = _rowset_meta_pb.add_segments_key_bounds();
         *new_key_bounds = key_bounds;
     }
 
-    int32_t truncation_threshold = config::segments_key_bounds_truncation_threshold;
-    if (config::random_segments_key_bounds_truncation) {
-        std::mt19937 generator(std::random_device {}());
-        std::uniform_int_distribution<int> distribution(-10, 40);
-        truncation_threshold = distribution(generator);
-    }
+    int32_t truncation_threshold = get_segments_key_bounds_truncation_threshold();
     bool really_do_truncation {false};
     if (truncation_threshold > 0) {
         for (auto& segment_key_bounds : *_rowset_meta_pb.mutable_segments_key_bounds()) {
-            if (segment_key_bounds.min_key().size() > truncation_threshold) {
-                really_do_truncation = true;
-                segment_key_bounds.mutable_min_key()->resize(truncation_threshold);
-            }
-            if (segment_key_bounds.max_key().size() > truncation_threshold) {
-                really_do_truncation = true;
-                segment_key_bounds.mutable_max_key()->resize(truncation_threshold);
-            }
+            really_do_truncation |= truncate_key_bounds(&segment_key_bounds, truncation_threshold);
+        }
+        if (_rowset_meta_pb.has_rowset_key_bounds()) {
+            really_do_truncation |= truncate_key_bounds(
+                    _rowset_meta_pb.mutable_rowset_key_bounds(), truncation_threshold);
         }
     }
     set_segments_key_bounds_truncated(really_do_truncation || is_segments_key_bounds_truncated());
@@ -339,6 +381,17 @@ void RowsetMeta::merge_rowset_meta(const RowsetMeta& other) {
                 _rowset_meta_pb.clear_num_segment_rows();
             }
         }
+    }
+    KeyBoundsPB other_last_key_bound;
+    if (other.get_last_segment_key_bound(&other_last_key_bound)) {
+        if (!_rowset_meta_pb.has_rowset_key_bounds()) {
+            KeyBoundsPB first_key_bound;
+            if (get_first_segment_key_bound(&first_key_bound) ||
+                other.get_first_segment_key_bound(&first_key_bound)) {
+                _rowset_meta_pb.mutable_rowset_key_bounds()->set_min_key(first_key_bound.min_key());
+            }
+        }
+        _rowset_meta_pb.mutable_rowset_key_bounds()->set_max_key(other_last_key_bound.max_key());
     }
     for (auto&& key_bound : other.get_segments_key_bounds()) {
         add_segment_key_bounds(key_bound);
@@ -403,5 +456,7 @@ bool operator==(const RowsetMeta& a, const RowsetMeta& b) {
         return false;
     return true;
 }
+
+#include "common/compile_check_end.h"
 
 } // namespace doris

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -344,6 +344,12 @@ public:
 
     auto& get_segments_key_bounds() const { return _rowset_meta_pb.segments_key_bounds(); }
 
+    bool has_rowset_key_bounds() const { return _rowset_meta_pb.has_rowset_key_bounds(); }
+
+    const KeyBoundsPB& rowset_key_bounds() const { return _rowset_meta_pb.rowset_key_bounds(); }
+
+    void set_rowset_key_bounds(const KeyBoundsPB& rowset_key_bounds);
+
     bool is_segments_key_bounds_truncated() const {
         return _rowset_meta_pb.has_segments_key_bounds_truncated() &&
                _rowset_meta_pb.segments_key_bounds_truncated();
@@ -353,7 +359,11 @@ public:
         _rowset_meta_pb.set_segments_key_bounds_truncated(truncated);
     }
 
-    bool get_first_segment_key_bound(KeyBoundsPB* key_bounds) {
+    bool get_first_segment_key_bound(KeyBoundsPB* key_bounds) const {
+        if (_rowset_meta_pb.has_rowset_key_bounds()) {
+            *key_bounds = _rowset_meta_pb.rowset_key_bounds();
+            return true;
+        }
         // for compatibility, old version has not segment key bounds
         if (_rowset_meta_pb.segments_key_bounds_size() == 0) {
             return false;
@@ -362,7 +372,11 @@ public:
         return true;
     }
 
-    bool get_last_segment_key_bound(KeyBoundsPB* key_bounds) {
+    bool get_last_segment_key_bound(KeyBoundsPB* key_bounds) const {
+        if (_rowset_meta_pb.has_rowset_key_bounds()) {
+            *key_bounds = _rowset_meta_pb.rowset_key_bounds();
+            return true;
+        }
         if (_rowset_meta_pb.segments_key_bounds_size() == 0) {
             return false;
         }

--- a/be/src/storage/task/index_builder.cpp
+++ b/be/src/storage/task/index_builder.cpp
@@ -307,7 +307,11 @@ Status IndexBuilder::update_inverted_index_info() {
         RETURN_IF_ERROR(input_rowset->get_segments_key_bounds(&key_bounds));
         rowset_meta->set_segments_key_bounds_truncated(
                 input_rowset_meta->is_segments_key_bounds_truncated());
-        rowset_meta->set_segments_key_bounds(key_bounds);
+        if (!key_bounds.empty()) {
+            rowset_meta->set_segments_key_bounds(key_bounds);
+        } else if (input_rowset_meta->has_rowset_key_bounds()) {
+            rowset_meta->set_rowset_key_bounds(input_rowset_meta->rowset_key_bounds());
+        }
         std::vector<uint32_t> num_segment_rows;
         input_rowset_meta->get_num_segment_rows(&num_segment_rows);
         rowset_meta->set_num_segment_rows(num_segment_rows);

--- a/be/test/storage/segment/segments_key_bounds_truncation_test.cpp
+++ b/be/test/storage/segment/segments_key_bounds_truncation_test.cpp
@@ -51,6 +51,8 @@ private:
 
 public:
     void SetUp() override {
+        config::enable_rowset_key_bounds_for_non_mow = false;
+        config::segments_key_bounds_truncation_threshold = -1;
         auto st = io::global_local_filesystem()->delete_directory(kSegmentDir);
         ASSERT_TRUE(st.ok()) << st;
         st = io::global_local_filesystem()->create_directory(kSegmentDir);
@@ -64,6 +66,8 @@ public:
     }
 
     void TearDown() override {
+        config::enable_rowset_key_bounds_for_non_mow = false;
+        config::segments_key_bounds_truncation_threshold = -1;
         EXPECT_TRUE(io::global_local_filesystem()->delete_directory(kSegmentDir).ok());
         engine_ref = nullptr;
         ExecEnv::GetInstance()->set_storage_engine(nullptr);
@@ -73,10 +77,10 @@ public:
         config::segments_key_bounds_truncation_threshold = -1;
     }
 
-    TabletSchemaSPtr create_schema(int varchar_length) {
+    TabletSchemaSPtr create_schema(int varchar_length, KeysType keys_type = DUP_KEYS) {
         TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
         TabletSchemaPB tablet_schema_pb;
-        tablet_schema_pb.set_keys_type(DUP_KEYS);
+        tablet_schema_pb.set_keys_type(keys_type);
         tablet_schema_pb.set_num_short_key_columns(1);
         tablet_schema_pb.set_num_rows_per_row_block(1024);
         tablet_schema_pb.set_compress_kind(COMPRESS_NONE);
@@ -146,7 +150,8 @@ public:
     RowsetWriterContext create_rowset_writer_context(TabletSchemaSPtr tablet_schema,
                                                      const SegmentsOverlapPB& overlap,
                                                      uint32_t max_rows_per_segment,
-                                                     Version version) {
+                                                     Version version,
+                                                     bool enable_unique_key_merge_on_write = false) {
         RowsetWriterContext rowset_writer_context;
         rowset_writer_context.rowset_id = engine_ref->next_rowset_id();
         rowset_writer_context.rowset_type = BETA_ROWSET;
@@ -156,6 +161,8 @@ public:
         rowset_writer_context.version = version;
         rowset_writer_context.segments_overlap = overlap;
         rowset_writer_context.max_rows_per_segment = max_rows_per_segment;
+        rowset_writer_context.enable_unique_key_merge_on_write =
+                enable_unique_key_merge_on_write;
         return rowset_writer_context;
     }
 
@@ -214,9 +221,11 @@ public:
 
     RowsetSharedPtr create_rowset(TabletSchemaSPtr tablet_schema, SegmentsOverlapPB overlap,
                                   const std::vector<Block> blocks, int64_t version,
-                                  bool is_vertical) {
+                                  bool is_vertical,
+                                  bool enable_unique_key_merge_on_write = false) {
         auto writer_context = create_rowset_writer_context(tablet_schema, overlap, UINT32_MAX,
-                                                           {version, version});
+                                                           {version, version},
+                                                           enable_unique_key_merge_on_write);
         auto res = RowsetFactory::create_rowset_writer(*engine_ref, writer_context, is_vertical);
         EXPECT_TRUE(res.has_value()) << res.error();
         auto rowset_writer = std::move(res).value();
@@ -386,7 +395,8 @@ TEST_F(SegmentsKeyBoundsTruncationTest, CompareFuncTest) {
 
 TEST_F(SegmentsKeyBoundsTruncationTest, BasicTruncationTest) {
     {
-        // 1. don't do segments key bounds truncation when the config is off
+        // 1. the new behavior is gated off by default for rollback compatibility
+        config::enable_rowset_key_bounds_for_non_mow = false;
         config::segments_key_bounds_truncation_threshold = -1;
 
         auto tablet_schema = create_schema(100);
@@ -403,10 +413,37 @@ TEST_F(SegmentsKeyBoundsTruncationTest, BasicTruncationTest) {
         rowset_meta->get_segments_key_bounds(&segments_key_bounds);
         EXPECT_EQ(segments_key_bounds.size(), data.size());
         check_key_bounds(data, segments_key_bounds);
+        ASSERT_TRUE(rowset_meta->has_rowset_key_bounds());
     }
 
     {
-        // 2. do segments key bounds truncation when the config is on
+        // 2. persist only rowset-level key bounds when the config is on for non-MoW rowsets
+        config::enable_rowset_key_bounds_for_non_mow = true;
+        config::segments_key_bounds_truncation_threshold = -1;
+
+        auto tablet_schema = create_schema(100);
+        std::vector<std::vector<std::string>> data {{std::string(2, 'x'), std::string(3, 'y')},
+                                                    {std::string(4, 'a'), std::string(15, 'b')},
+                                                    {std::string(18, 'c'), std::string(5, 'z')},
+                                                    {std::string(20, '0'), std::string(22, '1')}};
+        auto blocks = generate_blocks(tablet_schema, data);
+        RowsetSharedPtr rowset = create_rowset(tablet_schema, NONOVERLAPPING, blocks, 2, false);
+
+        auto rowset_meta = rowset->rowset_meta();
+        EXPECT_EQ(false, rowset_meta->is_segments_key_bounds_truncated());
+        std::vector<KeyBoundsPB> segments_key_bounds;
+        rowset_meta->get_segments_key_bounds(&segments_key_bounds);
+        EXPECT_TRUE(segments_key_bounds.empty());
+        ASSERT_TRUE(rowset_meta->has_rowset_key_bounds());
+        EXPECT_EQ(rowset_meta->rowset_key_bounds().min_key(),
+                  std::string {KeyConsts::KEY_NORMAL_MARKER} + data.front().front());
+        EXPECT_EQ(rowset_meta->rowset_key_bounds().max_key(),
+                  std::string {KeyConsts::KEY_NORMAL_MARKER} + data.back().back());
+    }
+
+    {
+        // 3. do rowset key bounds truncation when the config is on for non-MoW rowsets
+        config::enable_rowset_key_bounds_for_non_mow = true;
         config::segments_key_bounds_truncation_threshold = 10;
 
         auto tablet_schema = create_schema(100);
@@ -421,12 +458,17 @@ TEST_F(SegmentsKeyBoundsTruncationTest, BasicTruncationTest) {
         EXPECT_EQ(true, rowset_meta->is_segments_key_bounds_truncated());
         std::vector<KeyBoundsPB> segments_key_bounds;
         rowset_meta->get_segments_key_bounds(&segments_key_bounds);
-        EXPECT_EQ(segments_key_bounds.size(), data.size());
-        check_key_bounds(data, segments_key_bounds);
+        EXPECT_TRUE(segments_key_bounds.empty());
+        ASSERT_TRUE(rowset_meta->has_rowset_key_bounds());
+        EXPECT_EQ(rowset_meta->rowset_key_bounds().min_key(),
+                  do_trunacte(std::string {KeyConsts::KEY_NORMAL_MARKER} + data.front().front()));
+        EXPECT_EQ(rowset_meta->rowset_key_bounds().max_key(),
+                  do_trunacte(std::string {KeyConsts::KEY_NORMAL_MARKER} + data.back().back()));
     }
 
     {
-        // 3. segments_key_bounds_truncated should be set to false if no actual truncation happend
+        // 4. segments_key_bounds_truncated should be false if no actual truncation happened
+        config::enable_rowset_key_bounds_for_non_mow = true;
         config::segments_key_bounds_truncation_threshold = 100;
 
         auto tablet_schema = create_schema(100);
@@ -439,6 +481,30 @@ TEST_F(SegmentsKeyBoundsTruncationTest, BasicTruncationTest) {
 
         auto rowset_meta = rowset->rowset_meta();
         EXPECT_EQ(false, rowset_meta->is_segments_key_bounds_truncated());
+    }
+
+    {
+        // 5. keep per-segment key bounds for MoW rowsets
+        config::enable_rowset_key_bounds_for_non_mow = true;
+        config::segments_key_bounds_truncation_threshold = -1;
+
+        auto tablet_schema = create_schema(100, UNIQUE_KEYS);
+        std::vector<std::vector<std::string>> data {{std::string(2, 'x'), std::string(3, 'y')},
+                                                    {std::string(4, 'a'), std::string(15, 'b')},
+                                                    {std::string(18, 'c'), std::string(5, 'z')},
+                                                    {std::string(20, '0'), std::string(22, '1')}};
+        auto blocks = generate_blocks(tablet_schema, data);
+        RowsetSharedPtr rowset =
+                create_rowset(tablet_schema, NONOVERLAPPING, blocks, 2, false, true);
+
+        auto rowset_meta = rowset->rowset_meta();
+        std::vector<KeyBoundsPB> segments_key_bounds;
+        rowset_meta->get_segments_key_bounds(&segments_key_bounds);
+        EXPECT_EQ(segments_key_bounds.size(), data.size());
+        check_key_bounds(data, segments_key_bounds);
+        ASSERT_TRUE(rowset_meta->has_rowset_key_bounds());
+        EXPECT_EQ(rowset_meta->rowset_key_bounds().min_key(), segments_key_bounds.front().min_key());
+        EXPECT_EQ(rowset_meta->rowset_key_bounds().max_key(), segments_key_bounds.back().max_key());
     }
 }
 

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -5710,6 +5710,9 @@ std::size_t get_segments_key_bounds_bytes(const doris::RowsetMetaCloudPB& rowset
     for (const auto& key_bounds : rowset_meta.segments_key_bounds()) {
         ret += key_bounds.ByteSizeLong();
     }
+    if (rowset_meta.has_rowset_key_bounds()) {
+        ret += rowset_meta.rowset_key_bounds().ByteSizeLong();
+    }
     return ret;
 }
 

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -1112,6 +1112,7 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
         if (config::enable_recycle_rowset_strip_key_bounds) {
             // Strip key bounds to shrink operation log for ts compaction recycle entries
             recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds();
+            recycle_rowset.mutable_rowset_meta()->clear_rowset_key_bounds();
             recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds_truncated();
         }
         recycle_rowset.set_type(RecycleRowsetPB::COMPACT);
@@ -1672,6 +1673,7 @@ void process_schema_change_job(MetaServiceCode& code, std::string& msg, std::str
         if (config::enable_recycle_rowset_strip_key_bounds) {
             // Strip key bounds to shrink schema change recycle operation log entries
             recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds();
+            recycle_rowset.mutable_rowset_meta()->clear_rowset_key_bounds();
             recycle_rowset.mutable_rowset_meta()->clear_segments_key_bounds_truncated();
         }
         recycle_rowset.set_type(RecycleRowsetPB::DROP);

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -139,6 +139,11 @@ message RowsetMetaPB {
 
     // rows count for each segment
     repeated int64 num_segment_rows = 56;
+    // the encoded key range of this rowset. For non-MoW rowsets, Doris may persist
+    // only this rowset-level first/last segment key range instead of all segment bounds.
+    // ATTN: rowset_key_bounds may be truncated too, please refer to
+    // `segments_key_bounds_truncated`.
+    optional KeyBoundsPB rowset_key_bounds = 57;
 
     // For cloud
     // for data recycling
@@ -245,6 +250,11 @@ message RowsetMetaCloudPB {
 
     // rows count for each segment
     repeated int64 num_segment_rows = 56;
+    // the encoded key range of this rowset. For non-MoW rowsets, Doris may persist
+    // only this rowset-level first/last segment key range instead of all segment bounds.
+    // ATTN: rowset_key_bounds may be truncated too, please refer to
+    // `segments_key_bounds_truncated`.
+    optional KeyBoundsPB rowset_key_bounds = 57;
 
     // cloud
     // the field is a vector, rename it


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Persist rowset-level key bounds for non-MoW rowsets to reduce rowset meta memory usage and shrink the meta value stored in FoundationDB, avoiding value-size limit issues caused by full per-segment key bounds. The change keeps full segment key bounds for MoW rowsets and preserves the related compaction, snapshot, cloud conversion, and recycle flows.

### Release note

None

### Check List (For Author)

- Test: Attempted BE unit test and targeted object compilation
    - Unit Test / Manual test
- Behavior changed: Yes (non-MoW rowsets can persist rowset-level key bounds instead of full per-segment key bounds; this branch temporarily defaults enable_rowset_key_bounds_for_non_mow to true for CI, while the path remains config-gated)
- Does this need documentation: No
