### PR TITLE
[fix](csv reader) fix silent data corruption when enclose char is a prefix of multi-char column separator

### DIFF
--- a/be/src/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/format/file_reader/new_plain_text_line_reader.cpp
@@ -158,6 +158,24 @@ void EncloseCsvLineReaderCtx::_on_pre_match_enclose(const uint8_t* start, size_t
             } else if (_quote_escape) {
                 // the last char is quote, so we need to check if the current char is quote to determine if it is escaped by quote
                 if (start[_idx] == _enclose) {
+                    // When the column separator starts with the enclose char (e.g. enclose=':' and
+                    // sep='::'), the sequence "closing-enclose + separator" looks identical to a
+                    // double-quote escape followed by extra chars.  Disambiguate by peeking ahead:
+                    // if the bytes at the current position match the full column separator, the
+                    // previous enclose char was the actual closing enclose rather than half of a
+                    // double-quote escape.
+                    if (_sep_starts_with_enclose) {
+                        size_t remaining = len - _idx;
+                        if (remaining >= _column_sep_len &&
+                            memcmp(start + _idx, _column_sep.c_str(), _column_sep_len) == 0) {
+                            // The previous enclose char closed the field; the current position is
+                            // the start of the column separator.  Hand off to MATCH_ENCLOSE which
+                            // will record the separator position.
+                            _quote_escape = false;
+                            _state.forward_to(ReaderState::MATCH_ENCLOSE);
+                            return;
+                        }
+                    }
                     // double quote, escaped by quote
                     _quote_escape = false;
                 } else {

--- a/be/src/format/file_reader/new_plain_text_line_reader.h
+++ b/be/src/format/file_reader/new_plain_text_line_reader.h
@@ -167,6 +167,9 @@ public:
         } else {
             find_col_sep_func = &EncloseCsvLineReaderCtx::look_for_column_sep_pos<false>;
         }
+        // Precompute: whether the separator starts with the enclose char and has length > 1.
+        // Used in the hot loop of _on_pre_match_enclose to avoid repeated comparisons.
+        _sep_starts_with_enclose = (column_sep_len_ > 1 && _column_sep[0] == enclose);
         _column_sep_positions.reserve(col_sep_num);
     }
 
@@ -222,6 +225,9 @@ private:
 
     const std::string _column_sep;
     std::vector<size_t> _column_sep_positions;
+    // True when _column_sep[0] == _enclose && _column_sep_len > 1.
+    // Precomputed at construction to avoid per-iteration checks in the hot loop.
+    bool _sep_starts_with_enclose = false;
 
     FindDelimiterFunc find_col_sep_func;
 };

--- a/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
+++ b/be/test/format/file_reader/new_plain_text_line_reader_test.cpp
@@ -148,6 +148,49 @@ TEST_F(EncloseCsvLineReaderTest, QuoteEscaping) {
                      {{14, 42}});
 }
 
