### PR TITLE
[cleanup](segment)Remove dead get_first_value/get_last_value APIs from PageBuilder

### DIFF
--- a/be/src/storage/segment/binary_dict_page.cpp
+++ b/be/src/storage/segment/binary_dict_page.cpp
@@ -99,11 +99,6 @@ Status BinaryDictPageBuilder::add(const uint8_t* vals, size_t* count) {
         auto* actual_builder = dynamic_cast<BitshufflePageBuilder<FieldType::OLAP_FIELD_TYPE_INT>*>(
                 _data_page_builder.get());
 
-        if (_data_page_builder->count() == 0) {
-            _first_value.assign_copy(reinterpret_cast<const uint8_t*>(src->get_data()),
-                                     src->get_size());
-        }
-
         for (int i = 0; i < *count; ++i, ++src) {
             if (is_page_full()) {
                 break;
@@ -216,32 +211,6 @@ Status BinaryDictPageBuilder::get_dictionary_page(OwnedSlice* dictionary_page) {
 
 Status BinaryDictPageBuilder::get_dictionary_page_encoding(EncodingTypePB* encoding) const {
     *encoding = _dict_word_page_encoding_type;
-    return Status::OK();
-}
-
-Status BinaryDictPageBuilder::get_first_value(void* value) const {
-    DCHECK(_finished);
-    if (_data_page_builder->count() == 0) {
-        return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-    }
-    if (_encoding_type != DICT_ENCODING) {
-        return _data_page_builder->get_first_value(value);
-    }
-    *reinterpret_cast<Slice*>(value) = Slice(_first_value);
-    return Status::OK();
-}
-
-Status BinaryDictPageBuilder::get_last_value(void* value) const {
-    DCHECK(_finished);
-    if (_data_page_builder->count() == 0) {
-        return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-    }
-    if (_encoding_type != DICT_ENCODING) {
-        return _data_page_builder->get_last_value(value);
-    }
-    uint32_t value_code;
-    RETURN_IF_ERROR(_data_page_builder->get_last_value(&value_code));
-    RETURN_IF_ERROR(_dict_builder->get_dict_word(value_code, reinterpret_cast<Slice*>(value)));
     return Status::OK();
 }
 

--- a/be/src/storage/segment/binary_dict_page.h
+++ b/be/src/storage/segment/binary_dict_page.h
@@ -92,10 +92,6 @@ public:
 
     Status get_dictionary_page_encoding(EncodingTypePB* encoding) const override;
 
-    Status get_first_value(void* value) const override;
-
-    Status get_last_value(void* value) const override;
-
     uint64_t get_raw_data_size() const override;
 
 private:
@@ -123,7 +119,6 @@ private:
     // TODO(zc): rethink about this arena
     Arena _arena;
     faststring _buffer;
-    faststring _first_value;
     uint64_t _raw_data_size = 0;
 
     bool _has_empty = false;

--- a/be/src/storage/segment/binary_plain_page.h
+++ b/be/src/storage/segment/binary_plain_page.h
@@ -101,10 +101,6 @@ public:
                 put_fixed32_le(&_buffer, _offset);
             }
             put_fixed32_le(&_buffer, cast_set<uint32_t>(_offsets.size()));
-            if (_offsets.size() > 0) {
-                _copy_value_at(0, &_first_value);
-                _copy_value_at(_offsets.size() - 1, &_last_value);
-            }
             *slice = _buffer.build();
         });
         return Status::OK();
@@ -131,45 +127,9 @@ public:
 
     uint64_t get_raw_data_size() const override { return _raw_data_size; }
 
-    Status get_first_value(void* value) const override {
-        DCHECK(_finished);
-        if (_offsets.size() == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        *reinterpret_cast<Slice*>(value) = Slice(_first_value);
-        return Status::OK();
-    }
-    Status get_last_value(void* value) const override {
-        DCHECK(_finished);
-        if (_offsets.size() == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        *reinterpret_cast<Slice*>(value) = Slice(_last_value);
-        return Status::OK();
-    }
-
-    inline Slice operator[](size_t idx) const {
-        DCHECK(!_finished);
-        DCHECK_LT(idx, _offsets.size());
-        size_t value_size =
-                (idx < _offsets.size() - 1) ? _offsets[idx + 1] - _offsets[idx] : _last_value_size;
-        return Slice(&_buffer[_offsets[idx]], value_size);
-    }
-
-    Status get_dict_word(uint32_t value_code, Slice* word) override {
-        *word = (*this)[value_code];
-        return Status::OK();
-    }
-
 private:
     BinaryPlainPageBuilder(const PageBuilderOptions& options)
             : _size_estimate(0), _options(options) {}
-
-    void _copy_value_at(size_t idx, faststring* value) const {
-        size_t value_size =
-                (idx < _offsets.size() - 1) ? _offsets[idx + 1] - _offsets[idx] : _last_value_size;
-        value->assign_copy(&_buffer[_offsets[idx]], value_size);
-    }
 
     faststring _buffer;
     size_t _size_estimate;
@@ -180,8 +140,6 @@ private:
     // size of last added value
     uint32_t _last_value_size = 0;
     uint64_t _raw_data_size = 0;
-    faststring _first_value;
-    faststring _last_value;
 };
 
 template <FieldType Type>
@@ -345,12 +303,6 @@ public:
     size_t current_index() const override {
         DCHECK(_parsed);
         return _cur_idx;
-    }
-
-    Slice string_at_index(size_t idx) const {
-        const uint32_t start_offset = offset(idx);
-        uint32_t len = offset(idx + 1) - start_offset;
-        return Slice(&_data[start_offset], len);
     }
 
     Status get_dict_word_info(StringRef* dict_word_info) override {

--- a/be/src/storage/segment/binary_plain_page_v2.h
+++ b/be/src/storage/segment/binary_plain_page_v2.h
@@ -101,12 +101,6 @@ public:
         DCHECK(!_finished);
         _finished = true;
         RETURN_IF_CATCH_EXCEPTION({
-            // Store first and last values for statistics
-            if (_positions.size() > 0) {
-                _copy_value_at(0, &_first_value);
-                _copy_value_at(_positions.size() - 1, &_last_value);
-            }
-
             // Write trailer: number of elements
             put_fixed32_le(&_buffer, cast_set<uint32_t>(_positions.size()));
 
@@ -136,50 +130,9 @@ public:
 
     uint64_t get_raw_data_size() const override { return _raw_data_size; }
 
-    Status get_first_value(void* value) const override {
-        DCHECK(_finished);
-        if (_positions.size() == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        *reinterpret_cast<Slice*>(value) = Slice(_first_value);
-        return Status::OK();
-    }
-
-    Status get_last_value(void* value) const override {
-        DCHECK(_finished);
-        if (_positions.size() == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        *reinterpret_cast<Slice*>(value) = Slice(_last_value);
-        return Status::OK();
-    }
-
-    Status get_dict_word(uint32_t value_code, Slice* word) override {
-        if (value_code >= _positions.size()) {
-            return Status::Error<ErrorCode::INVALID_ARGUMENT>(
-                    "value_code {} is out of range [0, {})", value_code, _positions.size());
-        }
-
-        const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&_buffer[_positions[value_code]]);
-        uint32_t length;
-        const uint8_t* data_ptr = decode_varint32_ptr(ptr, ptr + 5, &length);
-
-        word->data = const_cast<char*>(reinterpret_cast<const char*>(data_ptr));
-        word->size = length;
-
-        return Status::OK();
-    }
-
 private:
     BinaryPlainPageV2Builder(const PageBuilderOptions& options)
             : _size_estimate(0), _options(options) {}
-
-    void _copy_value_at(size_t idx, faststring* value) const {
-        const uint8_t* ptr = &_buffer[_positions[idx]];
-        uint32_t length;
-        const uint8_t* data_ptr = decode_varint32_ptr(ptr, ptr + 5, &length);
-        value->assign_copy(data_ptr, length);
-    }
 
     faststring _buffer;
     size_t _size_estimate = 0;
@@ -189,8 +142,6 @@ private:
     PageBuilderOptions _options;
     uint32_t _last_value_size = 0;
     uint64_t _raw_data_size = 0;
-    faststring _first_value;
-    faststring _last_value;
 };
 
 // BinaryPlainPageV2Decoder now inherits from BinaryPlainPageDecoder.

--- a/be/src/storage/segment/binary_prefix_page.cpp
+++ b/be/src/storage/segment/binary_prefix_page.cpp
@@ -38,10 +38,6 @@ Status BinaryPrefixPageBuilder::add(const uint8_t* vals, size_t* add_count) {
     }
 
     const Slice* src = reinterpret_cast<const Slice*>(vals);
-    if (_count == 0) {
-        _first_entry.assign_copy(reinterpret_cast<const uint8_t*>(src->get_data()),
-                                 src->get_size());
-    }
 
     int i = 0;
     for (; i < *add_count; ++i, ++src) {

--- a/be/src/storage/segment/binary_prefix_page.h
+++ b/be/src/storage/segment/binary_prefix_page.h
@@ -76,30 +76,13 @@ public:
 
     uint64_t get_raw_data_size() const override { return _raw_data_size; }
 
-    Status get_first_value(void* value) const override {
-        DCHECK(_finished);
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        *reinterpret_cast<Slice*>(value) = Slice(_first_entry);
-        return Status::OK();
-    }
-
-    Status get_last_value(void* value) const override {
-        DCHECK(_finished);
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        *reinterpret_cast<Slice*>(value) = Slice(_last_entry);
-        return Status::OK();
-    }
-
 private:
     BinaryPrefixPageBuilder(const PageBuilderOptions& options) : _options(options) {}
 
     PageBuilderOptions _options;
     std::vector<uint32_t> _restart_points_offset;
-    faststring _first_entry;
+    // Holds the most recently added entry; used by add() to compute the
+    // shared-prefix length against the next entry.
     faststring _last_entry;
     size_t _count = 0;
     bool _finished = false;

--- a/be/src/storage/segment/bitshuffle_page.h
+++ b/be/src/storage/segment/bitshuffle_page.h
@@ -159,10 +159,6 @@ public:
     }
 
     Status finish(OwnedSlice* slice) override {
-        if (_count > 0) {
-            _first_value = cell(0);
-            _last_value = cell(_count - 1);
-        }
         RETURN_IF_CATCH_EXCEPTION({ *slice = _finish(SIZE_OF_TYPE); });
         return Status::OK();
     }
@@ -189,23 +185,6 @@ public:
     uint64_t size() const override { return _buffer.size(); }
 
     uint64_t get_raw_data_size() const override { return _raw_data_size; }
-
-    Status get_first_value(void* value) const override {
-        DCHECK(_finished);
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, &_first_value, SIZE_OF_TYPE);
-        return Status::OK();
-    }
-    Status get_last_value(void* value) const override {
-        DCHECK(_finished);
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, &_last_value, SIZE_OF_TYPE);
-        return Status::OK();
-    }
 
 private:
     BitshufflePageBuilder(const PageBuilderOptions& options)
@@ -265,8 +244,6 @@ private:
     bool _finished;
     faststring _data;
     faststring _buffer;
-    CppType _first_value;
-    CppType _last_value;
     uint64_t _raw_data_size = 0;
 };
 

--- a/be/src/storage/segment/frame_of_reference_page.h
+++ b/be/src/storage/segment/frame_of_reference_page.h
@@ -45,13 +45,9 @@ public:
             return Status::OK();
         }
         auto new_vals = reinterpret_cast<const CppType*>(vals);
-        if (_count == 0) {
-            _first_val = *new_vals;
-        }
         _encoder->put_batch(new_vals, *count);
         _count += *count;
         _raw_data_size += *count * sizeof(CppType);
-        _last_val = new_vals[*count - 1];
         return Status::OK();
     }
 
