### PR TITLE
[test](regression) Restore local Hive state after regression suites

### DIFF
--- a/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc.groovy
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.util.Hdfs
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.apache.hadoop.fs.Path
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -45,6 +47,9 @@ suite("test_hive_read_orc", "p0,external") {
         def defaultFS = "hdfs://${externalEnvIp}:${hdfs_port}"
         def outfile_path = "/user/doris/tmp_data"
         def uri = "${defaultFS}" + "${outfile_path}/exp_"
+        def generatedOutfilePath = null
+        Hdfs hdfs = new Hdfs(defaultFS, hdfsUserName, context.config.dataPath + "/")
+        def fs = hdfs.fs
 
 
         def export_table_name = "outfile_hive_read_orc_test"
@@ -66,6 +71,7 @@ suite("test_hive_read_orc", "p0,external") {
             def uuid = UUID.randomUUID().toString()
 
             outfile_path = "/user/doris/tmp_data/${uuid}"
+            generatedOutfilePath = outfile_path
             uri = "${defaultFS}" + "${outfile_path}/exp_"
 
             def res = sql """
@@ -103,6 +109,15 @@ suite("test_hive_read_orc", "p0,external") {
 
             logger.info("hive sql: " + create_table_str)
             hive_docker """ ${create_table_str} """
+        }
+
+        def cleanupHiveArtifacts = {
+            try_sql """DROP TABLE IF EXISTS ${export_table_name}"""
+            try_hive_docker """drop database if exists ${hive_database} cascade"""
+            if (generatedOutfilePath != null) {
+                fs.delete(new Path(generatedOutfilePath), true)
+                generatedOutfilePath = null
+            }
         }
 
         // test INT, String type
@@ -148,6 +163,7 @@ suite("test_hive_read_orc", "p0,external") {
             qt_hive_docker_01 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // test all types
@@ -261,6 +277,7 @@ suite("test_hive_read_orc", "p0,external") {
             qt_hive_docker_02""" SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
     }
 }

