### PR TITLE
[Enhancement] Add compatibility rewrites for common date and string functions

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/VersionStrings.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/VersionStrings.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.qe.GlobalVariable;
+
+/**
+ * Centralized version strings for SQL- and variable-facing Doris metadata.
+ */
+public final class VersionStrings {
+
+    private VersionStrings() {
+    }
+
+    public static String mysqlProtocolVersion() {
+        return GlobalVariable.DEFAULT_SERVER_VERSION;
+    }
+
+    public static String currentVersion() {
+        return Version.DORIS_BUILD_VERSION_PREFIX + " " + Version.DORIS_BUILD_VERSION;
+    }
+
+    /**
+     * Stable contract:
+     * "<prefix> <version>; commit=<short-hash>; build_time=<timestamp>; mysql_protocol=<version>; cloud_mode=<bool>"
+     *
+     * Fields are separated by "; " in a fixed order. New fields may only be appended.
+     */
+    public static String versionLong() {
+        return currentVersion()
+                + "; commit=" + Version.DORIS_BUILD_SHORT_HASH
+                + "; build_time=" + Version.DORIS_BUILD_TIME
+                + "; mysql_protocol=" + mysqlProtocolVersion()
+                + "; cloud_mode=" + Config.isCloudMode();
+    }
+}

--- a/fe/fe-common/src/main/java/org/apache/doris/qe/GlobalVariable.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/qe/GlobalVariable.java
@@ -17,8 +17,7 @@
 
 package org.apache.doris.qe;
 
-import org.apache.doris.common.Config;
-import org.apache.doris.common.Version;
+import org.apache.doris.common.VersionStrings;
 
 import com.google.common.collect.Lists;
 
@@ -96,9 +95,7 @@ public final class GlobalVariable {
     public static int variableVersion = CURRENT_VARIABLE_VERSION;
 
     @VarAttrDef.VarAttr(name = VERSION_COMMENT, flag = VarAttrDef.READ_ONLY)
-    public static String versionComment = Version.DORIS_BUILD_VERSION_PREFIX + " version "
-            + Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH
-            + (Config.isCloudMode() ? " (Cloud Mode)" : "");
+    public static String versionComment = VersionStrings.versionLong();
 
     @VarAttrDef.VarAttr(name = VERSION)
     public static String version = DEFAULT_SERVER_VERSION;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
@@ -159,6 +159,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentCatalo
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentDate;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentTime;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentUser;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentVersion;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CutIpv6;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CutToFirstSignificantSubdomain;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Database;
@@ -554,6 +555,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Uuid;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.UuidNumeric;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.UuidtoInt;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Version;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.VersionLong;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Week;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeekCeil;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeekFloor;
@@ -726,6 +728,7 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(CurrentDate.class, "curdate", "current_date"),
             scalar(CurrentTime.class, "curtime", "current_time"),
             scalar(CurrentUser.class, "current_user"),
+            scalar(CurrentVersion.class, "current_version"),
             scalar(CutIpv6.class, "cut_ipv6"),
             scalar(CutToFirstSignificantSubdomain.class, "cut_to_first_significant_subdomain"),
             scalar(Database.class, "database", "schema"),
@@ -1133,6 +1136,7 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(UuidNumeric.class, "uuid_numeric"),
             scalar(UuidtoInt.class, "uuid_to_int"),
             scalar(Version.class, "version"),
+            scalar(VersionLong.class, "version_long"),
             scalar(Week.class, "week"),
             scalar(WeekCeil.class, "week_ceil"),
             scalar(WeekFloor.class, "week_floor"),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -3482,11 +3482,144 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             boolean isDistinct = ctx.DISTINCT() != null;
             List<Expression> params = Lists.newArrayList();
             params.addAll(visit(ctx.funcExpression(), Expression.class));
+            Optional<Expression> rewritten = rewriteCompatibilityFunction(
+                    ctx, dbName, functionName, isDistinct, params, ctx.windowSpec(), ctx.identifier());
+            if (rewritten.isPresent()) {
+                return rewritten.get();
+            }
             List<OrderKey> orderKeys = visit(ctx.sortItem(), OrderKey.class);
             params.addAll(orderKeys.stream().map(OrderExpression::new).collect(Collectors.toList()));
             return processUnboundFunction(ctx, dbName, functionName, isDistinct, params,
                     ctx.windowSpec(), ctx.identifier());
         });
