### PR TITLE
[improvement](fe) Skip zero-length files in FileSplitter to avoid sending empty splits to BE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FileSplitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FileSplitter.java
@@ -101,6 +101,10 @@ public class FileSplitter {
                 List<String> partitionValues,
                 SplitCreator splitCreator)
                 throws IOException {
+        if (length <= 0) {
+            // Zero-length files contain no data; skip to avoid sending empty splits to BE.
+            return Lists.newArrayList();
+        }
         // Pass splitCreator.create() to set target file split size to calculate split weight.
         long targetFileSplitSize = specifiedFileSplitSize > 0 ? specifiedFileSplitSize : maxSplitSize;
         if (blockLocations == null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/FileSplitterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/FileSplitterTest.java
@@ -196,6 +196,30 @@ public class FileSplitterTest {
     }
 
     @Test
+    public void testZeroLengthFileProducesNoSplits() throws Exception {
+        LocationPath loc = LocationPath.of("hdfs://example.com/path/emptyfile");
+        BlockLocation[] locations = new BlockLocation[]{new BlockLocation(null, new String[]{"h1"}, 0L, 0L)};
+        FileSplitter fileSplitter = new FileSplitter(32 * MB, 64 * MB, DEFAULT_INITIAL_SPLITS);
+        // Non-splittable zero-length file
+        List<Split> splits = fileSplitter.splitFile(
+                loc, 0L, locations, 0L, 0L, false,
+                Collections.emptyList(), FileSplit.FileSplitCreator.DEFAULT);
+        Assert.assertTrue("Zero-length file should produce no splits", splits.isEmpty());
+        // Splittable zero-length file
+        splits = fileSplitter.splitFile(
+                loc, 0L, locations, 0L, 0L, true,
+                Collections.emptyList(), FileSplit.FileSplitCreator.DEFAULT);
+        Assert.assertTrue("Zero-length splittable file should produce no splits", splits.isEmpty());
+        // Null block locations with zero-length file
+        splits = fileSplitter.splitFile(
+                loc, 0L, null, 0L, 0L, true,
+                Collections.emptyList(), FileSplit.FileSplitCreator.DEFAULT);
+        Assert.assertTrue("Zero-length file with null locations should produce no splits", splits.isEmpty());
+        // Counter should not be decremented for skipped zero-length files
+        Assert.assertEquals(DEFAULT_INITIAL_SPLITS, fileSplitter.getRemainingInitialSplitNum());
+    }
+
+    @Test
     public void testSmallFileNoSplit() throws Exception {
         LocationPath loc = LocationPath.of("hdfs://example.com/path/small");
         BlockLocation[] locations = new BlockLocation[]{new BlockLocation(null, new String[]{"h1"}, 0L, 2 * MB)};


### PR DESCRIPTION
Issue Number: close #xxx

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

Zero-length files (length=0) on external storage (HDFS/S3) can produce empty splits that are assigned to BE, wasting RPC and scheduling resources. FileSplitter.splitFile() previously created splits even for length=0 files (specifically for non-splittable/compressed files). These splits carry no data but still consume a scan range slot and backend scheduling overhead.

This does NOT affect:
- Paimon JNI splits (length=0 but data in Paimon split object)
- Hudi log-only splits (length=0 but data in delta logs)
- Iceberg splits (create their own split objects) 
These formats bypass FileSplitter and create splits directly.

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