--- a/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc_complex_type.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/orc/test_hive_read_orc_complex_type.groovy
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.util.Hdfs
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.apache.hadoop.fs.Path
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -46,6 +48,9 @@ suite("test_hive_read_orc_complex_type", "p0,external") {
         def defaultFS = "hdfs://${externalEnvIp}:${hdfs_port}"
         def outfile_path = "/user/doris/tmp_data"
         def uri = "${defaultFS}" + "${outfile_path}/exp_"
+        def generatedOutfilePath = null
+        Hdfs hdfs = new Hdfs(defaultFS, hdfsUserName, context.config.dataPath + "/")
+        def fs = hdfs.fs
 
 
         def export_table_name = "outfile_hive_read_orc_complex_type_test"
@@ -95,6 +100,7 @@ suite("test_hive_read_orc_complex_type", "p0,external") {
             def uuid = UUID.randomUUID().toString()
 
             outfile_path = "/user/doris/tmp_data/${uuid}"
+            generatedOutfilePath = outfile_path
             uri = "${defaultFS}" + "${outfile_path}/exp_"
 
             def res = sql """
@@ -108,6 +114,15 @@ suite("test_hive_read_orc_complex_type", "p0,external") {
             """
             logger.info("outfile success path: " + res[0][3]);
             return res[0][3]
+        }
+
+        def cleanupHiveArtifacts = {
+            try_sql """DROP TABLE IF EXISTS ${export_table_name}"""
+            try_hive_docker """drop database if exists ${hive_database} cascade"""
+            if (generatedOutfilePath != null) {
+                fs.delete(new Path(generatedOutfilePath), true)
+                generatedOutfilePath = null
+            }
         }
 
         // 1. struct NULL type
@@ -149,6 +164,7 @@ suite("test_hive_read_orc_complex_type", "p0,external") {
             qt_hive_docker_01 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // 2. test Map
@@ -187,6 +203,7 @@ suite("test_hive_read_orc_complex_type", "p0,external") {
             qt_hive_docker_02 """ SELECT * FROM ${hive_database}.${hive_table};"""
                 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // 3. test ARRAY
@@ -227,6 +244,7 @@ suite("test_hive_read_orc_complex_type", "p0,external") {
             qt_hive_docker_03 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // 4. test struct with all type
@@ -278,6 +296,7 @@ suite("test_hive_read_orc_complex_type", "p0,external") {
             qt_hive_docker_04 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
     }
 }

--- a/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet.groovy
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.util.Hdfs
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.apache.hadoop.fs.Path
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -45,6 +47,9 @@ suite("test_hive_read_parquet", "p0,external") {
         def defaultFS = "hdfs://${externalEnvIp}:${hdfs_port}"
         def outfile_path = "/user/doris/tmp_data"
         def uri = "${defaultFS}" + "${outfile_path}/exp_"
+        def generatedOutfilePath = null
+        Hdfs hdfs = new Hdfs(defaultFS, hdfsUserName, context.config.dataPath + "/")
+        def fs = hdfs.fs
 
 
         def export_table_name = "outfile_hive_read_parquet_test"
@@ -66,6 +71,7 @@ suite("test_hive_read_parquet", "p0,external") {
             def uuid = UUID.randomUUID().toString()
 
             outfile_path = "/user/doris/tmp_data/${uuid}"
+            generatedOutfilePath = outfile_path
             uri = "${defaultFS}" + "${outfile_path}/exp_"
 
             def res = sql """
@@ -103,6 +109,15 @@ suite("test_hive_read_parquet", "p0,external") {
 
             logger.info("hive sql: " + create_table_str)
             hive_docker """ ${create_table_str} """
+        }
+
+        def cleanupHiveArtifacts = {
+            try_sql """DROP TABLE IF EXISTS ${export_table_name}"""
+            try_hive_docker """drop database if exists ${hive_database} cascade"""
+            if (generatedOutfilePath != null) {
+                fs.delete(new Path(generatedOutfilePath), true)
+                generatedOutfilePath = null
+            }
         }
 
         // test INT, String type
@@ -148,6 +163,7 @@ suite("test_hive_read_parquet", "p0,external") {
             qt_hive_docker_01 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // test all types
@@ -261,6 +277,7 @@ suite("test_hive_read_parquet", "p0,external") {
             qt_hive_docker_02 """ SELECT * FROM ${hive_database}.${hive_table};"""
             
         } finally {
+            cleanupHiveArtifacts()
         }
     }
 }

--- a/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
+++ b/regression-test/suites/external_table_p0/export/hive_read/parquet/test_hive_read_parquet_comlex_type.groovy
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.util.Hdfs
 import org.codehaus.groovy.runtime.IOGroovyMethods
+import org.apache.hadoop.fs.Path
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -46,6 +48,9 @@ suite("test_hive_read_parquet_complex_type", "p0,external") {
         def defaultFS_with_postfix = "hdfs://${externalEnvIp}:${hdfs_port}/"
         def outfile_path = "/user/doris/tmp_data"
         def uri = "${defaultFS}" + "${outfile_path}/exp_"
+        def generatedOutfilePath = null
+        Hdfs hdfs = new Hdfs(defaultFS, hdfsUserName, context.config.dataPath + "/")
+        def fs = hdfs.fs
 
 
         def export_table_name = "outfile_hive_read_parquet_complex_type_test"
@@ -95,6 +100,7 @@ suite("test_hive_read_parquet_complex_type", "p0,external") {
             def uuid = UUID.randomUUID().toString()
 
             outfile_path = "/user/doris/tmp_data/${uuid}"
+            generatedOutfilePath = outfile_path
             uri = "${defaultFS}" + "${outfile_path}/exp_"
 
             def res = sql """
@@ -107,6 +113,15 @@ suite("test_hive_read_parquet_complex_type", "p0,external") {
             """
             logger.info("outfile success path: " + res[0][3]);
             return res[0][3]
+        }
+
+        def cleanupHiveArtifacts = {
+            try_sql """DROP TABLE IF EXISTS ${export_table_name}"""
+            try_hive_docker """drop database if exists ${hive_database} cascade"""
+            if (generatedOutfilePath != null) {
+                fs.delete(new Path(generatedOutfilePath), true)
+                generatedOutfilePath = null
+            }
         }
 
         // because for hive, `null` is null, and there is no space between two elements
@@ -157,6 +172,7 @@ suite("test_hive_read_parquet_complex_type", "p0,external") {
             qt_hive_docker_02 """ SELECT * FROM ${hive_database}.${hive_table};"""
                 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // 2. test Map
@@ -196,6 +212,7 @@ suite("test_hive_read_parquet_complex_type", "p0,external") {
             qt_hive_docker_02 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // 3. test ARRAY
@@ -236,6 +253,7 @@ suite("test_hive_read_parquet_complex_type", "p0,external") {
             qt_hive_docker_03 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
 
         // 4. test struct with all type
@@ -281,6 +299,7 @@ suite("test_hive_read_parquet_complex_type", "p0,external") {
             qt_hive_docker_04 """ SELECT * FROM ${hive_database}.${hive_table};"""
 
         } finally {
+            cleanupHiveArtifacts()
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ctas.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ctas.groovy
@@ -47,7 +47,7 @@ suite("test_hive_ctas", "p0,external") {
             sql """ INSERT INTO `unpart_ctas_olap_src` (col1, col2) VALUES
                 (1, 'string value for col2'),
                 (2, 'another string value for col2'),
-                (3, 'yet another string value for col2'); 
+                (3, 'yet another string value for col2');
             """
             sql """ DROP TABLE IF EXISTS internal.test_ctas_olap.part_ctas_olap_src """
             sql """
@@ -90,7 +90,7 @@ suite("test_hive_ctas", "p0,external") {
             sql """ INSERT INTO `unpart_ctas_src` (col1, col2) VALUES
                 (1, 'string value for col2'),
                 (2, 'another string value for col2'),
-                (3, 'yet another string value for col2'); 
+                (3, 'yet another string value for col2');
             """
 
             sql """ DROP TABLE IF EXISTS `test_ctas`.part_ctas_src """
@@ -101,7 +101,7 @@ suite("test_hive_ctas", "p0,external") {
                   `pt2` VARCHAR COMMENT 'pt2'
                 ) ENGINE=hive
                 PARTITION BY LIST (pt1, pt2) (
-                    
+
                 )
                 PROPERTIES (
                   'file_format'='${file_format}'
@@ -134,7 +134,7 @@ suite("test_hive_ctas", "p0,external") {
                 String db = "test_ctas"
                 // 1. external to external un-partitioned table
                 sql """ DROP TABLE IF EXISTS hive_ctas1 """
-                sql """ CREATE TABLE hive_ctas1 ENGINE=hive AS SELECT col1 FROM unpart_ctas_src; 
+                sql """ CREATE TABLE hive_ctas1 ENGINE=hive AS SELECT col1 FROM unpart_ctas_src;
                 """
 
                 sql """ INSERT INTO hive_ctas1 SELECT col1 FROM unpart_ctas_src WHERE col1 > 1;
@@ -148,7 +148,7 @@ suite("test_hive_ctas", "p0,external") {
 
                 // 2. external to external un-partitioned table with columns
                 sql """ DROP TABLE IF EXISTS hive_ctas2 """
-                sql """ CREATE TABLE hive_ctas2 (col1) ENGINE=hive AS SELECT col1 FROM unpart_ctas_src; 
+                sql """ CREATE TABLE hive_ctas2 (col1) ENGINE=hive AS SELECT col1 FROM unpart_ctas_src;
                 """
 
                 sql """ INSERT INTO hive_ctas2 SELECT col1 FROM unpart_ctas_src WHERE col1 > 1;
@@ -241,12 +241,12 @@ suite("test_hive_ctas", "p0,external") {
 
                 // 1. external to external un-partitioned table
                 sql """ DROP TABLE IF EXISTS ${catalog_name}.test_ctas_ex.hive_ctas1 """
-                sql """ CREATE TABLE ${catalog_name}.test_ctas_ex.hive_ctas1 (col1) ENGINE=hive 
+                sql """ CREATE TABLE ${catalog_name}.test_ctas_ex.hive_ctas1 (col1) ENGINE=hive
                         PROPERTIES (
                             "location" = "/user/hive/warehouse/test_ctas_ex/loc_hive_ctas1",
                             "file_format"="orc",
                             "orc.compress"="zlib"
-                        ) AS SELECT col1 FROM test_ctas.unpart_ctas_src; 
+                        ) AS SELECT col1 FROM test_ctas.unpart_ctas_src;
                     """
                 sql """ INSERT INTO ${catalog_name}.test_ctas_ex.hive_ctas1
                         SELECT col1 FROM test_ctas.unpart_ctas_src WHERE col1 > 1;
@@ -260,14 +260,14 @@ suite("test_hive_ctas", "p0,external") {
 
                 // 2. external to external partitioned table
                 sql """ DROP TABLE IF EXISTS ${catalog_name}.test_ctas_ex.hive_ctas2 """
-                sql """ CREATE TABLE ${catalog_name}.test_ctas_ex.hive_ctas2 (col1,pt1,pt2) ENGINE=hive 
+                sql """ CREATE TABLE ${catalog_name}.test_ctas_ex.hive_ctas2 (col1,pt1,pt2) ENGINE=hive
                         PARTITION BY LIST (pt1, pt2) ()
                         PROPERTIES (
                             "location" = "/user/hive/warehouse/test_ctas_ex/loc_hive_ctas2",
                             "file_format"="parquet",
                             "parquet.compression"="snappy"
                         )
-                        AS SELECT col1,pt1,pt2 FROM test_ctas.part_ctas_src WHERE col1>0; 
+                        AS SELECT col1,pt1,pt2 FROM test_ctas.part_ctas_src WHERE col1>0;
                     """
                 sql """ INSERT INTO ${catalog_name}.test_ctas_ex.hive_ctas2 (col1,pt1,pt2)
                         SELECT col1,pt1,pt2 FROM test_ctas.part_ctas_src WHERE col1>=22;
@@ -310,7 +310,7 @@ suite("test_hive_ctas", "p0,external") {
                             "location" = "/user/hive/warehouse/test_ctas_ex/loc_ctas_o2",
                             "file_format"="orc",
                             "orc.compress"="zlib"
-                        ) 
+                        )
                         AS SELECT null as col1, pt2 as col2, pt1 FROM internal.test_ctas_olap.part_ctas_olap_src WHERE col1>0;
                     """
                 sql """ INSERT INTO ${catalog_name}.test_ctas_ex.ctas_o2 (col1,pt1,col2)
@@ -373,35 +373,35 @@ suite("test_hive_ctas", "p0,external") {
                     exception "Failed to get table: 'hive_ctas1'"
                 }
                 test {
-                    sql """ CREATE TABLE ${catalog_name}.test_no_err.hive_ctas1 (col1) ENGINE=hive 
+                    sql """ CREATE TABLE ${catalog_name}.test_no_err.hive_ctas1 (col1) ENGINE=hive
                             PROPERTIES (
                                 "file_format"="orc",
                                 "orc.compress"="zstd"
-                            ) AS SELECT col1,col2 FROM test_ctas.unpart_ctas_src; 
+                            ) AS SELECT col1,col2 FROM test_ctas.unpart_ctas_src;
                         """
                     exception "errCode = 2, detailMessage = ctas column size is not equal to the query's"
                 }
 
                 test {
-                    sql """ CREATE TABLE ${catalog_name}.test_no_err.ctas_o2 (col1,pt1,pt2) ENGINE=hive 
+                    sql """ CREATE TABLE ${catalog_name}.test_no_err.ctas_o2 (col1,pt1,pt2) ENGINE=hive
                         PARTITION BY LIST (pt1,pt2,pt3) ()
                         PROPERTIES (
                             "file_format"="parquet",
                             "orc.compress"="zstd"
                         )
-                        AS SELECT * FROM test_ctas.part_ctas_src WHERE col1>0; 
+                        AS SELECT * FROM test_ctas.part_ctas_src WHERE col1>0;
                     """
                     exception "errCode = 2, detailMessage = partition key pt3 is not exists"
                 }
 
                 sql """ DROP TABLE IF EXISTS ${catalog_name}.test_no_err.ctas_o2 """
-                sql """ CREATE TABLE ${catalog_name}.test_no_err.ctas_o2 (col1,col2,pt1) ENGINE=hive 
+                sql """ CREATE TABLE ${catalog_name}.test_no_err.ctas_o2 (col1,col2,pt1) ENGINE=hive
                         PARTITION BY LIST (pt1) ()
                         PROPERTIES (
                             "file_format"="parquet",
                             "parquet.compression"="zstd"
                         )
-                        AS SELECT col1,pt1 as col2,pt2 as pt1 FROM test_ctas.part_ctas_src WHERE col1>0; 
+                        AS SELECT col1,pt1 as col2,pt2 as pt1 FROM test_ctas.part_ctas_src WHERE col1>0;
                     """
 
                 test {
@@ -537,11 +537,11 @@ suite("test_hive_ctas", "p0,external") {
                 """
 
             sql """
-                    CREATE TABLE IF NOT EXISTS all_types_ctas2 (col1, col2, col3, col4, col6, col7, col8, col9, col11) 
+                    CREATE TABLE IF NOT EXISTS all_types_ctas2 (col1, col2, col3, col4, col6, col7, col8, col9, col11)
                     AS SELECT col1, col2, col3, col4, col6, col7, col8, col9, col11 FROM all_types_ctas_${file_format}
                 """
             sql """
-                    INSERT INTO all_types_ctas2 (col1, col3, col7, col9) 
+                    INSERT INTO all_types_ctas2 (col1, col3, col7, col9)
                     SELECT col1, col3, col7, col9 FROM all_types_ctas_${file_format}
                 """
             sql """
@@ -581,5 +581,15 @@ suite("test_hive_ctas", "p0,external") {
             test_ctas_exception(file_format, catalog_name)
             test_ctas_all_types(file_format, catalog_name)
         }
+        sql """drop catalog if exists ${catalog_name}"""
+    } finally {
+        try_hive_docker """drop database if exists test_ctas cascade"""
+        try_hive_docker """drop database if exists test_ctas_ex cascade"""
+        try_hive_docker """drop database if exists test_hive_ex_ctas cascade"""
+        try_hive_docker """drop database if exists test_err cascade"""
+        try_hive_docker """drop database if exists test_no_err cascade"""
+        try_hive_docker """drop database if exists test_ctas_all_type cascade"""
+        try_sql """drop database if exists internal.test_ctas_olap force"""
+        try_sql """drop catalog if exists test_${hivePrefix}_ctas"""
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ctas.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ctas.groovy
@@ -25,6 +25,7 @@ suite("test_hive_ctas", "p0,external") {
     for (String hivePrefix : [ "hive3"]) {
         def file_formats = ["parquet", "orc"]
         setHivePrefix(hivePrefix)
+        try {
         def generateSrcDDLForCTAS = { String file_format, String catalog_name ->
             sql """ switch `${catalog_name}` """
             sql """ create database if not exists `test_ctas` """;
@@ -592,4 +593,5 @@ suite("test_hive_ctas", "p0,external") {
         try_sql """drop database if exists internal.test_ctas_olap force"""
         try_sql """drop catalog if exists test_${hivePrefix}_ctas"""
     }
+}
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl.groovy
@@ -99,10 +99,10 @@ suite("test_hive_ddl", "p0,external") {
             sql  """ drop database if exists `test_hive_default_val` """
 
             sql  """ create database if not exists `test_hive_default_val` """
-            
+
             sql """use `test_hive_default_val`"""
             test {
-                sql """ 
+                sql """
                         CREATE TABLE all_default_values_${file_format}_hive2(
                           `col1` BOOLEAN DEFAULT 'false' COMMENT 'col1',
                           `col2` TINYINT DEFAULT '127' COMMENT 'col2'
@@ -118,7 +118,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                 CREATE TABLE all_default_values_${file_format}_err_bool(
                   `col1` BOOLEAN DEFAULT '-1' COMMENT 'col1'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
@@ -130,7 +130,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                 CREATE TABLE all_default_values_${file_format}_err_float(
                   `col1` FLOAT DEFAULT '1.1234' COMMENT 'col1'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
@@ -142,7 +142,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                 CREATE TABLE all_default_values_${file_format}_err_double(
                   `col1` DOUBLE DEFAULT 'abc' COMMENT 'col1'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
@@ -154,7 +154,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                 CREATE TABLE all_default_values_${file_format}_err_int(
                   `col1` INT DEFAULT 'abcd' COMMENT 'col1'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
@@ -166,7 +166,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                 CREATE TABLE all_default_values_${file_format}_err_date(
                   `col1` DATE DEFAULT '123' COMMENT 'col1'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
@@ -178,7 +178,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                 CREATE TABLE all_default_values_${file_format}_err_datetime(
                    `col1` DATETIME DEFAULT '1512561000000' COMMENT 'col1'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
@@ -190,7 +190,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                 CREATE TABLE all_default_values_${file_format}_err_datetime(
                    `col1` DATETIME DEFAULT '2020-09-20 02:60' COMMENT 'col1'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
@@ -266,7 +266,7 @@ suite("test_hive_ddl", "p0,external") {
             sql """
                     CREATE TABLE loc_tbl_${file_format}_default (
                       `col` STRING COMMENT 'col'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PROPERTIES (
                       'file_format'='${file_format}'
                     )
@@ -302,7 +302,7 @@ suite("test_hive_ddl", "p0,external") {
             sql """
                     CREATE TABLE loc_tbl_${file_format}_custom (
                       `col` STRING COMMENT 'col'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PROPERTIES (
                       'file_format'='${file_format}',
                       'location'='${tbl_loc}',
@@ -337,7 +337,7 @@ suite("test_hive_ddl", "p0,external") {
                                           `col1` INT COMMENT 'col1',
                                           `col2` STRING COMMENT 'col2',
                                           `pt1` VARCHAR COMMENT 'pt1'
-                                        )  ENGINE=hive 
+                                        )  ENGINE=hive
                                         COMMENT 'test'
                                         PARTITION BY LIST (pt1) ()
                                         PROPERTIES (
@@ -354,7 +354,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                         CREATE TABLE nullable_check (
                             `col` STRING NOT NULL COMMENT 'col'
-                        )  ENGINE=hive 
+                        )  ENGINE=hive
                         PROPERTIES (
                             'file_format'='${file_format}'
                         )
@@ -383,7 +383,7 @@ suite("test_hive_ddl", "p0,external") {
             sql """
                     CREATE TABLE tbl_${file_format}_${compression} (
                       `col` STRING COMMENT 'col'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PROPERTIES (
                       'file_format'='${file_format}',
                       'compression'='${compression}'
@@ -453,7 +453,7 @@ suite("test_hive_ddl", "p0,external") {
                 sql """
                         CREATE TABLE test_hive_cross_catalog_tbl (
                           `col` STRING COMMENT 'col'
-                        )  ENGINE=hive 
+                        )  ENGINE=hive
                     """
                 exception "Cannot create hive table in internal catalog, should switch to hive catalog."
             }
@@ -482,37 +482,37 @@ suite("test_hive_ddl", "p0,external") {
                   `col9` STRING COMMENT 'col9',
                   `col10` DATE COMMENT 'col10',
                   `col11` DATETIME COMMENT 'col11'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
             """;
 
             // test all columns
-            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`) 
-                    VALUES 
+            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`)
+                    VALUES
                     (true, 123, 9876543210, 'abcdefghij', 3.14, 6.28, 123.4567, 'varcharval', 'stringval');
                 """
             order_qt_insert01 """ SELECT `col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9` FROM unpart_tbl_${file_format};  """
 
             // test part of columns
-            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col8`, `col9`) 
-                    VALUES 
+            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col8`, `col9`)
+                    VALUES
                     (true, 123, 9876543210, 'varcharval', 'stringval');
                 """
-            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col8`, `col9`) 
-                    VALUES 
+            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col8`, `col9`)
+                    VALUES
                     (null, 123, 'varcharval', 8.98);
                 """
             order_qt_insert02 """ SELECT `col1`, `col2`, `col3`, `col7`, `col9` FROM unpart_tbl_${file_format};  """
 
             // test data diff
-            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`) 
-                    VALUES 
+            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`)
+                    VALUES
                     (true, null, 9876543210, 'abcdefghij', '2.3', 6.28, null, 'varcharval', 'stringval');
                 """
-            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`) 
-                    VALUES 
+            sql """ INSERT INTO unpart_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`)
+                    VALUES
                     (false, '1', 9876543210, 'abcdefghij', '2.3', 6.28, 0, 2223, 'stringval');
                 """
             order_qt_insert03 """ SELECT `col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9` FROM unpart_tbl_${file_format} """
@@ -528,7 +528,7 @@ suite("test_hive_ddl", "p0,external") {
                   `col4` DECIMAL(2,1) COMMENT 'col4',
                   `pt1` VARCHAR COMMENT 'pt1',
                   `pt2` VARCHAR COMMENT 'pt2'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PARTITION BY LIST (pt1, pt2) ()
                 PROPERTIES (
                   'file_format'='${file_format}'
@@ -575,13 +575,13 @@ suite("test_hive_ddl", "p0,external") {
                   `pt8` CHAR COMMENT 'pt8',
                   `pt9` VARCHAR COMMENT 'pt9',
                   `pt10` STRING COMMENT 'pt10'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PARTITION BY LIST (pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8, pt9, pt10) ()
                 PROPERTIES (
                   'file_format'='${file_format}'
                 )
                 """
-            sql """ 
+            sql """
                     INSERT INTO all_part_types_tbl_${file_format} (`col`, `pt1`, `pt2`, `pt3`, `pt4`, `pt5`, `pt6`, `pt7`, `pt8`, `pt9`, `pt10`)
                     VALUES
                     (1, true, 1, 123, 456789, 922232355, '2024-04-09', '2024-04-09 12:34:56', 'A', 'example', 'string_value');
@@ -602,7 +602,7 @@ suite("test_hive_ddl", "p0,external") {
                     CREATE TABLE all_part_types_tbl_${file_format}_err3(
                       `col` INT COMMENT 'col',
                       `pt1` STRING COMMENT 'pt1'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PARTITION BY LIST (pt000) ()
                     PROPERTIES (
                       'file_format'='${file_format}'
@@ -612,31 +612,31 @@ suite("test_hive_ddl", "p0,external") {
             }
 
             test {
-                sql """ 
+                sql """
                     CREATE TABLE all_part_types_tbl_${file_format}_err3(
                       `col` INT COMMENT 'col',
                       `pt1` STRING COMMENT 'pt1'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PARTITION BY LIST (pt1)
                     (PARTITION pp VALUES IN ('2014-01-01'))
                     PROPERTIES (
                       'file_format'='${file_format}'
-                    ) 
+                    )
                     """
                 exception "Partition values expressions is not supported in hive catalog."
             }
 
             test {
-                sql """ 
+                sql """
                     CREATE TABLE all_part_types_tbl_${file_format}_err3(
                       `col` INT COMMENT 'col',
                       `pt1` STRING COMMENT 'pt1'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PARTITION BY LIST (pt000)
                     (PARTITION pp VALUES IN ('2014-01-01'))
                     PROPERTIES (
                       'file_format'='${file_format}'
-                    ) 
+                    )
                     """
                 exception "partition key pt000 is not exists"
             }
@@ -646,7 +646,7 @@ suite("test_hive_ddl", "p0,external") {
                     CREATE TABLE all_part_types_tbl_${file_format}_err1(
                       `col` INT COMMENT 'col',
                       `pt1` LARGEINT COMMENT 'pt1'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PARTITION BY LIST (pt1) ()
                     PROPERTIES (
                       'file_format'='${file_format}'
@@ -660,7 +660,7 @@ suite("test_hive_ddl", "p0,external") {
                     CREATE TABLE all_part_types_tbl_${file_format}_err2(
                       `col` INT COMMENT 'col',
                       `pt1` FLOAT COMMENT 'pt1'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PARTITION BY LIST (pt1) ()
                     PROPERTIES (
                       'file_format'='${file_format}'
@@ -674,7 +674,7 @@ suite("test_hive_ddl", "p0,external") {
                     CREATE TABLE all_part_types_tbl_${file_format}_err3(
                       `col` INT COMMENT 'col',
                       `pt1` DOUBLE COMMENT 'pt1'
-                    )  ENGINE=hive 
+                    )  ENGINE=hive
                     PARTITION BY LIST (pt1) ()
                     PROPERTIES (
                       'file_format'='${file_format}'
@@ -753,6 +753,18 @@ suite("test_hive_ddl", "p0,external") {
             test_error_create(catalog_name)
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_hive_docker """drop database if exists test_hive_db cascade"""
+            try_hive_docker """drop database if exists test_hive_loc_db cascade"""
+            try_hive_docker """drop database if exists test_hive_loc_no_exist cascade"""
+            try_hive_docker """drop database if exists test_hive_loc_exist cascade"""
+            try_hive_docker """drop database if exists test_hive_default_val cascade"""
+            try_hive_docker """drop database if exists test_hive_loc cascade"""
+            try_hive_docker """drop database if exists test_hive_compress cascade"""
+            try_hive_docker """drop database if exists test_olap_cross_catalog cascade"""
+            try_hive_docker """drop database if exists test_hive_db_tbl cascade"""
+            try_hive_docker """drop database if exists test_hive_db_error_tbl cascade"""
+            try_sql """drop database if exists internal.test_hive_cross_catalog force"""
+            try_sql """drop catalog if exists test_hive_ddl"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_ddl_text_format.groovy
@@ -24,12 +24,11 @@ suite("test_hive_ddl_text_format", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "test_hive_ddl_text_format"
         try{
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_hive_ddl_text_format"
-            String table_name = "table_with_pars";
 
             sql """drop catalog if exists ${catalog_name};"""
 
@@ -148,6 +147,10 @@ suite("test_hive_ddl_text_format", "p0,external") {
             assertTrue(res.containsIgnoreCase("${escape_delim}"))
             assertTrue(res.containsIgnoreCase("${serialization_null_format}"))
         } finally {
+            try_hive_docker """drop table if exists default.text_table_default_properties"""
+            try_hive_docker """drop table if exists default.text_table_standard_properties"""
+            try_hive_docker """drop table if exists default.text_table_different_properties"""
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_drop_db.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_drop_db.groovy
@@ -23,12 +23,12 @@ suite("test_hive_drop_db", "p0,external") {
     }
 
     for (String hivePrefix : ["hive2", "hive3"]) {
+        String catalog_name = "test_${hivePrefix}_drop_db_ctl"
+        String db_name = "test_${hivePrefix}_drop_db"
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_drop_db_ctl"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-            String db_name = "test_${hivePrefix}_drop_db"
 
             sql """drop catalog if exists ${catalog_name}"""
             sql """create catalog if not exists ${catalog_name} properties (
@@ -44,7 +44,7 @@ suite("test_hive_drop_db", "p0,external") {
             sql """drop database if exists ${db_name} force"""
             sql """create database ${db_name}"""
             sql """use ${db_name}"""
-            sql """ 
+            sql """
                     CREATE TABLE test_hive_drop_db_tbl1 (
                       `col1` BOOLEAN,
                       `col2` TINYINT
@@ -52,7 +52,7 @@ suite("test_hive_drop_db", "p0,external") {
                 """
             sql """insert into test_hive_drop_db_tbl1 values(true, 1);"""
             qt_sql_tbl1 """select * from test_hive_drop_db_tbl1"""
-            sql """ 
+            sql """
                     CREATE TABLE test_hive_drop_db_tbl2 (
                       `col1` BOOLEAN,
                       `col2` TINYINT
@@ -60,7 +60,7 @@ suite("test_hive_drop_db", "p0,external") {
                 """
             sql """insert into test_hive_drop_db_tbl2 values(false, 2);"""
             qt_sql_tbl2 """select * from test_hive_drop_db_tbl2"""
-            sql """ 
+            sql """
                     CREATE TABLE test_hive_drop_db_tbl3 (
                       `col1` BOOLEAN,
                       `col2` TINYINT
@@ -84,7 +84,7 @@ suite("test_hive_drop_db", "p0,external") {
                 sql """show tables from ${db_name}"""
                 exception "Unknown database"
             }
-    
+
             // use tvf to check if table is dropped
             String tbl1_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/test_${hivePrefix}_drop_db.db/test_hive_drop_db_tbl1"
             String tbl2_path = "hdfs://${externalEnvIp}:${hdfs_port}/user/hive/warehouse/test_${hivePrefix}_drop_db.db/test_hive_drop_db_tbl2"
@@ -101,6 +101,8 @@ suite("test_hive_drop_db", "p0,external") {
                   "format" = "orc"); """
 
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists ${db_name} cascade"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_truncate_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_truncate_table.groovy
@@ -23,30 +23,31 @@ suite("test_hive_truncate_table", "p0,external") {
         String hdfs_port = context.config.otherConfigs.get("hive3HdfsPort")
         String catalog_name = "test_hive3_truncate_table"
         String database_name = "hive_truncate"
-        sql """drop catalog if exists ${catalog_name};"""
+        try {
+            sql """drop catalog if exists ${catalog_name};"""
 
-        sql """
-            create catalog if not exists ${catalog_name} properties (
-                'type'='hms',
-                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
-                'use_meta_cache' = 'true',
-                'hive.version'='3.0'
-            );
-        """
+            sql """
+                create catalog if not exists ${catalog_name} properties (
+                    'type'='hms',
+                    'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                    'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
+                    'use_meta_cache' = 'true',
+                    'hive.version'='3.0'
+                );
+            """
 
-        logger.info("catalog " + catalog_name + " created")
-        sql """switch ${catalog_name};"""
-        logger.info("switched to catalog " + catalog_name)
-        
-        sql """create database if not exists ${database_name};"""
-        sql """use ${database_name};"""
-        logger.info("use database " + database_name)
+            logger.info("catalog " + catalog_name + " created")
+            sql """switch ${catalog_name};"""
+            logger.info("switched to catalog " + catalog_name)
 
-        // 1. test no partition table
-        String table_name = "table_no_pars"
-        sql """create table if not exists ${table_name}(col1 bigint, col2 string); """
-        checkNereidsExecute("truncate table ${table_name};")
+            sql """create database if not exists ${database_name};"""
+            sql """use ${database_name};"""
+            logger.info("use database " + database_name)
+
+            // 1. test no partition table
+            String table_name = "table_no_pars"
+            sql """create table if not exists ${table_name}(col1 bigint, col2 string); """
+            checkNereidsExecute("truncate table ${table_name};")
 
         sql """insert into ${table_name} values(3234424, '44'); """
         sql """insert into ${table_name} values(222, 'aoe'); """
@@ -98,8 +99,11 @@ suite("test_hive_truncate_table", "p0,external") {
         checkNereidsExecute("truncate table ${table_name}")
         order_qt_truncate_09 """ select * from ${table_name}; """
 
-        sql """drop table ${table_name};"""
-        sql """drop database ${database_name};"""
-        sql """drop catalog ${catalog_name};"""
+            sql """drop table ${table_name};"""
+            sql """drop database ${database_name};"""
+            sql """drop catalog ${catalog_name};"""
+        } finally {
+            try_sql """drop catalog if exists ${catalog_name};"""
+        }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/ddl/test_hive_write_type.groovy
@@ -181,7 +181,7 @@ suite("test_hive_write_type", "p0,external") {
                   `pt3` DATE COMMENT 'pt3',
                   `pt1` VARCHAR COMMENT 'pt1',
                   `pt2` STRING COMMENT 'pt2'
-                )  ENGINE=hive 
+                )  ENGINE=hive
                 PARTITION BY LIST (pt1, pt2) ()
                 PROPERTIES (
                   'file_format'='${file_format}'
@@ -190,8 +190,8 @@ suite("test_hive_write_type", "p0,external") {
 
             try {
                 // test  columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`)
+                    VALUES
                     (true, 123, 987654321099, 'abcdefghij', 3.1214, 63.28, 123.4567, 'varcharval', 'stringval');
                 """
             } catch (Exception e) {
@@ -202,8 +202,8 @@ suite("test_hive_write_type", "p0,external") {
 
             try {
                 // test type diff columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `col6`, `col7`, `col8`, `col9`)
+                    VALUES
                     ('1', 123, 987654319, 'abcdefghij', '3.15', '6.28', 123.4567, 432, 'stringval');
                 """
             } catch (Exception e) {
@@ -215,7 +215,7 @@ suite("test_hive_write_type", "p0,external") {
                 sql """
                         CREATE TABLE test_hive_ex.ex_tbl_${file_format}(
                           `col1` BOOLEAN COMMENT 'col1'
-                        )  ENGINE=hive 
+                        )  ENGINE=hive
                         PROPERTIES (
                           'file_format'='${file_format}'
                         )
@@ -225,8 +225,8 @@ suite("test_hive_write_type", "p0,external") {
 
             test {
                 // test columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`) 
-                        VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`)
+                        VALUES
                         (true, 123, 9876543210, 'abcdefghij', 3.14, 6.28, 123.4567, 'varcharval', 'stringval');
                 """
                 exception "errCode = 2, detailMessage = Column count doesn't match value count"
@@ -234,8 +234,8 @@ suite("test_hive_write_type", "p0,external") {
 
             test {
                 // test columns
-                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `pt00`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} (`col1`, `col2`, `col3`, `col4`, `col5`, `pt00`)
+                    VALUES
                     (true, 123, 9876543210, 'abcdefghij', 3.14, 'error');
                 """
                 exception "errCode = 2, detailMessage = Unknown column 'pt00' in target table."
@@ -243,8 +243,8 @@ suite("test_hive_write_type", "p0,external") {
 
             // TODO: support partition spec
             test {
-                sql """ INSERT INTO ex_tbl_${file_format} partition(`pt1`,`pt2`) (`col3`, `col6`, `col9`) 
-                    VALUES 
+                sql """ INSERT INTO ex_tbl_${file_format} partition(`pt1`,`pt2`) (`col3`, `col6`, `col9`)
+                    VALUES
                     (9876543210, 6.28, 'no_error');
                 """
                 exception "errCode = 2, detailMessage = Not support insert with partition spec in hive catalog"
@@ -334,6 +334,11 @@ suite("test_hive_write_type", "p0,external") {
             }
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_hive_docker """drop database if exists test_complex_type cascade"""
+            try_hive_docker """drop database if exists test_hive_ex cascade"""
+            try_hive_docker """drop database if exists test_columns_out_of_order cascade"""
+            try_hive_docker """drop database if exists test_hive_db_error_tbl cascade"""
+            try_sql """drop catalog if exists test_${hivePrefix}_write_type"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_file_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_file_meta_cache.groovy
@@ -42,40 +42,41 @@ suite("test_file_meta_cache", "p0,external") {
                 hive_docker """show databases;"""
                 hive_docker """drop table if exists default.test_file_meta_cache;  """
                 hive_docker """
-                                create table default.test_file_meta_cache (col1  int, col2 string) STORED AS ${fileFormat}; 
+                                create table default.test_file_meta_cache (col1  int, col2 string) STORED AS ${fileFormat};
                             """
                 hive_docker """insert into default.test_file_meta_cache values (1, "a"),(2, "b"); """
 
-                sql """ refresh  catalog test_file_meta_cache """ 
+                sql """ refresh  catalog test_file_meta_cache """
                 qt_1 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
 
-                hive_docker """ TRUNCATE TABLE test_file_meta_cache """ 
+                hive_docker """ TRUNCATE TABLE test_file_meta_cache """
                 hive_docker """insert into default.test_file_meta_cache values (3, "c"), (4, "d"); """
-                
-                sql """ refresh  catalog test_file_meta_cache """ 
+
+                sql """ refresh  catalog test_file_meta_cache """
                 qt_2 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
 
-                
 
-                hive_docker """ drop TABLE test_file_meta_cache """ 
+
+                hive_docker """ drop TABLE test_file_meta_cache """
                 hive_docker """
-                                create table default.test_file_meta_cache (col1  int, col2 string) STORED AS PARQUET; 
+                                create table default.test_file_meta_cache (col1  int, col2 string) STORED AS PARQUET;
                             """
                 hive_docker """insert into default.test_file_meta_cache values (5, "e"), (6, "f"); """
-                
-                sql """ refresh  catalog test_file_meta_cache """ 
+
+                sql """ refresh  catalog test_file_meta_cache """
                 qt_3 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
 
                 hive_docker """ INSERT OVERWRITE TABLE test_file_meta_cache values (7,'g'), (8, 'h'); """
 
-                sql """ refresh  catalog test_file_meta_cache """ 
+                sql """ refresh  catalog test_file_meta_cache """
                 qt_4 """ select * from test_file_meta_cache.`default`.test_file_meta_cache order by col1 ; """
 
 
             } finally {
+                try_sql """drop catalog if exists test_file_meta_cache"""
+                try_hive_docker """drop table if exists default.test_file_meta_cache"""
             }
         }
     }
 
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_case_sensibility.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_case_sensibility.groovy
@@ -72,7 +72,7 @@ suite("test_hive_case_sensibility", "p0,external") {
                     exception "database doesn't exist"
                     exception "CASE_DB1"
                 }
-                sql """drop database if exists CASE_DB1;""" 
+                sql """drop database if exists CASE_DB1;"""
                 qt_sql4 """show databases like "%case_db1%";""" // still exists
                 sql """drop database case_db1;"""
                 qt_sql5 """show databases like "%case_db1%";""" // empty
@@ -93,7 +93,7 @@ suite("test_hive_case_sensibility", "p0,external") {
                     exception "database doesn't exist"
                     exception "case_db2"
                 }
-                sql """drop database if exists case_db2;""" 
+                sql """drop database if exists case_db2;"""
                 qt_sql6 """show databases like "%case_db1%";""" // empty
                 qt_sql7 """show databases like "%case_db2%";""" // empty
 
@@ -105,7 +105,7 @@ suite("test_hive_case_sensibility", "p0,external") {
                     sql """use CASE_DB2"""
                     exception "Unknown database 'CASE_DB2'"
                 }
-                
+
                 test {
                     sql """create table CASE_DB2.case_tbl21 (k1 int);"""
                     exception "Failed to get database: 'CASE_DB2'"
@@ -114,7 +114,7 @@ suite("test_hive_case_sensibility", "p0,external") {
                     sql """create table if not exists CASE_DB2.case_tbl21 (k1 int);"""
                     exception "Failed to get database: 'CASE_DB2'"
                 }
-                sql """create table case_db2.case_tbl21 (k1 int);""" 
+                sql """create table case_db2.case_tbl21 (k1 int);"""
                 sql """create table case_db2.CASE_TBL22 (k1 int);"""
                 sql """create table case_db1.case_tbl11 (k1 int);"""
 
@@ -145,7 +145,7 @@ suite("test_hive_case_sensibility", "p0,external") {
                 order_qt_sql14 """select * from information_schema.columns where TABLE_SCHEMA="case_db1";"""
 
                 // 4. insert
-                /// full qualified name 
+                /// full qualified name
                 test {
                     sql """insert into CASE_DB2.CASE_TBL22 values(1);"""
                     exception "Database [CASE_DB2] does not exist"
@@ -303,7 +303,7 @@ suite("test_hive_case_sensibility", "p0,external") {
                     exception "Failed to get table: 'case_tbl22'"
                 }
                 sql """drop table if exists case_db2.case_tbl22"""
-                    
+
                 test {
                     sql """select * from case_db2.case_tbl22;"""
                     exception "Table [case_tbl22] does not exist in database [case_db2]"
@@ -330,7 +330,7 @@ suite("test_hive_case_sensibility", "p0,external") {
                 }
 
                 // 7. re create and insert
-                sql """create table case_db2.case_tbl12 (k1 int);""" 
+                sql """create table case_db2.case_tbl12 (k1 int);"""
                 sql """insert into  case_db2.case_tbl12 values(6);"""
                 order_qt_sql22 """select * from case_db2.case_tbl12;"""
                 sql """insert overwrite table  case_db2.case_tbl12 values(7);"""
@@ -357,6 +357,8 @@ suite("test_hive_case_sensibility", "p0,external") {
             }
        }
     } finally {
-        // sql """set enable_external_table_batch_mode=true"""
+        try_hive_docker """drop database if exists case_db1 cascade"""
+        try_hive_docker """drop database if exists case_db2 cascade"""
+        try_sql """drop catalog if exists hive3_test_case_sensibility"""
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_meta_cache.groovy
@@ -26,6 +26,7 @@ suite("test_hive_meta_cache", "p0,external") {
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
+            try {
 
             // 1. test default catalog
             sql """drop catalog if exists ${catalog_name};"""
@@ -356,7 +357,11 @@ suite("test_hive_meta_cache", "p0,external") {
             println "${sql_sct01_6col}"
             assertTrue(sql_sct01_6col[0][1].contains("CREATE TABLE `sales`(\n  `id` int,\n  `amount` double,\n  `k1` string,\n  `k2` string,\n  `k3` string)\nPARTITIONED BY (\n `year` int)"));
             sql """drop table test_hive_meta_cache_db.sales"""
+            } finally {
+                try_hive_docker """drop database if exists test_hive_meta_cache_db cascade"""
+                try_sql """drop catalog if exists ${catalog_name}"""
+                try_sql """drop catalog if exists ${catalog_name_no_cache}"""
+            }
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_metadata_refresh_interval.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_metadata_refresh_interval.groovy
@@ -94,8 +94,8 @@ suite("test_hive_metadata_refresh_interval", "p0,external") {
             sql """drop catalog ${catalog_name}"""
 
         } finally {
-            sql """drop catalog if exists test_${hivePrefix}_refresh_interval"""
-            hive_docker "drop database if exists test_refresh_interval_db cascade"
+            try_sql """drop catalog if exists test_${hivePrefix}_refresh_interval"""
+            try_hive_docker "drop database if exists test_refresh_interval_db cascade"
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
@@ -54,17 +54,17 @@ suite("test_hive_partition_values_tvf", "p0,external") {
 
         // 4. test alias
         qt_sql31 """ select pv.t_float, pv.t_int from orc_partitioned_columns\$partitions as pv group by t_int, t_float order by t_int, t_float"""
-        
+
         // 5. test CTE
         qt_sql41 """ with v1 as (select t_string, t_int from orc_partitioned_columns\$partitions order by t_int, t_float, t_string) select max(t_int) from v1; """
         qt_sql42 """ with v1 as (select t_string, t_int from orc_partitioned_columns\$partitions order by t_int, t_float, t_string) select c1 from (select max(t_string) as c1 from v1) x; """
- 
+
         // 6. test subquery
         qt_sql51 """select c1 from (select max(t_string) as c1 from (select * from multi_catalog.orc_partitioned_columns\$partitions)x)y;"""
 
         // 7. test where
         qt_sql61 """select * from orc_partitioned_columns\$partitions where t_int != "__HIVE_DEFAULT_PARTITION__" order by t_int, t_float, t_string; """
-        
+
         // 8. test view
         sql """drop database if exists internal.partition_values_db"""
         sql """create database if not exists internal.partition_values_db"""
@@ -72,7 +72,7 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         qt_sql71 """select * from internal.partition_values_db.v1"""
         qt_sql72 """select t_string, t_int from internal.partition_values_db.v1 where t_int != "__HIVE_DEFAULT_PARTITION__""""
         qt_sql73 """with v1 as (select t_string, t_int from internal.partition_values_db.v1 order by t_int, t_float, t_string) select c1 from (select max(t_string) as c1 from v1) x;"""
-        
+
         // 9. test join
         qt_sql81 """select * from orc_partitioned_columns\$partitions p1 join orc_partitioned_columns\$partitions p2 on p1.t_int = p2.t_int order by p1.t_int, p1.t_float"""
 
@@ -137,6 +137,8 @@ suite("test_hive_partition_values_tvf", "p0,external") {
 
         qt_sql112 """select * from partition_values_all_types order by k1;"""
         qt_sql113 """select * from partition_values_all_types\$partitions order by p1,p2,p3;"""
+        sql """drop database if exists partition_values_db"""
+        sql """drop database if exists internal.partition_values_db force"""
+        sql """drop catalog if exists ${catalog_name}"""
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
@@ -73,7 +73,7 @@ suite("test_hive_partition_values_tvf", "p0,external") {
             sql """create database if not exists internal.${internalDbName}"""
             sql """create view internal.${internalDbName}.v1 as select * from ${catalog_name}.multi_catalog.orc_partitioned_columns\$partitions"""
             qt_sql71 """select * from internal.${internalDbName}.v1"""
-            qt_sql72 """select t_string, t_int from internal.${internalDbName}.v1 where t_int != "__HIVE_DEFAULT_PARTITION__""""
+            qt_sql72 """select t_string, t_int from internal.${internalDbName}.v1 where t_int != "__HIVE_DEFAULT_PARTITION__" """
             qt_sql73 """with v1 as (select t_string, t_int from internal.${internalDbName}.v1 order by t_int, t_float, t_string) select c1 from (select max(t_string) as c1 from v1) x;"""
 
         // 9. test join

--- a/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partition_values_tvf.groovy
@@ -25,21 +25,24 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         String extHiveHmsHost = context.config.otherConfigs.get("externalEnvIp")
         String extHiveHmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_external_catalog_hive_partition"
+        String internalDbName = "partition_values_db"
+        String externalDbName = "partition_values_db"
 
-        sql """drop catalog if exists ${catalog_name};"""
-        sql """
-            create catalog if not exists ${catalog_name} properties (
-                'type'='hms',
-                'hive.metastore.uris' = 'thrift://${extHiveHmsHost}:${extHiveHmsPort}'
-            );
-        """
+        try {
+            sql """drop catalog if exists ${catalog_name};"""
+            sql """
+                create catalog if not exists ${catalog_name} properties (
+                    'type'='hms',
+                    'hive.metastore.uris' = 'thrift://${extHiveHmsHost}:${extHiveHmsPort}'
+                );
+            """
 
-        // 1. test qualifier
-        qt_sql01 """ select * from ${catalog_name}.multi_catalog.orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
-        sql """ switch ${catalog_name} """
-        qt_sql02 """ select * from multi_catalog.orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
-        sql """ use multi_catalog"""
-        qt_sql03 """ select * from orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
+            // 1. test qualifier
+            qt_sql01 """ select * from ${catalog_name}.multi_catalog.orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
+            sql """ switch ${catalog_name} """
+            qt_sql02 """ select * from multi_catalog.orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
+            sql """ use multi_catalog"""
+            qt_sql03 """ select * from orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
 
         // 2. test select order
         qt_sql11 """ select * except(t_string) from orc_partitioned_columns\$partitions order by t_int, t_float, t_string"""
@@ -65,13 +68,13 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         // 7. test where
         qt_sql61 """select * from orc_partitioned_columns\$partitions where t_int != "__HIVE_DEFAULT_PARTITION__" order by t_int, t_float, t_string; """
 
-        // 8. test view
-        sql """drop database if exists internal.partition_values_db"""
-        sql """create database if not exists internal.partition_values_db"""
-        sql """create view internal.partition_values_db.v1 as select * from ${catalog_name}.multi_catalog.orc_partitioned_columns\$partitions"""
-        qt_sql71 """select * from internal.partition_values_db.v1"""
-        qt_sql72 """select t_string, t_int from internal.partition_values_db.v1 where t_int != "__HIVE_DEFAULT_PARTITION__""""
-        qt_sql73 """with v1 as (select t_string, t_int from internal.partition_values_db.v1 order by t_int, t_float, t_string) select c1 from (select max(t_string) as c1 from v1) x;"""
+            // 8. test view
+            sql """drop database if exists internal.${internalDbName}"""
+            sql """create database if not exists internal.${internalDbName}"""
+            sql """create view internal.${internalDbName}.v1 as select * from ${catalog_name}.multi_catalog.orc_partitioned_columns\$partitions"""
+            qt_sql71 """select * from internal.${internalDbName}.v1"""
+            qt_sql72 """select t_string, t_int from internal.${internalDbName}.v1 where t_int != "__HIVE_DEFAULT_PARTITION__""""
+            qt_sql73 """with v1 as (select t_string, t_int from internal.${internalDbName}.v1 order by t_int, t_float, t_string) select c1 from (select max(t_string) as c1 from v1) x;"""
 
         // 9. test join
         qt_sql81 """select * from orc_partitioned_columns\$partitions p1 join orc_partitioned_columns\$partitions p2 on p1.t_int = p2.t_int order by p1.t_int, p1.t_float"""
@@ -94,24 +97,24 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         }
 
         // 12. test inner table
-        sql """create table internal.partition_values_db.pv_inner1 (k1 int) distributed by hash (k1) buckets 1 properties("replication_num" = "1")"""
-        qt_sql101 """desc internal.partition_values_db.pv_inner1"""
-        qt_sql102 """select * from internal.partition_values_db.pv_inner1"""
+            sql """create table internal.${internalDbName}.pv_inner1 (k1 int) distributed by hash (k1) buckets 1 properties("replication_num" = "1")"""
+            qt_sql101 """desc internal.${internalDbName}.pv_inner1"""
+            qt_sql102 """select * from internal.${internalDbName}.pv_inner1"""
         test {
-            sql """desc internal.partition_values_db.pv_inner1\$partitions"""
+                sql """desc internal.${internalDbName}.pv_inner1\$partitions"""
             exception """sys table not found: partitions"""
         }
 
         test {
-            sql """select * from internal.partition_values_db.pv_inner1\$partitions"""
+                sql """select * from internal.${internalDbName}.pv_inner1\$partitions"""
             exception """Unknown sys table 'pv_inner1\$partitions'"""
         }
 
-        // 13. test all types of partition columns
-        sql """switch ${catalog_name}"""
-        sql """drop database if exists partition_values_db""";
-        sql """create database partition_values_db"""
-        sql """use partition_values_db"""
+            // 13. test all types of partition columns
+            sql """switch ${catalog_name}"""
+            sql """drop database if exists ${externalDbName}""";
+            sql """create database ${externalDbName}"""
+            sql """use ${externalDbName}"""
 
         sql """create table partition_values_all_types (
             k1 int,
@@ -127,18 +130,24 @@ suite("test_hive_partition_values_tvf", "p0,external") {
         ) partition by list(p1, p2, p3, p4, p5, p6, p7, p8)();
         """
 
-        qt_sql111 """desc partition_values_all_types\$partitions;"""
+            qt_sql111 """desc partition_values_all_types\$partitions;"""
 
-        sql """insert into partition_values_all_types values
-            (1, "test1", true, -128, -32768, -2147483648, -9223372036854775808, "1900-01-01", "1899-01-01 23:59:59", ""),
-            (2, null, false, 127, 32767, 2147483647, 9223372036854775807, "9999-12-31", "0001-01-01 00:00:01.321", "boston"),
-            (3, "", null, null, null, null, null, null, null, null);
-        """
+            sql """insert into partition_values_all_types values
+                (1, "test1", true, -128, -32768, -2147483648, -9223372036854775808, "1900-01-01", "1899-01-01 23:59:59", ""),
+                (2, null, false, 127, 32767, 2147483647, 9223372036854775807, "9999-12-31", "0001-01-01 00:00:01.321", "boston"),
+                (3, "", null, null, null, null, null, null, null, null);
+            """
 
-        qt_sql112 """select * from partition_values_all_types order by k1;"""
-        qt_sql113 """select * from partition_values_all_types\$partitions order by p1,p2,p3;"""
-        sql """drop database if exists partition_values_db"""
-        sql """drop database if exists internal.partition_values_db force"""
-        sql """drop catalog if exists ${catalog_name}"""
+            qt_sql112 """select * from partition_values_all_types order by k1;"""
+            qt_sql113 """select * from partition_values_all_types\$partitions order by p1,p2,p3;"""
+        } finally {
+            try_sql """drop view if exists internal.${internalDbName}.v1"""
+            try_sql """drop table if exists internal.${internalDbName}.pv_inner1"""
+            try_sql """drop database if exists internal.${internalDbName} force"""
+            try_sql """switch ${catalog_name}"""
+            try_sql """drop table if exists ${externalDbName}.partition_values_all_types"""
+            try_sql """drop database if exists ${externalDbName}"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+        }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
@@ -78,9 +78,9 @@ suite("test_hive_partitions", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "${hivePrefix}_test_partitions"
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String catalog_name = "${hivePrefix}_test_partitions"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""

--- a/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_partitions.groovy
@@ -127,7 +127,7 @@ suite("test_hive_partitions", "p0,external") {
                         VALUES (3, 'hive_pt3')
                     """
 
-                    sql """refresh catalog `${catalog_name}`"""      
+                    sql """refresh catalog `${catalog_name}`"""
                     // Doris reads data to populate cache (only knows about 3 partitions)
                     def result1 = sql """SELECT COUNT(*) as cnt FROM `${catalog_name}`.`${dbName}`.`${tblName}`"""
                     assertEquals(3, result1[0][0])
@@ -201,7 +201,7 @@ suite("test_hive_partitions", "p0,external") {
             }
             sql """unset variable num_partitions_in_batch_mode"""
         } finally {
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_serde_prop.groovy
@@ -28,41 +28,48 @@ suite("test_hive_serde_prop", "p0,external") {
         String ex_db_name = "`stats_test`"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+        String tempSerdeTable = "serde_test8_tmp"
 
-        sql """drop catalog if exists ${catalog_name} """
+        try {
+            sql """drop catalog if exists ${catalog_name} """
 
-        sql """CREATE CATALOG ${catalog_name} PROPERTIES (
-                'type'='hms',
-                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-                'hadoop.username' = 'hive'
-            );"""
+            sql """CREATE CATALOG ${catalog_name} PROPERTIES (
+                    'type'='hms',
+                    'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                    'hadoop.username' = 'hive'
+                );"""
 
-		qt_1 """select * from ${catalog_name}.${ex_db_name}.employee_gz order by name;"""
+		    qt_1 """select * from ${catalog_name}.${ex_db_name}.employee_gz order by name;"""
 
 
-        qt_2 """select * from ${catalog_name}.regression.serde_test1 order by id;"""
-        qt_3 """select * from ${catalog_name}.regression.serde_test2 order by id;"""
-        qt_4 """select * from ${catalog_name}.regression.serde_test3 order by id;"""
-        qt_5 """select * from ${catalog_name}.regression.serde_test4 order by id;"""
-        qt_6 """select * from ${catalog_name}.regression.serde_test5 order by id;"""
-        qt_7 """select * from ${catalog_name}.regression.serde_test6 order by id;"""
-        qt_8 """select * from ${catalog_name}.regression.serde_test7 order by id;"""
+            qt_2 """select * from ${catalog_name}.regression.serde_test1 order by id;"""
+            qt_3 """select * from ${catalog_name}.regression.serde_test2 order by id;"""
+            qt_4 """select * from ${catalog_name}.regression.serde_test3 order by id;"""
+            qt_5 """select * from ${catalog_name}.regression.serde_test4 order by id;"""
+            qt_6 """select * from ${catalog_name}.regression.serde_test5 order by id;"""
+            qt_7 """select * from ${catalog_name}.regression.serde_test6 order by id;"""
+            qt_8 """select * from ${catalog_name}.regression.serde_test7 order by id;"""
 
-        hive_docker """truncate table regression.serde_test8;"""
-        sql """insert into ${catalog_name}.regression.serde_test8 select * from ${catalog_name}.regression.serde_test7;"""
-        qt_9 """select * from ${catalog_name}.regression.serde_test8 order by id;"""
+            hive_docker """drop table if exists regression.${tempSerdeTable}"""
+            hive_docker """create table regression.${tempSerdeTable} like regression.serde_test8"""
+            sql """refresh catalog ${catalog_name}"""
+            sql """insert into ${catalog_name}.regression.${tempSerdeTable} select * from ${catalog_name}.regression.serde_test7;"""
+            qt_9 """select * from ${catalog_name}.regression.${tempSerdeTable} order by id;"""
 
-        qt_test_open_csv_default_prop """select * from ${catalog_name}.regression.test_open_csv_default_prop order by id;"""
-        qt_test_open_csv_standard_prop """select * from ${catalog_name}.regression.test_open_csv_standard_prop order by id;"""
-        qt_test_open_csv_custom_prop """select * from ${catalog_name}.regression.test_open_csv_custom_prop order by id;"""
+            qt_test_open_csv_default_prop """select * from ${catalog_name}.regression.test_open_csv_default_prop order by id;"""
+            qt_test_open_csv_standard_prop """select * from ${catalog_name}.regression.test_open_csv_standard_prop order by id;"""
+            qt_test_open_csv_custom_prop """select * from ${catalog_name}.regression.test_open_csv_custom_prop order by id;"""
 
-        qt_test_empty_null_format_text """select * from ${catalog_name}.regression.test_empty_null_format_text order by id;"""
-        qt_test_empty_null_format_text2 """select * from ${catalog_name}.regression.test_empty_null_format_text where name is null order by id;"""
-        qt_test_empty_null_format_text3 """select * from ${catalog_name}.regression.test_empty_null_format_text where name = '' order by id;"""
+            qt_test_empty_null_format_text """select * from ${catalog_name}.regression.test_empty_null_format_text order by id;"""
+            qt_test_empty_null_format_text2 """select * from ${catalog_name}.regression.test_empty_null_format_text where name is null order by id;"""
+            qt_test_empty_null_format_text3 """select * from ${catalog_name}.regression.test_empty_null_format_text where name = '' order by id;"""
 
-        qt_test_empty_null_defined_text """select * from ${catalog_name}.regression.test_empty_null_defined_text order by id;"""
-        qt_test_empty_null_defined_text2 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name is null order by id;"""
-        qt_test_empty_null_defined_text3 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name = '' order by id;"""
+            qt_test_empty_null_defined_text """select * from ${catalog_name}.regression.test_empty_null_defined_text order by id;"""
+            qt_test_empty_null_defined_text2 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name is null order by id;"""
+            qt_test_empty_null_defined_text3 """select * from ${catalog_name}.regression.test_empty_null_defined_text where name = '' order by id;"""
+        } finally {
+            try_hive_docker """drop table if exists regression.${tempSerdeTable}"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+        }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
@@ -29,6 +29,9 @@ suite("test_hive_special_char_partition", "p0,external") {
         String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
         String catalog_name = "${hivePrefix}_test_hive_special_char_partition"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String table_name_1 = "partition_special_characters_1"
+        String table_name_2 = "partition_special_characters_2"
+        String table_name_3 = "partition_special_characters_3"
 
         try {
             sql """drop catalog if exists ${catalog_name}"""
@@ -58,10 +61,6 @@ suite("test_hive_special_char_partition", "p0,external") {
 
 
         // append some case.
-        String table_name_1 = "partition_special_characters_1"
-        String table_name_2 = "partition_special_characters_2"
-        String table_name_3 = "partition_special_characters_3"
-
         hive_docker """ set hive.stats.column.autogather=false """
         hive_docker """ use `default`"""
         def special_characters = [

--- a/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_special_char_partition.groovy
@@ -30,37 +30,38 @@ suite("test_hive_special_char_partition", "p0,external") {
         String catalog_name = "${hivePrefix}_test_hive_special_char_partition"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
-        sql """drop catalog if exists ${catalog_name}"""
-        sql """create catalog if not exists ${catalog_name} properties (
-            'type'='hms',
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-            'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
-        );"""
-        logger.info("catalog " + catalog_name + " created")
-        sql """switch ${catalog_name};"""
-        logger.info("switched to catalog " + catalog_name)
-        sql """use multi_catalog;"""
-        qt_1 "select * from special_character_1_partition order by name"
-        qt_2 "select name from special_character_1_partition where part='2023 01 01'"
-        qt_3 "select name from special_character_1_partition where part='2023/01/01'"
-        qt_4 "select * from special_character_1_partition where part='2023?01?01'"
-        qt_5 "select * from special_character_1_partition where part='2023.01.01'"
-        qt_6 "select * from special_character_1_partition where part='2023<01><01>'"
-        qt_7 "select * from special_character_1_partition where part='2023:01:01'"
-        qt_8 "select * from special_character_1_partition where part='2023=01=01'"
-        qt_9 "select * from special_character_1_partition where part='2023\"01\"01'"
-        qt_10 "select * from special_character_1_partition where part='2023\\'01\\'01'"
-        qt_11 "select * from special_character_1_partition where part='2023\\\\01\\\\01'"
-        qt_12 "select * from special_character_1_partition where part='2023%01%01'"
-        qt_13 "select * from special_character_1_partition where part='2023#01#01'"
+        try {
+            sql """drop catalog if exists ${catalog_name}"""
+            sql """create catalog if not exists ${catalog_name} properties (
+                'type'='hms',
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
+            );"""
+            logger.info("catalog " + catalog_name + " created")
+            sql """switch ${catalog_name};"""
+            logger.info("switched to catalog " + catalog_name)
+            sql """use multi_catalog;"""
+            qt_1 "select * from special_character_1_partition order by name"
+            qt_2 "select name from special_character_1_partition where part='2023 01 01'"
+            qt_3 "select name from special_character_1_partition where part='2023/01/01'"
+            qt_4 "select * from special_character_1_partition where part='2023?01?01'"
+            qt_5 "select * from special_character_1_partition where part='2023.01.01'"
+            qt_6 "select * from special_character_1_partition where part='2023<01><01>'"
+            qt_7 "select * from special_character_1_partition where part='2023:01:01'"
+            qt_8 "select * from special_character_1_partition where part='2023=01=01'"
+            qt_9 "select * from special_character_1_partition where part='2023\"01\"01'"
+            qt_10 "select * from special_character_1_partition where part='2023\\'01\\'01'"
+            qt_11 "select * from special_character_1_partition where part='2023\\\\01\\\\01'"
+            qt_12 "select * from special_character_1_partition where part='2023%01%01'"
+            qt_13 "select * from special_character_1_partition where part='2023#01#01'"
 
 
 
         // append some case.
-        String table_name_1 = "partition_special_characters_1"  
-        String table_name_2 = "partition_special_characters_2" 
-        String table_name_3 = "partition_special_characters_3" 
-    
+        String table_name_1 = "partition_special_characters_1"
+        String table_name_2 = "partition_special_characters_2"
+        String table_name_3 = "partition_special_characters_3"
+
         hive_docker """ set hive.stats.column.autogather=false """
         hive_docker """ use `default`"""
         def special_characters = [
@@ -70,17 +71,17 @@ suite("test_hive_special_char_partition", "p0,external") {
                 ]
 
 
-        logger.info(""" docker insert 1""")            
+        logger.info(""" docker insert 1""")
 
-        hive_docker """ drop table if exists ${table_name_1} """ 
+        hive_docker """ drop table if exists ${table_name_1} """
         hive_docker """ create table ${table_name_1} (id int) partitioned by (pt string) """
         special_characters.eachWithIndex { item, index ->
             hive_docker """ insert into  ${table_name_1} partition(pt="${item}")      values ("${index}"); """
             hive_docker """ insert into  ${table_name_1} partition(pt="${item}")      values ("${index*100}"); """
-            println("Index: ${index}, Item: ${item}")    
+            println("Index: ${index}, Item: ${item}")
         }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -89,26 +90,26 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql2 """ show partitions from ${table_name_1} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id""" 
+            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id"""
         }
 
 
 
-        logger.info(""" docker insert 2""")            
-        hive_docker """ drop table if exists ${table_name_2} """ 
+        logger.info(""" docker insert 2""")
+        hive_docker """ drop table if exists ${table_name_2} """
         hive_docker """ create table ${table_name_2} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string) """
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
 
                 hive_docker """ insert into  ${table_name_2} partition(pt1="${outerItem}",`pt2=x!!!! **1+1/&^%3`="${innerItem}")   values ("${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -117,25 +118,25 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql4 """ show partitions from ${table_name_2} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id""" 
+            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id"""
         }
 
 
-        logger.info(""" docker insert 3""")            
-        hive_docker """ drop table if exists ${table_name_3} """ 
+        logger.info(""" docker insert 3""")
+        hive_docker """ drop table if exists ${table_name_3} """
         hive_docker """ create table ${table_name_3} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string,pt3 string,pt4 string,pt5 string) """
 
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
                 hive_docker """ insert into  ${table_name_3} partition(pt1="${outerItem}", `pt2=x!!!! **1+1/&^%3`="1", pt3="1",pt4="${innerItem}",pt5="1")   values ("${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-                    
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -144,7 +145,7 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql6 """ show partitions from ${table_name_3} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id""" 
+            qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id"""
         }
 
 
@@ -154,8 +155,8 @@ suite("test_hive_special_char_partition", "p0,external") {
 
         logger.info("""  ---------- doris insert  -------------""")
 
-        logger.info(""" doris insert 1""")            
-        hive_docker """ drop table if exists ${table_name_1} """ 
+        logger.info(""" doris insert 1""")
+        hive_docker """ drop table if exists ${table_name_1} """
         hive_docker """ create table ${table_name_1} (id int) partitioned by (pt string) """
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
@@ -164,10 +165,10 @@ suite("test_hive_special_char_partition", "p0,external") {
             sql """ insert into  ${table_name_1} (pt,id)  values ("${item}","${index}"); """
             sql """ insert into  ${table_name_1} (pt,id)  values ("${item}","${index*100}"); """
 
-            println("Index: ${index}, Item: ${item}")    
+            println("Index: ${index}, Item: ${item}")
         }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -176,13 +177,13 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql2 """ show partitions from ${table_name_1} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id """ 
+            qt_sql_where1 """ select * from  ${table_name_1} where pt = "${item}" order by id """
         }
 
 
 
-        logger.info(""" doris insert 2""")            
-        hive_docker """ drop table if exists ${table_name_2} """ 
+        logger.info(""" doris insert 2""")
+        hive_docker """ drop table if exists ${table_name_2} """
         hive_docker """ create table ${table_name_2} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string) """
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
@@ -190,15 +191,15 @@ suite("test_hive_special_char_partition", "p0,external") {
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
 
                 sql """ insert into  ${table_name_2} (pt1,`pt2=x!!!! **1+1/&^%3`,id)   values ("${outerItem}","${innerItem}","${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-        
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
@@ -207,14 +208,14 @@ suite("test_hive_special_char_partition", "p0,external") {
         qt_sql4 """ show partitions from ${table_name_2} """
 
         special_characters.eachWithIndex { item, index ->
-            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id""" 
+            qt_sql_where2 """ select * from  ${table_name_2} where `pt2=x!!!! **1+1/&^%3` = "${item}"  order by id"""
         }
 
 
 
 
-        logger.info(""" docker insert 3""")            
-        hive_docker """ drop table if exists ${table_name_3} """ 
+        logger.info(""" docker insert 3""")
+        hive_docker """ drop table if exists ${table_name_3} """
         hive_docker """ create table ${table_name_3} (id int) partitioned by (pt1 string, `pt2=x!!!! **1+1/&^%3` string,pt3 string,pt4 string,pt5 string) """
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
@@ -222,28 +223,29 @@ suite("test_hive_special_char_partition", "p0,external") {
 
         special_characters.eachWithIndex { outerItem, outerIndex ->
             special_characters.eachWithIndex { innerItem, innerIndex ->
-                
+
                 def insert_value = outerIndex * 100 + innerIndex;
                 sql """ insert into  ${table_name_3} (pt1, `pt2=x!!!! **1+1/&^%3`, pt3,pt4,pt5,id)   values ("${outerItem}","1","1","${innerItem}","1","${insert_value}"); """
                 println("  Outer Item: ${outerItem}, Inner Item: ${innerItem}, value = ${insert_value}")
             }
-        }   
+        }
 
-                    
+
         sql """refresh catalog ${catalog_name} """
         sql """switch ${catalog_name} """
         sql """ use `default` """
 
-        qt_sql5 """ select * from ${table_name_3} order by id """
-        qt_sql6 """ show partitions from ${table_name_3} """
+            qt_sql5 """ select * from ${table_name_3} order by id """
+            qt_sql6 """ show partitions from ${table_name_3} """
 
-        special_characters.eachWithIndex { item, index ->
-            qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id""" 
+            special_characters.eachWithIndex { item, index ->
+                qt_sql_where3 """ select * from  ${table_name_3} where pt4 = "${item}"  order by id"""
+            }
+        } finally {
+            try_hive_docker """drop table if exists default.${table_name_1}"""
+            try_hive_docker """drop table if exists default.${table_name_2}"""
+            try_hive_docker """drop table if exists default.${table_name_3}"""
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
-
-
-
-
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_false.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_false.groovy
@@ -61,7 +61,7 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                     'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
                     'use_meta_cache' = '${use_meta_cache_string}'
                 );"""
-                
+
                 // create from Doris, the cache will be filled immediately
                 String database= "test_use_meta_cache_db_${use_meta_cache}"
                 String table = "test_use_meta_cache_tbl_${use_meta_cache}"
@@ -83,7 +83,7 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                 order_qt_sql04 "show tables"
                 sql "drop database ${database}"
                 order_qt_sql05 "show databases like '%${database}%'";
-            
+
                 // create from Hive, the cache has different behavior
                 order_qt_sql01 "show databases like '%${database_hive}%'";
                 hive_docker "drop database if exists ${database_hive}"
@@ -141,7 +141,7 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
                     // 4. drop table
                     sql "drop table another_table_creation_test";
                 }
-                
+
                 // test Hive Metastore table partition file listing
                 hive_docker "create table ${database_hive}.${partitioned_table_hive} (k1 int) partitioned by (p1 string)"
                 sql "refresh catalog ${catalog}"
@@ -172,6 +172,12 @@ suite("test_hive_use_meta_cache_false", "p0,external") {
             }
             // test_use_meta_cache(false)
         } finally {
+            try_hive_docker "drop database if exists test_use_meta_cache_db_true force"
+            try_hive_docker "drop database if exists test_use_meta_cache_db_hive_true cascade"
+            try_hive_docker "drop database if exists test_use_meta_cache_db_false force"
+            try_hive_docker "drop database if exists test_use_meta_cache_db_hive_false cascade"
+            try_sql """drop catalog if exists test_${hivePrefix}_use_meta_cache_true"""
+            try_sql """drop catalog if exists test_${hivePrefix}_use_meta_cache_false"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_use_meta_cache_true.groovy
@@ -40,7 +40,7 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                     'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}',
                     'use_meta_cache' = '${use_meta_cache_string}'
                 );"""
-                
+
                 // create from Doris, the cache will be filled immediately
                 String database= "test_use_meta_cache_db_${use_meta_cache}"
                 String table = "test_use_meta_cache_tbl_${use_meta_cache}"
@@ -62,7 +62,7 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                 order_qt_sql04 "show tables"
                 sql "drop database ${database}"
                 order_qt_sql05 "show databases like '%${database}%'";
-            
+
                 // create from Hive, the cache has different behavior
                 order_qt_sql01 "show databases like '%${database_hive}%'";
                 hive_docker "drop database if exists ${database_hive}"
@@ -120,7 +120,7 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
                     // 4. drop table
                     sql "drop table another_table_creation_test";
                 }
-                
+
                 // test Hive Metastore table partition file listing
                 hive_docker "create table ${database_hive}.${partitioned_table_hive} (k1 int) partitioned by (p1 string)"
                 sql "refresh catalog ${catalog}"
@@ -151,6 +151,12 @@ suite("test_hive_use_meta_cache_true", "p0,external") {
             }
             test_use_meta_cache(true)
         } finally {
+            try_hive_docker "drop database if exists test_use_meta_cache_db_true force"
+            try_hive_docker "drop database if exists test_use_meta_cache_db_hive_true cascade"
+            try_hive_docker "drop database if exists test_use_meta_cache_db_false force"
+            try_hive_docker "drop database if exists test_use_meta_cache_db_hive_false cascade"
+            try_sql """drop catalog if exists test_${hivePrefix}_use_meta_cache_true"""
+            try_sql """drop catalog if exists test_${hivePrefix}_use_meta_cache_false"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_varbinary_type.groovy
@@ -24,7 +24,7 @@ suite("test_hive_varbinary_type", "p0,external") {
     }
 
     for (String hivePrefix : ["hive3"]) {
-    
+        setHivePrefix(hivePrefix)
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name_no_mapping = "${hivePrefix}_test_varbinary_no_mapping"
         String catalog_name_with_mapping = "${hivePrefix}_test_varbinary_with_mapping"
@@ -32,61 +32,85 @@ suite("test_hive_varbinary_type", "p0,external") {
         def hdfsUserName = "doris"
         String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
         def defaultFS = "hdfs://${externalEnvIp}:${hdfs_port}"
+        String tempOrcWriteNoMapping = "test_hive_binary_orc_write_no_mapping_tmp"
+        String tempParquetWriteNoMapping = "test_hive_binary_parquet_write_no_mapping_tmp"
+        String tempOrcWriteWithMapping = "test_hive_binary_orc_write_with_mapping_tmp"
+        String tempParquetWriteWithMapping = "test_hive_binary_parquet_write_with_mapping_tmp"
 
-        sql """drop catalog if exists ${catalog_name_no_mapping}"""
-        sql """create catalog if not exists ${catalog_name_no_mapping} properties (
-            "type"="hms",
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
-        );"""
-        
-        sql """drop catalog if exists ${catalog_name_with_mapping}"""
-        sql """create catalog if not exists ${catalog_name_with_mapping} properties (
-            "type"="hms",
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
-            "enable.mapping.varbinary"="true"
-        );"""
+        try {
+            sql """drop catalog if exists ${catalog_name_no_mapping}"""
+            sql """create catalog if not exists ${catalog_name_no_mapping} properties (
+                "type"="hms",
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
+            );"""
 
-        // no mapping
-        sql """ switch ${catalog_name_no_mapping}"""
-        sql """ use `test_varbinary` """
-        qt_select1 """ select * from test_hive_binary_orc order by id; """
-        qt_select2 """ select * from test_hive_binary_parquet order by id; """
-        qt_select3 """ select * from test_hive_uuid_fixed_orc order by id; """
-        qt_select4 """ select * from test_hive_uuid_fixed_parquet order by id; """
-        qt_select5 """ select * from test_hive_binary_edge_cases order by id; """
+            sql """drop catalog if exists ${catalog_name_with_mapping}"""
+            sql """create catalog if not exists ${catalog_name_with_mapping} properties (
+                "type"="hms",
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                "enable.mapping.varbinary"="true"
+            );"""
 
-        // write orc
-        qt_select6 """ insert into test_hive_binary_orc_write_no_mapping select * from test_hive_binary_orc; """
-        qt_select7 """ insert into test_hive_binary_orc_write_no_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select8 """ insert into test_hive_binary_orc_write_no_mapping values(NULL,NULL,NULL); """
-        qt_select9 """ select * from test_hive_binary_orc_write_no_mapping order by id; """
+            hive_docker """drop table if exists test_varbinary.${tempOrcWriteNoMapping}"""
+            hive_docker """create table test_varbinary.${tempOrcWriteNoMapping} like test_varbinary.test_hive_binary_orc_write_no_mapping"""
+            hive_docker """drop table if exists test_varbinary.${tempParquetWriteNoMapping}"""
+            hive_docker """create table test_varbinary.${tempParquetWriteNoMapping} like test_varbinary.test_hive_binary_parquet_write_no_mapping"""
+            hive_docker """drop table if exists test_varbinary.${tempOrcWriteWithMapping}"""
+            hive_docker """create table test_varbinary.${tempOrcWriteWithMapping} like test_varbinary.test_hive_binary_orc_write_with_mapping"""
+            hive_docker """drop table if exists test_varbinary.${tempParquetWriteWithMapping}"""
+            hive_docker """create table test_varbinary.${tempParquetWriteWithMapping} like test_varbinary.test_hive_binary_parquet_write_with_mapping"""
+            sql """refresh catalog ${catalog_name_no_mapping}"""
+            sql """refresh catalog ${catalog_name_with_mapping}"""
 
-        // write parquet
-        qt_select10 """ insert into test_hive_binary_parquet_write_no_mapping select * from test_hive_binary_parquet; """
-        qt_select11 """ insert into test_hive_binary_parquet_write_no_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select12 """ insert into test_hive_binary_parquet_write_no_mapping values(NULL,NULL,NULL); """
-        qt_select13 """ select * from test_hive_binary_parquet_write_no_mapping order by id; """
+            // no mapping
+            sql """ switch ${catalog_name_no_mapping}"""
+            sql """ use `test_varbinary` """
+            qt_select1 """ select * from test_hive_binary_orc order by id; """
+            qt_select2 """ select * from test_hive_binary_parquet order by id; """
+            qt_select3 """ select * from test_hive_uuid_fixed_orc order by id; """
+            qt_select4 """ select * from test_hive_uuid_fixed_parquet order by id; """
+            qt_select5 """ select * from test_hive_binary_edge_cases order by id; """
 
-        // with mapping
-        sql """ switch ${catalog_name_with_mapping} """
-        sql """ use `test_varbinary` """
-        qt_select14 """ select * from test_hive_binary_orc order by id; """
-        qt_select15 """ select * from test_hive_binary_parquet order by id; """
-        qt_select16 """ select * from test_hive_uuid_fixed_orc order by id; """
-        qt_select17 """ select * from test_hive_uuid_fixed_parquet order by id; """
-        qt_select18 """ select * from test_hive_binary_edge_cases order by id; """
+            // write orc
+            qt_select6 """ insert into ${tempOrcWriteNoMapping} select * from test_hive_binary_orc; """
+            qt_select7 """ insert into ${tempOrcWriteNoMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select8 """ insert into ${tempOrcWriteNoMapping} values(NULL,NULL,NULL); """
+            qt_select9 """ select * from ${tempOrcWriteNoMapping} order by id; """
 
-        // write orc
-        qt_select19 """ insert into test_hive_binary_orc_write_with_mapping select * from test_hive_binary_orc; """
-        qt_select20 """ insert into test_hive_binary_orc_write_with_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select21 """ insert into test_hive_binary_orc_write_with_mapping values(NULL,NULL,NULL); """
-        qt_select22 """ select * from test_hive_binary_orc_write_with_mapping order by id; """
+            // write parquet
+            qt_select10 """ insert into ${tempParquetWriteNoMapping} select * from test_hive_binary_parquet; """
+            qt_select11 """ insert into ${tempParquetWriteNoMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select12 """ insert into ${tempParquetWriteNoMapping} values(NULL,NULL,NULL); """
+            qt_select13 """ select * from ${tempParquetWriteNoMapping} order by id; """
 
-        // write parquet
-        qt_select23 """ insert into test_hive_binary_parquet_write_with_mapping select * from test_hive_binary_parquet; """
-        qt_select24 """ insert into test_hive_binary_parquet_write_with_mapping values(6,X"ABAB",X"ABAB"); """
-        qt_select25 """ insert into test_hive_binary_parquet_write_with_mapping values(NULL,NULL,NULL); """
-        qt_select26 """ select * from test_hive_binary_parquet_write_with_mapping order by id; """
+            // with mapping
+            sql """ switch ${catalog_name_with_mapping} """
+            sql """ use `test_varbinary` """
+            qt_select14 """ select * from test_hive_binary_orc order by id; """
+            qt_select15 """ select * from test_hive_binary_parquet order by id; """
+            qt_select16 """ select * from test_hive_uuid_fixed_orc order by id; """
+            qt_select17 """ select * from test_hive_uuid_fixed_parquet order by id; """
+            qt_select18 """ select * from test_hive_binary_edge_cases order by id; """
+
+            // write orc
+            qt_select19 """ insert into ${tempOrcWriteWithMapping} select * from test_hive_binary_orc; """
+            qt_select20 """ insert into ${tempOrcWriteWithMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select21 """ insert into ${tempOrcWriteWithMapping} values(NULL,NULL,NULL); """
+            qt_select22 """ select * from ${tempOrcWriteWithMapping} order by id; """
+
+            // write parquet
+            qt_select23 """ insert into ${tempParquetWriteWithMapping} select * from test_hive_binary_parquet; """
+            qt_select24 """ insert into ${tempParquetWriteWithMapping} values(6,X"ABAB",X"ABAB"); """
+            qt_select25 """ insert into ${tempParquetWriteWithMapping} values(NULL,NULL,NULL); """
+            qt_select26 """ select * from ${tempParquetWriteWithMapping} order by id; """
+        } finally {
+            try_hive_docker """drop table if exists test_varbinary.${tempOrcWriteNoMapping}"""
+            try_hive_docker """drop table if exists test_varbinary.${tempParquetWriteNoMapping}"""
+            try_hive_docker """drop table if exists test_varbinary.${tempOrcWriteWithMapping}"""
+            try_hive_docker """drop table if exists test_varbinary.${tempParquetWriteWithMapping}"""
+            try_sql """drop catalog if exists ${catalog_name_no_mapping}"""
+            try_sql """drop catalog if exists ${catalog_name_with_mapping}"""
+        }
     }
 
 }

--- a/regression-test/suites/external_table_p0/hive/test_hms_event_notification.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hms_event_notification.groovy
@@ -22,14 +22,16 @@ suite("test_hms_event_notification", "p0,external") {
         return;
     }
     for (String hivePrefix : ["hive3"]) {
+        String catalog_name = "test_hms_event_notification_${hivePrefix}"
+        String catalog_name_2 = "test_hms_event_notification_${hivePrefix}_2"
+        String db1  = "${catalog_name}_db_1"
+        String db2  = "${catalog_name}_db_2"
         try {
             setHivePrefix(hivePrefix)
             hive_docker """ set hive.stats.autogather=false; """
-            
+
 
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String catalog_name = "test_hms_event_notification_${hivePrefix}"
-            String catalog_name_2 = "test_hms_event_notification_${hivePrefix}_2"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             int wait_time = 10000;
 
@@ -46,43 +48,41 @@ suite("test_hms_event_notification", "p0,external") {
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
                 "hive.enable_hms_events_incremental_sync" ="true"
             );"""
-            
+
             sleep(wait_time);
 
             sql """ switch ${catalog_name} """
-            
+
             String tb1 = """${catalog_name}_tb_1"""
             String tb2 = """${catalog_name}_tb_2"""
-            String db1  = "${catalog_name}_db_1";
-            String db2  = "${catalog_name}_db_2";
-            String partition_tb = "${catalog_name}_partition_tb"; 
+            String partition_tb = "${catalog_name}_partition_tb";
 
             try {
-                hive_docker """ use  ${db1};""" 
+                hive_docker """ use  ${db1};"""
             }catch (Exception e){
             }
 
-            hive_docker """ drop table if exists ${tb1};""" 
-            hive_docker """ drop table if exists ${tb2};""" 
-            hive_docker """ drop table if exists ${partition_tb} """ 
-            hive_docker """ drop database if exists ${db1};""" 
+            hive_docker """ drop table if exists ${tb1};"""
+            hive_docker """ drop table if exists ${tb2};"""
+            hive_docker """ drop table if exists ${partition_tb} """
+            hive_docker """ drop database if exists ${db1};"""
             hive_docker """ drop database if exists ${db2};"""
 
-//CREATE DATABASE            
-            hive_docker """ create  database  ${db1};""" 
+//CREATE DATABASE
+            hive_docker """ create  database  ${db1};"""
             hive_docker """ create  database  ${db2};"""
             sleep(wait_time);
 
-            List<List<String>>  dbs = sql """ show databases """ 
+            List<List<String>>  dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            
-            int flag_db_count = 0 ; 
+
+            int flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0] == db1) {
                     flag_db_count ++;
                 }else if (it[0] == db2) {
                     flag_db_count ++;
-                } 
+                }
             }
             assertTrue(flag_db_count == 2);
 
@@ -91,11 +91,11 @@ suite("test_hms_event_notification", "p0,external") {
 
 //ALTER DATABASE
             if (hivePrefix == "hive3") {
-                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("db2 location = " + db2_location )
 
                 def loc_start = db2_location.indexOf("hdfs://")
-                def loc_end = db2_location.indexOf(".db") + 3 
+                def loc_end = db2_location.indexOf(".db") + 3
                 db2_location  = db2_location.substring(loc_start, loc_end)
                 logger.info("db2 location = " + db2_location )
 
@@ -106,12 +106,12 @@ suite("test_hms_event_notification", "p0,external") {
                 hive_docker """ ALTER DATABASE  ${db2} SET LOCATION '${new_db2_location}'; """
                 logger.info(" alter database end")
                 sleep(wait_time);
-                
-                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+
+                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("query_db2_location  =  ${query_db2_location} ")
 
                 loc_start = query_db2_location.indexOf("hdfs://")
-                loc_end = query_db2_location.indexOf(".db") + 3 
+                loc_end = query_db2_location.indexOf(".db") + 3
                 query_db2_location = query_db2_location.substring(loc_start, loc_end)
 
                 assertTrue(query_db2_location == new_db2_location);
@@ -121,24 +121,24 @@ suite("test_hms_event_notification", "p0,external") {
 //DROP DATABASE
             hive_docker """drop  database ${db2}; """;
             sleep(wait_time);
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0].toString() == db1) {
                     flag_db_count ++;
                 } else if (it[0].toString() == db2) {
                     logger.info(" exists ${db2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_db_count == 1);
 
 
 //CREATE TABLE
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """                         
-            List<List<String>>  tbs = sql """ show tables; """ 
+            sql """ use ${db1} """
+            List<List<String>>  tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
             assertTrue(tbs.isEmpty())
 
@@ -146,9 +146,9 @@ suite("test_hms_event_notification", "p0,external") {
             hive_docker """ create  table ${tb1} (id int,name string) ;"""
             hive_docker """ create  table ${tb2} (id int,name string) ;"""
             sleep(wait_time);
-            tbs = sql """ show tables; """ 
+            tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
-            int flag_tb_count = 0 ; 
+            int flag_tb_count = 0 ;
             tbs.forEach {
                 logger.info("it[0] = " + it[0])
                 if (it[0].toString() == "${tb1}") {
@@ -157,28 +157,28 @@ suite("test_hms_event_notification", "p0,external") {
                 }else if (it[0].toString() == tb2) {
                     flag_tb_count ++;
                     logger.info(" ${tb2} exists ")
-                } 
+                }
             }
             assertTrue(flag_tb_count == 2);
-            
+
 
 //ALTER TABLE
-            List<List<String>> ans = sql """ select * from ${tb1} """ 
+            List<List<String>> ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.isEmpty())
-            
-            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """    
+
+            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} """ 
+            ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 1)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][1].toString() == "xxx")
 
 
-            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """    
+            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} order by id """ 
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -187,7 +187,7 @@ suite("test_hms_event_notification", "p0,external") {
             assertTrue(ans[1][1].toString() == "yyy")
 
 
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
@@ -195,16 +195,16 @@ suite("test_hms_event_notification", "p0,external") {
             assertTrue(ans[1][0].toString() == "name")
             assertTrue(ans[1][1].toString() == "text")
 
-            hive_docker """ alter table ${tb1} change column id id bigint; """    
+            hive_docker """ alter table ${tb1} change column id id bigint; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -214,16 +214,16 @@ suite("test_hms_event_notification", "p0,external") {
 
 
 
-            hive_docker """ alter table ${tb1} change column name new_name string; """    
+            hive_docker """ alter table ${tb1} change column name new_name string; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "new_name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -233,26 +233,26 @@ suite("test_hms_event_notification", "p0,external") {
 
 
 //DROP TABLE
-            hive_docker  """ drop table ${tb2} """ 
+            hive_docker  """ drop table ${tb2} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
             logger.info(""" tbs = ${tbs}""")
 
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 if (it[0] == tb1) {
                     flag_tb_count ++;
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb1}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_tb_count == 1);
 
 
-            
-            hive_docker  """ drop table ${tb1} """ 
+
+            hive_docker  """ drop table ${tb1} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
@@ -265,26 +265,26 @@ suite("test_hms_event_notification", "p0,external") {
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
 
 //ADD PARTITION
 
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """  
+            sql """ use ${db1} """
 
             hive_docker  """ CREATE TABLE ${partition_tb} (
                         id INT,
                         name STRING,
                         age INT
                     )
-                    PARTITIONED BY (country STRING); """ 
-            hive_docker """ 
+                    PARTITIONED BY (country STRING); """
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='USA')
                 VALUES (1, 'John Doe', 30),
                        (2, 'Jane Smith', 25);"""
-                       
-            hive_docker """ 
+
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='India')
                 VALUES (3, 'Rahul Kumar', 28),
                        (4, 'Priya Singh', 24);
@@ -295,34 +295,34 @@ suite("test_hms_event_notification", "p0,external") {
             assertTrue(ans.size() == 4)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][3].toString() == "USA")
-            assertTrue(ans[1][3].toString() == "USA")            
+            assertTrue(ans[1][3].toString() == "USA")
             assertTrue(ans[3][0].toString() == "4")
             assertTrue(ans[2][3].toString() == "India")
             assertTrue(ans[3][3].toString() == "India")
 
 
-            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            int flag_partition_count = 0 ; 
+            int flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0] == "country=India") {
                     flag_partition_count ++;
                 } else if (it[0] == "country=USA") {
                     flag_partition_count ++;
-                } 
+                }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
 
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} ADD PARTITION (country='Canada');
                 """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -332,18 +332,18 @@ suite("test_hms_event_notification", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
 //ALTER PARTITION
-            hive_docker """ 
+            hive_docker """
                 alter table ${partition_tb} partition(country='USA') rename to partition(country='US') ;
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -353,17 +353,17 @@ suite("test_hms_event_notification", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 //DROP PARTITION
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} DROP PARTITION (country='Canada');
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 
+            flag_partition_count = 0
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -374,15 +374,18 @@ suite("test_hms_event_notification", "p0,external") {
                     assertTrue(false);
                 }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
 
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_hive_docker """drop database if exists ${db1} cascade"""
+            try_hive_docker """drop database if exists ${db2} cascade"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_sql """drop catalog if exists ${catalog_name_2}"""
         }
     }
 }
-
 
 
 

--- a/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hms_event_notification_multi_catalog.groovy
@@ -23,14 +23,16 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
     }
 
     for (String hivePrefix : ["hive3"]) {
+        String catalog_name = "test_hms_event_notification_multi_catalog_${hivePrefix}"
+        String catalog_name_2 = "test_hms_event_notification_multi_catalog_${hivePrefix}_2"
+        String db1  = "${catalog_name}_db_1"
+        String db2  = "${catalog_name}_db_2"
         try {
             setHivePrefix(hivePrefix)
             hive_docker """ set hive.stats.autogather=false; """
-            
+
 
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-            String catalog_name = "test_hms_event_notification_multi_catalog_${hivePrefix}"
-            String catalog_name_2 = "test_hms_event_notification_multi_catalog_${hivePrefix}_2"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             int wait_time = 10000;
 
@@ -52,66 +54,64 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sleep(wait_time);
 
             sql """ switch ${catalog_name} """
-            
+
             String tb1 = """${catalog_name}_tb_1"""
             String tb2 = """${catalog_name}_tb_2"""
-            String db1  = "${catalog_name}_db_1";
-            String db2  = "${catalog_name}_db_2";
-            String partition_tb = "${catalog_name}_partition_tb"; 
+            String partition_tb = "${catalog_name}_partition_tb";
 
             try {
-                hive_docker """ use  ${db1};""" 
+                hive_docker """ use  ${db1};"""
             }catch (Exception e){
             }
 
-            hive_docker """ drop table if exists ${tb1};""" 
-            hive_docker """ drop table if exists ${tb2};""" 
-            hive_docker """ drop table if exists ${partition_tb} """ 
-            hive_docker """ drop database if exists ${db1};""" 
+            hive_docker """ drop table if exists ${tb1};"""
+            hive_docker """ drop table if exists ${tb2};"""
+            hive_docker """ drop table if exists ${partition_tb} """
+            hive_docker """ drop database if exists ${db1};"""
             hive_docker """ drop database if exists ${db2};"""
 
-//CREATE DATABASE            
-            hive_docker """ create  database  ${db1};""" 
+//CREATE DATABASE
+            hive_docker """ create  database  ${db1};"""
             hive_docker """ create  database  ${db2};"""
             sleep(wait_time);
 
-            List<List<String>>  dbs = sql """ show databases """ 
+            List<List<String>>  dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            
-            int flag_db_count = 0 ; 
+
+            int flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0] == db1) {
                     flag_db_count ++;
                 }else if (it[0] == db2) {
                     flag_db_count ++;
-                } 
+                }
             }
             assertTrue(flag_db_count == 2);
 
             sql """ switch ${catalog_name_2} """
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0] == db1) {
                     flag_db_count ++;
                 }else if (it[0] == db2) {
                     flag_db_count ++;
-                } 
+                }
             }
             assertTrue(flag_db_count == 2);
-            
+
             sql """ switch ${catalog_name} """
 
 
 
 //ALTER DATABASE
             if (hivePrefix == "hive3") {
-                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+                String db2_location = (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("db2 location = " + db2_location )
 
                 def loc_start = db2_location.indexOf("hdfs://")
-                def loc_end = db2_location.indexOf(".db") + 3 
+                def loc_end = db2_location.indexOf(".db") + 3
                 db2_location  = db2_location.substring(loc_start, loc_end)
                 logger.info("db2 location = " + db2_location )
 
@@ -122,23 +122,23 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 hive_docker """ ALTER DATABASE  ${db2} SET LOCATION '${new_db2_location}'; """
                 logger.info(" alter database end")
                 sleep(wait_time);
-                
-                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+
+                String query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("query_db2_location  =  ${query_db2_location} ")
 
                 loc_start = query_db2_location.indexOf("hdfs://")
-                loc_end = query_db2_location.indexOf(".db") + 3 
+                loc_end = query_db2_location.indexOf(".db") + 3
                 query_db2_location = query_db2_location.substring(loc_start, loc_end)
                 assertTrue(query_db2_location == new_db2_location);
 
 
 
                 sql """ switch ${catalog_name_2} """
-                query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1] 
+                query_db2_location =  (sql """ SHOW CREATE DATABASE ${db2} """)[0][1]
                 logger.info("query_db2_location  =  ${query_db2_location} ")
 
                 loc_start = query_db2_location.indexOf("hdfs://")
-                loc_end = query_db2_location.indexOf(".db") + 3 
+                loc_end = query_db2_location.indexOf(".db") + 3
                 query_db2_location = query_db2_location.substring(loc_start, loc_end)
                 assertTrue(query_db2_location == new_db2_location);
                 sql """ switch ${catalog_name} """
@@ -148,38 +148,38 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 //DROP DATABASE
             hive_docker """drop  database ${db2}; """;
             sleep(wait_time);
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0].toString() == db1) {
                     flag_db_count ++;
                 } else if (it[0].toString() == db2) {
                     logger.info(" exists ${db2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_db_count == 1);
 
             sql """ switch ${catalog_name_2} """
-            dbs = sql """ show databases """ 
+            dbs = sql """ show databases """
             logger.info("result = " + dbs);
-            flag_db_count = 0 ; 
+            flag_db_count = 0 ;
             dbs.forEach {
                 if (it[0].toString() == db1) {
                     flag_db_count ++;
                 } else if (it[0].toString() == db2) {
                     logger.info(" exists ${db2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_db_count == 1);
             sql """ switch ${catalog_name} """
 
 //CREATE TABLE
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """                         
-            List<List<String>>  tbs = sql """ show tables; """ 
+            sql """ use ${db1} """
+            List<List<String>>  tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
             assertTrue(tbs.isEmpty())
 
@@ -187,9 +187,9 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             hive_docker """ create  table ${tb1} (id int,name string) ;"""
             hive_docker """ create  table ${tb2} (id int,name string) ;"""
             sleep(wait_time);
-            tbs = sql """ show tables; """ 
+            tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
-            int flag_tb_count = 0 ; 
+            int flag_tb_count = 0 ;
             tbs.forEach {
                 logger.info("it[0] = " + it[0])
                 if (it[0].toString() == "${tb1}") {
@@ -198,16 +198,16 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 }else if (it[0].toString() == tb2) {
                     flag_tb_count ++;
                     logger.info(" ${tb2} exists ")
-                } 
+                }
             }
             assertTrue(flag_tb_count == 2);
-            
+
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            tbs = sql """ show tables; """ 
+            tbs = sql """ show tables; """
             logger.info(" tbs = ${tbs}")
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 logger.info("it[0] = " + it[0])
                 if (it[0].toString() == "${tb1}") {
@@ -216,7 +216,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 }else if (it[0].toString() == tb2) {
                     flag_tb_count ++;
                     logger.info(" ${tb2} exists ")
-                } 
+                }
             }
             assertTrue(flag_tb_count == 2);
             sql """ switch ${catalog_name} """
@@ -224,13 +224,13 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 //ALTER TABLE
-            List<List<String>> ans = sql """ select * from ${tb1} """ 
+            List<List<String>> ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.isEmpty())
-            
-            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """    
+
+            hive_docker """ insert into  ${tb1}  select 1,"xxx"; """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} """ 
+            ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 1)
             assertTrue(ans[0][0].toString() == "1")
