### PR TITLE
[chore](typo) Fix 'depedency', 'avaliable', 'consitent' in comments

### DIFF
--- a/be/src/core/column/column.h
+++ b/be/src/core/column/column.h
@@ -185,7 +185,7 @@ public:
                                "Method erase is not supported for " + get_name());
     }
 
-    /// cut or expand inplace. `this` would be moved, only the return value is avaliable.
+    /// cut or expand inplace. `this` would be moved, only the return value is available.
     virtual Ptr shrink(size_t length) const final {
         // NOLINTBEGIN(performance-move-const-arg)
         MutablePtr res = std::move(*this).mutate();

--- a/be/src/core/value/vdatetime_value.h
+++ b/be/src/core/value/vdatetime_value.h
@@ -599,7 +599,7 @@ public:
     void unix_timestamp(int64_t* timestamp, const cctz::time_zone& ctz) const;
 
     //construct datetime_value from timestamp and timezone
-    //timestamp is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC. negative avaliable.
+    //timestamp is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC. negative available.
     //we don't do any check in it because it's hot path. any usage want ensure the time legality should check itself.
     bool from_unixtime(int64_t, const std::string& timezone);
     void from_unixtime(int64_t, const cctz::time_zone& ctz);
@@ -1103,7 +1103,7 @@ public:
     void unix_timestamp(std::pair<int64_t, int64_t>* timestamp, const cctz::time_zone& ctz) const;
 
     //construct datetime_value from timestamp and timezone
-    //timestamp is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC. negative avaliable.
+    //timestamp is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC. negative available.
     //we don't do any check in it because it's hot path. any usage want ensure the time legality should check itself.
     bool from_unixtime(int64_t, const std::string& timezone);
     void from_unixtime(int64_t, const cctz::time_zone& ctz);

--- a/be/src/exec/common/string_searcher.h
+++ b/be/src/exec/common/string_searcher.h
@@ -112,7 +112,7 @@ public:
     template <typename CharT>
     // requires (sizeof(CharT) == 1)
     const CharT* search(const CharT* haystack, size_t haystack_size) const {
-        // cast to unsigned int8 to be consitent with needle type
+        // cast to unsigned int8 to be consistent with needle type
         // ensure unsigned type compare
         return reinterpret_cast<const CharT*>(
                 _search(reinterpret_cast<const uint8_t*>(haystack), haystack_size));
@@ -121,7 +121,7 @@ public:
     template <typename CharT>
     // requires (sizeof(CharT) == 1)
     const CharT* search(const CharT* haystack, const CharT* haystack_end) const {
-        // cast to unsigned int8 to be consitent with needle type
+        // cast to unsigned int8 to be consistent with needle type
         // ensure unsigned type compare
         return reinterpret_cast<const CharT*>(
                 _search(reinterpret_cast<const uint8_t*>(haystack),
@@ -131,7 +131,7 @@ public:
     template <typename CharT>
     // requires (sizeof(CharT) == 1)
     ALWAYS_INLINE bool compare(const CharT* haystack, const CharT* haystack_end, CharT* pos) const {
-        // cast to unsigned int8 to be consitent with needle type
+        // cast to unsigned int8 to be consistent with needle type
         // ensure unsigned type compare
         return _compare(reinterpret_cast<const uint8_t*>(haystack),
                         reinterpret_cast<const uint8_t*>(haystack_end),

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -214,7 +214,7 @@ Status EngineCloneTask::_do_clone() {
         if (tablet->replica_id() < _clone_req.replica_id) {
             // `tablet` may be a dropped replica in FE, e.g:
             //   BE1 migrates replica of tablet_1 to BE2, but before BE1 drop this replica, another new replica of tablet_1 is migrated to BE1.
-            // Clone can still continue in this case. But to keep `replica_id` consitent with FE, MUST reset `replica_id` with request `replica_id`.
+            // Clone can still continue in this case. But to keep `replica_id` consistent with FE, MUST reset `replica_id` with request `replica_id`.
             tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
         }
 

--- a/common/cpp/sync_point.h
+++ b/common/cpp/sync_point.h
@@ -223,7 +223,7 @@ auto try_any_cast_ret(std::vector<std::any>& any) {
 # define TEST_SYNC_POINT_SINGLETON()
 #else
 // Use TEST_SYNC_POINT to specify sync points inside code base.
-// Sync points can have happens-after depedency on other sync points,
+// Sync points can have happens-after dependency on other sync points,
 // configured at runtime via SyncPoint::load_dependency. This could be
 // utilized to re-produce race conditions between threads.
 # define TEST_SYNC_POINT(x) SYNC_POINT(x)


### PR DESCRIPTION
## What problem was fixed

Several source comments contain misspelled English words (`depedency`, `avaliable`, `consitent`), making them harder to grep for by the correct spelling and slightly lowering the quality of in-repo documentation.

## How it was fixed

Comment-only typo corrections — no code paths, APIs, log messages, or behavior changed. The fixes:

- `common/cpp/sync_point.h`: `depedency` → `dependency`
- `be/src/core/column/column.h`: `avaliable` → `available`
- `be/src/core/value/vdatetime_value.h` (2x): `avaliable` → `available`
- `be/src/exec/common/string_searcher.h` (3x): `consitent` → `consistent`
- `be/src/storage/task/engine_clone_task.cpp`: `consitent` → `consistent`

## Behavior change

None. This PR only touches `//` / `/* */` comments. No functions were renamed, no log strings, no public APIs. Compiled binary should be byte-identical (modulo debug info that captures the source file hash).

## Impact / risk

Minimal. No migration needed. No effect on protocol, storage, query planner, or any user-visible behavior.

## Test plan

No new tests needed for comment-only changes. Existing CI is sufficient to confirm the files still compile.