### PR TITLE
[opt](function) use AVX2 SIMD libdivide in int_divide vector-constant path

### DIFF
--- a/be/benchmark/benchmark_int_divide.hpp
+++ b/be/benchmark/benchmark_int_divide.hpp
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// ============================================================
+// Benchmark: int_divide vector-constant path
+//
+// Compares the current scalar libdivide loop with an AVX2-SIMD
+// libdivide loop for the vector_constant case.
+//
+// Types benchmarked: Int32, UInt32, Int64, UInt64
+// ============================================================
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+#include <libdivide.h>
+
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#ifdef __AVX2__
+#include <immintrin.h>
+#endif
+
+namespace doris {
+
+static constexpr size_t INT_DIVIDE_N = 4096;
+
+// ---------- helpers --------------------------------------------------
+
+template <typename T>
+static std::vector<T> make_random_data(size_t n, T lo, T hi) {
+    std::mt19937_64 rng(42);
+    std::uniform_int_distribution<T> dist(lo, hi);
+    std::vector<T> v(n);
+    for (auto& x : v) {
+        x = dist(rng);
+    }
+    return v;
+}
+
+// ---------- Old: scalar libdivide loop (current Doris) ---------------
+
+template <typename T>
+static void int_divide_scalar_old(const T* __restrict a, T b, T* __restrict c, size_t size) {
+    const libdivide::divider<T> divider(b);
+    for (size_t i = 0; i < size; i++) {
+        c[i] = a[i] / divider;
+    }
+}
+
+// ---------- New: AVX2 SIMD libdivide loop ----------------------------
+
+#ifdef LIBDIVIDE_AVX2
+template <typename T>
+static void int_divide_simd_new(const T* __restrict a, T b, T* __restrict c, size_t size) {
+    const libdivide::divider<T> divider(b);
+
+    constexpr size_t values_per_reg = sizeof(__m256i) / sizeof(T);
+    const size_t simd_size = size / values_per_reg * values_per_reg;
+
+    size_t i = 0;
+    for (; i < simd_size; i += values_per_reg) {
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(c + i),
+                            _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a + i)) / divider);
+    }
+    // tail
+    for (; i < size; i++) {
+        c[i] = a[i] / divider;
+    }
+}
+#else
+template <typename T>
+static void int_divide_simd_new(const T* __restrict a, T b, T* __restrict c, size_t size) {
+    // fallback to scalar when AVX2 not available
+    int_divide_scalar_old(a, b, c, size);
+}
+#endif
+
+// ---------- Benchmark definitions ------------------------------------
+
+#define DEFINE_INT_DIVIDE_BENCH(TNAME, T, DIVISOR)                                            \
+    static void BM_IntDiv_##TNAME##_Old(benchmark::State& state) {                            \
+        auto a = make_random_data<T>(INT_DIVIDE_N, 1, std::numeric_limits<T>::max() / 2);     \
+        std::vector<T> c(INT_DIVIDE_N);                                                        \
+        for (auto _ : state) {                                                                 \
+            int_divide_scalar_old<T>(a.data(), static_cast<T>(DIVISOR), c.data(),             \
+                                     INT_DIVIDE_N);                                            \
+            benchmark::DoNotOptimize(c.data()[0]);                                               \
+        }                                                                                      \
+        state.SetItemsProcessed(state.iterations() * INT_DIVIDE_N);                           \
+    }                                                                                          \
+    BENCHMARK(BM_IntDiv_##TNAME##_Old);                                                        \
+                                                                                               \
+    static void BM_IntDiv_##TNAME##_New(benchmark::State& state) {                            \
+        auto a = make_random_data<T>(INT_DIVIDE_N, 1, std::numeric_limits<T>::max() / 2);     \
+        std::vector<T> c(INT_DIVIDE_N);                                                        \
+        for (auto _ : state) {                                                                 \
+            int_divide_simd_new<T>(a.data(), static_cast<T>(DIVISOR), c.data(),               \
+                                   INT_DIVIDE_N);                                              \
+            benchmark::DoNotOptimize(c.data()[0]);                                               \
+        }                                                                                      \
+        state.SetItemsProcessed(state.iterations() * INT_DIVIDE_N);                           \
+    }                                                                                          \
+    BENCHMARK(BM_IntDiv_##TNAME##_New)
+
+DEFINE_INT_DIVIDE_BENCH(Int32, int32_t, 7);
+DEFINE_INT_DIVIDE_BENCH(UInt32, uint32_t, 7);
+DEFINE_INT_DIVIDE_BENCH(Int64, int64_t, 7);
+DEFINE_INT_DIVIDE_BENCH(UInt64, uint64_t, 7);
+
+#undef DEFINE_INT_DIVIDE_BENCH
+
+} // namespace doris

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -24,6 +24,7 @@
 #include "benchmark_fastunion.hpp"
 #include "benchmark_hll_merge.hpp"
 #include "benchmark_hybrid_set.hpp"
+#include "benchmark_int_divide.hpp"
 #include "benchmark_string.hpp"
 #include "benchmark_string_replace.hpp"
 #include "binary_cast_benchmark.hpp"

--- a/be/src/exprs/function/int_div.cpp
+++ b/be/src/exprs/function/int_div.cpp
@@ -20,6 +20,10 @@
 
 #include <libdivide.h>
 
