### PR TITLE
[chore](CI) Increase AI Review timeout to 120 minutes

### DIFF
--- a/.github/workflows/opencode-review-runner.yml
+++ b/.github/workflows/opencode-review-runner.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
 
       - name: Run automated code review
         id: review
-        timeout-minutes: 55
+        timeout-minutes: 115
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -61,7 +61,7 @@ jobs:
   sync-status:
     name: Sync review status
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     if: github.event_name == 'pull_request_target'
     steps:
       - name: Check automated review decision for current PR head


### PR DESCRIPTION
Because we previously modified the thinking level to xhigh, the existing 60-minute thinking time is expected to be insufficient for large PRs.