@@ -238,7 +238,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ select * from ${tb1} """ 
+            ans = sql """ select * from ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 1)
             assertTrue(ans[0][0].toString() == "1")
@@ -247,9 +247,9 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
 
-            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """    
+            hive_docker """ insert into  ${tb1} values( 2,"yyy"); """
             sleep(wait_time);
-            ans = sql """ select * from ${tb1} order by id """ 
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -258,7 +258,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans[1][1].toString() == "yyy")
 
 
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
@@ -269,7 +269,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ select * from ${tb1} order by id """ 
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -277,7 +277,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans[1][0].toString() == "2")
             assertTrue(ans[1][1].toString() == "yyy")
 
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
@@ -289,16 +289,16 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ use ${db1} """
 
 
-            hive_docker """ alter table ${tb1} change column id id bigint; """    
+            hive_docker """ alter table ${tb1} change column id id bigint; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -309,14 +309,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -329,16 +329,16 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            hive_docker """ alter table ${tb1} change column name new_name string; """    
+            hive_docker """ alter table ${tb1} change column name new_name string; """
             sleep(wait_time);
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "new_name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -348,14 +348,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            ans = sql """ desc ${tb1} """ 
+            ans = sql """ desc ${tb1} """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "id")
             assertTrue(ans[0][1].toString() == "bigint")
             assertTrue(ans[1][0].toString() == "new_name")
-            assertTrue(ans[1][1].toString() == "text")    
-            ans = sql """ select * from ${tb1} order by id """ 
+            assertTrue(ans[1][1].toString() == "text")
+            ans = sql """ select * from ${tb1} order by id """
             logger.info("ans = ${ans}")
             assertTrue(ans.size() == 2)
             assertTrue(ans[0][0].toString() == "1")
@@ -366,24 +366,24 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
 
-            
+
 
 
 //DROP TABLE
-            hive_docker  """ drop table ${tb2} """ 
+            hive_docker  """ drop table ${tb2} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
             logger.info(""" tbs = ${tbs}""")
 
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 if (it[0] == tb1) {
                     flag_tb_count ++;
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb1}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_tb_count == 1);
 
