### PR TITLE
[opt](point query) reduce fe CPU usage by eliminating unnecessary operation

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1521,6 +1521,20 @@ public class Config extends ConfigBase {
     public static int grpc_keep_alive_second = 10;
 
     /**
+     * Whether to use gRPC directExecutor() for BackendServiceClient.
+     *
+     * WARNING: When enabled, gRPC client call listeners (including protobuf parsing/completion) may run on
+     * Netty EventLoop threads. If response messages are large, this can block transport threads and delay
+     * unrelated RPCs on the same channel.
+     *
+     * This option should only be enabled when you are sure responses are small and the risk is acceptable.
+     * Takes effect after FE restart.
+     */
+    @ConfField(description = {"是否为 BackendServiceClient 使用 gRPC directExecutor",
+            "Whether to use gRPC directExecutor for BackendServiceClient"})
+    public static boolean grpc_backend_client_use_direct_executor = false;
+
+    /**
      * Used to set minimal number of replication per tablet.
      */
     @ConfField(mutable = true, masterOnly = true)

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -109,7 +109,7 @@ public class Profile {
     // summaryProfile will be serialized to storage as JSON, and we can recover it from storage
     // recover of SummaryProfile is important, because it contains the meta information of the profile
     // we need it to construct memory index for profile retrieving.
-    private SummaryProfile summaryProfile = new SummaryProfile();
+    private SummaryProfile summaryProfile;
     // executionProfiles will be stored to storage as text, when getting profile content, we will read
     // from storage directly.
     List<ExecutionProfile> executionProfiles = Lists.newArrayList();
@@ -140,10 +140,12 @@ public class Profile {
     private String changedSessionVarCache = "";
 
     // Need default constructor for read from storage
-    public Profile() {}
+    public Profile() {
+        this.summaryProfile = new SummaryProfile();
+    }
 
     public Profile(boolean isEnable, int profileLevel, long autoProfileDurationMs) {
-        this.summaryProfile = new SummaryProfile();
+        this.summaryProfile = new SummaryProfile(isEnable);
         // if disabled, just set isFinished to true, so that update() will do nothing
         this.isQueryFinished = !isEnable;
         this.profileLevel = profileLevel;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -436,7 +436,13 @@ public class SummaryProfile {
     private Map<Backend, Long> assignedWeightPerBackend;
 
     public SummaryProfile() {
-        init();
+        this(true);
+    }
+
+    public SummaryProfile(boolean isEnable) {
+        if (isEnable) {
+            init();
+        }
     }
 
     public static SummaryProfile read(DataInput input) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundResultSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundResultSink.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.plans.algebra.Sink;
 import org.apache.doris.nereids.trees.plans.commands.NeedAuditEncryption;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSink;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+import org.apache.doris.nereids.util.LazyCompute;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.base.Preconditions;
@@ -37,12 +38,14 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * unbound result sink
  */
 public class UnboundResultSink<CHILD_TYPE extends Plan> extends LogicalSink<CHILD_TYPE>
         implements NeedAuditEncryption, Unbound, Sink, BlockFuncDepsPropagation {
+    private Supplier<String> digest = LazyCompute.of(() -> child().toDigest());
 
     public UnboundResultSink(CHILD_TYPE child) {
         super(PlanType.LOGICAL_UNBOUND_RESULT_SINK, ImmutableList.of(), child);
@@ -93,7 +96,7 @@ public class UnboundResultSink<CHILD_TYPE extends Plan> extends LogicalSink<CHIL
 
     @Override
     public String toDigest() {
-        return child().toDigest();
+        return digest.get();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -87,6 +87,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -342,10 +343,9 @@ public class OlapScanNode extends ScanNode {
             if (isPointQuery() && partitionInfo.getPartitionColumns().size() == 1) {
                 // short circuit, a quick path to find partition
                 ColumnRange filterRange = columnNameToRange.get(partitionInfo.getPartitionColumns().get(0).getName());
-                LiteralExpr lowerBound = filterRange.getRangeSet().get().asRanges().stream()
-                        .findFirst().get().lowerEndpoint().getValue();
-                LiteralExpr upperBound = filterRange.getRangeSet().get().asRanges().stream()
-                        .findFirst().get().upperEndpoint().getValue();
+                Range<ColumnBound> range = filterRange.getRangeSet().get().span();
+                LiteralExpr lowerBound = range.lowerEndpoint().getValue();
+                LiteralExpr upperBound = range.upperEndpoint().getValue();
                 cachedPartitionPruner.update(keyItemMap);
                 return cachedPartitionPruner.prune(lowerBound, upperBound);
             }
@@ -655,10 +655,16 @@ public class OlapScanNode extends ScanNode {
             scanRange.setPaloScanRange(paloRange);
             locations.setScanRange(scanRange);
 
+            addBucketSeqStatsIfNeeded(tabletId, locations, oneReplicaBytes);
+            scanRangeLocations.add(locations);
+        }
+    }
+
+    private void addBucketSeqStatsIfNeeded(long tabletId, TScanRangeLocations locations, long oneReplicaBytes) {
+        if (!isPointQuery()) {
             Integer bucketSeq = tabletId2BucketSeq.get(tabletId);
             bucketSeq2locations.put(bucketSeq, locations);
             bucketSeq2Bytes.merge(bucketSeq, oneReplicaBytes, Long::sum);
-            scanRangeLocations.add(locations);
         }
     }
 
@@ -900,8 +906,10 @@ public class OlapScanNode extends ScanNode {
                 scanTabletIds.addAll(allTabletIds);
             }
 
-            for (int i = 0; i < allTabletIds.size(); i++) {
-                tabletId2BucketSeq.put(allTabletIds.get(i), i);
+            if (!isPointQuery()) {
+                for (int i = 0; i < allTabletIds.size(); i++) {
+                    tabletId2BucketSeq.put(allTabletIds.get(i), i);
+                }
             }
 
             totalTabletsNum += selectedTable.getTablets().size();
@@ -928,7 +936,9 @@ public class OlapScanNode extends ScanNode {
         computePartitionInfo();
         scanBackendIds.clear();
         scanTabletIds.clear();
+        tabletId2BucketSeq.clear();
         bucketSeq2locations.clear();
+        bucketSeq2Bytes.clear();
         scanReplicaIds.clear();
         sampleTabletIds.clear();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RangeMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RangeMap.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public class RangeMap<C extends Comparable<C>, V> {
 
@@ -35,13 +34,11 @@ public class RangeMap<C extends Comparable<C>, V> {
     }
 
     public List<V> getOverlappingRangeValues(Range<C> searchRange) {
-        return getOverlappingRanges(searchRange).stream()
-                .map(Map.Entry::getValue)
-                .collect(Collectors.toList());
+        return getOverlappingRanges(searchRange);
     }
 
-    public List<Map.Entry<Range<C>, V>> getOverlappingRanges(Range<C> searchRange) {
-        List<Map.Entry<Range<C>, V>> overlappingRanges = new ArrayList<>();
+    private List<V> getOverlappingRanges(Range<C> searchRange) {
+        List<V> overlappingRanges = new ArrayList<>();
 
         // Find the possible starting point for the search
         Map.Entry<Range<C>, V> floorEntry = rangeMap.floorEntry(searchRange);
@@ -58,7 +55,7 @@ public class RangeMap<C extends Comparable<C>, V> {
                 break; // No more overlapping ranges possible
             }
             if (entry.getKey().isConnected(searchRange) && !entry.getKey().intersection(searchRange).isEmpty()) {
-                overlappingRanges.add(entry);
+                overlappingRanges.add(entry.getValue());
             }
         }
         return overlappingRanges;

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -48,12 +48,22 @@ public class BackendServiceClient {
         // Use resolved IP address instead of hostname to avoid DNS resolution issues
         // If resolvedIp is empty or null, fallback to hostname
         String targetHost = (resolvedIp != null && !resolvedIp.isEmpty()) ? resolvedIp : address.getHostname();
-        channel = NettyChannelBuilder.forAddress(targetHost, address.getPort())
-                .executor(executor).keepAliveTime(Config.grpc_keep_alive_second, TimeUnit.SECONDS)
+
+        NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(targetHost, address.getPort())
+                .keepAliveTime(Config.grpc_keep_alive_second, TimeUnit.SECONDS)
                 .flowControlWindow(Config.grpc_max_message_size_bytes)
                 .keepAliveWithoutCalls(true)
-                .maxInboundMessageSize(Config.grpc_max_message_size_bytes).enableRetry().maxRetryAttempts(MAX_RETRY_NUM)
-                .usePlaintext().build();
+                .maxInboundMessageSize(Config.grpc_max_message_size_bytes)
+                .enableRetry().maxRetryAttempts(MAX_RETRY_NUM)
+                .usePlaintext();
+
+        if (Config.grpc_backend_client_use_direct_executor) {
+            channelBuilder.directExecutor();
+        } else {
+            channelBuilder.executor(executor);
+        }
+
+        channel = channelBuilder.build();
         stub = PBackendServiceGrpc.newFutureStub(channel);
         blockingStub = PBackendServiceGrpc.newBlockingStub(channel);
         // execPlanTimeout should be greater than future.get timeout, otherwise future will throw ExecutionException

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/ProfileTest.java
@@ -67,6 +67,15 @@ public class ProfileTest {
     }
 
     @Test
+    public void testDisableProfileSkipSummaryInitialization() {
+        Profile disabledProfile = new Profile(false, 1, -1);
+
+        Assertions.assertTrue(disabledProfile.isQueryFinished);
+        Assertions.assertTrue(disabledProfile.getSummaryProfile().getSummary().getInfoStrings().isEmpty());
+        Assertions.assertTrue(disabledProfile.getSummaryProfile().getExecutionSummary().getInfoStrings().isEmpty());
+    }
+
+    @Test
     public void testUpdateSummary() {
         Map<String, String> summaryInfo = new HashMap<>();
         summaryInfo.put("TestKey", "TestValue");

--- a/fe/fe-core/src/test/java/org/apache/doris/rpc/BackendServiceClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rpc/BackendServiceClientTest.java
@@ -27,7 +27,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
@@ -35,7 +35,7 @@ import java.util.concurrent.Executors;
  * resolved IP addresses instead of hostnames for gRPC connections.
  */
 public class BackendServiceClientTest {
-    private Executor executor;
+    private ExecutorService executor;
     private int originalGrpcKeepAliveSeconds;
     private int originalGrpcMaxMessageSize;
     private long originalRemoteFragmentExecTimeout;
@@ -62,6 +62,10 @@ public class BackendServiceClientTest {
         Config.grpc_keep_alive_second = originalGrpcKeepAliveSeconds;
         Config.grpc_max_message_size_bytes = originalGrpcMaxMessageSize;
         Config.remote_fragment_exec_timeout_ms = originalRemoteFragmentExecTimeout;
+
+        if (executor != null) {
+            executor.shutdown();
+        }
     }
 
     /**


### PR DESCRIPTION
1. If the profile is disabled, then the initialization of the info string in SummaryProfile can be skipped.
2. The plan of the prepared statement has been saved, so the corresponding digest can also be cached to avoid repeated generation during each execution.
3. bucketSeq is not useful for point queries. When the table bucket is large, skipping the generation of bucketSeq in point queries can significantly reduce map-related operations.
4. RangeMap: Performing only one traversal when generating overlapping ranges.
5. GRPC: directExecutor() ensures that all callbacks are executed directly on Netty transport threads (EventLoop), eliminating the overhead of thread-pool switching and task queuing. Since all our current operations are extremely lightweight, we can safely switch to using directExecutor.

Through these optimizations, our fe (64 core) experiences approximately a 20% reduction in CPU usage at 25w qps/s.