### PR TITLE
branch-4.1: [fix](fe) Support IAM role auth in S3 filesystem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -24,7 +24,10 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.S3URI;
 import org.apache.doris.common.util.S3Util;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.property.common.AwsCredentialsProviderFactory;
+import org.apache.doris.datasource.property.common.AwsCredentialsProviderMode;
 import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
+import org.apache.doris.datasource.property.storage.S3Properties;
 import org.apache.doris.fs.GlobListResult;
 import org.apache.doris.fs.remote.RemoteFile;
 
@@ -35,7 +38,13 @@ import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
@@ -66,6 +75,10 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -80,6 +93,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class S3ObjStorage implements ObjStorage<S3Client> {
@@ -246,7 +260,55 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
 
     @Override
     public Triple<String, String, String> getStsToken() throws DdlException {
-        return null;
+        Map<String, String> backendProperties = s3Properties.getBackendConfigProperties();
+        String roleArn = backendProperties.get(S3Properties.Env.ROLE_ARN);
+        if (StringUtils.isBlank(roleArn)) {
+            throw new DdlException("Missing [AWS_ROLE_ARN] in properties.");
+        }
+        String externalId = backendProperties.get(S3Properties.Env.EXTERNAL_ID);
+        String region = StringUtils.defaultIfBlank(s3Properties.getRegion(), "us-east-1");
+        try (StsClient stsClient = buildStsClient(buildStsSourceCredentialsProvider(backendProperties), region)) {
+            AssumeRoleRequest.Builder requestBuilder = AssumeRoleRequest.builder()
+                    .roleArn(roleArn)
+                    .durationSeconds(Config.sts_duration)
+                    .roleSessionName("doris_" + UUID.randomUUID().toString().replace("-", ""));
+            if (StringUtils.isNotBlank(externalId)) {
+                requestBuilder.externalId(externalId);
+            }
+            AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(requestBuilder.build());
+            Credentials credentials = assumeRoleResponse.credentials();
+            return Triple.of(credentials.accessKeyId(), credentials.secretAccessKey(), credentials.sessionToken());
+        } catch (Exception e) {
+            LOG.warn("Failed to get s3 sts token, roleArn={}", roleArn, e);
+            throw new DdlException("Failed to get s3 sts token: " + Util.getRootCauseMessage(e));
+        }
+    }
+
+    protected StsClient buildStsClient(AwsCredentialsProvider credentialsProvider, String region) {
+        return StsClient.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(Region.of(region))
+                .build();
+    }
+
+    private AwsCredentialsProvider buildStsSourceCredentialsProvider(Map<String, String> backendProperties) {
+        String accessKey = backendProperties.get(S3Properties.Env.ACCESS_KEY);
+        String secretKey = backendProperties.get(S3Properties.Env.SECRET_KEY);
+        String sessionToken = backendProperties.get(S3Properties.Env.TOKEN);
+        if (StringUtils.isNotBlank(accessKey) && StringUtils.isNotBlank(secretKey)) {
+            if (StringUtils.isNotBlank(sessionToken)) {
+                return StaticCredentialsProvider.create(
+                        AwsSessionCredentials.create(accessKey, secretKey, sessionToken));
+            }
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        }
+
+        if (Config.aws_credentials_provider_version.equalsIgnoreCase("v2")) {
+            String providerType = backendProperties.get("AWS_CREDENTIALS_PROVIDER_TYPE");
+            AwsCredentialsProviderMode providerMode = AwsCredentialsProviderMode.fromString(providerType);
+            return AwsCredentialsProviderFactory.createV2(providerMode, false);
+        }
+        return DefaultCredentialsProvider.create();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/storage/S3PropertiesTest.java
@@ -248,6 +248,21 @@ public class S3PropertiesTest {
         Assertions.assertEquals("arn:aws:iam::123456789012:role/MyTestRole", backendProperties.get("AWS_ROLE_ARN"));
     }
 
+    @Test
+    public void testCreatePrimaryWithAwsRoleArnOnly() throws UserException {
+        Map<String, String> props = new HashMap<>();
+        props.put("AWS_ENDPOINT", "s3.us-west-2.amazonaws.com");
+        props.put("AWS_REGION", "us-west-2");
+        props.put("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/MyTestRole");
+
+        S3Properties s3Props = (S3Properties) StorageProperties.createPrimary(props);
+
+        Assertions.assertEquals("arn:aws:iam::123456789012:role/MyTestRole", s3Props.getBackendConfigProperties()
+                .get("AWS_ROLE_ARN"));
+        Assertions.assertEquals("us-west-2", s3Props.getRegion());
+        Assertions.assertEquals("s3.us-west-2.amazonaws.com", s3Props.getEndpoint());
+    }
+
 
     @Test
     public void testGetAwsCredentialsProviderWithIamRoleAndExternalId(@Mocked StsClientBuilder mockBuilder,

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
@@ -21,8 +21,10 @@ import org.apache.doris.backup.Status;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
 import org.apache.doris.fs.remote.RemoteFile;
 
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -53,6 +55,10 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -553,5 +559,57 @@ public class S3ObjStorageTest {
         // Verify that the prefix was adjusted correctly for the directory bucket.
         // "data/files*.csv" -> longest prefix is "data/files", adjusted to "data/"
         Assertions.assertEquals("data/", captor.getValue().prefix());
+    }
+
+    @Test
+    public void testGetStsTokenWithRoleArn() throws Exception {
+        Map<String, String> props = new HashMap<>();
+        props.put("AWS_ENDPOINT", "https://s3.us-west-2.amazonaws.com");
+        props.put("AWS_REGION", "us-west-2");
+        props.put("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/snapshot-role");
+        props.put("AWS_EXTERNAL_ID", "external-123");
+
+        StsClient mockStsClient = Mockito.mock(StsClient.class);
+        Mockito.when(mockStsClient.assumeRole(Mockito.any(AssumeRoleRequest.class)))
+                .thenReturn(AssumeRoleResponse.builder()
+                        .credentials(Credentials.builder()
+                                .accessKeyId("sts-ak")
+                                .secretAccessKey("sts-sk")
+                                .sessionToken("sts-token")
+                                .build())
+                        .build());
+
+        S3ObjStorage roleBasedStorage = new TestableRoleBasedS3ObjStorage(
+                (AbstractS3CompatibleProperties) StorageProperties.createPrimary(props), mockStsClient);
+
+        Triple<String, String, String> stsToken = roleBasedStorage.getStsToken();
+
+        Assertions.assertEquals(Triple.of("sts-ak", "sts-sk", "sts-token"), stsToken);
+        org.mockito.ArgumentCaptor<AssumeRoleRequest> requestCaptor =
+                org.mockito.ArgumentCaptor.forClass(AssumeRoleRequest.class);
+        Mockito.verify(mockStsClient).assumeRole(requestCaptor.capture());
+        Assertions.assertEquals("arn:aws:iam::123456789012:role/snapshot-role",
+                requestCaptor.getValue().roleArn());
+        Assertions.assertEquals("external-123", requestCaptor.getValue().externalId());
+    }
+
+    @Test
+    public void testGetStsTokenWithoutRoleArn() {
+        Assertions.assertThrows(DdlException.class, () -> storage.getStsToken());
+    }
+
+    private static class TestableRoleBasedS3ObjStorage extends S3ObjStorage {
+        private final StsClient stsClient;
+
+        TestableRoleBasedS3ObjStorage(AbstractS3CompatibleProperties properties, StsClient stsClient) {
+            super(properties);
+            this.stsClient = stsClient;
+        }
+
+        @Override
+        protected StsClient buildStsClient(
+                software.amazon.awssdk.auth.credentials.AwsCredentialsProvider credentialsProvider, String region) {
+            return stsClient;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
@@ -65,8 +65,10 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class S3ObjStorageTest {


### PR DESCRIPTION
Cherry-pick #62584

the S3 filesystem accepts AWS_ROLE_ARN-based configuration and can build STS assume-role credentials.