### PR TITLE
[fix](typo) fix typo 'sucess' -> 'success' typo in meta_service_http response

### DIFF
--- a/cloud/src/meta-service/meta_service_http.cpp
+++ b/cloud/src/meta-service/meta_service_http.cpp
@@ -374,7 +374,7 @@ static HttpResponse process_adjust_rate_limit(MetaServiceImpl* service, brpc::Co
                                    "`qps_limit` should not be less than 0");
         }
         if (cb(qps_limit)) {
-            return http_json_reply(MetaServiceCode::OK, "sucess to adjust rate limit");
+            return http_json_reply(MetaServiceCode::OK, "success to adjust rate limit");
         }
         return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
                                fmt::format("failed to adjust rate limit for qps_limit={}, "


### PR DESCRIPTION
blocked by #61502

## Proposed changes
HTTP response message in `cloud/src/meta-service/meta_service_http.cpp` line 377 reads:
```
"sucess to adjust rate limit"
```
Fixed to `"success to adjust rate limit"`. String-literal-only change; no logic change.

## Checklist
- [x] Does not affect any functionalities