### PR TITLE
[refactor](fe) Extract isDynamicScheduleTable method to reduce code duplication

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -972,6 +972,16 @@ public class DynamicPartitionScheduler extends MasterDaemon {
         createOrUpdateRuntimeInfo(tableId, DROP_PARTITION_MSG, DEFAULT_RUNTIME_VALUE);
     }
 
+    /**
+     * DynamicPartitionScheduler keeps two kinds of tables in {@code dynamicPartitionTableInfo}: dynamic partition
+     * tables with scheduling enabled, and auto partition tables that rely on {@code partition.retention_count} for
+     * periodic cleanup.
+     */
+    private boolean isDynamicScheduleTable(Table table) {
+        return table instanceof OlapTable && (((OlapTable) table).getPartitionRetentionCount() > 0
+                || DynamicPartitionUtil.isDynamicPartitionTable(table));
+    }
+
     private void initDynamicPartitionTable() {
         for (Long dbId : Env.getCurrentEnv().getInternalCatalog().getDbIds()) {
             Database db = Env.getCurrentInternalCatalog().getDbNullable(dbId);
@@ -982,9 +992,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             for (Table table : tableList) {
                 table.readLock();
                 try {
-                    if (table instanceof OlapTable
-                            && (((OlapTable) table).getPartitionRetentionCount() > 0
-                            || DynamicPartitionUtil.isDynamicPartitionTable(table))) {
+                    if (isDynamicScheduleTable(table)) {
                         registerDynamicPartitionTable(db.getId(), table.getId());
                     }
                 } finally {


### PR DESCRIPTION
Related PR: https://github.com/apache/doris/pull/61954

Problem Summary:

Extract the dynamic partition table check logic into a private helper method `isDynamicScheduleTable()` and add documentation explaining that DynamicPartitionScheduler tracks both dynamic partition tables with scheduling enabled and auto partition tables using `partition.retention_count` for periodic cleanup.