### PR TITLE
[fix](eager-agg) push aggregation down through filter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriter.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * eager aggregation
@@ -502,7 +503,28 @@ public class EagerAggRewriter extends DefaultPlanRewriter<PushDownAggContext> {
 
     @Override
     public Plan visitLogicalFilter(LogicalFilter<? extends Plan> filter, PushDownAggContext context) {
-        return genAggregate(filter, context);
+        if (filter.child() instanceof LogicalRelation) {
+            return genAggregate(filter, context);
+        } else {
+            List<SlotReference> filterInputSlots = filter.getInputSlots().stream()
+                    .map(slot -> (SlotReference) slot)
+                    .collect(Collectors.toList());
+            List<SlotReference> childGroupKeys = Stream.concat(
+                            context.getGroupKeys().stream(),
+                            filterInputSlots.stream())
+                    .distinct()
+                    .collect(Collectors.toList());
+            PushDownAggContext childContext = context.withGroupKeys(childGroupKeys);
+            if (!childContext.isValid()) {
+                return filter;
+            }
+            Plan newChild = filter.child().accept(this, childContext);
+            if (newChild != filter.child()) {
+                return filter.withChildren(newChild);
+            } else {
+                return filter;
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriter.java
@@ -505,26 +505,27 @@ public class EagerAggRewriter extends DefaultPlanRewriter<PushDownAggContext> {
     public Plan visitLogicalFilter(LogicalFilter<? extends Plan> filter, PushDownAggContext context) {
         if (filter.child() instanceof LogicalRelation) {
             return genAggregate(filter, context);
-        } else {
-            List<SlotReference> filterInputSlots = filter.getInputSlots().stream()
-                    .map(slot -> (SlotReference) slot)
-                    .collect(Collectors.toList());
-            List<SlotReference> childGroupKeys = Stream.concat(
-                            context.getGroupKeys().stream(),
-                            filterInputSlots.stream())
-                    .distinct()
-                    .collect(Collectors.toList());
-            PushDownAggContext childContext = context.withGroupKeys(childGroupKeys);
-            if (!childContext.isValid()) {
-                return filter;
-            }
-            Plan newChild = filter.child().accept(this, childContext);
-            if (newChild != filter.child()) {
-                return filter.withChildren(newChild);
-            } else {
-                return filter;
-            }
         }
+        if (filter.getConjuncts().stream().anyMatch(Expression::containsUniqueFunction)) {
+            return genAggregate(filter, context);
+        }
+        List<SlotReference> filterInputSlots = filter.getInputSlots().stream()
+                .map(slot -> (SlotReference) slot)
+                .collect(Collectors.toList());
+        List<SlotReference> childGroupKeys = Stream.concat(
+                        context.getGroupKeys().stream(),
+                        filterInputSlots.stream())
+                .distinct()
+                .collect(Collectors.toList());
+        PushDownAggContext childContext = context.withGroupKeys(childGroupKeys);
+        if (!childContext.isValid()) {
+            return genAggregate(filter, context);
+        }
+        Plan newChild = filter.child().accept(this, childContext);
+        if (newChild != filter.child()) {
+            return filter.withChildren(newChild);
+        }
+        return genAggregate(filter, context);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/eageraggregation/EagerAggRewriterTest.java
@@ -17,10 +17,14 @@
 
 package org.apache.doris.nereids.rules.rewrite.eageraggregation;
 
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.utframe.TestWithFeService;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class EagerAggRewriterTest extends TestWithFeService implements MemoPatternMatchSupported {
@@ -365,5 +369,74 @@ class EagerAggRewriterTest extends TestWithFeService implements MemoPatternMatch
             connectContext.getSessionVariable().setEagerAggregationMode(0);
             connectContext.getSessionVariable().setDisableJoinReorder(false);
         }
+    }
+
+    @Test
+    void testUniqueFunctionFilterBlocksPushDownThroughFilter() {
+        connectContext.getSessionVariable().setEagerAggregationMode(1);
+        connectContext.getSessionVariable().setDisableJoinReorder(true);
+        try {
+            String sql = "select count(s.name1), t2.id2"
+                    + " from (select * from (select id1, name as name1 from t1) s1 where random() < 0.5) s"
+                    + " join t2 on s.id1 = t2.id2 group by t2.id2";
+            Plan plan = PlanChecker.from(connectContext)
+                    .analyze(sql)
+                    .rewrite()
+                    .getPlan();
+            Assertions.assertEquals(2, countPlans(plan, LogicalAggregate.class), plan.treeString());
+            LogicalFilter<?> filter = findFirstPlan(plan, LogicalFilter.class);
+            Assertions.assertNotNull(filter, plan.treeString());
+            Assertions.assertFalse(containsPlan(filter.child(), LogicalAggregate.class), plan.treeString());
+        } finally {
+            connectContext.getSessionVariable().setEagerAggregationMode(0);
+            connectContext.getSessionVariable().setDisableJoinReorder(false);
+        }
+    }
+
+    @Test
+    void testInvalidFilterContextFallsBackToCurrentFilter() {
+        connectContext.getSessionVariable().setEagerAggregationMode(1);
+        connectContext.getSessionVariable().setDisableJoinReorder(true);
+        try {
+            String sql = "select count(s.name1), t2.id2"
+                    + " from (select * from (select id1, name as name1 from t1) s1 where s1.name1 is not null) s"
+                    + " join t2 on s.id1 = t2.id2 group by t2.id2";
+            Plan plan = PlanChecker.from(connectContext)
+                    .analyze(sql)
+                    .rewrite()
+                    .getPlan();
+            Assertions.assertEquals(2, countPlans(plan, LogicalAggregate.class), plan.treeString());
+            LogicalFilter<?> filter = findFirstPlan(plan, LogicalFilter.class);
+            Assertions.assertNotNull(filter, plan.treeString());
+            Assertions.assertFalse(containsPlan(filter.child(), LogicalAggregate.class), plan.treeString());
+        } finally {
+            connectContext.getSessionVariable().setEagerAggregationMode(0);
+            connectContext.getSessionVariable().setDisableJoinReorder(false);
+        }
+    }
+
+    private int countPlans(Plan plan, Class<? extends Plan> clazz) {
+        int count = clazz.isInstance(plan) ? 1 : 0;
+        for (Plan child : plan.children()) {
+            count += countPlans(child, clazz);
+        }
+        return count;
+    }
+
+    private boolean containsPlan(Plan plan, Class<? extends Plan> clazz) {
+        return countPlans(plan, clazz) > 0;
+    }
+
+    private <T extends Plan> T findFirstPlan(Plan plan, Class<T> clazz) {
+        if (clazz.isInstance(plan)) {
+            return clazz.cast(plan);
+        }
+        for (Plan child : plan.children()) {
+            T matched = findFirstPlan(child, clazz);
+            if (matched != null) {
+                return matched;
+            }
+        }
+        return null;
     }
 }

--- a/regression-test/data/query_p0/eager_agg/eager_agg.out
+++ b/regression-test/data/query_p0/eager_agg/eager_agg.out
@@ -367,3 +367,20 @@ PhysicalResultSink
 \N	3
 10	3
 
+-- !check_filter_slots_preserved_pushdown --
+PhysicalResultSink
+--hashAgg[GLOBAL]
+----filter(OR[( not (id = 1)),id IS NULL])
+------hashJoin[LEFT_OUTER_JOIN] hashCondition=((a.id = b.id)) otherCondition=()
+--------hashAgg[GLOBAL]
+----------PhysicalOlapScan[eager_agg_filter_t1(a)]
+--------PhysicalOlapScan[eager_agg_filter_t2(b)]
+
+Hint log:
+Used: [broadcast]_1
+UnUsed:
+SyntaxError:
+
+-- !filter_slots_preserved_eager_on --
+2	20
+

--- a/regression-test/suites/query_p0/eager_agg/eager_agg.groovy
+++ b/regression-test/suites/query_p0/eager_agg/eager_agg.groovy
@@ -422,6 +422,8 @@ suite("eager_agg") {
         drop table if exists eager_agg_t1;
         drop table if exists eager_agg_t2;
         drop table if exists eager_agg_t3;
+        drop table if exists eager_agg_filter_t1;
+        drop table if exists eager_agg_filter_t2;
 
         CREATE TABLE eager_agg_t1 (
             id INT NOT NULL,
@@ -441,9 +443,23 @@ suite("eager_agg") {
         ) DISTRIBUTED BY HASH(id2) BUCKETS 1
         PROPERTIES ('replication_num' = '1');
 
+        CREATE TABLE eager_agg_filter_t1 (
+            id INT NOT NULL,
+            flag INT NOT NULL,
+            v INT NOT NULL
+        ) DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ('replication_num' = '1');
+
+        CREATE TABLE eager_agg_filter_t2 (
+            id INT NOT NULL
+        ) DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ('replication_num' = '1');
+
         INSERT INTO eager_agg_t1 VALUES (1, 10);
         INSERT INTO eager_agg_t2 VALUES (1, 100), (2, 200);
         INSERT INTO eager_agg_t3 VALUES (100, 10), (200, 20), (300, 30);
+        INSERT INTO eager_agg_filter_t1 VALUES (1, 0, 10), (2, 1, 20);
+        INSERT INTO eager_agg_filter_t2 VALUES (1);
     """
 
     // sum(literal) should NOT be pushed below RIGHT JOIN to the nullable left side
@@ -527,5 +543,24 @@ suite("eager_agg") {
     right join eager_agg_t3 as c on b.id2 = c.id2 and a.val = c.val
     group by a.val
     order by a.val;
+    """
+
+    qt_check_filter_slots_preserved_pushdown """
+    explain shape plan
+    select /*+SET_VAR(eager_aggregation_mode=1, disable_join_reorder = true)*/
+        a.id, sum(a.v) as s
+    from eager_agg_filter_t1 as a
+    left join[broadcast] eager_agg_filter_t2 as b on a.id = b.id
+    where b.id <> 1 or b.id is null
+    group by a.id;
+    """
+
+    order_qt_filter_slots_preserved_eager_on """
+    select /*+SET_VAR(eager_aggregation_mode=1, disable_join_reorder = true)*/
+        a.id, sum(a.v) as s
+    from eager_agg_filter_t1 as a
+    left join[broadcast] eager_agg_filter_t2 as b on a.id = b.id
+    where b.id <> 1 or b.id is null
+    group by a.id;
     """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

push aggregation down through filter, if filter.child() is not Scan

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Regression test case updated; out refreshed in working tree
- Behavior changed: Yes (eager agg can safely push through filter while preserving filter-required slots)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

