### PR TITLE
[fix](streaming-job) roll sample window before accumulating in checkDataQuality

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -173,6 +173,10 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     private long sampleWindowScannedRows;
     private long sampleWindowFilteredRows;
 
+    protected StreamingInsertJob() {
+        // for testing and gson deserialization
+    }
+
     public StreamingInsertJob(String jobName,
             JobStatus jobStatus,
             String dbName,
@@ -1257,6 +1261,16 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
             return;
         }
 
+        // Roll the window before accumulating, otherwise a boundary batch is merged into the expired window.
+        long now = System.currentTimeMillis();
+        if ((now - sampleStartTime) > sampleWindowMs) {
+            this.sampleStartTime = now;
+            this.sampleWindowScannedRows = 0L;
+            this.sampleWindowFilteredRows = 0L;
+            log.info("streaming multi table job {} enter next sample window, startTime={}",
+                    getJobId(), TimeUtils.longToTimeString(sampleStartTime));
+        }
+
         this.sampleWindowScannedRows += offsetRequest.getScannedRows();
         this.sampleWindowFilteredRows += offsetRequest.getFilteredRows();
 
@@ -1278,16 +1292,6 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
             this.setFailureReason(failureReason);
             this.updateJobStatus(JobStatus.PAUSED);
             throw new JobException(failureReason.getMsg());
