### PR TITLE
[refine](storage) remove mock column workaround in segment iterator common expr evaluation

### DIFF
--- a/be/src/exec/operator/table_function_operator.cpp
+++ b/be/src/exec/operator/table_function_operator.cpp
@@ -716,7 +716,8 @@ Status TableFunctionLocalState::_get_expanded_block_for_outer_conjuncts(RuntimeS
         ColumnNumbers columns_to_filter(column_count);
         std::iota(columns_to_filter.begin(), columns_to_filter.end(), 0);
         RETURN_IF_ERROR(VExprContext::execute_conjuncts_and_filter_block(
-                _expand_conjuncts_ctxs, output_block, columns_to_filter, column_count, filter));
+                _expand_conjuncts_ctxs, output_block, columns_to_filter, column_count, filter,
+                output_block->rows()));
         size_t remain_row_count = output_block->rows();
         // for outer table function, need to handle those child rows which all expanded rows are filtered out
         auto handled_child_row_count = handled_row_indices.size();

--- a/be/src/exprs/vexpr_context.cpp
+++ b/be/src/exprs/vexpr_context.cpp
@@ -357,12 +357,19 @@ Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs&
 
 Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs& ctxs, Block* block,
                                                         std::vector<uint32_t>& columns_to_filter,
-                                                        int column_to_keep,
-                                                        IColumn::Filter& filter) {
+                                                        int column_to_keep, IColumn::Filter& filter,
+                                                        size_t num_rows) {
     _reset_memory_usage(ctxs);
-    filter.resize_fill(block->rows(), 1);
-    bool can_filter_all;
-    RETURN_IF_ERROR(execute_conjuncts(ctxs, nullptr, false, block, &filter, &can_filter_all));
+    filter.resize_fill(num_rows, 1);
+    bool can_filter_all = false;
+    auto* __restrict result_filter_data = filter.data();
+    for (const auto& ctx : ctxs) {
+        RETURN_IF_ERROR(
+                ctx->execute_filter(block, result_filter_data, num_rows, false, &can_filter_all));
+        if (can_filter_all) {
+            break;
+        }
+    }
 
     // Accumulate the usage of `result_filter` into the first context.
     if (!ctxs.empty()) {

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -314,9 +314,13 @@ public:
             const VExprContextSPtrs& ctxs, Block* block, std::vector<uint32_t>& columns_to_filter,
             int column_to_keep);
 
+    // Uses an explicit num_rows instead of block->rows() to determine the filter size.
+    // This is needed when block columns may have different row counts
+    // (e.g., during segment iterator lazy materialization).
     static Status execute_conjuncts_and_filter_block(const VExprContextSPtrs& ctxs, Block* block,
                                                      std::vector<uint32_t>& columns_to_filter,
-                                                     int column_to_keep, IColumn::Filter& filter);
+                                                     int column_to_keep, IColumn::Filter& filter,
+                                                     size_t num_rows);
 
     [[nodiscard]] static Status get_output_block_after_execute_exprs(const VExprContextSPtrs&,
                                                                      const Block&, Block*,

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -2826,20 +2826,8 @@ Status SegmentIterator::_process_eof(Block* block) {
 
 Status SegmentIterator::_process_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size,
                                              Block* block) {
-    // Here we just use col0 as row_number indicator. when reach here, we will calculate the predicates first.
-    //  then use the result to reduce our data read(that is, expr push down). there's now row in block means the first
-    //  column is not in common expr. so it's safe to replace it temporarily to provide correct `selected_size`.
     VLOG_DEBUG << fmt::format("Execute common expr. block rows {}, selected size {}", block->rows(),
                               _selected_size);
-
-    bool need_mock_col = block->rows() != selected_size;
-    MutableColumnPtr col0;
-    if (need_mock_col) {
-        col0 = std::move(*block->get_by_position(0).column).mutate();
-        block->replace_by_position(
-                0, block->get_by_position(0).type->create_column_const_with_default_value(
-                           _selected_size));
-    }
 
     std::vector<VExprContext*> common_ctxs;
     common_ctxs.reserve(_common_expr_ctxs_push_down.size());
@@ -2850,10 +2838,6 @@ Status SegmentIterator::_process_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
     block->shrink_char_type_column_suffix_zero(_char_type_idx);
     RETURN_IF_ERROR(_execute_common_expr(_sel_rowid_idx.data(), _selected_size, block));
 
-    if (need_mock_col) {
-        block->replace_by_position(0, std::move(col0));
-    }
-
     VLOG_DEBUG << fmt::format("Execute common expr end. block rows {}, selected size {}",
                               block->rows(), _selected_size);
     return Status::OK();
@@ -2863,14 +2847,15 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
                                              Block* block) {
     SCOPED_RAW_TIMER(&_opts.stats->expr_filter_ns);
     DCHECK(!_remaining_conjunct_roots.empty());
-    DCHECK(block->rows() != 0);
+    DCHECK(selected_size > 0);
     int prev_columns = block->columns();
     uint16_t original_size = selected_size;
     _opts.stats->expr_cond_input_rows += original_size;
 
     IColumn::Filter filter;
     RETURN_IF_ERROR(VExprContext::execute_conjuncts_and_filter_block(
-            _common_expr_ctxs_push_down, block, _columns_to_filter, prev_columns, filter));
+            _common_expr_ctxs_push_down, block, _columns_to_filter, prev_columns, filter,
+            selected_size));
 
     selected_size = _evaluate_common_expr_filter(sel_rowid_idx, selected_size, filter);
     _opts.stats->rows_expr_cond_filtered += original_size - selected_size;
