### PR TITLE
[fix](csv reader) fix "\N" being parsed as NULL when using enclose

### DIFF
--- a/be/src/format/csv/csv_reader.cpp
+++ b/be/src/format/csv/csv_reader.cpp
@@ -200,6 +200,7 @@ CsvReader::CsvReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounte
     _size = _range.size;
 
     _split_values.reserve(_file_slot_descs.size());
+    _split_values_were_enclosed.reserve(_file_slot_descs.size());
     _init_system_properties();
     _init_file_description();
     _serdes = create_data_type_serdes(_file_slot_descs);
@@ -473,15 +474,33 @@ Status CsvReader::get_parsed_schema(std::vector<std::string>* col_names,
     return Status::OK();
 }
 
-Status CsvReader::_deserialize_nullable_string(IColumn& column, Slice& slice) {
-    auto& null_column = assert_cast<ColumnNullable&>(column);
-    if (_empty_field_as_null) {
-        if (slice.size == 0) {
-            null_column.insert_data(nullptr, 0);
-            return Status::OK();
+bool CsvReader::is_enclosed_csv_field(const Slice& line, size_t value_start_offset,
+                                      size_t value_len, char enclose, bool trim_tailing_spaces) {
+    if (trim_tailing_spaces) {
+        while (value_len > 0 && line.data[value_start_offset + value_len - 1] == ' ') {
+            --value_len;
         }
     }
-    if (_options.null_len > 0 && !(_options.converted_from_string && slice.trim_double_quotes())) {
+    return value_len > 1 && line.data[value_start_offset] == enclose &&
+           line.data[value_start_offset + value_len - 1] == enclose;
+}
+
+Status CsvReader::_deserialize_nullable_string(IColumn& column, Slice& slice, bool was_enclosed) {
+    auto& null_column = assert_cast<ColumnNullable&>(column);
+
+    bool is_quoted_string = was_enclosed;
+    if (_options.converted_from_string) {
+        bool trimmed = slice.trim_double_quotes();
+        if (!was_enclosed) {
+            is_quoted_string = trimmed;
+        }
+    }
+
+    if (_empty_field_as_null && slice.size == 0 && !is_quoted_string) {
+        null_column.insert_data(nullptr, 0);
+        return Status::OK();
+    }
+    if (_options.null_len > 0 && !is_quoted_string) {
         if (slice.compare(Slice(_options.null_format, _options.null_len)) == 0) {
             null_column.insert_data(nullptr, 0);
             return Status::OK();
@@ -677,7 +696,9 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
             // For load task, we always read "string" from file.
             // So serdes[i] here must be DataTypeNullableSerDe, and DataTypeNullableSerDe -> nested_serde must be DataTypeStringSerDe.
             // So we use deserialize_nullable_string and stringSerDe to reduce virtual function calls.
-            RETURN_IF_ERROR(_deserialize_nullable_string(*col_ptr, value));
+            bool was_enclosed = col_idx < _split_values_were_enclosed.size() &&
+                                _split_values_were_enclosed[col_idx];
+            RETURN_IF_ERROR(_deserialize_nullable_string(*col_ptr, value, was_enclosed));
         } else {
             RETURN_IF_ERROR(_deserialize_one_cell(_serdes[i], *col_ptr, value));
         }
@@ -772,6 +793,30 @@ Status CsvReader::_line_split_to_values(const Slice& line, bool* success) {
 void CsvReader::_split_line(const Slice& line) {
     _split_values.clear();
     _fields_splitter->split_line(line, &_split_values);
+    _record_split_value_enclosed_flags(line);
+}
+
+void CsvReader::_record_split_value_enclosed_flags(const Slice& line) {
+    _split_values_were_enclosed.clear();
+    _split_values_were_enclosed.reserve(_split_values.size());
+    if (_enclose_reader_ctx == nullptr) {
+        _split_values_were_enclosed.resize(_split_values.size(), 0);
+        return;
+    }
+
+    size_t value_start_offset = 0;
+    for (auto idx : _enclose_reader_ctx->column_sep_positions()) {
+        _split_values_were_enclosed.push_back(
+                is_enclosed_csv_field(line, value_start_offset, idx - value_start_offset, _enclose,
+                                      _trim_tailing_spaces));
+        value_start_offset = idx + _value_separator_length;
+    }
+    if (line.size >= value_start_offset) {
+        _split_values_were_enclosed.push_back(
+                is_enclosed_csv_field(line, value_start_offset, line.size - value_start_offset,
+                                      _enclose, _trim_tailing_spaces));
+    }
+    DCHECK_EQ(_split_values_were_enclosed.size(), _split_values.size());
 }
 
 Status CsvReader::_parse_col_nums(size_t* col_nums) {

--- a/be/src/format/csv/csv_reader.h
+++ b/be/src/format/csv/csv_reader.h
@@ -196,7 +196,9 @@ protected:
     virtual Status _init_options();
     virtual Status _create_line_reader();
     virtual Status _deserialize_one_cell(DataTypeSerDeSPtr serde, IColumn& column, Slice& slice);
-    virtual Status _deserialize_nullable_string(IColumn& column, Slice& slice);
+    virtual Status _deserialize_nullable_string(IColumn& column, Slice& slice, bool was_enclosed);
+    static bool is_enclosed_csv_field(const Slice& line, size_t value_start_offset,
+                                      size_t value_len, char enclose, bool trim_tailing_spaces);
     // check the utf8 encoding of a line.
     // return error status to stop processing.
     // If return Status::OK but "success" is false, which means this is load request
@@ -227,6 +229,7 @@ private:
     Status _fill_empty_line(Block* block, std::vector<MutableColumnPtr>& columns, size_t* rows);
     Status _line_split_to_values(const Slice& line, bool* success);
     void _split_line(const Slice& line);
+    void _record_split_value_enclosed_flags(const Slice& line);
     void _init_system_properties();
     void _init_file_description();
 
@@ -282,6 +285,7 @@ private:
     std::shared_ptr<EncloseCsvLineReaderCtx> _enclose_reader_ctx;
     // save source text which have been splitted.
     std::vector<Slice> _split_values;
+    std::vector<uint8_t> _split_values_were_enclosed;
     std::vector<int> _use_nullable_string_opt;
 };
 } // namespace doris

--- a/be/src/format/text/text_reader.cpp
+++ b/be/src/format/text/text_reader.cpp
@@ -162,7 +162,8 @@ Status TextReader::_validate_line(const Slice& line, bool* success) {
     return Status::OK();
 }
 
-Status TextReader::_deserialize_nullable_string(IColumn& column, Slice& slice) {
+Status TextReader::_deserialize_nullable_string(IColumn& column, Slice& slice, bool was_enclosed) {
+    static_cast<void>(was_enclosed);
     auto& null_column = assert_cast<ColumnNullable&>(column);
     if (slice.compare(Slice(_options.null_format, _options.null_len)) == 0) {
         null_column.insert_data(nullptr, 0);

--- a/be/src/format/text/text_reader.h
+++ b/be/src/format/text/text_reader.h
@@ -64,7 +64,7 @@ private:
     Status _create_line_reader() override;
     Status _deserialize_one_cell(DataTypeSerDeSPtr serde, IColumn& column, Slice& slice) override;
     Status _validate_line(const Slice& line, bool* success) override;
-    Status _deserialize_nullable_string(IColumn& column, Slice& slice) override;
+    Status _deserialize_nullable_string(IColumn& column, Slice& slice, bool was_enclosed) override;
 };
 
 } // namespace doris

--- a/be/test/format/csv_reader_test.cpp
+++ b/be/test/format/csv_reader_test.cpp
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/csv/csv_reader.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/column/column_nullable.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_string.h"
+
+namespace doris {
+namespace {
+
+const std::vector<SlotDescriptor*>& empty_slot_descs() {
+    static const std::vector<SlotDescriptor*> slots;
+    return slots;
+}
+
+class CsvReaderForTest : public CsvReader {
+public:
+    CsvReaderForTest(const TFileScanRangeParams& params, const TFileRangeDesc& range)
+            : CsvReader(nullptr, nullptr, nullptr, params, range, empty_slot_descs(), nullptr) {}
+
+    using CsvReader::_deserialize_nullable_string;
+    using CsvReader::_init_options;
+    using CsvReader::is_enclosed_csv_field;
+};
+
+TFileScanRangeParams make_csv_params(bool empty_field_as_null) {
+    TFileScanRangeParams params;
+    params.__set_format_type(TFileFormatType::FORMAT_CSV_PLAIN);
+    params.__set_compress_type(TFileCompressType::UNKNOWN);
+    params.__set_file_type(TFileType::FILE_LOCAL);
+    params.file_attributes.text_params.column_separator = ",";
+    params.file_attributes.text_params.line_delimiter = "\n";
+    params.file_attributes.text_params.__isset.null_format = true;
+    params.file_attributes.text_params.null_format = "\\N";
+    params.file_attributes.text_params.__isset.empty_field_as_null = true;
+    params.file_attributes.text_params.empty_field_as_null = empty_field_as_null;
+    params.file_attributes.__isset.trim_double_quotes = true;
+    params.file_attributes.trim_double_quotes = true;
+    return params;
+}
+
+} // namespace
+
+TEST(CsvReaderTest, EnclosedFieldDetectionTracksTrimmedQuotes) {
+    std::string quoted_null = "\"\\N\"";
+    EXPECT_TRUE(CsvReaderForTest::is_enclosed_csv_field(Slice(quoted_null), 0, quoted_null.size(),
+                                                        '"', false));
+
+    std::string quoted_null_with_spaces = "\"\\N\"   ";
+    EXPECT_TRUE(CsvReaderForTest::is_enclosed_csv_field(Slice(quoted_null_with_spaces), 0,
+                                                        quoted_null_with_spaces.size(), '"', true));
+    EXPECT_FALSE(CsvReaderForTest::is_enclosed_csv_field(
+            Slice(quoted_null_with_spaces), 0, quoted_null_with_spaces.size(), '"', false));
+
+    std::string bare_null = "\\N";
+    EXPECT_FALSE(CsvReaderForTest::is_enclosed_csv_field(Slice(bare_null), 0, bare_null.size(), '"',
+                                                         false));
+}
+
+TEST(CsvReaderTest, NullableStringKeepsQuotedNullLiteralAsString) {
+    TFileScanRangeParams params = make_csv_params(true);
+    TFileRangeDesc range;
+    CsvReaderForTest reader(params, range);
+    ASSERT_TRUE(reader._init_options().ok());
+
+    auto column = make_nullable(std::make_shared<DataTypeString>())->create_column();
+    auto& nullable_column = assert_cast<ColumnNullable&>(*column);
+
+    std::string bare_null_literal = "\\N";
+    Slice bare_null_slice(bare_null_literal);
+    EXPECT_TRUE(reader._deserialize_nullable_string(*column, bare_null_slice, false).ok());
+    EXPECT_TRUE(nullable_column.is_null_at(0));
+
+    std::string enclosed_null_literal = "\\N";
+    Slice enclosed_null_slice(enclosed_null_literal);
+    EXPECT_TRUE(reader._deserialize_nullable_string(*column, enclosed_null_slice, true).ok());
+    EXPECT_FALSE(nullable_column.is_null_at(1));
+    EXPECT_EQ(nullable_column.get_nested_column().get_data_at(1).to_string(), "\\N");
+
+    std::string plain_quoted_null_literal = "\"\\N\"";
+    Slice plain_quoted_null_slice(plain_quoted_null_literal);
+    EXPECT_TRUE(reader._deserialize_nullable_string(*column, plain_quoted_null_slice, false).ok());
+    EXPECT_FALSE(nullable_column.is_null_at(2));
+    EXPECT_EQ(nullable_column.get_nested_column().get_data_at(2).to_string(), "\\N");
+
+    std::string enclosed_empty_string;
+    Slice enclosed_empty_slice(enclosed_empty_string);
+    EXPECT_TRUE(reader._deserialize_nullable_string(*column, enclosed_empty_slice, true).ok());
+    EXPECT_FALSE(nullable_column.is_null_at(3));
+    EXPECT_EQ(nullable_column.get_nested_column().get_data_at(3).to_string(), "");
+}
+
+} // namespace doris


### PR DESCRIPTION
### 1. What is the problem?

When CSV parsing is configured with:

- `trim_double_quotes=true`
- `enclose='"'`
- nullable string columns

quoted `"\N"` is incorrectly parsed as `NULL`.

The expected behavior is:

- bare `\N` -> `NULL`
- quoted `"\N"` -> string `\N`

The root cause is that the CSV splitter removes enclosing quotes before nullable string
null detection runs, so quoted `"\N"` and bare `\N` become indistinguishable by the time
the null check happens.

This affects the shared CSV reader path, so the same issue appears in `s3()`, `file()`,
and `http_stream()`.

### 2. How is it fixed?

The fix preserves whether each CSV field was originally enclosed by the configured
`enclose` character when the line is split.

That enclosed-state is then passed into nullable string deserialization, so null detection
can distinguish:

- a bare null literal
- a quoted string literal that happens to equal `\N`

Instead of relying only on the already-trimmed `Slice`, the nullable string path now uses
the preserved enclosed-state to decide whether `\N` should be treated as NULL.

### 3. What is the behavior after the fix?

After the fix:

- bare `\N` is still parsed as `NULL`
- quoted `"\N"` is preserved as string `\N`
- quoted empty string remains an empty string
- unquoted empty field still follows `empty_field_as_null` behavior

In other words, quoted values are no longer mistaken for null literals just because their
content matches `\N`.

### 4. What test cases were added?

Added unit tests cover:

- enclosed-field detection for quoted values
- enclosed-field detection with trailing spaces
- bare `\N` -> `NULL`
- quoted `\N` with preserved enclosed-state -> string `\N`
- non-enclose path quoted `"\\N"` with `trim_double_quotes` -> string `\N`
- quoted empty string does not become `NULL`