@@ -392,14 +392,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """ use ${db1} """
             tbs = sql """ show tables; """
             logger.info(""" tbs = ${tbs}""")
-            flag_tb_count = 0 ; 
+            flag_tb_count = 0 ;
             tbs.forEach {
                 if (it[0] == tb1) {
                     flag_tb_count ++;
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
             assertTrue(flag_tb_count == 1);
 
@@ -408,8 +408,8 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            
-            hive_docker  """ drop table ${tb1} """ 
+
+            hive_docker  """ drop table ${tb1} """
             sleep(wait_time);
             tbs = sql """ show tables; """
 
@@ -422,7 +422,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
 
 
@@ -437,7 +437,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                 } else if (it[0] == tb2) {
                     logger.info("exists ${tb2}")
                     assertTrue(false);
-                } 
+                }
             }
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
@@ -447,20 +447,20 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 //ADD PARTITION
 
             hive_docker """ use ${db1} """
-            sql """ use ${db1} """  
+            sql """ use ${db1} """
 
             hive_docker  """ CREATE TABLE ${partition_tb} (
                         id INT,
                         name STRING,
                         age INT
                     )
-                    PARTITIONED BY (country STRING); """ 
-            hive_docker """ 
+                    PARTITIONED BY (country STRING); """
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='USA')
                 VALUES (1, 'John Doe', 30),
                        (2, 'Jane Smith', 25);"""
-                       
-            hive_docker """ 
+
+            hive_docker """
                 INSERT INTO TABLE ${partition_tb} PARTITION (country='India')
                 VALUES (3, 'Rahul Kumar', 28),
                        (4, 'Priya Singh', 24);
@@ -471,7 +471,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans.size() == 4)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][3].toString() == "USA")
-            assertTrue(ans[1][3].toString() == "USA")            
+            assertTrue(ans[1][3].toString() == "USA")
             assertTrue(ans[3][0].toString() == "4")
             assertTrue(ans[2][3].toString() == "India")
             assertTrue(ans[3][3].toString() == "India")
@@ -483,7 +483,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             assertTrue(ans.size() == 4)
             assertTrue(ans[0][0].toString() == "1")
             assertTrue(ans[0][3].toString() == "USA")
-            assertTrue(ans[1][3].toString() == "USA")            
+            assertTrue(ans[1][3].toString() == "USA")
             assertTrue(ans[3][0].toString() == "4")
             assertTrue(ans[2][3].toString() == "India")
             assertTrue(ans[3][3].toString() == "India")
@@ -493,33 +493,33 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            List<List<String>> pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            int flag_partition_count = 0 ; 
+            int flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0] == "country=India") {
                     flag_partition_count ++;
                 } else if (it[0] == "country=USA") {
                     flag_partition_count ++;
-                } 
+                }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0] == "country=India") {
                     flag_partition_count ++;
                 } else if (it[0] == "country=USA") {
                     flag_partition_count ++;
-                } 
+                }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
@@ -527,14 +527,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} ADD PARTITION (country='Canada');
                 """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -544,15 +544,15 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -562,7 +562,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
             sql """ switch ${catalog_name} """
