### PR TITLE
[test](regression) Isolate local Hive regression side effects

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -152,9 +152,7 @@ class Suite implements GroovyInterceptable {
     String getHiveTempName(String baseName, String extra = "") {
         String sanitizedBase = sanitizeHiveIdentifier(baseName)
         String sanitizedExtra = sanitizeHiveIdentifier(extra)
-        String sanitizedSuite = sanitizeHiveIdentifier(name)
-        String sanitizedPrefix = sanitizeHiveIdentifier(hivePrefix)
-        String suffix = "${sanitizedSuite}_${sanitizedPrefix}_${getHiveTempSuffix()}"
+        String suffix = getHiveTempSuffix()
 
         def nameParts = []
         if (!Strings.isNullOrEmpty(sanitizedBase)) {
@@ -170,12 +168,25 @@ class Suite implements GroovyInterceptable {
             return generatedName
         }
 
+        // If too long, truncate base name
         int maxPrefixLength = 128 - suffix.length() - 1
+        if (!Strings.isNullOrEmpty(sanitizedExtra)) {
+            maxPrefixLength -= (sanitizedExtra.length() + 1)
+        }
         String trimmedBase = sanitizedBase
         if (trimmedBase.length() > maxPrefixLength) {
             trimmedBase = trimmedBase.substring(0, maxPrefixLength)
         }
-        return "${trimmedBase}_${suffix}"
+
+        nameParts.clear()
+        if (!Strings.isNullOrEmpty(trimmedBase)) {
+            nameParts.add(trimmedBase)
+        }
+        if (!Strings.isNullOrEmpty(sanitizedExtra)) {
+            nameParts.add(sanitizedExtra)
+        }
+        nameParts.add(suffix)
+        return nameParts.join("_")
     }
 
     void cleanupHiveDockerTable(String dbName, String tableName) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -97,6 +97,7 @@ class Suite implements GroovyInterceptable {
 
     // set this in suite to determine which hive docker to use
     String hivePrefix = "hive2"
+    private String hiveTempSuffix = null
 
     final List<Closure> successCallbacks = new Vector<>()
     final List<Closure> failCallbacks = new Vector<>()
@@ -128,6 +129,62 @@ class Suite implements GroovyInterceptable {
 
     String getSuiteConf(String key, String defaultValue = null) {
         return getConf("suites." + name + "." + key, defaultValue)
+    }
+
+    String getHiveTempSuffix() {
+        if (hiveTempSuffix == null) {
+            hiveTempSuffix = UUID.randomUUID().toString().replace("-", "").substring(0, 12)
+        }
+        return hiveTempSuffix
+    }
+
+    private String sanitizeHiveIdentifier(String value) {
+        if (Strings.isNullOrEmpty(value)) {
+            return ""
+        }
+        return value.toLowerCase()
+                .replaceAll("[^a-z0-9_]", "_")
+                .replaceAll("_+", "_")
+                .replaceAll("^_+", "")
+                .replaceAll("_+\$", "")
+    }
+
+    String getHiveTempName(String baseName, String extra = "") {
+        String sanitizedBase = sanitizeHiveIdentifier(baseName)
+        String sanitizedExtra = sanitizeHiveIdentifier(extra)
+        String sanitizedSuite = sanitizeHiveIdentifier(name)
+        String sanitizedPrefix = sanitizeHiveIdentifier(hivePrefix)
+        String suffix = "${sanitizedSuite}_${sanitizedPrefix}_${getHiveTempSuffix()}"
+
+        def nameParts = []
+        if (!Strings.isNullOrEmpty(sanitizedBase)) {
+            nameParts.add(sanitizedBase)
+        }
+        if (!Strings.isNullOrEmpty(sanitizedExtra)) {
+            nameParts.add(sanitizedExtra)
+        }
+        nameParts.add(suffix)
+
+        String generatedName = nameParts.join("_")
+        if (generatedName.length() <= 128) {
+            return generatedName
+        }
+
+        int maxPrefixLength = 128 - suffix.length() - 1
+        String trimmedBase = sanitizedBase
+        if (trimmedBase.length() > maxPrefixLength) {
+            trimmedBase = trimmedBase.substring(0, maxPrefixLength)
+        }
+        return "${trimmedBase}_${suffix}"
+    }
+
+    void cleanupHiveDockerTable(String dbName, String tableName) {
+        try_hive_docker """DROP TABLE IF EXISTS `${dbName}`.`${tableName}`"""
+    }
+
+    void cleanupHiveDockerDatabase(String dbName, boolean cascade = false) {
+        String cascadeClause = cascade ? " CASCADE" : ""
+        try_hive_docker """DROP DATABASE IF EXISTS `${dbName}`${cascadeClause}"""
     }
 
     Properties getConfs(String prefix) {
@@ -646,7 +703,7 @@ class Suite implements GroovyInterceptable {
         }
     }
 
-    def sql_return_maparray_impl(String sqlStr, Connection conn = null) {        
+    def sql_return_maparray_impl(String sqlStr, Connection conn = null) {
         logger.info("Execute sql: ${sqlStr}".toString())
         if (conn == null) {
             conn = context.getConnection()
@@ -664,7 +721,7 @@ class Suite implements GroovyInterceptable {
         // which cannot be handled by maps and will result in an error directly.
         Set<String> uniqueSet = new HashSet<>()
         Set<String> duplicates = new HashSet<>()
-    
+
         for (String str : columnNames) {
             if (uniqueSet.contains(str)) {
                 duplicates.add(str)
@@ -673,7 +730,7 @@ class Suite implements GroovyInterceptable {
             }
         }
         if (!duplicates.isEmpty()) {
-            def errorMessage = "${sqlStr} returns duplicates headers: ${duplicates}"   
+            def errorMessage = "${sqlStr} returns duplicates headers: ${duplicates}"
             throw new Exception(errorMessage)
         }
 
@@ -1653,16 +1710,16 @@ class Suite implements GroovyInterceptable {
             throw new RuntimeException("spark-iceberg container not found. Please ensure the container is running.")
         }
         String masterUrl = "spark://${containerName}:7077"
-        
+
         // Escape double quotes in SQL string for shell command
         String escapedSql = sqlStr.replaceAll('"', '\\\\"')
-        
+
         // Build docker exec command
         String command = """docker exec ${containerName} spark-sql --master ${masterUrl} --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions -e "${escapedSql}" """
-        
+
         logger.info("Executing Spark Iceberg SQL: ${sqlStr}".toString())
         logger.info("Container: ${containerName}".toString())
-        
+
         try {
             String result = cmd(command, timeoutSeconds)
             logger.info("Spark Iceberg SQL result: ${result}".toString())
@@ -1677,7 +1734,7 @@ class Suite implements GroovyInterceptable {
      * Execute multiple Spark SQL statements on the spark-iceberg container.
      * Statements are separated by semicolons.
      * All statements are executed in one spark-sql process to reduce startup overhead.
-     * 
+     *
      * Usage:
      *   spark_iceberg_multi '''
      *       CREATE DATABASE IF NOT EXISTS demo.test_db;
@@ -1873,7 +1930,7 @@ class Suite implements GroovyInterceptable {
 
     def executeQueryByTag(String tag, Object arg) {
         Tuple2<List<List<Object>>, ResultSetMetaData> tupleResult = null
-        
+
         if (tag.contains("hive_docker")) {
             tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(hivePrefix), (String) arg)
         } else if (tag.contains("hive_remote")) {
@@ -2627,7 +2684,7 @@ class Suite implements GroovyInterceptable {
     def create_sync_mv = { db, table_name, mv_name, mv_sql ->
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name} ON ${table_name};"""
         sql"""
-        CREATE MATERIALIZED VIEW ${mv_name} 
+        CREATE MATERIALIZED VIEW ${mv_name}
         AS ${mv_sql}
         """
         waitingMVTaskFinishedByMvName(db, table_name, mv_name)
@@ -2638,10 +2695,10 @@ class Suite implements GroovyInterceptable {
 
         sql """DROP MATERIALIZED VIEW IF EXISTS ${db}.${mv_name}"""
         sql"""
-        CREATE MATERIALIZED VIEW ${db}.${mv_name} 
+        CREATE MATERIALIZED VIEW ${db}.${mv_name}
         BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
         DISTRIBUTED BY RANDOM BUCKETS 2
-        PROPERTIES ('replication_num' = '1') 
+        PROPERTIES ('replication_num' = '1')
         AS ${mv_sql}
         """
         def job_name = getJobName(db, mv_name);
@@ -2654,11 +2711,11 @@ class Suite implements GroovyInterceptable {
 
         sql """DROP MATERIALIZED VIEW IF EXISTS ${db}.${mv_name}"""
         sql"""
-        CREATE MATERIALIZED VIEW ${db}.${mv_name} 
-        BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL 
-        PARTITION BY ${partition_col} 
-        DISTRIBUTED BY RANDOM BUCKETS 2 
-        PROPERTIES ('replication_num' = '1')  
+        CREATE MATERIALIZED VIEW ${db}.${mv_name}
+        BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
+        PARTITION BY ${partition_col}
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES ('replication_num' = '1')
         AS ${mv_sql}
         """
         def job_name = getJobName(db, mv_name);
@@ -2927,10 +2984,10 @@ class Suite implements GroovyInterceptable {
         }
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name}"""
         sql"""
-        CREATE MATERIALIZED VIEW ${mv_name} 
+        CREATE MATERIALIZED VIEW ${mv_name}
         BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
         DISTRIBUTED BY RANDOM BUCKETS 2
-        PROPERTIES ('replication_num' = '1') 
+        PROPERTIES ('replication_num' = '1')
         AS ${mv_sql}
         """
         def job_name = getJobName(db, mv_name);
@@ -2947,10 +3004,10 @@ class Suite implements GroovyInterceptable {
         }
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name}"""
         sql"""
-        CREATE MATERIALIZED VIEW ${mv_name} 
+        CREATE MATERIALIZED VIEW ${mv_name}
         BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
         DISTRIBUTED BY RANDOM BUCKETS 2
-        PROPERTIES ('replication_num' = '1') 
+        PROPERTIES ('replication_num' = '1')
         AS ${mv_sql}
         """
 
@@ -2968,10 +3025,10 @@ class Suite implements GroovyInterceptable {
         }
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name}"""
         sql"""
-        CREATE MATERIALIZED VIEW ${mv_name} 
+        CREATE MATERIALIZED VIEW ${mv_name}
         BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
         DISTRIBUTED BY RANDOM BUCKETS 2
-        PROPERTIES ('replication_num' = '1') 
+        PROPERTIES ('replication_num' = '1')
         AS ${mv_sql}
         """
 
@@ -2985,10 +3042,10 @@ class Suite implements GroovyInterceptable {
     def async_create_mv = { db, mv_sql, mv_name ->
         sql """DROP MATERIALIZED VIEW IF EXISTS ${mv_name}"""
         sql"""
-        CREATE MATERIALIZED VIEW ${mv_name} 
+        CREATE MATERIALIZED VIEW ${mv_name}
         BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
         DISTRIBUTED BY RANDOM BUCKETS 2
-        PROPERTIES ('replication_num' = '1') 
+        PROPERTIES ('replication_num' = '1')
         AS ${mv_sql}
         """
 
@@ -3603,7 +3660,7 @@ class Suite implements GroovyInterceptable {
         spb.each {
             beIdToHost[it.BackendId] = it.Host
         }
-        beIdToHost 
+        beIdToHost
     }
 
     def getTabletAndBeHostFromBe = { bes ->
@@ -3641,7 +3698,7 @@ class Suite implements GroovyInterceptable {
         }
     }
 
-    def getRowsetFileCacheDirFromBe = { beHttpPort, msHttpPort, tabletId, version, fileSuffix = "dat" -> 
+    def getRowsetFileCacheDirFromBe = { beHttpPort, msHttpPort, tabletId, version, fileSuffix = "dat" ->
         def hashValues = []
         def segmentFiles = []
         getSegmentFilesFromMs(msHttpPort, tabletId, version) {

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
@@ -24,12 +24,15 @@ suite("test_hive_ddl_text_format", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = getHiveTempName("test_hive_ddl_text_format", "catalog")
+        String database_name = getHiveTempName("test_hive_ddl_text_format", "db")
+        String defaultTableName = getHiveTempName("text_table_default_properties", "tbl")
+        String standardTableName = getHiveTempName("text_table_standard_properties", "tbl")
+        String differentTableName = getHiveTempName("text_table_different_properties", "tbl")
         try{
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_hive_ddl_text_format"
-            String table_name = "table_with_pars";
 
             sql """drop catalog if exists ${catalog_name};"""
 
@@ -44,11 +47,12 @@ suite("test_hive_ddl_text_format", "p0,external") {
             logger.info("catalog " + catalog_name + " created")
             sql """switch ${catalog_name};"""
             logger.info("switched to catalog " + catalog_name)
-            sql """use `default`;"""
+            sql """create database if not exists `${database_name}`;"""
+            sql """use `${database_name}`;"""
 
-            sql """ drop table if exists text_table_default_properties """
+            sql """ drop table if exists ${defaultTableName} """
             sql """
-            create table text_table_default_properties (
+            create table ${defaultTableName} (
                 id int,
                 `name` string,
                 tags array<string>,
@@ -58,19 +62,19 @@ suite("test_hive_ddl_text_format", "p0,external") {
             );
             """
             sql """
-            INSERT INTO text_table_default_properties VALUES
+            INSERT INTO ${defaultTableName} VALUES
                 (1, 'Alice', array('tag1', 'tag2'), map('key1', 'value1', 'key2', 'value2')),
                 (2, 'Bob', array('tagA', 'tagB'), map('keyA', 'valueA', 'keyB', 'valueB')),
                 (3, 'Charlie', NULL, map('keyC', 'valueC', 'keyD', 'valueD'));
             """
-            order_qt_default_properties """ select * from text_table_default_properties """
+            order_qt_default_properties """ select * from ${defaultTableName} """
 
-            order_qt_hive_docker_default_properties""" select * from text_table_default_properties """
+            order_qt_hive_docker_default_properties""" select * from ${defaultTableName} """
 
-            sql """ drop table if exists text_table_standard_properties """
+            sql """ drop table if exists ${standardTableName} """
             // Escape characters need to be considered in groovy scripts
             sql """
-            create table text_table_standard_properties (
+            create table ${standardTableName} (
                 id int,
                 `name` string,
                 tags array<string>,
@@ -87,17 +91,17 @@ suite("test_hive_ddl_text_format", "p0,external") {
             );
             """
             sql """
-            INSERT INTO text_table_standard_properties VALUES
+            INSERT INTO ${standardTableName} VALUES
                 (1, 'Alice', array('tag1', 'tag2'), map('key1', 'value1', 'key2', 'value2')),
                 (2, 'Bob', array('tagA', 'tagB'), map('keyA', 'valueA', 'keyB', 'valueB')),
                 (3, 'Charlie', NULL, map('keyC', 'valueC', 'keyD', 'valueD'));
             """
-            order_qt_standard_properties """ select * from text_table_standard_properties """
-            order_qt_hive_docker_standard_properties """ select * from text_table_standard_properties order by id; """
+            order_qt_standard_properties """ select * from ${standardTableName} """
+            order_qt_hive_docker_standard_properties """ select * from ${standardTableName} order by id; """
 
-            sql """ drop table if exists text_table_different_properties """
+            sql """ drop table if exists ${differentTableName} """
             sql """
-            create table text_table_different_properties (
+            create table ${differentTableName} (
                 id int,
                 `name` string,
                 tags array<string>,
@@ -114,13 +118,13 @@ suite("test_hive_ddl_text_format", "p0,external") {
             );
             """
             sql """
-            INSERT INTO text_table_different_properties VALUES
+            INSERT INTO ${differentTableName} VALUES
                 (1, 'Alice', array('tag1', 'tag2'), map('key1', 'value1', 'key2', 'value2')),
                 (2, 'Bob', array('tagA', 'tagB'), map('keyA', 'valueA', 'keyB', 'valueB')),
                 (3, 'Charlie', NULL, map('keyC', 'valueC', 'keyD', 'valueD'));
             """
-            order_qt_different_properties """ select * from text_table_different_properties """
-            order_qt_hive_docker_different_properties """ select * from text_table_different_properties order by id; """
+            order_qt_different_properties """ select * from ${differentTableName} """
+            order_qt_hive_docker_different_properties """ select * from ${differentTableName} order by id; """
 
             String serde = "'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'"
             String input_format = "'org.apache.hadoop.mapred.TextInputFormat'"
@@ -133,7 +137,7 @@ suite("test_hive_ddl_text_format", "p0,external") {
             String escape_delim = "'escape.delim'"
             String serialization_null_format = "'serialization.null.format'"
 
-            def create_tbl_res = sql """ show create table text_table_standard_properties """
+            def create_tbl_res = sql """ show create table ${standardTableName} """
             String res = create_tbl_res.toString()
             logger.info("${res}")
             assertTrue(res.containsIgnoreCase("${serde}"))
@@ -148,6 +152,7 @@ suite("test_hive_ddl_text_format", "p0,external") {
             assertTrue(res.containsIgnoreCase("${escape_delim}"))
             assertTrue(res.containsIgnoreCase("${serialization_null_format}"))
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
@@ -69,7 +69,7 @@ suite("test_hive_ddl_text_format", "p0,external") {
             """
             order_qt_default_properties """ select * from ${defaultTableName} """
 
-            order_qt_hive_docker_default_properties""" select * from ${defaultTableName} """
+            order_qt_hive_docker_default_properties""" select * from ${database_name}.${defaultTableName} """
 
             sql """ drop table if exists ${standardTableName} """
             // Escape characters need to be considered in groovy scripts
@@ -97,7 +97,7 @@ suite("test_hive_ddl_text_format", "p0,external") {
                 (3, 'Charlie', NULL, map('keyC', 'valueC', 'keyD', 'valueD'));
             """
             order_qt_standard_properties """ select * from ${standardTableName} """
-            order_qt_hive_docker_standard_properties """ select * from ${standardTableName} order by id; """
+            order_qt_hive_docker_standard_properties """ select * from ${database_name}.${standardTableName} order by id; """
 
             sql """ drop table if exists ${differentTableName} """
             sql """
@@ -124,7 +124,7 @@ suite("test_hive_ddl_text_format", "p0,external") {
                 (3, 'Charlie', NULL, map('keyC', 'valueC', 'keyD', 'valueD'));
             """
             order_qt_different_properties """ select * from ${differentTableName} """
-            order_qt_hive_docker_different_properties """ select * from ${differentTableName} order by id; """
+            order_qt_hive_docker_different_properties """ select * from ${database_name}.${differentTableName} order by id; """
 
             String serde = "'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'"
             String input_format = "'org.apache.hadoop.mapred.TextInputFormat'"

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_drop_db.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_drop_db.groovy
@@ -23,12 +23,13 @@ suite("test_hive_drop_db", "p0,external") {
     }
 
     for (String hivePrefix : ["hive2", "hive3"]) {
+        String catalog_name = null
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_drop_db_ctl"
+            catalog_name = getHiveTempName("test_${hivePrefix}_drop_db_ctl", "catalog")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-            String db_name = "test_${hivePrefix}_drop_db"
+            String db_name = getHiveTempName("test_${hivePrefix}_drop_db", "db")
 
             sql """drop catalog if exists ${catalog_name}"""
             sql """create catalog if not exists ${catalog_name} properties (
@@ -44,7 +45,7 @@ suite("test_hive_drop_db", "p0,external") {
             sql """drop database if exists ${db_name} force"""
             sql """create database ${db_name}"""
             sql """use ${db_name}"""
-            sql """ 
+            sql """
                     CREATE TABLE test_hive_drop_db_tbl1 (
                       `col1` BOOLEAN,
                       `col2` TINYINT
@@ -52,7 +53,7 @@ suite("test_hive_drop_db", "p0,external") {
                 """
             sql """insert into test_hive_drop_db_tbl1 values(true, 1);"""
             qt_sql_tbl1 """select * from test_hive_drop_db_tbl1"""
-            sql """ 
+            sql """
                     CREATE TABLE test_hive_drop_db_tbl2 (
                       `col1` BOOLEAN,
                       `col2` TINYINT
@@ -60,7 +61,7 @@ suite("test_hive_drop_db", "p0,external") {
                 """
             sql """insert into test_hive_drop_db_tbl2 values(false, 2);"""
             qt_sql_tbl2 """select * from test_hive_drop_db_tbl2"""
-            sql """ 
+            sql """
                     CREATE TABLE test_hive_drop_db_tbl3 (
                       `col1` BOOLEAN,
                       `col2` TINYINT
@@ -84,11 +85,11 @@ suite("test_hive_drop_db", "p0,external") {
                 sql """show tables from ${db_name}"""
                 exception "Unknown database"
             }
-    
+
             // use tvf to check if table is dropped
-            String tbl1_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/test_${hivePrefix}_drop_db.db/test_hive_drop_db_tbl1"
-            String tbl2_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/test_${hivePrefix}_drop_db.db/test_hive_drop_db_tbl2"
-            String tbl3_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/test_${hivePrefix}_drop_db.db/test_hive_drop_db_tbl3"
+            String tbl1_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/${db_name}.db/test_hive_drop_db_tbl1"
+            String tbl2_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/${db_name}.db/test_hive_drop_db_tbl2"
+            String tbl3_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/${db_name}.db/test_hive_drop_db_tbl3"
 
             qt_test_1 """ select * from HDFS(
                   "uri" = "${tbl1_path}/*",
@@ -101,6 +102,7 @@ suite("test_hive_drop_db", "p0,external") {
                   "format" = "orc"); """
 
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_truncate_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_truncate_table.groovy
@@ -21,85 +21,89 @@ suite("test_hive_truncate_table", "p0,external") {
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String hms_port = context.config.otherConfigs.get("hive3HmsPort")
         String hdfs_port = context.config.otherConfigs.get("hive3HdfsPort")
-        String catalog_name = "test_hive3_truncate_table"
-        String database_name = "hive_truncate"
-        sql """drop catalog if exists ${catalog_name};"""
+        String catalog_name = getHiveTempName("test_hive3_truncate_table", "catalog")
+        String database_name = getHiveTempName("hive_truncate", "db")
+        try {
+            sql """drop catalog if exists ${catalog_name};"""
 
-        sql """
-            create catalog if not exists ${catalog_name} properties (
-                'type'='hms',
-                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
-                'use_meta_cache' = 'true',
-                'hive.version'='3.0'
-            );
-        """
+            sql """
+                create catalog if not exists ${catalog_name} properties (
+                    'type'='hms',
+                    'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                    'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
+                    'use_meta_cache' = 'true',
+                    'hive.version'='3.0'
+                );
+            """
 
-        logger.info("catalog " + catalog_name + " created")
-        sql """switch ${catalog_name};"""
-        logger.info("switched to catalog " + catalog_name)
-        
-        sql """create database if not exists ${database_name};"""
-        sql """use ${database_name};"""
-        logger.info("use database " + database_name)
+            logger.info("catalog " + catalog_name + " created")
+            sql """switch ${catalog_name};"""
+            logger.info("switched to catalog " + catalog_name)
 
-        // 1. test no partition table
-        String table_name = "table_no_pars"
-        sql """create table if not exists ${table_name}(col1 bigint, col2 string); """
-        checkNereidsExecute("truncate table ${table_name};")
+            sql """create database if not exists ${database_name};"""
+            sql """use ${database_name};"""
+            logger.info("use database " + database_name)
 
-        sql """insert into ${table_name} values(3234424, '44'); """
-        sql """insert into ${table_name} values(222, 'aoe'); """
-        order_qt_truncate_01_pre """ select * from table_no_pars;  """
-        checkNereidsExecute("truncate table ${table_name};")
-        order_qt_truncate_01 """ select * from ${table_name}; """
+            // 1. test no partition table
+            String table_name = "table_no_pars"
+            sql """create table if not exists ${table_name}(col1 bigint, col2 string); """
+            checkNereidsExecute("truncate table ${table_name};")
 
-        sql """insert into ${table_name} values(3234424, '44'); """
-        checkNereidsExecute("truncate table ${table_name};")
-        order_qt_truncate_02 """ select * from ${table_name};  """
+            sql """insert into ${table_name} values(3234424, '44'); """
+            sql """insert into ${table_name} values(222, 'aoe'); """
+            order_qt_truncate_01_pre """ select * from table_no_pars;  """
+            checkNereidsExecute("truncate table ${table_name};")
+            order_qt_truncate_01 """ select * from ${table_name}; """
 
-        sql """insert into ${table_name} values(222, 'aoe'); """
-        checkNereidsExecute("truncate table ${table_name};")
-        order_qt_truncate_03 """ select * from ${table_name}; """
-        sql """insert into ${table_name} values(222, 'aoe'); """
-        sql """drop table ${table_name}"""
+            sql """insert into ${table_name} values(3234424, '44'); """
+            checkNereidsExecute("truncate table ${table_name};")
+            order_qt_truncate_02 """ select * from ${table_name};  """
 
-        // 2. test partition table
-        table_name = "table_with_pars";
-        sql """create table if not exists ${table_name}(col1 bigint, col2 string, pt1 varchar, pt2 date)
-               partition by list(pt1, pt2)() """
-        checkNereidsExecute("truncate table ${table_name};")
+            sql """insert into ${table_name} values(222, 'aoe'); """
+            checkNereidsExecute("truncate table ${table_name};")
+            order_qt_truncate_03 """ select * from ${table_name}; """
+            sql """insert into ${table_name} values(222, 'aoe'); """
+            sql """drop table ${table_name}"""
 
-        sql """insert into ${table_name} values(33, 'awe', 'wuu', '2023-02-04') """
-        sql """insert into ${table_name} values(5535, '3', 'dre', '2023-04-04') """
-        order_qt_truncate_04_pre """ select * from ${table_name}; """
-        checkNereidsExecute("truncate table ${table_name};")
-        order_qt_truncate_04 """ select * from ${table_name}; """
+            // 2. test partition table
+            table_name = "table_with_pars";
+            sql """create table if not exists ${table_name}(col1 bigint, col2 string, pt1 varchar, pt2 date)
+                   partition by list(pt1, pt2)() """
+            checkNereidsExecute("truncate table ${table_name};")
 
-        // 3. test partition table and truncate partitions
-        sql """insert into ${table_name} values(44, 'etg', 'wuweu', '2022-02-04') """
-        sql """insert into ${table_name} values(88, 'etg', 'wuweu', '2022-01-04') """
-        sql """insert into ${table_name} values(095, 'etgf', 'hiyr', '2021-05-06') """
-        sql """insert into ${table_name} values(555, 'etgf', 'wet', '2021-05-06') """
-        // checkNereidsExecute("truncate table hive_truncate.table_with_pars partition pt1;")
-        // order_qt_truncate_05 """ select * from table_with_pars; """
-        // checkNereidsExecute("truncate table hive_truncate.table_with_pars partition pt2;")
-        order_qt_truncate_06 """ select * from ${table_name}; """
+            sql """insert into ${table_name} values(33, 'awe', 'wuu', '2023-02-04') """
+            sql """insert into ${table_name} values(5535, '3', 'dre', '2023-04-04') """
+            order_qt_truncate_04_pre """ select * from ${table_name}; """
+            checkNereidsExecute("truncate table ${table_name};")
+            order_qt_truncate_04 """ select * from ${table_name}; """
 
-        sql """insert into ${table_name} values(22, 'ttt', 'gggw', '2022-02-04')"""
-        sql """insert into ${table_name} values(44, 'etg', 'wuweu', '2022-02-04') """
-        sql """insert into ${table_name} values(88, 'etg', 'wuweu', '2022-01-04') """
-        sql """insert into ${table_name} values(095, 'etgf', 'hiyr', '2021-05-06') """
-        sql """insert into ${table_name} values(555, 'etgf', 'wet', '2021-05-06') """
-        // checkNereidsExecute("truncate table ${catalog_name}.hive_truncate.table_with_pars partition pt1;")
-        // order_qt_truncate_07 """ select * from table_with_pars; """
-        // checkNereidsExecute("truncate table ${catalog_name}.hive_truncate.table_with_pars partition pt2;")
-        // order_qt_truncate_08 """ select * from table_with_pars; """
-        checkNereidsExecute("truncate table ${table_name}")
-        order_qt_truncate_09 """ select * from ${table_name}; """
+            // 3. test partition table and truncate partitions
+            sql """insert into ${table_name} values(44, 'etg', 'wuweu', '2022-02-04') """
+            sql """insert into ${table_name} values(88, 'etg', 'wuweu', '2022-01-04') """
+            sql """insert into ${table_name} values(095, 'etgf', 'hiyr', '2021-05-06') """
+            sql """insert into ${table_name} values(555, 'etgf', 'wet', '2021-05-06') """
+            // checkNereidsExecute("truncate table hive_truncate.table_with_pars partition pt1;")
+            // order_qt_truncate_05 """ select * from table_with_pars; """
+            // checkNereidsExecute("truncate table hive_truncate.table_with_pars partition pt2;")
+            order_qt_truncate_06 """ select * from ${table_name}; """
 
-        sql """drop table ${table_name};"""
-        sql """drop database ${database_name};"""
-        sql """drop catalog ${catalog_name};"""
+            sql """insert into ${table_name} values(22, 'ttt', 'gggw', '2022-02-04')"""
+            sql """insert into ${table_name} values(44, 'etg', 'wuweu', '2022-02-04') """
+            sql """insert into ${table_name} values(88, 'etg', 'wuweu', '2022-01-04') """
+            sql """insert into ${table_name} values(095, 'etgf', 'hiyr', '2021-05-06') """
+            sql """insert into ${table_name} values(555, 'etgf', 'wet', '2021-05-06') """
+            // checkNereidsExecute("truncate table ${catalog_name}.hive_truncate.table_with_pars partition pt1;")
+            // order_qt_truncate_07 """ select * from table_with_pars; """
+            // checkNereidsExecute("truncate table ${catalog_name}.hive_truncate.table_with_pars partition pt2;")
+            // order_qt_truncate_08 """ select * from table_with_pars; """
+            checkNereidsExecute("truncate table ${table_name}")
+            order_qt_truncate_09 """ select * from ${table_name}; """
+
+            sql """drop table ${table_name};"""
+            sql """drop database ${database_name};"""
+            sql """drop catalog ${catalog_name};"""
+        } finally {
+            try_sql """drop catalog if exists ${catalog_name};"""
+        }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
@@ -25,9 +25,10 @@ suite("test_hive_write_type", "p0,external") {
     for (String hivePrefix : ["hive2", "hive3"]) {
         def file_formats = ["parquet", "orc"]
         def test_complex_type_tbl = { String file_format, String catalog_name ->
+            String complexTypeDb = getHiveTempName("test_complex_type", file_format)
             sql """ switch ${catalog_name} """
-            sql """ create database if not exists `test_complex_type` """;
-            sql """ use `${catalog_name}`.`test_complex_type` """
+            sql """ create database if not exists `${complexTypeDb}` """;
+            sql """ use `${catalog_name}`.`${complexTypeDb}` """
 
             sql """ drop table if exists unpart_tbl_${file_format} """
             sql """
@@ -154,21 +155,22 @@ suite("test_hive_write_type", "p0,external") {
             order_qt_complex_type02 """ SELECT * FROM unpart_tbl_${file_format} WHERE col2='b' """
 
             sql """ drop table unpart_tbl_${file_format} """
-            sql """ drop database if exists `test_complex_type` """;
+            sql """ drop database if exists `${complexTypeDb}` """;
         }
 
         def test_insert_exception = { String file_format, String catalog_name ->
+            String hiveExDb = getHiveTempName("test_hive_ex", file_format)
             sql """ switch ${catalog_name} """
 
-            sql """ create database if not exists `test_hive_ex` """;
+            sql """ create database if not exists `${hiveExDb}` """;
             test {
-                sql """ create database `test_hive_ex` """
-                exception "errCode = 2, detailMessage = Can't create database 'test_hive_ex'; database exists"
+                sql """ create database `${hiveExDb}` """
+                exception "errCode = 2, detailMessage = Can't create database '${hiveExDb}'; database exists"
             }
-            sql """use `${catalog_name}`.`test_hive_ex`"""
+            sql """use `${catalog_name}`.`${hiveExDb}`"""
 
             sql """
-                CREATE TABLE IF NOT EXISTS test_hive_ex.ex_tbl_${file_format}(
+                CREATE TABLE IF NOT EXISTS ${hiveExDb}.ex_tbl_${file_format}(
                   `col1` BOOLEAN COMMENT 'col1',
                   `col2` INT COMMENT 'col2',
                   `col3` BIGINT COMMENT 'col3',
@@ -181,7 +183,7 @@ suite("test_hive_write_type", "p0,external") {
                   `pt3` DATE COMMENT 'pt3',
                   `pt1` VARCHAR COMMENT 'pt1',
                   `pt2` STRING COMMENT 'pt2'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PARTITION BY LIST (pt1, pt2) ()
                 PROPERTIES (
                   'file_format'='${file_format}'
@@ -190,8 +192,8 @@ suite("test_hive_write_type", "p0,external") {
 
             try {
                 // test  columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`)
+                    VALUES
                     (true, 123, 987654321099, 'abcdefghij', 3.1214, 63.28, 123.4567, 'varcharval', 'stringval');
                 """
             } catch (Exception e) {
@@ -202,8 +204,8 @@ suite("test_hive_write_type", "p0,external") {
 
             try {
                 // test type diff columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`)
+                    VALUES
                     ('1', 123, 987654319, 'abcdefghij', '3.15', '6.28', 123.4567, 432, 'stringval');
                 """
             } catch (Exception e) {
@@ -213,9 +215,9 @@ suite("test_hive_write_type", "p0,external") {
 
             test {
                 sql """
-                        CREATE TABLE test_hive_ex.ex_tbl_${file_format}(
+                        CREATE TABLE ${hiveExDb}.ex_tbl_${file_format}(
                           `col1` BOOLEAN COMMENT 'col1'
-                        )  ENGINE=hive 
+                        )  ENGINE=hive
                         PROPERTIES (
                           'file_format'='${file_format}'
                         )
@@ -225,8 +227,8 @@ suite("test_hive_write_type", "p0,external") {
 
             test {
                 // test columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`) 
-                        VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`)
+                        VALUES
                         (true, 123, 9876543210, 'abcdefghij', 3.14, 6.28, 123.4567, 'varcharval', 'stringval');
                 """
                 exception "errCode = 2, detailMessage = Column count doesn't match value count"
@@ -234,8 +236,8 @@ suite("test_hive_write_type", "p0,external") {
 
             test {
                 // test columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `pt00`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `pt00`)
+                    VALUES
                     (true, 123, 9876543210, 'abcdefghij', 3.14, 'error');
                 """
                 exception "errCode = 2, detailMessage = Unknown column 'pt00' in target table."
@@ -243,21 +245,22 @@ suite("test_hive_write_type", "p0,external") {
 
             // TODO: support partition spec
             test {
-                sql """ INSERT INTO ex_tbl_${file_format} partition(`pt1`,`pt2`) (`col3`, `col6`, `col9`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} partition(`pt1`,`pt2`) (`col3`, `col6`, `col9`)
+                    VALUES
                     (9876543210, 6.28, 'no_error');
                 """
                 exception "errCode = 2, detailMessage = Not support insert with partition spec in hive catalog"
             }
 
-            sql """ DROP TABLE ${catalog_name}.test_hive_ex.ex_tbl_${file_format} """
-            sql """ DROP DATABASE ${catalog_name}.test_hive_ex """
+            sql """ DROP TABLE ${catalog_name}.${hiveExDb}.ex_tbl_${file_format} """
+            sql """ DROP DATABASE ${catalog_name}.${hiveExDb} """
         }
 
         def test_columns_out_of_order = { String file_format, String catalog_name ->
+            String columnsOutOfOrderDb = getHiveTempName("test_columns_out_of_order", file_format)
             sql """ switch ${catalog_name} """
-            sql """ create database if not exists `test_columns_out_of_order` """;
-            sql """ use `${catalog_name}`.`test_columns_out_of_order` """
+            sql """ create database if not exists `${columnsOutOfOrderDb}` """;
+            sql """ use `${catalog_name}`.`${columnsOutOfOrderDb}` """
 
             sql """ drop table if exists columns_out_of_order_source_tbl_${file_format} """
             sql """
@@ -307,13 +310,14 @@ suite("test_hive_write_type", "p0,external") {
 
             sql """ drop table columns_out_of_order_source_tbl_${file_format} """
             sql """ drop table columns_out_of_order_target_tbl_${file_format} """
-            sql """ drop database if exists `test_columns_out_of_order` """;
+            sql """ drop database if exists `${columnsOutOfOrderDb}` """;
         }
 
+        String catalog_name = null
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_write_type"
+            catalog_name = getHiveTempName("test_${hivePrefix}_write_type", "catalog")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""
@@ -334,6 +338,7 @@ suite("test_hive_write_type", "p0,external") {
             }
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_file_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_file_meta_cache.groovy
@@ -29,53 +29,56 @@ suite("test_file_meta_cache", "p0,external") {
     for (String fileFormat : ["PARQUET",  "ORC"] ) {
         for (String hivePrefix : ["hive2", "hive3"]) {
             setHivePrefix(hivePrefix)
+            String catalogName = getHiveTempName("test_file_meta_cache", fileFormat)
+            String tableName = getHiveTempName("test_file_meta_cache", fileFormat)
             try {
                 String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
                 String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
 
-                sql """ drop catalog if exists test_file_meta_cache """
-                sql """CREATE CATALOG test_file_meta_cache PROPERTIES (
+                sql """ drop catalog if exists ${catalogName} """
+                sql """CREATE CATALOG ${catalogName} PROPERTIES (
                     'type'='hms',
                     'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
                 );"""
 
                 hive_docker """show databases;"""
-                hive_docker """drop table if exists default.test_file_meta_cache;  """
+                hive_docker """drop table if exists default.${tableName};  """
                 hive_docker """
-                                create table default.test_file_meta_cache (col1  int, col2 string) STORED AS ${fileFormat}; 
+                                create table default.${tableName} (col1  int, col2 string) STORED AS ${fileFormat};
                             """
-                hive_docker """insert into default.test_file_meta_cache values (1, "a"),(2, "b"); """
+                hive_docker """insert into default.${tableName} values (1, "a"),(2, "b"); """
 
-                sql """ refresh  catalog test_file_meta_cache """ 
-                qt_1 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
+                sql """ refresh  catalog ${catalogName} """
+                qt_1 """ select * from ${catalogName}.`default`.${tableName} order by col1 ; """
 
-                hive_docker """ TRUNCATE TABLE test_file_meta_cache """ 
-                hive_docker """insert into default.test_file_meta_cache values (3, "c"), (4, "d"); """
-                
-                sql """ refresh  catalog test_file_meta_cache """ 
-                qt_2 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
+                hive_docker """ TRUNCATE TABLE ${tableName} """
+                hive_docker """insert into default.${tableName} values (3, "c"), (4, "d"); """
 
-                
+                sql """ refresh  catalog ${catalogName} """
+                qt_2 """ select * from ${catalogName}.`default`.${tableName} order by col1 ; """
 
-                hive_docker """ drop TABLE test_file_meta_cache """ 
+
+
+                hive_docker """ drop TABLE ${tableName} """
                 hive_docker """
-                                create table default.test_file_meta_cache (col1  int, col2 string) STORED AS PARQUET; 
+                                create table default.${tableName} (col1  int, col2 string) STORED AS PARQUET;
                             """
-                hive_docker """insert into default.test_file_meta_cache values (5, "e"), (6, "f"); """
-                
-                sql """ refresh  catalog test_file_meta_cache """ 
-                qt_3 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
+                hive_docker """insert into default.${tableName} values (5, "e"), (6, "f"); """
 
-                hive_docker """ INSERT OVERWRITE TABLE test_file_meta_cache values (7,'g'), (8, 'h'); """
+                sql """ refresh  catalog ${catalogName} """
+                qt_3 """ select * from ${catalogName}.`default`.${tableName} order by col1 ; """
 
-                sql """ refresh  catalog test_file_meta_cache """ 
-                qt_4 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
+                hive_docker """ INSERT OVERWRITE TABLE ${tableName} values (7,'g'), (8, 'h'); """
+
+                sql """ refresh  catalog ${catalogName} """
+                qt_4 """ select * from ${catalogName}.`default`.${tableName} order by col1 ; """
 
 
             } finally {
+                try_sql """drop catalog if exists ${catalogName}"""
+                try_hive_docker """drop table if exists default.${tableName}"""
             }
         }
     }
 
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
@@ -16,17 +16,18 @@
 // under the License.
 
 suite("test_hive_meta_cache", "p0,external") {
-    String catalog_name = "test_hive_meta_cache"
-    String catalog_name_no_cache = "test_hive_meta_no_cache"
-
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         for (String hivePrefix : ["hive3"]) {
             setHivePrefix(hivePrefix)
+            String catalog_name = getHiveTempName("test_hive_meta_cache", "catalog")
+            String catalog_name_no_cache = getHiveTempName("test_hive_meta_no_cache", "catalog")
+            String dbName = getHiveTempName("test_hive_meta_cache_db", "db")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
 
+            try {
             // 1. test default catalog
             sql """drop catalog if exists ${catalog_name};"""
             sql """
@@ -38,31 +39,31 @@ suite("test_hive_meta_cache", "p0,external") {
             );
             """
             sql """switch ${catalog_name}"""
-            hive_docker """drop database if exists test_hive_meta_cache_db CASCADE"""
-            hive_docker """create database test_hive_meta_cache_db"""
+            hive_docker """drop database if exists ${dbName} CASCADE"""
+            hive_docker """create database ${dbName}"""
             hive_docker """
-                CREATE TABLE test_hive_meta_cache_db.sales (
+                CREATE TABLE ${dbName}.sales (
                   id INT,
                   amount DOUBLE
                 )
                 PARTITIONED BY (year INT)
             """
             hive_docker """ set hive.stats.column.autogather=false """
-            hive_docker """insert into test_hive_meta_cache_db.sales partition(year=2024) values(1, 2.0)"""
+            hive_docker """insert into ${dbName}.sales partition(year=2024) values(1, 2.0)"""
             // select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
             // insert into same partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(2, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(2, 2.0, 2024)"""
             // still select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
             // insert into new partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 3.0, 2025)"""
+            hive_docker """insert into ${dbName}.sales values(1, 3.0, 2025)"""
             // still select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
-            sql """refresh table test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
+            sql """refresh table ${dbName}.sales"""
             // select 3 rows
-            order_qt_sql_3row """select * from test_hive_meta_cache_db.sales"""
-            sql """drop table test_hive_meta_cache_db.sales"""
+            order_qt_sql_3row """select * from ${dbName}.sales"""
+            sql """drop table ${dbName}.sales"""
 
             // 2. test catalog with file.meta.cache.ttl-second
             sql """drop catalog if exists ${catalog_name_no_cache};"""
@@ -90,31 +91,31 @@ suite("test_hive_meta_cache", "p0,external") {
             );
             """
             sql """switch ${catalog_name_no_cache}"""
-            hive_docker """drop database if exists test_hive_meta_cache_db CASCADE"""
-            hive_docker """create database test_hive_meta_cache_db"""
+            hive_docker """drop database if exists ${dbName} CASCADE"""
+            hive_docker """create database ${dbName}"""
             hive_docker """
-                CREATE TABLE test_hive_meta_cache_db.sales (
+                CREATE TABLE ${dbName}.sales (
                   id INT,
                   amount DOUBLE
                 )
                 PARTITIONED BY (year INT)
                 STORED AS PARQUET;
             """
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(1, 2.0, 2024)"""
             // select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
             // insert into same partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(2, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(2, 2.0, 2024)"""
             // select 2 rows
-            order_qt_sql_2row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_2row """select * from ${dbName}.sales"""
             // insert into new partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 3.0, 2025)"""
+            hive_docker """insert into ${dbName}.sales values(1, 3.0, 2025)"""
             // still select 2 rows
-            order_qt_sql_2row """select * from test_hive_meta_cache_db.sales"""
-            sql """refresh table test_hive_meta_cache_db.sales"""
+            order_qt_sql_2row """select * from ${dbName}.sales"""
+            sql """refresh table ${dbName}.sales"""
             // select 3 rows
-            order_qt_sql_3row """select * from test_hive_meta_cache_db.sales"""
-            sql """drop table test_hive_meta_cache_db.sales"""
+            order_qt_sql_3row """select * from ${dbName}.sales"""
+            sql """drop table ${dbName}.sales"""
 
             // 3. test catalog with partition.cache.ttl-second
             sql """drop catalog if exists ${catalog_name_no_cache};"""
@@ -142,31 +143,31 @@ suite("test_hive_meta_cache", "p0,external") {
             );
             """
             sql """switch ${catalog_name_no_cache}"""
-            hive_docker """drop database if exists test_hive_meta_cache_db CASCADE"""
-            hive_docker """create database test_hive_meta_cache_db"""
+            hive_docker """drop database if exists ${dbName} CASCADE"""
+            hive_docker """create database ${dbName}"""
             hive_docker """
-                CREATE TABLE test_hive_meta_cache_db.sales (
+                CREATE TABLE ${dbName}.sales (
                   id INT,
                   amount DOUBLE
                 )
                 PARTITIONED BY (year INT)
                 STORED AS PARQUET;
             """
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(1, 2.0, 2024)"""
             // select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
             // insert into same partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(2, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(2, 2.0, 2024)"""
             // still select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
             // insert into new partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 3.0, 2025)"""
+            hive_docker """insert into ${dbName}.sales values(1, 3.0, 2025)"""
             // select 2 rows
-            order_qt_sql_2row """select * from test_hive_meta_cache_db.sales"""
-            sql """refresh table test_hive_meta_cache_db.sales"""
+            order_qt_sql_2row """select * from ${dbName}.sales"""
+            sql """refresh table ${dbName}.sales"""
             // select 3 rows
-            order_qt_sql_3row """select * from test_hive_meta_cache_db.sales"""
-            sql """drop table test_hive_meta_cache_db.sales"""
+            order_qt_sql_3row """select * from ${dbName}.sales"""
+            sql """drop table ${dbName}.sales"""
 
             // test modify ttl property
             sql """drop catalog if exists ${catalog_name_no_cache};"""
@@ -180,23 +181,23 @@ suite("test_hive_meta_cache", "p0,external") {
             );
             """
             sql """switch ${catalog_name_no_cache}"""
-            hive_docker """drop database if exists test_hive_meta_cache_db CASCADE"""
-            hive_docker """create database test_hive_meta_cache_db"""
+            hive_docker """drop database if exists ${dbName} CASCADE"""
+            hive_docker """create database ${dbName}"""
             hive_docker """
-                CREATE TABLE test_hive_meta_cache_db.sales (
+                CREATE TABLE ${dbName}.sales (
                   id INT,
                   amount DOUBLE
                 )
                 PARTITIONED BY (year INT)
                 STORED AS PARQUET;
             """
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(1, 2.0, 2024)"""
             // select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
             // insert into same partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(2, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(2, 2.0, 2024)"""
             // still select 1 row
-            order_qt_sql_1row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_1row """select * from ${dbName}.sales"""
             // alter wrong catalog property
             test {
                 sql """alter catalog ${catalog_name_no_cache} set properties ("file.meta.cache.ttl-second" = "-2")"""
@@ -205,16 +206,16 @@ suite("test_hive_meta_cache", "p0,external") {
             // alter catalog property, disable file list cache
             sql """alter catalog ${catalog_name_no_cache} set properties ("file.meta.cache.ttl-second" = "0")"""
             // select 2 rows
-            order_qt_sql_2row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_2row """select * from ${dbName}.sales"""
             // insert into same partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(3, 2.0, 2024)"""
+            hive_docker """insert into ${dbName}.sales values(3, 2.0, 2024)"""
             // select 3 row
-            order_qt_sql_3row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_3row """select * from ${dbName}.sales"""
 
             // insert into new partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 3.0, 2025)"""
+            hive_docker """insert into ${dbName}.sales values(1, 3.0, 2025)"""
             // still select 3 rows
-            order_qt_sql_3row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_3row """select * from ${dbName}.sales"""
             // alter wrong catalog property
             test {
                 sql """alter catalog ${catalog_name_no_cache} set properties ("partition.cache.ttl-second" = "-2")"""
@@ -223,12 +224,12 @@ suite("test_hive_meta_cache", "p0,external") {
             // alter catalog property, disable partition cache
             sql """alter catalog ${catalog_name_no_cache} set properties ("partition.cache.ttl-second" = "0")"""
             // select 4 rows
-            order_qt_sql_4row """select * from test_hive_meta_cache_db.sales"""
+            order_qt_sql_4row """select * from ${dbName}.sales"""
             // insert into new partition
-            hive_docker """insert into test_hive_meta_cache_db.sales values(1, 4.0, 2026)"""
+            hive_docker """insert into ${dbName}.sales values(1, 4.0, 2026)"""
             // select 5 rows
-            order_qt_sql_5row """select * from test_hive_meta_cache_db.sales"""
-            sql """drop table test_hive_meta_cache_db.sales"""
+            order_qt_sql_5row """select * from ${dbName}.sales"""
+            sql """drop table ${dbName}.sales"""
 
             // test schema cache
             sql """drop catalog if exists ${catalog_name_no_cache};"""
@@ -242,10 +243,10 @@ suite("test_hive_meta_cache", "p0,external") {
             );
             """
             sql """switch ${catalog_name_no_cache}"""
-            hive_docker """drop database if exists test_hive_meta_cache_db CASCADE"""
-            hive_docker """create database test_hive_meta_cache_db"""
+            hive_docker """drop database if exists ${dbName} CASCADE"""
+            hive_docker """create database ${dbName}"""
             hive_docker """
-                CREATE TABLE test_hive_meta_cache_db.sales (
+                CREATE TABLE ${dbName}.sales (
                   id INT,
                   amount DOUBLE
                 )
@@ -253,15 +254,15 @@ suite("test_hive_meta_cache", "p0,external") {
                 STORED AS PARQUET;
             """
             // desc table, 3 columns
-            qt_sql_3col "desc test_hive_meta_cache_db.sales";
+            qt_sql_3col "desc ${dbName}.sales";
             // add a new column in hive
-            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k3 string)"
+            hive_docker "alter table ${dbName}.sales add columns(k3 string)"
             // desc table, still 3 columns
-            qt_sql_3col "desc test_hive_meta_cache_db.sales";
+            qt_sql_3col "desc ${dbName}.sales";
             // refresh and check
-            sql "refresh table test_hive_meta_cache_db.sales";
+            sql "refresh table ${dbName}.sales";
             // desc table, 4 columns
-            qt_sql_4col "desc test_hive_meta_cache_db.sales";
+            qt_sql_4col "desc ${dbName}.sales";
 
             // create catalog without schema cache
             sql """drop catalog if exists ${catalog_name_no_cache};"""
@@ -276,11 +277,11 @@ suite("test_hive_meta_cache", "p0,external") {
             """
             sql """switch ${catalog_name_no_cache}"""
             // desc table, 4 columns
-            qt_sql_4col "desc test_hive_meta_cache_db.sales";
+            qt_sql_4col "desc ${dbName}.sales";
             // add a new column in hive
-            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k4 string)"
+            hive_docker "alter table ${dbName}.sales add columns(k4 string)"
             // desc table, 5 columns
-            qt_sql_5col "desc test_hive_meta_cache_db.sales";
+            qt_sql_5col "desc ${dbName}.sales";
 
             // modify property
             // alter wrong catalog property
@@ -290,12 +291,12 @@ suite("test_hive_meta_cache", "p0,external") {
             }
             sql """alter catalog ${catalog_name_no_cache} set properties ("schema.cache.ttl-second" = "0")"""
             // desc table, 5 columns
-            qt_sql_5col "desc test_hive_meta_cache_db.sales";
+            qt_sql_5col "desc ${dbName}.sales";
             // add a new column in hive
-            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k5 string)"
+            hive_docker "alter table ${dbName}.sales add columns(k5 string)"
             // desc table, 6 columns
-            qt_sql_6col "desc test_hive_meta_cache_db.sales";
-            sql """drop table test_hive_meta_cache_db.sales"""
+            qt_sql_6col "desc ${dbName}.sales";
+            sql """drop table ${dbName}.sales"""
 
             // test schema cache with get_schema_from_table
             sql """drop catalog if exists ${catalog_name_no_cache};"""
@@ -311,10 +312,10 @@ suite("test_hive_meta_cache", "p0,external") {
             );
             """
             sql """switch ${catalog_name_no_cache}"""
-            hive_docker """drop database if exists test_hive_meta_cache_db CASCADE"""
-            hive_docker """create database test_hive_meta_cache_db"""
+            hive_docker """drop database if exists ${dbName} CASCADE"""
+            hive_docker """create database ${dbName}"""
             hive_docker """
-                CREATE TABLE test_hive_meta_cache_db.sales (
+                CREATE TABLE ${dbName}.sales (
                   id INT,
                   amount DOUBLE
                 )
@@ -322,41 +323,45 @@ suite("test_hive_meta_cache", "p0,external") {
                 STORED AS PARQUET;
             """
             // desc table, 3 columns
-            qt_sql_3col "desc test_hive_meta_cache_db.sales";
+            qt_sql_3col "desc ${dbName}.sales";
             // show create table , 3 columns
-            def sql_sct01_3col = sql "show create table test_hive_meta_cache_db.sales"
+            def sql_sct01_3col = sql "show create table ${dbName}.sales"
             println "${sql_sct01_3col}"
             assertTrue(sql_sct01_3col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double)\nPARTITIONED BY (\n `year` int)"));
-            
+
             // add a new column in hive
-            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k1 string)"
+            hive_docker "alter table ${dbName}.sales add columns(k1 string)"
             // desc table, 4 columns
-            qt_sql_4col "desc test_hive_meta_cache_db.sales";
+            qt_sql_4col "desc ${dbName}.sales";
             // show create table, 4 columns
-            def sql_sct01_4col = sql "show create table test_hive_meta_cache_db.sales"
+            def sql_sct01_4col = sql "show create table ${dbName}.sales"
             println "${sql_sct01_4col}"
             assertTrue(sql_sct01_4col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string)\nPARTITIONED BY (\n `year` int)"));
 
             // open schema cache
             sql """alter catalog ${catalog_name_no_cache} set properties ("schema.cache.ttl-second" = "120")"""
             // add a new column in hive
-            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k2 string)"
+            hive_docker "alter table ${dbName}.sales add columns(k2 string)"
             // desc table, 5 columns
-            qt_sql_5col "desc test_hive_meta_cache_db.sales";
+            qt_sql_5col "desc ${dbName}.sales";
             // show create table, 5 columns
-            def sql_sct01_5col = sql "show create table test_hive_meta_cache_db.sales"
+            def sql_sct01_5col = sql "show create table ${dbName}.sales"
             println "${sql_sct01_5col}"
             assertTrue(sql_sct01_5col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string)\nPARTITIONED BY (\n `year` int)"));
             // add a new column in hive
-            hive_docker "alter table test_hive_meta_cache_db.sales add columns(k3 string)"
+            hive_docker "alter table ${dbName}.sales add columns(k3 string)"
             // desc table, still 5 columns
-            qt_sql_5col "desc test_hive_meta_cache_db.sales";
+            qt_sql_5col "desc ${dbName}.sales";
             // show create table always see latest schema, 6 columns
-            def sql_sct01_6col = sql "show create table test_hive_meta_cache_db.sales"
+            def sql_sct01_6col = sql "show create table ${dbName}.sales"
             println "${sql_sct01_6col}"
             assertTrue(sql_sct01_6col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string,\n  `k3` string)\nPARTITIONED BY (\n `year` int)"));
-            sql """drop table test_hive_meta_cache_db.sales"""
+            sql """drop table ${dbName}.sales"""
+            } finally {
+                cleanupHiveDockerDatabase(dbName, true)
+                try_sql """drop catalog if exists ${catalog_name}"""
+                try_sql """drop catalog if exists ${catalog_name_no_cache}"""
+            }
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_metadata_refresh_interval.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_metadata_refresh_interval.groovy
@@ -25,15 +25,14 @@ suite("test_hive_metadata_refresh_interval", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = getHiveTempName("test_${hivePrefix}_refresh_interval", "catalog")
+        String test_db = getHiveTempName("test_refresh_interval_db", "db")
+        String table1 = getHiveTempName("test_refresh_table_1", "tbl")
+        String table2 = getHiveTempName("test_refresh_table_2", "tbl")
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-
-            String catalog_name = "test_${hivePrefix}_refresh_interval"
-            String test_db = "test_refresh_interval_db"
-            String table1 = "test_refresh_table_1"
-            String table2 = "test_refresh_table_2"
 
             sql """drop catalog if exists ${catalog_name}"""
             hive_docker "drop database if exists ${test_db} cascade"
@@ -94,8 +93,8 @@ suite("test_hive_metadata_refresh_interval", "p0,external") {
             sql """drop catalog ${catalog_name}"""
 
         } finally {
-            sql """drop catalog if exists test_${hivePrefix}_refresh_interval"""
-            hive_docker "drop database if exists test_refresh_interval_db cascade"
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker "drop database if exists ${test_db} cascade"
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
@@ -24,15 +24,17 @@ suite("test_hive_partition_values_tvf", "p0,external") {
     for (String hivePrefix : ["hive3"]) {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name = "${hivePrefix}_test_external_catalog_hive_partition"
+        String catalog_name = getHiveTempName("${hivePrefix}_test_external_catalog_hive_partition", "catalog")
+        String partitionValuesDb = getHiveTempName("partition_values_db", "db")
 
-        sql """drop catalog if exists ${catalog_name};"""
-        sql """
-            create catalog if not exists ${catalog_name} properties (
-                'type'='hms',
-                'hive.metastore.uris' = 'thrift://${extHiveHmsHost}:${extHiveHmsPort}'
-            );
-        """
+        try {
+            sql """drop catalog if exists ${catalog_name};"""
+            sql """
+                create catalog if not exists ${catalog_name} properties (
+                    'type'='hms',
+                    'hive.metastore.uris' = 'thrift://${extHiveHmsHost}:${extHiveHmsPort}'
+                );
+            """
 
         // 1. test qualifier
         qt_sql01 """ select * from ${catalog_name}.multi_catalog.orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
@@ -54,17 +56,17 @@ suite("test_hive_partition_values_tvf", "p0,external") {
 
         // 4. test alias
         qt_sql31 """ select pv.t_float, pv.t_int from orc_partitioned_columns\$partitions as pv group by t_int, t_float order by t_int, t_float"""
-        
+
         // 5. test CTE
         qt_sql41 """ with v1 as (select t_string, t_int from orc_partitioned_columns\$partitions order by t_int, t_float, t_string) select max(t_int) from v1; """
         qt_sql42 """ with v1 as (select t_string, t_int from orc_partitioned_columns\$partitions order by t_int, t_float, t_string) select c1 from (select max(t_string) as c1 from v1) x; """
- 
+
         // 6. test subquery
         qt_sql51 """select c1 from (select max(t_string) as c1 from (select * from multi_catalog.orc_partitioned_columns\$partitions)x)y;"""
 
         // 7. test where
         qt_sql61 """select * from orc_partitioned_columns\$partitions where t_int != "__HIVE_DEFAULT_PARTITION__" order by t_int, t_float, t_string; """
-        
+
         // 8. test view
         sql """drop database if exists internal.partition_values_db"""
         sql """create database if not exists internal.partition_values_db"""
@@ -72,7 +74,7 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         qt_sql71 """select * from internal.partition_values_db.v1"""
         qt_sql72 """select t_string, t_int from internal.partition_values_db.v1 where t_int != "__HIVE_DEFAULT_PARTITION__""""
         qt_sql73 """with v1 as (select t_string, t_int from internal.partition_values_db.v1 order by t_int, t_float, t_string) select c1 from (select max(t_string) as c1 from v1) x;"""
-        
+
         // 9. test join
         qt_sql81 """select * from orc_partitioned_columns\$partitions p1 join orc_partitioned_columns\$partitions p2 on p1.t_int = p2.t_int order by p1.t_int, p1.t_float"""
 
@@ -108,10 +110,10 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         }
 
         // 13. test all types of partition columns
-        sql """switch ${catalog_name}"""
-        sql """drop database if exists partition_values_db""";
-        sql """create database partition_values_db"""
-        sql """use partition_values_db"""
+            sql """switch ${catalog_name}"""
+            sql """drop database if exists ${partitionValuesDb}""";
+            sql """create database ${partitionValuesDb}"""
+            sql """use ${partitionValuesDb}"""
 
         sql """create table partition_values_all_types (
             k1 int,
@@ -136,7 +138,9 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         """
 
         qt_sql112 """select * from partition_values_all_types order by k1;"""
-        qt_sql113 """select * from partition_values_all_types\$partitions order by p1,p2,p3;"""
+            qt_sql113 """select * from partition_values_all_types\$partitions order by p1,p2,p3;"""
+        } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
+        }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
@@ -140,6 +140,7 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         qt_sql112 """select * from partition_values_all_types order by k1;"""
             qt_sql113 """select * from partition_values_all_types\$partitions order by p1,p2,p3;"""
         } finally {
+            try_sql """drop database if exists ${partitionValuesDb}"""
             try_sql """drop catalog if exists ${catalog_name}"""
         }
     }

--- a/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
@@ -80,7 +80,7 @@ suite("test_hive_partitions", "p0,external") {
         setHivePrefix(hivePrefix)
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String catalog_name = "${hivePrefix}_test_partitions"
+            String catalog_name = getHiveTempName("${hivePrefix}_test_partitions", "catalog")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""
@@ -94,8 +94,8 @@ suite("test_hive_partitions", "p0,external") {
 
             // Test cache miss scenario: Hive adds partition, then Doris writes to it
             def test_cache_miss = {
-                def dbName = "test_cache_miss_db"
-                def tblName = "test_cache_miss_table"
+                def dbName = getHiveTempName("test_cache_miss_db", "db")
+                def tblName = getHiveTempName("test_cache_miss_table", "tbl")
 
                 try {
                     // Clean up
@@ -127,7 +127,7 @@ suite("test_hive_partitions", "p0,external") {
                         VALUES (3, 'hive_pt3')
                     """
 
-                    sql """refresh catalog `${catalog_name}`"""      
+                    sql """refresh catalog `${catalog_name}`"""
                     // Doris reads data to populate cache (only knows about 3 partitions)
                     def result1 = sql """SELECT COUNT(*) as cnt FROM `${catalog_name}`.`${dbName}`.`${tblName}`"""
                     assertEquals(3, result1[0][0])
@@ -201,7 +201,7 @@ suite("test_hive_partitions", "p0,external") {
             }
             sql """unset variable num_partitions_in_batch_mode"""
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
@@ -78,9 +78,9 @@ suite("test_hive_partitions", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = getHiveTempName("${hivePrefix}_test_partitions", "catalog")
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String catalog_name = getHiveTempName("${hivePrefix}_test_partitions", "catalog")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
@@ -24,45 +24,52 @@ suite("test_hive_serde_prop", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
-        String catalog_name = "test_${hivePrefix}_serde_prop"
+        String catalog_name = getHiveTempName("test_${hivePrefix}_serde_prop", "catalog")
         String ex_db_name = "`stats_test`"
+        String tempSerdeTable = getHiveTempName("serde_test8", "serde")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
 
         sql """drop catalog if exists ${catalog_name} """
 
-        sql """CREATE CATALOG ${catalog_name} PROPERTIES (
-                'type'='hms',
-                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-                'hadoop.username' = 'hive'
-            );"""
+        try {
+            sql """CREATE CATALOG ${catalog_name} PROPERTIES (
+                    'type'='hms',
+                    'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                    'hadoop.username' = 'hive'
+                );"""
 
-		qt_1 """select * from ${catalog_name}.${ex_db_name}.employee_gz order by name;"""
+		    qt_1 """select * from ${catalog_name}.${ex_db_name}.employee_gz order by name;"""
 
 
-        qt_2 """select * from ${catalog_name}.regression.serde_test1 order by id;"""
-        qt_3 """select * from ${catalog_name}.regression.serde_test2 order by id;"""
-        qt_4 """select * from ${catalog_name}.regression.serde_test3 order by id;"""
-        qt_5 """select * from ${catalog_name}.regression.serde_test4 order by id;"""
-        qt_6 """select * from ${catalog_name}.regression.serde_test5 order by id;"""
-        qt_7 """select * from ${catalog_name}.regression.serde_test6 order by id;"""
-        qt_8 """select * from ${catalog_name}.regression.serde_test7 order by id;"""
+            qt_2 """select * from ${catalog_name}.regression.serde_test1 order by id;"""
+            qt_3 """select * from ${catalog_name}.regression.serde_test2 order by id;"""
+            qt_4 """select * from ${catalog_name}.regression.serde_test3 order by id;"""
+            qt_5 """select * from ${catalog_name}.regression.serde_test4 order by id;"""
+            qt_6 """select * from ${catalog_name}.regression.serde_test5 order by id;"""
+            qt_7 """select * from ${catalog_name}.regression.serde_test6 order by id;"""
+            qt_8 """select * from ${catalog_name}.regression.serde_test7 order by id;"""
 
-        hive_docker """truncate table regression.serde_test8;"""
-        sql """insert into ${catalog_name}.regression.serde_test8 select * from ${catalog_name}.regression.serde_test7;"""
-        qt_9 """select * from ${catalog_name}.regression.serde_test8 order by id;"""
+            hive_docker """drop table if exists regression.${tempSerdeTable};"""
+            hive_docker """create table regression.${tempSerdeTable} like regression.serde_test8;"""
+            sql """refresh catalog ${catalog_name};"""
+            sql """insert into ${catalog_name}.regression.${tempSerdeTable} select * from ${catalog_name}.regression.serde_test7;"""
+            qt_9 """select * from ${catalog_name}.regression.${tempSerdeTable} order by id;"""
 
-        qt_test_open_csv_default_prop """select * from ${catalog_name}.regression.test_open_csv_default_prop order by id;"""
-        qt_test_open_csv_standard_prop """select * from ${catalog_name}.regression.test_open_csv_standard_prop order by id;"""
-        qt_test_open_csv_custom_prop """select * from ${catalog_name}.regression.test_open_csv_custom_prop order by id;"""
+            qt_test_open_csv_default_prop """select * from ${catalog_name}.regression.test_open_csv_default_prop order by id;"""
+            qt_test_open_csv_standard_prop """select * from ${catalog_name}.regression.test_open_csv_standard_prop order by id;"""
+            qt_test_open_csv_custom_prop """select * from ${catalog_name}.regression.test_open_csv_custom_prop order by id;"""
 
-        qt_test_empty_null_format_text """select * from ${catalog_name}.regression.test_empty_null_format_text order by id;"""
-        qt_test_empty_null_format_text2 """select * from ${catalog_name}.regression.test_empty_null_format_text where name is null order by id;"""
-        qt_test_empty_null_format_text3 """select * from ${catalog_name}.regression.test_empty_null_format_text where name = '' order by id;"""
+            qt_test_empty_null_format_text """select * from ${catalog_name}.regression.test_empty_null_format_text order by id;"""
+            qt_test_empty_null_format_text2 """select * from ${catalog_name}.regression.test_empty_null_format_text where name is null order by id;"""
+            qt_test_empty_null_format_text3 """select * from ${catalog_name}.regression.test_empty_null_format_text where name = '' order by id;"""
 
-        qt_test_empty_null_defined_text """select * from ${catalog_name}.regression.test_empty_null_defined_text order by id;"""
-        qt_test_empty_null_defined_text2 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name is null order by id;"""
-        qt_test_empty_null_defined_text3 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name = '' order by id;"""
+            qt_test_empty_null_defined_text """select * from ${catalog_name}.regression.test_empty_null_defined_text order by id;"""
+            qt_test_empty_null_defined_text2 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name is null order by id;"""
+            qt_test_empty_null_defined_text3 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name = '' order by id;"""
+        } finally {
+            try_hive_docker """drop table if exists regression.${tempSerdeTable};"""
+            try_sql """drop catalog if exists ${catalog_name} """
+        }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
@@ -27,60 +27,57 @@ suite("test_hive_special_char_partition", "p0,external") {
         setHivePrefix(hivePrefix)
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-        String catalog_name = "${hivePrefix}_test_hive_special_char_partition"
+        String catalog_name = getHiveTempName("${hivePrefix}_test_hive_special_char_partition", "catalog")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String table_name_1 = getHiveTempName("partition_special_characters_1", "tbl")
+        String table_name_2 = getHiveTempName("partition_special_characters_2", "tbl")
+        String table_name_3 = getHiveTempName("partition_special_characters_3", "tbl")
 
-        sql """drop catalog if exists ${catalog_name}"""
-        sql """create catalog if not exists ${catalog_name} properties (
-            'type'='hms',
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-            'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
-        );"""
-        logger.info("catalog " + catalog_name + " created")
-        sql """switch ${catalog_name};"""
-        logger.info("switched to catalog " + catalog_name)
-        sql """use multi_catalog;"""
-        qt_1 "select * from special_character_1_partition order by name"
-        qt_2 "select name from special_character_1_partition where part='2023 01 01'"
-        qt_3 "select name from special_character_1_partition where part='2023/01/01'"
-        qt_4 "select * from special_character_1_partition where part='2023?01?01'"
-        qt_5 "select * from special_character_1_partition where part='2023.01.01'"
-        qt_6 "select * from special_character_1_partition where part='2023<01><01>'"
-        qt_7 "select * from special_character_1_partition where part='2023:01:01'"
-        qt_8 "select * from special_character_1_partition where part='2023=01=01'"
-        qt_9 "select * from special_character_1_partition where part='2023\"01\"01'"
-        qt_10 "select * from special_character_1_partition where part='2023\\'01\\'01'"
-        qt_11 "select * from special_character_1_partition where part='2023\\\\01\\\\01'"
-        qt_12 "select * from special_character_1_partition where part='2023%01%01'"
-        qt_13 "select * from special_character_1_partition where part='2023#01#01'"
+        try {
+            sql """drop catalog if exists ${catalog_name}"""
+            sql """create catalog if not exists ${catalog_name} properties (
+                'type'='hms',
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
+            );"""
+            logger.info("catalog " + catalog_name + " created")
+            sql """switch ${catalog_name};"""
+            logger.info("switched to catalog " + catalog_name)
+            sql """use multi_catalog;"""
+            qt_1 "select * from special_character_1_partition order by name"
+            qt_2 "select name from special_character_1_partition where part='2023 01 01'"
+            qt_3 "select name from special_character_1_partition where part='2023/01/01'"
+            qt_4 "select * from special_character_1_partition where part='2023?01?01'"
+            qt_5 "select * from special_character_1_partition where part='2023.01.01'"
+            qt_6 "select * from special_character_1_partition where part='2023<01><01>'"
+            qt_7 "select * from special_character_1_partition where part='2023:01:01'"
+            qt_8 "select * from special_character_1_partition where part='2023=01=01'"
+            qt_9 "select * from special_character_1_partition where part='2023\"01\"01'"
+            qt_10 "select * from special_character_1_partition where part='2023\\'01\\'01'"
+            qt_11 "select * from special_character_1_partition where part='2023\\\\01\\\\01'"
+            qt_12 "select * from special_character_1_partition where part='2023%01%01'"
+            qt_13 "select * from special_character_1_partition where part='2023#01#01'"
 
-
-
-        // append some case.
-        String table_name_1 = "partition_special_characters_1"  
-        String table_name_2 = "partition_special_characters_2" 
-        String table_name_3 = "partition_special_characters_3" 
-    
-        hive_docker """ set hive.stats.column.autogather=false """
-        hive_docker """ use `default`"""
-        def special_characters = [
-                                    "1,1=1, 3=2+1, 1=3-2, 3/3=1, 2/2=1, 2/1=2, 2/1=2 +1 -1,2/1=2 *3 /3",
-                                    " %100, @@@@@@ ,  %100 , !!asd!!, A%%Z",
-                                    "abc:xyz,  1123,1222,  :::::::"
-                ]
+            hive_docker """ set hive.stats.column.autogather=false """
+            hive_docker """ use `default`"""
+            def special_characters = [
+                                        "1,1=1, 3=2+1, 1=3-2, 3/3=1, 2/2=1, 2/1=2, 2/1=2 +1 -1,2/1=2 *3 /3",
+                                        " %100, @@@@@@ ,  %100 , !!asd!!, A%%Z",
+                                        "abc:xyz,  1123,1222,  :::::::"
+                    ]
 
 
-        logger.info(""" docker insert 1""")            
+            logger.info(""" docker insert 1""")
 
-        hive_docker """ drop table if exists ${table_name_1} """ 
+        hive_docker """ drop table if exists ${table_name_1} """
         hive_docker """ create table ${table_name_1} (id int) partitioned by (pt string) """
         special_characters.eachWithIndex { item, index ->
             hive_docker """ insert into  ${table_name_1} partition(pt="${item}")      values ("${index}"); """
             hive_docker """ insert into  ${table_name_1} partition(pt="${item}")      values ("${index*100}"); """
-            println("Index: ${index}, Item: ${item}")    
+            println("Index: ${index}, Item: ${item}")
         }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -89,26 +86,26 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql2 """ show partitions from ${table_name_1} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id""" 
+            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id"""
         }
 
 
 
-        logger.info(""" docker insert 2""")            
-        hive_docker """ drop table if exists ${table_name_2} """ 
+            logger.info(""" docker insert 2""")
+        hive_docker """ drop table if exists ${table_name_2} """
         hive_docker """ create table ${table_name_2} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string) """
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
 
                 hive_docker """ insert into  ${table_name_2} partition(pt1="${outerItem}",`pt2=x!!!! **1+1/&^%3`="${innerItem}")   values ("${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -117,25 +114,25 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql4 """ show partitions from ${table_name_2} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id""" 
+            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id"""
         }
 
 
-        logger.info(""" docker insert 3""")            
-        hive_docker """ drop table if exists ${table_name_3} """ 
+            logger.info(""" docker insert 3""")
+        hive_docker """ drop table if exists ${table_name_3} """
         hive_docker """ create table ${table_name_3} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string,pt3 string,pt4 string,pt5 string) """
 
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
                 hive_docker """ insert into  ${table_name_3} partition(pt1="${outerItem}", `pt2=x!!!! **1+1/&^%3`="1", pt3="1",pt4="${innerItem}",pt5="1")   values ("${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-                    
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -144,7 +141,7 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql6 """ show partitions from ${table_name_3} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id""" 
+            qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id"""
         }
 
 
@@ -152,10 +149,10 @@ suite("test_hive_special_char_partition", "p0,external") {
 
 
 
-        logger.info("""  ---------- doris insert  -------------""")
+            logger.info("""  ---------- doris insert  -------------""")
 
-        logger.info(""" doris insert 1""")            
-        hive_docker """ drop table if exists ${table_name_1} """ 
+            logger.info(""" doris insert 1""")
+        hive_docker """ drop table if exists ${table_name_1} """
         hive_docker """ create table ${table_name_1} (id int) partitioned by (pt string) """
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
@@ -164,10 +161,10 @@ suite("test_hive_special_char_partition", "p0,external") {
             sql """ insert into  ${table_name_1} (pt,id)  values ("${item}","${index}"); """
             sql """ insert into  ${table_name_1} (pt,id)  values ("${item}","${index*100}"); """
 
-            println("Index: ${index}, Item: ${item}")    
+            println("Index: ${index}, Item: ${item}")
         }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -176,13 +173,13 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql2 """ show partitions from ${table_name_1} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id """ 
+            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id """
         }
 
 
 
-        logger.info(""" doris insert 2""")            
-        hive_docker """ drop table if exists ${table_name_2} """ 
+            logger.info(""" doris insert 2""")
+        hive_docker """ drop table if exists ${table_name_2} """
         hive_docker """ create table ${table_name_2} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string) """
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
@@ -190,15 +187,15 @@ suite("test_hive_special_char_partition", "p0,external") {
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
 
                 sql """ insert into  ${table_name_2} (pt1,`pt2=x!!!! **1+1/&^%3`,id)   values ("${outerItem}","${innerItem}","${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -207,14 +204,14 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql4 """ show partitions from ${table_name_2} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id""" 
+            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id"""
         }
 
 
 
 
-        logger.info(""" docker insert 3""")            
-        hive_docker """ drop table if exists ${table_name_3} """ 
+            logger.info(""" docker insert 3""")
+        hive_docker """ drop table if exists ${table_name_3} """
         hive_docker """ create table ${table_name_3} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string,pt3 string,pt4 string,pt5 string) """
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
@@ -222,14 +219,14 @@ suite("test_hive_special_char_partition", "p0,external") {
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
                 sql """ insert into  ${table_name_3} (pt1, `pt2=x!!!! **1+1/&^%3`, pt3,pt4,pt5,id)   values ("${outerItem}","1","1","${innerItem}","1","${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-                    
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -238,12 +235,17 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql6 """ show partitions from ${table_name_3} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id""" 
+            qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id"""
         }
 
 
 
 
+        } finally {
+            try_hive_docker """drop table if exists default.${table_name_1}"""
+            try_hive_docker """drop table if exists default.${table_name_2}"""
+            try_hive_docker """drop table if exists default.${table_name_3}"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+        }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_false.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_false.groovy
@@ -51,7 +51,7 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                 String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
                 String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
                 String use_meta_cache_string = use_meta_cache ? "true" : "false"
-                String catalog = "test_${hivePrefix}_use_meta_cache_${use_meta_cache}"
+                String catalog = getHiveTempName("test_${hivePrefix}_use_meta_cache_${use_meta_cache}", "catalog")
                 String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
                 sql """drop catalog if exists ${catalog}"""
@@ -61,13 +61,14 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                     'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
                     'use_meta_cache' = '${use_meta_cache_string}'
                 );"""
-                
+
                 // create from Doris, the cache will be filled immediately
-                String database= "test_use_meta_cache_db_${use_meta_cache}"
-                String table = "test_use_meta_cache_tbl_${use_meta_cache}"
-                String database_hive = "test_use_meta_cache_db_hive_${use_meta_cache}"
-                String table_hive = "test_use_meta_cache_tbl_hive_${use_meta_cache}"
-                String partitioned_table_hive = "test_use_meta_cache_partitioned_tbl_hive_${use_meta_cache}"
+                String database= getHiveTempName("test_use_meta_cache_db_${use_meta_cache}", "db")
+                String table = getHiveTempName("test_use_meta_cache_tbl_${use_meta_cache}", "tbl")
+                String database_hive = getHiveTempName("test_use_meta_cache_db_hive_${use_meta_cache}", "db")
+                String table_hive = getHiveTempName("test_use_meta_cache_tbl_hive_${use_meta_cache}", "tbl")
+                String partitioned_table_hive = getHiveTempName("test_use_meta_cache_partitioned_tbl_hive_${use_meta_cache}", "tbl")
+                String anotherTableCreationTest = getHiveTempName("another_table_creation_test", "tbl")
 
                 sql "switch ${catalog}"
                 sql "drop database if exists ${database} force"
@@ -83,7 +84,7 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                 order_qt_sql04 "show tables"
                 sql "drop database ${database}"
                 order_qt_sql05 "show databases like '%${database}%'";
-            
+
                 // create from Hive, the cache has different behavior
                 order_qt_sql01 "show databases like '%${database_hive}%'";
                 hive_docker "drop database if exists ${database_hive}"
@@ -128,20 +129,20 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                 // the main point is to select the table first before creation.
                 if (use_meta_cache) {
                     // 0. create env
-                    hive_docker "drop table if exists ${database_hive}.another_table_creation_test"
+                    hive_docker "drop table if exists ${database_hive}.${anotherTableCreationTest}"
                     // 1. select a non exist table
                     test {
-                        sql "select * from another_table_creation_test";
+                        sql "select * from ${anotherTableCreationTest}";
                         exception "does not exist in database"
                     }
                     // 2. use hive to create this table
-                    hive_docker "create table ${database_hive}.another_table_creation_test (k1 int)"
+                    hive_docker "create table ${database_hive}.${anotherTableCreationTest} (k1 int)"
                     // 3. use doris to select, can see
-                    qt_aother_test_sql "select * from another_table_creation_test";
+                    qt_aother_test_sql "select * from ${anotherTableCreationTest}";
                     // 4. drop table
-                    sql "drop table another_table_creation_test";
+                    sql "drop table ${anotherTableCreationTest}";
                 }
-                
+
                 // test Hive Metastore table partition file listing
                 hive_docker "create table ${database_hive}.${partitioned_table_hive} (k1 int) partitioned by (p1 string)"
                 sql "refresh catalog ${catalog}"
@@ -169,6 +170,9 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                 sql "refresh catalog ${catalog}"
                 // can not see
                 order_qt_sql13 "show databases like '%${database_hive}%'";
+
+                cleanupHiveDockerDatabase(database_hive, true)
+                try_sql """drop catalog if exists ${catalog}"""
             }
             // test_use_meta_cache(false)
         } finally {

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
@@ -52,24 +52,31 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                 sql "switch ${catalog}"
                 sql "drop database if exists ${database} force"
                 sql "drop database if exists ${database_hive} force"
-                order_qt_sql01 "show databases like '%${database}%'";
+                def result01 = sql "show databases like '%${database}%'"
+                assertTrue(result01.isEmpty(), "Database should not exist before creation")
                 sql "drop database if exists ${database} force"
                 sql "create database ${database}"
-                order_qt_sql02 "show databases like '%${database}%'";
+                def result02 = sql "show databases like '%${database}%'"
+                assertTrue(result02.size() == 1, "Database should exist after creation")
                 sql "use ${database}"
                 sql "create table ${table} (k1 int)"
-                order_qt_sql03 "show tables"
+                def result03 = sql "show tables"
+                assertTrue(result03.size() == 1, "Table should exist after creation")
                 sql "drop table ${table}"
-                order_qt_sql04 "show tables"
+                def result04 = sql "show tables"
+                assertTrue(result04.isEmpty(), "Table should not exist after drop")
                 sql "drop database ${database}"
-                order_qt_sql05 "show databases like '%${database}%'";
+                def result05 = sql "show databases like '%${database}%'"
+                assertTrue(result05.isEmpty(), "Database should not exist after drop")
 
                 // create from Hive, the cache has different behavior
-                order_qt_sql01 "show databases like '%${database_hive}%'";
+                def result11 = sql "show databases like '%${database_hive}%'"
+                assertTrue(result11.isEmpty(), "Hive database should not exist before creation")
                 hive_docker "drop database if exists ${database_hive}"
                 hive_docker "create database ${database_hive}"
                 // not see
-                order_qt_sql02 "show databases like '%${database_hive}%'";
+                def result12 = sql "show databases like '%${database_hive}%'"
+                assertTrue(result12.isEmpty(), "Hive database should not be visible without refresh when cache enabled")
                 if (use_meta_cache) {
                     // if use meta cache, can use
                     sql "use ${database_hive}"
@@ -82,27 +89,33 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                 }
 
                 // can see
-                order_qt_sql03 "show databases like '%${database_hive}%'";
+                def result13 = sql "show databases like '%${database_hive}%'"
+                assertTrue(result13.size() == 1, "Hive database should be visible after refresh")
                 // show tables first to fill cache
-                order_qt_sql04 "show tables"
+                def result14 = sql "show tables"
+                assertTrue(result14.isEmpty(), "Tables should be empty initially")
                 hive_docker "create table ${database_hive}.${table_hive} (k1 int)"
                 // not see
-                order_qt_sql05 "show tables"
+                def result15 = sql "show tables"
+                assertTrue(result15.isEmpty(), "Hive table should not be visible without refresh")
                 if (use_meta_cache) {
                     // but can select
                     sql "select * from ${table_hive}"
                     // after select, the names cache is refresh, so can see
-                    order_qt_sql06 "show tables"
+                    def result16 = sql "show tables"
+                    assertTrue(result16.size() == 1, "Table should be visible after select")
                     sql "refresh database ${database_hive}"
                 } else {
                     // if not use meta cache, can not select
                     sql "refresh database ${database_hive}"
                     sql "select * from ${table_hive}"
                     // after select, the names cache is refresh, so can see
-                    order_qt_sql06 "show tables"
+                    def result16 = sql "show tables"
+                    assertTrue(result16.size() == 1, "Table should be visible after select")
                 }
                 // can see
-                order_qt_sql07 "show tables"
+                def result17 = sql "show tables"
+                assertTrue(result17.size() == 1, "Table should be visible")
 
                 // another table creation test only for use_meta_cache=true
                 // the main point is to select the table first before creation.

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
@@ -30,7 +30,7 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                 String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
                 String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
                 String use_meta_cache_string = use_meta_cache ? "true" : "false"
-                String catalog = "test_${hivePrefix}_use_meta_cache_${use_meta_cache}"
+                String catalog = getHiveTempName("test_${hivePrefix}_use_meta_cache_${use_meta_cache}", "catalog")
                 String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
                 sql """drop catalog if exists ${catalog}"""
@@ -40,13 +40,14 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                     'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
                     'use_meta_cache' = '${use_meta_cache_string}'
                 );"""
-                
+
                 // create from Doris, the cache will be filled immediately
-                String database= "test_use_meta_cache_db_${use_meta_cache}"
-                String table = "test_use_meta_cache_tbl_${use_meta_cache}"
-                String database_hive = "test_use_meta_cache_db_hive_${use_meta_cache}"
-                String table_hive = "test_use_meta_cache_tbl_hive_${use_meta_cache}"
-                String partitioned_table_hive = "test_use_meta_cache_partitioned_tbl_hive_${use_meta_cache}"
+                String database= getHiveTempName("test_use_meta_cache_db_${use_meta_cache}", "db")
+                String table = getHiveTempName("test_use_meta_cache_tbl_${use_meta_cache}", "tbl")
+                String database_hive = getHiveTempName("test_use_meta_cache_db_hive_${use_meta_cache}", "db")
+                String table_hive = getHiveTempName("test_use_meta_cache_tbl_hive_${use_meta_cache}", "tbl")
+                String partitioned_table_hive = getHiveTempName("test_use_meta_cache_partitioned_tbl_hive_${use_meta_cache}", "tbl")
+                String anotherTableCreationTest = getHiveTempName("another_table_creation_test", "tbl")
 
                 sql "switch ${catalog}"
                 sql "drop database if exists ${database} force"
@@ -62,7 +63,7 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                 order_qt_sql04 "show tables"
                 sql "drop database ${database}"
                 order_qt_sql05 "show databases like '%${database}%'";
-            
+
                 // create from Hive, the cache has different behavior
                 order_qt_sql01 "show databases like '%${database_hive}%'";
                 hive_docker "drop database if exists ${database_hive}"
@@ -107,20 +108,20 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                 // the main point is to select the table first before creation.
                 if (use_meta_cache) {
                     // 0. create env
-                    hive_docker "drop table if exists ${database_hive}.another_table_creation_test"
+                    hive_docker "drop table if exists ${database_hive}.${anotherTableCreationTest}"
                     // 1. select a non exist table
                     test {
-                        sql "select * from another_table_creation_test";
+                        sql "select * from ${anotherTableCreationTest}";
                         exception "does not exist in database"
                     }
                     // 2. use hive to create this table
-                    hive_docker "create table ${database_hive}.another_table_creation_test (k1 int)"
+                    hive_docker "create table ${database_hive}.${anotherTableCreationTest} (k1 int)"
                     // 3. use doris to select, can see
-                    qt_aother_test_sql "select * from another_table_creation_test";
+                    qt_aother_test_sql "select * from ${anotherTableCreationTest}";
                     // 4. drop table
-                    sql "drop table another_table_creation_test";
+                    sql "drop table ${anotherTableCreationTest}";
                 }
-                
+
                 // test Hive Metastore table partition file listing
                 hive_docker "create table ${database_hive}.${partitioned_table_hive} (k1 int) partitioned by (p1 string)"
                 sql "refresh catalog ${catalog}"
@@ -148,6 +149,9 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                 sql "refresh catalog ${catalog}"
                 // can not see
                 order_qt_sql13 "show databases like '%${database_hive}%'";
+
+                cleanupHiveDockerDatabase(database_hive, true)
+                try_sql """drop catalog if exists ${catalog}"""
             }
             test_use_meta_cache(true)
         } finally {

--- a/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
@@ -24,69 +24,94 @@ suite("test_hive_varbinary_type", "p0,external") {
     }
 
     for (String hivePrefix : ["hive3"]) {
-    
+        setHivePrefix(hivePrefix)
+
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name_no_mapping = "${hivePrefix}_test_varbinary_no_mapping"
-        String catalog_name_with_mapping = "${hivePrefix}_test_varbinary_with_mapping"
+        String catalog_name_no_mapping = getHiveTempName("${hivePrefix}_test_varbinary_no_mapping", "catalog")
+        String catalog_name_with_mapping = getHiveTempName("${hivePrefix}_test_varbinary_with_mapping", "catalog")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         def hdfsUserName = "doris"
         String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
         def defaultFS = "hdfs://${externalEnvIp}:${hdfs_port}"
+        String tempOrcWriteNoMapping = getHiveTempName("test_hive_binary_orc_write_no_mapping", "tbl")
+        String tempParquetWriteNoMapping = getHiveTempName("test_hive_binary_parquet_write_no_mapping", "tbl")
+        String tempOrcWriteWithMapping = getHiveTempName("test_hive_binary_orc_write_with_mapping", "tbl")
+        String tempParquetWriteWithMapping = getHiveTempName("test_hive_binary_parquet_write_with_mapping", "tbl")
 
-        sql """drop catalog if exists ${catalog_name_no_mapping}"""
-        sql """create catalog if not exists ${catalog_name_no_mapping} properties (
-            "type"="hms",
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
-        );"""
-        
-        sql """drop catalog if exists ${catalog_name_with_mapping}"""
-        sql """create catalog if not exists ${catalog_name_with_mapping} properties (
-            "type"="hms",
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-            "enable.mapping.varbinary"="true"
-        );"""
+        try {
+            sql """drop catalog if exists ${catalog_name_no_mapping}"""
+            sql """create catalog if not exists ${catalog_name_no_mapping} properties (
+                "type"="hms",
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
+            );"""
 
-        // no mapping
-        sql """ switch ${catalog_name_no_mapping}"""
-        sql """ use `test_varbinary` """
-        qt_select1 """ select * from test_hive_binary_orc order by id; """
-        qt_select2 """ select * from test_hive_binary_parquet order by id; """
-        qt_select3 """ select * from test_hive_uuid_fixed_orc order by id; """
-        qt_select4 """ select * from test_hive_uuid_fixed_parquet order by id; """
-        qt_select5 """ select * from test_hive_binary_edge_cases order by id; """
+            sql """drop catalog if exists ${catalog_name_with_mapping}"""
+            sql """create catalog if not exists ${catalog_name_with_mapping} properties (
+                "type"="hms",
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                "enable.mapping.varbinary"="true"
+            );"""
 
-        // write orc
-        qt_select6 """ insert into test_hive_binary_orc_write_no_mapping select * from test_hive_binary_orc; """
-        qt_select7 """ insert into test_hive_binary_orc_write_no_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select8 """ insert into test_hive_binary_orc_write_no_mapping values(NULL,NULL,NULL); """
-        qt_select9 """ select * from test_hive_binary_orc_write_no_mapping order by id; """
+            hive_docker """drop table if exists test_varbinary.${tempOrcWriteNoMapping}"""
+            hive_docker """create table test_varbinary.${tempOrcWriteNoMapping} like test_varbinary.test_hive_binary_orc_write_no_mapping"""
+            hive_docker """drop table if exists test_varbinary.${tempParquetWriteNoMapping}"""
+            hive_docker """create table test_varbinary.${tempParquetWriteNoMapping} like test_varbinary.test_hive_binary_parquet_write_no_mapping"""
+            hive_docker """drop table if exists test_varbinary.${tempOrcWriteWithMapping}"""
+            hive_docker """create table test_varbinary.${tempOrcWriteWithMapping} like test_varbinary.test_hive_binary_orc_write_with_mapping"""
+            hive_docker """drop table if exists test_varbinary.${tempParquetWriteWithMapping}"""
+            hive_docker """create table test_varbinary.${tempParquetWriteWithMapping} like test_varbinary.test_hive_binary_parquet_write_with_mapping"""
+            sql """refresh catalog ${catalog_name_no_mapping}"""
+            sql """refresh catalog ${catalog_name_with_mapping}"""
 
-        // write parquet
-        qt_select10 """ insert into test_hive_binary_parquet_write_no_mapping select * from test_hive_binary_parquet; """
-        qt_select11 """ insert into test_hive_binary_parquet_write_no_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select12 """ insert into test_hive_binary_parquet_write_no_mapping values(NULL,NULL,NULL); """
-        qt_select13 """ select * from test_hive_binary_parquet_write_no_mapping order by id; """
+            // no mapping
+            sql """ switch ${catalog_name_no_mapping}"""
+            sql """ use `test_varbinary` """
+            qt_select1 """ select * from test_hive_binary_orc order by id; """
+            qt_select2 """ select * from test_hive_binary_parquet order by id; """
+            qt_select3 """ select * from test_hive_uuid_fixed_orc order by id; """
+            qt_select4 """ select * from test_hive_uuid_fixed_parquet order by id; """
+            qt_select5 """ select * from test_hive_binary_edge_cases order by id; """
 
-        // with mapping
-        sql """ switch ${catalog_name_with_mapping} """
-        sql """ use `test_varbinary` """
-        qt_select14 """ select * from test_hive_binary_orc order by id; """
-        qt_select15 """ select * from test_hive_binary_parquet order by id; """
-        qt_select16 """ select * from test_hive_uuid_fixed_orc order by id; """
-        qt_select17 """ select * from test_hive_uuid_fixed_parquet order by id; """
-        qt_select18 """ select * from test_hive_binary_edge_cases order by id; """
+            // write orc
+            qt_select6 """ insert into ${tempOrcWriteNoMapping} select * from test_hive_binary_orc; """
+            qt_select7 """ insert into ${tempOrcWriteNoMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select8 """ insert into ${tempOrcWriteNoMapping} values(NULL,NULL,NULL); """
+            qt_select9 """ select * from ${tempOrcWriteNoMapping} order by id; """
 
-        // write orc
-        qt_select19 """ insert into test_hive_binary_orc_write_with_mapping select * from test_hive_binary_orc; """
-        qt_select20 """ insert into test_hive_binary_orc_write_with_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select21 """ insert into test_hive_binary_orc_write_with_mapping values(NULL,NULL,NULL); """
-        qt_select22 """ select * from test_hive_binary_orc_write_with_mapping order by id; """
+            // write parquet
+            qt_select10 """ insert into ${tempParquetWriteNoMapping} select * from test_hive_binary_parquet; """
+            qt_select11 """ insert into ${tempParquetWriteNoMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select12 """ insert into ${tempParquetWriteNoMapping} values(NULL,NULL,NULL); """
+            qt_select13 """ select * from ${tempParquetWriteNoMapping} order by id; """
 
-        // write parquet
-        qt_select23 """ insert into test_hive_binary_parquet_write_with_mapping select * from test_hive_binary_parquet; """
-        qt_select24 """ insert into test_hive_binary_parquet_write_with_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select25 """ insert into test_hive_binary_parquet_write_with_mapping values(NULL,NULL,NULL); """
-        qt_select26 """ select * from test_hive_binary_parquet_write_with_mapping order by id; """
+            // with mapping
+            sql """ switch ${catalog_name_with_mapping} """
+            sql """ use `test_varbinary` """
+            qt_select14 """ select * from test_hive_binary_orc order by id; """
+            qt_select15 """ select * from test_hive_binary_parquet order by id; """
+            qt_select16 """ select * from test_hive_uuid_fixed_orc order by id; """
+            qt_select17 """ select * from test_hive_uuid_fixed_parquet order by id; """
+            qt_select18 """ select * from test_hive_binary_edge_cases order by id; """
+
+            // write orc
+            qt_select19 """ insert into ${tempOrcWriteWithMapping} select * from test_hive_binary_orc; """
+            qt_select20 """ insert into ${tempOrcWriteWithMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select21 """ insert into ${tempOrcWriteWithMapping} values(NULL,NULL,NULL); """
+            qt_select22 """ select * from ${tempOrcWriteWithMapping} order by id; """
+
+            // write parquet
+            qt_select23 """ insert into ${tempParquetWriteWithMapping} select * from test_hive_binary_parquet; """
+            qt_select24 """ insert into ${tempParquetWriteWithMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select25 """ insert into ${tempParquetWriteWithMapping} values(NULL,NULL,NULL); """
+            qt_select26 """ select * from ${tempParquetWriteWithMapping} order by id; """
+        } finally {
+            try_hive_docker """drop table if exists test_varbinary.${tempOrcWriteNoMapping}"""
+            try_hive_docker """drop table if exists test_varbinary.${tempParquetWriteNoMapping}"""
+            try_hive_docker """drop table if exists test_varbinary.${tempOrcWriteWithMapping}"""
+            try_hive_docker """drop table if exists test_varbinary.${tempParquetWriteWithMapping}"""
+            try_sql """drop catalog if exists ${catalog_name_no_mapping}"""
+            try_sql """drop catalog if exists ${catalog_name_with_mapping}"""
+        }
     }
 
 }

--- a/regression-test/suites/external_table_p0/hive/test_hms_event_notification.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hms_event_notification.groovy
@@ -22,14 +22,18 @@ suite("test_hms_event_notification", "p0,external") {
         return;
     }
     for (String hivePrefix : ["hive3"]) {
+        String catalog_name = null
+        String catalog_name_2 = null
+        String db1 = null
+        String db2 = null
         try {
             setHivePrefix(hivePrefix)
             hive_docker """ set hive.stats.autogather=false; """
-            
+
 
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String catalog_name = "test_hms_event_notification_${hivePrefix}"
-            String catalog_name_2 = "test_hms_event_notification_${hivePrefix}_2"
+            catalog_name = getHiveTempName("test_hms_event_notification_${hivePrefix}", "catalog")
+            catalog_name_2 = getHiveTempName("test_hms_event_notification_${hivePrefix}_2", "catalog")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             int wait_time = 10000;
 
@@ -46,43 +50,43 @@ suite("test_hms_event_notification", "p0,external") {
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
                 "hive.enable_hms_events_incremental_sync" ="true"
             );"""
-            
+
             sleep(wait_time);
 
             sql """ switch ${catalog_name} """
-            
-            String tb1 = """${catalog_name}_tb_1"""
-            String tb2 = """${catalog_name}_tb_2"""
-            String db1  = "${catalog_name}_db_1";
-            String db2  = "${catalog_name}_db_2";
-            String partition_tb = "${catalog_name}_partition_tb"; 
+
+            String tb1 = getHiveTempName("${catalog_name}_tb_1", "tbl")
+            String tb2 = getHiveTempName("${catalog_name}_tb_2", "tbl")
+            db1  = getHiveTempName("${catalog_name}_db_1", "db")
+            db2  = getHiveTempName("${catalog_name}_db_2", "db")
+            String partition_tb = getHiveTempName("${catalog_name}_partition_tb", "tbl")
 
             try {
-                hive_docker """ use  ${db1};""" 
+                hive_docker """ use  ${db1};"""
             }catch (Exception e){
             }
 
-            hive_docker """ drop table if exists ${tb1};""" 
-            hive_docker """ drop table if exists ${tb2};""" 
-            hive_docker """ drop table if exists ${partition_tb} """ 
-            hive_docker """ drop database if exists ${db1};""" 
+            hive_docker """ drop table if exists ${tb1};"""
+            hive_docker """ drop table if exists ${tb2};"""
+            hive_docker """ drop table if exists ${partition_tb} """
+            hive_docker """ drop database if exists ${db1};"""
             hive_docker """ drop database if exists ${db2};"""
 
-//CREATE DATABASE            
-            hive_docker """ create  database  ${db1};""" 
+//CREATE DATABASE
+            hive_docker """ create  database  ${db1};"""
             hive_docker """ create  database  ${db2};"""
             sleep(wait_time);
 
-            List<List<String>>  dbs = sql """ show databases """ 
+            List<List<String>>  dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            
-            int flag_db_count = 0 ; 
+
+            int flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0] == db1) {
                     flag_db_count ++;
                 }else if (it[0] == db2) {
                     flag_db_count ++;
-                } 
+                }
             }
             assertTrue(flag_db_count == 2);
 
@@ -91,11 +95,11 @@ suite("test_hms_event_notification", "p0,external") {
 
 //ALTER DATABASE
             if (hivePrefix == "hive3") {
-                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("db2 location = " + db2_location )
 
                 def loc_start = db2_location.indexOf("hdfs://")
-                def loc_end = db2_location.indexOf(".db") + 3 
+                def loc_end = db2_location.indexOf(".db") + 3
                 db2_location  = db2_location.substring(loc_start, loc_end)
                 logger.info("db2 location = " + db2_location )
 
@@ -106,12 +110,12 @@ suite("test_hms_event_notification", "p0,external") {
                 hive_docker """ ALTER DATABASE  ${db2} SET LOCATION '${new_db2_location}'; """
                 logger.info(" alter database end")
                 sleep(wait_time);
-                
-                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+
+                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("query_db2_location  =  ${query_db2_location} ")
 
                 loc_start = query_db2_location.indexOf("hdfs://")
-                loc_end = query_db2_location.indexOf(".db") + 3 
+                loc_end = query_db2_location.indexOf(".db") + 3
                 query_db2_location = query_db2_location.substring(loc_start, loc_end)
 
                 assertTrue(query_db2_location == new_db2_location);
@@ -121,24 +125,24 @@ suite("test_hms_event_notification", "p0,external") {
 //DROP DATABASE
             hive_docker """drop  database ${db2}; """;
             sleep(wait_time);
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0].toString() == db1) {
                     flag_db_count ++;
                 } else if (it[0].toString() == db2) {
                     logger.info(" exists ${db2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_db_count == 1);
 
 
 //CREATE TABLE
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """                         
-            List<List<String>>  tbs = sql """ show tables; """ 
+            sql """ use ${db1} """
+            List<List<String>>  tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
             assertTrue(tbs.isEmpty())
 
@@ -146,9 +150,9 @@ suite("test_hms_event_notification", "p0,external") {
             hive_docker """ create  table ${tb1} (id int,name string) ;"""
             hive_docker """ create  table ${tb2} (id int,name string) ;"""
             sleep(wait_time);
-            tbs = sql """ show tables; """ 
+            tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
-            int flag_tb_count = 0 ; 
+            int flag_tb_count = 0 ;
             tbs.forEach {
                 logger.info("it[0] = " + it[0])
                 if (it[0].toString() == "${tb1}") {
@@ -157,28 +161,28 @@ suite("test_hms_event_notification", "p0,external") {
                 }else if (it[0].toString() == tb2) {
                     flag_tb_count ++;
                     logger.info(" ${tb2} exists ")
-                } 
+                }
             }
             assertTrue(flag_tb_count == 2);
-            
+
 
 //ALTER TABLE
-            List<List<String>> ans = sql """ select * from ${tb1} """ 
+            List<List<String>> ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.isEmpty())
-            
-            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """    
+
+            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} """ 
+            ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 1)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][1].toString() == "xxx")
 
 
-            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """    
+            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} order by id """ 
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -187,7 +191,7 @@ suite("test_hms_event_notification", "p0,external") {
             assertTrue(ans[1][1].toString() == "yyy")
 
 
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
@@ -195,16 +199,16 @@ suite("test_hms_event_notification", "p0,external") {
             assertTrue(ans[1][0].toString() == "name")
             assertTrue(ans[1][1].toString() == "text")
 
-            hive_docker """ alter table ${tb1} change column id id bigint; """    
+            hive_docker """ alter table ${tb1} change column id id bigint; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -214,16 +218,16 @@ suite("test_hms_event_notification", "p0,external") {
 
 
 
-            hive_docker """ alter table ${tb1} change column name new_name string; """    
+            hive_docker """ alter table ${tb1} change column name new_name string; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "new_name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -233,26 +237,26 @@ suite("test_hms_event_notification", "p0,external") {
 
 
 //DROP TABLE
-            hive_docker  """ drop table ${tb2} """ 
+            hive_docker  """ drop table ${tb2} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
             logger.info(""" tbs = ${tbs}""")
 
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 if (it[0] == tb1) {
                     flag_tb_count ++;
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb1}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_tb_count == 1);
 
 
-            
-            hive_docker  """ drop table ${tb1} """ 
+
+            hive_docker  """ drop table ${tb1} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
@@ -265,26 +269,26 @@ suite("test_hms_event_notification", "p0,external") {
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
 
 //ADD PARTITION
 
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """  
+            sql """ use ${db1} """
 
             hive_docker  """ CREATE TABLE ${partition_tb} (
                         id INT,
                         name STRING,
                         age INT
                     )
-                    PARTITIONED BY (country STRING); """ 
-            hive_docker """ 
+                    PARTITIONED BY (country STRING); """
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='USA')
                 VALUES (1, 'John Doe', 30),
                        (2, 'Jane Smith', 25);"""
-                       
-            hive_docker """ 
+
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='India')
                 VALUES (3, 'Rahul Kumar', 28),
                        (4, 'Priya Singh', 24);
@@ -295,34 +299,34 @@ suite("test_hms_event_notification", "p0,external") {
             assertTrue(ans.size() == 4)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][3].toString() == "USA")
-            assertTrue(ans[1][3].toString() == "USA")            
+            assertTrue(ans[1][3].toString() == "USA")
             assertTrue(ans[3][0].toString() == "4")
             assertTrue(ans[2][3].toString() == "India")
             assertTrue(ans[3][3].toString() == "India")
 
 
-            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            int flag_partition_count = 0 ; 
+            int flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0] == "country=India") {
                     flag_partition_count ++;
                 } else if (it[0] == "country=USA") {
                     flag_partition_count ++;
-                } 
+                }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
 
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} ADD PARTITION (country='Canada');
                 """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -332,18 +336,18 @@ suite("test_hms_event_notification", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
 //ALTER PARTITION
-            hive_docker """ 
+            hive_docker """
                 alter table ${partition_tb} partition(country='USA') rename to partition(country='US') ;
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -353,17 +357,17 @@ suite("test_hms_event_notification", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 //DROP PARTITION
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} DROP PARTITION (country='Canada');
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 
+            flag_partition_count = 0
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -374,15 +378,17 @@ suite("test_hms_event_notification", "p0,external") {
                     assertTrue(false);
                 }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
 
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_hive_docker """drop database if exists ${db1} cascade"""
+            try_hive_docker """drop database if exists ${db2} cascade"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_sql """drop catalog if exists ${catalog_name_2}"""
         }
     }
 }
-
-
 
 

--- a/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
@@ -666,8 +666,12 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """drop catalog if exists ${catalog_name}"""
             sql """drop catalog if exists ${catalog_name_2}"""
         } finally {
-            try_hive_docker """drop database if exists ${db1} cascade"""
-            try_hive_docker """drop database if exists ${db2} cascade"""
+            if (db1 != null) {
+                try_hive_docker """drop database if exists ${db1} cascade"""
+            }
+            if (db2 != null) {
+                try_hive_docker """drop database if exists ${db2} cascade"""
+            }
             try_sql """drop catalog if exists ${catalog_name}"""
             try_sql """drop catalog if exists ${catalog_name_2}"""
         }

--- a/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
@@ -23,14 +23,18 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
     }
 
     for (String hivePrefix : ["hive3"]) {
+        String catalog_name = null
+        String catalog_name_2 = null
+        String db1 = null
+        String db2 = null
         try {
             setHivePrefix(hivePrefix)
             hive_docker """ set hive.stats.autogather=false; """
-            
+
 
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String catalog_name = "test_hms_event_notification_multi_catalog_${hivePrefix}"
-            String catalog_name_2 = "test_hms_event_notification_multi_catalog_${hivePrefix}_2"
+            catalog_name = getHiveTempName("test_hms_event_notification_multi_catalog_${hivePrefix}", "catalog")
+            catalog_name_2 = getHiveTempName("test_hms_event_notification_multi_catalog_${hivePrefix}_2", "catalog")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             int wait_time = 10000;
 
@@ -52,66 +56,66 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sleep(wait_time);
 
             sql """ switch ${catalog_name} """
-            
-            String tb1 = """${catalog_name}_tb_1"""
-            String tb2 = """${catalog_name}_tb_2"""
-            String db1  = "${catalog_name}_db_1";
-            String db2  = "${catalog_name}_db_2";
-            String partition_tb = "${catalog_name}_partition_tb"; 
+
+            String tb1 = getHiveTempName("${catalog_name}_tb_1", "tbl")
+            String tb2 = getHiveTempName("${catalog_name}_tb_2", "tbl")
+            db1  = getHiveTempName("${catalog_name}_db_1", "db")
+            db2  = getHiveTempName("${catalog_name}_db_2", "db")
+            String partition_tb = getHiveTempName("${catalog_name}_partition_tb", "tbl")
 
             try {
-                hive_docker """ use  ${db1};""" 
+                hive_docker """ use  ${db1};"""
             }catch (Exception e){
             }
 
-            hive_docker """ drop table if exists ${tb1};""" 
-            hive_docker """ drop table if exists ${tb2};""" 
-            hive_docker """ drop table if exists ${partition_tb} """ 
-            hive_docker """ drop database if exists ${db1};""" 
+            hive_docker """ drop table if exists ${tb1};"""
+            hive_docker """ drop table if exists ${tb2};"""
+            hive_docker """ drop table if exists ${partition_tb} """
+            hive_docker """ drop database if exists ${db1};"""
             hive_docker """ drop database if exists ${db2};"""
 
-//CREATE DATABASE            
-            hive_docker """ create  database  ${db1};""" 
+//CREATE DATABASE
+            hive_docker """ create  database  ${db1};"""
             hive_docker """ create  database  ${db2};"""
             sleep(wait_time);
 
-            List<List<String>>  dbs = sql """ show databases """ 
+            List<List<String>>  dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            
-            int flag_db_count = 0 ; 
+
+            int flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0] == db1) {
                     flag_db_count ++;
                 }else if (it[0] == db2) {
                     flag_db_count ++;
-                } 
+                }
             }
             assertTrue(flag_db_count == 2);
 
             sql """ switch ${catalog_name_2} """
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0] == db1) {
                     flag_db_count ++;
                 }else if (it[0] == db2) {
                     flag_db_count ++;
-                } 
+                }
             }
             assertTrue(flag_db_count == 2);
-            
+
             sql """ switch ${catalog_name} """
 
 
 
 //ALTER DATABASE
             if (hivePrefix == "hive3") {
-                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("db2 location = " + db2_location )
 
                 def loc_start = db2_location.indexOf("hdfs://")
-                def loc_end = db2_location.indexOf(".db") + 3 
+                def loc_end = db2_location.indexOf(".db") + 3
                 db2_location  = db2_location.substring(loc_start, loc_end)
                 logger.info("db2 location = " + db2_location )
 
@@ -122,23 +126,23 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 hive_docker """ ALTER DATABASE  ${db2} SET LOCATION '${new_db2_location}'; """
                 logger.info(" alter database end")
                 sleep(wait_time);
-                
-                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+
+                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("query_db2_location  =  ${query_db2_location} ")
 
                 loc_start = query_db2_location.indexOf("hdfs://")
-                loc_end = query_db2_location.indexOf(".db") + 3 
+                loc_end = query_db2_location.indexOf(".db") + 3
                 query_db2_location = query_db2_location.substring(loc_start, loc_end)
                 assertTrue(query_db2_location == new_db2_location);
 
 
 
                 sql """ switch ${catalog_name_2} """
-                query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+                query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("query_db2_location  =  ${query_db2_location} ")
 
                 loc_start = query_db2_location.indexOf("hdfs://")
-                loc_end = query_db2_location.indexOf(".db") + 3 
+                loc_end = query_db2_location.indexOf(".db") + 3
                 query_db2_location = query_db2_location.substring(loc_start, loc_end)
                 assertTrue(query_db2_location == new_db2_location);
                 sql """ switch ${catalog_name} """
@@ -148,38 +152,38 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 //DROP DATABASE
             hive_docker """drop  database ${db2}; """;
             sleep(wait_time);
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0].toString() == db1) {
                     flag_db_count ++;
                 } else if (it[0].toString() == db2) {
                     logger.info(" exists ${db2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_db_count == 1);
 
             sql """ switch ${catalog_name_2} """
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0].toString() == db1) {
                     flag_db_count ++;
                 } else if (it[0].toString() == db2) {
                     logger.info(" exists ${db2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_db_count == 1);
             sql """ switch ${catalog_name} """
 
 //CREATE TABLE
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """                         
-            List<List<String>>  tbs = sql """ show tables; """ 
+            sql """ use ${db1} """
+            List<List<String>>  tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
             assertTrue(tbs.isEmpty())
 
@@ -187,9 +191,9 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             hive_docker """ create  table ${tb1} (id int,name string) ;"""
             hive_docker """ create  table ${tb2} (id int,name string) ;"""
             sleep(wait_time);
-            tbs = sql """ show tables; """ 
+            tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
-            int flag_tb_count = 0 ; 
+            int flag_tb_count = 0 ;
             tbs.forEach {
                 logger.info("it[0] = " + it[0])
                 if (it[0].toString() == "${tb1}") {
@@ -198,16 +202,16 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 }else if (it[0].toString() == tb2) {
                     flag_tb_count ++;
                     logger.info(" ${tb2} exists ")
-                } 
+                }
             }
             assertTrue(flag_tb_count == 2);
-            
+
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            tbs = sql """ show tables; """ 
+            tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 logger.info("it[0] = " + it[0])
                 if (it[0].toString() == "${tb1}") {
@@ -216,7 +220,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 }else if (it[0].toString() == tb2) {
                     flag_tb_count ++;
                     logger.info(" ${tb2} exists ")
-                } 
+                }
             }
             assertTrue(flag_tb_count == 2);
             sql """ switch ${catalog_name} """
@@ -224,13 +228,13 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 //ALTER TABLE
-            List<List<String>> ans = sql """ select * from ${tb1} """ 
+            List<List<String>> ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.isEmpty())
-            
-            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """    
+
+            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} """ 
+            ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 1)
             assertTrue(ans[0][0].toString() == "1")
@@ -238,7 +242,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ select * from ${tb1} """ 
+            ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 1)
             assertTrue(ans[0][0].toString() == "1")
@@ -247,9 +251,9 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
 
-            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """    
+            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} order by id """ 
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -258,7 +262,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans[1][1].toString() == "yyy")
 
 
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
@@ -269,7 +273,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ select * from ${tb1} order by id """ 
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -277,7 +281,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans[1][0].toString() == "2")
             assertTrue(ans[1][1].toString() == "yyy")
 
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
@@ -289,16 +293,16 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ use ${db1} """
 
 
-            hive_docker """ alter table ${tb1} change column id id bigint; """    
+            hive_docker """ alter table ${tb1} change column id id bigint; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -309,14 +313,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -329,16 +333,16 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            hive_docker """ alter table ${tb1} change column name new_name string; """    
+            hive_docker """ alter table ${tb1} change column name new_name string; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "new_name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -348,14 +352,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "new_name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -366,24 +370,24 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
 
-            
+
 
 
 //DROP TABLE
-            hive_docker  """ drop table ${tb2} """ 
+            hive_docker  """ drop table ${tb2} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
             logger.info(""" tbs = ${tbs}""")
 
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 if (it[0] == tb1) {
                     flag_tb_count ++;
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb1}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_tb_count == 1);
 
@@ -392,14 +396,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ use ${db1} """
             tbs = sql """ show tables; """
             logger.info(""" tbs = ${tbs}""")
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 if (it[0] == tb1) {
                     flag_tb_count ++;
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_tb_count == 1);
 
@@ -408,8 +412,8 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            
-            hive_docker  """ drop table ${tb1} """ 
+
+            hive_docker  """ drop table ${tb1} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
@@ -422,7 +426,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
 
 
@@ -437,7 +441,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
@@ -447,20 +451,20 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 //ADD PARTITION
 
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """  
+            sql """ use ${db1} """
 
             hive_docker  """ CREATE TABLE ${partition_tb} (
                         id INT,
                         name STRING,
                         age INT
                     )
-                    PARTITIONED BY (country STRING); """ 
-            hive_docker """ 
+                    PARTITIONED BY (country STRING); """
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='USA')
                 VALUES (1, 'John Doe', 30),
                        (2, 'Jane Smith', 25);"""
-                       
-            hive_docker """ 
+
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='India')
                 VALUES (3, 'Rahul Kumar', 28),
                        (4, 'Priya Singh', 24);
@@ -471,7 +475,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans.size() == 4)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][3].toString() == "USA")
-            assertTrue(ans[1][3].toString() == "USA")            
+            assertTrue(ans[1][3].toString() == "USA")
             assertTrue(ans[3][0].toString() == "4")
             assertTrue(ans[2][3].toString() == "India")
             assertTrue(ans[3][3].toString() == "India")
@@ -483,7 +487,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans.size() == 4)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][3].toString() == "USA")
-            assertTrue(ans[1][3].toString() == "USA")            
+            assertTrue(ans[1][3].toString() == "USA")
             assertTrue(ans[3][0].toString() == "4")
             assertTrue(ans[2][3].toString() == "India")
             assertTrue(ans[3][3].toString() == "India")
@@ -493,33 +497,33 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            int flag_partition_count = 0 ; 
+            int flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0] == "country=India") {
                     flag_partition_count ++;
                 } else if (it[0] == "country=USA") {
                     flag_partition_count ++;
-                } 
+                }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0] == "country=India") {
                     flag_partition_count ++;
                 } else if (it[0] == "country=USA") {
                     flag_partition_count ++;
-                } 
+                }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
@@ -527,14 +531,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} ADD PARTITION (country='Canada');
                 """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -544,15 +548,15 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -562,7 +566,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
             sql """ switch ${catalog_name} """
@@ -572,14 +576,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 //ALTER PARTITION
-            hive_docker """ 
+            hive_docker """
                 alter table ${partition_tb} partition(country='USA') rename to partition(country='US') ;
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -589,15 +593,15 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -607,7 +611,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
@@ -616,14 +620,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 //DROP PARTITION
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} DROP PARTITION (country='Canada');
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 
+            flag_partition_count = 0
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -634,15 +638,15 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     assertTrue(false);
                 }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 
+            flag_partition_count = 0
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -653,7 +657,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     assertTrue(false);
                 }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
 
@@ -662,10 +666,12 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """drop catalog if exists ${catalog_name}"""
             sql """drop catalog if exists ${catalog_name_2}"""
         } finally {
+            try_hive_docker """drop database if exists ${db1} cascade"""
+            try_hive_docker """drop database if exists ${db2} cascade"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_sql """drop catalog if exists ${catalog_name_2}"""
         }
     }
 }
-
-
 
 

--- a/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
@@ -24,22 +24,32 @@ suite("test_multi_delimit_serde", "p0,external") {
 
     for (String hivePrefix : ["hive3"]) {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name = "${hivePrefix}_test_multi_delimit_serde"
+        String catalog_name = getHiveTempName("${hivePrefix}_test_multi_delimit_serde", "catalog")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-
-        sql """drop catalog if exists ${catalog_name}"""
-        sql """create catalog if not exists ${catalog_name} properties (
-            "type"="hms",
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
-        );"""
-
-        logger.info("catalog " + catalog_name + " created")
-        sql """switch ${catalog_name};"""
-        logger.info("switched to catalog " + catalog_name)
-
-        sql """use regression;"""
+        String tempMultiDelimitTest = getHiveTempName("multi_delimit_test", "tbl")
+        String tempMultiDelimitTest2 = getHiveTempName("multi_delimit_test2", "tbl")
+        String tempMultiDelimitComplexTest = getHiveTempName("multi_delimit_complex_test", "tbl")
 
         try {
+            sql """drop catalog if exists ${catalog_name}"""
+            sql """create catalog if not exists ${catalog_name} properties (
+                "type"="hms",
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
+            );"""
+
+            logger.info("catalog " + catalog_name + " created")
+            sql """switch ${catalog_name};"""
+            logger.info("switched to catalog " + catalog_name)
+
+            sql """use regression;"""
+            hive_docker """drop table if exists regression.${tempMultiDelimitTest}"""
+            hive_docker """create table regression.${tempMultiDelimitTest} like regression.multi_delimit_test"""
+            hive_docker """drop table if exists regression.${tempMultiDelimitTest2}"""
+            hive_docker """create table regression.${tempMultiDelimitTest2} like regression.multi_delimit_test2"""
+            hive_docker """drop table if exists regression.${tempMultiDelimitComplexTest}"""
+            hive_docker """create table regression.${tempMultiDelimitComplexTest} like regression.multi_delimit_complex_test"""
+            sql """refresh catalog ${catalog_name}"""
+
             // Test 1: MultiDelimitSerDe with |+| delimiter - using pre-created table
             qt_01 """SELECT * FROM multi_delimit_test ORDER BY k1"""
 
@@ -54,21 +64,21 @@ suite("test_multi_delimit_serde", "p0,external") {
             logger.info("Test 4: Testing Doris INSERT to Hive MultiDelimitSerDe tables")
 
             // Test 4.1: Insert to basic multi-delimit table
-            sql """INSERT INTO multi_delimit_test VALUES (4, 400, 'test4'), (5, 500, 'test5')"""
-            qt_04 """SELECT * FROM multi_delimit_test WHERE k1 >= 4 ORDER BY k1"""
+            sql """INSERT INTO ${tempMultiDelimitTest} VALUES (4, 400, 'test4'), (5, 500, 'test5')"""
+            qt_04 """SELECT * FROM ${tempMultiDelimitTest} WHERE k1 >= 4 ORDER BY k1"""
 
             // Test 4.2: Insert to double-pipe delimited table
-            sql """INSERT INTO multi_delimit_test2 VALUES (4, 4.5, 'description4'), (5, 5.5, 'description5')"""
-            qt_05 """SELECT * FROM multi_delimit_test2 WHERE id >= 4 ORDER BY id"""
+            sql """INSERT INTO ${tempMultiDelimitTest2} VALUES (4, 4.5, 'description4'), (5, 5.5, 'description5')"""
+            qt_05 """SELECT * FROM ${tempMultiDelimitTest2} WHERE id >= 4 ORDER BY id"""
 
             // Test 4.3: Insert to complex types table with arrays and maps
-            sql """INSERT INTO multi_delimit_complex_test VALUES
+            sql """INSERT INTO ${tempMultiDelimitComplexTest} VALUES
                 (3, 'user3', ARRAY('tagX', 'tagY'), MAP('newkey', 'newvalue'), ARRAY(ARRAY(7, 8)))"""
-            qt_06 """SELECT id, name, tags, properties FROM multi_delimit_complex_test WHERE id = 3 ORDER BY id"""
+            qt_06 """SELECT id, name, tags, properties FROM ${tempMultiDelimitComplexTest} WHERE id = 3 ORDER BY id"""
 
             // Test 5: Show create table to check SerDe properties
             logger.info("Test 5: Checking show create table")
-            def createTableResult = sql """SHOW CREATE TABLE multi_delimit_test"""
+            def createTableResult = sql """SHOW CREATE TABLE ${tempMultiDelimitTest}"""
             logger.info("Create table result: " + createTableResult.toString())
 
             assertTrue(createTableResult.toString().contains("MultiDelimitSerDe"))
@@ -78,7 +88,11 @@ suite("test_multi_delimit_serde", "p0,external") {
             if (e.getMessage().contains("Unsupported hive table serde")) {
                 logger.info("Got expected 'Unsupported hive table serde' error before implementing MultiDelimitSerDe support")
             }
+        } finally {
+            try_hive_docker """drop table if exists regression.${tempMultiDelimitTest}"""
+            try_hive_docker """drop table if exists regression.${tempMultiDelimitTest2}"""
+            try_hive_docker """drop table if exists regression.${tempMultiDelimitComplexTest}"""
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
-        sql """drop catalog if exists ${catalog_name}"""
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_prepare_hive_data_in_case.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_prepare_hive_data_in_case.groovy
@@ -25,36 +25,39 @@ suite("test_prepare_hive_data_in_case", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String tableName = getHiveTempName("test_prepare_hive_data_in_case")
+        String catalogName = getHiveTempName("test_prepare_hive_data_in_case", "catalog")
         try {
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
 
             hive_docker """show databases;"""
-            hive_docker """drop table if exists default.test_prepare_hive_data_in_case;  """
+            hive_docker """drop table if exists default.${tableName};  """
             hive_docker """
-                            create table default.test_prepare_hive_data_in_case (k1 String, k2 String); 
+                            create table default.${tableName} (k1 String, k2 String);
                         """
-            hive_docker """insert into default.test_prepare_hive_data_in_case values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
-            def values = hive_docker """select count(*) from `default`.test_prepare_hive_data_in_case;"""
-            
+            hive_docker """insert into default.${tableName} values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
+            def values = hive_docker """select count(*) from `default`.${tableName};"""
+
             log.info(values.toString())
 
-            sql """drop catalog if exists test_prepare_hive_data_in_case;"""
-            sql """CREATE CATALOG test_prepare_hive_data_in_case PROPERTIES (
+            sql """drop catalog if exists ${catalogName};"""
+            sql """CREATE CATALOG ${catalogName} PROPERTIES (
                 'type'='hms',
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
             );"""
-            def values2 = sql """select count(*) from test_prepare_hive_data_in_case.`default`.test_prepare_hive_data_in_case;"""
+            def values2 = sql """select count(*) from ${catalogName}.`default`.${tableName};"""
             log.info(values2.toString())
             assertEquals(values[0][0],values2[0][0])
 
             // Execute in Hive in unstable, remove it
             // qt_hive_docker_01 """select * from default.test_prepare_hive_data_in_case order by k1 desc  ;"""
-            
-            qt_sql_02 """ select * from test_prepare_hive_data_in_case.`default`.test_prepare_hive_data_in_case order by k1 desc;"""
+
+            qt_sql_02 """ select * from ${catalogName}.`default`.${tableName} order by k1 desc;"""
 
         } finally {
+            try_sql """drop catalog if exists ${catalogName};"""
+            try_hive_docker """drop table if exists default.${tableName};"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
@@ -26,6 +26,8 @@ suite("test_hive_ctas_to_doris", "p0,external") {
         }
 
         setHivePrefix(hivePrefix)
+        String catalog = null
+        String db_name = null
         try {
             String str1 = "0123456789" * 6554   // string.length() = 65540
             String str2 = str1.substring(0, 65533)
@@ -33,9 +35,9 @@ suite("test_hive_ctas_to_doris", "p0,external") {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-            String catalog = "test_hive_ctas_to_doris"
-            String hive_tb = "tb_test_hive_ctas_to_doris"
-            String db_name = "db_test_hive_ctas_to_doris"
+            catalog = getHiveTempName("test_hive_ctas_to_doris", "catalog")
+            String hive_tb = getHiveTempName("tb_test_hive_ctas_to_doris", "tbl")
+            db_name = getHiveTempName("db_test_hive_ctas_to_doris", "db")
 
             // create hive table
             sql """drop catalog if exists ${catalog}"""
@@ -45,7 +47,7 @@ suite("test_hive_ctas_to_doris", "p0,external") {
             );"""
             sql """ create database if not exists ${catalog}.${db_name} """
             sql """ drop table if exists ${catalog}.${db_name}.${hive_tb}"""
-            sql """ create table ${catalog}.${db_name}.${hive_tb} 
+            sql """ create table ${catalog}.${db_name}.${hive_tb}
                 (id int, str1 string, str2 string, str3 string) """
             sql """ insert into ${catalog}.${db_name}.${hive_tb} values (1, '${str1}', '${str2}', 'str3') """
 
@@ -95,7 +97,8 @@ suite("test_hive_ctas_to_doris", "p0,external") {
             }
 
         } finally {
+            try_sql """drop catalog if exists ${catalog}"""
+            try_sql """drop database if exists internal.${db_name} force"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_insert_overwrite_with_empty_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_insert_overwrite_with_empty_table.groovy
@@ -26,16 +26,17 @@ suite("test_hive_insert_overwrite_with_empty_table", "p0,external") {
         }
 
         setHivePrefix(hivePrefix)
+        String catalog = null
         try {
 
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-            String catalog = "test_hive_insert_overwrite_with_empty_table"
-            String db1 = catalog + "_db"
-            String tb1 = db1 + "_tb1"
-            String tb2 = db1 + "_tb2"
-            String tb3 = db1 + "_tb3"
+            catalog = getHiveTempName("test_hive_insert_overwrite_with_empty_table", "catalog")
+            String db1 = getHiveTempName("${catalog}_db", "db")
+            String tb1 = getHiveTempName("${db1}_tb1", "tbl")
+            String tb2 = getHiveTempName("${db1}_tb2", "tbl")
+            String tb3 = getHiveTempName("${db1}_tb3", "tbl")
 
             sql """drop catalog if exists ${catalog}"""
             sql """create catalog if not exists ${catalog} properties (
@@ -75,7 +76,7 @@ suite("test_hive_insert_overwrite_with_empty_table", "p0,external") {
             sql """ drop catalog ${catalog} """
 
         } finally {
+            try_sql """drop catalog if exists ${catalog} """
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_staging_dir.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_staging_dir.groovy
@@ -46,10 +46,10 @@ suite("test_hive_staging_dir", "p0,external") {
 
     for (String hivePrefix : ["hive3"]) {
         setHivePrefix(hivePrefix)
-        String catalogName = "test_${hivePrefix}_staging_dir"
+        String catalogName = getHiveTempName("test_${hivePrefix}_staging_dir", "catalog")
         String dbName = "write_test"
-        String tableRel = "staging_dir_rel_${hivePrefix}"
-        String tableAbs = "staging_dir_abs_${hivePrefix}"
+        String tableRel = getHiveTempName("staging_dir_rel_${hivePrefix}", "tbl")
+        String tableAbs = getHiveTempName("staging_dir_abs_${hivePrefix}", "tbl")
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String hdfsPort = context.config.otherConfigs.get(hivePrefix + "HdfsPort")

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_text_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_text_write_insert.groovy
@@ -883,10 +883,11 @@ suite("test_hive_text_write_insert", "p0,external") {
 
     for (String hivePrefix : ["hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = getHiveTempName("test_${hivePrefix}_text_write_insert", "catalog")
+        String temp_db = getHiveTempName("write_test", "db")
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_text_write_insert"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""
@@ -895,9 +896,19 @@ suite("test_hive_text_write_insert", "p0,external") {
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
                 'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
             );"""
-            sql """use `${catalog_name}`.`write_test`"""
-            logger.info("hive sql: " + """ use `write_test` """)
-            hive_docker """use `write_test`"""
+            hive_docker """drop database if exists `${temp_db}` cascade"""
+            hive_docker """create database if not exists `${temp_db}`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_text`"""
+            hive_docker """create table `${temp_db}`.`all_types_text` like `write_test`.`all_types_text`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_par_text`"""
+            hive_docker """create table `${temp_db}`.`all_types_par_text` like `write_test`.`all_types_par_text`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_parquet_snappy_src`"""
+            hive_docker """create table `${temp_db}`.`all_types_parquet_snappy_src` like `write_test`.`all_types_parquet_snappy_src`"""
+            hive_docker """insert into `${temp_db}`.`all_types_parquet_snappy_src` select * from `write_test`.`all_types_parquet_snappy_src`"""
+            sql """refresh catalog ${catalog_name}"""
+            sql """use `${catalog_name}`.`${temp_db}`"""
+            logger.info("hive sql: " + """ use `${temp_db}` """)
+            hive_docker """use `${temp_db}`"""
 
             sql """set enable_fallback_to_original_planner=false;"""
 
@@ -914,7 +925,8 @@ suite("test_hive_text_write_insert", "p0,external") {
             sql """set hive_text_compression = 'uncompresssed';"""
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists `${temp_db}` cascade"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_different_path.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_different_path.groovy
@@ -26,15 +26,21 @@ suite("test_hive_write_different_path", "p0,external") {
         }
 
         setHivePrefix(hivePrefix)
+        String catalog1 = null
+        String catalog2 = null
+        String catalog3 = null
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port2 = context.config.otherConfigs.get("hive2HdfsPort")
             String hdfs_port3 = context.config.otherConfigs.get("hive3HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
-            String catalog1 = "test_${hivePrefix}_write_insert_without_defaultfs"
-            String catalog2 = "test_${hivePrefix}_write_insert_with_hdfs2"
-            String catalog3 = "test_${hivePrefix}_write_insert_with_hdfs3"
+            catalog1 = getHiveTempName("test_${hivePrefix}_write_insert_without_defaultfs", "catalog")
+            catalog2 = getHiveTempName("test_${hivePrefix}_write_insert_with_hdfs2", "catalog")
+            catalog3 = getHiveTempName("test_${hivePrefix}_write_insert_with_hdfs3", "catalog")
+            String dbName = getHiveTempName("write_test", "db")
+            String tableWithHdfs2 = getHiveTempName("tb_with_hdfs2", "tbl")
+            String tableWithHdfs3 = getHiveTempName("tb_with_hdfs3", "tbl")
 
             sql """drop catalog if exists ${catalog1}"""
             sql """drop catalog if exists ${catalog2}"""
@@ -44,30 +50,31 @@ suite("test_hive_write_different_path", "p0,external") {
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
                 'use_meta_cache' = 'true'
             );"""
+            sql """create database if not exists ${catalog1}.${dbName}"""
 
-            sql """ use ${catalog1}.write_test """
-            sql """ drop table if exists tb_with_hdfs2 """
-            sql """ drop table if exists tb_with_hdfs3 """
+            sql """ use ${catalog1}.${dbName} """
+            sql """ drop table if exists ${tableWithHdfs2} """
+            sql """ drop table if exists ${tableWithHdfs3} """
 
             sql """
-              CREATE TABLE `tb_with_hdfs2`
+              CREATE TABLE `${tableWithHdfs2}`
               (
                 `col_bigint_undef_signed` BIGINT NULL,
                 `col_varchar_10__undef_signed` VARCHAR(10) NULL,
                 `col_varchar_64__undef_signed` VARCHAR(64) NULL,
                 `pk` INT NULL ) properties (
-                'location' = 'hdfs://${externalEnvIp}:${hdfs_port2}/user/hive/warehouse/write_test.db/tb_with_hdfs2/'
+                'location' = 'hdfs://${externalEnvIp}:${hdfs_port2}/user/hive/warehouse/${dbName}.db/${tableWithHdfs2}/'
               );
             """
 
             sql """
-              CREATE TABLE `tb_with_hdfs3`
+              CREATE TABLE `${tableWithHdfs3}`
               (
                 `col_bigint_undef_signed` BIGINT NULL,
                 `col_varchar_10__undef_signed` VARCHAR(10) NULL,
                 `col_varchar_64__undef_signed` VARCHAR(64) NULL,
                 `pk` INT NULL ) properties (
-                'location' = 'hdfs://${externalEnvIp}:${hdfs_port3}/user/hive/warehouse/write_test.db/tb_with_hdfs3/'
+                'location' = 'hdfs://${externalEnvIp}:${hdfs_port3}/user/hive/warehouse/${dbName}.db/${tableWithHdfs3}/'
               );
             """
 
@@ -82,26 +89,33 @@ suite("test_hive_write_different_path", "p0,external") {
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
                 'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port3}'
             );"""
+            sql """create database if not exists ${catalog2}.${dbName}"""
+            sql """create database if not exists ${catalog3}.${dbName}"""
+            sql """refresh catalog ${catalog1}"""
+            sql """refresh catalog ${catalog2}"""
+            sql """refresh catalog ${catalog3}"""
 
-            sql """ insert into ${catalog1}.write_test.tb_with_hdfs2 values (1,'a','a',1) """
-            sql """ insert into ${catalog2}.write_test.tb_with_hdfs2 values (2,'b','a',1) """
-            sql """ insert into ${catalog3}.write_test.tb_with_hdfs2 values (3,'c','a',1) """
-            sql """ insert into ${catalog1}.write_test.tb_with_hdfs3 values (4,'d','a',1) """
-            sql """ insert into ${catalog2}.write_test.tb_with_hdfs3 values (5,'e','a',1) """
-            sql """ insert into ${catalog3}.write_test.tb_with_hdfs3 values (6,'f','a',1) """
+            sql """ insert into ${catalog1}.${dbName}.${tableWithHdfs2} values (1,'a','a',1) """
+            sql """ insert into ${catalog2}.${dbName}.${tableWithHdfs2} values (2,'b','a',1) """
+            sql """ insert into ${catalog3}.${dbName}.${tableWithHdfs2} values (3,'c','a',1) """
+            sql """ insert into ${catalog1}.${dbName}.${tableWithHdfs3} values (4,'d','a',1) """
+            sql """ insert into ${catalog2}.${dbName}.${tableWithHdfs3} values (5,'e','a',1) """
+            sql """ insert into ${catalog3}.${dbName}.${tableWithHdfs3} values (6,'f','a',1) """
 
-            order_qt_q001 """ select * from ${catalog1}.write_test.tb_with_hdfs2 order by col_bigint_undef_signed """
-            order_qt_q002 """ select * from ${catalog1}.write_test.tb_with_hdfs3 order by col_bigint_undef_signed """
+            order_qt_q001 """ select * from ${catalog1}.${dbName}.${tableWithHdfs2} order by col_bigint_undef_signed """
+            order_qt_q002 """ select * from ${catalog1}.${dbName}.${tableWithHdfs3} order by col_bigint_undef_signed """
 
-            sql """drop table ${catalog1}.write_test.tb_with_hdfs2"""
-            sql """drop table ${catalog1}.write_test.tb_with_hdfs3"""
+            sql """drop table ${catalog1}.${dbName}.${tableWithHdfs2}"""
+            sql """drop table ${catalog1}.${dbName}.${tableWithHdfs3}"""
 
             sql """drop catalog if exists ${catalog1}"""
             sql """drop catalog if exists ${catalog2}"""
             sql """drop catalog if exists ${catalog3}"""
 
         } finally {
+            try_sql """drop catalog if exists ${catalog1}"""
+            try_sql """drop catalog if exists ${catalog2}"""
+            try_sql """drop catalog if exists ${catalog3}"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
@@ -522,7 +522,7 @@ suite("test_hive_write_insert", "p0,external") {
         """
 
         sql """
-        
+
 INSERT INTO all_types_par_${format_compression}_${catalog_name}_q03
         VALUES  (
           1, -- boolean_col
@@ -882,10 +882,11 @@ INSERT INTO all_types_par_${format_compression}_${catalog_name}_q03
 
     for (String hivePrefix : ["hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = getHiveTempName("test_${hivePrefix}_write_insert", "catalog")
+        String temp_db = getHiveTempName("write_test", "db")
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_write_insert"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""
@@ -894,9 +895,26 @@ INSERT INTO all_types_par_${format_compression}_${catalog_name}_q03
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
                 'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
             );"""
-            sql """use `${catalog_name}`.`write_test`"""
-            logger.info("hive sql: " + """ use `write_test` """)
-            hive_docker """use `write_test`"""
+            hive_docker """drop database if exists `${temp_db}` cascade"""
+            hive_docker """create database if not exists `${temp_db}`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_parquet_snappy`"""
+            hive_docker """create table `${temp_db}`.`all_types_parquet_snappy` like `write_test`.`all_types_parquet_snappy`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_orc_zlib`"""
+            hive_docker """create table `${temp_db}`.`all_types_orc_zlib` like `write_test`.`all_types_orc_zlib`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_par_parquet_snappy`"""
+            hive_docker """create table `${temp_db}`.`all_types_par_parquet_snappy` like `write_test`.`all_types_par_parquet_snappy`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_par_orc_zlib`"""
+            hive_docker """create table `${temp_db}`.`all_types_par_orc_zlib` like `write_test`.`all_types_par_orc_zlib`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_parquet_snappy_src`"""
+            hive_docker """create table `${temp_db}`.`all_types_parquet_snappy_src` like `write_test`.`all_types_parquet_snappy_src`"""
+            hive_docker """insert into `${temp_db}`.`all_types_parquet_snappy_src` select * from `write_test`.`all_types_parquet_snappy_src`"""
+            hive_docker """drop table if exists `${temp_db}`.`all_types_par_parquet_snappy_src`"""
+            hive_docker """create table `${temp_db}`.`all_types_par_parquet_snappy_src` like `write_test`.`all_types_par_parquet_snappy_src`"""
+            hive_docker """insert into `${temp_db}`.`all_types_par_parquet_snappy_src` select * from `write_test`.`all_types_par_parquet_snappy_src`"""
+            sql """refresh catalog ${catalog_name}"""
+            sql """use `${catalog_name}`.`${temp_db}`"""
+            logger.info("hive sql: " + """ use `${temp_db}` """)
+            hive_docker """use `${temp_db}`"""
 
             sql """set enable_fallback_to_original_planner=false;"""
 
@@ -910,7 +928,8 @@ INSERT INTO all_types_par_${format_compression}_${catalog_name}_q03
 
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists `${temp_db}` cascade"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_partitions.groovy
@@ -192,7 +192,7 @@ suite("test_hive_write_partitions", "p0,external") {
     def test_doris_write_hive_partition_table = { String catalog_name ->
         // After writing to a Hive partitioned table and adding a new partition using Doris,
         // writing data to the same partition using Hive results in an error: "Partition column xxx conflicts with table columns."
-        String tableName = "test_doris_write_hive_partition_table"
+        String tableName = getHiveTempName("test_doris_write_hive_partition_table", "tbl")
         String originalTableName = "test_doris_write_hive_partition_table_original"
         hive_docker """ drop table if exists ${tableName}; """
         hive_docker """ create table ${tableName} like ${originalTableName}; """
@@ -217,7 +217,7 @@ suite("test_hive_write_partitions", "p0,external") {
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_write_partitions"
+            String catalog_name = getHiveTempName("test_${hivePrefix}_write_partitions", "catalog")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_prepare_hive_data_in_case.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_prepare_hive_data_in_case.groovy
@@ -21,6 +21,8 @@ suite("test_trino_prepare_hive_data_in_case", "p0,external") {
     def catalog_name = "test_trino_prepare_hive_data_in_case"
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         def host_ips = new ArrayList()
+        String tableName = getHiveTempName(catalog_name)
+        String trinoCatalogName = getHiveTempName(catalog_name, "catalog")
         String[][] backends = sql """ show backends """
         for (def b in backends) {
             host_ips.add(b[1])
@@ -35,33 +37,34 @@ suite("test_trino_prepare_hive_data_in_case", "p0,external") {
             String hms_port = context.config.otherConfigs.get("hive2HmsPort")
 
             hive_docker """show databases;"""
-            hive_docker """drop table if exists default.${catalog_name};  """
+            hive_docker """drop table if exists default.${tableName};  """
             hive_docker """
-                            create table default.${catalog_name} (k1 String, k2 String); 
+                            create table default.${tableName} (k1 String, k2 String);
                         """
-            hive_docker """insert into default.${catalog_name} values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
-            def values = hive_docker """select count(*) from `default`.${catalog_name};"""
-            
+            hive_docker """insert into default.${tableName} values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
+            def values = hive_docker """select count(*) from `default`.${tableName};"""
+
             log.info(values.toString())
 
-            sql """drop catalog if exists ${catalog_name};"""
+            sql """drop catalog if exists ${trinoCatalogName};"""
             sql """
-                create catalog if not exists ${catalog_name} properties (
+                create catalog if not exists ${trinoCatalogName} properties (
                     "type"="trino-connector",
                     "trino.connector.name"="hive",
                     'trino.hive.metastore.uri' = 'thrift://${externalEnvIp}:${hms_port}'
                 );
             """
-            def values2 = sql """select count(*) from ${catalog_name}.`default`.${catalog_name};"""
+            def values2 = sql """select count(*) from ${trinoCatalogName}.`default`.${tableName};"""
             log.info(values2.toString())
             assertEquals(values[0][0],values2[0][0])
 
-            qt_hive_docker_01 """select * from default.${catalog_name} order by k1 desc  ;"""
-            
-            qt_sql_02 """ select * from ${catalog_name}.`default`.${catalog_name} order by k1 desc;"""
+            qt_hive_docker_01 """select * from default.${tableName} order by k1 desc  ;"""
+
+            qt_sql_02 """ select * from ${trinoCatalogName}.`default`.${tableName} order by k1 desc;"""
 
         } finally {
+            try_sql """drop catalog if exists ${trinoCatalogName};"""
+            try_hive_docker """drop table if exists default.${tableName};"""
         }
     }
 }
-


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:
This PR reduces shared local Hive Docker side effects across regression suites by moving many local-Hive write paths to per-run temporary Hive objects and best-effort cleanup. The goal is to make local Hive state safer for CI reuse and reruns.

Covered in this PR:
- add shared helper methods in the regression suite framework for per-run temporary Hive object naming and cleanup
- isolate many local Hive Docker write suites to temporary tables or databases
- add cleanup in `finally` blocks so failed runs also attempt to recover local Hive state
- avoid direct writes to several shared baseline Hive tables by copying data into temporary write targets first

Remaining follow-up after this PR:
- `regression-test/suites/external_table_p0/hive/ddl/test_hive_ctas.groovy`
- `regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl.groovy`
- `regression-test/suites/external_table_p0/hive/test_hive_case_sensibility.groovy`

### Release note

None

### Check List (For Author)

- Test: No need to test (workflow preparation only; `git diff --check` was run in this environment)
- Behavior changed: Yes (local Hive regression suites use temporary Hive objects and cleanup more aggressively)
- Does this need documentation: No
