### PR TITLE
[fix](regression) Add DROP TABLE before CREATE in test_inverted_index_v3

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_inverted_index_v3.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index_v3.groovy
@@ -141,6 +141,9 @@ suite("test_inverted_index_v3", "p0"){
     } finally {
     }
 
+    sql "DROP TABLE IF EXISTS `t1`"
+    sql "DROP TABLE IF EXISTS `t2`"
+
     sql """
       CREATE TABLE `t1` (
         `id` int NOT NULL,


### PR DESCRIPTION
## Summary
- Add `DROP TABLE IF EXISTS` for tables `t1` and `t2` before `CREATE TABLE` in `test_inverted_index_v3`
- Without this, the test fails with "Table 't1' already exists" on subsequent runs within the same pipeline

## Verification
- First run: PASSED
- Second run without fix: FAILED ("Table 't1' already exists")  
- Second run with fix: PASSED

## Test plan
- [x] Verified on live CI environment (build 188671)
- [x] Reproduced failure by running the test twice

🤖 Generated with [Claude Code](https://claude.com/claude-code)