@@ -572,14 +572,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 //ALTER PARTITION
-            hive_docker """ 
+            hive_docker """
                 alter table ${partition_tb} partition(country='USA') rename to partition(country='US') ;
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -589,15 +589,15 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 3)
-            flag_partition_count = 0 ; 
+            flag_partition_count = 0 ;
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -607,7 +607,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     flag_partition_count ++;
                 }
             }
-            assertTrue(flag_partition_count ==3) 
+            assertTrue(flag_partition_count ==3)
 
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
@@ -616,14 +616,14 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
 
 
 //DROP PARTITION
-            hive_docker """ 
+            hive_docker """
                 ALTER TABLE ${partition_tb} DROP PARTITION (country='Canada');
             """
             sleep(wait_time);
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 
+            flag_partition_count = 0
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -634,15 +634,15 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     assertTrue(false);
                 }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
 
 
             sql """ switch ${catalog_name_2} """
             sql """ use ${db1} """
-            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """ 
+            pars = sql """ SHOW PARTITIONS from  ${partition_tb}; """
             logger.info("pars = ${pars}")
             assertTrue(pars.size() == 2)
-            flag_partition_count = 0 
+            flag_partition_count = 0
             pars.forEach {
                 if (it[0].toString() == "country=India") {
                     flag_partition_count ++;
@@ -653,7 +653,7 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
                     assertTrue(false);
                 }
             }