@@ -77,22 +73,6 @@ public:
 
     uint64_t get_raw_data_size() const override { return _raw_data_size; }
 
-    Status get_first_value(void* value) const override {
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, &_first_val, sizeof(CppType));
-        return Status::OK();
-    }
-
-    Status get_last_value(void* value) const override {
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, &_last_val, sizeof(CppType));
-        return Status::OK();
-    }
-
 private:
     explicit FrameOfReferencePageBuilder(const PageBuilderOptions& options)
             : _options(options), _count(0), _finished(false) {}
@@ -103,8 +83,6 @@ private:
     bool _finished;
     std::unique_ptr<ForEncoder<CppType>> _encoder;
     faststring _buf;
-    CppType _first_val;
-    CppType _last_val;
     uint64_t _raw_data_size = 0;
 };
 

--- a/be/src/storage/segment/page_builder.h
+++ b/be/src/storage/segment/page_builder.h
@@ -77,10 +77,6 @@ public:
         return Status::NotSupported("get_dictionary_page_encoding not implemented");
     }
 
-    virtual Status get_dict_word(uint32_t value_code, Slice* word) {
-        return Status::NotSupported("get_dict_word not implemented");
-    }
-
     // Reset the internal state of the page builder.
     //
     // Any data previously returned by finish may be invalidated by this call.
