### PR TITLE
[opt](iceberg) lazy load iceberg delete file to improve exectue proformance

### DIFF
--- a/be/src/format/parquet/vparquet_reader.cpp
+++ b/be/src/format/parquet/vparquet_reader.cpp
@@ -911,7 +911,15 @@ Status ParquetReader::_next_row_group_reader() {
     }
 
     // process page index and generate the ranges to read
-    auto& row_group = _t_metadata->row_groups[_current_row_group_index.row_group_id];
+    const auto& row_group = _t_metadata->row_groups[_current_row_group_index.row_group_id];
+
+    // On the first confirmed-viable data read, allow subclasses to complete deferred
+    // delete-file loading before the RowGroupReader is created, ensuring _delete_rows
+    // is set before _get_position_delete_ctx() consumes it.
+    if (!_delete_files_hook_called) {
+        RETURN_IF_ERROR(on_before_read_with_deletes());
+        _delete_files_hook_called = true;
+    }
 
     RowGroupReader::PositionDeleteContext position_delete_ctx =
             _get_position_delete_ctx(row_group, _current_row_group_index);

--- a/be/src/format/parquet/vparquet_reader.h
+++ b/be/src/format/parquet/vparquet_reader.h
@@ -227,6 +227,12 @@ protected:
         return Status::OK();
     }
 
