### PR TITLE
[opt](function) optimize repeat with preallocated fast_repeat path

### DIFF
--- a/be/benchmark/benchmark_string.hpp
+++ b/be/benchmark/benchmark_string.hpp
@@ -175,6 +175,63 @@ struct OldUnHexImpl {
     }
 };
 
+struct OldRepeatImpl {
+    static Status vector_vector(const ColumnString::Chars& data,
+                                const ColumnString::Offsets& offsets,
+                                const ColumnInt32::Container& repeats,
+                                ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                                ColumnUInt8::Container& null_map) {
+        const size_t input_row_size = offsets.size();
+
+        fmt::memory_buffer buffer;
+        res_offsets.resize(input_row_size);
+        null_map.resize_fill(input_row_size, 0);
+        for (size_t i = 0; i < input_row_size; ++i) {
+            buffer.clear();
+            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
+            const size_t size = offsets[i] - offsets[i - 1];
+            const int repeat = repeats[i];
+            if (repeat <= 0) {
+                StringOP::push_empty_string(i, res_data, res_offsets);
+                continue;
+            }
+
+            ColumnString::check_chars_length(static_cast<size_t>(repeat) * size + res_data.size(),
+                                             0);
+            for (int j = 0; j < repeat; ++j) {
+                buffer.append(raw_str, raw_str + size);
+            }
+            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
+                                        res_offsets);
+        }
+        return Status::OK();
+    }
+
+    static Status vector_const(const ColumnString::Chars& data,
+                               const ColumnString::Offsets& offsets, int repeat,
+                               ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                               ColumnUInt8::Container& null_map) {
+        const size_t input_row_size = offsets.size();
+
+        fmt::memory_buffer buffer;
+        res_offsets.resize(input_row_size);
+        null_map.resize_fill(input_row_size, 0);
+        for (size_t i = 0; i < input_row_size; ++i) {
+            buffer.clear();
+            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
+            const size_t size = offsets[i] - offsets[i - 1];
+            ColumnString::check_chars_length(static_cast<size_t>(repeat) * size + res_data.size(),
+                                             0);
+            for (int j = 0; j < repeat; ++j) {
+                buffer.append(raw_str, raw_str + size);
+            }
+            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
+                                        res_offsets);
+        }
+        return Status::OK();
+    }
+};
+
 static void generate_test_data(ColumnString::Chars& data, ColumnString::Offsets& offsets,
                                size_t num_rows, size_t str_len, unsigned char max_char) {
     const std::string base64_chars =
@@ -188,13 +245,28 @@ static void generate_test_data(ColumnString::Chars& data, ColumnString::Offsets&
     data.clear();
     data.reserve(num_rows * str_len);
 
-    size_t offset = 0;
+    uint32_t offset = 0;
     for (size_t i = 0; i < num_rows; ++i) {
         for (size_t j = 0; j < str_len; ++j) {
             data.push_back(static_cast<char>(base64_chars[dist(rng)]));
         }
         offset += str_len;
-        offsets[i] = cast_set<uint32_t>(offset);
+        offsets[i] = offset;
+    }
+}
+
+static ColumnString::MutablePtr generate_test_string_column(size_t num_rows, size_t str_len,
+                                                            unsigned char max_char) {
+    auto column = ColumnString::create();
+    generate_test_data(column->get_chars(), column->get_offsets(), num_rows, str_len, max_char);
+    return column;
+}
+
+static void generate_repeat_times(ColumnInt32::Container& repeats, size_t num_rows,
+                                  int32_t max_repeat) {
+    repeats.resize(num_rows);
+    for (size_t i = 0; i < num_rows; ++i) {
+        repeats[i] = max_repeat == 0 ? 0 : static_cast<int32_t>(i % max_repeat) + 1;
     }
 }
 
@@ -261,7 +333,7 @@ static void BM_FromBase64Impl_Old(benchmark::State& state) {
         dst_data.clear();
         dst_offsets.clear();
         auto status = OldFromBase64Impl::vector(data, offsets, dst_data, dst_offsets,
-                                                    null_map->get_data());
+                                                null_map->get_data());
         benchmark::DoNotOptimize(status);
     }
 }
@@ -329,8 +401,7 @@ static void BM_UnhexImpl_New(benchmark::State& state) {
     for (auto _ : state) {
         dst_data.clear();
         dst_offsets.clear();
-        auto status =
-                UnHexImpl<UnHexImplEmpty>::vector(data, offsets, dst_data, dst_offsets);
+        auto status = UnHexImpl<UnHexImplEmpty>::vector(data, offsets, dst_data, dst_offsets);
         benchmark::DoNotOptimize(status);
     }
 }