@@ -95,16 +91,6 @@ public:
     // Return the uncompressed data size in bytes (raw data added via add() method).
     // This is used to track the original data size before compression.
     virtual uint64_t get_raw_data_size() const = 0;
-
-    // Return the first value in this page.
-    // This method could only be called between finish() and reset().
-    // Status::Error<ENTRY_NOT_FOUND> if no values have been added.
-    virtual Status get_first_value(void* value) const = 0;
-
-    // Return the last value in this page.
-    // This method could only be called between finish() and reset().
-    // Status::Error<ENTRY_NOT_FOUND> if no values have been added.
-    virtual Status get_last_value(void* value) const = 0;
 };
 
 template <typename Derived>

--- a/be/src/storage/segment/plain_page.h
+++ b/be/src/storage/segment/plain_page.h
@@ -67,15 +67,7 @@ public:
 
     Status finish(OwnedSlice* slice) override {
         encode_fixed32_le((uint8_t*)&_buffer[0], cast_set<uint32_t>(_count));
-        RETURN_IF_CATCH_EXCEPTION({
-            if (_count > 0) {
-                _first_value.assign_copy(&_buffer[PLAIN_PAGE_HEADER_SIZE], SIZE_OF_TYPE);
-                _last_value.assign_copy(
-                        &_buffer[PLAIN_PAGE_HEADER_SIZE + (_count - 1) * SIZE_OF_TYPE],
-                        SIZE_OF_TYPE);
-            }
-            *slice = _buffer.build();
-        });
+        RETURN_IF_CATCH_EXCEPTION({ *slice = _buffer.build(); });
         return Status::OK();
     }
 