+#ifdef LIBDIVIDE_AVX2
+#include <immintrin.h>
+#endif
+
 #include <utility>
 
 #include "core/data_type/data_type_number.h"
@@ -131,7 +135,21 @@ struct DivideIntegralImpl {
             if constexpr (!std::is_floating_point_v<Arg> && !std::is_same_v<Arg, Int128> &&
                           !std::is_same_v<Arg, Int8> && !std::is_same_v<Arg, UInt8>) {
                 const auto divider = libdivide::divider<Arg>(Arg(b));
-                for (size_t i = 0; i < size; i++) {
+                size_t i = 0;
+#ifdef LIBDIVIDE_AVX2
+                if constexpr (std::is_same_v<Arg, Int32> || std::is_same_v<Arg, UInt32> ||
+                              std::is_same_v<Arg, Int64> || std::is_same_v<Arg, UInt64>) {
+                    constexpr size_t values_per_reg = sizeof(__m256i) / sizeof(Arg);
+                    const size_t simd_size = size / values_per_reg * values_per_reg;
+                    for (; i < simd_size; i += values_per_reg) {
+                        _mm256_storeu_si256(
+                                reinterpret_cast<__m256i*>(c.data() + i),
+                                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a.data() + i)) /
+                                        divider);
+                    }
+                }
+#endif
+                for (; i < size; i++) {
                     c[i] = a[i] / divider;
                 }
             } else {


### PR DESCRIPTION
## Problem

`DivideIntegralImpl::apply()` in `int_div.cpp` handles the `vector / constant` case using
`libdivide::divider<T>` to avoid the expensive `idiv` instruction. However, the inner loop
calls the **scalar** `operator/(T)` overload:

```cpp
const auto divider = libdivide::divider<Arg>(Arg(b));
for (size_t i = 0; i < size; i++) {
    c[i] = a[i] / divider;   // scalar: 1 element per iteration
}
```

The compiler cannot auto-vectorize libdivide's internal (multiply + shift + conditional-add)
sequence even though the BE is compiled with `-mavx2` and `LIBDIVIDE_AVX2`. Each iteration
stays at scalar throughput.

## Solution

Exploit the `__m256i operator/(__m256i, divider<T>)` overload that libdivide provides when
`LIBDIVIDE_AVX2` is defined. Add an explicit AVX2 inner loop for `Int32/UInt32/Int64/UInt64`,
processing 8 or 4 elements per iteration respectively, then handle the tail with the existing
scalar loop.

No separate compilation unit is needed — Doris BE already defines `LIBDIVIDE_AVX2` globally
via CMake when `USE_AVX2=ON` (the default).

```cpp
#ifdef LIBDIVIDE_AVX2
if constexpr (std::is_same_v<Arg, Int32> || std::is_same_v<Arg, UInt32> ||
              std::is_same_v<Arg, Int64> || std::is_same_v<Arg, UInt64>) {
    constexpr size_t values_per_reg = sizeof(__m256i) / sizeof(Arg);
    const size_t simd_size = size / values_per_reg * values_per_reg;
    for (; i < simd_size; i += values_per_reg) {
        _mm256_storeu_si256(
                reinterpret_cast<__m256i*>(c.data() + i),
                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a.data() + i)) / divider);
    }
}
#endif
for (; i < size; i++) {
    c[i] = a[i] / divider;
}
```

## Benchmark

4096 rows per call, Release build, divisor = 7.

**Run on:** 192-core x86 server (192 x 3800 MHz), Release build.

```
Run on (192 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x96)
  L1 Instruction 32 KiB (x96)
  L2 Unified 2048 KiB (x96)
  L3 Unified 99840 KiB (x2)
Load Average: 76.33, 84.99, 84.20
***WARNING*** CPU scaling is enabled

-------------------------------------------------------------------------------
Benchmark                     Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------
BM_IntDiv_Int32_Old         845 ns          839 ns       854674 items_per_second=4.88415G/s
BM_IntDiv_Int32_New         661 ns          657 ns      1137562 items_per_second=6.23665G/s
BM_IntDiv_UInt32_Old        837 ns          833 ns       842528 items_per_second=4.91938G/s
BM_IntDiv_UInt32_New        645 ns          641 ns      1071347 items_per_second=6.38588G/s
BM_IntDiv_Int64_Old        4333 ns         4313 ns       158000 items_per_second=949.735M/s
BM_IntDiv_Int64_New        3087 ns         3073 ns       228848 items_per_second=1.33301G/s
BM_IntDiv_UInt64_Old       3174 ns         3163 ns       224296 items_per_second=1.29506G/s
BM_IntDiv_UInt64_New       2237 ns         2227 ns       300466 items_per_second=1.83932G/s
```

| Type   | Old (items/s) | New (items/s) | Speedup |
|--------|--------------|--------------|---------|
| Int32  | 4.88 G/s     | 6.24 G/s     | **1.28x** |
| UInt32 | 4.92 G/s     | 6.39 G/s     | **1.30x** |
| Int64  | 950 M/s      | 1.33 G/s     | **1.40x** |
| UInt64 | 1.30 G/s     | 1.84 G/s     | **1.42x** |

## Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

