### PR TITLE
[improvement](fe) Add current_database builtin alias

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
@@ -728,7 +728,7 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(CurrentUser.class, "current_user"),
             scalar(CutIpv6.class, "cut_ipv6"),
             scalar(CutToFirstSignificantSubdomain.class, "cut_to_first_significant_subdomain"),
-            scalar(Database.class, "database", "schema"),
+            scalar(Database.class, "database", "schema", "current_database"),
             scalar(Date.class, "date"),
             scalar(DateDiff.class, "datediff"),
             scalar(DateFormat.class, "date_format"),

--- a/regression-test/suites/query_p0/system/test_query_sys.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys.groovy
@@ -20,6 +20,7 @@ suite("test_query_sys", "query,p0") {
 
     def tableName = "test"
     sql "SELECT DATABASE();"
+    sql "SELECT CURRENT_DATABASE();"
     sql "SELECT \"welecome to my blog!\";"
     sql "describe ${tableName};"
     sql "select version();"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Add current_database() as a small compatibility alias for the existing database() builtin so portable SQL can resolve the current database name without rewrites.

### Release note

Support current_database() as an alias of database().

### Check List (For Author)

- Test: FE checkstyle and regression test update
    - Manual test / No need to test (with reason)
- Behavior changed: Yes (adds a compatibility alias for current database lookup)
- Does this need documentation: No