### PR TITLE
[bug](jdbc) test_jdbc_connection rpc should check enable_java_support firstly

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -991,6 +991,13 @@ void PInternalService::test_jdbc_connection(google::protobuf::RpcController* con
                                             const PJdbcTestConnectionRequest* request,
                                             PJdbcTestConnectionResult* result,
                                             google::protobuf::Closure* done) {
+    if (!doris::config::enable_java_support) {
+        doris::Status status = doris::Status::InternalError(
+                "you can change be config enable_java_support to true and restart be.");
+        status.to_protobuf(result->mutable_status());
+        done->Run();
+        return;
+    }
     bool ret = _heavy_work_pool.try_offer([request, result, done]() {
         VLOG_RPC << "test jdbc connection";
         brpc::ClosureGuard closure_guard(done);


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
if enable_java_support=false, and the rpc of test_jdbc_connection may cause coredump

```
*** Query id: 0-0 ***
*** tablet id: 0 ***
*** Aborted at 1776056623 (unix time) try "date -d @1776056623" if you are using GNU date ***
*** Current BE git commitID: 000395ded91 ***
*** SIGSEGV address not mapped to object (@0x10) received by PID 3520046 (TID 3524680 OR 0x10cc164ee640) from PID 16; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at ../src/common/signal_handler.h:417
 1# PosixSignals::chained_handler(int, siginfo*, void*) in /mnt/disk6/common/jdk-17.0.16/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /mnt/disk6/common/jdk-17.0.16/lib/server/libjvm.so
 3# 0x000014D80A03E6F0 in /lib64/libc.so.6
 4# setTLSExceptionStrings at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-hadoop-3.4.2.2-for-doris/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c:908
 5# printExceptionAndFreeV at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-hadoop-3.4.2.2-for-doris/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c:196
 6# printExceptionAndFree at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-hadoop-3.4.2.2-for-doris/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c:226
 7# getJNIEnv at /home/runner/work/doris-thirdparty/doris-thirdparty/thirdparty/src/doris-thirdparty-hadoop-3.4.2.2-for-doris/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c:824
 8# doris::Jni::Env::GetJNIEnvSlowPath(JNIEnv_**) at ./be/build_ASAN/../src/util/jni-util.cpp:182
 9# doris::Jni::Env::Get(JNIEnv_**) at ../src/util/jni-util.h:57
10# doris::JniReader::open(doris::RuntimeState*, doris::RuntimeProfile*) at ./be/build_ASAN/../src/format/jni/jni_reader.cpp:97
11# doris::PInternalService::test_jdbc_connection(google::protobuf::RpcController*, doris::PJdbcTestConnectionRequest const*, doris::PJdbcTestConnectionResult*, google::protobuf::Closure*)::$_0::operator()() const at ./be/build_ASAN/../src/service/internal_service.cpp:1084 
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

