### PR TITLE
fix: runtime filter pushdown error in Grouping Sets scenarios

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPushDownVisitor.java
@@ -38,6 +38,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalLazyMaterializeOlap
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalRepeat;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSchemaScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
@@ -55,9 +56,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * push down rf
@@ -188,6 +191,23 @@ public class RuntimeFilterPushDownVisitor extends PlanVisitor<Boolean, PushDownC
             }
         }
         return pushed;
+    }
+
+    @Override
+    public Boolean visitPhysicalRepeat(PhysicalRepeat<? extends Plan> repeat, PushDownContext ctx) {
+        // Do not push down runtime filter through grouping sets (PhysicalRepeat)
+        // Grouping sets generate multiple aggregation groups, which may cause incorrect results
+        // if runtime filters are pushed down through them
+        boolean allMatch = repeat.getGroupingSets().stream().allMatch(expressions -> {
+            Set<Slot> inputSlots = expressions.stream().map(Expression::getInputSlots)
+                    .flatMap(Collection::stream).collect(Collectors.toSet());
+            return inputSlots.containsAll(ctx.probeExpr.getInputSlots());
+        });
+        if (allMatch) {
+            return repeat.child().accept(this, ctx);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/runtimefilterv2/PushDownVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/runtimefilterv2/PushDownVisitor.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalRepeat;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSetOperation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalWindow;
@@ -36,10 +37,12 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.thrift.TRuntimeFilterType;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * PushDownVisitor
@@ -174,6 +177,23 @@ public class PushDownVisitor extends PlanVisitor<Boolean, PushDownContext> {
     @Override
     public Boolean visitPhysicalTopN(PhysicalTopN<? extends Plan> topN, PushDownContext ctx) {
         return false;
+    }
+
+    @Override
+    public Boolean visitPhysicalRepeat(PhysicalRepeat<? extends Plan> repeat, PushDownContext ctx) {
+        // Do not push down runtime filter through grouping sets (PhysicalRepeat)
+        // Grouping sets generate multiple aggregation groups, which may cause incorrect results
+        // if runtime filters are pushed down through them
+        boolean allMatch = repeat.getGroupingSets().stream().allMatch(expressions -> {
+            Set<Slot> inputSlots = expressions.stream().map(Expression::getInputSlots)
+                    .flatMap(Collection::stream).collect(Collectors.toSet());
+            return inputSlots.containsAll(ctx.getTargetExpression().getInputSlots());
+        });
+        if (allMatch) {
+            return repeat.child().accept(this, ctx);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -450,4 +450,28 @@ public class RuntimeFilterTest extends SSBTestBase {
         List<RuntimeFilter> filters = context.getNereidsRuntimeFilter();
         Assertions.assertEquals(0, filters.size());
     }
+
+    @Test
+    public void testRuntimeFilterBlockByGroupingSets() {
+        String sql = "SELECT d_datekey FROM ("
+                + "SELECT lo_custkey, lo_orderdate FROM lineorder GROUP BY GROUPING SETS ((lo_custkey, lo_orderdate), (lo_custkey))) t "
+                + "inner join dates "
+                + "on lo_orderdate = d_datekey";
+        List<RuntimeFilter> filters = getRuntimeFilters(sql).get();
+        // Runtime filter should not be generated because lo_orderdate is not in all grouping sets
+        Assertions.assertEquals(0, filters.size());
+    }
+
+    @Test
+    public void testRuntimeFilterPushdownThroughGroupingSetsWhenAllMatch() {
+        String sql = "SELECT d_datekey FROM ("
+                + "SELECT lo_custkey, lo_orderdate FROM lineorder GROUP BY GROUPING SETS ((lo_custkey, lo_orderdate), (lo_custkey))) t "
+                + "inner join dates "
+                + "on lo_custkey = d_datekey";
+        List<RuntimeFilter> filters = getRuntimeFilters(sql).get();
+        // Runtime filter should be generated because lo_custkey is in all grouping sets
+        Assertions.assertEquals(1, filters.size());
+        checkRuntimeFilterExprs(filters, ImmutableList.of(
+                Pair.of("d_datekey", "lo_custkey")));
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

修复Grouping Sets场景下runtime filter下推错误问题，只有当所有GroupingSets都满足下推条件时才能下推，比如以下SQL中的第一组grouping sets (a3)中不包含a2列，所以a2列就无法下推：

SELECT
    a.a1
FROM
    iceberg_table a
    INNER JOIN (
        SELECT
            IF (a2 IS NULL, -1, a2) AS ad_ids
        FROM
            iceberg_table
        WHERE
            p1=20250226
        GROUP BY
            grouping sets (
                (a3),
                (a2, a3)
            )
    ) b ON 1=1
    and a.a1=b.ad_ids
WHERE
    a.p1>=20250225
    AND a.p1<=20250225
    and a.p2 >= 1 
    and a.p2 <= 1
LIMIT
    30;