### PR TITLE
[refine](column) replace field-based nested default with column-level operation in ColumnVariant

### DIFF
--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -2499,6 +2499,12 @@ bool ColumnVariant::try_insert_default_from_nested(const Subcolumns::NodePtr& en
         return false;
     }
 
+    // Preserve the original null guard: if the donor leaf's last row is NULL,
+    // fall back to insert_default() so that a missing sibling stays NULL too.
+    if (leaf->data.is_null_at(leaf_size - 1)) {
+        return false;
+    }
+
     FieldInfo field_info = {
             .scalar_type_id = entry->data.least_common_type.get_base_type_id(),
             .num_dimensions = entry->data.get_dimensions(),

--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -2488,64 +2488,27 @@ bool ColumnVariant::try_insert_many_defaults_from_nested(const Subcolumns::NodeP
     return true;
 }
 
-/// Visitor that keeps @num_dimensions_to_keep dimensions in arrays
-/// and replaces all scalars or nested arrays to @replacement at that level.
-class FieldVisitorReplaceScalars : public StaticVisitor<Field> {
-public:
-    FieldVisitorReplaceScalars(const Field& replacement_, size_t num_dimensions_to_keep_)
-            : replacement(replacement_), num_dimensions_to_keep(num_dimensions_to_keep_) {}
-
-    template <PrimitiveType T>
-    Field apply(const typename PrimitiveTypeTraits<T>::CppType& x) const {
-        if constexpr (T == TYPE_ARRAY) {
-            if (num_dimensions_to_keep == 0) {
-                return replacement;
-            }
-
-            const size_t size = x.size();
-            Array res(size);
-            for (size_t i = 0; i < size; ++i) {
-                res[i] = apply_visitor(
-                        FieldVisitorReplaceScalars(replacement, num_dimensions_to_keep - 1), x[i]);
-            }
-            return Field::create_field<TYPE_ARRAY>(res);
-        } else {
-            return replacement;
-        }
-    }
-
-private:
-    const Field& replacement;
-    size_t num_dimensions_to_keep;
-};
-
 bool ColumnVariant::try_insert_default_from_nested(const Subcolumns::NodePtr& entry) const {
     const auto* leaf = get_leaf_of_the_same_nested(entry);
     if (!leaf) {
         return false;
     }
 
-    auto last_field = leaf->data.get_last_field();
-    if (last_field.is_null()) {
+    size_t leaf_size = leaf->data.size();
+    if (leaf_size == 0) {
         return false;
     }
 
-    size_t leaf_num_dimensions = leaf->data.get_dimensions();
-    size_t entry_num_dimensions = entry->data.get_dimensions();
+    FieldInfo field_info = {
+            .scalar_type_id = entry->data.least_common_type.get_base_type_id(),
+            .num_dimensions = entry->data.get_dimensions(),
+    };
 
-    if (entry_num_dimensions > leaf_num_dimensions) {
-        throw doris::Exception(
-                ErrorCode::INVALID_ARGUMENT,
-                "entry_num_dimensions > leaf_num_dimensions, entry_num_dimensions={}, "
-                "leaf_num_dimensions={}",
-                entry_num_dimensions, leaf_num_dimensions);
-    }
-
-    auto default_scalar = entry->data.get_least_common_type()->get_default();
-
-    auto default_field = apply_visitor(
-            FieldVisitorReplaceScalars(default_scalar, leaf_num_dimensions), last_field);
-    entry->data.insert(std::move(default_field));
+    // Reuse the same column-level approach as try_insert_many_defaults_from_nested:
+    // cut the last row from leaf, replace scalar values with defaults, keep array structure.
+    auto new_subcolumn = leaf->data.cut(leaf_size - 1, 1).clone_with_default_values(field_info);
+    entry->data.insert_range_from(new_subcolumn, 0, 1);
+    ENABLE_CHECK_CONSISTENCY(this);
     return true;
 }
 

--- a/be/src/exec/common/variant_util.cpp
+++ b/be/src/exec/common/variant_util.cpp
@@ -1821,35 +1821,6 @@ static void append_field_to_binary_chars(const Field& field, ColumnString::Chars
                                field.get_type());
     }
 }
