### PR TITLE
[fix](schema-change) Use actual schema change alter version in cloud capture

### DIFF
--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -181,6 +181,10 @@ Status CloudSchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& reque
         }
     }
 
+    // Use the registered alter_version returned by meta-service instead of the original FE task
+    // version. The task can be created when FE still sees version 1, but by the time BE starts
+    // the schema change new data may already have been published and start_tablet_job can advance
+    // alter_version. In that case we still need to capture historical rowsets in [2, alter_version].
     if (start_resp.alter_version() > 1) {
         // [0-1] is a placeholder rowset, no need to convert
         RETURN_IF_ERROR(_base_tablet->capture_rs_readers({2, start_resp.alter_version()},

--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -181,7 +181,7 @@ Status CloudSchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& reque
         }
     }
 
-    if (request.alter_version > 1) {
+    if (start_resp.alter_version() > 1) {
         // [0-1] is a placeholder rowset, no need to convert
         RETURN_IF_ERROR(_base_tablet->capture_rs_readers({2, start_resp.alter_version()},
                                                          &rs_splits,

--- a/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_inverted_index_sc_version1_race.groovy
+++ b/regression-test/suites/cloud_p1/schema_change/compaction_optimization/test_inverted_index_sc_version1_race.groovy
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_inverted_index_sc_version1_race', 'nonConcurrent,docker') {
+
+    def options = new ClusterOptions()
+    options.cloudMode = true
+    options.enableDebugPoints()
+    options.beConfigs += ['enable_java_support=false']
+    options.beConfigs += ['alter_tablet_worker_count=1']
+    options.beNum = 1
+
+    docker(options) {
+        def tableName = 'test_inverted_index_sc_version1_race'
+        def scBlock = 'CloudSchemaChangeJob::process_alter_tablet.block'
+
+        def getJobState = { tbl ->
+            def result = sql """SHOW ALTER TABLE COLUMN WHERE TableName='${tbl}' ORDER BY CreateTime DESC LIMIT 1"""
+            logger.info("getJobState: ${result}")
+            if (result == null || result.isEmpty()) {
+                return ''
+            }
+            return result[0][9]
+        }
+
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                id INT NOT NULL,
+                title STRING NOT NULL
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            )
+        """
+
+        GetDebugPoint().enableDebugPointForAllBEs(scBlock)
+
+        try {
+            sql """ALTER TABLE ${tableName} ADD INDEX idx_title (title) USING INVERTED PROPERTIES(\"parser\" = \"english\")"""
+
+            int runningTries = 60
+            while (runningTries-- > 0) {
+                if (getJobState(tableName) == 'RUNNING') {
+                    break
+                }
+                sleep(1000)
+            }
+            assertEquals('RUNNING', getJobState(tableName))
+
+            sql """INSERT INTO ${tableName} VALUES (1, 'alpha beta'), (2, 'beta gamma'), (3, 'gamma delta')"""
+            assertEquals(3L, (sql "SELECT count(*) FROM ${tableName}")[0][0])
+
+        } finally {
+            GetDebugPoint().disableDebugPointForAllBEs(scBlock)
+        }
+
+        int maxTries = 180
+        def finalState = ''
+        while (maxTries-- > 0) {
+            finalState = getJobState(tableName)
+            if (finalState == 'FINISHED' || finalState == 'CANCELLED') {
+                break
+            }
+            sleep(1000)
+        }
+        assertEquals('FINISHED', finalState)
+
+        def showIndexResult = sql "SHOW INDEX FROM ${tableName}"
+        assertTrue(showIndexResult.any { row -> row[2].toString() == 'idx_title' })
+
+        def queryResult = sql "SELECT id FROM ${tableName} WHERE title MATCH 'beta' ORDER BY id"
+        assertEquals([[1], [2]], queryResult)
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Cloud schema change in BE decides whether to capture historical rowsets using the original FE task alter version, but later executes and commits using the alter version registered in meta service. When the FE task is created at version 1 and the registered schema change job uses a later alter version, BE can skip capturing historical rowsets and then commit an empty schema change output.

This change uses the registered schema change alter version consistently when deciding whether historical rowsets need to be captured.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->
              - Small conditional fix in cloud schema change capture logic only; no test was run in this session.

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->
          - Cloud schema change now decides whether to capture historical rowsets using the alter version registered in meta service, avoiding empty schema change output in the version-1 to later-version race.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->