### PR TITLE
[fix](fe) Support IAM role auth in S3 filesystem

### DIFF
--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystemProvider.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3FileSystemProvider.java
@@ -40,9 +40,13 @@ public class S3FileSystemProvider implements FileSystemProvider {
         String accessKey = normalized.get(S3ObjStorage.PROP_ACCESS_KEY);
         String endpoint = normalized.get(S3ObjStorage.PROP_ENDPOINT);
         String region = normalized.get(S3ObjStorage.PROP_REGION);
-        // Require access key + (endpoint or region)
-        return accessKey != null && !accessKey.isEmpty()
-                && (endpoint != null || region != null);
+        String roleArn = normalized.get(S3ObjStorage.PROP_ROLE_ARN);
+        boolean hasCredential = accessKey != null && !accessKey.isEmpty()
+                || roleArn != null && !roleArn.isEmpty();
+        boolean hasLocation = endpoint != null && !endpoint.isEmpty()
+                || region != null && !region.isEmpty();
+        // Support both AK/SK and IAM role based access for cloud snapshot and stage flows.
+        return hasCredential && hasLocation;
     }
 
     @Override

--- a/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/main/java/org/apache/doris/filesystem/s3/S3ObjStorage.java
@@ -65,6 +65,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
@@ -217,7 +218,15 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         }
     }
 
-    private AwsCredentialsProvider buildCredentialsProvider() {
+    protected AwsCredentialsProvider buildCredentialsProvider() {
+        String roleArn = properties.get(PROP_ROLE_ARN);
+        if (roleArn != null && !roleArn.isEmpty()) {
+            return buildAssumeRoleCredentialsProvider(roleArn, properties.get(PROP_EXTERNAL_ID));
+        }
+        return buildClientBaseCredentialsProvider();
+    }
+
+    private AwsCredentialsProvider buildClientBaseCredentialsProvider() {
         String accessKey = properties.get(PROP_ACCESS_KEY);
         String secretKey = properties.get(PROP_SECRET_KEY);
         String token = properties.get(PROP_TOKEN);
@@ -236,6 +245,42 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                         DefaultCredentialsProvider.create(),
                         AnonymousCredentialsProvider.create())
                 .build();
+    }
+
+    private AwsCredentialsProvider buildStsSourceCredentialsProvider() {
+        String accessKey = properties.get(PROP_ACCESS_KEY);
+        String secretKey = properties.get(PROP_SECRET_KEY);
+        String token = properties.get(PROP_TOKEN);
+
+        if (accessKey != null && !accessKey.isEmpty() && secretKey != null && !secretKey.isEmpty()) {
+            if (token != null && !token.isEmpty()) {
+                return StaticCredentialsProvider.create(
+                        AwsSessionCredentials.create(accessKey, secretKey, token));
+            }
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        }
+        return DefaultCredentialsProvider.create();
+    }
+
+    protected StsClient buildStsClient(AwsCredentialsProvider credentialsProvider, String region) {
+        return StsClient.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(region))
+                .build();
+    }
+
+    private AwsCredentialsProvider buildAssumeRoleCredentialsProvider(String roleArn, String externalId) {
+        String region = properties.getOrDefault(PROP_REGION, "us-east-1");
+        StsClient stsClient = buildStsClient(buildStsSourceCredentialsProvider(), region);
+        return StsAssumeRoleCredentialsProvider.builder()
+                .stsClient(stsClient)
+                .refreshRequest(builder -> {
+                    builder.roleArn(roleArn)
+                            .roleSessionName("doris_" + UUID.randomUUID().toString().replace("-", ""));
+                    if (externalId != null && !externalId.isEmpty()) {
+                        builder.externalId(externalId);
+                    }
+                }).build();
     }
 
     @Override
@@ -458,15 +503,9 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         if (roleArn == null || roleArn.isEmpty()) {
             throw new IOException("STS role ARN (AWS_ROLE_ARN) is not configured");
         }