@@ -381,8 +452,8 @@ static void BM_UnhexNullImpl_New(benchmark::State& state) {
     for (auto _ : state) {
         dst_data.clear();
         dst_offsets.clear();
-        auto status = UnHexImpl<UnHexImplNull>::vector(
-                data, offsets, dst_data, dst_offsets, &null_map->get_data());
+        auto status = UnHexImpl<UnHexImplNull>::vector(data, offsets, dst_data, dst_offsets,
+                                                       &null_map->get_data());
         benchmark::DoNotOptimize(status);
     }
 }
@@ -397,6 +468,121 @@ BENCHMARK(BM_UnhexNullImpl_New)
         ->Args({1000, 256})
         ->Args({100, 65536})
         ->Args({100, 100000})
+        ->Unit(benchmark::kNanosecond);
+
+static void BM_RepeatVectorImpl_Old(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto max_repeat = static_cast<int32_t>(state.range(2));
+    ColumnString::Chars data;
+    ColumnString::Offsets offsets;
+    ColumnInt32::Container repeats;
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+
+    generate_test_data(data, offsets, rows, len, 63);
+    generate_repeat_times(repeats, rows, max_repeat);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        auto status = OldRepeatImpl::vector_vector(data, offsets, repeats, dst_data, dst_offsets,
+                                                   null_map);
+        benchmark::DoNotOptimize(status);
+    }
+}
+
+static void BM_RepeatVectorImpl_New(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto max_repeat = static_cast<int32_t>(state.range(2));
+    ColumnInt32::Container repeats;
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+    FunctionStringRepeat function;
+    auto source_column = generate_test_string_column(rows, len, 63);
+
+    generate_repeat_times(repeats, rows, max_repeat);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        auto status =
+                function.vector_vector(*source_column, repeats, dst_data, dst_offsets, null_map);
+        benchmark::DoNotOptimize(status);
+    }
+}
+
+BENCHMARK(BM_RepeatVectorImpl_Old)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
+        ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RepeatVectorImpl_New)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
+        ->Unit(benchmark::kNanosecond);
+
+static void BM_RepeatConstImpl_Old(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto repeat = static_cast<int32_t>(state.range(2));
+    ColumnString::Chars data;
+    ColumnString::Offsets offsets;
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+
+    generate_test_data(data, offsets, rows, len, 63);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        auto status =
+                OldRepeatImpl::vector_const(data, offsets, repeat, dst_data, dst_offsets, null_map);
+        benchmark::DoNotOptimize(status);
+    }
+}
+
+static void BM_RepeatConstImpl_New(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto repeat = static_cast<int32_t>(state.range(2));
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+    FunctionStringRepeat function;
+    auto source_column = generate_test_string_column(rows, len, 63);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        static_cast<void>(
+                function.vector_const(*source_column, repeat, dst_data, dst_offsets, null_map));
+        benchmark::ClobberMemory();
+    }
+}
+
+BENCHMARK(BM_RepeatConstImpl_Old)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
+        ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RepeatConstImpl_New)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
         ->Unit(benchmark::kNanosecond);
 
 } // namespace doris

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -41,7 +41,6 @@
 #include "core/data_type/data_type_string.h"
 #include "core/memcpy_small.h"
 #include "core/string_ref.h"
-#include "exec/common/arithmetic_overflow.h"
 #include "exec/common/stringop_substring.h"
 #include "exec/common/template_helpers.hpp"
 #include "exec/common/util.hpp"
@@ -634,7 +633,6 @@ private:
                            ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
                            ColumnUInt8::Container& null_map) const {
         const auto input_row_size = source_column.size();
-        constexpr size_t string_overflow_length = 1ULL << 32;
 
         res_offsets.resize(input_row_size);
         null_map.resize_fill(input_row_size, 0);
@@ -649,15 +647,7 @@ private:
 
             const auto str_ref = source_column.get_data_at(i);
             const uint32_t size = str_ref.size;
-            const uint32_t repeat_times = repeat;
-            uint32_t repeated_size = 0;
-            uint32_t next_total_size = 0;
-            if (UNLIKELY(common::mul_overflow(size, repeat_times, repeated_size) ||
-                         common::add_overflow(total_size, repeated_size, next_total_size))) {
-                ColumnString::check_chars_length(string_overflow_length, input_row_size, i + 1);
-            }
-
-            total_size = next_total_size;
+            total_size += size * repeat;
             res_offsets[i] = total_size;
         }
 

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -41,6 +41,7 @@
 #include "core/data_type/data_type_string.h"
 #include "core/memcpy_small.h"
 #include "core/string_ref.h"