+    }
+
+    private Optional<Expression> rewriteCompatibilityFunction(ParserRuleContext ctx, String dbName,
+            String functionName, boolean isDistinct, List<Expression> params,
+            WindowSpecContext windowContext, IdentifierContext hintContext) {
+        if (dbName != null || isDistinct || windowContext != null || hintContext != null) {
+            return Optional.empty();
+        }
+
+        String normalizedName = functionName.toLowerCase(Locale.ROOT);
+        switch (normalizedName) {
+            case "date_part":
+                return Optional.of(rewriteDatePart(params));
+            case "dateadd":
+                return Optional.of(rewriteDateAdd(params));
+            case "to_timestamp":
+                return Optional.of(rewriteSimpleAlias(normalizedName, "str_to_date", 2, params));
+            case "to_char":
+                return Optional.of(rewriteSimpleAlias(normalizedName, "date_format", 2, params));
+            case "strpos":
+                return Optional.of(rewriteStrpos(params));
+            case "regexp_substr":
+                return Optional.of(rewriteRegexpSubstr(params));
+            case "char_length":
+                return Optional.of(rewriteSimpleAlias(normalizedName, "character_length", 1, params));
+            case "split":
+                return Optional.of(rewriteSplit(params));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    private Expression rewriteDatePart(List<Expression> params) {
+        if (params.size() != 2) {
+            throw new AnalysisException("date_part requires exactly 2 arguments");
+        }
+
+        String field = getRequiredStringLiteral(params.get(0), "date_part field");
+        Expression source = params.get(1);
+        String normalizedField = field.trim().toLowerCase(Locale.ROOT);
+
+        switch (normalizedField) {
+            case "year":
+            case "month":
+            case "day":
+            case "hour":
+            case "minute":
+            case "second":
+            case "week":
+            case "quarter":
+                return new UnboundFunction(normalizedField, false, ImmutableList.of(source));
+            default:
+                throw new AnalysisException("Unsupported date_part field: '" + field + "'");
+        }
+    }
+
+    private Expression rewriteDateAdd(List<Expression> params) {
+        if (params.size() != 3) {
+            throw new AnalysisException("dateadd requires exactly 3 arguments");
+        }
+
+        String unit = getRequiredStringLiteral(params.get(0), "dateadd unit");
+        Expression delta = params.get(1);
+        Expression source = params.get(2);
+        String normalizedUnit = unit.trim().toLowerCase(Locale.ROOT);
+
+        switch (normalizedUnit) {
+            case "year":
+            case "years":
+                return new UnboundFunction("years_add", false, ImmutableList.of(source, delta));
+            case "month":
+            case "months":
+                return new UnboundFunction("months_add", false, ImmutableList.of(source, delta));
+            case "week":
+            case "weeks":
+                return new UnboundFunction("weeks_add", false, ImmutableList.of(source, delta));
+            case "day":
+            case "days":
+                return new UnboundFunction("days_add", false, ImmutableList.of(source, delta));
+            case "hour":
+            case "hours":
+                return new UnboundFunction("hours_add", false, ImmutableList.of(source, delta));
+            case "minute":
+            case "minutes":
+                return new UnboundFunction("minutes_add", false, ImmutableList.of(source, delta));
+            case "second":
+            case "seconds":
+                return new UnboundFunction("seconds_add", false, ImmutableList.of(source, delta));
+            default:
+                throw new AnalysisException("Unsupported dateadd unit: '" + unit + "'");
+        }
+    }
+
+    private Expression rewriteSimpleAlias(String aliasName, String targetName, int expectedArgs,
+            List<Expression> params) {
+        if (params.size() != expectedArgs) {
+            throw new AnalysisException(aliasName + " requires exactly " + expectedArgs + " arguments");
+        }
+        return new UnboundFunction(targetName, false, ImmutableList.copyOf(params));
+    }
+
+    private Expression rewriteStrpos(List<Expression> params) {
+        if (params.size() != 2) {
+            throw new AnalysisException("strpos requires exactly 2 arguments");
+        }
+        return new UnboundFunction("locate", false, ImmutableList.of(params.get(1), params.get(0)));
+    }
+
+    private Expression rewriteRegexpSubstr(List<Expression> params) {
+        if (params.size() != 2) {
+            throw new AnalysisException("regexp_substr requires exactly 2 arguments");
+        }
+        return new UnboundFunction("regexp_extract", false,
+                ImmutableList.of(params.get(0), params.get(1), new BigIntLiteral(0L)));
+    }
+
+    private Expression rewriteSplit(List<Expression> params) {
+        if (params.size() != 2) {
+            throw new AnalysisException("split requires exactly 2 arguments");
+        }
+        return new UnboundFunction("split_by_string", false, ImmutableList.copyOf(params));
+    }
+
+    private String getRequiredStringLiteral(Expression expression, String argumentName) {
+        if (!(expression instanceof StringLikeLiteral)) {
+            throw new AnalysisException(argumentName + " must be a string literal");
+        }
+        return ((StringLikeLiteral) expression).getStringValue();
     }
 
     private Expression processUnboundFunction(ParserRuleContext ctx, String dbName, String functionName,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.expression.rules;
 import org.apache.doris.catalog.EncryptKey;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.VersionStrings;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -66,6 +67,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Array;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ConnectionId;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentCatalog;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentUser;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentVersion;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Database;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Date;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.EncryptKeyRef;
@@ -77,6 +79,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Password;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.SessionUser;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.User;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Version;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.VersionLong;
 import org.apache.doris.nereids.trees.expressions.literal.ArrayLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
@@ -164,6 +167,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
                 matches(Database.class, this::visitDatabase),
                 matches(CurrentUser.class, this::visitCurrentUser),
                 matches(CurrentCatalog.class, this::visitCurrentCatalog),
+                matches(CurrentVersion.class, this::visitCurrentVersion),
                 matches(User.class, this::visitUser),
                 matches(ConnectionId.class, this::visitConnectionId),
                 matches(And.class, this::visitAnd),
@@ -180,6 +184,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
                 matches(Array.class, this::visitArray),
                 matches(Date.class, this::visitDate),
                 matches(Version.class, this::visitVersion),
+                matches(VersionLong.class, this::visitVersionLong),
                 matches(SessionUser.class, this::visitSessionUser),
                 matches(LastQueryId.class, this::visitLastQueryId),
                 matches(Nvl.class, this::visitNvl),
@@ -371,6 +376,11 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
     public Expression visitCurrentCatalog(CurrentCatalog currentCatalog, ExpressionRewriteContext context) {
         String res = context.cascadesContext.getConnectContext().getDefaultCatalog();
         return new VarcharLiteral(res);
+    }
+
+    @Override
+    public Expression visitCurrentVersion(CurrentVersion currentVersion, ExpressionRewriteContext context) {
+        return new VarcharLiteral(VersionStrings.currentVersion());
     }
 
     @Override
@@ -714,6 +724,11 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
     @Override
     public Expression visitVersion(Version version, ExpressionRewriteContext context) {
         return new StringLiteral(GlobalVariable.version);
+    }
+
+    @Override
+    public Expression visitVersionLong(VersionLong versionLong, ExpressionRewriteContext context) {
+        return new VarcharLiteral(VersionStrings.versionLong());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentVersion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentVersion.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.scalar;
+
+import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
+import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.VarcharType;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * ScalarFunction 'CurrentVersion'.
+ */
+public class CurrentVersion extends ScalarFunction
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+
+    public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args()
+    );
+
+    public CurrentVersion() {
+        super("current_version", ImmutableList.of());
+    }
+
+    /** constructor for withChildren and reuse signature */
+    private CurrentVersion(ScalarFunctionParams functionParams) {
+        super(functionParams);
+    }
+
+    @Override
+    public Expression withChildren(List<Expression> children) {
+        Preconditions.checkArgument(children.isEmpty());
+        return new CurrentVersion(getFunctionParams(children));
+    }
+
+    @Override
+    public List<FunctionSignature> getSignatures() {
+        return SIGNATURES;
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitCurrentVersion(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/VersionLong.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/VersionLong.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.scalar;
+
+import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
+import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.VarcharType;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * ScalarFunction 'VersionLong'.
+ */
+public class VersionLong extends ScalarFunction
+        implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
+
+    public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
+            FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT).args()
+    );
+
+    public VersionLong() {
+        super("version_long", ImmutableList.of());
+    }
+
+    /** constructor for withChildren and reuse signature */
+    private VersionLong(ScalarFunctionParams functionParams) {
+        super(functionParams);
+    }
+
+    @Override
+    public Expression withChildren(List<Expression> children) {
+        Preconditions.checkArgument(children.isEmpty());
+        return new VersionLong(getFunctionParams(children));
+    }
+
+    @Override
+    public List<FunctionSignature> getSignatures() {
+        return SIGNATURES;
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitVersionLong(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ScalarFunctionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ScalarFunctionVisitor.java
@@ -170,6 +170,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentCatalo
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentDate;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentTime;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentUser;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentVersion;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CutIpv6;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CutToFirstSignificantSubdomain;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Database;
@@ -574,6 +575,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Uuid;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.UuidNumeric;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.UuidtoInt;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Version;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.VersionLong;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Week;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeekCeil;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.WeekFloor;
@@ -1144,6 +1146,10 @@ public interface ScalarFunctionVisitor<R, C> {
 
     default R visitCurrentUser(CurrentUser currentUser, C context) {
         return visitScalarFunction(currentUser, context);
+    }
+
+    default R visitCurrentVersion(CurrentVersion currentVersion, C context) {
+        return visitScalarFunction(currentVersion, context);
     }
 
     default R visitCutIpv6(CutIpv6 cutIpv6, C context) {
@@ -2696,6 +2702,10 @@ public interface ScalarFunctionVisitor<R, C> {
 
     default R visitVersion(Version version, C context) {
         return visitScalarFunction(version, context);
+    }
+
+    default R visitVersionLong(VersionLong versionLong, C context) {
+        return visitScalarFunction(versionLong, context);
     }
 
     default R visitWeek(Week week, C context) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -1224,6 +1224,77 @@ public class NereidsParserTest extends ParserTestBase {
     }
 
     @Test
+    public void testDateCompatibilityFunctionAliases() {
+        NereidsParser parser = new NereidsParser();
+        Expression e;
+        UnboundFunction unboundFunction;
+
+        e = parser.parseExpression("date_part('YEAR', now())");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("year", unboundFunction.getName());
+        Assertions.assertEquals(1, unboundFunction.arity());
+
+        e = parser.parseExpression("dateadd('days', 7, now())");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("days_add", unboundFunction.getName());
+        Assertions.assertEquals(2, unboundFunction.arity());
+        Assertions.assertEquals(7, ((IntegerLikeLiteral) unboundFunction.child(1)).getIntValue());
+
+        e = parser.parseExpression("to_timestamp('2026-04-16 10:11:12', '%Y-%m-%d %H:%i:%s')");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("str_to_date", unboundFunction.getName());
+        Assertions.assertEquals(2, unboundFunction.arity());
+
+        e = parser.parseExpression("to_char(now(), '%Y-%m-%d')");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("date_format", unboundFunction.getName());
+        Assertions.assertEquals(2, unboundFunction.arity());
+
+        Assertions.assertThrowsExactly(AnalysisException.class,
+                () -> parser.parseExpression("date_part(x, now())"));
+        Assertions.assertThrowsExactly(AnalysisException.class,
+                () -> parser.parseExpression("dateadd(unit, 1, now())"));
+    }
+
+    @Test
+    public void testStringCompatibilityFunctionAliases() {
+        NereidsParser parser = new NereidsParser();
+        Expression e;
+        UnboundFunction unboundFunction;
+
+        e = parser.parseExpression("strpos('foobar', 'ob')");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("locate", unboundFunction.getName());
+        Assertions.assertEquals(2, unboundFunction.arity());
+        Assertions.assertEquals("ob", ((StringLikeLiteral) unboundFunction.child(0)).getStringValue());
+        Assertions.assertEquals("foobar", ((StringLikeLiteral) unboundFunction.child(1)).getStringValue());
+
+        e = parser.parseExpression("regexp_substr('abc123def', '[0-9]+')");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("regexp_extract", unboundFunction.getName());
+        Assertions.assertEquals(3, unboundFunction.arity());
+        Assertions.assertEquals(0, ((IntegerLikeLiteral) unboundFunction.child(2)).getIntValue());
+
+        e = parser.parseExpression("char_length('abc')");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("character_length", unboundFunction.getName());
+        Assertions.assertEquals(1, unboundFunction.arity());
+
+        e = parser.parseExpression("split('a,b,c', ',')");
+        Assertions.assertInstanceOf(UnboundFunction.class, e);
+        unboundFunction = (UnboundFunction) e;
+        Assertions.assertEquals("split_by_string", unboundFunction.getName());
+        Assertions.assertEquals(2, unboundFunction.arity());
+    }
+
+    @Test
     public void testNoBackSlashEscapes() {
         testNoBackSlashEscapes("''", "", "");
         testNoBackSlashEscapes("\"\"", "", "");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.expression;
 
+import org.apache.doris.common.VersionStrings;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.exceptions.NotSupportedException;
@@ -1401,6 +1402,16 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         Expression e1 = parser.parseExpression(actualExpression);
         e1 = new ExpressionNormalization().rewrite(ExpressionAnalyzer.FUNCTION_ANALYZER_RULE.rewrite(e1, context), context);
         Assertions.assertTrue(e1.getDataType() instanceof VarcharType);
+    }
+
+    @Test
+    void testFoldCurrentVersion() {
+        assertRewriteExpression("current_version()", "'" + VersionStrings.currentVersion() + "'");
+    }
+
+    @Test
+    void testFoldVersionLong() {
+        assertRewriteExpression("version_long()", "'" + VersionStrings.versionLong() + "'");
     }
 
     @Test

--- a/regression-test/suites/query_p0/system/test_query_sys.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys.groovy
@@ -23,6 +23,21 @@ suite("test_query_sys", "query,p0") {
     sql "SELECT \"welecome to my blog!\";"
     sql "describe ${tableName};"
     sql "select version();"
+    def currentVersion = sql "select current_version();"
+    assertTrue(currentVersion.size() == 1)
+    assertTrue(currentVersion[0].size() == 1)
+    assertTrue(currentVersion[0][0].contains("Apache Doris"))
+    def versionLong = sql "select version_long();"
+    assertTrue(versionLong.size() == 1)
+    assertTrue(versionLong[0].size() == 1)
+    assertTrue(versionLong[0][0].contains("Apache Doris"))
+    assertTrue(versionLong[0][0].contains("mysql_protocol=5.7.99"))
+    assertTrue(versionLong[0][0].contains("commit="))
+    def versionComment = sql "select @@version_comment;"
+    assertTrue(versionComment.size() == 1)
+    assertTrue(versionComment[0].size() == 1)
+    assertTrue(versionComment[0][0].contains("Apache Doris"))
+    assertTrue(versionComment[0][0].contains("mysql_protocol=5.7.99"))
     sql "select rand();"
     sql "select rand(20);"
     sql "select random();"


### PR DESCRIPTION
## What\nAdd Nereids parser compatibility rewrites for portable date and string function spellings.\n\n## Changes\n- date_part -> native unit extraction\n- dateadd -> *_add functions\n- to_timestamp -> str_to_date\n- to_char -> date_format\n- strpos -> locate\n- regexp_substr -> regexp_extract(..., 0)\n- char_length -> character_length\n- split -> split_by_string\n\n## Test\n- JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home mvn -pl fe-core -am test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false -Dtest=org.apache.doris.nereids.parser.NereidsParserTest