### PR TITLE
branch-4.1: [improvement](docker) Make thirdparty jar download mirror configurable

### DIFF
--- a/docker/thirdparties/custom_settings.env
+++ b/docker/thirdparties/custom_settings.env
@@ -24,3 +24,7 @@ CONTAINER_UID="doris--"
 export s3Endpoint="oss-cn-hongkong.aliyuncs.com"
 export s3BucketName="doris-regression-hk"
 export OSSBucket="doris-regression-bj"
+
+# Optional Maven repository override for thirdparty jar downloads.
+# export MAVEN_REPOSITORY_URL="https://maven.aliyun.com/repository/central"
+export MAVEN_REPOSITORY_URL="${MAVEN_REPOSITORY_URL:-https://repo1.maven.org/maven2}"

--- a/docker/thirdparties/docker-compose/hudi/hudi.env.tpl
+++ b/docker/thirdparties/docker-compose/hudi/hudi.env.tpl
@@ -33,18 +33,18 @@ HUDI_BUCKET=datalake
 # Hudi 1.0.2 supports Spark 3.5.x (default), 3.4.x, and 3.3.x
 # Using Spark 3.5 bundle to match Spark 3.5.7 image (default build)
 HUDI_BUNDLE_VERSION=1.0.2
-HUDI_BUNDLE_URL=https://repo1.maven.org/maven2/org/apache/hudi/hudi-spark3.5-bundle_2.12/1.0.2/hudi-spark3.5-bundle_2.12-1.0.2.jar
+HUDI_BUNDLE_URL=${HUDI_BUNDLE_URL}
 
 # Hadoop AWS S3A filesystem (required for S3A support)
 # Note: Version must match Spark's built-in Hadoop version (3.3.4 for Spark 3.5.7)
 HADOOP_AWS_VERSION=3.3.4
-HADOOP_AWS_URL=https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
+HADOOP_AWS_URL=${HADOOP_AWS_URL}
 
 # AWS Java SDK Bundle v1 (required for Hadoop 3.3.4 S3A support)
 # Note: Hadoop 3.3.x uses AWS SDK v1, version 1.12.x is recommended
 AWS_SDK_BUNDLE_VERSION=1.12.262
-AWS_SDK_BUNDLE_URL=https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
+AWS_SDK_BUNDLE_URL=${AWS_SDK_BUNDLE_URL}
 
 # PostgreSQL JDBC driver (required for Hive Metastore connection)
 POSTGRESQL_JDBC_VERSION=42.7.1
-POSTGRESQL_JDBC_URL=https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.1/postgresql-42.7.1.jar
+POSTGRESQL_JDBC_URL=${POSTGRESQL_JDBC_URL}

--- a/docker/thirdparties/juicefs-helpers.sh
+++ b/docker/thirdparties/juicefs-helpers.sh
@@ -19,7 +19,8 @@
 # Shared JuiceFS helper functions used by build and docker scripts.
 
 JUICEFS_DEFAULT_VERSION="${JUICEFS_DEFAULT_VERSION:-1.3.1}"
-JUICEFS_HADOOP_MAVEN_REPO="${JUICEFS_HADOOP_MAVEN_REPO:-https://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop}"
+MAVEN_REPOSITORY_URL="${MAVEN_REPOSITORY_URL:-https://repo1.maven.org/maven2}"
+JUICEFS_HADOOP_MAVEN_REPO="${JUICEFS_HADOOP_MAVEN_REPO:-${MAVEN_REPOSITORY_URL}/io/juicefs/juicefs-hadoop}"
 
 juicefs_find_hadoop_jar_by_globs() {
     local jar_glob=""

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -613,6 +613,10 @@ start_iceberg() {
 start_hudi() {
     HUDI_DIR=${ROOT}/docker-compose/hudi
     export CONTAINER_UID=${CONTAINER_UID}
+    export HUDI_BUNDLE_URL="${HUDI_BUNDLE_URL:-${MAVEN_REPOSITORY_URL}/org/apache/hudi/hudi-spark3.5-bundle_2.12/1.0.2/hudi-spark3.5-bundle_2.12-1.0.2.jar}"
+    export HADOOP_AWS_URL="${HADOOP_AWS_URL:-${MAVEN_REPOSITORY_URL}/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar}"
+    export AWS_SDK_BUNDLE_URL="${AWS_SDK_BUNDLE_URL:-${MAVEN_REPOSITORY_URL}/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar}"
+    export POSTGRESQL_JDBC_URL="${POSTGRESQL_JDBC_URL:-${MAVEN_REPOSITORY_URL}/org/postgresql/postgresql/42.7.1/postgresql-42.7.1.jar}"
     envsubst <"${HUDI_DIR}"/hudi.env.tpl >"${HUDI_DIR}"/hudi.env
     set -a
     . "${HUDI_DIR}"/hudi.env


### PR DESCRIPTION
Issue Number: close #none

Related PR: #none
bp  https://github.com/apache/doris/pull/62376

Problem Summary: Allow thirdparty docker components to derive jar download URLs from a configurable Maven mirror, so environments that cannot access Maven Central can switch to an alternative repository without editing multiple hardcoded URLs.

None

- Test: Manual test
    - Verified bash syntax for updated scripts
    - Verified hudi env rendering with default and mirror-based URLs
    - Verified Aliyun Maven mirror can serve all required jars with HTTP HEAD and ranged GET requests
- Behavior changed: Yes (thirdparty jar download source can now be configured through MAVEN_REPOSITORY_URL)
- Does this need documentation: No

(cherry picked from commit fe1b946d40ca36cc61673059ae257edfce55c600)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