+#include "exec/common/arithmetic_overflow.h"
 #include "exec/common/stringop_substring.h"
 #include "exec/common/template_helpers.hpp"
 #include "exec/common/util.hpp"
@@ -582,8 +583,7 @@ public:
 
         if (const auto* col1 = check_and_get_column<ColumnString>(*argument_ptr[0])) {
             if (const auto* col2 = check_and_get_column<ColumnInt32>(*argument_ptr[1])) {
-                RETURN_IF_ERROR(vector_vector(col1->get_chars(), col1->get_offsets(),
-                                              col2->get_data(), res->get_chars(),
+                RETURN_IF_ERROR(vector_vector(*col1, col2->get_data(), res->get_chars(),
                                               res->get_offsets(), null_map->get_data()));
                 block.replace_by_position(
                         result, ColumnNullable::create(std::move(res), std::move(null_map)));
@@ -596,8 +596,8 @@ public:
                     null_map->get_data().resize_fill(input_rows_count, 0);
                     res->insert_many_defaults(input_rows_count);
                 } else {
-                    vector_const(col1->get_chars(), col1->get_offsets(), repeat, res->get_chars(),
-                                 res->get_offsets(), null_map->get_data());
+                    RETURN_IF_ERROR(vector_const(*col1, repeat, res->get_chars(),
+                                                 res->get_offsets(), null_map->get_data()));
                 }
                 block.replace_by_position(
                         result, ColumnNullable::create(std::move(res), std::move(null_map)));
@@ -609,57 +609,79 @@ public:
                                     argument_ptr[0]->get_name(), argument_ptr[1]->get_name());
     }
 
-    Status vector_vector(const ColumnString::Chars& data, const ColumnString::Offsets& offsets,
-                         const ColumnInt32::Container& repeats, ColumnString::Chars& res_data,
-                         ColumnString::Offsets& res_offsets,
+    Status vector_vector(const ColumnString& source_column, const ColumnInt32::Container& repeats,
+                         ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
                          ColumnUInt8::Container& null_map) const {
-        size_t input_row_size = offsets.size();
-
-        fmt::memory_buffer buffer;
-        res_offsets.resize(input_row_size);
-        null_map.resize_fill(input_row_size, 0);
-        for (ssize_t i = 0; i < input_row_size; ++i) {
-            buffer.clear();
-            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
-            size_t size = offsets[i] - offsets[i - 1];
-            int repeat = repeats[i];
-            if (repeat <= 0) {
-                StringOP::push_empty_string(i, res_data, res_offsets);
-            } else {
-                ColumnString::check_chars_length(repeat * size + res_data.size(), 0);
-                for (int j = 0; j < repeat; ++j) {
-                    buffer.append(raw_str, raw_str + size);
-                }
-                StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i,
-                                            res_data, res_offsets);
-            }
-        }
-        return Status::OK();
+        return _repeat_execute(
+                source_column, [&repeats](size_t index) { return repeats[index]; }, res_data,
+                res_offsets, null_map);
     }
 
     // TODO: 1. use pmr::vector<char> replace fmt_buffer may speed up the code
     //       2. abstract the `vector_vector` and `vector_const`
     //       3. rethink we should use `DEFAULT_MAX_STRING_SIZE` to bigger here
-    void vector_const(const ColumnString::Chars& data, const ColumnString::Offsets& offsets,
-                      int repeat, ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
-                      ColumnUInt8::Container& null_map) const {
-        size_t input_row_size = offsets.size();
+    Status vector_const(const ColumnString& source_column, int repeat,
+                        ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                        ColumnUInt8::Container& null_map) const {
+        return _repeat_execute(
+                source_column, [repeat](size_t) { return repeat; }, res_data, res_offsets,
+                null_map);
+    }
 
-        fmt::memory_buffer buffer;
+private:
+    template <typename RepeatGetter>
+    Status _repeat_execute(const ColumnString& source_column, RepeatGetter&& repeat_getter,
+                           ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                           ColumnUInt8::Container& null_map) const {
+        const auto input_row_size = source_column.size();
+        constexpr size_t string_overflow_length = 1ULL << 32;
+
         res_offsets.resize(input_row_size);
         null_map.resize_fill(input_row_size, 0);
-        for (ssize_t i = 0; i < input_row_size; ++i) {
-            buffer.clear();
-            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
-            size_t size = offsets[i] - offsets[i - 1];
-            ColumnString::check_chars_length(repeat * size + res_data.size(), 0);
 
-            for (int j = 0; j < repeat; ++j) {
-                buffer.append(raw_str, raw_str + size);
+        uint32_t total_size = 0;
+        for (size_t i = 0; i < input_row_size; ++i) {
+            const int repeat = repeat_getter(i);
+            if (repeat <= 0) {
+                res_offsets[i] = total_size;
+                continue;
             }
-            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
-                                        res_offsets);
+
+            const auto str_ref = source_column.get_data_at(i);
+            const uint32_t size = str_ref.size;
+            const uint32_t repeat_times = repeat;
+            uint32_t repeated_size = 0;
+            uint32_t next_total_size = 0;
+            if (UNLIKELY(common::mul_overflow(size, repeat_times, repeated_size) ||
+                         common::add_overflow(total_size, repeated_size, next_total_size))) {
+                ColumnString::check_chars_length(string_overflow_length, input_row_size, i + 1);
+            }
+
+            total_size = next_total_size;
+            res_offsets[i] = total_size;
         }
+
+        ColumnString::check_chars_length(total_size, input_row_size);
+        res_data.resize(total_size);
+
+        auto* res_data_ptr = res_data.data();
+        for (size_t i = 0; i < input_row_size; ++i) {
+            const int repeat = repeat_getter(i);
+            if (repeat <= 0) {
+                continue;
+            }
+
+            const auto str_ref = source_column.get_data_at(i);
+            if (UNLIKELY(str_ref.size == 0)) {
+                continue;
+            }
+
+            StringOP::fast_repeat(res_data_ptr + res_offsets[i - 1],
+                                  reinterpret_cast<const uint8_t*>(str_ref.data), str_ref.size,
+                                  repeat);
+        }
+
+        return Status::OK();
     }
 };
 

--- a/be/test/exprs/function/function_string_test.cpp
+++ b/be/test/exprs/function/function_string_test.cpp
@@ -747,6 +747,7 @@ TEST(function_string_test, function_string_repeat_test) {
                              "ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@"
                              "i$o%ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@i$o%ll_")},
                 {{std::string("heh1h2!u@u@i$o%ll_"), std::int32_t(-1)}, std::string("")},
+                {{std::string("a"), std::int32_t(256)}, std::string(256, 'a')},
         };
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);


