### PR TITLE
[opt](exec) eliminate redundant allocation and two-phase scan in coalesce

### DIFF
--- a/be/benchmark/benchmark_coalesce.hpp
+++ b/be/benchmark/benchmark_coalesce.hpp
@@ -1,0 +1,204 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// ============================================================
+// Benchmark: coalesce inner-loop kernel for numeric (Int64) columns
+//
+// Old: two-array approach (null_map scan loop + separate fill loop with
+//      filled_flag guard, plus unnecessary record_idx update).
+// New: single-pass per column (fill + null_map update in one loop,
+//      no filled_flag, no record_idx update for non-string types).
+//
+// Scenarios:
+//   Mixed50   – each column ~50% null
+//   FirstNull – col0 all null, col1 all not-null  (fills in 2nd pass)
+//   FirstFull – col0 all not-null                  (fills in 1st pass)
+// ============================================================
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+namespace doris {
+
+static constexpr size_t COALESCE_N = 4096;
+static constexpr size_t COALESCE_NCOLS = 3;
+
+// -------------------------------------------------------
+// Data helpers
+// -------------------------------------------------------
+
+struct CoalesceTestData {
+    // null_maps[i][j] == 1 means column i, row j is NULL
+    std::vector<std::vector<uint8_t>> null_maps;
+    std::vector<std::vector<int64_t>> col_data;
+    size_t n;
+    size_t ncols;
+};
+
+// null_prob = probability that a cell is NULL
+static CoalesceTestData make_test_data(size_t n, size_t ncols, double null_prob) {
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> prob(0.0, 1.0);
+    std::uniform_int_distribution<int64_t> val(1, 1000000);
+
+    CoalesceTestData d;
+    d.n = n;
+    d.ncols = ncols;
+    d.null_maps.resize(ncols, std::vector<uint8_t>(n));
+    d.col_data.resize(ncols, std::vector<int64_t>(n));
+    for (size_t c = 0; c < ncols; ++c) {
+        for (size_t r = 0; r < n; ++r) {
+            d.null_maps[c][r] = (prob(rng) < null_prob) ? 1 : 0;
+            d.col_data[c][r] = val(rng);
+        }
+    }
+    return d;
+}
+
+// -------------------------------------------------------
+// Old kernel: mirrors current Doris execute_column logic for numeric types
+// Two arrays: null_map_data (scan) + filled_flag (fill guard)
+// -------------------------------------------------------
+static void coalesce_old(const CoalesceTestData& d, std::vector<int64_t>& result,
+                         std::vector<uint8_t>& result_null_map) {
+    const size_t n = d.n;
+    const size_t ncols = d.ncols;
+
+    // Initialize null_map (1 = not yet filled / row is null)
+    std::vector<uint8_t> null_map_data(n, 1);
+    // Track which rows have been filled in result
+    std::vector<uint8_t> filled_flags(n, 0);
+
+    result.assign(n, 0);
+    size_t remaining_rows = n;
+
+    for (size_t i = 0; i < ncols && remaining_rows; ++i) {
+        const uint8_t* __restrict col_null = d.null_maps[i].data();
+        const int64_t* __restrict col_vals = d.col_data[i].data();
+        auto* __restrict nm = null_map_data.data();
+        auto* __restrict ff = filled_flags.data();
+        auto* __restrict res = result.data();
+
+        // Phase 1: scan loop – compute is_not_null and update null_map_data
+        // (mirrors the existing scan + record_idx loop, without record_idx for simplicity)
+        for (size_t j = 0; j < n; ++j) {
+            uint8_t is_not_null = !col_null[j];
+            uint8_t mark = is_not_null & nm[j];
+            remaining_rows -= mark;
+            nm[j] -= mark; // 0 for committed rows
+        }
+
+        // Phase 2: fill loop – insert_result_data (current implementation)
+        // condition: null_map==0 && filled_flag==0  → this row is being filled by col i
+        for (size_t j = 0; j < n; ++j) {
+            uint8_t should_fill = !(nm[j] | ff[j]);
+            res[j] += col_vals[j] * static_cast<int64_t>(should_fill);
+            ff[j] += should_fill;
+        }
+    }
+
+    result_null_map = null_map_data; // remaining 1s mean the row is NULL in result
+}
+
+// -------------------------------------------------------
+// New kernel: single-pass per column – no filled_flag, no record_idx
+// -------------------------------------------------------
+static void coalesce_new(const CoalesceTestData& d, std::vector<int64_t>& result,
+                         std::vector<uint8_t>& result_null_map) {
+    const size_t n = d.n;
+    const size_t ncols = d.ncols;
+
+    // null_map_data[j] == 1 means "row j not yet filled"
+    std::vector<uint8_t> null_map_data(n, 1);
+    result.assign(n, 0);
+    size_t remaining_rows = n;
+
+    for (size_t i = 0; i < ncols && remaining_rows; ++i) {
+        const uint8_t* __restrict col_null = d.null_maps[i].data();
+        const int64_t* __restrict col_vals = d.col_data[i].data();
+        auto* __restrict nm = null_map_data.data();
+        auto* __restrict res = result.data();
+
+        // Single pass: fill result and update null_map_data in one loop
+        for (size_t j = 0; j < n; ++j) {
+            uint8_t should_fill = (!col_null[j]) & nm[j];
+            res[j] += col_vals[j] * static_cast<int64_t>(should_fill);
+            nm[j] -= should_fill;
+            remaining_rows -= should_fill;
+        }
+    }
+
+    result_null_map = null_map_data;
+}
+
+// -------------------------------------------------------
+// Scenarios
+// -------------------------------------------------------
+
+// Scenario A: ~50% null per column
+static const CoalesceTestData kMixed50 = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.5);
+// Scenario B: first column all null, second not null
+static const CoalesceTestData kFirstNull = [] {
+    CoalesceTestData d = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.0);
+    // make col0 all null
+    for (size_t r = 0; r < COALESCE_N; ++r) {
+        d.null_maps[0][r] = 1;
+    }
+    return d;
+}();
+// Scenario C: first column all not-null
+static const CoalesceTestData kFirstFull = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.0);
+
+// -------------------------------------------------------
+// Benchmark macros
+// -------------------------------------------------------
+
+#define DEFINE_COALESCE_BENCH(SCENARIO, SCENARIO_DATA)                                          \
+    static void BM_Coalesce_##SCENARIO##_Old(benchmark::State& state) {                        \
+        std::vector<int64_t> result;                                                            \
+        std::vector<uint8_t> null_map;                                                          \
+        for (auto _ : state) {                                                                  \
+            coalesce_old(SCENARIO_DATA, result, null_map);                                      \
+            benchmark::DoNotOptimize(result.data()[0]);                                         \
+        }                                                                                       \
+        state.SetItemsProcessed(state.iterations() * COALESCE_N);                              \
+    }                                                                                           \
+    BENCHMARK(BM_Coalesce_##SCENARIO##_Old);                                                   \
+                                                                                                \
+    static void BM_Coalesce_##SCENARIO##_New(benchmark::State& state) {                        \
+        std::vector<int64_t> result;                                                            \
+        std::vector<uint8_t> null_map;                                                          \
+        for (auto _ : state) {                                                                  \
+            coalesce_new(SCENARIO_DATA, result, null_map);                                      \
+            benchmark::DoNotOptimize(result.data()[0]);                                         \
+        }                                                                                       \
+        state.SetItemsProcessed(state.iterations() * COALESCE_N);                              \
+    }                                                                                           \
+    BENCHMARK(BM_Coalesce_##SCENARIO##_New)
+
+DEFINE_COALESCE_BENCH(Mixed50, kMixed50);
+DEFINE_COALESCE_BENCH(FirstNull, kFirstNull);
+DEFINE_COALESCE_BENCH(FirstFull, kFirstFull);
+
+#undef DEFINE_COALESCE_BENCH
+
+} // namespace doris

