### PR TITLE
[fix](test) Fix flaky assertion in test_streaming_insert_job_fetch_meta_error

### DIFF
--- a/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_fetch_meta_error.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_fetch_meta_error.groovy
@@ -80,7 +80,7 @@ suite("test_streaming_insert_job_fetch_meta_error", "nonConcurrent") {
 
         def jobStatus = sql """select Status, ErrorMsg from jobs("type"="insert") where Name='${jobName}'"""
         assert jobStatus.get(0).get(0) == "PAUSED"
-        assert jobStatus.get(0).get(1).contains("Failed to list S3 files")
+        assert jobStatus.get(0).get(1).contains("Failed to fetch meta")
 
         sql """
             DROP JOB IF EXISTS where jobname = '${jobName}'

--- a/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_fetch_meta_error.groovy
+++ b/regression-test/suites/job_p0/streaming_job/test_streaming_insert_job_fetch_meta_error.groovy
@@ -80,7 +80,7 @@ suite("test_streaming_insert_job_fetch_meta_error", "nonConcurrent") {
 
         def jobStatus = sql """select Status, ErrorMsg from jobs("type"="insert") where Name='${jobName}'"""
         assert jobStatus.get(0).get(0) == "PAUSED"
-        assert jobStatus.get(0).get(1).contains("Failed to fetch meta")
+        assert jobStatus.get(0).get(1).contains("simulated S3 auth error")
 
         sql """
             DROP JOB IF EXISTS where jobname = '${jobName}'


### PR DESCRIPTION
### What problem does this PR solve?

PR #62023 refactored the filesystem SPI, which changed the error propagation path in `S3SourceOffsetProvider.fetchRemoteMeta()`. 

Previously (#61284), the debug point created a `GlobListResult` with an error status, and the subsequent status check threw an exception with message `"Failed to list S3 files: ..."`. After the refactoring in #62023, the debug point was changed to directly throw an `IOException`, which is caught by `StreamingInsertJob.fetchMeta()` and wrapped as `"Failed to fetch meta, ..."`. However, the regression test assertion was not updated accordingly, causing the test to fail intermittently.

### How does this PR fix it?

Update the assertion in `test_streaming_insert_job_fetch_meta_error` from checking `"Failed to list S3 files"` to `"Failed to fetch meta"`, matching the actual error message produced by the current code path.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a test fix — corrects the assertion string to match the actual error message.

### Check List (For Reviewer who is not the Author)

- [ ] Confirm that the problem is correctly described and the solution makes sense
- [ ] Confirm that no Copyright information is lost
- [ ] Confirm that no sensitive data is included (such as S3 keys)