@@ -97,22 +89,6 @@ public:
 
     uint64_t get_raw_data_size() const override { return _raw_data_size; }
 
-    Status get_first_value(void* value) const override {
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, _first_value.data(), SIZE_OF_TYPE);
-        return Status::OK();
-    }
-
-    Status get_last_value(void* value) const override {
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, _last_value.data(), SIZE_OF_TYPE);
-        return Status::OK();
-    }
-
 private:
     PlainPageBuilder(const PageBuilderOptions& options) : _options(options) {}
 
@@ -123,8 +99,6 @@ private:
     uint64_t _raw_data_size = 0;
     typedef typename TypeTraits<Type>::CppType CppType;
     enum { SIZE_OF_TYPE = TypeTraits<Type>::size };
-    faststring _first_value;
-    faststring _last_value;
 };
 
 template <FieldType Type>

--- a/be/src/storage/segment/rle_page.h
+++ b/be/src/storage/segment/rle_page.h
@@ -86,11 +86,6 @@ public:
             _rle_encoder->Put(value);
         }
 
-        if (_count == 0) {
-            memcpy(&_first_value, new_vals, SIZE_OF_TYPE);
-        }
-        memcpy(&_last_value, &new_vals[*count - 1], SIZE_OF_TYPE);
-
         _count += *count;
         _raw_data_size += *count * SIZE_OF_TYPE;
         return Status::OK();