-            assertTrue(flag_partition_count ==2) 
+            assertTrue(flag_partition_count ==2)
             sql """ switch ${catalog_name} """
             sql """ use ${db1} """
 
@@ -662,10 +662,13 @@ suite("test_hms_event_notification_multi_catalog", "p0,external") {
             sql """drop catalog if exists ${catalog_name}"""
             sql """drop catalog if exists ${catalog_name_2}"""
         } finally {
+            try_hive_docker """drop database if exists ${db1} cascade"""
+            try_hive_docker """drop database if exists ${db2} cascade"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_sql """drop catalog if exists ${catalog_name_2}"""
         }
     }
 }
-
 
 
 

--- a/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_multi_delimit_serde.groovy
@@ -26,20 +26,30 @@ suite("test_multi_delimit_serde", "p0,external") {
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
         String catalog_name = "${hivePrefix}_test_multi_delimit_serde"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-
-        sql """drop catalog if exists ${catalog_name}"""
-        sql """create catalog if not exists ${catalog_name} properties (
-            "type"="hms",
-            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
-        );"""
-
-        logger.info("catalog " + catalog_name + " created")
-        sql """switch ${catalog_name};"""
-        logger.info("switched to catalog " + catalog_name)
-
-        sql """use regression;"""
+        String tempMultiDelimitTest = "multi_delimit_test_tmp"
+        String tempMultiDelimitTest2 = "multi_delimit_test2_tmp"
+        String tempMultiDelimitComplexTest = "multi_delimit_complex_test_tmp"
 
         try {
+            sql """drop catalog if exists ${catalog_name}"""
+            sql """create catalog if not exists ${catalog_name} properties (
+                "type"="hms",
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
+            );"""
+
+            logger.info("catalog " + catalog_name + " created")
+            sql """switch ${catalog_name};"""
+            logger.info("switched to catalog " + catalog_name)
+
+            sql """use regression;"""
+            hive_docker """drop table if exists regression.${tempMultiDelimitTest}"""
+            hive_docker """create table regression.${tempMultiDelimitTest} like regression.multi_delimit_test"""
+            hive_docker """drop table if exists regression.${tempMultiDelimitTest2}"""
+            hive_docker """create table regression.${tempMultiDelimitTest2} like regression.multi_delimit_test2"""
+            hive_docker """drop table if exists regression.${tempMultiDelimitComplexTest}"""
+            hive_docker """create table regression.${tempMultiDelimitComplexTest} like regression.multi_delimit_complex_test"""
+            sql """refresh catalog ${catalog_name}"""
+
             // Test 1: MultiDelimitSerDe with |+| delimiter - using pre-created table
             qt_01 """SELECT * FROM multi_delimit_test ORDER BY k1"""
 
@@ -54,21 +64,21 @@ suite("test_multi_delimit_serde", "p0,external") {
             logger.info("Test 4: Testing Doris INSERT to Hive MultiDelimitSerDe tables")
 
             // Test 4.1: Insert to basic multi-delimit table
-            sql """INSERT INTO multi_delimit_test VALUES (4, 400, 'test4'), (5, 500, 'test5')"""
-            qt_04 """SELECT * FROM multi_delimit_test WHERE k1 >= 4 ORDER BY k1"""
+            sql """INSERT INTO ${tempMultiDelimitTest} VALUES (4, 400, 'test4'), (5, 500, 'test5')"""
+            qt_04 """SELECT * FROM ${tempMultiDelimitTest} WHERE k1 >= 4 ORDER BY k1"""
 
             // Test 4.2: Insert to double-pipe delimited table
-            sql """INSERT INTO multi_delimit_test2 VALUES (4, 4.5, 'description4'), (5, 5.5, 'description5')"""
-            qt_05 """SELECT * FROM multi_delimit_test2 WHERE id >= 4 ORDER BY id"""
+            sql """INSERT INTO ${tempMultiDelimitTest2} VALUES (4, 4.5, 'description4'), (5, 5.5, 'description5')"""
+            qt_05 """SELECT * FROM ${tempMultiDelimitTest2} WHERE id >= 4 ORDER BY id"""
 
             // Test 4.3: Insert to complex types table with arrays and maps
-            sql """INSERT INTO multi_delimit_complex_test VALUES
+            sql """INSERT INTO ${tempMultiDelimitComplexTest} VALUES
                 (3, 'user3', ARRAY('tagX', 'tagY'), MAP('newkey', 'newvalue'), ARRAY(ARRAY(7, 8)))"""
-            qt_06 """SELECT id, name, tags, properties FROM multi_delimit_complex_test WHERE id = 3 ORDER BY id"""
+            qt_06 """SELECT id, name, tags, properties FROM ${tempMultiDelimitComplexTest} WHERE id = 3 ORDER BY id"""
 
             // Test 5: Show create table to check SerDe properties
             logger.info("Test 5: Checking show create table")
-            def createTableResult = sql """SHOW CREATE TABLE multi_delimit_test"""
+            def createTableResult = sql """SHOW CREATE TABLE ${tempMultiDelimitTest}"""
             logger.info("Create table result: " + createTableResult.toString())
 
             assertTrue(createTableResult.toString().contains("MultiDelimitSerDe"))
@@ -78,7 +88,11 @@ suite("test_multi_delimit_serde", "p0,external") {
             if (e.getMessage().contains("Unsupported hive table serde")) {
                 logger.info("Got expected 'Unsupported hive table serde' error before implementing MultiDelimitSerDe support")
             }
+        } finally {
+            try_hive_docker """drop table if exists regression.${tempMultiDelimitTest}"""
+            try_hive_docker """drop table if exists regression.${tempMultiDelimitTest2}"""
+            try_hive_docker """drop table if exists regression.${tempMultiDelimitComplexTest}"""
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
-        sql """drop catalog if exists ${catalog_name}"""
     }
 }

