### PR TITLE
[fix](build) Refresh FE build version after cached builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -859,6 +859,76 @@ function build_fe_modules() {
     return 1
 }
 
+function refresh_fe_build_version_if_commit_changed() {
+    [[ -d "${DORIS_HOME}/.git" ]] || return 0
+
+    local version_java="${DORIS_HOME}/fe/fe-common/target/generated-sources/build/org/apache/doris/common/Version.java"
+    local version_class_dir="${DORIS_HOME}/fe/fe-common/target/classes"
+    local fe_common_target_jar="${DORIS_HOME}/fe/fe-common/target/doris-fe-common.jar"
+    local version_h="${DORIS_HOME}/gensrc/build/gen_cpp/version.h"
+    local cloud_version_h="${DORIS_HOME}/gensrc/build/gen_cpp/cloud_version.h"
+
+    [[ -f "${version_java}" ]] || return 0
+
+    local current_hash
+    current_hash="$(cd "${DORIS_HOME}" && git log -1 --pretty=format:"%h" 2>/dev/null || true)"
+    [[ -n "${current_hash}" ]] || return 0
+
+    local baked_hash
+    baked_hash="$(sed -n 's/.*DORIS_BUILD_SHORT_HASH[^"]*"\([^"]*\)".*/\1/p' "${version_java}" | head -1)"
+    if [[ "${baked_hash}" == "${current_hash}" ]]; then
+        return 0
+    fi
+
+    echo "Fix stale FE build version: ${baked_hash:-<missing>} -> ${current_hash}"
+    rm -f "${version_java}" "${version_h}" "${cloud_version_h}"
+    (cd "${DORIS_HOME}" && bash gensrc/script/gen_build_version.sh)
+
+    if [[ ! -f "${version_java}" ]]; then
+        echo "ERROR: failed to regenerate ${version_java}"
+        exit 1
+    fi
+
+    local javac_cmd
+    if [[ -n "${JAVA_HOME}" ]]; then
+        javac_cmd="${JAVA_HOME}/bin/javac"
+    else
+        javac_cmd="$(command -v javac)"
+    fi
+    if [[ ! -x "${javac_cmd}" ]]; then
+        echo "ERROR: javac is not available to refresh Version.class"
+        exit 1
+    fi
+
+    mkdir -p "${version_class_dir}/org/apache/doris/common"
+    "${javac_cmd}" -encoding UTF-8 -d "${version_class_dir}" "${version_java}"
+
+    local version_class_rel="org/apache/doris/common/Version.class"
+    local version_class="${version_class_dir}/${version_class_rel}"
+    if [[ ! -f "${version_class}" ]]; then
+        echo "ERROR: ${version_class} is missing after recompilation"
+        exit 1
+    fi
+
+    pushd "${version_class_dir}" >/dev/null
+    if [[ -f "${fe_common_target_jar}" ]]; then
+        jar uf "${fe_common_target_jar}" "${version_class_rel}"
+    fi
+
+    local fe_common_runtime_jar
+    for fe_common_runtime_jar in "${DORIS_HOME}/fe/fe-core/target/lib"/fe-common-*.jar; do
+        [[ -f "${fe_common_runtime_jar}" ]] || continue
+        jar uf "${fe_common_runtime_jar}" "${version_class_rel}"
+    done
+
+    local output_common_jar
+    for output_common_jar in "${DORIS_HOME}/output/fe/lib"/fe-common-*.jar; do
+        [[ -f "${output_common_jar}" ]] || continue
+        jar uf "${output_common_jar}" "${version_class_rel}"
+    done
+    popd >/dev/null
+}
+
 # FE UI must be built before building FE
 if [[ "${BUILD_FE}" -eq 1 ]]; then
     if [[ "${BUILD_UI}" -eq 1 ]]; then
@@ -874,6 +944,7 @@ if [[ "${FE_MODULES}" != '' ]]; then
         clean_fe
     fi
     build_fe_modules
+    refresh_fe_build_version_if_commit_changed
     cd "${DORIS_HOME}"
 fi
 

--- a/tools/fast-compile-fe.sh
+++ b/tools/fast-compile-fe.sh
@@ -67,9 +67,9 @@ error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 # via heartbeat and `show frontends` shows as the Version column. A full mvn build
 # regenerates it, but fast-compile never triggers that, so the hash goes stale.
 # Here we compare the on-disk Version.java's hash against `git log -1 %h` and, when
-# they differ, delete Version.java (gen_build_version.sh early-exits if it exists),
-# re-run the generator, recompile Version.class, and refresh the fe-common jars so
-# the running FE picks up the new commit.
+# they differ, delete Version.java (gen_build_version.sh early-exits if generated
+# files already exist), re-run the generator, recompile Version.class, and refresh
+# the fe-common jars so the running FE picks up the new commit.
 update_version_if_commit_changed() {
     [[ -d "$DORIS_HOME/.git" ]] || return 0
     local current_hash
@@ -78,7 +78,7 @@ update_version_if_commit_changed() {
 
     local baked_hash=""
     if [[ -f "$VERSION_JAVA" ]]; then
-        baked_hash="$(sed -n 's/.*DORIS_BUILD_SHORT_HASH[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$VERSION_JAVA" | head -1)"
+        baked_hash="$(sed -n 's/.*DORIS_BUILD_SHORT_HASH[^"]*"\([^"]*\)".*/\1/p' "$VERSION_JAVA" | head -1)"
     fi
 
     if [[ "$baked_hash" == "$current_hash" ]]; then
@@ -87,8 +87,6 @@ update_version_if_commit_changed() {
 
     info "Git commit changed: ${baked_hash:-<missing>} → $current_hash, regenerating Version.java"
 
-    # gen_build_version.sh exits early when all three generated files exist, so
-    # force regeneration by removing Version.java first.
     rm -f "$VERSION_JAVA"
     (cd "$DORIS_HOME" && bash gensrc/script/gen_build_version.sh) \
         || { error "gen_build_version.sh failed"; return 1; }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Keep FE version metadata in sync with the current git commit when Maven build cache or incremental compilation restores stale fe-common outputs. After FE builds finish, refresh Version.java/Version.class and update the packaged fe-common jars when the baked short hash no longer matches HEAD.

### Release note

Fix FE version reporting so cached builds and fast incremental compilation update the reported git short hash to the current commit.

### Check List (For Author)

- Test: Manual test
    - CUSTOM_UI_DIST=/mnt/disk4/zhouminghong/doris/ui/dist ./build.sh --fe
    - ./tools/fast-compile-fe.sh
- Behavior changed: Yes (FE build and fast incremental compile now refresh version metadata when cached outputs are stale)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

