### PR TITLE
[Enhancement](compile) Specific x86-64-v3 arch when AVX2 enabled

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -404,6 +404,8 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
     add_compile_options(-msse4.2)
     add_definitions(-DLIBDIVIDE_SSE2)
     if (USE_AVX2)
+        # for almost all platform support AVX2, x86-64-v3 is supported.
+        add_compile_options(-march=x86-64-v3)
         add_compile_options(-mavx2)
         add_definitions(-DUSE_AVX2)
         add_definitions(-DLIBDIVIDE_AVX2)

--- a/be/test/util/metrics_test.cpp
+++ b/be/test/util/metrics_test.cpp
@@ -420,7 +420,7 @@ TEST_F(MetricsTest, HistogramRegistryOutput) {
 
         MetricPrototype task_duration_type(MetricType::HISTOGRAM, MetricUnit::MILLISECONDS,
                                            "task_duration");
-        HistogramMetric* task_duration =
+        auto* task_duration =
                 (HistogramMetric*)entity->register_metric<HistogramMetric>(&task_duration_type);
         for (int j = 1; j <= 100; j++) {
             task_duration->add(j);
@@ -443,7 +443,7 @@ test_registry_task_duration_standard_deviation 28.8661
         EXPECT_EQ(
                 R"*([{"tags":{"metric":"task_duration"},"unit":"milliseconds",)*"
                 R"*("value":{"total_count":100,"min":1,"average":50.5,"median":50.0,)*"
-                R"*("percentile_50":50.0,"percentile_75":75.0,"percentile_90":95.83333333333334,"percentile_95":100.0,"percentile_99":100.0,)*"
+                R"*("percentile_50":50.0,"percentile_75":75.0,"percentile_90":95.83333333333333,"percentile_95":100.0,"percentile_99":100.0,)*"
                 R"*("standard_deviation":28.86607004772212,"max":100,"total_sum":5050}}])*",
                 registry.to_json());
         registry.deregister_entity(entity);
@@ -455,7 +455,7 @@ test_registry_task_duration_standard_deviation 28.8661
 
         MetricPrototype task_duration_type(MetricType::HISTOGRAM, MetricUnit::MILLISECONDS,
                                            "task_duration", "", "", {{"type", "create_tablet"}});
-        HistogramMetric* task_duration =
+        auto* task_duration =
                 (HistogramMetric*)entity->register_metric<HistogramMetric>(&task_duration_type);
         for (int j = 1; j <= 100; j++) {
             task_duration->add(j);
@@ -479,7 +479,7 @@ test_registry_task_duration_standard_deviation{instance="test",type="create_tabl
         EXPECT_EQ(
                 R"*([{"tags":{"metric":"task_duration","type":"create_tablet","instance":"test"},"unit":"milliseconds",)*"
                 R"*("value":{"total_count":100,"min":1,"average":50.5,"median":50.0,)*"
-                R"*("percentile_50":50.0,"percentile_75":75.0,"percentile_90":95.83333333333334,"percentile_95":100.0,"percentile_99":100.0,)*"
+                R"*("percentile_50":50.0,"percentile_75":75.0,"percentile_90":95.83333333333333,"percentile_95":100.0,"percentile_99":100.0,)*"
                 R"*("standard_deviation":28.86607004772212,"max":100,"total_sum":5050}}])*",
                 registry.to_json());
         registry.deregister_entity(entity);


### PR DESCRIPTION
`AVX2` is only a part of `x86-64-v3`. when avx2 supported, it can be basically determined that `x86-64-v3` is also supported. Enabling it introduces some performance benefits.