+    // Called when the first row group passes statistics filtering (min/max, bloom filter),
+    // immediately before the RowGroupReader is created. Subclasses override this to defer
+    // delete file loading until data is confirmed to exist, avoiding wasted IO when all
+    // row groups are filtered out.
+    virtual Status on_before_read_with_deletes() { return Status::OK(); }
+
     // Protected accessors so CRTP mixin subclasses can reach private members
     io::IOContext* get_io_ctx() const { return _io_ctx; }
     std::unordered_map<std::string, uint32_t>*& col_name_to_block_idx_ref() {
@@ -373,6 +379,8 @@ private:
     RowGroupReader::RowGroupIndex _current_row_group_index {-1, 0, 0};
     // read to the end of current reader
     bool _row_group_eof = true;
+    // Ensures on_before_read_with_deletes() fires exactly once per file.
+    bool _delete_files_hook_called = false;
     size_t _total_groups; // num of groups(stripes) of a parquet(orc) file
 
     std::shared_ptr<ConditionCacheContext> _condition_cache_ctx;

--- a/be/src/format/table/iceberg_reader.h
+++ b/be/src/format/table/iceberg_reader.h
@@ -85,6 +85,8 @@ protected:
     // Parquet-specific schema matching via on_before_init_reader hook
     Status on_before_init_reader(ReaderInitContext* ctx) override;
 
+    Status on_before_read_with_deletes() override { return _load_pending_delete_files(); }
+
     std::unique_ptr<GenericReader> _create_equality_reader(
             const TFileRangeDesc& delete_desc) final {
         return ParquetReader::create_unique(this->get_profile(), this->get_scan_params(),

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -30,19 +30,12 @@
 #include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/column/column_struct.h"
-#include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "format/generic_reader.h"
 #include "format/table/deletion_vector_reader.h"
 #include "format/table/equality_delete.h"
 #include "format/table/table_schema_change_helper.h"
 #include "runtime/runtime_profile.h"
-#include "runtime/runtime_state.h"
-#include "storage/olap_common.h"
-
-namespace doris {
-class TIcebergDeleteFileDesc;
-} // namespace doris
 
 namespace doris {
 
@@ -106,6 +99,10 @@ public:
     void set_create_row_id_column_iterator_func(
             std::function<std::shared_ptr<segment_v2::RowIdColumnIteratorV2>()> create_func) {
         _create_topn_row_id_column_iterator = create_func;
+    }
+
+    bool has_delete_operations() const override {
+        return !this->get_scan_range().table_format_params.iceberg_params.delete_files.empty();
     }
 
 protected:
@@ -214,6 +211,8 @@ protected:
     // ---- Shared Iceberg methods ----
 
     Status _init_row_filters();
+    Status _prepare_pending_delete_files();
+    Status _load_pending_delete_files();
     Status _position_delete_base(const std::string data_file_path,
                                  const std::vector<TIcebergDeleteFileDesc>& delete_files);
     Status _equality_delete_base(const std::vector<TIcebergDeleteFileDesc>& delete_files);
@@ -319,6 +318,12 @@ protected:
     std::vector<std::string> _all_required_col_names;
     Fileformat _file_format = Fileformat::NONE;
 
+    // Pending position-delete / deletion-vector files accumulated during (_init_row_filters).
+    // They are loaded in on_before_read_with_deletes(), which fires
+    // only after data reads are confirmed necessary (statistics filtering passed).
+    std::vector<TIcebergDeleteFileDesc> _pending_pos_delete_files;
+    std::vector<TIcebergDeleteFileDesc> _pending_dv_files;
+
     const int64_t MIN_SUPPORT_DELETE_FILES_VERSION = 2;
     const std::string ICEBERG_FILE_PATH = "file_path";
     const std::string ICEBERG_ROW_POS = "pos";
@@ -376,43 +381,69 @@ Status IcebergReaderMixin<BaseReader>::_init_row_filters() {
         return Status::OK();
     }
 
-    std::vector<TIcebergDeleteFileDesc> position_delete_files;
     std::vector<TIcebergDeleteFileDesc> equality_delete_files;
-    std::vector<TIcebergDeleteFileDesc> deletion_vector_files;
     for (const TIcebergDeleteFileDesc& desc : table_desc.delete_files) {
         if (desc.content == POSITION_DELETE) {
-            position_delete_files.emplace_back(desc);
+            _pending_pos_delete_files.emplace_back(desc);
+        } else if (desc.content == DELETION_VECTOR) {
+            _pending_dv_files.emplace_back(desc);
         } else if (desc.content == EQUALITY_DELETE) {
             equality_delete_files.emplace_back(desc);
-        } else if (desc.content == DELETION_VECTOR) {
-            deletion_vector_files.emplace_back(desc);
         }
     }
 
+    // Equality delete: load schema AND row data eagerly. The column names/types are
+    // required immediately to configure the projection in _do_init_reader().
     if (!equality_delete_files.empty()) {
         RETURN_IF_ERROR(_equality_delete_base(equality_delete_files));
         this->set_push_down_agg_type(TPushAggOp::NONE);
+        COUNTER_UPDATE(_iceberg_profile.num_delete_files, equality_delete_files.size());
     }
 
-    if (!deletion_vector_files.empty()) {
-        if (deletion_vector_files.size() != 1) [[unlikely]] {
-            /*
-             * Deletion vectors are a binary representation of deletes for a single data file that is more efficient
-             * at execution time than position delete files. Unlike equality or position delete files, there can be
-             * at most one deletion vector for a given data file in a snapshot.
-             */
-            return Status::DataQualityError("This iceberg data file has multiple DVs.");
-        }
-        RETURN_IF_ERROR(
-                read_deletion_vector(table_desc.original_file_path, deletion_vector_files[0]));
-        this->set_push_down_agg_type(TPushAggOp::NONE);
-    } else if (!position_delete_files.empty()) {
-        RETURN_IF_ERROR(
-                _position_delete_base(table_desc.original_file_path, position_delete_files));
-        this->set_push_down_agg_type(TPushAggOp::NONE);
+    DCHECK(_file_format == Fileformat::PARQUET || _file_format == Fileformat::ORC);
+    RETURN_IF_ERROR(_prepare_pending_delete_files());
+    if (_file_format == Fileformat::PARQUET) {
+        // Parquet: statistics filtering (min/max, bloom filter) happens in _next_row_group_reader()
+        // before any data row is read. Defer pos delete / DV IO to on_before_read_with_deletes()
+        // so that if all row groups are statistics-filtered we skip the delete-file IO entirely.
+        // The num_delete_files counter for these is updated inside on_before_read_with_deletes().
+    } else {
+        // ORC: stripe filtering is internal to the ORC library and cannot be intercepted before
+        // IO starts, so there is no safe early-exit point. Load pos delete / DV eagerly.
+        RETURN_IF_ERROR(_load_pending_delete_files());
     }
 
-    COUNTER_UPDATE(_iceberg_profile.num_delete_files, table_desc.delete_files.size());
+    return Status::OK();
+}
+
+template <typename BaseReader>
+Status IcebergReaderMixin<BaseReader>::_prepare_pending_delete_files() {
+    if (_pending_pos_delete_files.empty() && _pending_dv_files.empty()) {
+        return Status::OK();
+    }
+    if (!_pending_dv_files.empty() && _pending_dv_files.size() != 1) [[unlikely]] {
+        return Status::DataQualityError("This iceberg data file has multiple DVs.");
+    }
+    this->set_push_down_agg_type(TPushAggOp::NONE);
+    return Status::OK();
+}
+
+template <typename BaseReader>
+Status IcebergReaderMixin<BaseReader>::_load_pending_delete_files() {
+    if (_pending_pos_delete_files.empty() && _pending_dv_files.empty()) {
+        return Status::OK();
+    }
+    const auto& table_desc = this->get_scan_range().table_format_params.iceberg_params;
+    if (!_pending_dv_files.empty()) {
+        RETURN_IF_ERROR(read_deletion_vector(table_desc.original_file_path, _pending_dv_files[0]));
+        COUNTER_UPDATE(_iceberg_profile.num_delete_files, 1);
+        _pending_dv_files.clear();
+    } else {
+        RETURN_IF_ERROR(
+                _position_delete_base(table_desc.original_file_path, _pending_pos_delete_files));
+        COUNTER_UPDATE(_iceberg_profile.num_delete_files, _pending_pos_delete_files.size());
+        _pending_pos_delete_files.clear();
+    }
     return Status::OK();
 }
 

--- a/be/src/format/table/paimon_reader.cpp
+++ b/be/src/format/table/paimon_reader.cpp
@@ -194,10 +194,6 @@ Status PaimonParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
 }
 
 Status PaimonParquetReader::on_after_init_reader(ReaderInitContext* /*ctx*/) {
-    return _init_deletion_vector();
-}
-
-Status PaimonParquetReader::_init_deletion_vector() {
     const auto& table_desc = get_scan_range().table_format_params.paimon_params;
     if (!table_desc.__isset.deletion_file) {
         return Status::OK();
@@ -206,6 +202,20 @@ Status PaimonParquetReader::_init_deletion_vector() {
     if (!get_scan_range().table_format_params.paimon_params.__isset.row_count) {
         set_push_down_agg_type(TPushAggOp::NONE);
     }
+    _has_pending_dv = true;
+    return Status::OK();
+}
+
+Status PaimonParquetReader::on_before_read_with_deletes() {
+    if (!_has_pending_dv) {
+        return Status::OK();
+    }
+    _has_pending_dv = false;
+    return _init_deletion_vector();
+}
+
+Status PaimonParquetReader::_init_deletion_vector() {
+    const auto& table_desc = get_scan_range().table_format_params.paimon_params;
     const auto& deletion_file = table_desc.deletion_file;
 
     Status create_status = Status::OK();

--- a/be/src/format/table/paimon_reader.h
+++ b/be/src/format/table/paimon_reader.h
@@ -44,6 +44,10 @@ public:
     }
     ~PaimonOrcReader() final = default;
 
+    bool has_delete_operations() const override {
+        return get_scan_range().table_format_params.paimon_params.__isset.deletion_file;
+    }
+
 protected:
     Status on_before_init_reader(ReaderInitContext* ctx) override;
 
@@ -79,10 +83,16 @@ public:
     }
     ~PaimonParquetReader() final = default;
 
+    bool has_delete_operations() const override {
+        return get_scan_range().table_format_params.paimon_params.__isset.deletion_file;
+    }
+
 protected:
     Status on_before_init_reader(ReaderInitContext* ctx) override;
 
     Status on_after_init_reader(ReaderInitContext* /*ctx*/) override;
+
+    Status on_before_read_with_deletes() override;
 
 private:
     void _init_paimon_profile();
@@ -97,6 +107,7 @@ private:
     const std::vector<int64_t>* _delete_rows = nullptr;
     ShardedKVCache* _kv_cache;
     PaimonProfile _paimon_profile;
+    bool _has_pending_dv = false;
 };
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

lazy loading for Iceberg delete files to improve query performance. Previously, all delete files were eagerly loaded which caused unnecessary I/O and memory overhead when many files were not actually needed.
delete files are loaded only when required, and skipped if corresponding data files are pruned. This reduces execution overhead, especially for tables with large numbers of delete files. 


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