+// Regression test: enclose char is a prefix of the multi-char column separator.
+// e.g. enclose=':', sep='::'.  A closing enclose followed immediately by the
+// separator (:::) was previously misread as a double-quote escape (::) plus an
+// orphaned ':', causing silent data corruption.
+TEST_F(EncloseCsvLineReaderTest, EncloseIsPrefixOfSeparator) {
+    // Row: 1:::alpha::beta:::ok
+    //   field0 = "1"
+    //   sep "::"
+    //   field1 = ":alpha::beta:"  (enclose-wrapped; '::' inside is literal content)
+    //   sep "::"
+    //   field2 = "ok"
+    // Expected column_sep_positions: [1, 16]
+    verify_csv_split("1:::alpha::beta:::ok", "\n", "::", ':', 0, false, {"1:::alpha::beta:::ok"},
+                     {{1, 16}});
+
+    // Row: 2:::plain:::tail  (no separator inside the enclosed field)
+    // Expected: [1, 10]
+    verify_csv_split("2:::plain:::tail", "\n", "::", ':', 0, false, {"2:::plain:::tail"},
+                     {{1, 10}});
+
+    // Two rows together
+    verify_csv_split("1:::alpha::beta:::ok\n2:::plain:::tail", "\n", "::", ':', 0, false,
+                     {"1:::alpha::beta:::ok", "2:::plain:::tail"}, {{1, 16}, {1, 10}});
+}
+
+// Verify that a non-zero escape character does not interfere with the
+// enclose-prefix-of-separator fix.  The _should_escape path short-circuits
+// before _quote_escape is tested, so the two mechanisms are independent —
+// this test guards against future refactoring breaking that invariant.
+TEST_F(EncloseCsvLineReaderTest, EncloseIsPrefixOfSeparatorWithEscape) {
+    // escape='\', enclose=':', sep='::'
+    // Row: 1:::alpha\::beta:::ok
+    //   '\:' inside the field — the ':' is escape-suppressed, does not set _quote_escape.
+    //   The closing ':' at pos 15 is still correctly identified via the separator peek.
+    // Expected sep positions: [1, 16]  (same as the no-escape case)
+    verify_csv_split("1:::alpha\\::beta:::ok", "\n", "::", ':', '\\', false,
+                     {"1:::alpha\\::beta:::ok"}, {{1, 16}});
+
+    // Without an escaped colon inside the field (baseline).
+    // Closing enclose is at pos 9; separator '::' starts at pos 10.
+    verify_csv_split("1:::alpha:::ok", "\n", "::", ':', '\\', false, {"1:::alpha:::ok"}, {{1, 10}});
+}
+
 TEST_F(EncloseCsvLineReaderTest, MultiCharDelimiters) {
     // Test multi-character line delimiter
     verify_csv_split("a,b,c\r\n\nd,e,f", "\r\n\n", ",", '"', '\\', false, {"a,b,c", "d,e,f"},


### PR DESCRIPTION
<h2 style="margin-top: 0px; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">When <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">enclose</code> is a single character that is also the <strong>first character of a multi-char <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">column_separator</code></strong> (e.g. <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">enclose=':'</code>, <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">column_sep='::'</code>), the CSV parser silently produces wrong data: it finds fewer column separators than actually exist and fills trailing columns with <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NULL</code>.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Reproduction</strong></p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Properties: <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">column_separator = '::'</code>, <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">enclose = ':'</code></p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">File content:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(255, 255, 255); border-color: rgb(200, 200, 200); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">id::name::remark
1:::alpha::beta:::ok
2:::plain:::tail
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Expected:</p>
id | name | remark
-- | -- | --
1 | alpha::beta | ok
2 | plain | tail

<h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Root Cause</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EncloseCsvLineReaderCtx::_on_pre_match_enclose</code> uses a double-quote-escape heuristic: two consecutive enclose chars (<code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">::</code>) inside an enclosed field are treated as an escaped enclose and scanning continues. This is correct in isolation, but breaks when the separator itself starts with the enclose char.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">For the line <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">1:::alpha::beta:::ok</code>, the closing sequence at positions 15–17 is:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(255, 255, 255); border-color: rgb(200, 200, 200); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">pos:  15  16  17  18
char:  :   :   :   o
       ↑   ↑───┘
       │   separator '::'
       closing enclose
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The state machine consumed positions 15–16 as a double-quote escape, then set <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_quote_escape=true</code> at 17, and finally triggered MATCH_ENCLOSE at 18 (<code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">'o'</code>) — producing a bogus field boundary. Only <strong>one</strong> separator was recorded instead of two, so column 3 became <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NULL</code>.</p><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">In <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_on_pre_match_enclose</code>, when <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_quote_escape=true</code> and the current character is again the enclose char, <strong>peek ahead <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">column_sep_len</code> bytes</strong> before deciding:</p><ul style="padding-inline-start: 2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>If the bytes at the current position equal the full column separator → the<span> </span><strong>previous</strong><span> </span>enclose char was the closing enclose; transition to<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">MATCH_ENCLOSE</code><span> </span>so the separator is recorded correctly.</li><li>Otherwise → fall through to the existing double-quote escape path.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The check is guarded by <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">_column_sep_len &gt; 1 &amp;&amp; _column_sep[0] == _enclose</code>, so it only activates for this specific combination. All other formats (standard CSV <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sep=','</code> / <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">enclose='"'</code>, multi-char separators that don't start with the enclose char, etc.) are completely unaffected.</p><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Limitation</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">When <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">enclose</code> is a prefix of <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sep</code>, fields whose <strong>content ends with the separator string itself</strong> (e.g. storing <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">alpha::</code> with <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">enclose=':'</code>, <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sep='::'</code>) are inherently ambiguous at the byte level — no algorithm can distinguish the two interpretations from the same byte sequence. This edge case was already broken before this fix and remains best-effort.</p><h2 style="color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Added <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EncloseIsPrefixOfSeparator</code> in <code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">be/test/format/file_reader/new_plain_text_line_reader_test.cpp</code>:</p><ul style="padding-inline-start: 2em; color: rgb(97, 97, 97); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(243, 243, 243); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">1:::alpha::beta:::ok</code><span> </span>with<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sep='::'</code>,<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">enclose=':'</code><span> </span>→ sep positions<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[1, 16]</code><span> </span>✓</li><li><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">2:::plain:::tail</code><span> </span>→ sep positions<span> </span><code style="font-family: monospace; color: rgb(163, 21, 21); background-color: rgba(0, 0, 0, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[1, 10]</code><span> </span>✓</li><li>Both rows together ✓</li></ul>

