### PR TITLE
[improvement](be) Add check_column_type to validate column types before reading

### DIFF
--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "common/demangle.h"
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/binary_cast.hpp"
@@ -36,6 +37,7 @@
 #include "core/column/column_array.h"
 #include "core/column/column_map.h"
 #include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
 #include "core/column/column_struct.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_agg_state.h"
@@ -60,6 +62,7 @@
 #include "storage/olap_common.h"
 #include "storage/predicate/block_column_predicate.h"
 #include "storage/predicate/column_predicate.h"
+#include "storage/schema.h"
 #include "storage/segment/binary_dict_page.h" // for BinaryDictPageDecoder
 #include "storage/segment/binary_plain_page.h"
 #include "storage/segment/column_meta_accessor.h"
@@ -2560,6 +2563,124 @@ Status RowIdColumnIteratorV2::read_by_rowids(const rowid_t* rowids, const size_t
         GlobalRowLoacationV2 location(_version, _backend_id, _file_id, row_id);
         string_column->insert_data(reinterpret_cast<const char*>(&location),
                                    sizeof(GlobalRowLoacationV2));
+    }
+    return Status::OK();
+}
+
+// Helper: unwrap ColumnNullable if present, return the inner column.
+static const IColumn& unwrap_nullable(const IColumn& col) {
+    if (const auto* nullable = check_and_get_column<ColumnNullable>(col)) {
+        return nullable->get_nested_column();
+    }
+    return col;
+}
+
+Status FileColumnIterator::check_column_type(const IColumn& dst) const {
+    const auto& inner = unwrap_nullable(dst);
+
+    // Compare against the canonical runtime column implementation produced from
+    // the storage type. This validates dst's actual column class, not the meta
+    // itself, and catches FE/storage mismatches before read hot paths use it.
+    auto expected_vec_col = _reader->get_vec_data_type()->create_column();
+    const auto& expected_vec_inner = unwrap_nullable(*expected_vec_col);
+    if (typeid(inner) == typeid(expected_vec_inner)) {
+        return Status::OK();
+    }
+
+    // Check 2: ColumnDictI32 (valid only for string-like storage types)
+    if (inner.is_column_dictionary()) {
+        FieldType mt = _reader->get_meta_type();
+        if (mt == FieldType::OLAP_FIELD_TYPE_CHAR || mt == FieldType::OLAP_FIELD_TYPE_VARCHAR ||
+            mt == FieldType::OLAP_FIELD_TYPE_STRING || mt == FieldType::OLAP_FIELD_TYPE_JSONB) {
+            return Status::OK();
+        }
+    }
+
+    // Check 3: PredicateColumnType matching the storage type.
+    // Use READER_ALTER_TABLE to bypass ColumnDictI32 optimization and always get
+    // PredicateColumnType, then compare typeid against the actual dst column.
+    try {
+        auto pred_col = Schema::get_predicate_column_ptr(_reader->get_meta_type(), false,
+                                                         ReaderType::READER_ALTER_TABLE);
+        const auto& pred_inner = unwrap_nullable(*pred_col);
+        if (typeid(inner) == typeid(pred_inner)) {
+            return Status::OK();
+        }
+    } catch (const Exception&) {
+        // Storage type doesn't support PredicateColumnType (e.g., HLL, BITMAP)
+    }
+
+    return Status::InternalError(
+            "Column type mismatch in FileColumnIterator for column '{}': "
+            "storage type is '{}' but got column type '{}'",
+            _column_name, _reader->get_vec_data_type()->get_name(), demangle(typeid(inner).name()));
+}
+
+Status MapFileColumnIterator::check_column_type(const IColumn& dst) const {
+    const auto& inner = unwrap_nullable(dst);
+    const auto* map_col = check_and_get_column<ColumnMap>(inner);
+    if (!map_col) {
+        return Status::InternalError(
+                "Column type mismatch in MapFileColumnIterator for column '{}': "
+                "expected ColumnMap but got {}",
+                _column_name, demangle(typeid(inner).name()));
+    }
+    // Recursively check key and value sub-columns
+    if (_key_iterator) {
+        RETURN_IF_ERROR(_key_iterator->check_column_type(map_col->get_keys()));
+    }
+    if (_val_iterator) {
+        RETURN_IF_ERROR(_val_iterator->check_column_type(map_col->get_values()));
+    }
+    return Status::OK();
+}
+
+Status StructFileColumnIterator::check_column_type(const IColumn& dst) const {
+    const auto& inner = unwrap_nullable(dst);
+    const auto* struct_col = check_and_get_column<ColumnStruct>(inner);
+    if (!struct_col) {
+        return Status::InternalError(
+                "Column type mismatch in StructFileColumnIterator for column '{}': "
+                "expected ColumnStruct but got {}",
+                _column_name, demangle(typeid(inner).name()));
+    }
+    // Enforce exact arity — mismatched tuple size would cause out-of-bounds
+    // access in next_batch which iterates over tuple_size().
+    if (_sub_column_iterators.size() != struct_col->tuple_size()) {
+        return Status::InternalError(
+                "Struct arity mismatch in StructFileColumnIterator for column '{}': "
+                "iterator has {} sub-columns but destination ColumnStruct has {}",
+                _column_name, _sub_column_iterators.size(), struct_col->tuple_size());
+    }
+    // Recursively check each sub-column
+    for (size_t i = 0; i < _sub_column_iterators.size(); ++i) {
+        RETURN_IF_ERROR(_sub_column_iterators[i]->check_column_type(struct_col->get_column(i)));
+    }
+    return Status::OK();
+}
+
+Status ArrayFileColumnIterator::check_column_type(const IColumn& dst) const {
+    const auto& inner = unwrap_nullable(dst);
+    const auto* array_col = check_and_get_column<ColumnArray>(inner);
+    if (!array_col) {
+        return Status::InternalError(
+                "Column type mismatch in ArrayFileColumnIterator for column '{}': "
+                "expected ColumnArray but got {}",
+                _column_name, demangle(typeid(inner).name()));
+    }
+    // Recursively check item sub-column
+    if (_item_iterator) {
+        RETURN_IF_ERROR(_item_iterator->check_column_type(array_col->get_data()));
+    }
+    return Status::OK();
+}
+
+Status RowIdColumnIteratorV2::check_column_type(const IColumn& dst) const {
+    if (!check_and_get_column<ColumnString>(dst)) {
+        return Status::InternalError(
+                "Column type mismatch in RowIdColumnIteratorV2: "
+                "expected ColumnString but got {}",
+                demangle(typeid(dst).name()));
     }
     return Status::OK();
 }

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "common/demangle.h"
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/binary_cast.hpp"
@@ -36,6 +37,7 @@
 #include "core/column/column_array.h"
 #include "core/column/column_map.h"
 #include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
 #include "core/column/column_struct.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_agg_state.h"
