### PR TITLE
[fix](fe) Fix testExpiredJobCancellation hanging due to race condition with daemon thread

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchemaInitializer;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
@@ -34,6 +35,7 @@ import org.apache.doris.utframe.TestWithFeService;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -61,12 +63,18 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
     }
 
     @Test
+    @Timeout(60)
     public void testExpiredJobCancellation() throws Exception {
         InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
         Database database = Mockito.mock(Database.class);
         OlapTable olapTable = Mockito.mock(OlapTable.class);
 
-        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+        try (MockedStatic<StatisticsUtil> mockedStatisticsUtil = Mockito.mockStatic(StatisticsUtil.class);
+                MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            // Prevent the daemon thread "Expired Analysis Task Killer" from starting,
+            // so only the test thread calls tryToCancel() — eliminating the race condition.
+            mockedEnv.when(Env::isCheckpointThread).thenReturn(true);
+
             mockedStatisticsUtil.when(() -> StatisticsUtil.convertIdToObjects(
                     Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
                     .thenReturn(new DBObjects(catalog, database, olapTable));


### PR DESCRIPTION
[fix](fe) Fix testExpiredJobCancellation hanging due to race condition with daemon thread

### What problem does this PR solve?

Issue Number: close #DORIS-25120

Problem Summary: The `testExpiredJobCancellation` test in `AnalysisTaskExecutorTest`
hangs indefinitely due to a race condition. The `AnalysisTaskExecutor` constructor
starts a daemon thread ("Expired Analysis Task Killer") that calls `tryToCancel()`,
which blocks on `taskQueue.take()`. The test also calls `tryToCancel()` directly.
Two consumers race for the single item in the queue — if the daemon thread wins,
the test thread blocks forever.

This was introduced by commit 833a8a8f98b (#62221, JMockit→Mockito migration).
The removed JMockit agent bytecode instrumentation overhead was incidentally slowing
daemon thread startup, making the main thread usually win the race.

The fix mocks `Env.isCheckpointThread()` to return `true` so the constructor skips
`cancelExpiredTask()`, preventing the daemon thread from starting. This ensures only
the test thread calls `tryToCancel()`, eliminating the race. A `@Timeout(60)` annotation
is added as a safety net. Only the test is modified — the production `take()` blocking
behavior is correct by design (single consumer in production).

### Release note

None

### Check List (For Author)

- Test: Unit Test (ran 5 times with 0 flakiness)
- Behavior changed: No
- Does this need documentation: No