### PR TITLE
[chore](ci) Remove code-review from required status checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,7 +62,6 @@ github:
           - Build Third Party Libraries (macOS)
           - Build Third Party Libraries (macOS-arm64)
           - COMPILE (DORIS_COMPILE)
-          - code-review
           - Cloud UT (Doris Cloud UT)
           - performance (Doris Performance)
           - check_coverage (Coverage)


### PR DESCRIPTION
Remove the code-review check from the required GitHub status checks list in .asf.yaml, as this check is no longer needed in the CI workflow.