### PR TITLE
[refine](column) enforce nullable nested types for array and map

### DIFF
--- a/be/src/core/data_type/data_type_array.cpp
+++ b/be/src/core/data_type/data_type_array.cpp
@@ -48,7 +48,13 @@ namespace ErrorCodes {
 extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
 
-DataTypeArray::DataTypeArray(const DataTypePtr& nested_) : nested {nested_} {}
+DataTypeArray::DataTypeArray(const DataTypePtr& nested_) {
+    DataTypePtr nullable_nested = make_nullable(nested_);
+    auto nested_type = std::dynamic_pointer_cast<const DataTypeNullable>(nullable_nested);
+    DORIS_CHECK(nested_type != nullptr);
+    nested = std::move(nested_type);
+    nested_as_base = nested;
+}
 
 MutableColumnPtr DataTypeArray::create_column() const {
     return ColumnArray::create(nested->create_column(), ColumnArray::ColumnOffsets::create());
@@ -72,9 +78,10 @@ bool DataTypeArray::equals(const IDataType& rhs) const {
 
 // here we should remove nullable, otherwise here always be 1
 size_t DataTypeArray::get_number_of_dimensions() const {
-    const DataTypeArray* nested_array =
-            typeid_cast<const DataTypeArray*>(remove_nullable(nested).get());
-    if (!nested_array) return 1;
+    auto* nested_array = typeid_cast<const DataTypeArray*>(remove_nullable(nested).get());
+    if (!nested_array) {
+        return 1;
+    }
     return 1 +
            nested_array
                    ->get_number_of_dimensions(); /// Every modern C++ compiler optimizes tail recursion.
@@ -133,7 +140,7 @@ const char* DataTypeArray::deserialize(const char* buf, MutableColumnPtr* column
 
 void DataTypeArray::to_pb_column_meta(PColumnMeta* col_meta) const {
     IDataType::to_pb_column_meta(col_meta);
-    auto children = col_meta->add_children();
+    auto* children = col_meta->add_children();
     get_nested_type()->to_pb_column_meta(children);
 }
 

--- a/be/src/core/data_type/data_type_array.h
+++ b/be/src/core/data_type/data_type_array.h
@@ -29,6 +29,7 @@
 
 #include "common/status.h"
 #include "core/data_type/data_type.h"
+#include "core/data_type/data_type_nullable.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/data_type_serde/data_type_array_serde.h"
 #include "core/data_type_serde/data_type_serde.h"
@@ -47,7 +48,8 @@ namespace doris {
 class DataTypeArray final : public IDataType {
 private:
     /// The type of array elements.
-    DataTypePtr nested;
+    DataTypeNullablePtr nested;
+    DataTypePtr nested_as_base;
 
 public:
     static constexpr PrimitiveType PType = TYPE_ARRAY;
@@ -79,7 +81,8 @@ public:
 
     bool equals(const IDataType& rhs) const override;
 
-    const DataTypePtr& get_nested_type() const { return nested; }
+    const DataTypePtr& get_nested_type() const { return nested_as_base; }
+    const DataTypeNullablePtr& get_nullable_nested_type() const { return nested; }
 
     /// 1 for plain array, 2 for array of arrays and so on.
     size_t get_number_of_dimensions() const;
@@ -99,7 +102,7 @@ public:
     void to_protobuf(PTypeDesc* ptype, PTypeNode* node, PScalarType* scalar_type) const override {
         node->set_type(TTypeNodeType::ARRAY);
         node->set_contains_null(nested->is_nullable());
-        nested->to_protobuf(ptype);
+        get_nested_type()->to_protobuf(ptype);
     }
 
 #ifdef BE_TEST
@@ -107,7 +110,7 @@ public:
         node.type = TTypeNodeType::ARRAY;
         node.__isset.contains_nulls = true;
         node.contains_nulls.push_back(nested->is_nullable());
-        nested->to_thrift(thrift_type);
+        get_nested_type()->to_thrift(thrift_type);
     }
 #endif
 };

--- a/be/src/core/data_type/primitive_type.h
+++ b/be/src/core/data_type/primitive_type.h
@@ -92,10 +92,12 @@ class DataTypeHLL;
 class DataTypeJsonb;
 class DataTypeArray;
 class DataTypeMap;
+class DataTypeNullable;
 class DataTypeVariant;
 class DataTypeStruct;
 class DataTypeBitMap;
 class DataTypeQuantileState;
+using DataTypeNullablePtr = std::shared_ptr<const DataTypeNullable>;
 template <PrimitiveType T>
 class ColumnVector;
 using ColumnUInt8 = ColumnVector<TYPE_BOOLEAN>;

--- a/be/src/core/data_type_serde/data_type_array_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_array_serde.cpp
@@ -84,7 +84,7 @@ Status DataTypeArraySerDe::deserialize_one_cell_from_json(IColumn& column, Slice
     auto& array_column = assert_cast<ColumnArray&>(column);
     auto& offsets = array_column.get_offsets();
     IColumn& nested_column = array_column.get_data();
-    DCHECK(nested_column.is_nullable());
+    DORIS_CHECK(nested_column.is_nullable());
     if (slice[0] != '[') {
         return Status::InvalidArgument("Array does not start with '[' character, found '{}'",
                                        slice[0]);
@@ -162,7 +162,7 @@ Status DataTypeArraySerDe::deserialize_one_cell_from_hive_text(
     auto& array_column = assert_cast<ColumnArray&>(column);
     auto& offsets = array_column.get_offsets();
     IColumn& nested_column = array_column.get_data();
-    DCHECK(nested_column.is_nullable());
+    DORIS_CHECK(nested_column.is_nullable());
 
     char collection_delimiter =
             options.get_collection_delimiter(hive_text_complex_type_delimiter_level);

--- a/be/src/core/data_type_serde/data_type_array_serde.h
+++ b/be/src/core/data_type_serde/data_type_array_serde.h
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "common/status.h"
+#include "core/data_type_serde/data_type_nullable_serde.h"
 #include "core/data_type_serde/data_type_serde.h"
 
 namespace doris {
@@ -39,7 +40,12 @@ class IDataType;
 class DataTypeArraySerDe : public DataTypeSerDe {
 public:
     DataTypeArraySerDe(DataTypeSerDeSPtr _nested_serde, int nesting_level = 1)
-            : DataTypeSerDe(nesting_level), nested_serde(std::move(_nested_serde)) {}
+            : DataTypeSerDe(nesting_level) {
+        auto nullable_serde =
+                std::dynamic_pointer_cast<DataTypeNullableSerDe>(std::move(_nested_serde));
+        DORIS_CHECK(nullable_serde != nullptr);
+        nested_serde = std::move(nullable_serde);
+    }
 
     std::string get_name() const override { return "Array(" + nested_serde->get_name() + ")"; }
 
@@ -133,6 +139,6 @@ private:
     template <bool is_strict_mode>
     Status _from_string(StringRef& str, IColumn& column, const FormatOptions& options) const;
 
-    DataTypeSerDeSPtr nested_serde;
+    DataTypeNullableSerDeSPtr nested_serde;
 };
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_nullable_serde.h
+++ b/be/src/core/data_type_serde/data_type_nullable_serde.h
@@ -129,4 +129,7 @@ public:
 private:
     DataTypeSerDeSPtr nested_serde;
 };
+
+using DataTypeNullableSerDeSPtr = std::shared_ptr<DataTypeNullableSerDe>;
+
 } // namespace doris

--- a/be/src/exprs/function/cast/cast_to_array.h
+++ b/be/src/exprs/function/cast/cast_to_array.h
@@ -51,7 +51,7 @@ WrapperType create_array_wrapper(FunctionContext* context, const DataTypePtr& fr
                 "CAST AS Array can only be performed between same-dimensional array types");
     }
 
-    const DataTypePtr& to_nested_type = to_type.get_nested_type();
+    DataTypePtr to_nested_type = to_type.get_nested_type();
 
     /// Prepare nested type conversion
     const auto nested_function =

--- a/be/test/core/data_type_serde/data_type_serde_string_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_string_test.cpp
@@ -32,6 +32,7 @@
 #include "core/assert_cast.h"
 #include "core/column/column.h"
 #include "core/column/column_array.h"
+#include "core/column/column_nullable.h"
 #include "core/data_type/common_data_type_serder_test.h"
 #include "core/data_type/common_data_type_test.h"
 #include "core/data_type/data_type.h"
@@ -308,9 +309,12 @@ TEST_F(DataTypeStringSerDeTest, ArrowMemNotAlignedNestedArr) {
     EXPECT_EQ(values_address % 4, 1);
 
     // 5.Test read_column_from_arrow
-    auto ser_col = ColumnArray::create(ColumnString::create(), ColumnOffset64::create());
+    auto ser_col = ColumnArray::create(
+            ColumnNullable::create(ColumnString::create(), ColumnUInt8::create()),
+            ColumnOffset64::create());
     cctz::time_zone tz;
-    auto serde_list = std::make_shared<DataTypeArraySerDe>(serde_str);
+    auto serde_nullable_str = std::make_shared<DataTypeNullableSerDe>(serde_str);
+    auto serde_list = std::make_shared<DataTypeArraySerDe>(serde_nullable_str);
     auto st = serde_list->read_column_from_arrow(*ser_col, arr.get(), 0, 1, tz);
     EXPECT_TRUE(st.ok());
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -5259,7 +5259,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         return ParserUtils.withOrigin(ctx, () -> {
             switch (ctx.complex.getType()) {
                 case DorisParser.ARRAY:
-                    return ArrayType.of(typedVisit(ctx.dataType(0)), true);
+                    return ArrayType.of(typedVisit(ctx.dataType(0)));
                 case DorisParser.MAP:
                     return MapType.of(typedVisit(ctx.dataType(0)), typedVisit(ctx.dataType(1)));
                 case DorisParser.STRUCT:

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -629,13 +629,13 @@ public class FoldConstantRuleOnBE implements ExpressionPatternRuleFactory {
 
     private static Pair<DataType, Integer> convertToNereidsType(List<PTypeNode> typeNodes, int start) {
         PScalarType pScalarType = typeNodes.get(start).getScalarType();
-        boolean containsNull = typeNodes.get(start).getContainsNull();
         TPrimitiveType tPrimitiveType = TPrimitiveType.findByValue(pScalarType.getType());
         DataType type;
         int parsedNodes;
         if (tPrimitiveType == TPrimitiveType.ARRAY) {
             Pair<DataType, Integer> itemType = convertToNereidsType(typeNodes, start + 1);
-            type = ArrayType.of(itemType.key(), containsNull);
+            // Array elements are always nullable
+            type = ArrayType.of(itemType.key());
             parsedNodes = 1 + itemType.value();
         } else if (tPrimitiveType == TPrimitiveType.MAP) {
             Pair<DataType, Integer> keyType = convertToNereidsType(typeNodes, start + 1);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
@@ -503,8 +503,7 @@ public class NestedColumnPruning implements CustomRewriter {
                         children.values().iterator().next().pruneCastType(
                                 origin.children.values().iterator().next(),
                                 cast.children.values().iterator().next()
-                        ),
-                        ((ArrayType) cast.type).containsNull()
+                        )
                 );
             } else if (type instanceof MapType) {
                 return MapType.of(
@@ -717,7 +716,7 @@ public class NestedColumnPruning implements CustomRewriter {
                 }
                 return new StructType(newFields);
             } else if (dataType instanceof ArrayType) {
-                return ArrayType.of(newChildrenTypes.get(0).second, ((ArrayType) dataType).containsNull());
+                return ArrayType.of(newChildrenTypes.get(0).second);
             } else if (dataType instanceof MapType) {
                 return MapType.of(newChildrenTypes.get(0).second, newChildrenTypes.get(1).second);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ArrayItemReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ArrayItemReference.java
@@ -77,7 +77,8 @@ public class ArrayItemReference extends NamedExpression implements ExpectsInputT
 
     @Override
     public boolean nullable() {
-        return ((ArrayType) (this.children.get(0).getDataType())).containsNull();
+        // Array elements are always nullable
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggCombinerFunctionBuilder.java
@@ -96,7 +96,8 @@ public class AggCombinerFunctionBuilder extends FunctionBuilder {
                         "foreach must be input array type: '" + nestedName);
             }
             DataType itemType = ((ArrayType) arrayType).getItemType();
-            return new SlotReference("mocked", itemType, (((ArrayType) arrayType).containsNull()));
+            // Array elements are always nullable
+            return new SlotReference("mocked", itemType, true);
         }).collect(Collectors.toList());
         return (AggregateFunction) nestedBuilder.build(nestedName, forEachargs).first;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
@@ -483,7 +483,7 @@ public class ComputeSignatureHelper {
             return signature;
         }
         ArrayType arrayType = (ArrayType) signature.returnType;
-        return signature.withReturnType(ArrayType.of(arrayType.getItemType(), true));
+        return signature.withReturnType(ArrayType.of(arrayType.getItemType()));
     }
 
     // for time type with precision(now are DateTimeV2Type and TimeV2Type),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/combinator/ForEachCombinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/combinator/ForEachCombinator.java
@@ -119,7 +119,7 @@ public class ForEachCombinator extends NullableAggregateFunction
 
     @Override
     public DataType getDataType() {
-        return ArrayType.of(nested.getDataType(), true);
+        return ArrayType.of(nested.getDataType());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArrayMap.java
@@ -68,7 +68,7 @@ public class ArrayMap extends ScalarFunction
     public DataType getDataType() {
         Preconditions.checkArgument(children.get(0) instanceof Lambda,
                 "The first arg of array_map must be lambda");
-        return ArrayType.of(((Lambda) children.get(0)).getRetType(), true);
+        return ArrayType.of(((Lambda) children.get(0)).getRetType());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArraySort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/ArraySort.java
@@ -90,11 +90,11 @@ public class ArraySort extends ScalarFunction
             ArrayItemReference argRef = lambda.getLambdaArguments().get(0);
             Expression arrayExpr = argRef.getArrayExpression();
             ArrayType arrayType = (ArrayType) arrayExpr.getDataType();
-            return ArrayType.of(arrayType.getItemType(), true);
+            return ArrayType.of(arrayType.getItemType());
         } else if (children.get(0).getDataType() instanceof ArrayType) {
             Expression arrayExpr = children.get(0);
             ArrayType arrayType = (ArrayType) arrayExpr.getDataType();
-            return ArrayType.of(arrayType.getItemType(), true);
+            return ArrayType.of(arrayType.getItemType());
         } else {
             throw new AnalysisException("The first arg of array_sort must be lambda or array");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/ArrayType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/ArrayType.java
@@ -24,48 +24,43 @@ import java.util.Objects;
 
 /**
  * Array type in Nereids.
+ *
+ * <p>Note: Array elements are always nullable in Doris. The NOT NULL constraint on array elements
+ * (e.g., ARRAY&lt;INT NOT NULL&gt;) is not supported. This simplification aligns with the actual
+ * behavior where both FE planning and BE execution always treat array elements as nullable.</p>
  */
 public class ArrayType extends DataType implements ComplexDataType, NestedColumnPrunable {
 
-    public static final ArrayType SYSTEM_DEFAULT = new ArrayType(NullType.INSTANCE, true);
+    public static final ArrayType SYSTEM_DEFAULT = new ArrayType(NullType.INSTANCE);
 
     public static final int WIDTH = 64;
 
     private final DataType itemType;
-    private final boolean containsNull;
 
-    private ArrayType(DataType itemType, boolean containsNull) {
+    private ArrayType(DataType itemType) {
         this.itemType = Objects.requireNonNull(itemType, "itemType can not be null");
-        this.containsNull = containsNull;
     }
 
     public static ArrayType of(DataType itemType) {
-        return of(itemType, true);
-    }
-
-    public static ArrayType of(DataType itemType, boolean containsNull) {
         if (itemType.equals(NullType.INSTANCE)) {
             return SYSTEM_DEFAULT;
         }
-        return new ArrayType(itemType, containsNull);
+        return new ArrayType(itemType);
     }
 
     @Override
     public DataType conversion() {
-        return new ArrayType(itemType.conversion(), containsNull);
+        return new ArrayType(itemType.conversion());
     }
 
     public DataType getItemType() {
         return itemType;
     }
 
-    public boolean containsNull() {
-        return containsNull;
-    }
-
     @Override
     public Type toCatalogDataType() {
-        return new org.apache.doris.catalog.ArrayType(itemType.toCatalogDataType(), containsNull);
+        // Catalog ArrayType defaults containsNull to true via single-arg constructor
+        return new org.apache.doris.catalog.ArrayType(itemType.toCatalogDataType());
     }
 
     @Override
@@ -85,8 +80,7 @@ public class ArrayType extends DataType implements ComplexDataType, NestedColumn
             return false;
         }
         ArrayType arrayType = (ArrayType) o;
-        return Objects.equals(itemType, arrayType.itemType)
-                && Objects.equals(containsNull, arrayType.containsNull);
+        return Objects.equals(itemType, arrayType.itemType);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -476,7 +476,7 @@ public abstract class DataType {
             return MapType.of(fromCatalogType(mapType.getKeyType()), fromCatalogType(mapType.getValueType()));
         } else if (type.isArrayType()) {
             org.apache.doris.catalog.ArrayType arrayType = (org.apache.doris.catalog.ArrayType) type;
-            return ArrayType.of(fromCatalogType(arrayType.getItemType()), arrayType.getContainsNull());
+            return ArrayType.of(fromCatalogType(arrayType.getItemType()));
         } else if (type.isVariantType()) {
             // In the past, variant metadata used the ScalarType type.
             // Now, we use VariantType, which inherits from ScalarType, as the new metadata storage.
@@ -803,7 +803,7 @@ public abstract class DataType {
             return arrayType.getItemType()
                     .getAllPromotions()
                     .stream()
-                    .map(promotionType -> ArrayType.of(promotionType, arrayType.containsNull()))
+                    .map(promotionType -> ArrayType.of(promotionType))
                     .collect(ImmutableList.toImmutableList());
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -385,8 +385,7 @@ public class TypeCoercionUtils {
     public static DataType replaceSpecifiedType(DataType dataType,
             Class<? extends DataType> specifiedType, DataType newType) {
         if (dataType instanceof ArrayType) {
-            return ArrayType.of(replaceSpecifiedType(((ArrayType) dataType).getItemType(), specifiedType, newType),
-                    ((ArrayType) dataType).containsNull());
+            return ArrayType.of(replaceSpecifiedType(((ArrayType) dataType).getItemType(), specifiedType, newType));
         } else if (dataType instanceof MapType) {
             return MapType.of(replaceSpecifiedType(((MapType) dataType).getKeyType(), specifiedType, newType),
                     replaceSpecifiedType(((MapType) dataType).getValueType(), specifiedType, newType));

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TypeTest.java
@@ -35,9 +35,9 @@ public class TypeTest {
         ArrayType a3 = new ArrayType(new ArrayType(Type.BIGINT, true), true);
         Assert.assertFalse(Type.matchExactType(a1, a3, false));
 
-        // containsNull differs -> matchesType fails
+        // containsNull is always true now, so a4 is equivalent to a1
         ArrayType a4 = new ArrayType(new ArrayType(Type.INT, true), false);
-        Assert.assertFalse(Type.matchExactType(a1, a4, false));
+        Assert.assertTrue(Type.matchExactType(a1, a4, false));
 
         // array nested decimal test
         ArrayType a5 = new ArrayType(new ArrayType(ScalarType.createDecimalV3Type(8, 2), true), true);
@@ -63,7 +63,7 @@ public class TypeTest {
         Assert.assertFalse(Type.matchExactType(m1, m3, false));
         Assert.assertFalse(Type.matchExactType(m1, m3, true));
 
-        // key/value containsNull differs -> doesn't matter for matching
+        // key/value containsNull differs, but MapType.equals() ignores it -> matches
         MapType m4 = new MapType(Type.INT, arrayOfD, false, true);
         Assert.assertTrue(Type.matchExactType(m1, m4, false));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
@@ -64,7 +64,7 @@ class LiteralTest {
         for (int i = 0; i < elementsArray.length; ++i) {
             elementsArray[i] = i;
         }
-        DataType arrayType = ArrayType.of(IntegerType.INSTANCE, true);
+        DataType arrayType = ArrayType.of(IntegerType.INSTANCE);
         PGenericType.Builder childTypeBuilder = PGenericType.newBuilder();
         childTypeBuilder.setId(TypeId.INT32);
         PGenericType.Builder typeBuilder = PGenericType.newBuilder();
@@ -94,8 +94,8 @@ class LiteralTest {
         for (int i = 0; i < elementsArray.length; ++i) {
             elementsArray[i] = i;
         }
-        DataType nestedArrayType = ArrayType.of(IntegerType.INSTANCE, true);
-        DataType outArrayType = ArrayType.of(nestedArrayType, true);
+        DataType nestedArrayType = ArrayType.of(IntegerType.INSTANCE);
+        DataType outArrayType = ArrayType.of(nestedArrayType);
         PGenericType.Builder childTypeBuilder = PGenericType.newBuilder();
         childTypeBuilder.setId(TypeId.INT32);
         PGenericType.Builder typeBuilder = PGenericType.newBuilder();
@@ -134,8 +134,8 @@ class LiteralTest {
         for (int i = 0; i < elementsArray.length; ++i) {
             elementsArray[i] = i;
         }
-        DataType nestedArrayType = ArrayType.of(IntegerType.INSTANCE, true);
-        DataType outArrayType = ArrayType.of(nestedArrayType, true);
+        DataType nestedArrayType = ArrayType.of(IntegerType.INSTANCE);
+        DataType outArrayType = ArrayType.of(nestedArrayType);
         PGenericType.Builder childTypeBuilder = PGenericType.newBuilder();
         childTypeBuilder.setId(TypeId.INT32);
         PGenericType.Builder typeBuilder = PGenericType.newBuilder();
@@ -182,7 +182,7 @@ class LiteralTest {
             elementsArray[i] = i;
             nullMap[i] = (i % 2 == 1);
         }
-        DataType arrayType = ArrayType.of(IntegerType.INSTANCE, true);
+        DataType arrayType = ArrayType.of(IntegerType.INSTANCE);
         PGenericType.Builder childTypeBuilder = PGenericType.newBuilder();
         childTypeBuilder.setId(TypeId.INT32);
         PGenericType.Builder typeBuilder = PGenericType.newBuilder();

--- a/fe/fe-type/src/main/java/org/apache/doris/catalog/ArrayType.java
+++ b/fe/fe-type/src/main/java/org/apache/doris/catalog/ArrayType.java
@@ -31,6 +31,11 @@ import java.util.Objects;
 
 /**
  * Describes an ARRAY type.
+ *
+ * <p>Array elements are always nullable in Doris. The {@code containsNull} field is retained
+ * only for backward compatibility with serialized metadata (Gson). It is always treated as
+ * {@code true} at runtime. The two-argument constructor is kept but deprecated; prefer the
+ * single-argument constructor {@link #ArrayType(Type)} which defaults to nullable elements.</p>
  */
 public class ArrayType extends Type {
 
@@ -39,6 +44,8 @@ public class ArrayType extends Type {
     @SerializedName(value = "itemType")
     private final Type itemType;
 
+    // Retained for Gson deserialization compatibility with older metadata.
+    // Always treated as true at runtime — array elements are always nullable.
     @SerializedName(value = "containsNull")
     private final boolean containsNull;
 
@@ -48,20 +55,31 @@ public class ArrayType extends Type {
     }
 
     public ArrayType(Type itemType) {
-        this(itemType, true);
+        this.itemType = itemType;
+        this.containsNull = true;
     }
 
+    /**
+     * @deprecated Array elements are always nullable. Use {@link #ArrayType(Type)} instead.
+     *             This constructor is retained only for call-site compatibility during transition.
+     */
+    @Deprecated
     public ArrayType(Type itemType, boolean containsNull) {
         this.itemType = itemType;
-        this.containsNull = containsNull;
+        // Ignore the parameter — always true
+        this.containsNull = true;
     }
 
     public Type getItemType() {
         return itemType;
     }
 
+    /**
+     * Always returns {@code true}. Array elements are always nullable in Doris.
+     */
     public boolean getContainsNull() {
-        return containsNull;
+        // Always true — array elements are always nullable
+        return true;
     }
 
     @Override
@@ -83,10 +101,7 @@ public class ArrayType extends Type {
             return false;
         }
 
-        if (((ArrayType) t).getContainsNull() != getContainsNull()) {
-            return false;
-        }
-
+        // containsNull is always true, no need to compare
         return itemType.matchesType(((ArrayType) t).itemType);
     }
 
@@ -94,24 +109,27 @@ public class ArrayType extends Type {
         return new ArrayType();
     }
 
+    public static ArrayType create(Type type) {
+        return new ArrayType(type);
+    }
+
+    /**
+     * @deprecated Array elements are always nullable. Use {@link #create(Type)} instead.
+     */
+    @Deprecated
     public static ArrayType create(Type type, boolean containsNull) {
-        return new ArrayType(type, containsNull);
+        return new ArrayType(type);
     }
 
     @Override
     public String toSql(int depth) {
-        StringBuilder typeStr = new StringBuilder();
-        typeStr.append("array<").append(itemType.toSql(depth + 1));
-        if (!containsNull) {
-            typeStr.append(" not null");
-        }
-        typeStr.append(">");
-        return typeStr.toString();
+        // Array elements are always nullable, no "not null" suffix needed
+        return "array<" + itemType.toSql(depth + 1) + ">";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(itemType, containsNull);
+        return Objects.hash(itemType);
     }
 
     @Override
@@ -120,7 +138,7 @@ public class ArrayType extends Type {
             return false;
         }
         ArrayType otherArrayType = (ArrayType) other;
-        return otherArrayType.itemType.equals(itemType) && otherArrayType.containsNull == containsNull;
+        return otherArrayType.itemType.equals(itemType);
     }
 
     @Override
@@ -129,8 +147,9 @@ public class ArrayType extends Type {
         container.types.add(node);
         Preconditions.checkNotNull(itemType);
         node.setType(TTypeNodeType.ARRAY);
-        node.setContainsNull(containsNull);
-        node.setContainsNulls(Lists.newArrayList(containsNull));
+        // Array elements are always nullable
+        node.setContainsNull(true);
+        node.setContainsNulls(Lists.newArrayList(true));
         itemType.toThrift(container);
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This PR makes the nested types inside `Array` and `Map` explicitly nullable in BE type implementations, instead of relying on implicit caller-side conventions.

- `DataTypeArray` now always stores nullable nested element type
- `DataTypeMap` now always stores nullable key/value types
- `DataTypeArraySerDe` and `DataTypeMapSerDe` are updated to follow the same invariant

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