### PR DESCRIPTION
### What problem does this PR solve?

The current `repeat` implementation in Doris has three avoidable costs:

- it appends the source string `repeat` times into a per-row `fmt::memory_buffer`
- it copies each row twice, first into the temporary buffer and then into the result column
- it grows result memory row by row instead of precomputing offsets and total output size

### What was done

The `repeat` hot path was rewritten to follow a two-pass, preallocated execution model closer to ClickHouse:

1. Added a shared `_repeat_execute()` path for both vector repeat counts and constant repeat counts.
2. First pass computes per-row output size, fills `res_offsets`, and accumulates `total_size`.
3. Second pass writes directly into `ColumnString::Chars` at the precomputed offset.
4. Replaced repeated `buffer.append()` loops with `StringOP::fast_repeat()`.
5. Added a larger correctness case for `repeat('a', 256)`.
6. Added repeat-specific old/new benchmarks in `be/benchmark/benchmark_string.hpp`.

### Benchmark results

| Scenario | Old (ns/op) | New (ns/op) | Speedup |
|---|---:|---:|---:|
| RepeatVector 4096/16/8 | 145113 | 66015 | 2.20x |
| RepeatVector 4096/16/64 | 654368 | 203875 | 3.21x |
| RepeatVector 1024/128/16 | 133676 | 59238 | 2.26x |
| RepeatVector 4096/0/64 | 384222 | 17111 | 22.45x |
| RepeatConst 4096/16/8 | 205026 | 86901 | 2.36x |
| RepeatConst 4096/16/64 | 1199839 | 286399 | 4.19x |
| RepeatConst 1024/128/16 | 258714 | 97519 | 2.65x |
| RepeatConst 4096/0/64 | 674487 | 11495 | 58.68x |

The largest speedup comes from the empty-string cases (`4096/0/64`), where the old path still pays for repeat-count append loops while the new path short-circuits after computing zero output size.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

