### PR TITLE
[Fix](thirdparty) Fix pyudf core cased by Arrow Flight unstable status reconstruction

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
@@ -77,10 +77,6 @@ excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line 
     "cloud/multi_cluster," + // run in specific regression pipeline
     "cloud_p0/multi_cluster," + // run in specific regression pipeline
     "cloud_p0/cache," +
-    "pythonudaf_p0," + // will cause a core when the third-party is compiled by clang
-    "pythonudtf_p0," + // will cause a core when the third-party is compiled by clang
-    "pythonudf_p0," + // will cause a core when the third-party is compiled by clang
-    "pythonudf_complex_p0," + // will cause a core when the third-party is compiled by clang
     "shape_check," + // run only in p0 is enough
     "query_p0/cache," + // run only in p0 is enough
     "nereids_rules_p0/mv/increment_create," + // run only in p0 is enough

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -76,10 +76,6 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
 // this directories will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "cloud," +
-    "pythonudaf_p0," + // will cause a core when the third-party is compiled by clang
-    "pythonudtf_p0," + // will cause a core when the third-party is compiled by clang
-    "pythonudf_p0," + // will cause a core when the third-party is compiled by clang
-    "pythonudf_complex_p0," + // will cause a core when the third-party is compiled by clang
     "cloud_p0," +
     "external_table_p0/remote_doris," + // ubsan issue, need to investigate
     "workload_manager_p1," +

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -435,6 +435,10 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " ARROW " ]]; then
             # apache-arrow-17.0.0-force-write-int96-timestamps.patch : 
             # Introducing the parameter that forces writing int96 timestampes for compatibility with Paimon cpp. 
             patch -p1 <"${TP_PATCH_DIR}/apache-arrow-17.0.0-force-write-int96-timestamps.patch"
+
+            # apache-arrow-17.0.0-flight-safe-finish-status.patch :
+            # Keep Flight gRPC stream teardown on a minimal status conversion path.
+            patch -p1 <"${TP_PATCH_DIR}/apache-arrow-17.0.0-flight-safe-finish-status.patch"
             touch "${PATCHED_MARK}"
         fi
         cd -

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -437,7 +437,8 @@ if [[ " ${TP_ARCHIVES[*]} " =~ " ARROW " ]]; then
             patch -p1 <"${TP_PATCH_DIR}/apache-arrow-17.0.0-force-write-int96-timestamps.patch"
 
             # apache-arrow-17.0.0-flight-safe-finish-status.patch :
-            # Keep Flight gRPC stream teardown on a minimal status conversion path.
+            # Avoid Flight client crashes during stream teardown by skipping rich
+            # status reconstruction on gRPC finish errors.
             patch -p1 <"${TP_PATCH_DIR}/apache-arrow-17.0.0-flight-safe-finish-status.patch"
             touch "${PATCHED_MARK}"
         fi

