### PR TITLE
[fix](fe) Fix ReadListener leak on rejected worker task

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/ReadListener.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/ReadListener.java
@@ -26,6 +26,8 @@ import org.xnio.ChannelListener;
 import org.xnio.XnioIoThread;
 import org.xnio.conduits.ConduitStreamSourceChannel;
 
+import java.util.concurrent.RejectedExecutionException;
+
 /**
  * listener for handle mysql cmd.
  */
@@ -46,23 +48,36 @@ public class ReadListener implements ChannelListener<ConduitStreamSourceChannel>
         XnioIoThread.requireCurrentThread();
         ctx.suspendAcceptQuery();
         // start async query handle in task thread.
-        channel.getWorker().execute(() -> {
+        try {
+            channel.getWorker().execute(() -> {
+                ctx.setThreadLocalInfo();
+                try {
+                    connectProcessor.processOnce();
+                    if (!ctx.isKilled()) {
+                        ctx.resumeAcceptQuery();
+                    } else {
+                        ctx.stopAcceptQuery();
+                        ctx.cleanup();
+                    }
+                } catch (Throwable e) {
+                    LOG.warn("Exception happened in one session(" + ctx + ").", e);
+                    ctx.setKilled();
+                    ctx.cleanup();
+                } finally {
+                    ConnectContext.remove();
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            LOG.warn("Failed to submit query task for one session({}).", ctx, e);
+            // Keep the same ConnectContext thread-local lifecycle as the normal async path,
+            // so that cleanup()/close listener can access ConnectContext.get() if needed.
             ctx.setThreadLocalInfo();
             try {
-                connectProcessor.processOnce();
-                if (!ctx.isKilled()) {
-                    ctx.resumeAcceptQuery();
-                } else {
-                    ctx.stopAcceptQuery();
-                    ctx.cleanup();
-                }
-            } catch (Throwable e) {
-                LOG.warn("Exception happened in one session(" + ctx + ").", e);
                 ctx.setKilled();
                 ctx.cleanup();
             } finally {
                 ConnectContext.remove();
             }
-        });
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/ConnectionExceedTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/ConnectionExceedTest.java
@@ -23,7 +23,9 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.ConnectScheduler;
+import org.apache.doris.qe.QueryState;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.service.arrowflight.sessions.FlightSessionsWithTokenManager;
 import org.apache.doris.service.arrowflight.tokens.FlightTokenDetails;
@@ -31,9 +33,15 @@ import org.apache.doris.service.arrowflight.tokens.FlightTokenManager;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.xnio.StreamConnection;
+import org.xnio.XnioIoThread;
+import org.xnio.XnioWorker;
+import org.xnio.conduits.ConduitStreamSourceChannel;
+
+import java.util.concurrent.RejectedExecutionException;
 
 public class ConnectionExceedTest {
     private Auth mockAuth = Mockito.mock(Auth.class);
@@ -87,6 +95,33 @@ public class ConnectionExceedTest {
                     scheduler.getConnectionNum());
             Assert.assertEquals(expectedMsg, context3.getState().getErrorMessage());
             Assert.assertEquals(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, context3.getState().getErrorCode());
+        }
+    }
+
+    @Test
+    public void testHandleReadEventRejectedExecution() throws Exception {
+        try (MockedStatic<XnioIoThread> mockedIoThread = Mockito.mockStatic(XnioIoThread.class)) {
+            ConnectContext context = Mockito.mock(ConnectContext.class);
+            QueryState queryState = Mockito.mock(QueryState.class);
+            ConnectProcessor processor = Mockito.mock(ConnectProcessor.class);
+            ConduitStreamSourceChannel channel = Mockito.mock(ConduitStreamSourceChannel.class);
+            XnioWorker worker = Mockito.mock(XnioWorker.class);
+
+            Mockito.when(context.getState()).thenReturn(queryState);
+            Mockito.when(channel.getWorker()).thenReturn(worker);
+            Mockito.doThrow(new RejectedExecutionException("queue full"))
+                    .when(worker).execute(Mockito.any(Runnable.class));
+
+            ReadListener listener = new ReadListener(context, processor);
+            listener.handleEvent(channel);
+
+            InOrder contextInOrder = Mockito.inOrder(context);
+            contextInOrder.verify(context).suspendAcceptQuery();
+            contextInOrder.verify(context).setThreadLocalInfo();
+            contextInOrder.verify(context).setKilled();
+            contextInOrder.verify(context).cleanup();
+            Mockito.verifyNoInteractions(queryState);
+            Mockito.verifyNoInteractions(processor);
         }
     }
 


### PR DESCRIPTION
ReadListener does not handle RejectedExecutionException, which may cause the Client to hang when concurrency is extremely high. AcceptListener has already performed similar handling.