-        String accessKey = properties.get(PROP_ACCESS_KEY);
-        String secretKey = properties.get(PROP_SECRET_KEY);
         String region = properties.getOrDefault(PROP_REGION, "us-east-1");
         try {
-            AwsBasicCredentials basicCred = AwsBasicCredentials.create(accessKey, secretKey);
-            try (StsClient stsClient = StsClient.builder()
-                    .credentialsProvider(StaticCredentialsProvider.create(basicCred))
-                    .region(Region.of(region))
-                    .build()) {
+            try (StsClient stsClient = buildStsClient(buildStsSourceCredentialsProvider(), region)) {
                 AssumeRoleRequest.Builder reqBuilder = AssumeRoleRequest.builder()
                         .roleArn(roleArn)
                         .durationSeconds(SESSION_EXPIRE_SECONDS)

--- a/fe/fe-filesystem/fe-filesystem-s3/src/test/java/org/apache/doris/filesystem/s3/S3FileSystemProviderTest.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/test/java/org/apache/doris/filesystem/s3/S3FileSystemProviderTest.java
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.filesystem.s3;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class S3FileSystemProviderTest {
+
+    private final S3FileSystemProvider provider = new S3FileSystemProvider();
+
+    @Test
+    void supports_acceptsRoleBasedS3Configuration() {
+        Map<String, String> props = new HashMap<>();
+        props.put("AWS_ENDPOINT", "https://s3.us-west-2.amazonaws.com");
+        props.put("AWS_REGION", "us-west-2");
+        props.put("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/snapshot-role");
+
+        Assertions.assertTrue(provider.supports(props));
+    }
+
+    @Test
+    void supports_rejectsConfigurationWithoutCredentialsOrRole() {
+        Map<String, String> props = new HashMap<>();
+        props.put("AWS_ENDPOINT", "https://s3.us-west-2.amazonaws.com");
+        props.put("AWS_REGION", "us-west-2");
+
+        Assertions.assertFalse(provider.supports(props));
+    }
+}

--- a/fe/fe-filesystem/fe-filesystem-s3/src/test/java/org/apache/doris/filesystem/s3/S3ObjStorageMockTest.java
+++ b/fe/fe-filesystem/fe-filesystem-s3/src/test/java/org/apache/doris/filesystem/s3/S3ObjStorageMockTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
@@ -48,6 +49,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.services.sts.StsClient;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -345,6 +347,21 @@ class S3ObjStorageMockTest {
                 "Should throw when AWS_ROLE_ARN not configured");
     }
 
+    @Test
+    void buildCredentialsProvider_returnsAssumeRoleProviderWhenRoleArnConfigured() {
+        Map<String, String> props = new HashMap<>();
+        props.put("AWS_ENDPOINT", "https://s3.amazonaws.com");
+        props.put("AWS_REGION", "us-east-1");
+        props.put("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/MyRole");
+        props.put("AWS_EXTERNAL_ID", "snapshot-external-id");
+        InspectableS3ObjStorage roleArnStorage = new InspectableS3ObjStorage(props, mockS3);
+
+        AwsCredentialsProvider credentialsProvider = roleArnStorage.inspectBuildCredentialsProvider();
+
+        Assertions.assertEquals("StsAssumeRoleCredentialsProvider",
+                credentialsProvider.getClass().getSimpleName());
+    }
+
     // ------------------------------------------------------------------
     // close()
     // ------------------------------------------------------------------
@@ -372,6 +389,21 @@ class S3ObjStorageMockTest {
         @Override
         protected S3Client buildClient() {
             return mockClient;
+        }
+    }
+
+    private static class InspectableS3ObjStorage extends TestableS3ObjStorage {
+        InspectableS3ObjStorage(Map<String, String> properties, S3Client mockClient) {
+            super(properties, mockClient);
+        }
+
+        AwsCredentialsProvider inspectBuildCredentialsProvider() {
+            return buildCredentialsProvider();
+        }
+
+        @Override
+        protected StsClient buildStsClient(AwsCredentialsProvider credentialsProvider, String region) {
+            return Mockito.mock(StsClient.class);
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

the S3 filesystem accepts AWS_ROLE_ARN-based configuration and can build STS assume-role credentials.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

