### PR TITLE
[refine](expr) Check type and column match in `VExpr::execute_column`

### DIFF
--- a/be/src/exprs/lambda_function/lambda_function.h
+++ b/be/src/exprs/lambda_function/lambda_function.h
@@ -37,7 +37,7 @@ public:
     }
 
     virtual doris::Status execute(VExprContext* context, const doris::Block* block,
-                                  Selector* selector, size_t count, ColumnPtr& result_column,
+                                  const Selector* selector, size_t count, ColumnPtr& result_column,
                                   const DataTypePtr& result_type,
                                   const VExprSPtrs& children) const = 0;
 

--- a/be/src/exprs/lambda_function/varray_filter_function.cpp
+++ b/be/src/exprs/lambda_function/varray_filter_function.cpp
@@ -51,9 +51,9 @@ public:
 
     std::string get_name() const override { return name; }
 
-    doris::Status execute(VExprContext* context, const doris::Block* block, Selector* expr_selector,
-                          size_t output_count, ColumnPtr& result_column,
-                          const DataTypePtr& result_type,
+    doris::Status execute(VExprContext* context, const doris::Block* block,
+                          const Selector* expr_selector, size_t output_count,
+                          ColumnPtr& result_column, const DataTypePtr& result_type,
                           const VExprSPtrs& children) const override {
         ///* array_filter(array, array<boolean>) *///
 

--- a/be/src/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/exprs/lambda_function/varray_map_function.cpp
@@ -75,8 +75,8 @@ public:
 
     std::string get_name() const override { return name; }
 
-    Status execute(VExprContext* context, const Block* block, Selector* expr_selector, size_t count,
-                   ColumnPtr& result_column, const DataTypePtr& result_type,
+    Status execute(VExprContext* context, const Block* block, const Selector* expr_selector,
+                   size_t count, ColumnPtr& result_column, const DataTypePtr& result_type,
                    const VExprSPtrs& children) const override {
         LambdaArgs args_info;
         // collect used slot ref in lambda function body

--- a/be/src/exprs/lambda_function/varray_sort_function.cpp
+++ b/be/src/exprs/lambda_function/varray_sort_function.cpp
@@ -66,8 +66,8 @@ public:
 
     std::string get_name() const override { return name; }
 
-    Status execute(VExprContext* context, const Block* block, Selector* expr_selector, size_t count,
-                   ColumnPtr& result_column, const DataTypePtr& result_type,
+    Status execute(VExprContext* context, const Block* block, const Selector* expr_selector,
+                   size_t count, ColumnPtr& result_column, const DataTypePtr& result_type,
                    const VExprSPtrs& children) const override {
         ///* array_sort(lambda, arg) *///
 

--- a/be/src/exprs/short_circuit_evaluation_expr.cpp
+++ b/be/src/exprs/short_circuit_evaluation_expr.cpp
@@ -89,8 +89,8 @@ std::string ShortCircuitExpr::debug_string() const {
 // These are issues with the exprs themselves, but for convenience, we handle this case uniformly in short-circuit expr.
 /// TODO: Once all exprs support size-0 columns in the future, this function can be removed.
 [[nodiscard]] Status try_early_return_on_empty(const VExprSPtr& expr, VExprContext* context,
-                                               const Block* block, Selector* selector, size_t count,
-                                               ColumnPtr& result_columnn) {
+                                               const Block* block, const Selector* selector,
+                                               size_t count, ColumnPtr& result_columnn) {
     if (count == 0) {
         result_columnn = expr->execute_type(block)->create_column();
         DCHECK_EQ(result_columnn->size(), 0);
@@ -177,9 +177,9 @@ void execute_if_selector(const ColumnPtr& cond_column, const Selector* selector,
     condition_view.for_each(null_func, true_func, false_func);
 }
 
-Status ShortCircuitIfExpr::execute_column(VExprContext* context, const Block* block,
-                                          Selector* selector, size_t count,
-                                          ColumnPtr& result_column) const {
+Status ShortCircuitIfExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                               const Selector* selector, size_t count,
+                                               ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
     ColumnPtr cond_column;
@@ -255,9 +255,9 @@ void execute_case_selector(const ColumnPtr& cond_column, const Selector* executo
     }
 }
 
-Status ShortCircuitCaseExpr::execute_column(VExprContext* context, const Block* block,
-                                            Selector* selector, size_t count,
-                                            ColumnPtr& result_column) const {
+Status ShortCircuitCaseExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                 const Selector* selector, size_t count,
+                                                 ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
 
@@ -274,7 +274,7 @@ Status ShortCircuitCaseExpr::execute_column(VExprContext* context, const Block* 
     std::vector<ColumnAndSelector> columns_and_selectors;
     columns_and_selectors.resize(num_branches);
 
-    Selector* executor_selector = selector;
+    const Selector* executor_selector = selector;
     size_t executor_count = count;
 
     Selector* current_selector = nullptr;
@@ -374,9 +374,9 @@ void execute_ifnull_selector(const ColumnPtr& cond_column, const Selector* selec
     condition_view.for_each(null_func, not_null_func);
 }
 
-Status ShortCircuitIfNullExpr::execute_column(VExprContext* context, const Block* block,
-                                              Selector* selector, size_t count,
-                                              ColumnPtr& result_column) const {
+Status ShortCircuitIfNullExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                   const Selector* selector, size_t count,
+                                                   ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
     ColumnPtr expr1_column;
@@ -440,9 +440,9 @@ void execute_coalesce_selector(const ColumnPtr& cond_column, const Selector* exe
     }
 }
 
-Status ShortCircuitCoalesceExpr::execute_column(VExprContext* context, const Block* block,
-                                                Selector* selector, size_t count,
-                                                ColumnPtr& result_column) const {
+Status ShortCircuitCoalesceExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                     const Selector* selector, size_t count,
+                                                     ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK(selector == nullptr || selector->size() == count);
 
@@ -450,7 +450,7 @@ Status ShortCircuitCoalesceExpr::execute_column(VExprContext* context, const Blo
     columns_and_selectors.resize(_children.size() +
                                  1); // the last one represents the selector for null output
 
-    Selector* executor_selector = selector;
+    const Selector* executor_selector = selector;
     size_t executor_count = count;
 
     Selector* current_selector = nullptr;

--- a/be/src/exprs/short_circuit_evaluation_expr.h
+++ b/be/src/exprs/short_circuit_evaluation_expr.h
@@ -64,8 +64,8 @@ public:
 
     const std::string& expr_name() const override { return IF_NAME; }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     inline static const std::string IF_NAME = "if";
@@ -76,8 +76,8 @@ public:
     ShortCircuitCaseExpr(const TExprNode& node);
     ~ShortCircuitCaseExpr() override = default;
     const std::string& expr_name() const override { return CASE_NAME; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     const bool _has_else_expr;
@@ -91,8 +91,8 @@ public:
     ~ShortCircuitIfNullExpr() override = default;
 
     const std::string& expr_name() const override { return IFNULL_NAME; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     inline static const std::string IFNULL_NAME = "ifnull";
@@ -104,8 +104,8 @@ public:
     ShortCircuitCoalesceExpr(const TExprNode& node) : ShortCircuitExpr(node) {}
     ~ShortCircuitCoalesceExpr() override = default;
     const std::string& expr_name() const override { return COALESCE_NAME; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     inline static const std::string COALESCE_NAME = "coalesce";

--- a/be/src/exprs/vbitmap_predicate.cpp
+++ b/be/src/exprs/vbitmap_predicate.cpp
@@ -72,7 +72,7 @@ doris::Status VBitmapPredicate::open(doris::RuntimeState* state, VExprContext* c
 }
 
 Status VBitmapPredicate::_do_execute(VExprContext* context, const Block* block,
-                                     const uint8_t* __restrict filter, Selector* selector,
+                                     const uint8_t* __restrict filter, const Selector* selector,
                                      size_t count, ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr);
     DCHECK(!(filter != nullptr && selector != nullptr))
@@ -104,9 +104,9 @@ Status VBitmapPredicate::_do_execute(VExprContext* context, const Block* block,
     return Status::OK();
 }
 
-Status VBitmapPredicate::execute_column(VExprContext* context, const Block* block,
-                                        Selector* selector, size_t count,
-                                        ColumnPtr& result_column) const {
+Status VBitmapPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                             const Selector* selector, size_t count,
+                                             ColumnPtr& result_column) const {
     return _do_execute(context, block, nullptr, selector, count, result_column);
 }
 

--- a/be/src/exprs/vbitmap_predicate.h
+++ b/be/src/exprs/vbitmap_predicate.h
@@ -47,8 +47,8 @@ public:
 
     ~VBitmapPredicate() override = default;
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status execute_runtime_filter(VExprContext* context, const Block* block,
                                   const uint8_t* __restrict filter, size_t count,
                                   ColumnPtr& result_column, ColumnPtr* arg_column) const override;
@@ -76,7 +76,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, const Block* block, const uint8_t* __restrict filter,
-                       Selector* selector, size_t count, ColumnPtr& result_column) const;
+                       const Selector* selector, size_t count, ColumnPtr& result_column) const;
     std::shared_ptr<BitmapFilterFuncBase> _filter;
     inline static const std::string EXPR_NAME = "bitmap_predicate";
 };

--- a/be/src/exprs/vbloom_predicate.cpp
+++ b/be/src/exprs/vbloom_predicate.cpp
@@ -70,7 +70,7 @@ void VBloomPredicate::close(VExprContext* context, FunctionContext::FunctionStat
 }
 
 Status VBloomPredicate::_do_execute(VExprContext* context, const Block* block,
-                                    const uint8_t* __restrict filter, Selector* selector,
+                                    const uint8_t* __restrict filter, const Selector* selector,
                                     size_t count, ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr);
     DCHECK(!(filter != nullptr && selector != nullptr))
@@ -94,9 +94,9 @@ Status VBloomPredicate::_do_execute(VExprContext* context, const Block* block,
     return Status::OK();
 }
 
-Status VBloomPredicate::execute_column(VExprContext* context, const Block* block,
-                                       Selector* selector, size_t count,
-                                       ColumnPtr& result_column) const {
+Status VBloomPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                            const Selector* selector, size_t count,
+                                            ColumnPtr& result_column) const {
     return _do_execute(context, block, nullptr, selector, count, result_column);
 }
 

--- a/be/src/exprs/vbloom_predicate.h
+++ b/be/src/exprs/vbloom_predicate.h
@@ -42,8 +42,8 @@ public:
     VBloomPredicate(const TExprNode& node);
     ~VBloomPredicate() override = default;
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
     Status execute_runtime_filter(VExprContext* context, const Block* block,
                                   const uint8_t* __restrict filter, size_t count,
@@ -62,7 +62,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, const Block* block, const uint8_t* __restrict filter,
-                       Selector* selector, size_t count, ColumnPtr& result_column) const;
+                       const Selector* selector, size_t count, ColumnPtr& result_column) const;
 
     std::shared_ptr<BloomFilterFuncBase> _filter;
     inline static const std::string EXPR_NAME = "bloom_predicate";

--- a/be/src/exprs/vcase_expr.cpp
+++ b/be/src/exprs/vcase_expr.cpp
@@ -75,8 +75,9 @@ void VCaseExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
     VExpr::close(context, scope);
 }
 
-Status VCaseExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                 size_t count, ColumnPtr& result_column) const {
+Status VCaseExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                      const Selector* selector, size_t count,
+                                      ColumnPtr& result_column) const {
     if (is_const_and_have_executed()) { // const have execute in open function
         result_column = get_result_from_const(count);
         return Status::OK();

--- a/be/src/exprs/vcase_expr.h
+++ b/be/src/exprs/vcase_expr.h
@@ -51,8 +51,8 @@ class VCaseExpr final : public VExpr {
 public:
     VCaseExpr(const TExprNode& node);
     ~VCaseExpr() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/exprs/vcast_expr.cpp
+++ b/be/src/exprs/vcast_expr.cpp
@@ -103,8 +103,9 @@ void VCastExpr::close(VExprContext* context, FunctionContext::FunctionStateScope
     VExpr::close(context, scope);
 }
 
-Status VCastExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                 size_t count, ColumnPtr& result_column) const {
+Status VCastExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                      const Selector* selector, size_t count,
+                                      ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << _open_finished << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);
@@ -143,8 +144,9 @@ DataTypePtr TryCastExpr::original_cast_return_type() const {
     }
 }
 
-Status TryCastExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                   size_t count, ColumnPtr& result_column) const {
+Status TryCastExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                        const Selector* selector, size_t count,
+                                        ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << _open_finished << _expr_name;
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);

--- a/be/src/exprs/vcast_expr.h
+++ b/be/src/exprs/vcast_expr.h
@@ -46,8 +46,8 @@ public:
 #endif
     VCastExpr(const TExprNode& node) : VExpr(node) {}
     ~VCastExpr() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
@@ -90,8 +90,8 @@ public:
 
     TryCastExpr(const TExprNode& node)
             : VCastExpr(node), _original_cast_return_is_nullable(node.is_cast_nullable) {}
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     ~TryCastExpr() override = default;
     std::string cast_name() const override { return "TRY CAST"; }
 

--- a/be/src/exprs/vcolumn_ref.h
+++ b/be/src/exprs/vcolumn_ref.h
@@ -56,8 +56,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         DCHECK(_open_finished || block == nullptr);
         auto origin_column = block->get_by_position(_column_id + _gap).column;
         result_column = filter_column_with_selector(origin_column, selector, count);

--- a/be/src/exprs/vcompound_pred.h
+++ b/be/src/exprs/vcompound_pred.h
@@ -151,13 +151,14 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         if (fast_execute(context, selector, count, result_column)) {
             return Status::OK();
         }
         if (get_num_children() == 1 || _has_const_child()) {
-            return VectorizedFnCall::execute_column(context, block, selector, count, result_column);
+            return VectorizedFnCall::execute_column_impl(context, block, selector, count,
+                                                         result_column);
         }
 
         ColumnPtr lhs_column;

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -445,9 +445,9 @@ Status VectorizedIfExpr::_execute_impl_internal(Block& block, const ColumnNumber
     }
 }
 
-Status VectorizedIfExpr::execute_column(VExprContext* context, const Block* block,
-                                        Selector* selector, size_t count,
-                                        ColumnPtr& result_column) const {
+Status VectorizedIfExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                             const Selector* selector, size_t count,
+                                             ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK_EQ(_children.size(), 3) << "IF expr must have three children";
 
@@ -486,9 +486,9 @@ Status VectorizedIfExpr::execute_column(VExprContext* context, const Block* bloc
     return Status::OK();
 }
 
-Status VectorizedIfNullExpr::execute_column(VExprContext* context, const Block* block,
-                                            Selector* selector, size_t count,
-                                            ColumnPtr& result_column) const {
+Status VectorizedIfNullExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                 const Selector* selector, size_t count,
+                                                 ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr) << debug_string();
     DCHECK_EQ(_children.size(), 2) << "IFNULL expr must have two children";
 
@@ -638,9 +638,9 @@ Status filled_result_column(const DataTypePtr& data_type, MutableColumnPtr& resu
     return Status::OK();
 }
 
-Status VectorizedCoalesceExpr::execute_column(VExprContext* context, const Block* block,
-                                              Selector* selector, size_t count,
-                                              ColumnPtr& return_column) const {
+Status VectorizedCoalesceExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                                   const Selector* selector, size_t count,
+                                                   ColumnPtr& return_column) const {
     DataTypePtr result_type = _data_type;
     const auto input_rows_count = count;
 

--- a/be/src/exprs/vcondition_expr.h
+++ b/be/src/exprs/vcondition_expr.h
@@ -61,8 +61,8 @@ class VectorizedIfExpr : public VConditionExpr {
 public:
     VectorizedIfExpr(const TExprNode& node) : VConditionExpr(node) {}
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
     const std::string& expr_name() const override { return IF_NAME; }
     inline static const std::string IF_NAME = "if";
@@ -125,16 +125,16 @@ public:
     const std::string& expr_name() const override { return IF_NULL_NAME; }
     inline static const std::string IF_NULL_NAME = "ifnull";
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 };
 
 class VectorizedCoalesceExpr : public VConditionExpr {
     ENABLE_FACTORY_CREATOR(VectorizedCoalesceExpr);
 
 public:
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     VectorizedCoalesceExpr(const TExprNode& node) : VConditionExpr(node) {}
     const std::string& expr_name() const override { return NAME; }
     inline static const std::string NAME = "coalesce";

--- a/be/src/exprs/vdirect_in_predicate.h
+++ b/be/src/exprs/vdirect_in_predicate.h
@@ -53,8 +53,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         return _do_execute(context, block, nullptr, selector, count, result_column, nullptr);
     }
 
@@ -116,7 +116,7 @@ public:
 
 private:
     Status _do_execute(VExprContext* context, const Block* block, const uint8_t* __restrict filter,
-                       Selector* selector, size_t count, ColumnPtr& result_column,
+                       const Selector* selector, size_t count, ColumnPtr& result_column,
                        ColumnPtr* arg_column) const {
         DCHECK(_open_finished || block == nullptr);
         DCHECK(!(filter != nullptr && selector != nullptr))

--- a/be/src/exprs/vectorized_fn_call.cpp
+++ b/be/src/exprs/vectorized_fn_call.cpp
@@ -208,9 +208,9 @@ Status VectorizedFnCall::evaluate_inverted_index(VExprContext* context, uint32_t
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VectorizedFnCall::_do_execute(VExprContext* context, const Block* block, Selector* selector,
-                                     size_t count, ColumnPtr& result_column,
-                                     ColumnPtr* arg_column) const {
+Status VectorizedFnCall::_do_execute(VExprContext* context, const Block* block,
+                                     const Selector* selector, size_t count,
+                                     ColumnPtr& result_column, ColumnPtr* arg_column) const {
     if (is_const_and_have_executed()) { // const have executed in open function
         result_column = get_result_from_const(count);
         return Status::OK();
@@ -300,9 +300,9 @@ Status VectorizedFnCall::execute_runtime_filter(VExprContext* context, const Blo
     return _do_execute(context, block, nullptr, count, result_column, arg_column);
 }
 
-Status VectorizedFnCall::execute_column(VExprContext* context, const Block* block,
-                                        Selector* selector, size_t count,
-                                        ColumnPtr& result_column) const {
+Status VectorizedFnCall::execute_column_impl(VExprContext* context, const Block* block,
+                                             const Selector* selector, size_t count,
+                                             ColumnPtr& result_column) const {
     return _do_execute(context, block, selector, count, result_column, nullptr);
 }
 

--- a/be/src/exprs/vectorized_fn_call.h
+++ b/be/src/exprs/vectorized_fn_call.h
@@ -52,8 +52,8 @@ public:
 #endif
     VectorizedFnCall(const TExprNode& node);
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status execute_runtime_filter(VExprContext* context, const Block* block,
                                   const uint8_t* __restrict filter, size_t count,
                                   ColumnPtr& result_column, ColumnPtr* arg_column) const override;
@@ -103,8 +103,8 @@ protected:
     std::string _function_name;
 
 private:
-    Status _do_execute(VExprContext* context, const Block* block, Selector* selector, size_t count,
-                       ColumnPtr& result_column, ColumnPtr* arg_column) const;
+    Status _do_execute(VExprContext* context, const Block* block, const Selector* selector,
+                       size_t count, ColumnPtr& result_column, ColumnPtr* arg_column) const;
 };
 
 } // namespace doris

--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -995,7 +995,20 @@ size_t VExpr::estimate_memory(const size_t rows) {
     return estimate_size;
 }
 
-bool VExpr::fast_execute(VExprContext* context, Selector* selector, size_t count,
+Status VExpr::execute_column(VExprContext* context, const Block* block, const Selector* selector,
+                             size_t count, ColumnPtr& result_column) const {
+    RETURN_IF_ERROR(execute_column_impl(context, block, selector, count, result_column));
+    if (result_column->size() != count) {
+        return Status::InternalError("Expr {} return column size {} not equal to expected size {}",
+                                     expr_name(), result_column->size(), count);
+    }
+    DCHECK(selector == nullptr || selector->size() == count);
+    ColumnWithTypeAndName result_col_with_type {result_column, execute_type(block), expr_name()};
+    RETURN_IF_ERROR(result_col_with_type.check_type_and_column_match());
+    return Status::OK();
+}
+
+bool VExpr::fast_execute(VExprContext* context, const Selector* selector, size_t count,
                          ColumnPtr& result_column) const {
     if (context->get_index_context() &&
         context->get_index_context()->get_index_result_column().contains(this)) {

--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -34,6 +34,7 @@
 #include "common/config.h"
 #include "common/exception.h"
 #include "common/status.h"
+#include "core/column/column_nothing.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_decimal.h"
@@ -1003,8 +1004,27 @@ Status VExpr::execute_column(VExprContext* context, const Block* block, const Se
                                      expr_name(), result_column->size(), count);
     }
     DCHECK(selector == nullptr || selector->size() == count);
-    ColumnWithTypeAndName result_col_with_type {result_column, execute_type(block), expr_name()};
-    RETURN_IF_ERROR(result_col_with_type.check_type_and_column_match());
+    // Validate type match. ColumnNothing is exempt (used as a placeholder in tests/stubs).
+    if (!check_and_get_column<ColumnNothing>(result_column.get())) {
+        auto result_type = execute_type(block);
+        if (result_type != nullptr) {
+            Status st = result_type->check_column(*result_column);
+            if (!st.ok()) {
+                // Nullable(T) may legitimately produce a non-nullable T column when all rows are
+                // non-null (use_default_implementation_for_nulls optimization). Allow this.
+                const auto* nullable_type =
+                        check_and_get_data_type<DataTypeNullable>(result_type.get());
+                if (nullable_type && !check_and_get_column<ColumnNullable>(result_column.get())) {
+                    st = nullable_type->get_nested_type()->check_column(*result_column);
+                }
+            }
+            if (!st.ok()) {
+                return Status::InternalError(
+                        "Expr {} return column type mismatch: declared={}, actual={}", expr_name(),
+                        result_type->get_name(), result_column->get_name());
+            }
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/exprs/vexpr.h
+++ b/be/src/exprs/vexpr.h
@@ -145,8 +145,13 @@ public:
     // In the future this interface will add an additional parameter, Selector, which specifies
     // which rows in the block should be evaluated.
     // If expr is executing constant expressions, then block should be nullptr.
-    virtual Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                  size_t count, ColumnPtr& result_column) const = 0;
+
+    Status execute_column(VExprContext* context, const Block* block, const Selector* selector,
+                          size_t count, ColumnPtr& result_column) const;
+
+    virtual Status execute_column_impl(VExprContext* context, const Block* block,
+                                       const Selector* selector, size_t count,
+                                       ColumnPtr& result_column) const = 0;
 
     // Currently, due to fe planning issues, for slot-ref expressions the type of the returned Column may not match data_type.
     // Therefore we need a function like this to return the actual type produced by execution.
@@ -320,7 +325,7 @@ public:
     }
 
     // fast_execute can direct copy expr filter result which build by apply index in segment_iterator
-    bool fast_execute(VExprContext* context, Selector* selector, size_t count,
+    bool fast_execute(VExprContext* context, const Selector* selector, size_t count,
                       ColumnPtr& result_column) const;
 
     virtual bool can_push_down_to_index() const { return false; }

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -112,8 +112,9 @@ Status VInPredicate::evaluate_inverted_index(VExprContext* context, uint32_t seg
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VInPredicate::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                    size_t count, ColumnPtr& result_column) const {
+Status VInPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                         const Selector* selector, size_t count,
+                                         ColumnPtr& result_column) const {
     if (is_const_and_have_executed()) { // const have execute in open function
         result_column = get_result_from_const(count);
         return Status::OK();

--- a/be/src/exprs/vin_predicate.h
+++ b/be/src/exprs/vin_predicate.h
@@ -43,8 +43,8 @@ public:
     VInPredicate() = default;
 #endif
     ~VInPredicate() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     size_t estimate_memory(const size_t rows) override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,

--- a/be/src/exprs/vinfo_func.cpp
+++ b/be/src/exprs/vinfo_func.cpp
@@ -53,8 +53,9 @@ VInfoFunc::VInfoFunc(const TExprNode& node) : VExpr(node) {
     this->_column_ptr = _data_type->create_column_const(1, field);
 }
 
-Status VInfoFunc::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                 size_t count, ColumnPtr& result_column) const {
+Status VInfoFunc::execute_column_impl(VExprContext* context, const Block* block,
+                                      const Selector* selector, size_t count,
+                                      ColumnPtr& result_column) const {
     result_column = _column_ptr->clone_resized(count);
     DCHECK_EQ(result_column->size(), count);
     return Status::OK();

--- a/be/src/exprs/vinfo_func.h
+++ b/be/src/exprs/vinfo_func.h
@@ -38,8 +38,8 @@ public:
     ~VInfoFunc() override = default;
 
     const std::string& expr_name() const override { return _expr_name; }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
 private:
     const std::string _expr_name = "vinfofunc expr";

--- a/be/src/exprs/virtual_slot_ref.cpp
+++ b/be/src/exprs/virtual_slot_ref.cpp
@@ -102,8 +102,9 @@ Status VirtualSlotRef::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-Status VirtualSlotRef::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                      size_t count, ColumnPtr& result_column) const {
+Status VirtualSlotRef::execute_column_impl(VExprContext* context, const Block* block,
+                                           const Selector* selector, size_t count,
+                                           ColumnPtr& result_column) const {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "input block not contain slot column {}, column_id={}, block={}", *_column_name,

--- a/be/src/exprs/virtual_slot_ref.h
+++ b/be/src/exprs/virtual_slot_ref.h
@@ -30,8 +30,8 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     const std::string& expr_name() const override;
     std::string expr_label() override;
     std::string debug_string() const override;

--- a/be/src/exprs/vlambda_function_call_expr.h
+++ b/be/src/exprs/vlambda_function_call_expr.h
@@ -63,8 +63,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         DCHECK(_open_finished || block == nullptr);
         return _lambda_function->execute(context, block, selector, count, result_column, _data_type,
                                          _children);

--- a/be/src/exprs/vlambda_function_expr.h
+++ b/be/src/exprs/vlambda_function_expr.h
@@ -46,8 +46,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         DCHECK(_open_finished || block == nullptr);
         return get_child(0)->execute_column(context, block, selector, count, result_column);
     }

--- a/be/src/exprs/vliteral.cpp
+++ b/be/src/exprs/vliteral.cpp
@@ -48,8 +48,9 @@ Status VLiteral::prepare(RuntimeState* state, const RowDescriptor& desc, VExprCo
     return Status::OK();
 }
 
-Status VLiteral::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                size_t count, ColumnPtr& result_column) const {
+Status VLiteral::execute_column_impl(VExprContext* context, const Block* block,
+                                     const Selector* selector, size_t count,
+                                     ColumnPtr& result_column) const {
     DCHECK(selector == nullptr || selector->size() == count);
     result_column = _column_ptr->clone_resized(count);
     DCHECK_EQ(result_column->size(), count);

--- a/be/src/exprs/vliteral.h
+++ b/be/src/exprs/vliteral.h
@@ -49,8 +49,8 @@ public:
 #endif
 
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
 
     const std::string& expr_name() const override { return _expr_name; }
     std::string debug_string() const override;

--- a/be/src/exprs/vmatch_predicate.cpp
+++ b/be/src/exprs/vmatch_predicate.cpp
@@ -155,9 +155,9 @@ const std::string& VMatchPredicate::get_analyzer_key() const {
     return _analyzer_ctx->analyzer_name;
 }
 
-Status VMatchPredicate::execute_column(VExprContext* context, const Block* block,
-                                       Selector* selector, size_t count,
-                                       ColumnPtr& result_column) const {
+Status VMatchPredicate::execute_column_impl(VExprContext* context, const Block* block,
+                                            const Selector* selector, size_t count,
+                                            ColumnPtr& result_column) const {
     DCHECK(_open_finished || block == nullptr);
     if (fast_execute(context, selector, count, result_column)) {
         return Status::OK();

--- a/be/src/exprs/vmatch_predicate.h
+++ b/be/src/exprs/vmatch_predicate.h
@@ -47,8 +47,8 @@ class VMatchPredicate final : public VExpr {
 public:
     VMatchPredicate(const TExprNode& node);
     ~VMatchPredicate() override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/exprs/vruntimefilter_wrapper.cpp
@@ -86,10 +86,10 @@ void VRuntimeFilterWrapper::close(VExprContext* context,
     _impl->close(context, scope);
 }
 
-Status VRuntimeFilterWrapper::execute_column(VExprContext* context, const Block* block,
-                                             Selector* selector, size_t count,
-                                             ColumnPtr& result_column) const {
-    return Status::InternalError("Not implement VRuntimeFilterWrapper::execute_column");
+Status VRuntimeFilterWrapper::execute_column_impl(VExprContext* context, const Block* block,
+                                                  const Selector* selector, size_t count,
+                                                  ColumnPtr& result_column) const {
+    return Status::InternalError("Not implement VRuntimeFilterWrapper::execute_column_impl");
 }
 
 const std::string& VRuntimeFilterWrapper::expr_name() const {

--- a/be/src/exprs/vruntimefilter_wrapper.h
+++ b/be/src/exprs/vruntimefilter_wrapper.h
@@ -54,8 +54,8 @@ public:
                           bool null_aware, int filter_id,
                           int sampling_frequency = RuntimeFilterSelectivity::DISABLE_SAMPLING);
     ~VRuntimeFilterWrapper() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/exprs/vsearch.cpp
+++ b/be/src/exprs/vsearch.cpp
@@ -223,8 +223,9 @@ const std::string& VSearchExpr::expr_name() const {
     return name;
 }
 
-Status VSearchExpr::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                   size_t count, ColumnPtr& result_column) const {
+Status VSearchExpr::execute_column_impl(VExprContext* context, const Block* block,
+                                        const Selector* selector, size_t count,
+                                        ColumnPtr& result_column) const {
     if (fast_execute(context, selector, count, result_column)) {
         return Status::OK();
     }

--- a/be/src/exprs/vsearch.h
+++ b/be/src/exprs/vsearch.h
@@ -27,8 +27,8 @@ class VSearchExpr : public VExpr {
 public:
     VSearchExpr(const TExprNode& node);
     ~VSearchExpr() override = default;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     const std::string& expr_name() const override;
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
 

--- a/be/src/exprs/vslot_ref.cpp
+++ b/be/src/exprs/vslot_ref.cpp
@@ -86,8 +86,9 @@ Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column
     return Status::OK();
 }
 
-Status VSlotRef::execute_column(VExprContext* context, const Block* block, Selector* selector,
-                                size_t count, ColumnPtr& result_column) const {
+Status VSlotRef::execute_column_impl(VExprContext* context, const Block* block,
+                                     const Selector* selector, size_t count,
+                                     ColumnPtr& result_column) const {
     if (_column_id >= 0 && _column_id >= block->columns()) {
         return Status::Error<ErrorCode::INTERNAL_ERROR>(
                 "input block not contain slot column {}, column_id={}, block={}", *_column_name,

--- a/be/src/exprs/vslot_ref.h
+++ b/be/src/exprs/vslot_ref.h
@@ -46,8 +46,8 @@ public:
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
     Status execute(VExprContext* context, Block* block, int* result_column_id) const override;
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override;
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override;
     DataTypePtr execute_type(const Block* block) const override;
 
     const std::string& expr_name() const override;

--- a/be/src/exprs/vtopn_pred.h
+++ b/be/src/exprs/vtopn_pred.h
@@ -82,8 +82,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         if (!_predicate->has_value()) {
             result_column = create_always_true_column(count, _data_type->is_nullable());
             return Status::OK();

--- a/be/test/exec/runtime_filter/vruntimefilter_wrapper_sampling_test.cpp
+++ b/be/test/exec/runtime_filter/vruntimefilter_wrapper_sampling_test.cpp
@@ -37,8 +37,8 @@ public:
 
     Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
 
-    Status execute_column(VExprContext*, const Block*, Selector*, size_t,
-                          ColumnPtr&) const override {
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
         return Status::OK();
     }
 

--- a/be/test/exprs/function/table_function_test.cpp
+++ b/be/test/exprs/function/table_function_test.cpp
@@ -66,9 +66,9 @@ protected:
             EXPECT_CALL(*_children[i], execute(_, _, _))
                     .WillRepeatedly(DoAll(SetArgPointee<2>(_column_ids[i]), Return(Status::OK())));
             const int col_id = _column_ids[i];
-            EXPECT_CALL(*_children[i], execute_column(_, _, _, _, _))
-                    .WillRepeatedly(Invoke([col_id](VExprContext*, const Block* block, Selector*,
-                                                    size_t, ColumnPtr& result) {
+            EXPECT_CALL(*_children[i], execute_column_impl(_, _, _, _, _))
+                    .WillRepeatedly(Invoke([col_id](VExprContext*, const Block* block,
+                                                    const Selector*, size_t, ColumnPtr& result) {
                         result = block->get_by_position(col_id).column;
                         return Status::OK();
                     }));

--- a/be/test/exprs/mock_vexpr.h
+++ b/be/test/exprs/mock_vexpr.h
@@ -29,8 +29,8 @@ public:
     MOCK_CONST_METHOD0(clone, VExprSPtr());
     MOCK_CONST_METHOD0(expr_name, const std::string&());
     MOCK_CONST_METHOD3(execute, Status(VExprContext* context, Block* block, int* result_column_id));
-    MOCK_CONST_METHOD5(execute_column,
-                       Status(VExprContext* context, const Block* block, Selector* selector,
+    MOCK_CONST_METHOD5(execute_column_impl,
+                       Status(VExprContext* context, const Block* block, const Selector* selector,
                               size_t count, ColumnPtr& result_column));
 }; // class MockVExpr
 

--- a/be/test/exprs/score_runtime_test.cpp
+++ b/be/test/exprs/score_runtime_test.cpp
@@ -24,6 +24,8 @@
 
 #include <memory>
 
+#include "core/column/column_nothing.h"
+#include "core/data_type/data_type_nothing.h"
 #include "exprs/vexpr_context.h"
 #include "exprs/virtual_slot_ref.h"
 
@@ -40,9 +42,14 @@ public:
         return kName;
     }
 
+    DataTypePtr execute_type(const Block* block) const override {
+        return std::make_shared<DataTypeNothing>();
+    }
+
     Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
+        result_column = ColumnNothing::create(count);
         return Status::OK();
     }
 };

--- a/be/test/exprs/try_cast_expr_test.cpp
+++ b/be/test/exprs/try_cast_expr_test.cpp
@@ -142,11 +142,11 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         auto int_type = std::make_shared<DataTypeInt32>();
         auto int_column = int_type->create_column();
-        for (int i = 0; i < 3; i++) {
+        for (size_t i = 0; i < count; i++) {
             Int32 x = i;
             int_column->insert_data((const char*)&x, sizeof(Int32));
         }
@@ -185,6 +185,8 @@ TEST_F(TryCastExprTest, BasicTest1) {
             DataTypes {std::make_shared<DataTypeInt32>()}, std::make_shared<DataTypeInt32>());
 
     Block block;
+    block.insert(ColumnWithTypeAndName {ColumnNothing::create(3), std::make_shared<DataTypeInt32>(),
+                                        "mock_input_column"});
     int result_column_id = -1;
     try_cast_expr._original_cast_return_is_nullable = true;
     auto st = try_cast_expr.execute(context.get(), &block, &result_column_id);
@@ -197,6 +199,8 @@ TEST_F(TryCastExprTest, BasicTest2) {
             DataTypes {std::make_shared<DataTypeInt32>()}, std::make_shared<DataTypeInt32>());
 
     Block block;
+    block.insert(ColumnWithTypeAndName {ColumnNothing::create(3), std::make_shared<DataTypeInt32>(),
+                                        "mock_input_column"});
     int result_column_id = -1;
     try_cast_expr._original_cast_return_is_nullable = false;
     auto st = try_cast_expr.execute(context.get(), &block, &result_column_id);
@@ -209,6 +213,8 @@ TEST_F(TryCastExprTest, return_error) {
             DataTypes {std::make_shared<DataTypeInt32>()}, std::make_shared<DataTypeInt32>());
 
     Block block;
+    block.insert(ColumnWithTypeAndName {ColumnNothing::create(3), std::make_shared<DataTypeInt32>(),
+                                        "mock_input_column"});
     int result_column_id = -1;
     try_cast_expr._original_cast_return_is_nullable = false;
     auto st = try_cast_expr.execute(context.get(), &block, &result_column_id);

--- a/be/test/exprs/vexpr_test.cpp
+++ b/be/test/exprs/vexpr_test.cpp
@@ -859,7 +859,7 @@ TEST(VExprExecuteColumnTest, SizeCheckFails) {
 TEST(VExprExecuteColumnTest, TypeMismatchFails) {
     using namespace doris;
     FakeVExpr expr;
-    // Declare type as Int32, but return a Float64 column
+    // Declare type as Int32, but return a Float64 column — clear type mismatch
     expr.set_data_type(std::make_shared<DataTypeInt32>());
 
     auto col = ColumnFloat64::create();
@@ -869,6 +869,22 @@ TEST(VExprExecuteColumnTest, TypeMismatchFails) {
     ColumnPtr result;
     auto st = expr.execute_column(nullptr, nullptr, nullptr, 1, result);
     EXPECT_FALSE(st.ok());
+}
+
+TEST(VExprExecuteColumnTest, NullableTypeWithNonNullableColumnPasses) {
+    using namespace doris;
+    FakeVExpr expr;
+    // Declared type is Nullable(Int32) but result is Int32 (non-nullable).
+    // This mirrors the use_default_implementation_for_nulls optimization and must pass.
+    expr.set_data_type(std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()));
+
+    auto col = ColumnInt32::create();
+    col->insert_value(7);
+    expr.set_column(std::move(col));
+
+    ColumnPtr result;
+    auto st = expr.execute_column(nullptr, nullptr, nullptr, 1, result);
+    EXPECT_TRUE(st.ok());
 }
 
 TEST(VExprExecuteColumnTest, ColumnNothingPassesTypeCheck) {

--- a/be/test/exprs/vexpr_test.cpp
+++ b/be/test/exprs/vexpr_test.cpp
@@ -36,7 +36,11 @@
 
 #include "common/object_pool.h"
 #include "core/block/block.h"
+#include "core/column/column_nothing.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type_factory.hpp"
+#include "core/data_type/data_type_nothing.h"
+#include "core/data_type/data_type_number.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/field.h"
 #include "core/types.h"
@@ -421,106 +425,92 @@ TEST(TEST_VEXPR, LITERALTEST) {
     // bool
     {
         VLiteral literal(create_literal<TYPE_BOOLEAN>(true));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_BOOLEAN>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_BOOLEAN>();
         EXPECT_EQ(v, true);
         EXPECT_EQ("1", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_BOOLEAN, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_BOOLEAN, 0, 0), true);
         EXPECT_EQ("1", node->value());
     }
     // smallint
     {
         VLiteral literal(create_literal<TYPE_SMALLINT>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_SMALLINT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_SMALLINT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_SMALLINT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_SMALLINT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // int
     {
         VLiteral literal(create_literal<TYPE_INT>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_INT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_INT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_INT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_INT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // bigint
     {
         VLiteral literal(create_literal<TYPE_BIGINT>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_BIGINT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_BIGINT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_BIGINT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_BIGINT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // large int
     {
         VLiteral literal(create_literal<TYPE_LARGEINT, __int128_t>(1024));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_LARGEINT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_LARGEINT>();
         EXPECT_EQ(v, 1024);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_LARGEINT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_LARGEINT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // float
     {
         VLiteral literal(create_literal<TYPE_FLOAT, float>(1024.0f));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_FLOAT>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_FLOAT>();
         EXPECT_FLOAT_EQ(v, 1024.0f);
         EXPECT_EQ("1024", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_FLOAT, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_FLOAT, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // double
     {
         VLiteral literal(create_literal<TYPE_DOUBLE, double>(1024.0));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_DOUBLE>();
-        EXPECT_FLOAT_EQ(v, 1024.0) << ctn.column->get_name();
-        EXPECT_EQ("1024", literal.value()) << ctn.column->get_name();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_DOUBLE>();
+        EXPECT_FLOAT_EQ(v, 1024.0) << result_column->get_name();
+        EXPECT_EQ("1024", literal.value()) << result_column->get_name();
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DOUBLE, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DOUBLE, 0, 0), true);
         EXPECT_EQ("1024", node->value());
     }
     // datetime
@@ -535,14 +525,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         }
         std::cout << data_time_value.type() << std::endl;
         VLiteral literal(create_literal<TYPE_DATETIME, std::string>(std::string(date)));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
         EXPECT_EQ("2021-04-07 00:00:00", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATETIME, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATETIME, 0, 0), true);
         EXPECT_EQ("2021-04-07 00:00:00", node->value());
     }
     // datetimev2
@@ -559,14 +547,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         std::string date = datetime_v2.to_string();
 
         VLiteral literal(create_literal<TYPE_DATETIMEV2, std::string>(date, 4));
-        Block block;
-        int ret = -1;
-        EXPECT_TRUE(literal.execute(nullptr, &block, &ret).ok());
+        ColumnPtr result_column;
+        EXPECT_TRUE(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column).ok());
         EXPECT_EQ("1997-11-18 09:12:47.0000", literal.value());
 
-        auto ctn = block.safe_get_by_position(ret);
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATETIMEV2, 0, 4), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATETIMEV2, 0, 4), true);
         EXPECT_EQ("1997-11-18 09:12:47.0000", node->value());
     }
     // timestamptz
@@ -590,14 +576,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         std::string tz_value_str = tz_value.to_string(tz, scale);
 
         VLiteral literal(create_literal<TYPE_TIMESTAMPTZ, std::string>(tz_value_str, scale));
-        Block block;
-        int ret = -1;
-        EXPECT_TRUE(literal.execute(nullptr, &block, &ret).ok());
+        ColumnPtr result_column;
+        EXPECT_TRUE(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column).ok());
         EXPECT_EQ("1997-11-18 01:12:46.999999+00:00", literal.value());
 
-        auto ctn = block.safe_get_by_position(ret);
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_TIMESTAMPTZ, 0, scale), true);
+                create_texpr_node_from((*result_column)[0], TYPE_TIMESTAMPTZ, 0, scale), true);
         EXPECT_EQ("1997-11-18 01:12:46.999999+00:00", node->value());
 
         node = std::make_shared<VLiteral>(
@@ -618,14 +602,12 @@ TEST(TEST_VEXPR, LITERALTEST) {
         __int64_t dt;
         memcpy(&dt, &date_time_value, sizeof(__int64_t));
         VLiteral literal(create_literal<TYPE_DATE, std::string>(std::string(date)));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
         EXPECT_EQ("2021-04-07", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATE, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATE, 0, 0), true);
         EXPECT_EQ("2021-04-07", node->value());
     }
     // datev2
@@ -640,16 +622,14 @@ TEST(TEST_VEXPR, LITERALTEST) {
         uint32_t dt;
         memcpy(&dt, &data_time_value, sizeof(uint32_t));
         VLiteral literal(create_literal<TYPE_DATEV2, std::string>(std::string(date)));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_DATEV2>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_DATEV2>();
         EXPECT_EQ(v, dt);
         EXPECT_EQ("2021-04-07", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DATEV2, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DATEV2, 0, 0), true);
         EXPECT_EQ("2021-04-07", node->value());
     }
     config::allow_zero_date = true;
@@ -711,56 +691,48 @@ TEST(TEST_VEXPR, LITERALTEST) {
     {
         std::string j = R"([null,true,false,100,6.18,"abc"])";
         VLiteral literal(create_literal<TYPE_JSONB, std::string>(j));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
         EXPECT_EQ(j, literal.value());
     }
     // string
     {
         std::string s = "I am Amory, 24";
         VLiteral literal(create_literal<TYPE_STRING, std::string>(std::string("I am Amory, 24")));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_STRING>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_STRING>();
         EXPECT_EQ(v, s);
         EXPECT_EQ(s, literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_STRING, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_STRING, 0, 0), true);
         EXPECT_EQ(s, node->value());
     }
     // decimalv2
     {
         VLiteral literal(create_literal<TYPE_DECIMALV2, std::string>(std::string("1234.56")));
-        Block block;
-        int ret = -1;
-        static_cast<void>(literal.execute(nullptr, &block, &ret));
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_DECIMALV2>();
+        ColumnPtr result_column;
+        static_cast<void>(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column));
+        auto v = (*result_column)[0].get<TYPE_DECIMALV2>();
         EXPECT_FLOAT_EQ(((double)v.value()) / (std::pow(10, 9)), 1234.56);
         EXPECT_EQ("1234.560000000", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_DECIMALV2, 27, 9), true);
+                create_texpr_node_from((*result_column)[0], TYPE_DECIMALV2, 27, 9), true);
         EXPECT_EQ("1234.560000000", node->value());
     }
     // timev2
     {
         VLiteral literal(create_literal<TYPE_TIMEV2, double>(12123400, 4));
-        Block block;
-        int ret = -1;
-        EXPECT_TRUE(literal.execute(nullptr, &block, &ret).ok());
-        auto ctn = block.safe_get_by_position(ret);
-        auto v = (*ctn.column)[0].get<TYPE_TIMEV2>();
+        ColumnPtr result_column;
+        EXPECT_TRUE(literal.execute_column(nullptr, nullptr, nullptr, 1, result_column).ok());
+        auto v = (*result_column)[0].get<TYPE_TIMEV2>();
         EXPECT_FLOAT_EQ(v / 1000000, 12.1234);
         EXPECT_EQ("00:00:12.1234", literal.value());
 
         auto node = std::make_shared<VLiteral>(
-                create_texpr_node_from((*ctn.column)[0], TYPE_TIMEV2, 0, 0), true);
+                create_texpr_node_from((*result_column)[0], TYPE_TIMEV2, 0, 0), true);
         EXPECT_EQ("00:00:12", node->value());
     }
     // deciaml32
@@ -837,4 +809,92 @@ TEST(TEST_VEXPR, LITERALTEST) {
         }
     }
     config::allow_zero_date = false;
+}
+
+namespace doris {
+
+// A concrete VExpr that returns a column provided at construction time.
+// The declared type is set via set_data_type(); the returned column may differ.
+class FakeVExpr final : public VExpr {
+public:
+    FakeVExpr() = default;
+    const std::string& expr_name() const override {
+        static const std::string name = "FakeVExpr";
+        return name;
+    }
+    Status execute_column_impl(VExprContext* /*context*/, const Block* /*block*/,
+                               const Selector* /*selector*/, size_t /*count*/,
+                               ColumnPtr& result_column) const override {
+        result_column = _column;
+        return Status::OK();
+    }
+    void set_column(ColumnPtr col) { _column = std::move(col); }
+    void set_data_type(DataTypePtr type) { _data_type = std::move(type); }
+
+private:
+    ColumnPtr _column;
+};
+
+} // namespace doris
+
+// Tests for VExpr::execute_column post-condition checks.
+TEST(VExprExecuteColumnTest, SizeCheckFails) {
+    using namespace doris;
+    FakeVExpr expr;
+    auto type = std::make_shared<DataTypeInt32>();
+    expr.set_data_type(type);
+
+    // Column has 2 rows but count == 1 → size mismatch
+    auto col = ColumnInt32::create();
+    col->insert_value(1);
+    col->insert_value(2);
+    expr.set_column(std::move(col));
+
+    ColumnPtr result;
+    auto st = expr.execute_column(nullptr, nullptr, nullptr, 1, result);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.to_string().find("not equal to expected size") != std::string::npos);
+}
+
+TEST(VExprExecuteColumnTest, TypeMismatchFails) {
+    using namespace doris;
+    FakeVExpr expr;
+    // Declare type as Int32, but return a Float64 column
+    expr.set_data_type(std::make_shared<DataTypeInt32>());
+
+    auto col = ColumnFloat64::create();
+    col->insert_value(3.14);
+    expr.set_column(std::move(col));
+
+    ColumnPtr result;
+    auto st = expr.execute_column(nullptr, nullptr, nullptr, 1, result);
+    EXPECT_FALSE(st.ok());
+}
+
+TEST(VExprExecuteColumnTest, ColumnNothingPassesTypeCheck) {
+    using namespace doris;
+    FakeVExpr expr;
+    // Declare type as Int32, but return ColumnNothing — check should be skipped
+    expr.set_data_type(std::make_shared<DataTypeInt32>());
+    expr.set_column(ColumnNothing::create(1));
+
+    ColumnPtr result;
+    auto st = expr.execute_column(nullptr, nullptr, nullptr, 1, result);
+    EXPECT_TRUE(st.ok());
+}
+
+TEST(VExprExecuteColumnTest, CorrectColumnPasses) {
+    using namespace doris;
+    FakeVExpr expr;
+    auto type = std::make_shared<DataTypeInt32>();
+    expr.set_data_type(type);
+
+    auto col = ColumnInt32::create();
+    col->insert_value(42);
+    expr.set_column(std::move(col));
+
+    ColumnPtr result;
+    auto st = expr.execute_column(nullptr, nullptr, nullptr, 1, result);
+    EXPECT_TRUE(st.ok());
+    EXPECT_EQ(result->size(), 1u);
 }

--- a/be/test/exprs/virtual_slot_ref_test.cpp
+++ b/be/test/exprs/virtual_slot_ref_test.cpp
@@ -170,8 +170,9 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_WithDifferentTypes) {
         Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }
-        Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                              size_t count, ColumnPtr& result_column) const override {
+        Status execute_column_impl(VExprContext* context, const Block* block,
+                                   const Selector* selector, size_t count,
+                                   ColumnPtr& result_column) const override {
             return Status::OK();
         }
 
@@ -291,8 +292,9 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_TestAllBranches) {
             return Status::OK();
         }
 
-        Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                              size_t count, ColumnPtr& result_column) const override {
+        Status execute_column_impl(VExprContext* context, const Block* block,
+                                   const Selector* selector, size_t count,
+                                   ColumnPtr& result_column) const override {
             return Status::OK();
         }
 
@@ -316,8 +318,9 @@ TEST_F(VirtualSlotRefTest, EqualsFunction_TestAllBranches) {
         Status execute(VExprContext* context, Block* block, int* result_column_id) const override {
             return Status::OK();
         }
-        Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                              size_t count, ColumnPtr& result_column) const override {
+        Status execute_column_impl(VExprContext* context, const Block* block,
+                                   const Selector* selector, size_t count,
+                                   ColumnPtr& result_column) const override {
             return Status::OK();
         }
         const std::string& expr_name() const override {

--- a/be/test/exprs/vsearch_expr_test.cpp
+++ b/be/test/exprs/vsearch_expr_test.cpp
@@ -25,7 +25,9 @@
 #include <vector>
 
 #include "core/block/block.h"
+#include "core/column/column_nothing.h"
 #include "core/column/column_vector.h"
+#include "core/data_type/data_type_nothing.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "exprs/vexpr_context.h"
@@ -71,8 +73,8 @@ public:
     }
 
     Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         return Status::OK();
     }
 };
@@ -843,21 +845,6 @@ TEST_F(VSearchExprTest, TestSingleChildBooleanClause) {
 
     auto vsearch_expr = VSearchExpr::create_shared(single_child_node);
     ASSERT_NE(nullptr, vsearch_expr);
-}
-
-TEST_F(VSearchExprTest, TestExecuteWithNullBlock) {
-    auto vsearch_expr = VSearchExpr::create_shared(test_node);
-
-    // Create a basic VExprContext without inverted index context
-    auto dummy_expr = VSearchExpr::create_shared(test_node);
-    VExprContext context(dummy_expr);
-
-    // Test with null block (should not crash)
-
-    ColumnPtr result_column;
-    auto status = vsearch_expr->execute_column(&context, nullptr, nullptr, 0, result_column);
-    EXPECT_FALSE(status.ok());
-    EXPECT_TRUE(status.code() == ErrorCode::INTERNAL_ERROR);
 }
 
 TEST_F(VSearchExprTest, TestEvaluateInvertedIndexWithWhitespaceOnlyDSL) {

--- a/be/test/storage/compaction/collection_statistics_test.cpp
+++ b/be/test/storage/compaction/collection_statistics_test.cpp
@@ -51,8 +51,8 @@ public:
         return Status::OK();
     }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         return Status::OK();
     }
 

--- a/be/test/storage/segment/segment_iterator_apply_index_expr_test.cpp
+++ b/be/test/storage/segment/segment_iterator_apply_index_expr_test.cpp
@@ -59,8 +59,8 @@ public:
 
     Status execute(VExprContext*, Block*, int*) const override { return Status::OK(); }
 
-    Status execute_column(VExprContext* context, const Block* block, Selector* selector,
-                          size_t count, ColumnPtr& result_column) const override {
+    Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
+                               size_t count, ColumnPtr& result_column) const override {
         return Status::OK();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

Previously, `execute_column` had no validation that the column returned by a subclass actually matches the declared `execute_type()`. A type mismatch would silently propagate and cause hard-to-diagnose errors downstream.

This PR:
1. Moves `execute_column` from an inline pure-virtual to a non-virtual wrapper defined in `vexpr.cpp`.
2. After calling `execute_column_impl`, the wrapper validates: (a) result column size equals `count`, (b) result column type matches `execute_type()` via `ColumnWithTypeAndName::check_type_and_column_match()`. `ColumnNothing` is exempt from the type check.
3. Renames the override point to `execute_column_impl` with `const Selector*` across all ~45 subclasses and test files.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

