### PR TITLE
[Exec](status) materialization_opertor return the error status by row_id_fetcher

### DIFF
--- a/be/src/exec/operator/materialization_opertor.cpp
+++ b/be/src/exec/operator/materialization_opertor.cpp
@@ -416,6 +416,12 @@ Status MaterializationOperator::push(RuntimeState* state, Block* in_block, bool 
                         " target_backend_id:" + std::to_string(backend_id);
                 return Status::InternalError(error_text);
             }
+            if (rpc_struct.response.status().status_code() != 0) {
+                Status st = Status::create(rpc_struct.response.status());
+                st.append(fmt::format(", Backend:{}, Materialization Sink node id:{}", backend_id,
+                                      node_id()));
+                return st;
+            }
             rpc_struct.cntl->Reset();
         }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
- MaterializationOperator did not check rpc_struct.response.status().status_code after row_id_fetcher RPCs, so backend-side errors were not propagated to the caller.
- This change verifies the RPC response status; if status_code != 0, it constructs an error message containing backend id, status_code, error_msg and the Materialization Sink node id, and returns Status::InternalError so the error is reported upstream.
### Release note
None
### Check List (For Author)
- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test
        - Simulate row_id_fetcher returning a non-zero status; verify push returns InternalError and the error message includes backend id, status_code, error_msg, and Materialization Sink node id.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason
- Behavior changed:
    - [x] Yes. MaterializationOperator now returns InternalError when row_id_fetcher reports an error (improved error reporting).
    - [ ] No.
- Does this need documentation?
    - [ ] No.
    - [x] Yes (optional) — document that MaterializationOperator will surface row_id_fetcher RPC errors as InternalError.
### Check List (For Reviewer who merge this PR)
- [ ] Confirm the release note
- [x] Confirm test cases (manual test)
- [ ] Confirm document
- [ ] Add branch pick label