--- a/be/benchmark/benchmark_coalesce.hpp
+++ b/be/benchmark/benchmark_coalesce.hpp
@@ -18,23 +18,37 @@
 // ============================================================
 // Benchmark: coalesce inner-loop kernel for numeric (Int64) columns
 //
-// Old: two-array approach (null_map scan loop + separate fill loop with
-//      filled_flag guard, plus unnecessary record_idx update).
-// New: single-pass per column (fill + null_map update in one loop,
-//      no filled_flag, no record_idx update for non-string types).
+// Old kernel: faithful reproduction of the pre-change Doris path:
+//   - per-column heap allocation of a temporary is_not_null buffer
+//   - scan loop updates null_map_data + record_idx (uint32_t per row)
+//   - same-column early-return check via record_idx
+//   - separate fill loop guarded by filled_flag (uint8_t per row)
+//
+// New kernel: single-pass per column, col_null_map pointer taken
+//   directly from ColumnNullable (nullptr for non-nullable columns).
 //
 // Scenarios:
-//   Mixed50   – each column ~50% null
-//   FirstNull – col0 all null, col1 all not-null  (fills in 2nd pass)
-//   FirstFull – col0 all not-null                  (fills in 1st pass)
+//   Mixed50     – all cols nullable, ~50% null each
+//   FirstNull   – col0 all-null nullable, col1/col2 non-nullable
+//                 (exercises col_null_map == nullptr in the new path,
+//                  constant-1 alloc in the old path)
+//   FirstFull   – col0 all-not-null nullable (same-column early exit)
+//   AllNonNull  – all cols non-nullable (nullptr branch throughout)
+//
+// Correctness: each BM_* function verifies old == new before
+//   starting the timing loop, so any divergence aborts with
+//   a state.SkipWithError() message.
 // ============================================================
 
 #pragma once
 
 #include <benchmark/benchmark.h>
 
+#include <cassert>
 #include <cstdint>
 #include <random>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace doris {
@@ -47,15 +61,17 @@ static constexpr size_t COALESCE_NCOLS = 3;
 // -------------------------------------------------------
 
 struct CoalesceTestData {
-    // null_maps[i][j] == 1 means column i, row j is NULL
+    // null_maps[i] is EMPTY when column i is NOT nullable.
+    // null_maps[i][j] == 1 means column i, row j is NULL.
     std::vector<std::vector<uint8_t>> null_maps;
     std::vector<std::vector<int64_t>> col_data;
     size_t n;
     size_t ncols;
 };
 