@@ -60,6 +62,7 @@
 #include "storage/olap_common.h"
 #include "storage/predicate/block_column_predicate.h"
 #include "storage/predicate/column_predicate.h"
+#include "storage/schema.h"
 #include "storage/segment/binary_dict_page.h" // for BinaryDictPageDecoder
 #include "storage/segment/binary_plain_page.h"
 #include "storage/segment/column_meta_accessor.h"
@@ -2560,6 +2563,133 @@ Status RowIdColumnIteratorV2::read_by_rowids(const rowid_t* rowids, const size_t
         GlobalRowLoacationV2 location(_version, _backend_id, _file_id, row_id);
         string_column->insert_data(reinterpret_cast<const char*>(&location),
                                    sizeof(GlobalRowLoacationV2));
+    }
+    return Status::OK();
+}
+
+// Helper: unwrap ColumnNullable if present, return the inner column.
+// Sets *is_nullable = true if the outer column is nullable (if is_nullable is not null).
+static const IColumn& unwrap_nullable(const IColumn& col, bool* is_nullable) {
+    if (const auto* nullable = check_and_get_column<ColumnNullable>(col)) {
+        if (is_nullable) {
+            *is_nullable = true;
+        }
+        return nullable->get_nested_column();
+    }
+    if (is_nullable) {
+        *is_nullable = false;
+    }
+    return col;
+}
+
+Status FileColumnIterator::check_column_type(const IColumn& dst) const {
+    bool is_nullable = false;
+    const auto& inner = unwrap_nullable(dst, &is_nullable);
+
+    // Check 1: canonical column type from storage data type
+    auto canonical_col = _reader->get_vec_data_type()->create_column();
+    const auto& canonical_inner = unwrap_nullable(*canonical_col, nullptr);
+    if (typeid(inner) == typeid(canonical_inner)) {
+        return Status::OK();
+    }
+
+    // Check 2: ColumnDictI32 (valid only for string-like storage types)
+    if (inner.is_column_dictionary()) {
+        FieldType mt = _reader->get_meta_type();
+        if (mt == FieldType::OLAP_FIELD_TYPE_CHAR || mt == FieldType::OLAP_FIELD_TYPE_VARCHAR ||
+            mt == FieldType::OLAP_FIELD_TYPE_STRING || mt == FieldType::OLAP_FIELD_TYPE_JSONB) {
+            return Status::OK();
+        }
+    }
+
+    // Check 3: PredicateColumnType matching the storage type.
+    // Use READER_ALTER_TABLE to bypass ColumnDictI32 optimization and always get
+    // PredicateColumnType, then compare typeid against the actual dst column.
+    try {
+        auto pred_col = Schema::get_predicate_column_ptr(_reader->get_meta_type(), false,
+                                                         ReaderType::READER_ALTER_TABLE);
+        const auto& pred_inner = unwrap_nullable(*pred_col, nullptr);
+        if (typeid(inner) == typeid(pred_inner)) {
+            return Status::OK();
+        }
+    } catch (const Exception&) {
+        // Storage type doesn't support PredicateColumnType (e.g., HLL, BITMAP)
+    }
+
+    return Status::InternalError(
+            "Column type mismatch in FileColumnIterator for column '{}': "
+            "storage type is '{}' but got column type '{}'",
+            _column_name, _reader->get_vec_data_type()->get_name(), demangle(typeid(inner).name()));
+}
+
+Status MapFileColumnIterator::check_column_type(const IColumn& dst) const {
+    bool is_nullable = false;
+    const auto& inner = unwrap_nullable(dst, &is_nullable);
+    const auto* map_col = check_and_get_column<ColumnMap>(inner);
+    if (!map_col) {
+        return Status::InternalError(
+                "Column type mismatch in MapFileColumnIterator for column '{}': "
+                "expected ColumnMap but got {}",
+                _column_name, demangle(typeid(inner).name()));
+    }
+    // Recursively check key and value sub-columns
+    if (_key_iterator) {
+        RETURN_IF_ERROR(_key_iterator->check_column_type(map_col->get_keys()));
+    }
+    if (_val_iterator) {
+        RETURN_IF_ERROR(_val_iterator->check_column_type(map_col->get_values()));
+    }
+    return Status::OK();
+}
+
+Status StructFileColumnIterator::check_column_type(const IColumn& dst) const {
+    bool is_nullable = false;
+    const auto& inner = unwrap_nullable(dst, &is_nullable);
+    const auto* struct_col = check_and_get_column<ColumnStruct>(inner);
+    if (!struct_col) {
+        return Status::InternalError(
+                "Column type mismatch in StructFileColumnIterator for column '{}': "
+                "expected ColumnStruct but got {}",
+                _column_name, demangle(typeid(inner).name()));
+    }
+    // Enforce exact arity — mismatched tuple size would cause out-of-bounds
+    // access in next_batch which iterates over tuple_size().
+    if (_sub_column_iterators.size() != struct_col->tuple_size()) {
+        return Status::InternalError(
+                "Struct arity mismatch in StructFileColumnIterator for column '{}': "
+                "iterator has {} sub-columns but destination ColumnStruct has {}",
+                _column_name, _sub_column_iterators.size(), struct_col->tuple_size());
+    }
+    // Recursively check each sub-column
+    for (size_t i = 0; i < _sub_column_iterators.size(); ++i) {
+        RETURN_IF_ERROR(_sub_column_iterators[i]->check_column_type(struct_col->get_column(i)));
+    }
+    return Status::OK();
+}
+
+Status ArrayFileColumnIterator::check_column_type(const IColumn& dst) const {
+    bool is_nullable = false;
+    const auto& inner = unwrap_nullable(dst, &is_nullable);
+    const auto* array_col = check_and_get_column<ColumnArray>(inner);
+    if (!array_col) {
+        return Status::InternalError(
+                "Column type mismatch in ArrayFileColumnIterator for column '{}': "
+                "expected ColumnArray but got {}",
+                _column_name, demangle(typeid(inner).name()));
+    }
+    // Recursively check item sub-column
+    if (_item_iterator) {
+        RETURN_IF_ERROR(_item_iterator->check_column_type(array_col->get_data()));
+    }
+    return Status::OK();
+}
+
+Status RowIdColumnIteratorV2::check_column_type(const IColumn& dst) const {
+    if (!check_and_get_column<ColumnString>(dst)) {
+        return Status::InternalError(
+                "Column type mismatch in RowIdColumnIteratorV2: "
+                "expected ColumnString but got {}",
+                demangle(typeid(dst).name()));
     }
     return Status::OK();
 }

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -339,6 +339,12 @@ public:
         return Status::NotSupported("read_by_rowids not implement");
     }
 
