### PR TITLE
[cloud](fe) RestoreJob cannot deserialize Tablet when upgrade

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -526,7 +526,9 @@ public class GsonUtils {
         } else {
             // compatible with old cloud code.
             tabletTypeAdapterFactory.registerDefaultSubtype(CloudTablet.class);
+            tabletTypeAdapterFactory.registerCompatibleSubtype(CloudTablet.class, Tablet.class.getSimpleName());
             replicaTypeAdapterFactory.registerDefaultSubtype(CloudReplica.class);
+            replicaTypeAdapterFactory.registerCompatibleSubtype(CloudReplica.class, Replica.class.getSimpleName());
         }
     }
 


### PR DESCRIPTION
1. submit a RetoreJob in version 4.0.x
2. upgrade to 4.1.x, will get:
```
2026-04-20 15:14:05,362 ERROR (stateListener|119) [BDBJournalCursor.next():130] fail to read journal entity key=158123, will exit
com.google.gson.JsonParseException: cannot deserialize class org.apache.doris.catalog.Tablet subtype named Tablet; did you forget to register a subtype?
        at org.apache.doris.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:327)
        at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:204)
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82)
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoField(ReflectiveTypeAdapterFactory.java:212)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:433)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoField(ReflectiveTypeAdapterFactory.java:212)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:433)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:299)
        at org.apache.doris.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:330)
        at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:204)
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:186)
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:144)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoField(ReflectiveTypeAdapterFactory.java:212)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:433)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:299)
        at org.apache.doris.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:330)
        at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:204)
        at com.google.gson.Gson$FutureTypeAdapter.read(Gson.java:1367)
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:40)
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:186)
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:144)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoField(ReflectiveTypeAdapterFactory.java:212)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:433)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoField(ReflectiveTypeAdapterFactory.java:212)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:433)
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393)
        at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:965)
        at org.apache.doris.persist.gson.GsonUtils$PreProcessTypeAdapterFactory$1.read(GsonUtils.java:944)
        at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:299)
        at org.apache.doris.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:330)
        at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:204)
        at com.google.gson.Gson.fromJson(Gson.java:1227)
        at com.google.gson.Gson.fromJson(Gson.java:1137)
        at com.google.gson.Gson.fromJson(Gson.java:1047)
        at com.google.gson.Gson.fromJson(Gson.java:982)
        at org.apache.doris.backup.RestoreJob.read(RestoreJob.java:2754)
        at org.apache.doris.journal.JournalEntity.readFields(JournalEntity.java:331)
```