### PR TITLE
[Profile][exec] The profile hitcache not correct in force refresh and sink id not correct

### DIFF
--- a/be/src/exec/operator/cache_source_operator.cpp
+++ b/be/src/exec/operator/cache_source_operator.cpp
@@ -72,9 +72,11 @@ Status CacheSourceLocalState::init(RuntimeState* state, LocalStateInfo& info) {
     custom_profile()->add_info_string("CacheTabletId", tablet_ids_str);
 
     // 3. lookup the cache and find proper slot order
-    hit_cache = _global_cache->lookup(_cache_key, _version, &_query_cache_handle);
+    if (!cache_param.force_refresh_query_cache) {
+        hit_cache = _global_cache->lookup(_cache_key, _version, &_query_cache_handle);
+    }
     custom_profile()->add_info_string("HitCache", std::to_string(hit_cache));
-    if (hit_cache && !cache_param.force_refresh_query_cache) {
+    if (hit_cache) {
         _hit_cache_results = _query_cache_handle.get_cache_result();
         auto hit_cache_slot_orders = _query_cache_handle.get_cache_slot_orders();
 

--- a/be/src/exec/operator/olap_table_sink_operator.h
+++ b/be/src/exec/operator/olap_table_sink_operator.h
@@ -38,9 +38,9 @@ public:
 class OlapTableSinkOperatorX final : public DataSinkOperatorX<OlapTableSinkLocalState> {
 public:
     using Base = DataSinkOperatorX<OlapTableSinkLocalState>;
-    OlapTableSinkOperatorX(ObjectPool* pool, int operator_id, const RowDescriptor& row_desc,
-                           const std::vector<TExpr>& t_output_expr)
-            : Base(operator_id, 0, 0),
+    OlapTableSinkOperatorX(ObjectPool* pool, int operator_id, int node_id,
+                           const RowDescriptor& row_desc, const std::vector<TExpr>& t_output_expr)
+            : Base(operator_id, node_id, node_id),
               _row_desc(row_desc),
               _t_output_expr(t_output_expr),
               _pool(pool) {};

--- a/be/src/exec/operator/olap_table_sink_v2_operator.h
+++ b/be/src/exec/operator/olap_table_sink_v2_operator.h
@@ -39,9 +39,9 @@ public:
 class OlapTableSinkV2OperatorX final : public DataSinkOperatorX<OlapTableSinkV2LocalState> {
 public:
     using Base = DataSinkOperatorX<OlapTableSinkV2LocalState>;
-    OlapTableSinkV2OperatorX(ObjectPool* pool, int operator_id, const RowDescriptor& row_desc,
-                             const std::vector<TExpr>& t_output_expr)
-            : Base(operator_id, 0, 0),
+    OlapTableSinkV2OperatorX(ObjectPool* pool, int operator_id, int node_id,
+                             const RowDescriptor& row_desc, const std::vector<TExpr>& t_output_expr)
+            : Base(operator_id, node_id, node_id),
               _row_desc(row_desc),
               _t_output_expr(t_output_expr),
               _pool(pool) {};

--- a/be/src/exec/operator/result_sink_operator.cpp
+++ b/be/src/exec/operator/result_sink_operator.cpp
@@ -94,11 +94,11 @@ Status ResultSinkLocalState::open(RuntimeState* state) {
     return Status::OK();
 }
 
-ResultSinkOperatorX::ResultSinkOperatorX(int operator_id, const RowDescriptor& row_desc,
+ResultSinkOperatorX::ResultSinkOperatorX(int operator_id, int node_id,
+                                         const RowDescriptor& row_desc,
                                          const std::vector<TExpr>& t_output_expr,
                                          const TResultSink& sink)
-        : DataSinkOperatorX(operator_id, std::numeric_limits<int>::max(),
-                            std::numeric_limits<int>::max()),
+        : DataSinkOperatorX(operator_id, node_id, node_id),
           _sink_type(!sink.__isset.type || sink.type == TResultSinkType::MYSQL_PROTOCOL
                              ? TResultSinkType::MYSQL_PROTOCOL
                              : sink.type),

--- a/be/src/exec/operator/result_sink_operator.h
+++ b/be/src/exec/operator/result_sink_operator.h
@@ -156,7 +156,7 @@ private:
 
 class ResultSinkOperatorX final : public DataSinkOperatorX<ResultSinkLocalState> {
 public:
-    ResultSinkOperatorX(int operator_id, const RowDescriptor& row_desc,
+    ResultSinkOperatorX(int operator_id, int node_id, const RowDescriptor& row_desc,
                         const std::vector<TExpr>& select_exprs, const TResultSink& sink);
     Status prepare(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/exec/pipeline/pipeline_fragment_context.cpp
@@ -1067,8 +1067,11 @@ Status PipelineFragmentContext::_create_data_sink(ObjectPool* pool, const TDataS
             return Status::InternalError("Missing data buffer sink.");
         }
 
-        _sink = std::make_shared<ResultSinkOperatorX>(next_sink_operator_id(), row_desc,
-                                                      output_exprs, thrift_sink.result_sink);
+        auto& pipeline = _pipelines[cur_pipeline_id];
+        int child_node_id = pipeline->operators().back()->node_id();
+        _sink = std::make_shared<ResultSinkOperatorX>(next_sink_operator_id(), child_node_id + 1,
+                                                      row_desc, output_exprs,
+                                                      thrift_sink.result_sink);
         break;
     }
     case TDataSinkType::DICTIONARY_SINK: {
@@ -1082,14 +1085,16 @@ Status PipelineFragmentContext::_create_data_sink(ObjectPool* pool, const TDataS
     }
     case TDataSinkType::GROUP_COMMIT_OLAP_TABLE_SINK:
     case TDataSinkType::OLAP_TABLE_SINK: {
+        auto& pipeline = _pipelines[cur_pipeline_id];
+        int child_node_id = pipeline->operators().back()->node_id();
         if (state->query_options().enable_memtable_on_sink_node &&
             !_has_inverted_index_v1_or_partial_update(thrift_sink.olap_table_sink) &&
             !config::is_cloud_mode()) {
-            _sink = std::make_shared<OlapTableSinkV2OperatorX>(pool, next_sink_operator_id(),
-                                                               row_desc, output_exprs);
+            _sink = std::make_shared<OlapTableSinkV2OperatorX>(
+                    pool, next_sink_operator_id(), child_node_id + 1, row_desc, output_exprs);
         } else {
-            _sink = std::make_shared<OlapTableSinkOperatorX>(pool, next_sink_operator_id(),
-                                                             row_desc, output_exprs);
+            _sink = std::make_shared<OlapTableSinkOperatorX>(
+                    pool, next_sink_operator_id(), child_node_id + 1, row_desc, output_exprs);
         }
         break;
     }


### PR DESCRIPTION
 [fix](be) Fix incorrect HitCache profile in force refresh and sink operator node_id

 ### What problem does this PR solve?

 Issue Number: close #xxx

 Related PR: #xxx

 Problem Summary:
 Two profile correctness issues were fixed:

 1. **RESULT_SINK / OLAP_TABLE_SINK node_id incorrect**: `ResultSinkOperatorX`,
    `OlapTableSinkOperatorX`, and `OlapTableSinkV2OperatorX` were all passing
    `std::numeric_limits<int>::max()` (2147483647) as their `node_id`, so the
    profile showed `RESULT_SINK_OPERATOR(id=2147483647)` instead of a meaningful
    id. The fix derives `node_id` as `child_node_id + 1` (the `node_id` of the
    last operator on the pipeline plus one), and threads it through the
    constructors, so the profile now displays a correct, readable id.

 2. **CacheSourceOperator `HitCache` profile incorrect on force-refresh**: When
    `force_refresh_query_cache = true`, the cache is looked up but its result is
    intentionally discarded. Previously `HitCache` was set to `true` even in this
    case, misleading the profile. The fix moves the `add_info_string("HitCache",
    ...)` call to after the `force_refresh` check, so the reported value reflects
    whether the cache was actually *used*.

 ### Release note

 None

 ### Check List (For Author)

 - Test
     - [x] Manual test (verified profile output shows correct node id and
       HitCache value)
 - Behavior changed:
     - [x] Yes. Profile `id=` for RESULT_SINK / OLAP_TABLE_SINK operators now
       shows a correct child node_id+1 instead of 2147483647. The `HitCache`
       profile field now correctly reports `false` when
       `force_refresh_query_cache=true`.
 - Does this need documentation?
     - [x] No.


