### PR TITLE
[fix](web) FE startup fail due to websocket startup

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebServerFactoryCustomizerConfig.java
@@ -19,6 +19,10 @@ package org.apache.doris.httpv2.config;
 
 import org.apache.doris.common.Config;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.ee10.websocket.server.config.JettyWebSocketServletContainerInitializer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ServerConnector;
@@ -31,10 +35,24 @@ import java.util.Collections;
 
 @Configuration
 public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomizer<ConfigurableJettyWebServerFactory> {
+    private static final Logger LOG = LogManager.getLogger(WebServerFactoryCustomizerConfig.class);
+
     @Override
     public void customize(ConfigurableJettyWebServerFactory factory) {
 
         // Set HTTP header size for all connectors
+        ((JettyServletWebServerFactory) factory).addServerCustomizers(server -> {
+            WebAppContext context = server.getDescendant(WebAppContext.class);
+            if (context != null) {
+                try {
+                    JettyWebSocketServletContainerInitializer.configure(context, null);
+                } catch (Exception e) {
+                    LOG.error("Failed to initialize WebSocket support", e);
+                    throw new RuntimeException("Failed to initialize WebSocket support", e);
+                }
+            }
+        });
+
         factory.addServerCustomizers(server -> {
             for (org.eclipse.jetty.server.Connector connector : server.getConnectors()) {
                 if (connector instanceof ServerConnector) {
@@ -53,19 +71,18 @@ public class WebServerFactoryCustomizerConfig implements WebServerFactoryCustomi
                     Collections.singletonList(new HttpToHttpsJettyConfig())
             );
 
-            factory.addServerCustomizers(
-                    server -> {
-                        HttpConfiguration httpConfiguration = new HttpConfiguration();
-                        httpConfiguration.setSecurePort(Config.https_port);
-                        httpConfiguration.setSecureScheme("https");
-
-                        ServerConnector connector = new ServerConnector(server);
-                        connector.addConnectionFactory(new HttpConnectionFactory(httpConfiguration));
-                        connector.setPort(Config.http_port);
-
-                        server.addConnector(connector);
+            factory.addServerCustomizers(server -> {
+                if (server.getConnectors() != null && server.getConnectors().length > 0) {
+                    ServerConnector existingConnector = (ServerConnector) server.getConnectors()[0];
+                    HttpConnectionFactory httpFactory =
+                            existingConnector.getConnectionFactory(HttpConnectionFactory.class);
+                    if (httpFactory != null) {
+                        HttpConfiguration httpConfig = httpFactory.getHttpConfiguration();
+                        httpConfig.setSecurePort(Config.https_port);
+                        httpConfig.setSecureScheme("https");
                     }
-            );
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary
Pick #60369 to branch-4.1

## Changes
- Fix FE startup failure when enable_https=true by using Spring Boot's addServerCustomizers() hook to initialize WebSocket support before WebAppContext starts
- Compatible with branch-4.1's existing HTTP header size configuration

## Test
- [x] FE build passed

## Related Issue
close #60366