+    // Validates that dst column's type matches what this iterator expects.
+    // Called once per block before reading to catch FE/storage type mismatches early,
+    // avoiding undefined behavior from incorrect assert_cast in hot paths.
+    // Composite iterators (Map/Struct/Array) recursively check sub-columns.
+    virtual Status check_column_type(const IColumn& dst) const { return Status::OK(); }
+
     virtual ordinal_t get_current_ordinal() const = 0;
 
     virtual Status get_row_ranges_by_zone_map(
@@ -456,6 +462,8 @@ public:
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override;
+
+    Status check_column_type(const IColumn& dst) const override;
 
     ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 
@@ -607,6 +615,8 @@ public:
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override;
 
+    Status check_column_type(const IColumn& dst) const override;
+
     Status seek_to_ordinal(ordinal_t ord) override;
 
     ordinal_t get_current_ordinal() const override {
@@ -655,6 +665,8 @@ public:
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override;
 
+    Status check_column_type(const IColumn& dst) const override;
+
     Status seek_to_ordinal(ordinal_t ord) override;
 
     ordinal_t get_current_ordinal() const override {
@@ -702,6 +714,8 @@ public:
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override;
+
+    Status check_column_type(const IColumn& dst) const override;
 
     Status seek_to_ordinal(ordinal_t ord) override;
 
@@ -797,6 +811,8 @@ public:
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override;
+
+    Status check_column_type(const IColumn& dst) const override;
 
     ordinal_t get_current_ordinal() const override { return _current_rowid; }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -2099,6 +2099,7 @@ Status SegmentIterator::_read_columns(const std::vector<ColumnId>& column_ids,
         if (_prune_column(cid, column, true, rows_read)) {
             continue;
         }
+        RETURN_IF_ERROR(_column_iterators[cid]->check_column_type(*column));
         RETURN_IF_ERROR(_column_iterators[cid]->next_batch(&rows_read, column));
         if (nrows != rows_read) {
             return Status::Error<ErrorCode::INTERNAL_ERROR>("nrows({}) != rows_read({})", nrows,
@@ -2270,6 +2271,8 @@ Status SegmentIterator::_read_columns_by_index(uint32_t nrows_read_limit, uint16
                 }
             })
         }
+
+        RETURN_IF_ERROR(_column_iterators[cid]->check_column_type(*column));
 
         if (is_continuous) {
             size_t rows_read = nrows_read;
@@ -2497,6 +2500,7 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
                     "SegmentIterator meet invalid column, return columns size {}, cid {}",
                     _current_return_columns.size(), cid);
         }
+        RETURN_IF_ERROR(_column_iterators[cid]->check_column_type(*_current_return_columns[cid]));
         RETURN_IF_ERROR(_column_iterators[cid]->read_by_rowids(rowids.data(), select_size,
                                                                _current_return_columns[cid]));
     }


### PR DESCRIPTION
Issue Number: close #xxx

Problem Summary:
In column_reader.cpp, both read_by_rowids and next_batch use assert_cast to convert the dst column to the expected type. However, the FE-planned type may not match the storage type, leading to undefined behavior from incorrect assert_cast in hot paths. Using TypeCheckOnRelease::ENABLE on every read call would cause performance degradation.

This adds a check_column_type virtual method to ColumnIterator that validates column types once per block before reading, catching FE/storage type mismatches early without impacting hot-path performance.

The implementation:
- Adds check_column_type() to the ColumnIterator base class (default: OK)
- FileColumnIterator: compares typeid of dst vs expected column from DataType
- MapFileColumnIterator: validates ColumnMap structure, recursively checks keys/values
- StructFileColumnIterator: validates ColumnStruct, recursively checks sub-columns
- ArrayFileColumnIterator: validates ColumnArray, recursively checks item column
- RowIdColumnIteratorV2: validates ColumnString
- Called in all three read paths: _read_columns, _read_columns_by_index, _read_columns_by_rowids in SegmentIterator

None

- Test: No need to test - defensive runtime check that returns Status::InternalError on type mismatch; no behavioral change for correct types
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