-        }
-
-        long now = System.currentTimeMillis();
-
-        if ((now - sampleStartTime) > sampleWindowMs) {
-            this.sampleStartTime = now;
-            this.sampleWindowScannedRows = 0L;
-            this.sampleWindowFilteredRows = 0L;
-            log.info("streaming multi table job {} enter next sample window, startTime={}",
-                    getJobId(), TimeUtils.longToTimeString(sampleStartTime));
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobCheckDataQualityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobCheckDataQualityTest.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.job.extensions.insert.streaming;
+
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.job.cdc.request.CommitOffsetRequest;
+import org.apache.doris.job.common.JobStatus;
+import org.apache.doris.job.exception.JobException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class StreamingInsertJobCheckDataQualityTest {
+
+    private static final String MAX_FILTER_RATIO_KEY = "load.max_filter_ratio";
+
+    private static StreamingInsertJob newJob(double maxFilterRatio, long sampleWindowMs) {
+        StreamingInsertJob job = Deencapsulation.newInstance(StreamingInsertJob.class);
+        Deencapsulation.setField(job, "lock", new ReentrantReadWriteLock(true));
+        Deencapsulation.setField(job, "sampleWindowMs", sampleWindowMs);
+        Deencapsulation.setField(job, "sampleWindowScannedRows", 0L);
+        Deencapsulation.setField(job, "sampleWindowFilteredRows", 0L);
+        Deencapsulation.setField(job, "sampleStartTime", System.currentTimeMillis());
+
+        Map<String, String> targetProps = new HashMap<>();
+        targetProps.put(MAX_FILTER_RATIO_KEY, String.valueOf(maxFilterRatio));
+        Deencapsulation.setField(job, "targetProperties", targetProps);
+
+        Deencapsulation.setField(job, "jobId", 1L);
+        Deencapsulation.setField(job, "jobName", "test_job");
+        Deencapsulation.setField(job, "jobStatus", JobStatus.RUNNING);
+        return job;
+    }
+
+    private static void invokeCheckDataQuality(StreamingInsertJob job, long scannedRows, long filteredRows)
+            throws JobException {
+        CommitOffsetRequest req = new CommitOffsetRequest();
+        req.setScannedRows(scannedRows);
+        req.setFilteredRows(filteredRows);
+        try {
+            Deencapsulation.invoke(job, "checkDataQuality", req);
+        } catch (RuntimeException re) {
+            // Deencapsulation.invoke wraps the target exception, unwrap to surface JobException to the test.
+            Throwable cause = re.getCause();
+            if (cause instanceof JobException) {
+                throw (JobException) cause;
+            }
+            throw re;
+        }
+    }
+
+    @Test
+    public void testNormalBatchWithinWindow() throws Exception {
+        StreamingInsertJob job = newJob(0.10, 60_000L);
+        invokeCheckDataQuality(job, 1000, 50);
+        Assert.assertEquals(1000L, (long) Deencapsulation.getField(job, "sampleWindowScannedRows"));
+        Assert.assertEquals(50L, (long) Deencapsulation.getField(job, "sampleWindowFilteredRows"));
+        Assert.assertEquals(JobStatus.RUNNING, job.getJobStatus());
+    }
+
+    @Test
+    public void testCombinedRatioViolationInsideWindow() throws Exception {
+        StreamingInsertJob job = newJob(0.10, 60_000L);
+        Deencapsulation.setField(job, "sampleWindowScannedRows", 100L);
+        Deencapsulation.setField(job, "sampleWindowFilteredRows", 5L);
+        Deencapsulation.setField(job, "sampleStartTime", System.currentTimeMillis() - 1_000L);
+
+        JobException thrown = null;
+        try {
+            invokeCheckDataQuality(job, 100, 30);
+        } catch (JobException e) {
+            thrown = e;
+        }
+        Assert.assertNotNull("expected pause when combined ratio exceeds threshold", thrown);
+        Assert.assertEquals(JobStatus.PAUSED, job.getJobStatus());
+    }
+
+    // Bug reproducer: expired window with large clean data used to dilute a bad batch.
+    // Fixed code rolls the window first so the bad batch is judged on its own.
+    @Test
+    public void testExpiredWindowDoesNotMaskBadBatch() throws Exception {
+        StreamingInsertJob job = newJob(0.10, 60_000L);
+        Deencapsulation.setField(job, "sampleWindowScannedRows", 10_000L);
+        Deencapsulation.setField(job, "sampleWindowFilteredRows", 500L);
+        Deencapsulation.setField(job, "sampleStartTime", System.currentTimeMillis() - 120_000L);
+
+        JobException thrown = null;
+        try {
+            invokeCheckDataQuality(job, 100, 30);
+        } catch (JobException e) {
+            thrown = e;
+        }
+        Assert.assertNotNull("expected pause — bad batch (ratio=0.30) should not be diluted by expired window",
+                thrown);
+        Assert.assertEquals(JobStatus.PAUSED, job.getJobStatus());
+    }
+
+    @Test
+    public void testExpiredWindowRollsBeforeAccumulation() throws Exception {
+        StreamingInsertJob job = newJob(0.10, 60_000L);
+        Deencapsulation.setField(job, "sampleWindowScannedRows", 1000L);
+        Deencapsulation.setField(job, "sampleWindowFilteredRows", 50L);
+        long oldStartTime = System.currentTimeMillis() - 120_000L;
+        Deencapsulation.setField(job, "sampleStartTime", oldStartTime);
+
+        invokeCheckDataQuality(job, 100, 5);
+
+        Assert.assertEquals(100L, (long) Deencapsulation.getField(job, "sampleWindowScannedRows"));
+        Assert.assertEquals(5L, (long) Deencapsulation.getField(job, "sampleWindowFilteredRows"));
+        Assert.assertTrue((long) Deencapsulation.getField(job, "sampleStartTime") > oldStartTime);
+    }
+
+    @Test
+    public void testZeroScanBatchStillRollsExpiredWindow() throws Exception {
+        StreamingInsertJob job = newJob(0.10, 60_000L);
+        Deencapsulation.setField(job, "sampleWindowScannedRows", 1000L);
+        Deencapsulation.setField(job, "sampleWindowFilteredRows", 50L);
+        long oldStartTime = System.currentTimeMillis() - 120_000L;
+        Deencapsulation.setField(job, "sampleStartTime", oldStartTime);
+
+        invokeCheckDataQuality(job, 0, 0);
+
+        Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowScannedRows"));
+        Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowFilteredRows"));
+        Assert.assertTrue((long) Deencapsulation.getField(job, "sampleStartTime") > oldStartTime);
+    }
+
+    @Test
+    public void testMissingMaxFilterRatioIsNoop() throws Exception {
+        StreamingInsertJob job = newJob(0.10, 60_000L);
+        Deencapsulation.setField(job, "targetProperties", new HashMap<String, String>());
+
+        invokeCheckDataQuality(job, 100, 50);
+
+        Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowScannedRows"));
+        Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowFilteredRows"));
+        Assert.assertEquals(JobStatus.RUNNING, job.getJobStatus());
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`StreamingInsertJob.checkDataQuality()` is the per-commit data-quality gate for CDC multi-table jobs. It maintains a sample window (`max_interval * 10` seconds) and pauses the job when `filtered / scanned` exceeds `max_filter_ratio`. The current ordering is wrong:

1. accumulate current batch into the window
2. judge the combined ratio
3. if the window is expired, clear the counters

For a batch arriving right after window expiry, step 1 merges it into the old, stale window before step 2 judges it, and step 3 then wipes the counters.

Impact:
- **Delayed / missed pause**: a large clean old window can dilute a single bad batch so the combined ratio stays below the threshold, the pause is skipped, and the bad batch's counts are then cleared away with the old window — so the bad batch is neither caught nor carried into the new window.
- **Stuck window start time**: the expiry check sits after the `scannedRows <= 0` early return, so a long idle period of zero-scanned batches leaves `sampleStartTime` frozen; the first real batch after the idle period is then judged against an effectively infinite window.

Mathematically the bug cannot produce a false positive (combining two sub-threshold ratios stays sub-threshold), so the risk is under-detection, not wrongful pausing.

### Fix

Reorder `checkDataQuality()` to **roll the window before accumulating**:

1. if `(now - sampleStartTime) > sampleWindowMs`, reset `sampleStartTime`, `sampleWindowScannedRows`, `sampleWindowFilteredRows`
2. accumulate current batch
3. early-return on `scannedRows <= 0`
4. judge the ratio and pause if exceeded

This way the incoming batch is always attributed to the correct window, and the expiry check is no longer gated on the batch having data.

Also adds a `protected` no-arg constructor to `StreamingInsertJob` for unit testing and gson deserialization (same pattern as `KafkaRoutineLoadJob`).

### Release note

Fix streaming job CDC data quality check missing pauses when a bad batch arrives right after the sample window expires.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. CDC multi-table jobs now correctly pause on bad batches arriving at sample window boundaries; previously such batches could slip through.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label