@@ -2923,7 +2908,7 @@ void SegmentIterator::_output_index_result_column(const std::vector<VExprContext
                                                   uint16_t* sel_rowid_idx, uint16_t select_size,
                                                   Block* block) {
     SCOPED_RAW_TIMER(&_opts.stats->output_index_result_column_timer);
-    if (block->rows() == 0) {
+    if (select_size == 0) {
         return;
     }
     for (auto* expr_ctx_ptr : expr_ctxs) {
@@ -2937,7 +2922,7 @@ void SegmentIterator::_output_index_result_column(const std::vector<VExprContext
             const auto& index_result_bitmap = result_bitmap.get_data_bitmap();
             auto index_result_column = ColumnUInt8::create();
             ColumnUInt8::Container& vec_match_pred = index_result_column->get_data();
-            vec_match_pred.resize(block->rows());
+            vec_match_pred.resize(select_size);
             std::fill(vec_match_pred.begin(), vec_match_pred.end(), 0);
 
             const auto& null_bitmap = result_bitmap.get_null_bitmap();
@@ -2949,7 +2934,7 @@ void SegmentIterator::_output_index_result_column(const std::vector<VExprContext
             if (has_null_bitmap && expr_returns_nullable) {
                 null_map_column = ColumnUInt8::create();
                 auto& null_map_vec = null_map_column->get_data();
-                null_map_vec.resize(block->rows());
+                null_map_vec.resize(select_size);
                 std::fill(null_map_vec.begin(), null_map_vec.end(), 0);
                 null_map_data = &null_map_column->get_data();
             }
@@ -2966,7 +2951,7 @@ void SegmentIterator::_output_index_result_column(const std::vector<VExprContext
                 }
             }
 
-            DCHECK(block->rows() == vec_match_pred.size());
+            DCHECK(select_size == vec_match_pred.size());
 
             if (null_map_column) {
                 index_ctx->set_index_result_column_for_expr(


### PR DESCRIPTION
## What problem does this PR solve?

Previously, `_process_common_expr` in `SegmentIterator` had a workaround that temporarily replaced column 0 with a const default column of `selected_size` rows. This was necessary because `execute_conjuncts_and_filter_block` internally used `block->rows()` to determine the filter size, but during lazy materialization the block columns could have different row counts than the actual `selected_size`.

Now that `VExpr::execute_filter` and `VExpr::execute_column` accept an explicit `count`/`num_rows` parameter, this mock column trick is no longer needed. The filter size can be driven by `selected_size` directly.

## Changes

1. **Removed mock column logic from `_process_common_expr`** — deleted the `need_mock_col` / `col0` save/restore code and the associated comment.

2. **Added new `execute_conjuncts_and_filter_block` overload with explicit `num_rows`** — a new 6-argument overload in `VExprContext` that uses `num_rows` instead of `block->rows()` for the filter size. Internally it calls `execute_filter` with the explicit row count.

3. **Deleted old 5-argument overload** — the previous `execute_conjuncts_and_filter_block(ctxs, block, columns_to_filter, column_to_keep, filter)` overload (which used `block->rows()`) was removed. Its only external caller (`table_function_operator.cpp`) was migrated to the new 6-arg overload with `output_block->rows()`.

4. **Replaced `block->rows()` with `select_size` in `_output_index_result_column`** — the early return check, `vec_match_pred.resize`, `null_map_vec.resize`, and DCHECK all now use the `select_size` parameter instead of `block->rows()`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