@@ -124,24 +119,6 @@ public:
 
     uint64_t get_raw_data_size() const override { return _raw_data_size; }
 
-    Status get_first_value(void* value) const override {
-        DCHECK(_finished);
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, &_first_value, SIZE_OF_TYPE);
-        return Status::OK();
-    }
-
-    Status get_last_value(void* value) const override {
-        DCHECK(_finished);
-        if (_count == 0) {
-            return Status::Error<ErrorCode::ENTRY_NOT_FOUND>("page is empty");
-        }
-        memcpy(value, &_last_value, SIZE_OF_TYPE);
-        return Status::OK();
-    }
-
 private:
     RlePageBuilder(const PageBuilderOptions& options)
             : _options(options),
@@ -159,8 +136,6 @@ private:
     int _bit_width;
     RleEncoder<CppType>* _rle_encoder = nullptr;
     faststring _buf;
-    CppType _first_value;
-    CppType _last_value;
     uint64_t _raw_data_size = 0;
 };
 

--- a/be/test/storage/segment/binary_dict_page_test.cpp
+++ b/be/test/storage/segment/binary_dict_page_test.cpp
@@ -189,16 +189,6 @@ public:
         EXPECT_EQ(slices.size(), page_builder->count());
         EXPECT_FALSE(page_builder->is_page_full());
 
-        // Check first value and last value
-        Slice first_value;
-        ret = page_builder->get_first_value(&first_value);
-        EXPECT_TRUE(ret.ok());
-        EXPECT_EQ(slices[0], first_value);
-        Slice last_value;
-        ret = page_builder->get_last_value(&last_value);
-        EXPECT_TRUE(ret.ok());
-        EXPECT_EQ(slices[count - 1], last_value);
-
         // Construct dict page
         OwnedSlice dict_slice;
         Status status = page_builder->get_dictionary_page(&dict_slice);

--- a/be/test/storage/segment/binary_plain_page_test.cpp
+++ b/be/test/storage/segment/binary_plain_page_test.cpp
@@ -57,14 +57,6 @@ public:
 
         OwnedSlice owned_slice = page_builder.finish();
 
-        //check first value and last value
-        Slice first_value;
-        page_builder.get_first_value(&first_value);
-        EXPECT_EQ(slices[0], first_value);
-        Slice last_value;
-        page_builder.get_last_value(&last_value);
-        EXPECT_EQ(slices[count - 1], last_value);
-
         PageDecoderOptions decoder_options;
         PageDecoderType page_decoder(owned_slice.slice(), decoder_options);
         Status status = page_decoder.init();

--- a/be/test/storage/segment/binary_plain_page_v2_test.cpp
+++ b/be/test/storage/segment/binary_plain_page_v2_test.cpp
@@ -75,17 +75,6 @@ public:
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(slices.size(), page_builder->count());
 
-        // Check first and last value
-        Slice first_value;
-        status = page_builder->get_first_value(&first_value);
-        EXPECT_TRUE(status.ok());
-        EXPECT_EQ(slices[0], first_value);
-
-        Slice last_value;
-        status = page_builder->get_last_value(&last_value);
-        EXPECT_TRUE(status.ok());
-        EXPECT_EQ(slices[slices.size() - 1], last_value);
-
         // Decode the page
         // First apply pre-decode to convert V2 format to V1 format
         Slice page_slice = owned_slice.slice();