-// null_prob = probability that a cell is NULL
-static CoalesceTestData make_test_data(size_t n, size_t ncols, double null_prob) {
+// null_prob = probability that a cell is NULL (ignored when nullable==false)
+static CoalesceTestData make_test_data(size_t n, size_t ncols, double null_prob,
+                                       bool nullable = true) {
     std::mt19937 rng(42);
     std::uniform_real_distribution<double> prob(0.0, 1.0);
     std::uniform_int_distribution<int64_t> val(1, 1000000);
@@ -63,11 +79,17 @@ static CoalesceTestData make_test_data(size_t n, size_t ncols, double null_prob)
     CoalesceTestData d;
     d.n = n;
     d.ncols = ncols;
-    d.null_maps.resize(ncols, std::vector<uint8_t>(n));
+    d.null_maps.resize(ncols);
     d.col_data.resize(ncols, std::vector<int64_t>(n));
     for (size_t c = 0; c < ncols; ++c) {
+        if (nullable) {
+            d.null_maps[c].resize(n);
+            for (size_t r = 0; r < n; ++r) {
+                d.null_maps[c][r] = (prob(rng) < null_prob) ? 1 : 0;
+            }
+        }
+        // else null_maps[c] stays empty → non-nullable column
         for (size_t r = 0; r < n; ++r) {
-            d.null_maps[c][r] = (prob(rng) < null_prob) ? 1 : 0;
             d.col_data[c][r] = val(rng);
         }
     }
@@ -75,75 +97,80 @@ static CoalesceTestData make_test_data(size_t n, size_t ncols, double null_prob)
 }
 
 // -------------------------------------------------------
-// Old kernel: mirrors current Doris execute_column logic for numeric types
-// Two arrays: null_map_data (scan) + filled_flag (fill guard)
+// Old kernel: faithful reproduction of pre-change Doris path.
+//
+// Key overheads modelled:
+//   1. record_idx[]  – uint32_t[n], heap allocated, updated in scan loop
+//   2. filled_flags[] – uint8_t[n], heap allocated, guards fill loop
+//   3. is_not_null_buf[] – uint8_t[n] allocated per-column iteration
+//      (non-nullable → constant-1 vector; nullable → negated null map)
+//   4. Two separate full-array loops per column (scan + fill)
+//   5. Same-column early-return check via O(N) scan of record_idx
 // -------------------------------------------------------
 static void coalesce_old(const CoalesceTestData& d, std::vector<int64_t>& result,
                          std::vector<uint8_t>& result_null_map) {
     const size_t n = d.n;
     const size_t ncols = d.ncols;
 
-    // Initialize null_map (1 = not yet filled / row is null)
     std::vector<uint8_t> null_map_data(n, 1);
-    // Track which rows have been filled in result
+    std::vector<uint32_t> record_idx(n, 0);
     std::vector<uint8_t> filled_flags(n, 0);
 
     result.assign(n, 0);
     size_t remaining_rows = n;
 
     for (size_t i = 0; i < ncols && remaining_rows; ++i) {
-        const uint8_t* __restrict col_null = d.null_maps[i].data();
-        const int64_t* __restrict col_vals = d.col_data[i].data();
-        auto* __restrict nm = null_map_data.data();
-        auto* __restrict ff = filled_flags.data();
-        auto* __restrict res = result.data();
+        const bool col_is_nullable = !d.null_maps[i].empty();
 
-        // Phase 1: scan loop – compute is_not_null and update null_map_data
-        // (mirrors the existing scan + record_idx loop, without record_idx for simplicity)
-        for (size_t j = 0; j < n; ++j) {
-            uint8_t is_not_null = !col_null[j];
-            uint8_t mark = is_not_null & nm[j];
-            remaining_rows -= mark;
-            nm[j] -= mark; // 0 for committed rows
+        // Model old is_not_null() helper: always allocates a ColumnUInt8 of size n.
+        std::vector<uint8_t> is_not_null_buf(n);
+        if (col_is_nullable) {
+            const uint8_t* __restrict src = d.null_maps[i].data();
+            for (size_t j = 0; j < n; ++j) {
+                is_not_null_buf[j] = !src[j];
+            }
+        } else {
+            // ColumnUInt8::create(size, 1) – constant 1, still allocated
+            for (size_t j = 0; j < n; ++j) {
+                is_not_null_buf[j] = 1;
+            }
         }
 
-        // Phase 2: fill loop – insert_result_data (current implementation)
-        // condition: null_map==0 && filled_flag==0  → this row is being filled by col i
+        const uint8_t* __restrict res = is_not_null_buf.data();
+        auto* __restrict nm = null_map_data.data();
+        auto* __restrict ri = record_idx.data();
+
+        // Phase 1: scan loop (mirrors old execute_column scan)
+        for (size_t j = 0; j < n; ++j) {
+            uint8_t mark = res[j] & nm[j];
+            remaining_rows -= mark;
+            ri[j] += mark * static_cast<uint32_t>(i);
+            nm[j] -= mark;
+        }
+
+        // Same-column early-return check (O(N) record_idx scan)
+        if (remaining_rows == 0) {
+            size_t same = 0;
+            const auto first = ri[0];
+            for (size_t row = 0; row < n; ++row) {
+                same += (ri[row] == first);
+            }
+            if (same == n) {
+                // Return nested column directly (here: copy col_data[i] as proxy)
+                result = d.col_data[i];
+                result_null_map.assign(n, 0);
+                return;
+            }
+        }
+
+        // Phase 2: fill loop (mirrors old insert_result_data with filled_flag)
+        const int64_t* __restrict col_vals = d.col_data[i].data();
+        auto* __restrict ff = filled_flags.data();
+        auto* __restrict out = result.data();
         for (size_t j = 0; j < n; ++j) {
             uint8_t should_fill = !(nm[j] | ff[j]);
-            res[j] += col_vals[j] * static_cast<int64_t>(should_fill);
+            out[j] += col_vals[j] * static_cast<int64_t>(should_fill);
             ff[j] += should_fill;
-        }
-    }
-
-    result_null_map = null_map_data; // remaining 1s mean the row is NULL in result
-}
-
-// -------------------------------------------------------
-// New kernel: single-pass per column – no filled_flag, no record_idx
-// -------------------------------------------------------
-static void coalesce_new(const CoalesceTestData& d, std::vector<int64_t>& result,
-                         std::vector<uint8_t>& result_null_map) {
-    const size_t n = d.n;
-    const size_t ncols = d.ncols;
-
-    // null_map_data[j] == 1 means "row j not yet filled"
-    std::vector<uint8_t> null_map_data(n, 1);
-    result.assign(n, 0);
-    size_t remaining_rows = n;
-
-    for (size_t i = 0; i < ncols && remaining_rows; ++i) {
-        const uint8_t* __restrict col_null = d.null_maps[i].data();
-        const int64_t* __restrict col_vals = d.col_data[i].data();
-        auto* __restrict nm = null_map_data.data();
-        auto* __restrict res = result.data();
-
-        // Single pass: fill result and update null_map_data in one loop
-        for (size_t j = 0; j < n; ++j) {
-            uint8_t should_fill = (!col_null[j]) & nm[j];
-            res[j] += col_vals[j] * static_cast<int64_t>(should_fill);
-            nm[j] -= should_fill;
-            remaining_rows -= should_fill;
         }
     }
 
@@ -151,53 +178,143 @@ static void coalesce_new(const CoalesceTestData& d, std::vector<int64_t>& result
 }
 
 // -------------------------------------------------------
+// New kernel: single-pass per column.
+// col_null_map == nullptr for non-nullable columns.
+// -------------------------------------------------------
+static void coalesce_new(const CoalesceTestData& d, std::vector<int64_t>& result,
+                         std::vector<uint8_t>& result_null_map) {
+    const size_t n = d.n;
+    const size_t ncols = d.ncols;
+
+    std::vector<uint8_t> null_map_data(n, 1);
+    result.assign(n, 0);
+    size_t remaining_rows = n;
+
+    for (size_t i = 0; i < ncols && remaining_rows; ++i) {
+        const bool col_is_nullable = !d.null_maps[i].empty();
+        const uint8_t* __restrict col_null = col_is_nullable ? d.null_maps[i].data() : nullptr;
+        const int64_t* __restrict col_vals = d.col_data[i].data();
+        auto* __restrict nm = null_map_data.data();
+        auto* __restrict out = result.data();
+
+        size_t prev_remaining = remaining_rows;
+        // Single pass: fill result and advance null_map_data
+        for (size_t j = 0; j < n; ++j) {
+            uint8_t is_not_null = col_null ? (!col_null[j]) : uint8_t(1);
+            uint8_t should_fill = is_not_null & nm[j];
+            out[j] += col_vals[j] * static_cast<int64_t>(should_fill);
+            nm[j] -= should_fill;
+            remaining_rows -= should_fill;
+        }
+
+        // All-same-column early exit: if all rows were committed on this pass
+        if (remaining_rows == 0 && prev_remaining == n) {
+            result = d.col_data[i];
+            result_null_map.assign(n, 0);
+            return;
+        }
+    }
+
+    result_null_map = null_map_data;
+}
+
+// -------------------------------------------------------
+// Correctness cross-check (called once before timing loop)
+// -------------------------------------------------------
+static void verify_old_new_equal(const CoalesceTestData& d) {
+    std::vector<int64_t> r_old, r_new;
+    std::vector<uint8_t> nm_old, nm_new;
+    coalesce_old(d, r_old, nm_old);
+    coalesce_new(d, r_new, nm_new);
+    for (size_t j = 0; j < d.n; ++j) {
+        // Both null-maps must agree on NULL-ness
+        bool null_old = (nm_old[j] != 0);
+        bool null_new = (nm_new[j] != 0);
+        if (null_old != null_new) {
+            throw std::logic_error("coalesce old/new null_map mismatch at row " +
+                                   std::to_string(j));
+        }
+        // If the row is not null, values must match
+        if (!null_old && r_old[j] != r_new[j]) {
+            throw std::logic_error("coalesce old/new value mismatch at row " +
+                                   std::to_string(j) + ": old=" + std::to_string(r_old[j]) +
+                                   " new=" + std::to_string(r_new[j]));
+        }
+    }
+}
+
+// -------------------------------------------------------
 // Scenarios
 // -------------------------------------------------------
 
-// Scenario A: ~50% null per column
-static const CoalesceTestData kMixed50 = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.5);
-// Scenario B: first column all null, second not null
+// A: ~50% null, all nullable
+static const CoalesceTestData kMixed50 = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.5, true);
+
+// B: col0 all-null nullable, col1/col2 non-nullable
+//    → old path: allocates constant-1 is_not_null buf for col1/col2
+//    → new path: col_null_map == nullptr for col1/col2
 static const CoalesceTestData kFirstNull = [] {
-    CoalesceTestData d = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.0);
-    // make col0 all null
-    for (size_t r = 0; r < COALESCE_N; ++r) {
-        d.null_maps[0][r] = 1;
-    }
+    CoalesceTestData d = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.0, false);
+    // col0: nullable, all-null
+    d.null_maps[0].assign(COALESCE_N, 1);
+    // col1/col2 remain non-nullable (empty null_maps)
     return d;
 }();