--- a/regression-test/suites/external_table_p0/hive/test_prepare_hive_data_in_case.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_prepare_hive_data_in_case.groovy
@@ -25,36 +25,39 @@ suite("test_prepare_hive_data_in_case", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalogName = "test_prepare_hive_data_in_case"
+        String tableName = "test_prepare_hive_data_in_case"
         try {
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
 
             hive_docker """show databases;"""
-            hive_docker """drop table if exists default.test_prepare_hive_data_in_case;  """
+            hive_docker """drop table if exists default.${tableName};"""
             hive_docker """
-                            create table default.test_prepare_hive_data_in_case (k1 String, k2 String); 
+                            create table default.${tableName} (k1 String, k2 String);
                         """
-            hive_docker """insert into default.test_prepare_hive_data_in_case values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
-            def values = hive_docker """select count(*) from `default`.test_prepare_hive_data_in_case;"""
-            
+            hive_docker """insert into default.${tableName} values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
+            def values = hive_docker """select count(*) from `default`.${tableName};"""
+
             log.info(values.toString())
 
-            sql """drop catalog if exists test_prepare_hive_data_in_case;"""
-            sql """CREATE CATALOG test_prepare_hive_data_in_case PROPERTIES (
+            sql """drop catalog if exists ${catalogName};"""
+            sql """CREATE CATALOG ${catalogName} PROPERTIES (
                 'type'='hms',
                 'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
             );"""
-            def values2 = sql """select count(*) from test_prepare_hive_data_in_case.`default`.test_prepare_hive_data_in_case;"""
+            def values2 = sql """select count(*) from ${catalogName}.`default`.${tableName};"""
             log.info(values2.toString())
             assertEquals(values[0][0],values2[0][0])
 
             // Execute in Hive in unstable, remove it
             // qt_hive_docker_01 """select * from default.test_prepare_hive_data_in_case order by k1 desc  ;"""
-            
-            qt_sql_02 """ select * from test_prepare_hive_data_in_case.`default`.test_prepare_hive_data_in_case order by k1 desc;"""
+
+            qt_sql_02 """ select * from ${catalogName}.`default`.${tableName} order by k1 desc;"""
 
         } finally {
+            try_sql """drop catalog if exists ${catalogName};"""
+            try_hive_docker """drop table if exists default.${tableName};"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_ctas_to_doris.groovy
@@ -26,6 +26,8 @@ suite("test_hive_ctas_to_doris", "p0,external") {
         }
 
         setHivePrefix(hivePrefix)
+        String catalog = "test_hive_ctas_to_doris"
+        String db_name = "db_test_hive_ctas_to_doris"
         try {
             String str1 = "0123456789" * 6554   // string.length() = 65540
             String str2 = str1.substring(0, 65533)
@@ -33,9 +35,7 @@ suite("test_hive_ctas_to_doris", "p0,external") {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-            String catalog = "test_hive_ctas_to_doris"
             String hive_tb = "tb_test_hive_ctas_to_doris"
-            String db_name = "db_test_hive_ctas_to_doris"
 
             // create hive table
             sql """drop catalog if exists ${catalog}"""
@@ -45,7 +45,7 @@ suite("test_hive_ctas_to_doris", "p0,external") {
             );"""
             sql """ create database if not exists ${catalog}.${db_name} """
             sql """ drop table if exists ${catalog}.${db_name}.${hive_tb}"""
-            sql """ create table ${catalog}.${db_name}.${hive_tb} 
+            sql """ create table ${catalog}.${db_name}.${hive_tb}
                 (id int, str1 string, str2 string, str3 string) """
             sql """ insert into ${catalog}.${db_name}.${hive_tb} values (1, '${str1}', '${str2}', 'str3') """
 
@@ -95,7 +95,8 @@ suite("test_hive_ctas_to_doris", "p0,external") {
             }
 
         } finally {
+            try_sql """drop catalog if exists ${catalog}"""
+            try_sql """drop database if exists internal.${db_name} force"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_insert_overwrite_with_empty_table.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_insert_overwrite_with_empty_table.groovy
@@ -26,13 +26,13 @@ suite("test_hive_insert_overwrite_with_empty_table", "p0,external") {
         }
 
         setHivePrefix(hivePrefix)
+        String catalog = "test_hive_insert_overwrite_with_empty_table"
+        String db1 = catalog + "_db"
         try {
 
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-            String catalog = "test_hive_insert_overwrite_with_empty_table"
-            String db1 = catalog + "_db"
             String tb1 = db1 + "_tb1"
             String tb2 = db1 + "_tb2"
             String tb3 = db1 + "_tb3"
@@ -75,7 +75,8 @@ suite("test_hive_insert_overwrite_with_empty_table", "p0,external") {
             sql """ drop catalog ${catalog} """
 
         } finally {
+            try_sql """ drop catalog if exists ${catalog} """
+            try_hive_docker """ drop database if exists ${db1} cascade """
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_text_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_text_write_insert.groovy
@@ -883,10 +883,10 @@ suite("test_hive_text_write_insert", "p0,external") {
 
     for (String hivePrefix : ["hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "test_${hivePrefix}_text_write_insert"
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_text_write_insert"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""
@@ -914,7 +914,9 @@ suite("test_hive_text_write_insert", "p0,external") {
             sql """set hive_text_compression = 'uncompresssed';"""
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            try_hive_docker """truncate table all_types_text"""
+            try_hive_docker """drop table if exists all_types_par_text_q3"""
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_different_path.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_different_path.groovy
@@ -26,15 +26,14 @@ suite("test_hive_write_different_path", "p0,external") {
         }
 
         setHivePrefix(hivePrefix)
+        String catalog1 = "test_${hivePrefix}_write_insert_without_defaultfs"
+        String catalog2 = "test_${hivePrefix}_write_insert_with_hdfs2"
+        String catalog3 = "test_${hivePrefix}_write_insert_with_hdfs3"
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port2 = context.config.otherConfigs.get("hive2HdfsPort")
             String hdfs_port3 = context.config.otherConfigs.get("hive3HdfsPort")
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-
-            String catalog1 = "test_${hivePrefix}_write_insert_without_defaultfs"
-            String catalog2 = "test_${hivePrefix}_write_insert_with_hdfs2"
-            String catalog3 = "test_${hivePrefix}_write_insert_with_hdfs3"
 
             sql """drop catalog if exists ${catalog1}"""
             sql """drop catalog if exists ${catalog2}"""
@@ -101,7 +100,11 @@ suite("test_hive_write_different_path", "p0,external") {
             sql """drop catalog if exists ${catalog3}"""
 
         } finally {
+            try_sql """drop table if exists ${catalog1}.write_test.tb_with_hdfs2"""
+            try_sql """drop table if exists ${catalog1}.write_test.tb_with_hdfs3"""
+            try_sql """drop catalog if exists ${catalog1}"""
+            try_sql """drop catalog if exists ${catalog2}"""
+            try_sql """drop catalog if exists ${catalog3}"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_insert.groovy
@@ -522,7 +522,7 @@ suite("test_hive_write_insert", "p0,external") {
         """
 
         sql """
-        
+
 INSERT INTO all_types_par_${format_compression}_${catalog_name}_q03
         VALUES  (
           1, -- boolean_col
@@ -882,10 +882,10 @@ INSERT INTO all_types_par_${format_compression}_${catalog_name}_q03
 
     for (String hivePrefix : ["hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "test_${hivePrefix}_write_insert"
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_write_insert"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""
@@ -910,7 +910,12 @@ INSERT INTO all_types_par_${format_compression}_${catalog_name}_q03
 
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            for (String format_compression in format_compressions) {
+                try_hive_docker """truncate table all_types_${format_compression}"""
+                try_hive_docker """drop table if exists all_types_par_${format_compression}_${catalog_name}_q03"""
+                try_hive_docker """drop table if exists all_types_par_${format_compression}_${catalog_name}_q04"""
+            }
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }
-

--- a/regression-test/suites/external_table_p0/hive/write/test_hive_write_partitions.groovy
+++ b/regression-test/suites/external_table_p0/hive/write/test_hive_write_partitions.groovy
@@ -214,10 +214,10 @@ suite("test_hive_write_partitions", "p0,external") {
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "test_${hivePrefix}_write_partitions"
         try {
             String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
             String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
-            String catalog_name = "test_${hivePrefix}_write_partitions"
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
             sql """drop catalog if exists ${catalog_name}"""
@@ -242,6 +242,14 @@ suite("test_hive_write_partitions", "p0,external") {
             test_doris_write_hive_partition_table(catalog_name)
             sql """drop catalog if exists ${catalog_name}"""
         } finally {
+            for (String format_compression in format_compressions) {
+                try_hive_docker """drop table if exists write_test.all_types_par_${format_compression}_${catalog_name}_q01"""
+                try_hive_docker """drop table if exists write_test.all_partition_types1_${format_compression}_${catalog_name}_q02"""
+                try_hive_docker """drop table if exists write_test.all_partition_types2_${format_compression}_${catalog_name}_q03"""
+                try_hive_docker """drop table if exists write_test.all_partition_types1_${format_compression}_${catalog_name}_q04"""
+            }
+            try_hive_docker """drop table if exists write_test.test_doris_write_hive_partition_table"""
+            try_sql """drop catalog if exists ${catalog_name}"""
         }
     }
 }

--- a/regression-test/suites/external_table_p0/test_external_and_internal_describe.groovy
+++ b/regression-test/suites/external_table_p0/test_external_and_internal_describe.groovy
@@ -20,6 +20,7 @@ suite("test_external_and_internal_describe", "p0,external") {
 
     String enabled = context.config.otherConfigs.get("enableHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
+        try {
         for (String hivePrefix : ["hive3"]) {
             setHivePrefix(hivePrefix)
             String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
@@ -158,6 +159,10 @@ suite("test_external_and_internal_describe", "p0,external") {
 
 
         sql """unset variable show_column_comment_in_describe;"""
+        } finally {
+            try_hive_docker """drop database if exists test_external_describe cascade"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_sql """drop database if exists internal.test_external_and_internal_describe_db force"""
+        }
     }
 }
-

--- a/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_prepare_hive_data_in_case.groovy
+++ b/regression-test/suites/external_table_p0/trino_connector/hive/test_trino_prepare_hive_data_in_case.groovy
@@ -21,6 +21,8 @@ suite("test_trino_prepare_hive_data_in_case", "p0,external") {
     def catalog_name = "test_trino_prepare_hive_data_in_case"
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         def host_ips = new ArrayList()
+        def tableName = catalog_name
+        def trinoCatalogName = catalog_name
         String[][] backends = sql """ show backends """
         for (def b in backends) {
             host_ips.add(b[1])
@@ -35,33 +37,34 @@ suite("test_trino_prepare_hive_data_in_case", "p0,external") {
             String hms_port = context.config.otherConfigs.get("hive2HmsPort")
 
             hive_docker """show databases;"""
-            hive_docker """drop table if exists default.${catalog_name};  """
+            hive_docker """drop table if exists default.${tableName};"""
             hive_docker """
-                            create table default.${catalog_name} (k1 String, k2 String); 
+                            create table default.${tableName} (k1 String, k2 String);
                         """
-            hive_docker """insert into default.${catalog_name} values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
-            def values = hive_docker """select count(*) from `default`.${catalog_name};"""
-            
+            hive_docker """insert into default.${tableName} values ('aaa','bbb'),('ccc','ddd'),('eee','fff')"""
+            def values = hive_docker """select count(*) from `default`.${tableName};"""
+
             log.info(values.toString())
 
-            sql """drop catalog if exists ${catalog_name};"""
+            sql """drop catalog if exists ${trinoCatalogName};"""
             sql """
-                create catalog if not exists ${catalog_name} properties (
+                create catalog if not exists ${trinoCatalogName} properties (
                     "type"="trino-connector",
                     "trino.connector.name"="hive",
                     'trino.hive.metastore.uri' = 'thrift://${externalEnvIp}:${hms_port}'
                 );
             """
-            def values2 = sql """select count(*) from ${catalog_name}.`default`.${catalog_name};"""
+            def values2 = sql """select count(*) from ${trinoCatalogName}.`default`.${tableName};"""
             log.info(values2.toString())
             assertEquals(values[0][0],values2[0][0])
 
-            qt_hive_docker_01 """select * from default.${catalog_name} order by k1 desc  ;"""
-            
-            qt_sql_02 """ select * from ${catalog_name}.`default`.${catalog_name} order by k1 desc;"""
+            qt_hive_docker_01 """select * from default.${tableName} order by k1 desc  ;"""
+
+            qt_sql_02 """ select * from ${trinoCatalogName}.`default`.${tableName} order by k1 desc;"""
 
         } finally {
+            try_sql """drop catalog if exists ${trinoCatalogName};"""
+            try_hive_docker """drop table if exists default.${tableName};"""
         }
     }
 }
-

--- a/regression-test/suites/mtmv_p0/test_hive_default_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_default_mtmv.groovy
@@ -24,6 +24,8 @@ suite("test_hive_default_mtmv", "p0,external,hive,external_docker,external_docke
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "${hivePrefix}_default_mtmv_test_catalog"
+        try {
         // prepare data in hive
         def hive_database = "mtmv_default_partition_db"
         def hive_table = "test_hive_default_mtmv_t1"
@@ -62,7 +64,6 @@ suite("test_hive_default_mtmv", "p0,external,hive,external_docker,external_docke
 
         // prepare catalog
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name = "${hivePrefix}_default_mtmv_test_catalog"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
         sql """drop catalog if exists ${catalog_name}"""
@@ -109,6 +110,12 @@ suite("test_hive_default_mtmv", "p0,external,hive,external_docker,external_docke
         sql """drop materialized view if exists ${mvName};"""
 
         sql """drop catalog if exists ${catalog_name}"""
+        } finally {
+            try_sql """switch internal"""
+            try_sql """use regression_test_mtmv_p0"""
+            try_sql """drop materialized view if exists test_hive_default_mtmv"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists mtmv_default_partition_db cascade"""
+        }
     }
 }
-

--- a/regression-test/suites/mtmv_p0/test_hive_limit_partition_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_limit_partition_mtmv.groovy
@@ -24,6 +24,8 @@ suite("test_hive_limit_partition_mtmv", "p0,external,hive,external_docker,extern
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "test_${hivePrefix}_limit_partition_mtmv_catalog"
+        try {
         // prepare data in hive
         def hive_database = "test_hive_limit_partition_mtmv_db"
         def hive_table = "partition2"
@@ -76,7 +78,6 @@ suite("test_hive_limit_partition_mtmv", "p0,external,hive,external_docker,extern
 
         // prepare catalog
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name = "test_${hivePrefix}_limit_partition_mtmv_catalog"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
 
@@ -177,6 +178,12 @@ suite("test_hive_limit_partition_mtmv", "p0,external,hive,external_docker,extern
     assertTrue(showPartitionsResult.toString().contains("p_20380101"))
     sql """drop materialized view if exists ${mvName};"""
     sql """drop catalog if exists ${catalog_name}"""
+        } finally {
+            try_sql """switch internal"""
+            try_sql """use regression_test_mtmv_p0"""
+            try_sql """drop materialized view if exists test_hive_limit_partition_mtmv"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists test_hive_limit_partition_mtmv_db cascade"""
+        }
     }
 }
-

--- a/regression-test/suites/mtmv_p0/test_hive_multi_partition_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_multi_partition_mtmv.groovy
@@ -24,6 +24,8 @@ suite("test_hive_multi_partition_mtmv", "p0,external,hive,external_docker,extern
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "test_${hivePrefix}_multi_partition_mtmv_catalog"
+        try {
         // prepare data in hive
         def hive_database = "test_hive_multi_partition_mtmv_db"
         def hive_table = "partition2"
@@ -84,7 +86,6 @@ suite("test_hive_multi_partition_mtmv", "p0,external,hive,external_docker,extern
 
         // prepare catalog
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name = "test_${hivePrefix}_multi_partition_mtmv_catalog"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
         sql """drop catalog if exists ${catalog_name}"""
@@ -258,6 +259,13 @@ suite("test_hive_multi_partition_mtmv", "p0,external,hive,external_docker,extern
         hive_docker """ ${autogather_on_str} """
         sql """drop materialized view if exists ${mvName};"""
         sql """drop catalog if exists ${catalog_name}"""
+        } finally {
+            try_hive_docker """ set hive.stats.column.autogather = true; """
+            try_sql """switch internal"""
+            try_sql """use regression_test_mtmv_p0"""
+            try_sql """drop materialized view if exists test_hive_multi_partition_mtmv"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists test_hive_multi_partition_mtmv_db cascade"""
+        }
     }
 }
-

--- a/regression-test/suites/mtmv_p0/test_hive_pct_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_pct_mtmv.groovy
@@ -29,6 +29,8 @@ suite("test_hive_pct_mtmv", "p0,external,hive,external_docker,external_docker_hi
     String mvDbName = context.config.getDbNameByFile(context.file)
     for (String hivePrefix : ["hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "${hivePrefix}_${suiteName}_catalog"
+        try {
 
         def autogather_off_str = """ set hive.stats.column.autogather = false; """
         def autogather_on_str = """ set hive.stats.column.autogather = true; """
@@ -108,7 +110,6 @@ suite("test_hive_pct_mtmv", "p0,external,hive,external_docker,external_docker_hi
 
         // prepare catalog
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name = "${hivePrefix}_${suiteName}_catalog"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
         sql """drop catalog if exists ${catalog_name}"""
@@ -156,6 +157,13 @@ suite("test_hive_pct_mtmv", "p0,external,hive,external_docker,external_docker_hi
 
         sql """drop materialized view if exists ${mvName};"""
         sql """drop catalog if exists ${catalog_name}"""
+        } finally {
+            try_hive_docker """ set hive.stats.column.autogather = true; """
+            try_sql """switch internal"""
+            try_sql """use ${mvDbName}"""
+            try_sql """drop materialized view if exists ${mvName}"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists ${dbName} cascade"""
+        }
     }
 }
-

--- a/regression-test/suites/mtmv_p0/test_hive_refresh_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_hive_refresh_mtmv.groovy
@@ -24,6 +24,8 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
 
     for (String hivePrefix : ["hive2", "hive3"]) {
         setHivePrefix(hivePrefix)
+        String catalog_name = "${hivePrefix}_refresh_mtmv_test_catalog"
+        try {
         // prepare data in hive
         def hive_database = "mtmv_test_db"
         def hive_table = "test_hive_refresh_mtmv_t1"
@@ -64,7 +66,6 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
 
         // prepare catalog
         String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-        String catalog_name = "${hivePrefix}_refresh_mtmv_test_catalog"
         String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
 
         sql """drop catalog if exists ${catalog_name}"""
@@ -196,6 +197,13 @@ suite("test_hive_refresh_mtmv", "p0,external,hive,external_docker,external_docke
         sql """drop materialized view if exists ${mvName};"""
 
         sql """drop catalog if exists ${catalog_name}"""
+        } finally {
+            try_hive_docker """ set hive.stats.column.autogather = true; """
+            try_sql """switch internal"""
+            try_sql """use regression_test_mtmv_p0"""
+            try_sql """drop materialized view if exists test_hive_refresh_mtmv"""
+            try_sql """drop catalog if exists ${catalog_name}"""
+            try_hive_docker """drop database if exists mtmv_test_db cascade"""
+        }
     }
 }
-

--- a/regression-test/suites/nereids_rules_p0/mv/external_table/mv_contain_external_table.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/external_table/mv_contain_external_table.groovy
@@ -62,7 +62,10 @@ suite("mv_contain_external_table", "p0,external,hive,external_docker,external_do
     PARTITION(o_orderdate='2023-10-18') values(2, 2, 'ok', 109.2, 'c','d',2, 'mm')"""
     def insert_str3 = """ insert into ${hive_database}.${hive_table} 
     PARTITION(o_orderdate='2023-10-19') values(3, 3, 'ok', 99.5, 'a', 'b', 1, 'yy')"""
+    String db = context.config.getDbNameByFile(context.file)
+    def mv_name = suite_name + 'mv_join'
 
+    try {
     hive_docker """ ${autogather_off_str} """
     hive_docker """ ${drop_table_str} """
     hive_docker """ ${drop_database_str} """
@@ -89,7 +92,6 @@ suite("mv_contain_external_table", "p0,external,hive,external_docker,external_do
 
 
     // prepare olap table and data
-    String db = context.config.getDbNameByFile(context.file)
     sql "use ${db}"
     sql "SET enable_nereids_planner=true"
     sql "set runtime_filter_mode=OFF";
@@ -143,7 +145,6 @@ suite("mv_contain_external_table", "p0,external,hive,external_docker,external_do
     order_qt_query_sql """${query_sql}"""
 
     // create mv
-    def mv_name = suite_name + 'mv_join'
     sql """drop materialized view if exists ${mv_name}"""
     sql """
         CREATE MATERIALIZED VIEW ${mv_name}
@@ -197,4 +198,13 @@ suite("mv_contain_external_table", "p0,external,hive,external_docker,external_do
     hive_docker """ ${autogather_on_str} """
     sql """drop materialized view if exists ${mv_name};"""
     sql """drop catalog if exists ${catalog_name}"""
+    } finally {
+        try_hive_docker """ ${autogather_on_str} """
+        try_sql """switch internal"""
+        try_sql """use ${db}"""
+        try_sql """drop materialized view if exists ${mv_name};"""
+        try_sql """drop table if exists lineitem"""
+        try_sql """drop catalog if exists hive_test_mv_rewrite"""
+        try_hive_docker """drop database if exists ${hive_database} cascade"""
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:
Several local Hive external regression suites modify the shared Docker Hive environment and do not reliably restore state when the suite fails. This blocks sequential CI reuse of a prestarted Hive environment. This PR focuses on serial pipeline reuse by adding finally-based cleanup and redirecting a subset of shared write targets to fixed temporary Hive tables.

Scope of this PR:
- local Docker Hive suites only
- target sequential CI reuse, not concurrent Hive sharing
- shared baseline Hive tables remain read-only where needed
- suites use fixed suite-scoped temporary objects where direct shared-table mutation was unsafe

### Release note

None

### Check List (For Author)

- Test: No need to test (only `git diff --check` was run in this environment)
- Behavior changed: Yes (local Hive regression suites now try to restore Docker Hive state after execution)
- Does this need documentation: No
