### PR TITLE
[fix] Support AND predicates on CreateTime/FinishTime in SHOW ALTER

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BuildIndexProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BuildIndexProcDir.java
@@ -29,6 +29,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.common.util.OrderByPair;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -137,12 +138,27 @@ public class BuildIndexProcDir implements ProcDirInterface {
             return true;
         }
 
-        if (subExpr instanceof ComparisonPredicate) {
-            return filterSubExpression(subExpr, element);
-        } else if (subExpr instanceof Not) {
-            subExpr = subExpr.child(0);
-            if (subExpr instanceof EqualTo) {
-                return !filterSubExpression(subExpr, element);
+        return evaluateFilterExpression(subExpr, element);
+    }
+
+    private boolean evaluateFilterExpression(Expression expr, Comparable element) throws AnalysisException {
+        if (expr instanceof And) {
+            for (Expression child : expr.children()) {
+                if (!evaluateFilterExpression(child, element)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        if (expr instanceof ComparisonPredicate) {
+            return filterSubExpression(expr, element);
+        }
+
+        if (expr instanceof Not) {
+            Expression childExpr = expr.child(0);
+            if (childExpr instanceof EqualTo) {
+                return !filterSubExpression(childExpr, element);
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/RollupProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/RollupProcDir.java
@@ -31,6 +31,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.common.util.OrderByPair;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -250,12 +251,27 @@ public class RollupProcDir implements ProcDirInterface {
             return true;
         }
 
-        if (subExpr instanceof ComparisonPredicate) {
-            return filterSubExpression(subExpr, element);
-        } else if (subExpr instanceof Not) {
-            subExpr = subExpr.child(0);
-            if (subExpr instanceof EqualTo) {
-                return !filterSubExpression(subExpr, element);
+        return evaluateFilterExpression(subExpr, element);
+    }
+
+    private boolean evaluateFilterExpression(Expression expr, Comparable element) throws AnalysisException {
+        if (expr instanceof And) {
+            for (Expression child : expr.children()) {
+                if (!evaluateFilterExpression(child, element)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        if (expr instanceof ComparisonPredicate) {
+            return filterSubExpression(expr, element);
+        }
+
+        if (expr instanceof Not) {
+            Expression childExpr = expr.child(0);
+            if (childExpr instanceof EqualTo) {
+                return !filterSubExpression(childExpr, element);
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/SchemaChangeProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/SchemaChangeProcDir.java
@@ -31,6 +31,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.common.util.OrderByPair;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -140,12 +141,27 @@ public class SchemaChangeProcDir implements ProcDirInterface {
             return true;
         }
 
-        if (subExpr instanceof ComparisonPredicate) {
-            return filterSubExpression(subExpr, element);
-        } else if (subExpr instanceof Not) {
-            subExpr = subExpr.child(0);
-            if (subExpr instanceof EqualTo) {
-                return !filterSubExpression(subExpr, element);
+        return evaluateFilterExpression(subExpr, element);
+    }
+
+    private boolean evaluateFilterExpression(Expression expr, Comparable element) throws AnalysisException {
+        if (expr instanceof And) {
+            for (Expression child : expr.children()) {
+                if (!evaluateFilterExpression(child, element)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        if (expr instanceof ComparisonPredicate) {
+            return filterSubExpression(expr, element);
+        }
+
+        if (expr instanceof Not) {
+            Expression childExpr = expr.child(0);
+            if (childExpr instanceof EqualTo) {
+                return !filterSubExpression(childExpr, element);
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowAlterTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowAlterTableCommand.java
@@ -45,6 +45,7 @@ import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.qe.ShowResultSetMetaData;
@@ -133,6 +134,7 @@ public class ShowAlterTableCommand extends ShowCommand {
                 throw new AnalysisException("Where clause : TableName = \"table1\" or "
                     + "State = \"FINISHED|CANCELLED|RUNNING|PENDING|WAITING_TXN\"");
             }
+            filterMap.put(leftKey, isNotExpr ? new Not(subExpr) : subExpr);
         } else if (leftKey.equals(CREATE_TIME) || leftKey.equals(FINISH_TIME)) {
             if (!(subExpr.child(1) instanceof StringLikeLiteral)) {
                 throw new AnalysisException("Where clause : CreateTime/FinishTime =|>=|<=|>|<|!= "
@@ -142,12 +144,18 @@ public class ShowAlterTableCommand extends ShowCommand {
             Expression right = subExpr.child(1).castTo(Config.enable_date_conversion
                     ? DateTimeV2Type.MAX : DateTimeType.INSTANCE);
             subExpr = subExpr.withChildren(left, right);
+            Expression filterExpr = isNotExpr ? new Not(subExpr) : subExpr;
+            Expression existingExpr = filterMap.get(leftKey);
+            if (existingExpr == null) {
+                filterMap.put(leftKey, filterExpr);
+            } else {
+                filterMap.put(leftKey, ExpressionUtils.and(existingExpr, filterExpr));
+            }
         } else {
             throw new AnalysisException(
                 "The columns of TableName/IndexName/CreateTime/FinishTime/State/BaseIndexName/RollupIndexName "
                         + "are supported.");
         }
-        filterMap.put(leftKey.toLowerCase(), isNotExpr ? new Not(subExpr) : subExpr);
     }
 
     private void analyzeSubPredicate(Expression subExpr) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBuildIndexCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowBuildIndexCommand.java
@@ -44,6 +44,7 @@ import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.types.DateTimeType;
 import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.qe.ShowResultSetMetaData;
@@ -100,7 +101,8 @@ public class ShowBuildIndexCommand extends ShowCommand {
         this.filterMap = new HashMap<String, Expression>();
     }
 
-    private void validate(ConnectContext ctx) throws UserException {
+    @VisibleForTesting
+    protected void validate(ConnectContext ctx) throws UserException {
         if (Strings.isNullOrEmpty(dbName)) {
             dbName = ctx.getDatabase();
             if (Strings.isNullOrEmpty(dbName)) {
@@ -157,6 +159,7 @@ public class ShowBuildIndexCommand extends ShowCommand {
                 throw new AnalysisException("Where clause : TableName = \"table1\" or "
                         + "State = \"FINISHED|CANCELLED|RUNNING|PENDING|WAITING_TXN\"");
             }
+            filterMap.put(leftKey, isNotExpr ? new Not(subExpr) : subExpr);
         } else if (leftKey.equalsIgnoreCase(CREATE_TIME) || leftKey.equalsIgnoreCase(FINISH_TIME)) {
             if (!(subExpr.child(1) instanceof StringLikeLiteral)) {
                 throw new AnalysisException("Where clause : CreateTime/FinishTime =|>=|<=|>|<|!= "
@@ -166,11 +169,17 @@ public class ShowBuildIndexCommand extends ShowCommand {
             Expression right = subExpr.child(1).castTo(Config.enable_date_conversion
                     ? DateTimeV2Type.MAX : DateTimeType.INSTANCE);
             subExpr = subExpr.withChildren(left, right);
+            Expression filterExpr = isNotExpr ? new Not(subExpr) : subExpr;
+            Expression existingExpr = filterMap.get(leftKey);
+            if (existingExpr == null) {
+                filterMap.put(leftKey, filterExpr);
+            } else {
+                filterMap.put(leftKey, ExpressionUtils.and(existingExpr, filterExpr));
+            }
         } else {
             throw new AnalysisException(
                     "The columns of TableName/PartitionName/CreateTime/FinishTime/State are supported.");
         }
-        filterMap.put(leftKey.toLowerCase(), isNotExpr ? new Not(subExpr) : subExpr);
     }
 
     private void analyze(ConnectContext ctx) throws UserException {

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/AlterProcDirFilterExpressionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/AlterProcDirFilterExpressionTest.java
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
+import org.apache.doris.nereids.trees.expressions.LessThanEqual;
+import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
+import org.apache.doris.nereids.types.DateTimeV2Type;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class AlterProcDirFilterExpressionTest {
+
+    @Test
+    public void testSchemaChangeFilterResultExpressionWithAnd() throws AnalysisException {
+        SchemaChangeProcDir schemaChangeProcDir = new SchemaChangeProcDir(null, null);
+        HashMap<String, Expression> filter = buildCreateTimeRangeFilter();
+
+        Assert.assertTrue(schemaChangeProcDir.filterResultExpression(
+                "CreateTime", "2026-04-17 10:44:34.380", filter));
+        Assert.assertFalse(schemaChangeProcDir.filterResultExpression(
+                "CreateTime", "2026-04-17 10:44:23.070", filter));
+    }
+
+    @Test
+    public void testRollupFilterResultExpressionWithAnd() throws AnalysisException {
+        RollupProcDir rollupProcDir = new RollupProcDir(null, null);
+        HashMap<String, Expression> filter = buildCreateTimeRangeFilter();
+
+        Assert.assertTrue(rollupProcDir.filterResultExpression(
+                "CreateTime", "2026-04-17 10:44:34.380", filter));
+        Assert.assertFalse(rollupProcDir.filterResultExpression(
+                "CreateTime", "2026-04-17 10:44:23.070", filter));
+    }
+
+    private HashMap<String, Expression> buildCreateTimeRangeFilter() {
+        Expression rangeFilter = new And(
+                new GreaterThanEqual(new UnboundSlot("CreateTime"),
+                        new DateTimeV2Literal(DateTimeV2Type.MAX, "2026-04-17 10:44:34")),
+                new LessThanEqual(new UnboundSlot("CreateTime"),
+                        new DateTimeV2Literal(DateTimeV2Type.MAX, "2026-04-17 10:44:36")));
+        HashMap<String, Expression> filter = new HashMap<>();
+        filter.put("createtime", rangeFilter);
+        return filter;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/AlterProcDirFilterExpressionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/AlterProcDirFilterExpressionTest.java
@@ -55,6 +55,17 @@ public class AlterProcDirFilterExpressionTest {
                 "CreateTime", "2026-04-17 10:44:23.070", filter));
     }
 
+    @Test
+    public void testBuildIndexFilterResultExpressionWithAnd() throws AnalysisException {
+        BuildIndexProcDir buildIndexProcDir = new BuildIndexProcDir(null, null);
+        HashMap<String, Expression> filter = buildCreateTimeRangeFilter();
+
+        Assert.assertTrue(buildIndexProcDir.filterResultExpression(
+                "CreateTime", "2026-04-17 10:44:34.380", filter));
+        Assert.assertFalse(buildIndexProcDir.filterResultExpression(
+                "CreateTime", "2026-04-17 10:44:23.070", filter));
+    }
+
     private HashMap<String, Expression> buildCreateTimeRangeFilter() {
         Expression rangeFilter = new And(
                 new GreaterThanEqual(new UnboundSlot("CreateTime"),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowAlterTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowAlterTableCommandTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.properties.OrderKey;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
@@ -30,9 +31,12 @@ import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 
 public class ShowAlterTableCommandTest extends TestWithFeService {
     @Override
@@ -179,5 +183,37 @@ public class ShowAlterTableCommandTest extends TestWithFeService {
                 new StringLiteral("abc"));
         sa1 = new ShowAlterTableCommand("test", where22, null, 1, 0, ShowAlterTableCommand.AlterType.MV);
         sa1.handleShowAlterTable(connectContext, null);
+    }
+
+    @Test
+    void testTimeCompoundPredicateShouldKeepAndExpression() throws Exception {
+        Expression where = new And(
+                new GreaterThanEqual(new UnboundSlot(Lists.newArrayList("CreateTime")),
+                        new StringLiteral("2026-04-17 10:44:34")),
+                new LessThanEqual(new UnboundSlot(Lists.newArrayList("CreateTime")),
+                        new StringLiteral("2026-04-17 10:44:36")));
+
+        ShowAlterTableCommand sa1 = new ShowAlterTableCommand(
+                "test", where, null, -1, -1, ShowAlterTableCommand.AlterType.COLUMN);
+        sa1.validate(connectContext);
+
+        where = new And(
+                new GreaterThanEqual(new UnboundSlot(Lists.newArrayList("FinishTime")),
+                        new StringLiteral("2026-04-17 10:44:34")),
+                new LessThanEqual(new UnboundSlot(Lists.newArrayList("FinishTime")),
+                        new StringLiteral("2026-04-17 10:44:36")));
+
+        ShowAlterTableCommand sa2 = new ShowAlterTableCommand(
+                "test", where, null, -1, -1, ShowAlterTableCommand.AlterType.COLUMN);
+        sa2.validate(connectContext);
+
+        Field filterMapField = ShowAlterTableCommand.class.getDeclaredField("filterMap");
+        filterMapField.setAccessible(true);
+
+        Assertions.assertTrue(((Map<String, Expression>) filterMapField.get(sa1)).get("createtime") instanceof And,
+                "CreateTime compound predicate should be kept as AND expression");
+
+        Assertions.assertTrue(((Map<String, Expression>) filterMapField.get(sa2)).get("finishtime") instanceof And,
+                "FinishTime compound predicate should be kept as AND expression");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBuildIndexCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowBuildIndexCommandTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.properties.OrderKey;
+import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
@@ -30,9 +31,12 @@ import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Map;
 
 public class ShowBuildIndexCommandTest extends TestWithFeService {
     @Override
@@ -106,5 +110,35 @@ public class ShowBuildIndexCommandTest extends TestWithFeService {
                 new StringLiteral("xxx"));
         sa = new ShowBuildIndexCommand("test", where10, null, 1, 0);
         sa.handleShowBuildIndex(connectContext, null);
+    }
+
+    @Test
+    void testTimeCompoundPredicateShouldKeepAndExpression() throws Exception {
+        Expression where = new And(
+                new GreaterThanEqual(new UnboundSlot(Lists.newArrayList("CreateTime")),
+                        new StringLiteral("2026-04-17 10:44:34")),
+                new LessThanEqual(new UnboundSlot(Lists.newArrayList("CreateTime")),
+                        new StringLiteral("2026-04-17 10:44:36")));
+
+        ShowBuildIndexCommand cmd1 = new ShowBuildIndexCommand("test", where, null, -1, -1);
+        cmd1.validate(connectContext);
+
+        where = new And(
+                new GreaterThanEqual(new UnboundSlot(Lists.newArrayList("FinishTime")),
+                        new StringLiteral("2026-04-17 10:44:34")),
+                new LessThanEqual(new UnboundSlot(Lists.newArrayList("FinishTime")),
+                        new StringLiteral("2026-04-17 10:44:36")));
+
+        ShowBuildIndexCommand cmd2 = new ShowBuildIndexCommand("test", where, null, -1, -1);
+        cmd2.validate(connectContext);
+
+        Field filterMapField = ShowBuildIndexCommand.class.getDeclaredField("filterMap");
+        filterMapField.setAccessible(true);
+
+        Assertions.assertTrue(((Map<String, Expression>) filterMapField.get(cmd1)).get("createtime") instanceof And,
+                "CreateTime compound predicate should be kept as AND expression");
+
+        Assertions.assertTrue(((Map<String, Expression>) filterMapField.get(cmd2)).get("finishtime") instanceof And,
+                "FinishTime compound predicate should be kept as AND expression");
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
`SHOW ALTER TABLE ... WHERE ...` stores predicates in a map keyed by column name.
   For the same key, the later predicate overwrote the previous one.

   As a result, time-range filters could be incorrect.

   Example:

   ```sql
   show alter table column where createtime >= '2026-04-17 10:44:34' and createtime <= '2026-04-17 10:44:36';
```

 Before: only one side of the range was effectively applied (e.g. a row like 2026-04-17 10:44:23.070 could be returned).
 After: both bounds are applied with AND semantics (e.g. 2026-04-17 10:44:35.380 is kept, 2026-04-17 10:44:23.070 is excluded).

 This PR only changes same-key predicate behavior for:
 - CreateTime
 - FinishTime

 For other keys, existing behavior is unchanged (later predicate still overwrites earlier one).

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