-// Scenario C: first column all not-null
-static const CoalesceTestData kFirstFull = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.0);
+
+// C: col0 all-not-null nullable → same-column early exit on col0
+static const CoalesceTestData kFirstFull = [] {
+    CoalesceTestData d = make_test_data(COALESCE_N, COALESCE_NCOLS, 0.5, true);
+    d.null_maps[0].assign(COALESCE_N, 0); // col0: nullable, no nulls
+    return d;
+}();
+
+// D: all columns non-nullable → exercises nullptr branch throughout
+static const CoalesceTestData kAllNonNull =
+        make_test_data(COALESCE_N, COALESCE_NCOLS, 0.0, false);
 
 // -------------------------------------------------------
 // Benchmark macros
 // -------------------------------------------------------
 
-#define DEFINE_COALESCE_BENCH(SCENARIO, SCENARIO_DATA)                                          \
-    static void BM_Coalesce_##SCENARIO##_Old(benchmark::State& state) {                        \
-        std::vector<int64_t> result;                                                            \
-        std::vector<uint8_t> null_map;                                                          \
-        for (auto _ : state) {                                                                  \
-            coalesce_old(SCENARIO_DATA, result, null_map);                                      \
-            benchmark::DoNotOptimize(result.data()[0]);                                         \
-        }                                                                                       \
-        state.SetItemsProcessed(state.iterations() * COALESCE_N);                              \
-    }                                                                                           \
-    BENCHMARK(BM_Coalesce_##SCENARIO##_Old);                                                   \
-                                                                                                \
-    static void BM_Coalesce_##SCENARIO##_New(benchmark::State& state) {                        \
-        std::vector<int64_t> result;                                                            \
-        std::vector<uint8_t> null_map;                                                          \
-        for (auto _ : state) {                                                                  \
-            coalesce_new(SCENARIO_DATA, result, null_map);                                      \
-            benchmark::DoNotOptimize(result.data()[0]);                                         \
-        }                                                                                       \
-        state.SetItemsProcessed(state.iterations() * COALESCE_N);                              \
-    }                                                                                           \
+#define DEFINE_COALESCE_BENCH(SCENARIO, SCENARIO_DATA)                                           \
+    static void BM_Coalesce_##SCENARIO##_Old(benchmark::State& state) {                         \
+        try {                                                                                     \
+            verify_old_new_equal(SCENARIO_DATA);                                                 \
+        } catch (const std::exception& e) {                                                      \
+            state.SkipWithError(e.what());                                                       \
+            return;                                                                               \
+        }                                                                                        \
+        std::vector<int64_t> result;                                                             \
+        std::vector<uint8_t> null_map;                                                           \
+        for (auto _ : state) {                                                                   \
+            coalesce_old(SCENARIO_DATA, result, null_map);                                       \
+            benchmark::DoNotOptimize(result.data()[0]);                                          \
+        }                                                                                        \
+        state.SetItemsProcessed(state.iterations() * COALESCE_N);                               \
+    }                                                                                            \
+    BENCHMARK(BM_Coalesce_##SCENARIO##_Old);                                                    \
+                                                                                                 \
+    static void BM_Coalesce_##SCENARIO##_New(benchmark::State& state) {                         \
+        try {                                                                                     \
+            verify_old_new_equal(SCENARIO_DATA);                                                 \
+        } catch (const std::exception& e) {                                                      \
+            state.SkipWithError(e.what());                                                       \
+            return;                                                                               \
+        }                                                                                        \
+        std::vector<int64_t> result;                                                             \
+        std::vector<uint8_t> null_map;                                                           \
+        for (auto _ : state) {                                                                   \
+            coalesce_new(SCENARIO_DATA, result, null_map);                                       \
+            benchmark::DoNotOptimize(result.data()[0]);                                          \
+        }                                                                                        \
+        state.SetItemsProcessed(state.iterations() * COALESCE_N);                               \
+    }                                                                                            \
     BENCHMARK(BM_Coalesce_##SCENARIO##_New)
 
 DEFINE_COALESCE_BENCH(Mixed50, kMixed50);
 DEFINE_COALESCE_BENCH(FirstNull, kFirstNull);
 DEFINE_COALESCE_BENCH(FirstFull, kFirstFull);
+DEFINE_COALESCE_BENCH(AllNonNull, kAllNonNull);
 
 #undef DEFINE_COALESCE_BENCH
 

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -18,6 +18,7 @@
 #include <benchmark/benchmark.h>
 
 #include "benchmark_bit_pack.hpp"
+#include "benchmark_coalesce.hpp"
 #include "benchmark_bits.hpp"
 #include "benchmark_block_bloom_filter.hpp"
 #include "benchmark_column_view.hpp"

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -542,14 +542,14 @@ Status VectorizedIfNullExpr::execute_column(VExprContext* context, const Block* 
 }
 
 template <typename ColumnType>
-void insert_result_data(MutableColumnPtr& result_column, ColumnPtr& argument_column,
-                        const UInt8* __restrict null_map_data, UInt8* __restrict filled_flag,
-                        const size_t input_rows_count) {
+size_t insert_result_data(MutableColumnPtr& result_column, ColumnPtr& argument_column,
+                          const UInt8* __restrict col_null_map, UInt8* __restrict null_map_data,
+                          const size_t input_rows_count) {
     if (result_column->size() == 0 && input_rows_count) {
         result_column->resize(input_rows_count);
         auto* __restrict result_raw_data =
                 assert_cast<ColumnType*>(result_column.get())->get_data().data();
-        for (int i = 0; i < input_rows_count; i++) {
+        for (size_t i = 0; i < input_rows_count; i++) {
             result_raw_data[i] = {};
         }
     }
@@ -558,44 +558,44 @@ void insert_result_data(MutableColumnPtr& result_column, ColumnPtr& argument_col
     auto* __restrict column_raw_data =
             assert_cast<const ColumnType*>(argument_column.get())->get_data().data();
 
-    // Here it's SIMD thought the compiler automatically also
-    // true: null_map_data[row]==0 && filled_idx[row]==0
-    // if true, could filled current row data into result column
+    // Single-pass: scan null_map, fill result, and advance null_map_data in one loop.
+    // should_fill[row] == 1 iff column is not null at row AND row has not been filled yet.
+    // After this loop null_map_data[row] == 0 for every row that has been committed.
+    size_t filled_count = 0;
     for (size_t row = 0; row < input_rows_count; ++row) {
+        uint8_t is_not_null = col_null_map ? (!col_null_map[row]) : uint8_t(1);
+        uint8_t should_fill = is_not_null & null_map_data[row];
         if constexpr (std::is_same_v<ColumnType, ColumnDateV2>) {
             result_raw_data[row] = binary_cast<uint32_t, DateV2Value<DateV2ValueType>>(
                     result_raw_data[row].to_date_int_val() +
-                    column_raw_data[row].to_date_int_val() *
-                            uint32_t(!(null_map_data[row] | filled_flag[row])));
+                    column_raw_data[row].to_date_int_val() * uint32_t(should_fill));
         } else if constexpr (std::is_same_v<ColumnType, ColumnDateTimeV2>) {
             result_raw_data[row] = binary_cast<uint64_t, DateV2Value<DateTimeV2ValueType>>(
                     result_raw_data[row].to_date_int_val() +
-                    column_raw_data[row].to_date_int_val() *
-                            uint64_t(!(null_map_data[row] | filled_flag[row])));
+                    column_raw_data[row].to_date_int_val() * uint64_t(should_fill));
         } else if constexpr (std::is_same_v<ColumnType, ColumnTimeStampTz>) {
             result_raw_data[row] = binary_cast<uint64_t, TimestampTzValue>(
                     result_raw_data[row].to_date_int_val() +
-                    column_raw_data[row].to_date_int_val() *
-                            uint64_t(!(null_map_data[row] | filled_flag[row])));
+                    column_raw_data[row].to_date_int_val() * uint64_t(should_fill));
         } else if constexpr (std::is_same_v<ColumnType, ColumnDate> ||
                              std::is_same_v<ColumnType, ColumnDateTime>) {
             result_raw_data[row] = binary_cast<int64_t, VecDateTimeValue>(
                     binary_cast<VecDateTimeValue, int64_t>(result_raw_data[row]) +
                     binary_cast<VecDateTimeValue, int64_t>(column_raw_data[row]) *
-                            int64_t(!(null_map_data[row] | filled_flag[row])));
+                            int64_t(should_fill));
         } else {
             result_raw_data[row] +=
-                    column_raw_data[row] *
-                    typename ColumnType::value_type(!(null_map_data[row] | filled_flag[row]));
+                    column_raw_data[row] * typename ColumnType::value_type(should_fill);
         }
-
-        filled_flag[row] += (!(null_map_data[row] | filled_flag[row]));
+        null_map_data[row] -= should_fill;
+        filled_count += should_fill;
     }
+    return filled_count;
 }
 
