### PR TITLE
branch-4.0: [opt](memory) Remove unused dbId field from CloudReplica #62079

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -61,8 +61,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
             = new ConcurrentHashMap<String, List<Long>>();
     @SerializedName(value = "be")
     private ConcurrentHashMap<String, Long> primaryClusterToBackend = null;
-    @SerializedName(value = "dbId")
-    private long dbId = -1;
     @SerializedName(value = "tableId")
     private long tableId = -1;
     @SerializedName(value = "partitionId")
@@ -107,7 +105,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
     public CloudReplica(long replicaId, Long backendId, ReplicaState state, long version, int schemaHash,
             long dbId, long tableId, long partitionId, long indexId, long idx) {
         super(replicaId, -1, state, version, schemaHash);
-        this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.indexId = indexId;
@@ -560,10 +557,6 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         // depends this feature to implement snapshot partition version. See comments in
         // OlapScanNode.addScanRangeLocations for details.
         return true;
-    }
-
-    public long getDbId() {
-        return dbId;
     }
 
     public long getTableId() {


### PR DESCRIPTION
pick https://github.com/apache/doris/pull/62079

## Conflict resolution

Trivial conflict on line 63 of `CloudReplica.java`:
- Master initialized `primaryClusterToBackend = new ConcurrentHashMap<>()` (from a separate PR)
- Branch-4.0 still has `= null`

Resolution: kept branch-4.0's `= null` initialization unchanged, and only applied this PR's scope (removing the `dbId` field, constructor assignment, and `getDbId()` getter). No CloudReplica callers of `getDbId()` exist on branch-4.0.

---
🤖 *Generated by [ThinkOps](https://github.com/dataroaring/ThinkOps) — autonomous agent pipeline*