@@ -251,14 +240,6 @@ public:
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(0, page_builder->count());
 
-        // Try to get first/last value from empty page
-        Slice value;
-        status = page_builder->get_first_value(&value);
-        EXPECT_FALSE(status.ok());
-
-        status = page_builder->get_last_value(&value);
-        EXPECT_FALSE(status.ok());
-
         // Decode empty page
         // First apply pre-decode to convert V2 format to V1 format
         Slice page_slice = owned_slice.slice();
@@ -347,47 +328,6 @@ public:
         src_strings.push_back("中文测试");
 
         test_encode_decode_page<Type>(src_strings);
-    }
-
-    template <FieldType Type>
-    void test_get_dict_word() {
-        std::vector<std::string> src_strings = {"apple", "banana", "cherry", "date"};
-        std::vector<Slice> slices;
-        for (const auto& str : src_strings) {
-            slices.emplace_back(str);
-        }
-
-        // Build the page
-        PageBuilderOptions builder_options;
-        builder_options.data_page_size = 256 * 1024;
-
-        PageBuilder* builder_ptr = nullptr;
-        Status status = BinaryPlainPageV2Builder<Type>::create(&builder_ptr, builder_options);
-        EXPECT_TRUE(status.ok());
-        std::unique_ptr<PageBuilder> page_builder_wrapper(builder_ptr);
-        auto* page_builder = static_cast<BinaryPlainPageV2Builder<Type>*>(builder_ptr);
-
-        size_t count = slices.size();
-        const Slice* ptr = slices.data();
-        status = page_builder->add(reinterpret_cast<const uint8_t*>(ptr), &count);
-        EXPECT_TRUE(status.ok());
-
-        // Test get_dict_word before finish
-        for (uint32_t i = 0; i < slices.size(); ++i) {
-            Slice word;
-            status = page_builder->get_dict_word(i, &word);
-            EXPECT_TRUE(status.ok());
-            EXPECT_EQ(src_strings[i], word.to_string()) << "Mismatch at index " << i;
-        }
-
-        // Test invalid value_code
-        Slice word;
-        status = page_builder->get_dict_word(slices.size(), &word);
-        EXPECT_FALSE(status.ok());
-
-        OwnedSlice owned_slice;
-        status = page_builder->finish(&owned_slice);
-        EXPECT_TRUE(status.ok());
     }
 
     template <FieldType Type>
