### PR TITLE
[fix](storage) Fix typo 'occured' in user-facing error messages

### DIFF
--- a/be/src/storage/index/inverted/inverted_index_reader.cpp
+++ b/be/src/storage/index/inverted/inverted_index_reader.cpp
@@ -269,10 +269,10 @@ Status InvertedIndexReader::match_index_search(
             query->search(*term_match_bitmap);
         }
     } catch (const CLuceneError& e) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("CLuceneError occured: {}",
+        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("CLuceneError occurred: {}",
                                                                       e.what());
     } catch (const Exception& e) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("Exception occured: {}",
+        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("Exception occurred: {}",
                                                                       e.what());
     }
     return Status::OK();
@@ -389,7 +389,7 @@ Status FullTextIndexReader::query(const IndexQueryContextPtr& context,
         return Status::OK();
     } catch (const CLuceneError& e) {
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                "CLuceneError occured, error msg: {}", e.what());
+                "CLuceneError occurred, error msg: {}", e.what());
     }
 }
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -289,7 +289,7 @@ static Status load_data_dirs(const std::vector<DataDir*>& data_dirs) {
 
             auto st = data_dir->load();
             if (!st.ok()) {
-                LOG(WARNING) << "error occured when init load tables. res=" << st
+                LOG(WARNING) << "error occurred when init load tables. res=" << st
                              << ", data dir=" << data_dir->path();
                 std::lock_guard lock(result_mtx);
                 result = std::move(st);

--- a/be/src/storage/task/index_builder.cpp
+++ b/be/src/storage/task/index_builder.cpp
@@ -510,7 +510,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                                     })
                         } catch (const std::exception& e) {
                             return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                                    "CLuceneError occured: {}", e.what());
+                                    "CLuceneError occurred: {}", e.what());
                         }
 
                         if (inverted_index_builder) {
@@ -540,7 +540,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                                     })
                         } catch (const std::exception& e) {
                             return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                                    "CLuceneError occured: {}", e.what());
+                                    "CLuceneError occurred: {}", e.what());
                         }
 
                         if (index_writer) {
@@ -623,7 +623,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                     })
                 } catch (const std::exception& e) {
                     return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                            "CLuceneError occured: {}", e.what());
+                            "CLuceneError occurred: {}", e.what());
                 }
             }
 
@@ -736,7 +736,7 @@ Status IndexBuilder::_add_nullable(const std::string& column_name,
                     _index_column_writers[index_writer_sign]->add_array_nulls(null_map, num_rows));
         } catch (const std::exception& e) {
             return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                    "CLuceneError occured: {}", e.what());
+                    "CLuceneError occurred: {}", e.what());
         }
 
         return Status::OK();
@@ -769,7 +769,7 @@ Status IndexBuilder::_add_nullable(const std::string& column_name,
                             { _CLTHROWA(CL_ERR_IO, "debug point: _add_nullable_throw_exception"); })
         } while (offset < num_rows);
     } catch (const std::exception& e) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("CLuceneError occured: {}",
+        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("CLuceneError occurred: {}",
                                                                       e.what());
     }
 
@@ -802,7 +802,7 @@ Status IndexBuilder::_add_data(const std::string& column_name,
         DBUG_EXECUTE_IF("IndexBuilder::_add_data_throw_exception",
                         { _CLTHROWA(CL_ERR_IO, "debug point: _add_data_throw_exception"); })
     } catch (const std::exception& e) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("CLuceneError occured: {}",
+        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>("CLuceneError occurred: {}",
                                                                       e.what());
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Nine error messages in the storage BE misspell **'occurred'** as **'occured'**. Because these strings are returned in runtime `Status` error messages, they are visible to end users hitting inverted-index build/read errors and storage-engine init errors.

### Files changed

- `be/src/storage/index/inverted/inverted_index_reader.cpp` — 3 occurrences
- `be/src/storage/task/index_builder.cpp` — 5 occurrences
- `be/src/storage/storage_engine.cpp` — 1 occurrence

Each change is to the error-message string only; no behavior change.

### Release note

None