### PR TITLE
[chore](ci) Remove Need_2_Approval from required status checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,7 +62,6 @@ github:
           - Build Third Party Libraries (macOS)
           - Build Third Party Libraries (macOS-arm64)
           - COMPILE (DORIS_COMPILE)
-          - Need_2_Approval
           - Cloud UT (Doris Cloud UT)
           - performance (Doris Performance)
           - check_coverage (Coverage)


### PR DESCRIPTION
Remove the Need_2_Approval check from the required GitHub status checks list in .asf.yaml, as this approval requirement is no longer needed in the CI workflow.