--- a/thirdparty/patches/apache-arrow-17.0.0-flight-safe-finish-status.patch
+++ b/thirdparty/patches/apache-arrow-17.0.0-flight-safe-finish-status.patch
@@ -1,0 +1,216 @@
+--- arrow-apache-arrow-17.0.0-before-flight-finish-fix/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
++++ arrow-apache-arrow-17.0.0/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+@@ -71,108 +71,146 @@
+ struct ClientRpc {
+   ::grpc::ClientContext context;
+ 
+   explicit ClientRpc(const FlightCallOptions& options) {
+     if (options.timeout.count() >= 0) {
+       std::chrono::system_clock::time_point deadline =
+           std::chrono::time_point_cast<std::chrono::system_clock::time_point::duration>(
+               std::chrono::system_clock::now() + options.timeout);
+       context.set_deadline(deadline);
+     }
+     for (auto header : options.headers) {
+       context.AddMetadata(header.first, header.second);
+     }
+   }
+ 
+   /// \brief Add an auth token via an auth handler
+   Status SetToken(ClientAuthHandler* auth_handler) {
+     if (auth_handler) {
+       std::string token;
+       RETURN_NOT_OK(auth_handler->GetToken(&token));
+       context.AddMetadata(kGrpcAuthHeader, token);
+     }
+     return Status::OK();
+   }
+ };
+ 
+ class GrpcAddClientHeaders : public AddCallHeaders {
+  public:
+   explicit GrpcAddClientHeaders(std::multimap<::grpc::string, ::grpc::string>* metadata)
+       : metadata_(metadata) {}
+   ~GrpcAddClientHeaders() override = default;
+ 
+   void AddHeader(const std::string& key, const std::string& value) override {
+     metadata_->insert(std::make_pair(key, value));
+   }
+ 
+  private:
+   std::multimap<::grpc::string, ::grpc::string>* metadata_;
+ };
+ 
++// Terminal RPC status is observed while gRPC is already completing the call.
++// Keep conversion minimal here instead of rebuilding rich Flight details.
++Status MakeSafeTerminalStatus(const ::grpc::Status& grpc_status) {
++  if (grpc_status.ok()) {
++    return Status::OK();
++  }
++
++  const auto error_code = grpc_status.error_code();
++  const std::string error_message = grpc_status.error_message();
++  switch (error_code) {
++    case ::grpc::StatusCode::CANCELLED:
++      return Status::Cancelled("Flight stream finish failed with message: ",
++                               error_message);
++    case ::grpc::StatusCode::UNKNOWN:
++      return Status::UnknownError("Flight stream finish failed with message: ",
++                                  error_message);
++    case ::grpc::StatusCode::INVALID_ARGUMENT:
++    case ::grpc::StatusCode::FAILED_PRECONDITION:
++    case ::grpc::StatusCode::OUT_OF_RANGE:
++    case ::grpc::StatusCode::RESOURCE_EXHAUSTED:
++      return Status::Invalid("Flight stream finish failed with message: ",
++                             error_message);
++    case ::grpc::StatusCode::NOT_FOUND:
++      return Status::KeyError("Flight stream finish failed with message: ",
++                              error_message);
++    case ::grpc::StatusCode::ALREADY_EXISTS:
++      return Status::AlreadyExists("Flight stream finish failed with message: ",
++                                   error_message);
++    case ::grpc::StatusCode::UNIMPLEMENTED:
++      return Status::NotImplemented("Flight stream finish failed with message: ",
++                                    error_message);
++    default:
++      return Status::IOError("Flight stream finish failed with gRPC code ",
++                             static_cast<int>(error_code), ", message: ",
++                             error_message);
++  }
++}
++
+ class GrpcClientInterceptorAdapter : public ::grpc::experimental::Interceptor {
+  public:
+   explicit GrpcClientInterceptorAdapter(
+       std::vector<std::unique_ptr<ClientMiddleware>> middleware)
+       : middleware_(std::move(middleware)) {}
+ 
+   void Intercept(::grpc::experimental::InterceptorBatchMethods* methods) override {
+     using InterceptionHookPoints = ::grpc::experimental::InterceptionHookPoints;
+     if (methods->QueryInterceptionHookPoint(
+             InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
+       GrpcAddClientHeaders add_headers(methods->GetSendInitialMetadata());
+       for (const auto& middleware : middleware_) {
+         middleware->SendingHeaders(&add_headers);
+       }
+     }
+ 
+     if (methods->QueryInterceptionHookPoint(
+             InterceptionHookPoints::POST_RECV_INITIAL_METADATA)) {
+       if (!methods->GetRecvInitialMetadata()->empty()) {
+         ReceivedHeaders(*methods->GetRecvInitialMetadata());
+       }
+     }
+ 
+     if (methods->QueryInterceptionHookPoint(InterceptionHookPoints::POST_RECV_STATUS)) {
+       DCHECK_NE(nullptr, methods->GetRecvStatus());
+       DCHECK_NE(nullptr, methods->GetRecvTrailingMetadata());
+       ReceivedHeaders(*methods->GetRecvTrailingMetadata());
+-      const Status status = FromGrpcStatus(*methods->GetRecvStatus());
++      const Status status = MakeSafeTerminalStatus(*methods->GetRecvStatus());
+       for (const auto& middleware : middleware_) {
+         middleware->CallCompleted(status);
+       }
+     }
+ 
+     methods->Proceed();
+   }
+ 
+  private:
+   void ReceivedHeaders(
+       const std::multimap<::grpc::string_ref, ::grpc::string_ref>& metadata) {
+     CallHeaders headers;
+     for (const auto& entry : metadata) {
+       headers.insert({std::string_view(entry.first.data(), entry.first.length()),
+                       std::string_view(entry.second.data(), entry.second.length())});
+     }
+     for (const auto& middleware : middleware_) {
+       middleware->ReceivedHeaders(headers);
+     }
+   }
+ 
+   std::vector<std::unique_ptr<ClientMiddleware>> middleware_;
+ };
+ 
+ class GrpcClientInterceptorAdapterFactory
+     : public ::grpc::experimental::ClientInterceptorFactoryInterface {
+  public:
+   explicit GrpcClientInterceptorAdapterFactory(
+       std::vector<std::shared_ptr<ClientMiddlewareFactory>> middleware)
+       : middleware_(std::move(middleware)) {}
+ 
+   ::grpc::experimental::Interceptor* CreateClientInterceptor(
+       ::grpc::experimental::ClientRpcInfo* info) override {
+     std::vector<std::unique_ptr<ClientMiddleware>> middleware;
+ 
+     FlightMethod flight_method = FlightMethod::Invalid;
+     std::string_view method(info->method());
+     if (EndsWith(method, "/Handshake")) {
+       flight_method = FlightMethod::Handshake;
+     } else if (EndsWith(method, "/ListFlights")) {
+@@ -283,20 +321,10 @@
+       // Drain the read side to avoid gRPC hanging in Finish()
+     }
+ 
+-    server_status_ = FromGrpcStatus(stream_->Finish(), &rpc_->context);
+-    if (!server_status_.ok()) {
+-      server_status_ = Status::FromDetailAndArgs(
+-          server_status_.code(), server_status_.detail(), server_status_.message(),
+-          ". gRPC client debug context: ", rpc_->context.debug_error_string());
+-    }
++    server_status_ = MakeSafeTerminalStatus(stream_->Finish());
+     if (!transport_status_.ok()) {
+       if (server_status_.ok()) {
+         server_status_ = transport_status_;
+-      } else {
+-        server_status_ = Status::FromDetailAndArgs(
+-            server_status_.code(), server_status_.detail(), server_status_.message(),
+-            ". gRPC client debug context: ", rpc_->context.debug_error_string(),
+-            ". Additional context: ", transport_status_.ToString());
+       }
+     }
+     finished_ = true;
+@@ -349,10 +377,8 @@
+     done_writing_ = true;
+ 
+     Status st = Base::DoFinish();
+-    if (!finished_writes) {
+-      return Status::FromDetailAndArgs(
+-          st.code(), st.detail(), st.message(),
+-          ". Additionally, could not finish writing record batches before closing");
++    if (!finished_writes && st.ok()) {
++      return Status::IOError("Could not finish writing record batches before closing");
+     }
+     return st;
+   }
+@@ -502,7 +528,7 @@
+   ~GrpcResultStream() override {
+     if (stream_) {
+       rpc_.context.TryCancel();
+-      auto status = FromGrpcStatus(stream_->Finish(), &rpc_.context);
++      auto status = MakeSafeTerminalStatus(stream_->Finish());
+       if (!status.ok() && !status.IsCancelled()) {
+         ARROW_LOG(DEBUG)
+             << "DoAction result was not fully consumed, server returned error: "
+@@ -542,7 +568,7 @@
+       }
+       RETURN_NOT_OK(stop_token_.Poll());
+ 
+-      status_ = FromGrpcStatus(stream_->Finish(), &rpc_.context);
++      status_ = MakeSafeTerminalStatus(stream_->Finish());
+       stream_.reset();
+     }
+     RETURN_NOT_OK(status_);
+--- arrow-apache-arrow-17.0.0-before-flight-finish-fix/cpp/src/arrow/flight/transport.cc
++++ arrow-apache-arrow-17.0.0/cpp/src/arrow/flight/transport.cc
+@@ -47,9 +47,7 @@
+   auto server_status = DoFinish();
+   if (server_status.ok()) return st;
+ 
+-  return Status::FromDetailAndArgs(server_status.code(), server_status.detail(),
+-                                   server_status.message(),
+-                                   ". Client context: ", st.ToString());
++  return server_status;
+ }
+ 
+ Status ClientTransport::Authenticate(const FlightCallOptions& options,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Background

We found a BE core in Python UDF/UDAF related Arrow Flight paths when streams were closed under error conditions. The root cause is  unstable terminal status reconstruction in Arrow Flight teardown.

e.g.
```text
*** SIGSEGV invalid permissions for mapped object (@0x56448ff1ef38) received by PID 66637 (TID 67372 OR 0x7f2687017640) from PID 18446744071829581624; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at ../src/common/signal_handler.h:417
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-17-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F2836CE7520 in /lib/x86_64-linux-gnu/libc.so.6
 4# std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) at /usr/local/ldb-toolchain-v0.26/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/basic_string.h:707
 5# arrow::Status::WithDetail(std::shared_ptr<arrow::StatusDetail>) const in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
 6# arrow::flight::internal::TransportStatus::ToStatus() const in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
 7# arrow::flight::transport::grpc::FromGrpcStatus(grpc::Status const&, grpc::ClientContext*) in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
 8# arrow::flight::transport::grpc::(anonymous namespace)::GrpcClientInterceptorAdapter::Intercept(grpc::experimental::InterceptorBatchMethods*) in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
 9# grpc::internal::InterceptorBatchMethodsImpl::RunInterceptors() in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
10# grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata, grpc::internal::CallOpClientRecvStatus, grpc::internal::CallNoOp<3>, grpc::internal::CallNoOp<4>, grpc::internal::CallNoOp<5>, grpc::internal::CallNoOp<6> >::FinalizeResult(void**, bool*) in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
11# grpc::ClientReaderWriter<arrow::flight::protocol::FlightData, arrow::flight::protocol::FlightData>::Finish() in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
12# arrow::flight::transport::grpc::(anonymous namespace)::FinishableDataStream<grpc::ClientReaderWriter<arrow::flight::protocol::FlightData, arrow::flight::protocol::FlightData>, arrow::flight::internal::FlightData>::DoFinish() in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
13# arrow::flight::transport::grpc::(anonymous namespace)::WritableDataStream<grpc::ClientReaderWriter<arrow::flight::protocol::FlightData, arrow::flight::protocol::FlightData>, arrow::flight::internal::FlightData>::DoFinish() in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
14# arrow::flight::internal::ClientDataStream::Finish(arrow::Status) in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
15# arrow::flight::ClientStreamReader::Next() in /mnt/disk1/PERFORMANCE_ENV/be/lib/doris_be
16# doris::PythonClient::read_batch(std::shared_ptr<arrow::RecordBatch>*) at ./be/build_RELEASE/../src/udf/python/python_client.cpp:136
17# doris::PythonUDFClient::evaluate(arrow::RecordBatch const&, std::shared_ptr<arrow::RecordBatch>*) at ./be/build_RELEASE/../src/udf/python/python_udf_client.cpp:36 
```
### Fix
The issue at the Arrow Flight boundary by simplifying terminal error conversion during stream teardown. The direction is to stop rebuilding overly rich final statuses in teardown-sensitive paths, and keep the final error handling on a minimal and stable conversion path.

In short, the goal is:

- preserve failure visibility
- avoid unsafe teardown-time status reconstruction
- make both execution and cleanup paths use the same stable terminal error behavior

### Change Impact
This changes Arrow Flight behavior only in stream teardown error handling.

After this change, terminal errors during Flight stream close will no longer include some extra reconstructed context, such as detailed Flight metadata or client-side debug context. The visible error will be simpler, but still contains the terminal failure code/message.

This does not change normal successful Flight data exchange behavior. The impact is limited to how errors are reported when an Arrow Flight stream is being closed under failure conditions.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

