### PR TITLE
[fix](agg) fix redundant copy in collect_set merge

### DIFF
--- a/be/src/exprs/aggregate/aggregate_function_collect.h
+++ b/be/src/exprs/aggregate/aggregate_function_collect.h
@@ -76,7 +76,9 @@ struct AggregateFunctionCollectSetData {
                 data_set.insert(rhs_elem);
             }
         } else {
-            data_set.merge(Set(rhs.data_set));
+            for (const auto& elem : rhs.data_set) {
+                data_set.insert(elem);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`AggregateFunctionCollectSetData<T, false>::merge` (the no-limit variant) called:

```cpp
data_set.merge(Set(rhs.data_set));
```

`Set(rhs.data_set)` invokes the **copy constructor**, producing a full independent copy of `rhs.data_set` (O(N) heap allocation + O(N) element copy). `phmap::flat_hash_set::merge()` expects a non-const lvalue reference so that it can steal slots from the source — here it is merely consuming a temporary that was just allocated for this purpose. The overall cost is **3× O(N)**: copy + merge + destruct, instead of the correct **1× O(N)**.

The `HasLimit=true` branch and the `StringRef` specialisation both iterate and `insert` directly, which is correct.

## Solution

Replace the copy-then-merge with a direct element-wise insert:

```cpp
// Before
data_set.merge(Set(rhs.data_set));   // unnecessary O(N) copy

// After
for (const auto& elem : rhs.data_set) {
    data_set.insert(elem);
}
```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