-/// Visitor that keeps @num_dimensions_to_keep dimensions in arrays
-/// and replaces all scalars or nested arrays to @replacement at that level.
-class FieldVisitorReplaceScalars : public StaticVisitor<Field> {
-public:
-    FieldVisitorReplaceScalars(const Field& replacement_, size_t num_dimensions_to_keep_)
-            : replacement(replacement_), num_dimensions_to_keep(num_dimensions_to_keep_) {}
-    template <PrimitiveType T>
-    Field operator()(const typename PrimitiveTypeTraits<T>::CppType& x) const {
-        if constexpr (T == TYPE_ARRAY) {
-            if (num_dimensions_to_keep == 0) {
-                return replacement;
-            }
-            const size_t size = x.size();
-            Array res(size);
-            for (size_t i = 0; i < size; ++i) {
-                res[i] = apply_visitor(
-                        FieldVisitorReplaceScalars(replacement, num_dimensions_to_keep - 1), x[i]);
-            }
-            return Field::create_field<TYPE_ARRAY>(res);
-        } else {
-            return replacement;
-        }
-    }
-
-private:
-    const Field& replacement;
-    size_t num_dimensions_to_keep;
-};
-
 template <typename ParserImpl>
 void parse_json_to_variant_impl(IColumn& column, const char* src, size_t length,
                                 JSONDataParser<ParserImpl>* parser, const ParseConfig& config) {

--- a/be/test/core/column/column_variant_test.cpp
+++ b/be/test/core/column/column_variant_test.cpp
@@ -3082,30 +3082,6 @@ TEST_F(ColumnVariantTest, get_field_info_all_types) {
     }
 }
 
-TEST_F(ColumnVariantTest, field_visitor) {
-    // Test replacing scalar values in a flat array
-    {
-        Array array;
-        array.push_back(Field::create_field<TYPE_BIGINT>(Int64(1)));
-        array.push_back(Field::create_field<TYPE_BIGINT>(Int64(2)));
-        array.push_back(Field::create_field<TYPE_BIGINT>(Int64(3)));
-
-        Field field = Field::create_field<TYPE_ARRAY>(std::move(array));
-        Field replacement = Field::create_field<TYPE_BIGINT>(Int64(42));
-        Field result = apply_visitor(FieldVisitorReplaceScalars(replacement, 0), field);
-
-        EXPECT_EQ(result.get<TYPE_BIGINT>(), 42);
-
-        Field replacement1 = Field::create_field<TYPE_BIGINT>(Int64(42));
-        Field result1 = apply_visitor(FieldVisitorReplaceScalars(replacement, 1), field);
-
-        EXPECT_EQ(result1.get<TYPE_ARRAY>().size(), 3);
-        EXPECT_EQ(result1.get<TYPE_ARRAY>()[0].get<TYPE_BIGINT>(), 42);
-        EXPECT_EQ(result1.get<TYPE_ARRAY>()[1].get<TYPE_BIGINT>(), 42);
-        EXPECT_EQ(result1.get<TYPE_ARRAY>()[2].get<TYPE_BIGINT>(), 42);
-    }
-}
-
 TEST_F(ColumnVariantTest, subcolumn_operations_coverage) {
     // Test insert_range_from
     {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`ColumnVariant::try_insert_default_from_nested` was filling missing nested subcolumn rows by
converting the last row of a sibling leaf column to a `Field`, recursively walking the `Field`
tree via `FieldVisitorReplaceScalars` to replace scalar values with the type default, and then
inserting the resulting `Field` back into the column.

This approach was unnecessarily expensive (column → Field → Field tree traversal → column) and
inconsistent with the batch counterpart `try_insert_many_defaults_from_nested`, which operates
entirely at the column level using `cut` + `clone_with_default_values`.

The scalar visitor (`FieldVisitorReplaceScalars`) existed as duplicate dead code in both
`column_variant.cpp` and `variant_util.cpp`.

### Changes

- **`try_insert_default_from_nested`**: rewrite to use the same column-level approach as
  `try_insert_many_defaults_from_nested` — `leaf->data.cut(leaf_size - 1, 1).clone_with_default_values(field_info)` — eliminating the Field round-trip and the dependency on `get_default()` / `FieldVisitorReplaceScalars`.
- **Remove `FieldVisitorReplaceScalars`** from both `column_variant.cpp` and `variant_util.cpp`; neither file has any remaining callers.
- **Remove `field_visitor` unit test** in `column_variant_test.cpp` that directly tested the now-deleted visitor class.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

