### PR TITLE
[opt](function) optimize trim_in/ltrim_in/rtrim_in with SIMD-accelerated character lookup

### DIFF
--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -26,6 +26,7 @@
 #include "benchmark_hybrid_set.hpp"
 #include "benchmark_string.hpp"
 #include "benchmark_string_replace.hpp"
+#include "benchmark_trim.hpp"
 #include "binary_cast_benchmark.hpp"
 #include "core/block/block.h"
 #include "core/column/column_string.h"

--- a/be/benchmark/benchmark_trim.hpp
+++ b/be/benchmark/benchmark_trim.hpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "core/column/column_string.h"
+#include "exprs/function/url/find_symbols.h"
 #include "util/simd/vstring_function.h"
 
 namespace doris {
@@ -144,7 +145,120 @@ struct TrimInOld {
     }
 };
 
-// TrimInNew struct removed — New benchmarks call the real TrimInUtil::vector() directly
+// TrimInNew — mirrors the optimized implementation from function_string.cpp
+// Inlined here because TrimInUtil is defined inside a .cpp and not visible to benchmarks
+struct TrimInNew {
+    static void trim_in_ascii_new(const ColumnString::Chars& str_data,
+                                  const ColumnString::Offsets& str_offsets,
+                                  const StringRef& remove_str, ColumnString::Chars& res_data,
+                                  ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        SearchSymbols symbols(std::string(remove_str.data, remove_str.size));
+
+        bool char_lookup[256] = {};
+        for (size_t j = 0; j < remove_str.size; ++j) {
+            char_lookup[static_cast<unsigned char>(remove_str.data[j])] = true;
+        }
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            if (left_trim_pos < str_end &&
+                char_lookup[static_cast<unsigned char>(*left_trim_pos)]) {
+                left_trim_pos = find_first_not_symbols(
+                        std::string_view(str_begin, str_end - str_begin), symbols);
+            }
+
+            // rtrim
+            if (right_trim_pos > left_trim_pos &&
+                char_lookup[static_cast<unsigned char>(*(right_trim_pos - 1))]) {
+                const char* pos =
+                        find_last_not_symbols_or_null(left_trim_pos, right_trim_pos, symbols);
+                right_trim_pos = pos ? pos + 1 : left_trim_pos;
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+
+    static void trim_in_utf8_new(const ColumnString::Chars& str_data,
+                                 const ColumnString::Offsets& str_offsets,
+                                 const StringRef& remove_str, ColumnString::Chars& res_data,
+                                 ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        static constexpr size_t MAX_TRIM_CHARS = 32;
+        struct Utf8Char {
+            char data[6];
+            uint8_t len;
+        };
+        Utf8Char trim_chars[MAX_TRIM_CHARS];
+        size_t num_trim_chars = 0;
+
+        const char* remove_begin = remove_str.data;
+        const char* remove_end = remove_str.data + remove_str.size;
+
+        while (remove_begin < remove_end && num_trim_chars < MAX_TRIM_CHARS) {
+            uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*remove_begin));
+            if (remove_begin + byte_len > remove_end) break;
+            trim_chars[num_trim_chars].len = byte_len;
+            memcpy(trim_chars[num_trim_chars].data, remove_begin, byte_len);
+            ++num_trim_chars;
+            remove_begin += byte_len;
+        }
+
+        auto is_trim_char = [&](const char* pos, size_t byte_len) -> bool {
+            for (size_t c = 0; c < num_trim_chars; ++c) {
+                if (trim_chars[c].len == byte_len &&
+                    memcmp(trim_chars[c].data, pos, byte_len) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            while (left_trim_pos < str_end) {
+                uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*left_trim_pos));
+                if (left_trim_pos + byte_len > str_end) break;
+                if (!is_trim_char(left_trim_pos, byte_len)) break;
+                left_trim_pos += byte_len;
+            }
+
+            // rtrim
+            while (right_trim_pos > left_trim_pos) {
+                const char* prev_char_pos = right_trim_pos;
+                do {
+                    --prev_char_pos;
+                } while (prev_char_pos > left_trim_pos && (*prev_char_pos & 0xC0) == 0x80);
+                size_t byte_len = right_trim_pos - prev_char_pos;
+                if (!is_trim_char(prev_char_pos, byte_len)) break;
+                right_trim_pos = prev_char_pos;
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+};
 
 // ==================== Benchmark helpers ====================
 
@@ -248,10 +362,8 @@ static void BM_TrimInAscii_New(benchmark::State& state) {
 
     for (auto _ : state) {
         auto res = ColumnString::create();
-        // Call real implementation
-        static_cast<void>(TrimInUtil<true, true, false>::vector(
-                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
-                res->get_offsets()));
+        TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
         benchmark::DoNotOptimize(res);
     }
 
@@ -292,10 +404,8 @@ static void BM_TrimInUtf8_New(benchmark::State& state) {
 
     for (auto _ : state) {
         auto res = ColumnString::create();
-        // Call real implementation
-        static_cast<void>(TrimInUtil<true, true, false>::vector(
-                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
-                res->get_offsets()));
+        TrimInNew::trim_in_utf8_new(col->get_chars(), col->get_offsets(), remove_str,
+                                    res->get_chars(), res->get_offsets());
         benchmark::DoNotOptimize(res);
     }
 
@@ -337,10 +447,8 @@ static void BM_TrimInAsciiManyChars_New(benchmark::State& state) {
 
     for (auto _ : state) {
         auto res = ColumnString::create();
-        // Call real implementation
-        static_cast<void>(TrimInUtil<true, true, false>::vector(
-                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
-                res->get_offsets()));
+        TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
         benchmark::DoNotOptimize(res);
     }
 
@@ -390,10 +498,8 @@ static void BM_TrimInAsciiNoMatch_New(benchmark::State& state) {
 
     for (auto _ : state) {
         auto res = ColumnString::create();
-        // Call real implementation
-        static_cast<void>(TrimInUtil<true, true, false>::vector(
-                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
-                res->get_offsets()));
+        TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
         benchmark::DoNotOptimize(res);
     }
 

--- a/be/benchmark/benchmark_trim.hpp
+++ b/be/benchmark/benchmark_trim.hpp
@@ -145,8 +145,10 @@ struct TrimInOld {
     }
 };
 
-// TrimInNew — mirrors the optimized implementation from function_string.cpp
-// Inlined here because TrimInUtil is defined inside a .cpp and not visible to benchmarks
+// TrimInNew — mirrors the optimized hot path from function_string.cpp
+// Inlined here because TrimInUtil is defined inside a .cpp and not visible to benchmarks.
+// Only covers the <=16 ASCII chars and <=32 UTF-8 codepoints paths (benchmark scenarios
+// do not exercise the fallback paths for larger trim sets).
 struct TrimInNew {
     static void trim_in_ascii_new(const ColumnString::Chars& str_data,
                                   const ColumnString::Offsets& str_offsets,
@@ -361,6 +363,12 @@ static void BM_TrimInAscii_New(benchmark::State& state) {
     StringRef remove_str(trim_chars.data(), trim_chars.size());
 
     for (auto _ : state) {
+        // Match production overhead: is_ascii check on both remove_str and column data
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
         auto res = ColumnString::create();
         TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
                                      res->get_chars(), res->get_offsets());
@@ -403,6 +411,12 @@ static void BM_TrimInUtf8_New(benchmark::State& state) {
     StringRef remove_str(trim_chars.data(), trim_chars.size());
 
     for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
         auto res = ColumnString::create();
         TrimInNew::trim_in_utf8_new(col->get_chars(), col->get_offsets(), remove_str,
                                     res->get_chars(), res->get_offsets());
@@ -446,6 +460,12 @@ static void BM_TrimInAsciiManyChars_New(benchmark::State& state) {
     StringRef remove_str(trim_chars.data(), trim_chars.size());
 
     for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
         auto res = ColumnString::create();
         TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
                                      res->get_chars(), res->get_offsets());
@@ -461,7 +481,6 @@ static void BM_TrimInAsciiNoMatch_Old(benchmark::State& state) {
     std::string trim_chars = "xyz"; // chars unlikely in data
     auto col = ColumnString::create();
     // prepare data without any trim chars
-    std::mt19937 gen(42);
     for (size_t i = 0; i < num_rows; ++i) {
         std::string s(30, 'a');
         col->insert_data(s.data(), s.size());
@@ -497,6 +516,12 @@ static void BM_TrimInAsciiNoMatch_New(benchmark::State& state) {
     StringRef remove_str(trim_chars.data(), trim_chars.size());
 
     for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
         auto res = ColumnString::create();
         TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
                                      res->get_chars(), res->get_offsets());

--- a/be/benchmark/benchmark_trim.hpp
+++ b/be/benchmark/benchmark_trim.hpp
@@ -1,0 +1,467 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include <bitset>
+#include <random>
+#include <string>
+#include <unordered_set>
+
+#ifdef __SSE4_2__
+#include <nmmintrin.h>
+#endif
+
+#include "core/column/column_string.h"
+#include "util/simd/vstring_function.h"
+
+namespace doris {
+
+// ==================== Old implementations (current Doris) ====================
+
+struct TrimInOld {
+    // Old ASCII path: std::bitset<128> + scalar loop
+    static void trim_in_ascii_old(const ColumnString::Chars& str_data,
+                                  const ColumnString::Offsets& str_offsets,
+                                  const StringRef& remove_str, ColumnString::Chars& res_data,
+                                  ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        std::bitset<128> char_lookup;
+        const char* remove_begin = remove_str.data;
+        const char* remove_end = remove_str.data + remove_str.size;
+
+        while (remove_begin < remove_end) {
+            char_lookup.set(static_cast<unsigned char>(*remove_begin));
+            remove_begin += 1;
+        }
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            while (left_trim_pos < str_end) {
+                if (!char_lookup.test(static_cast<unsigned char>(*left_trim_pos))) {
+                    break;
+                }
+                ++left_trim_pos;
+            }
+
+            // rtrim
+            while (right_trim_pos > left_trim_pos) {
+                --right_trim_pos;
+                if (!char_lookup.test(static_cast<unsigned char>(*right_trim_pos))) {
+                    ++right_trim_pos;
+                    break;
+                }
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+
+    // Old UTF-8 path: unordered_set<string_view> + hash lookup
+    static void trim_in_utf8_old(const ColumnString::Chars& str_data,
+                                 const ColumnString::Offsets& str_offsets,
+                                 const StringRef& remove_str, ColumnString::Chars& res_data,
+                                 ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        std::unordered_set<std::string_view> char_lookup;
+        const char* remove_begin = remove_str.data;
+        const char* remove_end = remove_str.data + remove_str.size;
+
+        while (remove_begin < remove_end) {
+            size_t byte_len, char_len;
+            std::tie(byte_len, char_len) = simd::VStringFunctions::iterate_utf8_with_limit_length(
+                    remove_begin, remove_end, 1);
+            char_lookup.insert(std::string_view(remove_begin, byte_len));
+            remove_begin += byte_len;
+        }
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            while (left_trim_pos < str_end) {
+                size_t byte_len, char_len;
+                std::tie(byte_len, char_len) =
+                        simd::VStringFunctions::iterate_utf8_with_limit_length(left_trim_pos,
+                                                                               str_end, 1);
+                if (char_lookup.find(std::string_view(left_trim_pos, byte_len)) ==
+                    char_lookup.end()) {
+                    break;
+                }
+                left_trim_pos += byte_len;
+            }
+
+            // rtrim
+            while (right_trim_pos > left_trim_pos) {
+                const char* prev_char_pos = right_trim_pos;
+                do {
+                    --prev_char_pos;
+                } while ((*prev_char_pos & 0xC0) == 0x80);
+                size_t byte_len = right_trim_pos - prev_char_pos;
+                if (char_lookup.find(std::string_view(prev_char_pos, byte_len)) ==
+                    char_lookup.end()) {
+                    break;
+                }
+                right_trim_pos = prev_char_pos;
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+};
+
+// TrimInNew struct removed — New benchmarks call the real TrimInUtil::vector() directly
+
+// ==================== Benchmark helpers ====================
+
+static void prepare_ascii_column(ColumnString& col, size_t num_rows, size_t str_len,
+                                 const std::string& trim_chars_str) {
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> char_dist(32, 126); // printable ASCII
+    std::uniform_int_distribution<int> trim_count_dist(0, 10);
+
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s;
+        // Add random trim chars at front
+        int front_count = trim_count_dist(gen);
+        for (int j = 0; j < front_count; ++j) {
+            s += trim_chars_str[gen() % trim_chars_str.size()];
+        }
+        // Add random non-trim content
+        for (size_t j = 0; j < str_len; ++j) {
+            char c;
+            do {
+                c = static_cast<char>(char_dist(gen));
+            } while (trim_chars_str.find(c) != std::string::npos);
+            s += c;
+        }
+        // Add random trim chars at back
+        int back_count = trim_count_dist(gen);
+        for (int j = 0; j < back_count; ++j) {
+            s += trim_chars_str[gen() % trim_chars_str.size()];
+        }
+        col.insert_data(s.data(), s.size());
+    }
+}
+
+static void prepare_utf8_column(ColumnString& col, size_t num_rows) {
+    // Use a mix of ASCII and multi-byte UTF-8 characters
+    // trim chars: "你好" (6 bytes, 2 chars)
+    std::mt19937 gen(42);
+
+    // some multi-byte chars for content
+    const char* content_chars[] = {"a", "b", "c", "世", "界", "测", "试"};
+    const size_t num_content = 7;
+    // trim chars
+    const char* trim_parts[] = {"你", "好"};
+    const size_t num_trim = 2;
+
+    std::uniform_int_distribution<int> trim_count_dist(0, 5);
+    std::uniform_int_distribution<int> content_dist(0, num_content - 1);
+    std::uniform_int_distribution<int> trim_dist(0, num_trim - 1);
+
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s;
+        int front = trim_count_dist(gen);
+        for (int j = 0; j < front; ++j) {
+            s += trim_parts[trim_dist(gen)];
+        }
+        // 10 content chars
+        for (int j = 0; j < 10; ++j) {
+            s += content_chars[content_dist(gen)];
+        }
+        int back = trim_count_dist(gen);
+        for (int j = 0; j < back; ++j) {
+            s += trim_parts[trim_dist(gen)];
+        }
+        col.insert_data(s.data(), s.size());
+    }
+}
+
+// ==================== Benchmark functions ====================
+
+static void BM_TrimInAscii_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check on both remove_str and column data
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_ascii_old(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInAscii_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        auto res = ColumnString::create();
+        // Call real implementation
+        static_cast<void>(TrimInUtil<true, true, false>::vector(
+                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
+                res->get_offsets()));
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInUtf8_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    auto col = ColumnString::create();
+    prepare_utf8_column(*col, num_rows);
+
+    std::string trim_chars = "你好";
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_utf8_old(col->get_chars(), col->get_offsets(), remove_str,
+                                    res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInUtf8_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    auto col = ColumnString::create();
+    prepare_utf8_column(*col, num_rows);
+
+    std::string trim_chars = "你好";
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        auto res = ColumnString::create();
+        // Call real implementation
+        static_cast<void>(TrimInUtil<true, true, false>::vector(
+                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
+                res->get_offsets()));
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+// ---- ASCII: many trim chars (8 chars) ----
+static void BM_TrimInAsciiManyChars_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r.,-;";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_ascii_old(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInAsciiManyChars_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r.,-;";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        auto res = ColumnString::create();
+        // Call real implementation
+        static_cast<void>(TrimInUtil<true, true, false>::vector(
+                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
+                res->get_offsets()));
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+// ---- No-match scenario (nothing to trim) ----
+static void BM_TrimInAsciiNoMatch_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = "xyz"; // chars unlikely in data
+    auto col = ColumnString::create();
+    // prepare data without any trim chars
+    std::mt19937 gen(42);
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s(30, 'a');
+        col->insert_data(s.data(), s.size());
+    }
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_ascii_old(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInAsciiNoMatch_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = "xyz";
+    auto col = ColumnString::create();
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s(30, 'a');
+        col->insert_data(s.data(), s.size());
+    }
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        auto res = ColumnString::create();
+        // Call real implementation
+        static_cast<void>(TrimInUtil<true, true, false>::vector(
+                col->get_chars(), col->get_offsets(), remove_str, res->get_chars(),
+                res->get_offsets()));
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+} // namespace doris
+
+BENCHMARK(doris::BM_TrimInAscii_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAscii_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiManyChars_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiManyChars_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiNoMatch_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiNoMatch_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInUtf8_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInUtf8_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();

--- a/be/src/exprs/function/function_string.cpp
+++ b/be/src/exprs/function/function_string.cpp
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
+#include <unordered_set>
 
 #include "common/cast_set.h"
 #include "common/status.h"
@@ -764,13 +765,17 @@ private:
                                      ColumnString::Offsets& res_offsets) {
         const size_t offset_size = str_offsets.size();
 
-        // Use SearchSymbols for SIMD-accelerated lookup (SSE4.2 for >=5 chars, SSE2 for <5)
-        SearchSymbols symbols(std::string(remove_str.data, remove_str.size));
-
-        // Build scalar lookup table for early-exit: skip SIMD when first/last byte is not a trim char
+        // Build scalar lookup table (works for any number of trim chars)
         bool char_lookup[256] = {};
         for (size_t j = 0; j < remove_str.size; ++j) {
             char_lookup[static_cast<unsigned char>(remove_str.data[j])] = true;
+        }
+
+        // SearchSymbols buffer is capped at 16 bytes; use SIMD only when within limit
+        const bool use_simd = remove_str.size <= SearchSymbols::BUFFER_SIZE;
+        SearchSymbols symbols;
+        if (use_simd) {
+            symbols = SearchSymbols(std::string(remove_str.data, remove_str.size));
         }
 
         for (size_t i = 0; i < offset_size; ++i) {
@@ -783,17 +788,31 @@ private:
             if constexpr (is_ltrim) {
                 if (left_trim_pos < str_end &&
                     char_lookup[static_cast<unsigned char>(*left_trim_pos)]) {
-                    left_trim_pos = find_first_not_symbols(
-                            std::string_view(str_begin, str_end - str_begin), symbols);
+                    if (use_simd) {
+                        left_trim_pos = find_first_not_symbols(
+                                std::string_view(str_begin, str_end - str_begin), symbols);
+                    } else {
+                        while (left_trim_pos < str_end &&
+                               char_lookup[static_cast<unsigned char>(*left_trim_pos)]) {
+                            ++left_trim_pos;
+                        }
+                    }
                 }
             }
 
             if constexpr (is_rtrim) {
                 if (right_trim_pos > left_trim_pos &&
                     char_lookup[static_cast<unsigned char>(*(right_trim_pos - 1))]) {
-                    const char* pos =
-                            find_last_not_symbols_or_null(left_trim_pos, right_trim_pos, symbols);
-                    right_trim_pos = pos ? pos + 1 : left_trim_pos;
+                    if (use_simd) {
+                        const char* pos = find_last_not_symbols_or_null(left_trim_pos,
+                                                                        right_trim_pos, symbols);
+                        right_trim_pos = pos ? pos + 1 : left_trim_pos;
+                    } else {
+                        while (right_trim_pos > left_trim_pos &&
+                               char_lookup[static_cast<unsigned char>(*(right_trim_pos - 1))]) {
+                            --right_trim_pos;
+                        }
+                    }
                 }
             }
 
@@ -835,7 +854,23 @@ private:
             remove_begin += byte_len;
         }
 
+        // Fall back to unordered_set if trim set exceeds fixed array capacity
+        const bool use_set = remove_begin < remove_end;
+        std::unordered_set<std::string_view> trim_set;
+        if (use_set) {
+            remove_begin = remove_str.data;
+            while (remove_begin < remove_end) {
+                uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*remove_begin));
+                if (remove_begin + byte_len > remove_end) break;
+                trim_set.emplace(remove_begin, byte_len);
+                remove_begin += byte_len;
+            }
+        }
+
         auto is_trim_char = [&](const char* pos, size_t byte_len) -> bool {
+            if (use_set) {
+                return trim_set.count(std::string_view(pos, byte_len)) > 0;
+            }
             for (size_t c = 0; c < num_trim_chars; ++c) {
                 if (trim_chars[c].len == byte_len &&
                     memcmp(trim_chars[c].data, pos, byte_len) == 0) {

--- a/be/src/exprs/function/function_string.cpp
+++ b/be/src/exprs/function/function_string.cpp
@@ -23,7 +23,6 @@
 #include <unicode/unistr.h>
 #include <unicode/ustream.h>
 
-#include <bitset>
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
@@ -42,6 +41,7 @@
 #include "exprs/function/function_totype.h"
 #include "exprs/function/simple_function_factory.h"
 #include "exprs/function/string_hex_util.h"
+#include "exprs/function/url/find_symbols.h"
 #include "util/string_search.hpp"
 #include "util/url_coding.h"
 #include "util/utf8_check.h"
@@ -763,13 +763,14 @@ private:
                                      const StringRef& remove_str, ColumnString::Chars& res_data,
                                      ColumnString::Offsets& res_offsets) {
         const size_t offset_size = str_offsets.size();
-        std::bitset<128> char_lookup;
-        const char* remove_begin = remove_str.data;
-        const char* remove_end = remove_str.data + remove_str.size;
 
-        while (remove_begin < remove_end) {
-            char_lookup.set(static_cast<unsigned char>(*remove_begin));
-            remove_begin += 1;
+        // Use SearchSymbols for SIMD-accelerated lookup (SSE4.2 for >=5 chars, SSE2 for <5)
+        SearchSymbols symbols(std::string(remove_str.data, remove_str.size));
+
+        // Build scalar lookup table for early-exit: skip SIMD when first/last byte is not a trim char
+        bool char_lookup[256] = {};
+        for (size_t j = 0; j < remove_str.size; ++j) {
+            char_lookup[static_cast<unsigned char>(remove_str.data[j])] = true;
         }
 
         for (size_t i = 0; i < offset_size; ++i) {
@@ -780,21 +781,19 @@ private:
             const char* right_trim_pos = str_end;
 
             if constexpr (is_ltrim) {
-                while (left_trim_pos < str_end) {
-                    if (!char_lookup.test(static_cast<unsigned char>(*left_trim_pos))) {
-                        break;
-                    }
-                    ++left_trim_pos;
+                if (left_trim_pos < str_end &&
+                    char_lookup[static_cast<unsigned char>(*left_trim_pos)]) {
+                    left_trim_pos = find_first_not_symbols(
+                            std::string_view(str_begin, str_end - str_begin), symbols);
                 }
             }
 
             if constexpr (is_rtrim) {
-                while (right_trim_pos > left_trim_pos) {
-                    --right_trim_pos;
-                    if (!char_lookup.test(static_cast<unsigned char>(*right_trim_pos))) {
-                        ++right_trim_pos;
-                        break;
-                    }
+                if (right_trim_pos > left_trim_pos &&
+                    char_lookup[static_cast<unsigned char>(*(right_trim_pos - 1))]) {
+                    const char* pos =
+                            find_last_not_symbols_or_null(left_trim_pos, right_trim_pos, symbols);
+                    right_trim_pos = pos ? pos + 1 : left_trim_pos;
                 }
             }
 
@@ -814,17 +813,37 @@ private:
         res_offsets.resize(offset_size);
         res_data.reserve(str_data.size());
 
-        std::unordered_set<std::string_view> char_lookup;
+        // Pre-decode trim characters into a small fixed-size array
+        // Avoids unordered_set hash lookup overhead for typical small character sets
+        static constexpr size_t MAX_TRIM_CHARS = 32;
+        struct Utf8Char {
+            char data[6];
+            uint8_t len;
+        };
+        Utf8Char trim_chars[MAX_TRIM_CHARS];
+        size_t num_trim_chars = 0;
+
         const char* remove_begin = remove_str.data;
         const char* remove_end = remove_str.data + remove_str.size;
 
-        while (remove_begin < remove_end) {
-            size_t byte_len, char_len;
-            std::tie(byte_len, char_len) = simd::VStringFunctions::iterate_utf8_with_limit_length(
-                    remove_begin, remove_end, 1);
-            char_lookup.insert(std::string_view(remove_begin, byte_len));
+        while (remove_begin < remove_end && num_trim_chars < MAX_TRIM_CHARS) {
+            uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*remove_begin));
+            if (remove_begin + byte_len > remove_end) break;
+            trim_chars[num_trim_chars].len = byte_len;
+            memcpy(trim_chars[num_trim_chars].data, remove_begin, byte_len);
+            ++num_trim_chars;
             remove_begin += byte_len;
         }
+
+        auto is_trim_char = [&](const char* pos, size_t byte_len) -> bool {
+            for (size_t c = 0; c < num_trim_chars; ++c) {
+                if (trim_chars[c].len == byte_len &&
+                    memcmp(trim_chars[c].data, pos, byte_len) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        };
 
         for (size_t i = 0; i < offset_size; ++i) {
             const char* str_begin =
@@ -835,12 +854,9 @@ private:
 
             if constexpr (is_ltrim) {
                 while (left_trim_pos < str_end) {
-                    size_t byte_len, char_len;
-                    std::tie(byte_len, char_len) =
-                            simd::VStringFunctions::iterate_utf8_with_limit_length(left_trim_pos,
-                                                                                   str_end, 1);
-                    if (char_lookup.find(std::string_view(left_trim_pos, byte_len)) ==
-                        char_lookup.end()) {
+                    uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*left_trim_pos));
+                    if (left_trim_pos + byte_len > str_end) break;
+                    if (!is_trim_char(left_trim_pos, byte_len)) {
                         break;
                     }
                     left_trim_pos += byte_len;
@@ -852,10 +868,9 @@ private:
                     const char* prev_char_pos = right_trim_pos;
                     do {
                         --prev_char_pos;
-                    } while ((*prev_char_pos & 0xC0) == 0x80);
+                    } while (prev_char_pos > left_trim_pos && (*prev_char_pos & 0xC0) == 0x80);
                     size_t byte_len = right_trim_pos - prev_char_pos;
-                    if (char_lookup.find(std::string_view(prev_char_pos, byte_len)) ==
-                        char_lookup.end()) {
+                    if (!is_trim_char(prev_char_pos, byte_len)) {
                         break;
                     }
                     right_trim_pos = prev_char_pos;

--- a/be/src/exprs/function/url/find_symbols.h
+++ b/be/src/exprs/function/url/find_symbols.h
@@ -333,6 +333,8 @@ inline const char* find_first_symbols_sse42(const char* const begin, const char*
 template <bool positive, ReturnMode return_mode>
 inline const char* find_last_symbols_sse2(const char* const begin, const char* const end,
                                           const char* symbols, size_t num_chars) {
+    if (begin >= end) return return_mode == ReturnMode::End ? end : nullptr;
+
     const char* pos = end;
 
 #if defined(__SSE2__)
@@ -357,6 +359,8 @@ inline const char* find_last_symbols_sse2(const char* const begin, const char* c
 template <bool positive, ReturnMode return_mode>
 inline const char* find_last_symbols_sse42(const char* const begin, const char* const end,
                                            const SearchSymbols& symbols) {
+    if (begin >= end) return return_mode == ReturnMode::End ? end : nullptr;
+
     const char* pos = end;
 
     const auto num_chars = symbols.str.size();

--- a/be/src/exprs/function/url/find_symbols.h
+++ b/be/src/exprs/function/url/find_symbols.h
@@ -370,7 +370,7 @@ inline const char* find_last_symbols_sse42(const char* const begin, const char* 
 
     const __m128i set = symbols.simd_vector;
 
-    for (; pos - 16 >= begin; pos -= 16) {
+    for (; static_cast<size_t>(pos - begin) >= 16; pos -= 16) {
         __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos - 16));
 
         if constexpr (positive) {
@@ -384,9 +384,11 @@ inline const char* find_last_symbols_sse42(const char* const begin, const char* 
     }
 #endif
 
-    --pos;
-    for (; pos >= begin; --pos)
-        if (maybe_negate<positive>(is_in(*pos, symbols.str.data(), num_chars))) return pos;
+    // Scalar tail: scan remaining bytes from pos-1 down to begin
+    for (const char* p = pos; p != begin;) {
+        --p;
+        if (maybe_negate<positive>(is_in(*p, symbols.str.data(), num_chars))) return p;
+    }
 
     return return_mode == ReturnMode::End ? end : nullptr;
 }

--- a/be/src/exprs/function/url/find_symbols.h
+++ b/be/src/exprs/function/url/find_symbols.h
@@ -129,11 +129,11 @@ inline AlignedArray mm_is_in_prepare(const char* symbols, size_t num_chars) {
     return result;
 }
 
-inline __m128i mm_is_in_execute(__m128i bytes, const AlignedArray& needles) {
+inline __m128i mm_is_in_execute(__m128i bytes, const AlignedArray& needles, size_t num_chars) {
     __m128i accumulator = _mm_setzero_si128();
 
-    for (const auto& needle : needles) {
-        __m128i eq = _mm_cmpeq_epi8(bytes, reinterpret_cast<const __m128i&>(needle));
+    for (size_t i = 0; i < num_chars; ++i) {
+        __m128i eq = _mm_cmpeq_epi8(bytes, reinterpret_cast<const __m128i&>(needles[i]));
         accumulator = _mm_or_si128(accumulator, eq);
     }
 
@@ -190,7 +190,7 @@ inline const char* find_first_symbols_sse2(const char* const begin, const char* 
     for (; pos + 15 < end; pos += 16) {
         __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos));
 
-        __m128i eq = mm_is_in_execute(bytes, needles);
+        __m128i eq = mm_is_in_execute(bytes, needles, num_chars);
 
         uint16_t bit_mask = maybe_negate<positive>(uint16_t(_mm_movemask_epi8(eq)));
         if (bit_mask) return pos + __builtin_ctz(bit_mask);
@@ -342,7 +342,7 @@ inline const char* find_last_symbols_sse2(const char* const begin, const char* c
     for (; pos - 16 >= begin; pos -= 16) {
         __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos - 16));
 
-        __m128i eq = mm_is_in_execute(bytes, needles);
+        __m128i eq = mm_is_in_execute(bytes, needles, num_chars);
 
         uint16_t bit_mask = maybe_negate<positive>(uint16_t(_mm_movemask_epi8(eq)));
         if (bit_mask) return pos - 1 - (__builtin_clz(bit_mask) - 16);

--- a/be/src/exprs/function/url/find_symbols.h
+++ b/be/src/exprs/function/url/find_symbols.h
@@ -330,7 +330,62 @@ inline const char* find_first_symbols_sse42(const char* const begin, const char*
     return return_mode == ReturnMode::End ? end : nullptr;
 }
 
-/// NOTE No SSE 4.2 implementation for find_last_symbols_or_null. Not worth to do.
+template <bool positive, ReturnMode return_mode>
+inline const char* find_last_symbols_sse2(const char* const begin, const char* const end,
+                                          const char* symbols, size_t num_chars) {
+    const char* pos = end;
+
+#if defined(__SSE2__)
+    const auto needles = mm_is_in_prepare(symbols, num_chars);
+    for (; pos - 16 >= begin; pos -= 16) {
+        __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos - 16));
+
+        __m128i eq = mm_is_in_execute(bytes, needles);
+
+        uint16_t bit_mask = maybe_negate<positive>(uint16_t(_mm_movemask_epi8(eq)));
+        if (bit_mask) return pos - 1 - (__builtin_clz(bit_mask) - 16);
+    }
+#endif
+
+    --pos;
+    for (; pos >= begin; --pos)
+        if (maybe_negate<positive>(is_in(*pos, symbols, num_chars))) return pos;
+
+    return return_mode == ReturnMode::End ? end : nullptr;
+}
+
+template <bool positive, ReturnMode return_mode>
+inline const char* find_last_symbols_sse42(const char* const begin, const char* const end,
+                                           const SearchSymbols& symbols) {
+    const char* pos = end;
+
+    const auto num_chars = symbols.str.size();
+
+#if defined(__SSE4_2__)
+    constexpr int mode = _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_MOST_SIGNIFICANT;
+
+    const __m128i set = symbols.simd_vector;
+
+    for (; pos - 16 >= begin; pos -= 16) {
+        __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos - 16));
+
+        if constexpr (positive) {
+            if (_mm_cmpestrc(set, num_chars, bytes, 16, mode))
+                return pos - 16 + _mm_cmpestri(set, num_chars, bytes, 16, mode);
+        } else {
+            if (_mm_cmpestrc(set, num_chars, bytes, 16, mode | _SIDD_NEGATIVE_POLARITY))
+                return pos - 16 +
+                       _mm_cmpestri(set, num_chars, bytes, 16, mode | _SIDD_NEGATIVE_POLARITY);
+        }
+    }
+#endif
+
+    --pos;
+    for (; pos >= begin; --pos)
+        if (maybe_negate<positive>(is_in(*pos, symbols.str.data(), num_chars))) return pos;
+
+    return return_mode == ReturnMode::End ? end : nullptr;
+}
 
 template <bool positive, ReturnMode return_mode, char... symbols>
 inline const char* find_first_symbols_dispatch(const char* begin, const char* end)
@@ -356,6 +411,18 @@ inline const char* find_first_symbols_dispatch(const std::string_view haystack,
 #endif
         return find_first_symbols_sse2<positive, return_mode>(
                 haystack.begin(), haystack.end(), symbols.str.data(), symbols.str.size());
+}
+
+template <bool positive, ReturnMode return_mode>
+inline const char* find_last_symbols_dispatch(const char* begin, const char* end,
+                                              const SearchSymbols& symbols) {
+#if defined(__SSE4_2__)
+    if (symbols.str.size() >= 5)
+        return find_last_symbols_sse42<positive, return_mode>(begin, end, symbols);
+    else
+#endif
+        return find_last_symbols_sse2<positive, return_mode>(begin, end, symbols.str.data(),
+                                                             symbols.str.size());
 }
 
 } // namespace detail
@@ -460,6 +527,12 @@ inline char* find_last_not_symbols_or_null(char* begin, char* end) {
     return const_cast<char*>(
             ::detail::find_last_symbols_sse2<false, ::detail::ReturnMode::Nullptr, symbols...>(
                     begin, end));
+}
+
+inline const char* find_last_not_symbols_or_null(const char* begin, const char* end,
+                                                 const SearchSymbols& symbols) {
+    return ::detail::find_last_symbols_dispatch<false, ::detail::ReturnMode::Nullptr>(begin, end,
+                                                                                      symbols);
 }
 
 /// Slightly resembles boost::split. The drawback of boost::split is that it fires a false positive in clang static analyzer.

--- a/be/test/exprs/function/url/find_symbols_test.cpp
+++ b/be/test/exprs/function/url/find_symbols_test.cpp
@@ -1,0 +1,327 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/function/url/find_symbols.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace doris {
+
+class FindSymbolsTest : public ::testing::Test {};
+
+// ==================== find_last_not_symbols_or_null with SearchSymbols ====================
+
+// --- SSE2 path: < 5 trim characters ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_BasicTrim) {
+    // "   hello   " with trim chars " " -> last non-space is 'o' at index 7
+    std::string s = "   hello   ";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 7);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_AllMatch) {
+    // All characters are trim chars -> returns nullptr
+    std::string s = "    ";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_NoMatch) {
+    // No trim chars in string -> last char is the answer
+    std::string s = "hello";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_EmptyString) {
+    std::string s;
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_SingleChar_Match) {
+    std::string s = " ";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_SingleChar_NoMatch) {
+    std::string s = "x";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 0);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_MultipleSymbols) {
+    // 3 trim chars (SSE2 path): space, tab, newline
+    std::string s = "hello\t\n ";
+    SearchSymbols symbols(" \t\n");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_FourSymbols) {
+    // 4 trim chars (still SSE2 path)
+    std::string s = "data.,-;";
+    SearchSymbols symbols(".,-;");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'a');
+    EXPECT_EQ(result - s.data(), 3);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_TrailingNonTrim) {
+    // No trailing trim chars -> returns last char
+    std::string s = "   hello";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 7);
+}
+
+// --- SSE4.2 path: >= 5 trim characters ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_FiveSymbols) {
+    // Exactly 5 trim chars -> SSE4.2 PCMPESTRI path
+    std::string s = "hello.,;:-";
+    SearchSymbols symbols(".,;:-");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_EightSymbols) {
+    std::string s = "world \t\n\r.,-;";
+    SearchSymbols symbols(" \t\n\r.,-;");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'd');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_AllMatch) {
+    std::string s = " \t\n\r.";
+    SearchSymbols symbols(" \t\n\r.");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_NoMatch) {
+    std::string s = "helloworld";
+    SearchSymbols symbols(".,;:-!");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'd');
+    EXPECT_EQ(result - s.data(), 9);
+}
+
+// --- Long strings: cross SIMD 16-byte boundaries ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_LongString) {
+    // 50 spaces + "abc" + 50 spaces = 103 chars, crosses multiple SIMD chunks
+    std::string s(50, ' ');
+    s += "abc";
+    s += std::string(50, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'c');
+    EXPECT_EQ(result - s.data(), 52);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_LongString) {
+    // Same test but with >= 5 trim chars to force SSE4.2
+    std::string s(50, ' ');
+    s += "abc";
+    s += std::string(30, ' ');
+    s += std::string(20, '\t');
+    SearchSymbols symbols(" \t\n\r.;");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'c');
+    EXPECT_EQ(result - s.data(), 52);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_LongAllTrim) {
+    // 200 spaces -> nullptr
+    std::string s(200, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_LongNoTrim) {
+    // 200 'x' chars -> last char
+    std::string s(200, 'x');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 199);
+}
+
+// --- Edge: exactly 16 bytes (one SIMD chunk) ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_Exactly16Bytes_AllTrim) {
+    std::string s(16, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_Exactly16Bytes_LastNonTrim) {
+    std::string s(15, ' ');
+    s += 'x';
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 15);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_Exactly16Bytes_FirstNonTrim) {
+    std::string s = "x";
+    s += std::string(15, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 0);
+}
+
+// --- Edge: 17 bytes (one SIMD chunk + 1 scalar) ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_17Bytes_NonTrimAtBoundary) {
+    // 16 spaces + 'x' -> SIMD processes last 16 bytes [1..16], scalar handles byte 0
+    std::string s(16, ' ');
+    s += 'x';
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 16);
+}
+
+// --- Cross-verify: runtime SearchSymbols vs template version ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_CrossVerify_WithTemplate) {
+    // Compare runtime SearchSymbols version with compile-time template version
+    std::string s = "hello   \t\n ";
+    SearchSymbols symbols(" \t\n");
+
+    const char* runtime_result =
+            find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    const char* template_result =
+            find_last_not_symbols_or_null<' ', '\t', '\n'>(s.data(), s.data() + s.size());
+
+    ASSERT_NE(runtime_result, nullptr);
+    ASSERT_NE(template_result, nullptr);
+    EXPECT_EQ(runtime_result, template_result);
+    EXPECT_EQ(*runtime_result, 'o');
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_CrossVerify_AllTrim) {
+    std::string s = "   \t\n";
+    SearchSymbols symbols(" \t\n");
+
+    const char* runtime_result =
+            find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    const char* template_result =
+            find_last_not_symbols_or_null<' ', '\t', '\n'>(s.data(), s.data() + s.size());
+
+    EXPECT_EQ(runtime_result, nullptr);
+    EXPECT_EQ(template_result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_CrossVerify_LongString) {
+    std::string s(100, ' ');
+    s += "data";
+    s += std::string(100, '\t');
+    SearchSymbols symbols(" \t");
+
+    const char* runtime_result =
+            find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    const char* template_result =
+            find_last_not_symbols_or_null<' ', '\t'>(s.data(), s.data() + s.size());
+
+    ASSERT_NE(runtime_result, nullptr);
+    ASSERT_NE(template_result, nullptr);
+    EXPECT_EQ(runtime_result, template_result);
+    EXPECT_EQ(*runtime_result, 'a');
+    EXPECT_EQ(runtime_result - s.data(), 103);
+}
+
+// --- Various string lengths to stress SIMD alignment ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_VariousLengths) {
+    SearchSymbols symbols("ab");
+    for (size_t len = 1; len <= 64; ++len) {
+        // String of 'a' repeated, with 'X' at position 0
+        std::string s(len, 'a');
+        s[0] = 'X';
+        const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+        ASSERT_NE(result, nullptr) << "len=" << len;
+        EXPECT_EQ(*result, 'X') << "len=" << len;
+        EXPECT_EQ(result - s.data(), 0) << "len=" << len;
+    }
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_VariousLengths_NonTrimAtEnd) {
+    SearchSymbols symbols("ab");
+    for (size_t len = 1; len <= 64; ++len) {
+        // String of 'a' repeated, with 'X' at the last position
+        std::string s(len, 'a');
+        s[len - 1] = 'X';
+        const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+        ASSERT_NE(result, nullptr) << "len=" << len;
+        EXPECT_EQ(*result, 'X') << "len=" << len;
+        EXPECT_EQ(result - s.data(), (ptrdiff_t)(len - 1)) << "len=" << len;
+    }
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_VariousLengths_SSE42) {
+    // 6 trim chars -> SSE4.2 path
+    SearchSymbols symbols("abcdef");
+    for (size_t len = 1; len <= 64; ++len) {
+        std::string s(len, 'a');
+        s[0] = 'X';
+        const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+        ASSERT_NE(result, nullptr) << "len=" << len;
+        EXPECT_EQ(*result, 'X') << "len=" << len;
+        EXPECT_EQ(result - s.data(), 0) << "len=" << len;
+    }
+}
+
+} // namespace doris

--- a/be/test/exprs/function/url/find_symbols_test.cpp
+++ b/be/test/exprs/function/url/find_symbols_test.cpp
@@ -324,4 +324,20 @@ TEST_F(FindSymbolsTest, LastNotSymbols_VariousLengths_SSE42) {
     }
 }
 
+// --- Empty range: begin == end should not cause UB ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_EmptyRange_SSE2) {
+    SearchSymbols symbols("ab");
+    const char* p = "x";
+    const char* result = find_last_not_symbols_or_null(p, p, symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_EmptyRange_SSE42) {
+    SearchSymbols symbols("abcdef");
+    const char* p = "x";
+    const char* result = find_last_not_symbols_or_null(p, p, symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
 } // namespace doris

--- a/be/test/exprs/function/url/find_symbols_test.cpp
+++ b/be/test/exprs/function/url/find_symbols_test.cpp
@@ -340,4 +340,42 @@ TEST_F(FindSymbolsTest, LastNotSymbols_EmptyRange_SSE42) {
     EXPECT_EQ(result, nullptr);
 }
 
+// --- Embedded null bytes must NOT be treated as implicit trim symbols ---
+
+TEST_F(FindSymbolsTest, EmbeddedNullByte_SSE2_NotTrimmed) {
+    // "a\0" followed by 20 'x' bytes, trim set "ab" (SSE2 path: < 5 chars)
+    // After trimming leading 'a', the \0 byte should remain (not be treated as trim char)
+    std::string s;
+    s += 'a';
+    s += '\0';
+    s.append(20, 'x');
+    SearchSymbols symbols("ab");
+    // find_first_not_symbols should return pointer to the \0 byte (index 1), not skip it
+    const char* result = find_first_not_symbols(std::string_view(s.data(), s.size()), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result - s.data(), 1); // \0 at index 1 is NOT a trim char
+    EXPECT_EQ(*result, '\0');
+}
+
+TEST_F(FindSymbolsTest, EmbeddedNullByte_SSE2_LastNotSymbols) {
+    // 20 'x' bytes followed by "\0bb", trim set "ab" (SSE2 path: < 5 chars)
+    // find_last_not_symbols should return pointer to \0 (not skip it)
+    std::string s(20, 'x');
+    s += '\0';
+    s += "bb";
+    SearchSymbols symbols("ab");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result - s.data(), 20); // \0 at index 20 is NOT a trim char
+    EXPECT_EQ(*result, '\0');
+}
+
+TEST_F(FindSymbolsTest, EmbeddedNullByte_AllNulls_SSE2) {
+    // String of all \0 bytes with trim set "ab" — none should be trimmed
+    std::string s(32, '\0');
+    SearchSymbols symbols("ab");
+    const char* result = find_first_not_symbols(std::string_view(s.data(), s.size()), symbols);
+    EXPECT_EQ(result - s.data(), 0); // first \0 at index 0 is not a trim char
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The `trim_in` / `ltrim_in` / `rtrim_in` functions have suboptimal performance:
- **ASCII path**: byte-by-byte scanning with `std::bitset<128>` lookup, no SIMD vectorization
- **UTF-8 path**: `std::unordered_set<string_view>` hash lookup per character, high overhead for small trim sets

### What was done

#### ASCII path — reuse `find_symbols.h` SIMD infrastructure

For ≤ 16 distinct trim characters, replace `bitset<128>` scalar loop with `SearchSymbols` + `find_first_not_symbols` / `find_last_not_symbols_or_null` from the existing ClickHouse-derived `find_symbols.h`:

- **SSE2** (`_mm_cmpeq_epi8`): for < 5 trim characters, processes 16 bytes per iteration
- **SSE4.2** (`PCMPESTRI`): for ≥ 5 trim characters, processes 16 bytes per iteration with hardware string comparison
- **Scalar early-exit**: check the first/last byte with a `bool[256]` table before entering SIMD — if the boundary byte is not a trim character, skip SIMD entirely (zero overhead for no-match strings)
- **Fallback**: when trim character count exceeds the 16-byte `SearchSymbols` buffer limit, fall back to the `bool[256]` scalar loop (same correctness, no SIMD)

Extended `find_symbols.h` with runtime `find_last_symbols_sse2`, `find_last_symbols_sse42`, and `find_last_not_symbols_or_null(begin, end, SearchSymbols)` for reverse scanning (rtrim). Added empty-range guards to prevent UB when `begin == end`.

#### UTF-8 path — fixed-size array with `memcmp`, fallback to `unordered_set`

For ≤ 32 code points, replace `std::unordered_set<string_view>` with a stack-allocated `Utf8Char[32]` array and linear `memcmp` scan. No heap allocation, better cache locality. When the trim set exceeds 32 code points, fall back to `std::unordered_set<string_view>` to guarantee correctness for arbitrarily large trim strings.

### Benchmark results (Release build, 65536 rows)

| Scenario | Old (μs) | New (μs) | Speedup |
|---|---|---|---|
| ASCII, 4 trim chars (` \t\n\r`) | 2503 | 851 | **2.94×** |
| ASCII, 8 trim chars (` \t\n\r.,-;`) | 2520 | 981 | **2.57×** |
| ASCII, no match | 374 | 359 | **1.04×** |
| UTF-8, 2 trim chars (`你好`) | 8241 | 7290 | **1.13×** |

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

