### PR TITLE
[fix](audit log) fix empty workload_group value __internal_schema.audit_log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -75,6 +75,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.proto.Data;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.cache.CacheAnalyzer;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
 import org.apache.doris.thrift.TMasterOpRequest;
@@ -185,6 +186,34 @@ public abstract class ConnectProcessor {
         AuditLogHelper.logAuditLog(ctx, origStmt, parsedStmt, statistics, printFuzzyVariables);
     }
 
+    /**
+     * Pre-resolve the workload group name and set it on ConnectContext.
+     * This ensures the workload group is available for audit logging even if the query
+     * fails when analysing and before reaching Coordinator.exec (where it is normally
+     * set). The resolution follows the same priority as WorkloadGroupMgr:
+     * session variable -> user property -> default group.
+     * Callers should invoke this at the start of any command dispatch path that may
+     * emit an audit log (COM_QUERY / COM_STMT_EXECUTE / COM_FIELD_LIST / FlightSql
+     * handleQuery). It is also re-invoked at the top of every iteration of
+     * {@link #executeQuery}'s per-statement loop so multi-statement requests that
+     * change {@code @@workload_group} mid-batch still audit later statements with
+     * the effective value.
+     */
+    protected void resolveWorkloadGroupName() {
+        ctx.setWorkloadGroupName("");
+        if (!Config.enable_workload_group) {
+            return;
+        }
+        String groupName = ctx.getSessionVariable().getWorkloadGroup();
+        if (Strings.isNullOrEmpty(groupName)) {
+            groupName = Env.getCurrentEnv().getAuth().getWorkloadGroup(ctx.getQualifiedUser());
+        }
+        if (Strings.isNullOrEmpty(groupName)) {
+            groupName = WorkloadGroupMgr.DEFAULT_GROUP_NAME;
+        }
+        ctx.setWorkloadGroupName(groupName);
+    }
+
     // only throw an exception when there is a problem interacting with the requesting client
     protected void handleQuery(String originStmt) throws ConnectionException {
         // Before executing the query, the queryId should be set to empty.
@@ -287,6 +316,12 @@ public abstract class ConnectProcessor {
                 if (i > 0) {
                     ctx.resetReturnRows();
                 }
+                // Re-resolve per statement: an earlier statement in the same multi-stmt
+                // request (e.g. SET workload_group=...) may have changed the effective
+                // workload group, and later statements that fail before Coordinator.exec
+                // would otherwise be audited with the stale value picked up once per
+                // packet in dispatch().
+                resolveWorkloadGroupName();
 
                 StatementBase parsedStmt = stmts.get(i);
                 parsedStmt.setOrigStmt(new OriginStatement(auditStmt, usingOrigSingleStmt ? 0 : i));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -248,6 +248,7 @@ public class MysqlConnectProcessor extends ConnectProcessor {
         }
         ctx.setCommand(command);
         ctx.setStartTime();
+        resolveWorkloadGroupName();
 
         switch (command) {
             case COM_INIT_DB:

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
@@ -93,6 +93,7 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
     public void handleQuery(String query) throws ConnectionException {
         MysqlCommand command = MysqlCommand.COM_QUERY;
         prepare(command);
+        resolveWorkloadGroupName();
 
         ctx.setRunningQuery(query);
         super.handleQuery(query);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogWorkloadGroupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogWorkloadGroupTest.java
@@ -1,0 +1,431 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.ConnectionException;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.mysql.privilege.Auth;
+import org.apache.doris.proto.Data;
+import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
+import org.apache.doris.service.arrowflight.FlightSqlConnectProcessor;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests that the workload_group field on ConnectContext (which is written into the
+ * audit_log by {@link AuditLogHelper}) is always resolved before any command that
+ * may emit an audit log is dispatched. Covers every code path that writes the audit
+ * log when a query fails before reaching Coordinator.exec().
+ */
+public class AuditLogWorkloadGroupTest {
+
+    private static final String SESSION_WORKLOAD_GROUP = "wg_session";
+    private static final String USER_PROPERTY_WORKLOAD_GROUP = "wg_user";
+
+    private boolean originalEnableWorkloadGroup;
+
+    @Before
+    public void setUp() {
+        FeConstants.runningUnitTest = true;
+        originalEnableWorkloadGroup = Config.enable_workload_group;
+        Config.enable_workload_group = true;
+    }
+
+    @After
+    public void tearDown() {
+        Config.enable_workload_group = originalEnableWorkloadGroup;
+        ConnectContext.remove();
+    }
+
+    // ---------- Direct tests of resolveWorkloadGroupName() ---------- //
+
+    @Test
+    public void testResolveWorkloadGroupNameDisabled() {
+        Config.enable_workload_group = false;
+        ConnectContext ctx = newContextWithSessionWorkloadGroup(SESSION_WORKLOAD_GROUP);
+        // Pre-populate to confirm the method always clears first.
+        ctx.setWorkloadGroupName("stale");
+
+        runResolveUnderMockEnv(ctx, null);
+
+        Assert.assertEquals("", ctx.getWorkloadGroupName());
+    }
+
+    @Test
+    public void testResolveWorkloadGroupNameFromSessionVariable() {
+        ConnectContext ctx = newContextWithSessionWorkloadGroup(SESSION_WORKLOAD_GROUP);
+
+        runResolveUnderMockEnv(ctx, USER_PROPERTY_WORKLOAD_GROUP);
+
+        // Session variable has highest priority.
+        Assert.assertEquals(SESSION_WORKLOAD_GROUP, ctx.getWorkloadGroupName());
+    }
+
+    @Test
+    public void testResolveWorkloadGroupNameFromUserProperty() {
+        ConnectContext ctx = newContextWithSessionWorkloadGroup("");
+
+        runResolveUnderMockEnv(ctx, USER_PROPERTY_WORKLOAD_GROUP);
+
+        Assert.assertEquals(USER_PROPERTY_WORKLOAD_GROUP, ctx.getWorkloadGroupName());
+    }
+
+    @Test
+    public void testResolveWorkloadGroupNameFallbackToDefault() {
+        ConnectContext ctx = newContextWithSessionWorkloadGroup("");
+
+        runResolveUnderMockEnv(ctx, null);
+
+        Assert.assertEquals(WorkloadGroupMgr.DEFAULT_GROUP_NAME, ctx.getWorkloadGroupName());
+    }
+
+    // ---------- Entry-point tests: every audit-logging code path ---------- //
+
+    @Test
+    public void testMysqlDispatchResolvesBeforeComQuery() throws Exception {
+        verifyDispatchResolvesForCommand(buildQueryPacket("select 1"));
+    }
+
+    @Test
+    public void testMysqlDispatchResolvesBeforeComStmtPrepare() throws Exception {
+        ByteBuffer pkt = buildPacketWithCode(COM_STMT_PREPARE_CODE,
+                "select 1".getBytes(StandardCharsets.UTF_8));
+        verifyDispatchResolvesForCommand(pkt);
+    }
+
+    @Test
+    public void testMysqlDispatchResolvesBeforeComStmtExecute() throws Exception {
+        // COM_STMT_EXECUTE payload: stmtId(4) + flags(1) + iteration_count(4). We just
+        // need valid bytes; the processor returns early because no prepared stmt exists,
+        // which is fine — we only care that resolveWorkloadGroupName() ran first.
+        ByteBuffer pkt = ByteBuffer.allocate(1 + 4 + 1 + 4);
+        pkt.put(COM_STMT_EXECUTE_CODE);
+        for (int i = 0; i < 9; i++) {
+            pkt.put((byte) 0);
+        }
+        pkt.flip();
+        verifyDispatchResolvesForCommand(pkt);
+    }
+
+    @Test
+    public void testMysqlDispatchResolvesBeforeComFieldList() throws Exception {
+        byte[] tableName = "t\0".getBytes(StandardCharsets.UTF_8);
+        ByteBuffer pkt = ByteBuffer.allocate(1 + tableName.length);
+        pkt.put(COM_FIELD_LIST_CODE);
+        pkt.put(tableName);
+        pkt.flip();
+        verifyDispatchResolvesForCommand(pkt);
+    }
+
+    @Test
+    public void testFlightSqlHandleQueryResolvesWorkloadGroup() throws Exception {
+        ConnectContext ctx = newContextWithSessionWorkloadGroup(SESSION_WORKLOAD_GROUP);
+        RecordingFlightSqlProcessor processor = new RecordingFlightSqlProcessor(ctx);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockEnvAuth(mockedEnv, null);
+            try {
+                processor.handleQuery("select 1");
+            } catch (ConnectionException ignored) {
+                // ignored — this unit test does not run a real query pipeline.
+            } catch (RuntimeException ignored) {
+                // ignored
+            }
+        }
+
+        Assert.assertTrue("resolveWorkloadGroupName must be called before super.handleQuery",
+                processor.resolvedBeforeHandleQuery);
+        Assert.assertEquals(SESSION_WORKLOAD_GROUP, ctx.getWorkloadGroupName());
+    }
+
+    // ---------- Multi-statement per-iteration re-resolve ---------- //
+
+    /**
+     * Regression test for the "stale audit workload_group" issue on multi-statement
+     * requests. {@link ConnectProcessor#executeQuery} splits a single packet into
+     * N statements. If an earlier statement in the batch (effectively) changed
+     * {@code @@workload_group}, a later statement that fails before
+     * {@code Coordinator.exec} must still be audited with the post-change value,
+     * because {@link ConnectProcessor#resolveWorkloadGroupName} is invoked at the
+     * top of every loop iteration — not only once per packet in dispatch().
+     */
+    @Test
+    public void testExecuteQueryResolvesWorkloadGroupPerStatement() throws Exception {
+        final String firstStmtWg = "wg_first";
+        final String secondStmtWg = "wg_second";
+
+        ConnectContext ctx = newContextWithSessionWorkloadGroup(firstStmtWg);
+
+        List<StatementBase> parsedStmts = Arrays.asList(
+                Mockito.mock(StatementBase.class),
+                Mockito.mock(StatementBase.class));
+        List<String> auditedWorkloadGroups = new ArrayList<>();
+        int[] resolveCallCount = new int[]{0};
+
+        MultiStmtRecordingProcessor processor = new MultiStmtRecordingProcessor(
+                ctx, parsedStmts, auditedWorkloadGroups, resolveCallCount);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+                MockedConstruction<StmtExecutor> mc = Mockito.mockConstruction(StmtExecutor.class,
+                        Mockito.withSettings().defaultAnswer(Mockito.RETURNS_DEEP_STUBS),
+                        (mock, mockCtx) -> {
+                            if (mockCtx.getCount() == 1) {
+                                // First statement simulates "SET workload_group = wg_second"
+                                // by mutating the session variable inside execute().
+                                Mockito.doAnswer(inv -> {
+                                    ctx.getSessionVariable().setWorkloadGroup(secondStmtWg);
+                                    return null;
+                                }).when(mock).execute();
+                            }
+                        })) {
+            mockEnvAuth(mockedEnv, null);
+            try {
+                processor.executeQuery("select 1;select 2");
+            } catch (Exception ignored) {
+                // Not running a real query pipeline; tolerate any pipeline failures.
+            }
+        }
+
+        // resolveWorkloadGroupName() must be called at least once per statement,
+        // in addition to the caller-site invocation verified by the dispatch tests.
+        Assert.assertTrue("resolveWorkloadGroupName must be called for every statement"
+                        + " in the multi-stmt loop, got " + resolveCallCount[0],
+                resolveCallCount[0] >= 2);
+        // Both statements must be audited.
+        Assert.assertEquals(2, auditedWorkloadGroups.size());
+        // Statement 1 is audited with the initial session-variable value.
+        Assert.assertEquals(firstStmtWg, auditedWorkloadGroups.get(0));
+        // Statement 2 must be audited with the post-change value — *not* the stale
+        // value that the old once-per-packet resolve would have left on ctx.
+        Assert.assertEquals(secondStmtWg, auditedWorkloadGroups.get(1));
+    }
+
+    // ---------- Helpers ---------- //
+
+    private void verifyDispatchResolvesForCommand(ByteBuffer packet) throws Exception {
+        ConnectContext ctx = newContextWithSessionWorkloadGroup(SESSION_WORKLOAD_GROUP);
+        ctx.setWorkloadGroupName("stale");
+        RecordingMysqlProcessor processor = new RecordingMysqlProcessor(ctx);
+        // inject packet into the private packetBuf field
+        java.lang.reflect.Field f = MysqlConnectProcessor.class.getDeclaredField("packetBuf");
+        f.setAccessible(true);
+        f.set(processor, packet);
+
+        Method dispatch = MysqlConnectProcessor.class.getDeclaredMethod("dispatch");
+        dispatch.setAccessible(true);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockEnvAuth(mockedEnv, null);
+            try {
+                dispatch.invoke(processor);
+            } catch (Exception ignored) {
+                // The real command handlers are short-circuited; failures are fine.
+            }
+        }
+
+        Assert.assertTrue("resolveWorkloadGroupName must be invoked by dispatch()",
+                processor.resolveCalled);
+        // The resolution must have set the session-variable value, not left the stale one.
+        Assert.assertEquals(SESSION_WORKLOAD_GROUP, ctx.getWorkloadGroupName());
+    }
+
+    private ConnectContext newContextWithSessionWorkloadGroup(String wg) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.getSessionVariable().setWorkloadGroup(wg);
+        ctx.setThreadLocalInfo();
+        return ctx;
+    }
+
+    /**
+     * Invokes resolveWorkloadGroupName() through a minimal subclass while mocking
+     * Env.getCurrentEnv().getAuth().getWorkloadGroup() to return {@code userGroup}.
+     */
+    private void runResolveUnderMockEnv(ConnectContext ctx, String userGroup) {
+        DirectResolveProcessor processor = new DirectResolveProcessor(ctx);
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockEnvAuth(mockedEnv, userGroup);
+            processor.resolveWorkloadGroupName();
+        }
+    }
+
+    private void mockEnvAuth(MockedStatic<Env> mockedEnv, String userGroup) {
+        Env env = Mockito.mock(Env.class);
+        Auth auth = Mockito.mock(Auth.class);
+        Mockito.when(env.getAuth()).thenReturn(auth);
+        Mockito.when(auth.getWorkloadGroup(Mockito.anyString())).thenReturn(userGroup);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+    }
+
+    private ByteBuffer buildQueryPacket(String sql) {
+        return buildPacketWithCode(COM_QUERY_CODE, sql.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // MysqlCommand code constants (see MysqlCommand.java).
+    private static final byte COM_QUERY_CODE = 3;
+    private static final byte COM_FIELD_LIST_CODE = 4;
+    private static final byte COM_STMT_PREPARE_CODE = 22;
+    private static final byte COM_STMT_EXECUTE_CODE = 23;
+
+    private ByteBuffer buildPacketWithCode(byte code, byte[] payload) {
+        ByteBuffer buf = ByteBuffer.allocate(1 + payload.length);
+        buf.put(code);
+        buf.put(payload);
+        buf.flip();
+        return buf;
+    }
+
+    // ---------- Recording subclasses ---------- //
+
+    /** Subclass used purely to invoke the protected resolveWorkloadGroupName(). */
+    private static final class DirectResolveProcessor extends ConnectProcessor {
+        DirectResolveProcessor(ConnectContext ctx) {
+            super(ctx);
+        }
+
+        @Override
+        public void processOnce() {
+        }
+    }
+
+    /**
+     * Records whether resolveWorkloadGroupName() was called by dispatch() and
+     * short-circuits every handler so the test does not have to mock the full
+     * query/field-list pipeline.
+     */
+    private static final class RecordingMysqlProcessor extends MysqlConnectProcessor {
+        boolean resolveCalled;
+
+        RecordingMysqlProcessor(ConnectContext ctx) {
+            super(ctx);
+        }
+
+        @Override
+        protected void resolveWorkloadGroupName() {
+            resolveCalled = true;
+            super.resolveWorkloadGroupName();
+        }
+
+        @Override
+        public void executeQuery(String originStmt) {
+            // short-circuit; do not run the real query pipeline.
+        }
+
+        @Override
+        protected void handleFieldList(String tableName) {
+        }
+
+        @Override
+        protected void handleExecute(
+                org.apache.doris.nereids.trees.plans.commands.PrepareCommand command,
+                long stmtId,
+                PreparedStatementContext prepCtx,
+                ByteBuffer packetBuf,
+                org.apache.doris.thrift.TUniqueId queryId) {
+        }
+
+        // processOnce is not used here; dispatch() is invoked directly via reflection.
+    }
+
+    /**
+     * Records that resolveWorkloadGroupName() was invoked before super.handleQuery()
+     * is called inside FlightSqlConnectProcessor.handleQuery.
+     */
+    private static final class RecordingFlightSqlProcessor extends FlightSqlConnectProcessor {
+        boolean resolveCalled;
+        boolean resolvedBeforeHandleQuery;
+
+        RecordingFlightSqlProcessor(ConnectContext ctx) {
+            super(ctx);
+        }
+
+        @Override
+        protected void resolveWorkloadGroupName() {
+            resolveCalled = true;
+            super.resolveWorkloadGroupName();
+        }
+
+        @Override
+        public void executeQuery(String originStmt) {
+            // Record that resolve ran before the query pipeline starts.
+            resolvedBeforeHandleQuery = resolveCalled;
+        }
+    }
+
+    /**
+     * Test harness for the multi-statement per-iteration resolve test. Overrides
+     * {@code parseWithFallback} to return a pre-built statement list and
+     * {@code auditAfterExec} to record the workload group at audit time. Every
+     * call to {@code resolveWorkloadGroupName} is counted.
+     */
+    private static final class MultiStmtRecordingProcessor extends ConnectProcessor {
+        private final List<StatementBase> parsedStmts;
+        private final List<String> auditedWorkloadGroups;
+        private final int[] resolveCallCount;
+
+        MultiStmtRecordingProcessor(ConnectContext ctx, List<StatementBase> parsedStmts,
+                List<String> auditedWorkloadGroups, int[] resolveCallCount) {
+            super(ctx);
+            this.connectType = ConnectType.MYSQL;
+            this.parsedStmts = parsedStmts;
+            this.auditedWorkloadGroups = auditedWorkloadGroups;
+            this.resolveCallCount = resolveCallCount;
+        }
+
+        @Override
+        protected void resolveWorkloadGroupName() {
+            resolveCallCount[0]++;
+            super.resolveWorkloadGroupName();
+        }
+
+        @Override
+        protected List<StatementBase> parseWithFallback(String originStmt, String convertedStmt,
+                SessionVariable sessionVariable) {
+            return parsedStmts;
+        }
+
+        @Override
+        protected void auditAfterExec(String origStmt, StatementBase parsedStmt,
+                Data.PQueryStatistics statistics, boolean printFuzzyVariables) {
+            // Capture the resolved workload group at the moment the audit is emitted,
+            // which is exactly the value that would be written into audit_log.
+            auditedWorkloadGroups.add(ctx.getWorkloadGroupName());
+        }
+
+        @Override
+        public void processOnce() {
+        }
+    }
+}


### PR DESCRIPTION

When a SQL query fails before reaching Coordinator.exec() (e.g., "Database does not exist" during Nereids planning), the workload_group field in the audit_log is empty. This is because workload group name is only set on ConnectContext inside Coordinator.exec(), which is never reached for queries that fail during planning/analysis.

The workload group name was also never reset between queries on the same connection, so the bug only manifests on fresh connections where no previous query has reached Coordinator.exec(). On reused connections, the stale value from a prior query masks the issue.

Fix: Pre-resolve the workload group name at the start of StmtExecutor.execute() using the same resolution logic as WorkloadGroupMgr (session variable -> user property -> default). Coordinator.exec() will later overwrite this with the authoritative value after privilege checking and validation.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