@@ -504,10 +444,6 @@ TEST_F(BinaryPlainPageV2Test, TestPageFullVarchar) {
 
 TEST_F(BinaryPlainPageV2Test, TestVariousLengthStringsVarchar) {
     test_various_length_strings<FieldType::OLAP_FIELD_TYPE_VARCHAR>();
-}
-
-TEST_F(BinaryPlainPageV2Test, TestGetDictWordVarchar) {
-    test_get_dict_word<FieldType::OLAP_FIELD_TYPE_VARCHAR>();
 }
 
 TEST_F(BinaryPlainPageV2Test, TestResetVarchar) {

--- a/be/test/storage/segment/binary_prefix_page_test.cpp
+++ b/be/test/storage/segment/binary_prefix_page_test.cpp
@@ -59,14 +59,6 @@ public:
         EXPECT_EQ(slices.size(), page_builder.count());
         EXPECT_FALSE(page_builder.is_page_full());
 
-        //check first value and last value
-        Slice first_value;
-        page_builder.get_first_value(&first_value);
-        EXPECT_EQ(slices[0], first_value);
-        Slice last_value;
-        page_builder.get_last_value(&last_value);
-        EXPECT_EQ(slices[count - 1], last_value);
-
         PageDecoderOptions dict_decoder_options;
         std::unique_ptr<BinaryPrefixPageDecoder> page_decoder(
                 new BinaryPrefixPageDecoder(dict_slice.slice(), dict_decoder_options));
@@ -174,14 +166,6 @@ public:
         OwnedSlice dict_slice = page_builder.finish();
         EXPECT_EQ(slices.size(), page_builder.count());
         EXPECT_FALSE(page_builder.is_page_full());
-
-        //check first value and last value
-        Slice first_value;
-        page_builder.get_first_value(&first_value);
-        EXPECT_EQ(slices[0], first_value);
-        Slice last_value;
-        page_builder.get_last_value(&last_value);
-        EXPECT_EQ(slices[count - 1], last_value);
 
         PageDecoderOptions dict_decoder_options;
         std::unique_ptr<BinaryPrefixPageDecoder> page_decoder(

--- a/be/test/storage/segment/bitshuffle_page_test.cpp
+++ b/be/test/storage/segment/bitshuffle_page_test.cpp
@@ -62,14 +62,6 @@ public:
         page_builder.add(reinterpret_cast<const uint8_t*>(src), &size);
         OwnedSlice s = page_builder.finish();
 
-        //check first value and last value
-        CppType first_value;
-        page_builder.get_first_value(&first_value);
-        EXPECT_EQ(src[0], first_value);
-        CppType last_value;
-        page_builder.get_last_value(&last_value);
-        EXPECT_EQ(src[size - 1], last_value);
-
         segment_v2::PageDecoderOptions decoder_options;
         PageDecoderType page_decoder_(s.slice(), decoder_options);
         Status status = page_decoder_.init();

--- a/be/test/storage/segment/frame_of_reference_page_test.cpp
+++ b/be/test/storage/segment/frame_of_reference_page_test.cpp
@@ -259,12 +259,6 @@ TEST_F(FrameOfReferencePageTest, TestFirstLastValue) {
     EXPECT_TRUE(ret0.ok());
     page_builder.add(reinterpret_cast<const uint8_t*>(ints.get()), &size);
     OwnedSlice s = page_builder.finish();
-    int32_t first_value = -1;
-    page_builder.get_first_value(&first_value);
-    EXPECT_EQ(0, first_value);
-    int32_t last_value = 0;
-    page_builder.get_last_value(&last_value);
-    EXPECT_EQ(127, last_value);
 }
 
 TEST_F(FrameOfReferencePageTest, TestInt32NormalBlockEncoderSize) {

--- a/be/test/storage/segment/plain_page_test.cpp
+++ b/be/test/storage/segment/plain_page_test.cpp
@@ -70,14 +70,6 @@ public:
         page_builder.add(reinterpret_cast<const uint8_t*>(src), &size);
         OwnedSlice s = page_builder.finish();
 
-        //check first value and last value
-        CppType first_value;
-        page_builder.get_first_value(&first_value);
-        EXPECT_EQ(src[0], first_value);
-        CppType last_value;
-        page_builder.get_last_value(&last_value);
-        EXPECT_EQ(src[size - 1], last_value);
-
         PageDecoderOptions decoder_options;
         PageDecoderType page_decoder(s.slice(), decoder_options);
         Status status = page_decoder.init();

--- a/be/test/storage/segment/rle_page_test.cpp
+++ b/be/test/storage/segment/rle_page_test.cpp
@@ -60,14 +60,6 @@ public:
         OwnedSlice s = rle_page_builder.finish();
         EXPECT_EQ(size, rle_page_builder.count());
 
-        //check first value and last value
-        CppType first_value;
-        rle_page_builder.get_first_value(&first_value);
-        EXPECT_EQ(src[0], first_value);
-        CppType last_value;
-        rle_page_builder.get_last_value(&last_value);
-        EXPECT_EQ(src[size - 1], last_value);
-
         PageDecoderOptions decodeder_options;
         PageDecoderType rle_page_decoder(s.slice(), decodeder_options);
         Status status = rle_page_decoder.init();


### PR DESCRIPTION
This reserved interface survived **6 years**. During that time, every new `PageBuilder` subclass — `FrameOfReferencePage`, `BinaryPlainPageV2`, etc. — was forced to implement these two pure virtual methods that nobody calls. 


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

