### PR TITLE
[opt](function) optimize concat_ws by replacing per-row fmt::join with columnar two-pass memcpy

### DIFF
--- a/be/benchmark/benchmark_concat_ws.hpp
+++ b/be/benchmark/benchmark_concat_ws.hpp
@@ -1,0 +1,340 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// ============================================================
+// Benchmark: concat_ws — old (per-row fmt::join) vs new (columnar two-pass)
+//
+// Old: clears a views vector per row, calls fmt::format_to(buffer, "{}", fmt::join(views, sep))
+//      then StringOP::push_value_string — one heap-buffer write + one copy per row.
+// New: pass-1 counts total output bytes; single res_data.resize(); pass-2 writes
+//      directly to the output buffer via memcpy, no fmt overhead.
+//
+// Scenarios:
+//   - 3 string args, small strings (~20 bytes each)
+//   - 3 string args, medium strings (~100 bytes each)
+//   - 8 string args, small strings (~20 bytes each)
+//   - 3 string args, 30% null args (skip nulls)
+// ============================================================
+
+#include <benchmark/benchmark.h>
+#include <fmt/format.h>
+
+#include <cstring>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "core/column/column_string.h"
+#include "exec/common/stringop_substring.h"
+
+namespace doris {
+
+using Chars = ColumnString::Chars;
+using Offsets = ColumnString::Offsets;
+
+// ---- Helpers ----
+
+struct ColData {
+    Chars chars;
+    Offsets offsets;
+    std::vector<uint8_t> nullmap; // 0 = not null
+};
+
+// Build a ColData with random strings of given avg_len, null_rate in [0,1]
+static ColData build_col(size_t rows, size_t avg_len, double null_rate, unsigned seed = 42) {
+    ColData col;
+    col.offsets.resize(rows);
+    col.nullmap.resize(rows, 0);
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<uint8_t> char_dist('a', 'z');
+    std::uniform_int_distribution<size_t> len_dist(avg_len > 4 ? avg_len - 4 : 0, avg_len + 4);
+    std::uniform_real_distribution<double> null_dist(0.0, 1.0);
+
+    size_t offset = 0;
+    for (size_t i = 0; i < rows; ++i) {
+        if (null_rate > 0.0 && null_dist(rng) < null_rate) {
+            col.nullmap[i] = 1;
+            col.offsets[i] = static_cast<uint32_t>(offset);
+            continue;
+        }
+        size_t len = len_dist(rng);
+        col.chars.resize(offset + len);
+        for (size_t k = 0; k < len; ++k) {
+            col.chars[offset + k] = static_cast<uint8_t>(char_dist(rng));
+        }
+        offset += len;
+        col.offsets[i] = static_cast<uint32_t>(offset);
+    }
+    return col;
+}
+
+// Build a separator ColData (constant sep repeated for all rows)
+static ColData build_sep_col(size_t rows, const std::string& sep) {
+    ColData col;
+    col.offsets.resize(rows);
+    col.nullmap.resize(rows, 0);
+    col.chars.resize(sep.size() * rows);
+    size_t offset = 0;
+    for (size_t i = 0; i < rows; ++i) {
+        memcpy(col.chars.data() + offset, sep.data(), sep.size());
+        offset += sep.size();
+        col.offsets[i] = static_cast<uint32_t>(offset);
+    }
+    return col;
+}
+
+// ---- Old implementation: per-row fmt::join ----
+static void concat_ws_old(size_t input_rows_count, const std::vector<const Offsets*>& offsets_list,
+                          const std::vector<const Chars*>& chars_list,
+                          const std::vector<const std::vector<uint8_t>*>& null_list,
+                          Chars& res_data, Offsets& res_offset) {
+    const size_t argument_size = offsets_list.size();
+    fmt::memory_buffer buffer;
+    std::vector<std::string_view> views;
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        const auto& sep_offsets = *offsets_list[0];
+        const auto& sep_chars = *chars_list[0];
+        const auto& sep_nullmap = *null_list[0];
+        if (sep_nullmap[i]) {
+            res_offset[i] = static_cast<uint32_t>(res_data.size());
+            continue;
+        }
+
+        uint32_t sep_size = sep_offsets[i] - sep_offsets[i - 1];
+        const char* sep_data_ptr =
+                reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
+        std::string_view sep(sep_data_ptr, sep_size);
+
+        buffer.clear();
+        views.clear();
+        for (size_t j = 1; j < argument_size; ++j) {
+            const auto& current_offsets = *offsets_list[j];
+            const auto& current_chars = *chars_list[j];
+            const auto& current_nullmap = *null_list[j];
+            uint32_t size = current_offsets[i] - current_offsets[i - 1];
+            const char* ptr =
+                    reinterpret_cast<const char*>(&current_chars[current_offsets[i - 1]]);
+            if (!current_nullmap[i]) {
+                views.emplace_back(ptr, size);
+            }
+        }
+        fmt::format_to(buffer, "{}", fmt::join(views, sep));
+        StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
+                                    res_offset);
+    }
+}
+
+// ---- New implementation: two-pass + direct memcpy ----
+// Pass 1: sum up output bytes; Pass 2: write directly to res_data.
+static void concat_ws_new(size_t input_rows_count, const std::vector<const Offsets*>& offsets_list,
+                          const std::vector<const Chars*>& chars_list,
+                          const std::vector<const std::vector<uint8_t>*>& null_list,
+                          Chars& res_data, Offsets& res_offset) {
+    const size_t argument_size = offsets_list.size();
+
+    // Pass 1: compute total output size
+    size_t total_size = 0;
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if ((*null_list[0])[i]) {
+            continue;
+        }
+        const uint32_t sep_size = (*offsets_list[0])[i] - (*offsets_list[0])[i - 1];
+        int non_null_count = 0;
+        for (size_t j = 1; j < argument_size; ++j) {
+            if (!(*null_list[j])[i]) {
+                total_size += (*offsets_list[j])[i] - (*offsets_list[j])[i - 1];
+                ++non_null_count;
+            }
+        }
+        if (non_null_count > 1) {
+            total_size += static_cast<size_t>(sep_size) * (non_null_count - 1);
+        }
+    }
+
+    res_data.resize(total_size);
+
+    // Pass 2: write data
+    size_t dst_offset = 0;
+    auto* dst = reinterpret_cast<char*>(res_data.data());
+
+    for (size_t i = 0; i < input_rows_count; ++i) {
+        if ((*null_list[0])[i]) {
+            res_offset[i] = static_cast<uint32_t>(dst_offset);
+            continue;
+        }
+
+        const auto& sep_offsets = *offsets_list[0];
+        const auto& sep_chars = *chars_list[0];
+        const uint32_t sep_size = sep_offsets[i] - sep_offsets[i - 1];
+        const char* sep_data_ptr =
+                reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
+
+        bool first = true;
+        for (size_t j = 1; j < argument_size; ++j) {
+            if ((*null_list[j])[i]) {
+                continue;
+            }
+            const auto& cur_offsets = *offsets_list[j];
+            const auto& cur_chars = *chars_list[j];
+            const uint32_t size = cur_offsets[i] - cur_offsets[i - 1];
+
+            if (!first && sep_size > 0) {
+                memcpy(dst + dst_offset, sep_data_ptr, sep_size);
+                dst_offset += sep_size;
+            }
+            first = false;
+
+            if (size > 0) {
+                memcpy(dst + dst_offset, cur_chars.data() + cur_offsets[i - 1], size);
+                dst_offset += size;
+            }
+        }
+        res_offset[i] = static_cast<uint32_t>(dst_offset);
+    }
+}
+
+// ---- Dataset builder ----
+struct ConcatWsDataset {
+    // Index 0 = sep, 1..N = args
+    std::vector<ColData> cols;
+    std::vector<const Offsets*> offsets_list;
+    std::vector<const Chars*> chars_list;
+    std::vector<const std::vector<uint8_t>*> null_list;
+    size_t rows;
+};
+
+static ConcatWsDataset build_dataset(size_t rows, size_t num_args, size_t avg_len,
+                                     double null_rate, const std::string& sep = ",") {
+    ConcatWsDataset ds;
+    ds.rows = rows;
+    ds.cols.reserve(num_args + 1);
+
+    // Sep column (constant)
+    ds.cols.push_back(build_sep_col(rows, sep));
+    for (size_t j = 0; j < num_args; ++j) {
+        ds.cols.push_back(build_col(rows, avg_len, null_rate, static_cast<unsigned>(42 + j)));
+    }
+
+    ds.offsets_list.resize(num_args + 1);
+    ds.chars_list.resize(num_args + 1);
+    ds.null_list.resize(num_args + 1);
+    for (size_t i = 0; i <= num_args; ++i) {
+        ds.offsets_list[i] = &ds.cols[i].offsets;
+        ds.chars_list[i] = &ds.cols[i].chars;
+        ds.null_list[i] = &ds.cols[i].nullmap;
+    }
+    return ds;
+}
+
+// ---- Benchmarks ----
+
+// 3 args, small strings (~20 bytes), no nulls
+static void BM_ConcatWs_Old_3Args_Small(benchmark::State& state) {
+    auto ds = build_dataset(10000, 3, 20, 0.0);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_old(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+static void BM_ConcatWs_New_3Args_Small(benchmark::State& state) {
+    auto ds = build_dataset(10000, 3, 20, 0.0);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_new(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+// 3 args, medium strings (~100 bytes), no nulls
+static void BM_ConcatWs_Old_3Args_Medium(benchmark::State& state) {
+    auto ds = build_dataset(5000, 3, 100, 0.0);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_old(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+static void BM_ConcatWs_New_3Args_Medium(benchmark::State& state) {
+    auto ds = build_dataset(5000, 3, 100, 0.0);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_new(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+// 8 args, small strings, no nulls
+static void BM_ConcatWs_Old_8Args_Small(benchmark::State& state) {
+    auto ds = build_dataset(5000, 8, 20, 0.0);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_old(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+static void BM_ConcatWs_New_8Args_Small(benchmark::State& state) {
+    auto ds = build_dataset(5000, 8, 20, 0.0);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_new(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+// 3 args, small strings, 30% null args
+static void BM_ConcatWs_Old_3Args_Null(benchmark::State& state) {
+    auto ds = build_dataset(10000, 3, 20, 0.3);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_old(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+static void BM_ConcatWs_New_3Args_Null(benchmark::State& state) {
+    auto ds = build_dataset(10000, 3, 20, 0.3);
+    for (auto _ : state) {
+        Chars res_data;
+        Offsets res_offset(ds.rows);
+        concat_ws_new(ds.rows, ds.offsets_list, ds.chars_list, ds.null_list, res_data, res_offset);
+        benchmark::DoNotOptimize(res_data);
+    }
+}
+
+BENCHMARK(BM_ConcatWs_Old_3Args_Small);
+BENCHMARK(BM_ConcatWs_New_3Args_Small);
+BENCHMARK(BM_ConcatWs_Old_3Args_Medium);
+BENCHMARK(BM_ConcatWs_New_3Args_Medium);
+BENCHMARK(BM_ConcatWs_Old_8Args_Small);
+BENCHMARK(BM_ConcatWs_New_8Args_Small);
+BENCHMARK(BM_ConcatWs_Old_3Args_Null);
+BENCHMARK(BM_ConcatWs_New_3Args_Null);
+
+} // namespace doris

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -21,6 +21,7 @@
 #include "benchmark_bits.hpp"
 #include "benchmark_block_bloom_filter.hpp"
 #include "benchmark_column_view.hpp"
+#include "benchmark_concat_ws.hpp"
 #include "benchmark_fastunion.hpp"
 #include "benchmark_hll_merge.hpp"
 #include "benchmark_hybrid_set.hpp"

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -414,8 +414,6 @@ public:
         res_offset.resize(input_rows_count);
 
         VectorizedUtils::update_null_map(null_map->get_data(), *null_list[0]);
-        fmt::memory_buffer buffer;
-        std::vector<std::string_view> views;
 
         if (is_column<ColumnArray>(argument_columns[1].get())) {
             // Determine if the nested type of the array is String
@@ -429,13 +427,13 @@ public:
                                     get_name()));
             }
             // Concat string in array
-            _execute_array(input_rows_count, array_column, buffer, views, offsets_list, chars_list,
-                           null_list, res_data, res_offset);
+            _execute_array(input_rows_count, array_column, offsets_list, chars_list, null_list,
+                           res_data, res_offset);
 
         } else {
             // Concat string
-            _execute_string(input_rows_count, argument_size, buffer, views, offsets_list,
-                            chars_list, null_list, res_data, res_offset);
+            _execute_string(input_rows_count, argument_size, offsets_list, chars_list, null_list,
+                            res_data, res_offset);
         }
         if (is_null_type) {
             block.get_by_position(result).column =
@@ -448,7 +446,6 @@ public:
 
 private:
     void _execute_array(const size_t& input_rows_count, const ColumnArray& array_column,
-                        fmt::memory_buffer& buffer, std::vector<std::string_view>& views,
                         const std::vector<const Offsets*>& offsets_list,
                         const std::vector<const Chars*>& chars_list,
                         const std::vector<const ColumnUInt8::Container*>& null_list,
@@ -472,86 +469,145 @@ private:
         const Chars& string_src_chars = string_column.get_chars();
         const auto& src_string_offsets = string_column.get_offsets();
         const auto& src_array_offsets = array_column.get_offsets();
+
+        // Pass 1: compute total output size
+        size_t total_size = 0;
+        size_t scan_array_offset = 0;
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            const auto& sep_nullmap = *null_list[0];
+            const auto next_array_offset = src_array_offsets[i];
+            if (sep_nullmap[i]) {
+                scan_array_offset = next_array_offset;
+                continue;
+            }
+            const uint32_t sep_size = (*offsets_list[0])[i] - (*offsets_list[0])[i - 1];
+            int non_null_count = 0;
+            for (; scan_array_offset < next_array_offset; ++scan_array_offset) {
+                if (array_nested_null_map == nullptr || !array_nested_null_map[scan_array_offset]) {
+                    const auto str_begin =
+                            scan_array_offset ? src_string_offsets[scan_array_offset - 1] : 0;
+                    total_size += src_string_offsets[scan_array_offset] - str_begin;
+                    ++non_null_count;
+                }
+            }
+            if (non_null_count > 1) {
+                total_size += static_cast<size_t>(sep_size) * (non_null_count - 1);
+            }
+        }
+
+        ColumnString::check_chars_length(total_size, 0);
+        res_data.resize(total_size);
+
+        // Pass 2: write data directly
+        size_t dst_offset = 0;
+        auto* dst = reinterpret_cast<char*>(res_data.data());
         size_t current_src_array_offset = 0;
 
-        // Concat string in array
         for (size_t i = 0; i < input_rows_count; ++i) {
-            auto& sep_offsets = *offsets_list[0];
-            auto& sep_chars = *chars_list[0];
-            auto& sep_nullmap = *null_list[0];
+            const auto& sep_offsets = *offsets_list[0];
+            const auto& sep_chars = *chars_list[0];
+            const auto& sep_nullmap = *null_list[0];
 
             if (sep_nullmap[i]) {
-                res_offset[i] = res_data.size();
+                res_offset[i] = static_cast<uint32_t>(dst_offset);
                 current_src_array_offset += src_array_offsets[i] - src_array_offsets[i - 1];
                 continue;
             }
 
-            int sep_size = sep_offsets[i] - sep_offsets[i - 1];
-            const char* sep_data = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
+            const uint32_t sep_size = sep_offsets[i] - sep_offsets[i - 1];
+            const char* sep_ptr = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
 
-            std::string_view sep(sep_data, sep_size);
-            buffer.clear();
-            views.clear();
-
+            bool first = true;
             for (auto next_src_array_offset = src_array_offsets[i];
                  current_src_array_offset < next_src_array_offset; ++current_src_array_offset) {
-                const auto current_src_string_offset =
-                        current_src_array_offset ? src_string_offsets[current_src_array_offset - 1]
-                                                 : 0;
-                size_t bytes_to_copy =
-                        src_string_offsets[current_src_array_offset] - current_src_string_offset;
-                const char* ptr =
-                        reinterpret_cast<const char*>(&string_src_chars[current_src_string_offset]);
+                if (array_nested_null_map != nullptr &&
+                    array_nested_null_map[current_src_array_offset]) {
+                    continue;
+                }
+                const auto str_begin = current_src_array_offset
+                                               ? src_string_offsets[current_src_array_offset - 1]
+                                               : 0;
+                const uint32_t bytes_to_copy =
+                        src_string_offsets[current_src_array_offset] - str_begin;
 
-                if (array_nested_null_map == nullptr ||
-                    !array_nested_null_map[current_src_array_offset]) {
-                    views.emplace_back(ptr, bytes_to_copy);
+                if (!first && sep_size > 0) {
+                    memcpy(dst + dst_offset, sep_ptr, sep_size);
+                    dst_offset += sep_size;
+                }
+                first = false;
+                if (bytes_to_copy > 0) {
+                    memcpy(dst + dst_offset,
+                           reinterpret_cast<const char*>(&string_src_chars[str_begin]),
+                           bytes_to_copy);
+                    dst_offset += bytes_to_copy;
                 }
             }
-
-            fmt::format_to(buffer, "{}", fmt::join(views, sep));
-
-            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
-                                        res_offset);
+            res_offset[i] = static_cast<uint32_t>(dst_offset);
         }
     }
 
     void _execute_string(const size_t& input_rows_count, const size_t& argument_size,
-                         fmt::memory_buffer& buffer, std::vector<std::string_view>& views,
                          const std::vector<const Offsets*>& offsets_list,
                          const std::vector<const Chars*>& chars_list,
                          const std::vector<const ColumnUInt8::Container*>& null_list,
                          Chars& res_data, Offsets& res_offset) const {
-        // Concat string
+        // Pass 1: compute total output size
+        size_t total_size = 0;
         for (size_t i = 0; i < input_rows_count; ++i) {
-            auto& sep_offsets = *offsets_list[0];
-            auto& sep_chars = *chars_list[0];
-            auto& sep_nullmap = *null_list[0];
-            if (sep_nullmap[i]) {
-                res_offset[i] = res_data.size();
+            if ((*null_list[0])[i]) {
+                continue;
+            }
+            const uint32_t sep_size = (*offsets_list[0])[i] - (*offsets_list[0])[i - 1];
+            int non_null_count = 0;
+            for (size_t j = 1; j < argument_size; ++j) {
+                if (!(*null_list[j])[i]) {
+                    total_size += (*offsets_list[j])[i] - (*offsets_list[j])[i - 1];
+                    ++non_null_count;
+                }
+            }
+            if (non_null_count > 1) {
+                total_size += static_cast<size_t>(sep_size) * (non_null_count - 1);
+            }
+        }
+
+        ColumnString::check_chars_length(total_size, 0);
+        res_data.resize(total_size);
+
+        // Pass 2: write data directly
+        size_t dst_offset = 0;
+        auto* dst = reinterpret_cast<char*>(res_data.data());
+
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            if ((*null_list[0])[i]) {
+                res_offset[i] = static_cast<uint32_t>(dst_offset);
                 continue;
             }
 
-            int sep_size = sep_offsets[i] - sep_offsets[i - 1];
-            const char* sep_data = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
+            const auto& sep_offsets = *offsets_list[0];
+            const auto& sep_chars = *chars_list[0];
+            const uint32_t sep_size = sep_offsets[i] - sep_offsets[i - 1];
+            const char* sep_ptr = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
 
-            std::string_view sep(sep_data, sep_size);
-            buffer.clear();
-            views.clear();
+            bool first = true;
             for (size_t j = 1; j < argument_size; ++j) {
-                auto& current_offsets = *offsets_list[j];
-                auto& current_chars = *chars_list[j];
-                auto& current_nullmap = *null_list[j];
-                int size = current_offsets[i] - current_offsets[i - 1];
-                const char* ptr =
-                        reinterpret_cast<const char*>(&current_chars[current_offsets[i - 1]]);
-                if (!current_nullmap[i]) {
-                    views.emplace_back(ptr, size);
+                if ((*null_list[j])[i]) {
+                    continue;
+                }
+                const auto& cur_offsets = *offsets_list[j];
+                const auto& cur_chars = *chars_list[j];
+                const uint32_t size = cur_offsets[i] - cur_offsets[i - 1];
+
+                if (!first && sep_size > 0) {
+                    memcpy(dst + dst_offset, sep_ptr, sep_size);
+                    dst_offset += sep_size;
+                }
+                first = false;
+                if (size > 0) {
+                    memcpy(dst + dst_offset, cur_chars.data() + cur_offsets[i - 1], size);
+                    dst_offset += size;
                 }
             }
-            fmt::format_to(buffer, "{}", fmt::join(views, sep));
-            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
-                                        res_offset);
+            res_offset[i] = static_cast<uint32_t>(dst_offset);
         }
     }
 };


### PR DESCRIPTION
## Problem

`FunctionStringConcatWs::_execute_string` (and `_execute_array`) used `fmt::join` to
concatenate strings per row:

```cpp
// For every row:
buffer.clear();
views.clear();
for (size_t j = 1; j < argument_size; ++j) {
    if (!current_nullmap[i]) views.emplace_back(ptr, size);
}
fmt::format_to(buffer, "{}", fmt::join(views, sep));   // per-row heap write
StringOP::push_value_string(..., i, res_data, res_offset);  // copy again
```

This incurred multiple per-row overhead costs:
1. **`views` vector rebuild**: `clear()` + `push_back()` on every row, causing redundant
   branch and iterator work inside `fmt::join`.
2. **`fmt::memory_buffer` intermediate copy**: each row's output is first materialized into
   a temporary buffer, then copied again into `res_data` via `push_value_string`.
3. **`push_value_string` growth policy**: `res_data` grows incrementally (one row at a time),
   causing multiple reallocations over a batch.

## Solution

Replace with a **two-pass columnar approach**:

- **Pass 1** — scan all rows to accumulate the exact total output byte count (string lengths +
  separator contributions, null rows skipped).
- **Single allocation** — `res_data.resize(total_size)` once via `ColumnString::check_chars_length`.
- **Pass 2** — write directly into `res_data` with `memcpy`, interleaving separators inline.
  No intermediate buffer, no `views` vector, no fmt overhead.

The same pattern is applied to both `_execute_string` (fixed-argument list) and
`_execute_array` (array argument).

## Benchmark

10 000 rows (3-arg case) or 5 000 rows (8-arg and medium-string cases). Constant separator `,`.
Release build on a 192-core x86 server (192 × 3800 MHz).

```
Run on (192 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x96)
  L1 Instruction 32 KiB (x96)
  L2 Unified 2048 KiB (x96)
  L3 Unified 99840 KiB (x2)
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
BM_ConcatWs_Old_3Args_Small     1743164 ns      1728609 ns          371
BM_ConcatWs_New_3Args_Small      296626 ns       294089 ns         2324   x5.9
BM_ConcatWs_Old_3Args_Medium    4511487 ns      4480359 ns          160
BM_ConcatWs_New_3Args_Medium     193811 ns       191969 ns         3691   x23.3
BM_ConcatWs_Old_8Args_Small     2299644 ns      2283128 ns          297
BM_ConcatWs_New_8Args_Small      381030 ns       377581 ns         1880   x6.0
BM_ConcatWs_Old_3Args_Null      1469414 ns      1450171 ns          513
BM_ConcatWs_New_3Args_Null       445277 ns       442122 ns         1467   x3.3
```

- **Small strings** (~20 bytes/arg): **5.9x – 6.0x** faster — fmt overhead dominates even for
  tiny payloads.
- **Medium strings** (~100 bytes/arg): **23.3x** faster — intermediate buffer reallocation
  cost amplified with larger data.
- **With 30% null args**: **3.3x** faster — null skipping reduces effective work per row but
  fmt overhead still dominates.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