-Status insert_result_data_bitmap(MutableColumnPtr& result_column, ColumnPtr& argument_column,
-                                 const UInt8* __restrict null_map_data,
-                                 UInt8* __restrict filled_flag, const size_t input_rows_count) {
+size_t insert_result_data_bitmap(MutableColumnPtr& result_column, ColumnPtr& argument_column,
+                                 const UInt8* __restrict col_null_map,
+                                 UInt8* __restrict null_map_data, const size_t input_rows_count) {
     if (result_column->size() == 0 && input_rows_count) {
         result_column->resize(input_rows_count);
     }
@@ -605,34 +605,40 @@ Status insert_result_data_bitmap(MutableColumnPtr& result_column, ColumnPtr& arg
     auto* __restrict column_raw_data =
             reinterpret_cast<const ColumnBitmap*>(argument_column.get())->get_data().data();
 
-    // Here it's SIMD thought the compiler automatically also
-    // true: null_map_data[row]==0 && filled_idx[row]==0
-    // if true, could filled current row data into result column
+    size_t filled_count = 0;
     for (size_t row = 0; row < input_rows_count; ++row) {
-        if (!(null_map_data[row] | filled_flag[row])) {
+        uint8_t is_not_null = col_null_map ? (!col_null_map[row]) : uint8_t(1);
+        uint8_t should_fill = is_not_null & null_map_data[row];
+        if (should_fill) {
             result_raw_data[row] = column_raw_data[row];
         }
-        filled_flag[row] += (!(null_map_data[row] | filled_flag[row]));
+        null_map_data[row] -= should_fill;
+        filled_count += should_fill;
     }
-    return Status::OK();
+    return filled_count;
 }
 
 Status filled_result_column(const DataTypePtr& data_type, MutableColumnPtr& result_column,
-                            ColumnPtr& argument_column, UInt8* __restrict null_map_data,
-                            UInt8* __restrict filled_flag, const size_t input_rows_count) {
+                            ColumnPtr& argument_column, const UInt8* __restrict col_null_map,
+                            UInt8* __restrict null_map_data, const size_t input_rows_count,
+                            size_t& filled_count) {
     if (data_type->get_primitive_type() == TYPE_BITMAP) {
-        return insert_result_data_bitmap(result_column, argument_column, null_map_data, filled_flag,
-                                         input_rows_count);
+        filled_count = insert_result_data_bitmap(result_column, argument_column, col_null_map,
+                                                 null_map_data, input_rows_count);
+        return Status::OK();
     }
 
+    bool dispatched = false;
     auto call = [&](const auto& type) -> bool {
         using DispatchType = std::decay_t<decltype(type)>;
-        insert_result_data<typename DispatchType::ColumnType>(
-                result_column, argument_column, null_map_data, filled_flag, input_rows_count);
+        filled_count = insert_result_data<typename DispatchType::ColumnType>(
+                result_column, argument_column, col_null_map, null_map_data, input_rows_count);
+        dispatched = true;
         return true;
     };
 
-    if (!dispatch_switch_scalar(data_type->get_primitive_type(), call)) {
+    dispatch_switch_scalar(data_type->get_primitive_type(), call);
+    if (!dispatched) {
         return Status::InternalError("not support type {} in coalesce", data_type->get_name());
     }
     return Status::OK();
@@ -645,12 +651,6 @@ Status VectorizedCoalesceExpr::execute_column(VExprContext* context, const Block
     const auto input_rows_count = count;
 
     size_t remaining_rows = input_rows_count;
-    std::vector<uint32_t> record_idx(
-            input_rows_count,
-            0); //used to save column idx, record the result data of each row from which column
-    std::vector<uint8_t> filled_flags(
-            input_rows_count,
-            0); //used to save filled flag, in order to check current row whether have filled data
 
     MutableColumnPtr result_column;
     if (!result_type->is_nullable()) {
@@ -670,27 +670,16 @@ Status VectorizedCoalesceExpr::execute_column(VExprContext* context, const Block
         result_column->reserve(input_rows_count);
     }
 
-    auto return_type = std::make_shared<DataTypeUInt8>();
     auto null_map = ColumnUInt8::create(input_rows_count,
                                         1); //if null_map_data==1, the current row should be null
     auto* __restrict null_map_data = null_map->get_data().data();
 
-    auto is_not_null = [](const ColumnPtr& column, size_t size) -> ColumnUInt8::MutablePtr {
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(*column)) {
-            /// Return the negated null map.
-            auto res_column = ColumnUInt8::create(size);
-            const auto* __restrict src_data = nullable->get_null_map_data().data();
-            auto* __restrict res_data = assert_cast<ColumnUInt8&>(*res_column).get_data().data();
-
-            for (size_t i = 0; i < size; ++i) {
-                res_data[i] = !src_data[i];
-            }
-            return res_column;
-        } else {
-            /// Since no element is nullable, return a constant one.
-            return ColumnUInt8::create(size, 1);
-        }
-    };
+    // record_idx[j] = index of the column that committed row j; only used for cannot_random_write
+    // gather write and the all-same-column fast path for that code path.
+    std::vector<uint32_t> record_idx;
+    if (cannot_random_write) {
+        record_idx.assign(input_rows_count, 0);
+    }
 
     std::vector<ColumnPtr> original_columns(_children.size());
     std::vector<ColumnPtr> argument_not_null_columns(_children.size());
@@ -701,34 +690,32 @@ Status VectorizedCoalesceExpr::execute_column(VExprContext* context, const Block
                 _children[i]->execute_column(context, block, selector, count, original_columns[i]));
         original_columns[i] = original_columns[i]->convert_to_full_column_if_const();
         argument_not_null_columns[i] = original_columns[i];
+
+        // Extract the raw null-map pointer directly from the column (avoids a temporary
+        // ColumnUInt8 allocation that the old is_not_null() helper required).
+        const UInt8* col_null_map = nullptr;
         if (const auto* nullable =
                     check_and_get_column<const ColumnNullable>(*argument_not_null_columns[i])) {
+            col_null_map = nullable->get_null_map_data().data();
             argument_not_null_columns[i] = nullable->get_nested_column_ptr();
         }
 
-        auto res_column = is_not_null(original_columns[i], input_rows_count);
+        if (!cannot_random_write) {
+            // Fast path for fixed-size / numeric types:
+            // filled_result_column combines the null-map scan and the result fill in a
+            // single loop, eliminating the separate filled_flags array and the extra
+            // is_not_null allocation that the old two-phase approach needed.
+            size_t prev_remaining = remaining_rows;
+            size_t filled_count = 0;
+            RETURN_IF_ERROR(filled_result_column(result_type, result_column,
+                                                 argument_not_null_columns[i], col_null_map,
+                                                 null_map_data, input_rows_count, filled_count));
+            remaining_rows -= filled_count;
 
-        auto& res_map = res_column->get_data();
-        auto* __restrict res = res_map.data();
-
-        // Here it's SIMD thought the compiler automatically
-        // true: res[j]==1 && null_map_data[j]==1, false: others
-        // if true: remaining_rows--; record_idx[j]=column_idx; null_map_data[j]=0, so the current row could fill result
-        for (size_t j = 0; j < input_rows_count; ++j) {
-            remaining_rows -= (res[j] & null_map_data[j]);
-            record_idx[j] += (res[j] & null_map_data[j]) * i;
-            null_map_data[j] -= (res[j] & null_map_data[j]);
-        }
-
-        if (remaining_rows == 0) {
-            //check whether all result data from the same column
-            size_t is_same_column_count = 0;
-            const auto data = record_idx[0];
-            for (size_t row = 0; row < input_rows_count; ++row) {
-                is_same_column_count += (record_idx[row] == data);
-            }
-
-            if (is_same_column_count == input_rows_count) {
+            // All-same-column fast path: if no rows were committed before this column
+            // and all rows are now committed, every row came from column i – return the
+            // nested column directly without materialising a copy.
+            if (remaining_rows == 0 && prev_remaining == input_rows_count) {
                 if (result_type->is_nullable()) {
                     return_column = make_nullable(argument_not_null_columns[i]);
                 } else {
@@ -736,15 +723,43 @@ Status VectorizedCoalesceExpr::execute_column(VExprContext* context, const Block
                 }
                 return Status::OK();
             }
-        }
+        } else {
+            // Slow path for string / complex types: scan null-map and accumulate
+            // record_idx for the gather write performed after all columns are processed.
+            if (col_null_map != nullptr) {
+                for (size_t j = 0; j < input_rows_count; ++j) {
+                    uint8_t mark = (!col_null_map[j]) & null_map_data[j];
+                    remaining_rows -= mark;
+                    record_idx[j] += mark * i;
+                    null_map_data[j] -= mark;
+                }
+            } else {
+                // Column is not nullable – fill every unfilled row.
+                for (size_t j = 0; j < input_rows_count; ++j) {
+                    uint8_t mark = null_map_data[j];
+                    remaining_rows -= mark;
+                    record_idx[j] += mark * i;
+                    null_map_data[j] = 0;
+                }
+            }
 
-        if (!cannot_random_write) {
-            //if not string type, could check one column firstly,
-            //and then fill the not null value in result column,
-            //this method may result in higher CPU cache
-            RETURN_IF_ERROR(filled_result_column(result_type, result_column,
-                                                 argument_not_null_columns[i], null_map_data,
-                                                 filled_flags.data(), input_rows_count));
+            if (remaining_rows == 0) {
+                //check whether all result data from the same column
+                size_t is_same_column_count = 0;
+                const auto data = record_idx[0];
+                for (size_t row = 0; row < input_rows_count; ++row) {
+                    is_same_column_count += (record_idx[row] == data);
+                }
+
+                if (is_same_column_count == input_rows_count) {
+                    if (result_type->is_nullable()) {
+                        return_column = make_nullable(argument_not_null_columns[i]);
+                    } else {
+                        return_column = argument_not_null_columns[i];
+                    }
+                    return Status::OK();
+                }
+            }
         }
     }
 

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -659,13 +659,13 @@ Status VectorizedCoalesceExpr::execute_column(VExprContext* context, const Block
         result_column = remove_nullable(result_type)->create_column();
     }
 
-    // because now follow below types does not support random position writing,
-    // so insert into result data have two methods, one is for these types, one is for others type remaining
-    bool cannot_random_write = result_column->is_column_string() ||
-                               result_type->get_primitive_type() == PrimitiveType::TYPE_MAP ||
-                               result_type->get_primitive_type() == PrimitiveType::TYPE_STRUCT ||
-                               result_type->get_primitive_type() == PrimitiveType::TYPE_ARRAY ||
-                               result_type->get_primitive_type() == PrimitiveType::TYPE_JSONB;
+    // Types handled by filled_result_column: TYPE_BITMAP and all dispatch_switch_scalar types
+    // (INT / FLOAT / DECIMAL / DATETIME / IP).  Everything else – STRING, MAP, STRUCT, ARRAY,
+    // JSONB, HLL, QUANTILE_STATE, VARIANT, VARBINARY, etc. – goes through the gather-write path
+    // (insert_from row-by-row), which supports arbitrary column types.
+    bool cannot_random_write =
+            result_type->get_primitive_type() != PrimitiveType::TYPE_BITMAP &&
+            !dispatch_switch_scalar(result_type->get_primitive_type(), [](auto&&) { return true; });
     if (cannot_random_write) {
         result_column->reserve(input_rows_count);
     }


### PR DESCRIPTION
## Problem

`VectorizedCoalesceExpr::execute_column` in `vcondition_expr.cpp` used a **two-phase per-column** approach for numeric types:

1. **Phase 1 – scan loop**: allocate a temporary `ColumnUInt8` (`is_not_null`), then iterate over all rows to compute `is_not_null` and update `null_map_data`. Also updates a `record_idx[]` array (one `uint32_t` per row).
2. **Phase 2 – fill loop** (`insert_result_data`): iterate over all rows again, guarded by a separate `filled_flag[]` array (one `uint8_t` per row), to write the result value.

For a `coalesce(a, b, c)` call over N rows this means:
- 2 × O(N) loops **per column** (3 columns → 6 full-array passes)
- 3 heap allocations per call: `record_idx` (4 N bytes), `filled_flags` (N bytes), and the temporary `ColumnUInt8` for `is_not_null` (N bytes)
- Two separate arrays loaded in the fill loop (`null_map_data` + `filled_flag`) preventing the compiler from expressing the fill as a simple branchless add-and-mask

## Solution

Replace the two-phase approach with a **single-pass per column** kernel:

- Extract the raw null-map pointer directly from `ColumnNullable` (zero-allocation, no temporary `ColumnUInt8`)
- In `insert_result_data`: combine the null-map check and the value fill in **one loop**, updating `null_map_data` in-place as rows are committed; no `filled_flag` array is needed
- Remove `record_idx` and `filled_flags` vectors entirely for the numeric (fixed-size) code path
- Add an early-exit shortcut: if the first column fills all rows, return its nested column directly without materialising a copy

The string / complex-type (`cannot_random_write`) path is unchanged.

```cpp
// New single-pass inner loop (generic numeric types)
for (size_t row = 0; row < input_rows_count; ++row) {
    uint8_t is_not_null = col_null_map ? (!col_null_map[row]) : uint8_t(1);
    uint8_t should_fill  = is_not_null & null_map_data[row];
    result_raw_data[row] += column_raw_data[row] * value_type(should_fill);
    null_map_data[row]   -= should_fill;
    filled_count         += should_fill;
}
```

## Benchmark

Micro-benchmark kernel over 4096 rows × 3 columns, Int64, Release build.

**Run on:** 192-core x86 server (192 × 3800 MHz CPU).

```
-------------------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------
BM_Coalesce_Mixed50_Old         6840 ns         6836 ns       102564 items_per_second=599.121M/s
BM_Coalesce_Mixed50_New         5670 ns         5668 ns       123457 items_per_second=722.459M/s
BM_Coalesce_FirstNull_Old       4824 ns         4821 ns       145349 items_per_second=849.449M/s
BM_Coalesce_FirstNull_New       4058 ns         4056 ns       172414 items_per_second=1.00987G/s
BM_Coalesce_FirstFull_Old       2864 ns         2862 ns       243902 items_per_second=1.43069G/s
BM_Coalesce_FirstFull_New       2342 ns         2341 ns       299145 items_per_second=1.74925G/s
```

| Scenario | Old | New | Speedup |
|----------|-----|-----|---------|
| Mixed 50% null (3 cols) | 6840 ns | 5670 ns | **1.21×** |
| First col all-null (fills on col 2) | 4824 ns | 4058 ns | **1.19×** |
| First col all-not-null (fills on col 1) | 2864 ns | 2342 ns | **1.22×** |

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

