### PR TITLE
[fix](mtmv) Infer null-reject from INNER JoinEdge for multi-hop outer join MV rewrite

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -29,6 +29,7 @@ import org.apache.doris.mtmv.MTMVRelatedTableIf;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.jobs.executor.Rewriter;
+import org.apache.doris.nereids.jobs.joinorder.hypergraph.edge.JoinEdge;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.rules.exploration.ExplorationRuleFactory;
@@ -44,7 +45,6 @@ import org.apache.doris.nereids.rules.rewrite.MergeProjectable;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
-import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.DateTrunc;
@@ -871,36 +871,35 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
             StructInfo queryStructInfo,
             StructInfo viewStructInfo,
             CascadesContext cascadesContext) {
-        Set<Expression> queryPulledUpPredicates = queryPredicates.stream()
-                .flatMap(expr -> ExpressionUtils.extractConjunction(expr).stream())
-                .map(expr -> {
-                    // NOTICE inferNotNull generate Not with isGeneratedIsNotNull = false,
-                    //  so, we need set this flag to false before comparison.
-                    if (expr instanceof Not) {
-                        return ((Not) expr).withGeneratedIsNotNull(false);
-                    }
-                    return expr;
-                })
-                .collect(Collectors.toSet());
-        Set<Expression> queryNullRejectPredicates =
-                ExpressionUtils.inferNotNull(queryPulledUpPredicates, cascadesContext);
-        if (queryPulledUpPredicates.containsAll(queryNullRejectPredicates)) {
-            // Query has no null reject predicates, return
-            return false;
+        Set<Slot> queryNullRejectSlots = new HashSet<>();
+        for (Expression queryPredicate : queryPredicates) {
+            Optional<Slot> explicitNotNullSlot = TypeUtils.isNotNull(queryPredicate);
+            explicitNotNullSlot.ifPresent(queryNullRejectSlots::add);
         }
-        // Get query null reject predicate slots
-        Set<Expression> queryNullRejectSlotSet = new HashSet<>();
+        Set<Expression> queryNullRejectPredicates = ExpressionUtils.inferNotNull(queryPredicates, cascadesContext);
         for (Expression queryNullRejectPredicate : queryNullRejectPredicates) {
             Optional<Slot> notNullSlot = TypeUtils.isNotNull(queryNullRejectPredicate);
-            if (!notNullSlot.isPresent()) {
-                continue;
-            }
-            queryNullRejectSlotSet.add(notNullSlot.get());
+            notNullSlot.ifPresent(queryNullRejectSlots::add);
         }
-        // query slot need shuttle to use table slot, avoid alias influence
-        Set<Expression> queryUsedNeedRejectNullSlotsViewBased = ExpressionUtils.shuttleExpressionWithLineage(
-                        new ArrayList<>(queryNullRejectSlotSet), queryStructInfo.getTopPlan()).stream()
-                .map(expr -> ExpressionUtils.replace(expr, queryToViewMapping.toSlotReferenceMap()))
+        // INNER JOIN conditions guarantee NOT NULL on join-key slots.
+        // After EliminateOuterJoin converts LEFT→INNER, the JoinEdge objects in the HyperGraph
+        // retain the INNER type even though EliminateNotNull removes filter-level NOT NULL predicates.
+        for (JoinEdge joinEdge : queryStructInfo.getHyperGraph().getJoinEdges()) {
+            if (joinEdge.getJoinType().isInnerJoin()) {
+                queryNullRejectSlots.addAll(ExpressionUtils.inferNotNullSlots(
+                        ImmutableSet.copyOf(joinEdge.getExpressions()), cascadesContext));
+            }
+        }
+        if (queryNullRejectSlots.isEmpty()) {
+            return false;
+        }
+        Set<Slot> queryUsedNeedRejectNullSlotsViewBased = ExpressionUtils.shuttleExpressionWithLineage(
+                        new ArrayList<>(queryNullRejectSlots), queryStructInfo.getTopPlan()).stream()
+                .filter(Slot.class::isInstance)
+                .map(Slot.class::cast)
+                .map(slot -> ExpressionUtils.replace(slot, queryToViewMapping.toSlotReferenceMap()))
+                .filter(Slot.class::isInstance)
+                .map(Slot.class::cast)
                 .collect(Collectors.toSet());
         // view slot need shuttle to use table slot, avoid alias influence
         Set<Set<Slot>> shuttledRequireNoNullableViewSlot = new HashSet<>();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/NullRejectInferenceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/NullRejectInferenceTest.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.exploration.mv;
+
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleSet;
+import org.apache.doris.nereids.rules.exploration.mv.Predicates.SplitPredicate;
+import org.apache.doris.nereids.rules.exploration.mv.mapping.RelationMapping;
+import org.apache.doris.nereids.rules.exploration.mv.mapping.SlotMapping;
+import org.apache.doris.nereids.sqltest.SqlTestBase;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.util.PlanChecker;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class NullRejectInferenceTest extends SqlTestBase {
+
+    private static final TestMaterializedViewRule TEST_RULE = new TestMaterializedViewRule();
+
+    @Test
+    void testTwoHopNullRejectFromInnerJoinConditions() {
+        connectContext.getSessionVariable().setDisableNereidsRules("INFER_PREDICATES,PRUNE_EMPTY_PARTITION");
+        CascadesContext queryContext = createCascadesContext(
+                "select T1.id from T1 inner join T2 on T1.id = T2.id "
+                        + "inner join T3 on T2.id = T3.id where T3.score = 1",
+                connectContext
+        );
+        Plan queryPlan = PlanChecker.from(queryContext)
+                .analyze()
+                .rewrite()
+                .applyExploration(RuleSet.BUSHY_TREE_JOIN_REORDER)
+                .getAllPlan().get(0).child(0);
+
+        CascadesContext viewContext = createCascadesContext(
+                "select T1.id from T1 left outer join T2 on T1.id = T2.id "
+                        + "left outer join T3 on T2.id = T3.id",
+                connectContext
+        );
+        Plan viewPlan = PlanChecker.from(viewContext)
+                .analyze()
+                .rewrite()
+                .applyExploration(RuleSet.BUSHY_TREE_JOIN_REORDER)
+                .getAllPlan().get(0).child(0);
+
+        StructInfo queryStructInfo = StructInfo.of(queryPlan, queryPlan, queryContext);
+        StructInfo viewStructInfo = StructInfo.of(viewPlan, viewPlan, viewContext);
+        RelationMapping relationMapping = RelationMapping.generate(
+                queryStructInfo.getRelations(), viewStructInfo.getRelations(), 8).get(0);
+        SlotMapping queryToView = SlotMapping.generate(relationMapping);
+        SlotMapping viewToQuery = queryToView.inverse();
+        LogicalCompatibilityContext compatibilityContext = LogicalCompatibilityContext.from(
+                relationMapping, viewToQuery, queryStructInfo, viewStructInfo);
+        ComparisonResult comparisonResult = StructInfo.isGraphLogicalEquals(
+                queryStructInfo, viewStructInfo, compatibilityContext);
+
+        Assertions.assertFalse(comparisonResult.isInvalid());
+        Assertions.assertFalse(comparisonResult.getViewNoNullableSlot().isEmpty());
+
+        SplitPredicate compensatePredicates = TEST_RULE.predicatesCompensateForTest(
+                queryStructInfo, viewStructInfo, viewToQuery, comparisonResult, queryContext);
+        Assertions.assertFalse(compensatePredicates.isInvalid());
+    }
+
+    private static class TestMaterializedViewRule extends AbstractMaterializedViewRule {
+        @Override
+        public List<Rule> buildRules() {
+            return ImmutableList.of();
+        }
+
+        private SplitPredicate predicatesCompensateForTest(StructInfo queryStructInfo,
+                StructInfo viewStructInfo, SlotMapping viewToQuerySlotMapping,
+                ComparisonResult comparisonResult, CascadesContext cascadesContext) {
+            return predicatesCompensate(queryStructInfo, viewStructInfo, viewToQuerySlotMapping,
+                    comparisonResult, cascadesContext);
+        }
+    }
+}

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_1.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_1.groovy
@@ -385,7 +385,7 @@ suite("partition_mv_rewrite_dimension_1") {
         }
         for (int j = 0; j < join_type_stmt_list.size(); j++) {
             logger.info("j:" + j)
-            if (i == j) {
+            if (i == j || (j == 1 && i in [0, 2, 3])) {
                 mv_rewrite_success(join_type_stmt_list[j], join_type_mv)
                 compare_res(join_type_stmt_list[j] + " order by 1,2,3,4")
             } else {

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_left_join.groovy
@@ -223,7 +223,7 @@ suite("partition_mv_rewrite_dimension_2_1") {
         if (i == 0) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [ 0, 2, 4, 5, 10, 11]) {
+                if (j in [ 0, 2, 4, 5, 8, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -243,7 +243,7 @@ suite("partition_mv_rewrite_dimension_2_1") {
         } else if (i == 2) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [0, 2, 4, 5, 10, 11]) {
+                if (j in [0, 2, 4, 5, 8, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -294,7 +294,7 @@ suite("partition_mv_rewrite_dimension_2_1") {
         } else if (i == 7) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [4, 5, 7, 9, 10, 11]) {
+                if (j in [3, 4, 5, 7, 9, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -314,7 +314,7 @@ suite("partition_mv_rewrite_dimension_2_1") {
         } else if (i == 9) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [4, 5, 7, 9, 10, 11]) {
+                if (j in [3, 4, 5, 7, 9, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_2_right_join.groovy
@@ -224,7 +224,7 @@ suite("partition_mv_rewrite_dimension_2_right_join") {
         if (i == 0) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [ 0, 2, 4, 5, 10, 11]) {
+                if (j in [ 0, 2, 4, 5, 8, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -244,7 +244,7 @@ suite("partition_mv_rewrite_dimension_2_right_join") {
         } else if (i == 2) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [0, 2, 4, 5, 10, 11]) {
+                if (j in [0, 2, 4, 5, 8, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -295,7 +295,7 @@ suite("partition_mv_rewrite_dimension_2_right_join") {
         } else if (i == 7) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [4, 5, 7, 9, 10, 11]) {
+                if (j in [3, 4, 5, 7, 9, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -315,7 +315,7 @@ suite("partition_mv_rewrite_dimension_2_right_join") {
         } else if (i == 9) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [4, 5, 7, 9, 10, 11]) {
+                if (j in [3, 4, 5, 7, 9, 10, 11]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {

--- a/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_self_conn.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension/dimension_self_conn.groovy
@@ -308,7 +308,7 @@ suite("partition_mv_rewrite_dimension_self_conn") {
         } else {
             for (int j = 0; j < join_type_stmt_list.size(); j++) {
                 logger.info("j:" + j)
-                if (i == j) {
+                if (i == j || (j == 1 && i in [0, 2, 3])) {
                     mv_rewrite_success(join_type_stmt_list[j], join_type_self_conn_mv)
                     compare_res(join_type_stmt_list[j] + " order by 1,2,3")
                 } else {

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/left_join_filter.groovy
@@ -216,7 +216,7 @@ suite("left_join_filter") {
         } else if (i == 2) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [0, 2, 4, 9]) {
+                if (j in [0, 2, 4, 7, 9]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -276,7 +276,7 @@ suite("left_join_filter") {
         } else if (i == 8) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [4, 6, 8, 9]) {
+                if (j in [3, 4, 6, 8, 9]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {

--- a/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_join_filter.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/dimension_predicate/right_join_filter.groovy
@@ -226,7 +226,7 @@ suite("right_join_filter") {
         } else if (i == 3) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [1, 3, 4, 9]) {
+                if (j in [1, 3, 4, 8, 9]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {
@@ -266,7 +266,7 @@ suite("right_join_filter") {
         } else if (i == 7) {
             for (int j = 0; j < mv_list_1.size(); j++) {
                 logger.info("j:" + j)
-                if (j in [4, 5, 7, 9]) {
+                if (j in [2, 4, 5, 7, 9]) {
                     mv_rewrite_success(mv_list_1[j], mv_name)
                     compare_res(mv_list_1[j] + " order by 1,2,3,4,5")
                 } else {

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join_two_hop_null_reject.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join_two_hop_null_reject.groovy
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("outer_join_two_hop_null_reject") {
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
+    sql "set runtime_filter_mode=OFF"
+    sql "set enable_nereids_planner=true"
+    sql "set enable_fallback_to_original_planner=false"
+    sql "set enable_materialized_view_rewrite=true"
+    sql "set enable_nereids_timeout=false"
+
+    sql """drop table if exists fact_orders_2hop"""
+    sql """drop table if exists dim_stores_2hop"""
+    sql """drop table if exists dim_regions_2hop"""
+
+    sql """
+        CREATE TABLE IF NOT EXISTS fact_orders_2hop (
+          order_date DATE NOT NULL,
+          store_id INT NOT NULL,
+          amount DECIMALV3(10, 2) NOT NULL
+        )
+        DUPLICATE KEY(order_date, store_id)
+        DISTRIBUTED BY HASH(store_id) BUCKETS 1
+        PROPERTIES (
+          "replication_num" = "1"
+        )
+    """
+
+    sql """
+        CREATE TABLE IF NOT EXISTS dim_stores_2hop (
+          id INT NOT NULL,
+          store_name VARCHAR(32) NOT NULL
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+          "replication_num" = "1"
+        )
+    """
+
+    sql """
+        CREATE TABLE IF NOT EXISTS dim_regions_2hop (
+          store_id INT NOT NULL,
+          region_name VARCHAR(32) NOT NULL
+        )
+        DUPLICATE KEY(store_id)
+        DISTRIBUTED BY HASH(store_id) BUCKETS 1
+        PROPERTIES (
+          "replication_num" = "1"
+        )
+    """
+
+    sql """
+        insert into fact_orders_2hop values
+        ('2024-01-01', 1, 100.00),
+        ('2024-01-01', 2, 200.00),
+        ('2024-01-02', 3, 300.00),
+        ('2024-01-02', 4, 400.00)
+    """
+
+    sql """
+        insert into dim_stores_2hop values
+        (1, 'Store A'),
+        (2, 'Store B'),
+        (3, 'Store C')
+    """
+
+    sql """
+        insert into dim_regions_2hop values
+        (1, 'West'),
+        (2, 'East'),
+        (3, 'West')
+    """
+
+    sql """analyze table fact_orders_2hop with sync"""
+    sql """analyze table dim_stores_2hop with sync"""
+    sql """analyze table dim_regions_2hop with sync"""
+
+    def compare_res = { def stmt ->
+        sql "set enable_materialized_view_rewrite=false"
+        def origin_res = sql stmt
+        logger.info("origin_res: " + origin_res)
+        sql "set enable_materialized_view_rewrite=true"
+        def mv_origin_res = sql stmt
+        logger.info("mv_origin_res: " + mv_origin_res)
+        assertTrue((mv_origin_res == [] && origin_res == []) || (mv_origin_res.size() == origin_res.size()))
+        for (int row = 0; row < mv_origin_res.size(); row++) {
+            assertTrue(mv_origin_res[row].size() == origin_res[row].size())
+            for (int col = 0; col < mv_origin_res[row].size(); col++) {
+                assertTrue(mv_origin_res[row][col] == origin_res[row][col])
+            }
+        }
+    }
+
+    def mvName = "mv_orders_2hop_null_reject"
+    def mvSql = """
+        select o.order_date, o.store_id, d.store_name, r.region_name,
+               sum(o.amount) as total_amount
+        from fact_orders_2hop o
+        left join dim_stores_2hop d
+          on o.store_id = d.id
+        left join dim_regions_2hop r
+          on d.id = r.store_id
+        group by o.order_date, o.store_id, d.store_name, r.region_name
+    """
+    def querySql = """
+        select o.order_date, sum(o.amount)
+        from fact_orders_2hop o
+        left join dim_stores_2hop d
+          on o.store_id = d.id
+        left join dim_regions_2hop r
+          on d.id = r.store_id
+        where r.region_name = 'West'
+        group by o.order_date
+        order by 1
+    """
+
+    create_async_mv(db, mvName, mvSql)
+    mv_rewrite_success_without_check_chosen(querySql, mvName)
+    compare_res(querySql)
+
+    sql """drop materialized view if exists ${mvName}"""
+}

--- a/regression-test/suites/nereids_rules_p0/mv/join_elim_p_f_key/join_elim_line_pattern.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_elim_p_f_key/join_elim_line_pattern.groovy
@@ -326,7 +326,7 @@ suite("join_elim_line_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [3, 5, 7]) {
+        if (j in [2, 3, 4, 5, 6, 7]) {
             mv_rewrite_success_without_check_chosen(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 5)
         } else {
@@ -494,7 +494,7 @@ suite("join_elim_line_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [3, 5, 7]) {
+        if (j in [2, 3, 4, 5, 6, 7]) {
             mv_rewrite_success_without_check_chosen(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 5)
         } else {

--- a/regression-test/suites/nereids_rules_p0/mv/join_elim_p_f_key/join_elim_star_pattern.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_elim_p_f_key/join_elim_star_pattern.groovy
@@ -305,7 +305,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13]) {
+        if (j in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {
@@ -336,7 +336,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [9, 11, 13]) {
+        if (j in [8, 9, 10, 11, 12, 13]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {
@@ -368,7 +368,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [3, 5, 7]) {
+        if (j in [2, 3, 4, 5, 6, 7]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {
@@ -403,7 +403,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13]) {
+        if (j in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {
@@ -438,7 +438,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [1, 2, 3, 4, 5, 6, 7, 9, 11, 13]) {
+        if (j in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {
@@ -472,7 +472,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [1, 2, 3, 4, 5, 6, 7, 9, 11, 13]) {
+        if (j in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {
@@ -502,7 +502,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [9, 11, 13]) {
+        if (j in [8, 9, 10, 11, 12, 13]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {
@@ -533,7 +533,7 @@ suite("join_elim_star_pattern") {
     create_async_mv(db, mv_name, mv_stmt_2)
     for (int j = 1; j < query_list.size() + 1; j++) {
         logger.info("left mv current query index: " + j)
-        if (j in [3, 5, 7]) {
+        if (j in [2, 3, 4, 5, 6, 7]) {
             mv_rewrite_success(query_list[j - 1], mv_name)
             compare_res(query_list[j - 1], 4)
         } else {

--- a/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/inner_join_infer_and_derive.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/inner_join_infer_and_derive.groovy
@@ -221,32 +221,20 @@ suite("inner_join_infer_and_derive") {
         if (mtmv_it == 0) {
             for (int i = 0; i < query_list.size(); i++) {
                 logger.info("i: " + i)
-                if (i in [0, 2, 5, 6, 8, 11]) {
-                    mv_rewrite_fail(query_list[i], mv_name_1)
-                } else {
-                    mv_rewrite_success(query_list[i], mv_name_1)
-                    compare_res(query_list[i] + order_stmt)
-                }
+                mv_rewrite_success(query_list[i], mv_name_1)
+                compare_res(query_list[i] + order_stmt)
             }
         } else if (mtmv_it == 1) {
             for (int i = 0; i < query_list.size(); i++) {
                 logger.info("i: " + i)
-                if (i in [1, 3, 4, 7, 9, 10]) {
-                    mv_rewrite_fail(query_list[i], mv_name_1)
-                } else {
-                    mv_rewrite_success(query_list[i], mv_name_1)
-                    compare_res(query_list[i] + order_stmt)
-                }
+                mv_rewrite_success(query_list[i], mv_name_1)
+                compare_res(query_list[i] + order_stmt)
             }
         } else if (mtmv_it == 2) {
             for (int i = 0; i < query_list.size(); i++) {
                 logger.info("i: " + i)
-                if (i in [12, 13]) {
-                    mv_rewrite_success(query_list[i], mv_name_1)
-                    compare_res(query_list[i] + order_stmt)
-                } else {
-                    mv_rewrite_fail(query_list[i], mv_name_1)
-                }
+                mv_rewrite_success(query_list[i], mv_name_1)
+                compare_res(query_list[i] + order_stmt)
             }
         }
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name_1};"""

--- a/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/left_join_infer_and_derive.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/left_join_infer_and_derive.groovy
@@ -211,7 +211,7 @@ suite("left_join_infer_and_derive") {
         if (mtmv_it == 0) {
             for (int i = 0; i < query_list.size(); i++) {
                 logger.info("i: " + i)
-                if (i in [1, 3, 4, 6, 8, 11]) {
+                if (i in [1, 6]) {
                     mv_rewrite_fail(query_list[i], mv_name_1)
                 } else {
                     mv_rewrite_success(query_list[i], mv_name_1)

--- a/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/right_join_infer_and_derive.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join_infer_derive/right_join_infer_and_derive.groovy
@@ -211,7 +211,7 @@ suite("right_join_infer_and_derive") {
         if (mtmv_it == 0) {
             for (int i = 0; i < query_list.size(); i++) {
                 logger.info("i: " + i)
-                if (i in [0, 2, 5, 7, 9, 10]) {
+                if (i in [0, 7]) {
                     mv_rewrite_fail(query_list[i], mv_name_1)
                 } else {
                     mv_rewrite_success(query_list[i], mv_name_1)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #30374

Problem Summary:

In multi-hop LEFT JOIN materialized view transparent rewrite (e.g., `fact LEFT JOIN dim1 LEFT JOIN dim2`), when the query has a WHERE clause that null-rejects only the outermost dimension table (e.g., `WHERE dim2.col = 'value'`), the MV rewrite fails with "Predicate compensate fail".

**Root cause:** In `AbstractMaterializedViewRule.containsNullRejectSlot()`, the original code only checked **filter predicates** (`queryPredicates`) for NOT NULL evidence. After the Nereids rewrite pipeline runs:

1. `EliminateOuterJoin` converts all eligible LEFT JOINs → INNER (cascading through `InferJoinNotNull` across multiple passes)
2. `EliminateNotNull` **unconditionally removes** all generated NOT NULL predicates (`isGeneratedIsNotNull=true`)

By the time MV rewrite (exploration phase) runs, the query plan has INNER JOINs but **zero NOT NULL filter predicates**. The only surviving predicate is the user's WHERE clause (e.g., `dim2.region_name = 'West'`), which can only prove NOT NULL for outermost dim2 slots — leaving intermediate dim1 slots uncovered.

**Fix:** Read INNER JoinEdge conditions directly from the query HyperGraph. After `EliminateOuterJoin` converts LEFT→INNER, JoinEdge objects retain their INNER type and join condition expressions even though `EliminateNotNull` removes filter-level NOT NULL predicates. `ExpressionUtils.inferNotNullSlots()` extracts NOT NULL slots from these INNER join conditions, covering all intermediate join tables.

| File | Change Description |
|------|-------------------|
| `AbstractMaterializedViewRule.java` | `containsNullRejectSlot()`: Add loop over INNER JoinEdges to collect NOT NULL slots from join conditions via `inferNotNullSlots`. Also add `shuttleExpressionWithLineage` for correct slot-level mapping. |
| `NullRejectInferenceTest.java` (new) | FE unit test: query=2-hop INNER JOIN vs view=2-hop LEFT JOIN, verifies `predicatesCompensate` succeeds |
| `outer_join_two_hop_null_reject.groovy` (new) | Regression test: 3 tables, async MV with 2-hop LEFT JOIN + WHERE + aggregate rollup, verifies rewrite success and result correctness |

**2-hop example walkthrough:**

```
Query HyperGraph (after EliminateOuterJoin):
  JoinEdge 1 (INNER): o.store_id = d.id    → {o.store_id, d.id} NOT NULL
  JoinEdge 2 (INNER): d.id = r.store_id    → {d.id, r.store_id} NOT NULL
  FilterEdge:         r.region_name = 'West' → {r.region_name} NOT NULL

queryNullRejectSlots = {o.store_id, d.id, r.store_id, r.region_name}

requireNoNullableViewSlot (view has LEFT JOINs):
  Set 1: {d.id, d.store_name} ∩ queryNullRejectSlots → {d.id} ≠ ∅ ✓
  Set 2: {r.store_id, r.region_name} ∩ queryNullRejectSlots → {r.store_id, r.region_name} ≠ ∅ ✓
```

### Release note

Fix multi-hop LEFT JOIN materialized view transparent rewrite failure when the WHERE clause only references the outermost dimension table.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
