### PR TITLE
[bug](arrow) fix arrow type change cause read data coredump

### DIFF
--- a/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
@@ -127,23 +127,59 @@ Status DataTypeJsonbSerDe::read_column_from_arrow(IColumn& column, const arrow::
         std::shared_ptr<arrow::Buffer> buffer = concrete_array->value_data();
 
         const uint8_t* offsets_data = concrete_array->value_offsets()->data();
-        const size_t offset_size = sizeof(int32_t);
+        const int64_t offsets_buf_size = concrete_array->value_offsets()->size();
+
+        const int64_t base = arrow_array->offset();
+        const int64_t total_offsets_count = base + arrow_array->length() + 1;
+        const int64_t expected_int64_size = total_offsets_count * sizeof(int64_t);
+
+        // Detect schema/data mismatch: the sender may upgrade a utf8 builder to
+        // large_utf8 (int64 offsets) when a column exceeds MAX_ARROW_UTF8 but forget
+        // to update the schema, leaving int64 offsets behind a utf8 type tag. See
+        // DataTypeStringSerDeBase::read_column_from_arrow for the same workaround.
+        const bool offsets_are_int64 = (offsets_buf_size == expected_int64_size);
 
         JsonBinaryValue value;
-        for (auto offset_i = start; offset_i < end; ++offset_i) {
-            if (!concrete_array->IsNull(offset_i)) {
-                auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
-                auto end_offset =
-                        unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
+        if (offsets_are_int64) {
+            const size_t offset_size = sizeof(int64_t);
+            for (auto offset_i = start; offset_i < end; ++offset_i) {
+                if (!arrow_array->IsNull(offset_i)) {
+                    int64_t start_offset = 0;
+                    int64_t end_offset = 0;
+                    memcpy(&start_offset, offsets_data + (base + offset_i) * offset_size,
+                           offset_size);
+                    memcpy(&end_offset, offsets_data + (base + offset_i + 1) * offset_size,
+                           offset_size);
+                    const int64_t length = end_offset - start_offset;
+                    DCHECK_GE(length, 0);
+                    const auto* raw_data = buffer->data() + start_offset;
+                    RETURN_IF_ERROR(value.from_json_string(reinterpret_cast<const char*>(raw_data),
+                                                           static_cast<size_t>(length)));
+                    column.insert_data(value.value(), value.size());
+                } else {
+                    column.insert_default();
+                }
+            }
+        } else {
+            const size_t offset_size = sizeof(int32_t);
+            for (auto offset_i = start; offset_i < end; ++offset_i) {
+                if (!concrete_array->IsNull(offset_i)) {
+                    int32_t start_offset = 0;
+                    int32_t end_offset = 0;
+                    memcpy(&start_offset, offsets_data + (base + offset_i) * offset_size,
+                           offset_size);
+                    memcpy(&end_offset, offsets_data + (base + offset_i + 1) * offset_size,
+                           offset_size);
 
-                int32_t length = end_offset - start_offset;
-                const auto* raw_data = buffer->data() + start_offset;
+                    int32_t length = end_offset - start_offset;
+                    const auto* raw_data = buffer->data() + start_offset;
 
-                RETURN_IF_ERROR(
-                        value.from_json_string(reinterpret_cast<const char*>(raw_data), length));
-                column.insert_data(value.value(), value.size());
-            } else {
-                column.insert_default();
+                    RETURN_IF_ERROR(value.from_json_string(reinterpret_cast<const char*>(raw_data),
+                                                           length));
+                    column.insert_data(value.value(), value.size());
+                } else {
+                    column.insert_default();
+                }
             }
         }
     } else if (arrow_array->type_id() == arrow::Type::FIXED_SIZE_BINARY) {

--- a/be/src/core/data_type_serde/data_type_string_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_string_serde.cpp
@@ -261,22 +261,50 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
         arrow_array->type_id() == arrow::Type::BINARY) {
         const auto* concrete_array = dynamic_cast<const arrow::BinaryArray*>(arrow_array);
         std::shared_ptr<arrow::Buffer> buffer = concrete_array->value_data();
-        const uint8_t* offsets_data = concrete_array->value_offsets()->data();
-        const size_t offset_size = sizeof(int32_t);
 
-        for (auto offset_i = start; offset_i < end; ++offset_i) {
-            if (!concrete_array->IsNull(offset_i)) {
-                auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
-                auto end_offset =
-                        unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
+        const int64_t offsets_buf_size = concrete_array->value_offsets()->size();
+        const int64_t expected_int64_size = (arrow_array->length() + 1) * sizeof(int64_t);
 
-                int32_t length = end_offset - start_offset;
-                const auto* raw_data = buffer->data() + start_offset;
+        // Detect schema/data mismatch: sender may upgrade utf8 to large_utf8 (int64 offsets)
+        // without updating the schema. For N rows, int32 offsets need (N+1)*4 bytes while
+        // int64 offsets need (N+1)*8 bytes. These sizes never collide for N >= 0.
+        const bool offsets_are_int64 = (offsets_buf_size == expected_int64_size);
 
-                assert_cast<ColumnType&>(column).insert_data(
-                        reinterpret_cast<const char*>(raw_data), length);
-            } else {
-                assert_cast<ColumnType&>(column).insert_default();
+        if (offsets_are_int64) {
+            // Reconstruct as LargeBinaryArray to read int64 offsets correctly.
+            auto large_type = (arrow_array->type_id() == arrow::Type::STRING)
+                                      ? arrow::large_utf8()
+                                      : arrow::large_binary();
+            auto new_data = arrow::ArrayData::Make(large_type, arrow_array->length(),
+                                                   arrow_array->data()->buffers,
+                                                   arrow_array->null_count(),
+                                                   concrete_array->offset());
+            auto large_array = std::make_shared<arrow::LargeBinaryArray>(new_data);
+            std::shared_ptr<arrow::Buffer> large_buffer = large_array->value_data();
+
+            for (auto offset_i = start; offset_i < end; ++offset_i) {
+                if (!large_array->IsNull(offset_i)) {
+                    const auto* raw_data =
+                            large_buffer->data() + large_array->value_offset(offset_i);
+                    assert_cast<ColumnType&>(column).insert_data(
+                            reinterpret_cast<const char*>(raw_data),
+                            large_array->value_length(offset_i));
+                } else {
+                    assert_cast<ColumnType&>(column).insert_default();
+                }
+            }
+        } else {
+            for (auto offset_i = start; offset_i < end; ++offset_i) {
+                if (!concrete_array->IsNull(offset_i)) {
+                    const int32_t start_offset = concrete_array->value_offset(offset_i);
+                    const int32_t end_offset = concrete_array->value_offset(offset_i + 1);
+                    const int32_t length = end_offset - start_offset;
+                    const auto* raw_data = buffer->data() + start_offset;
+                    assert_cast<ColumnType&>(column).insert_data(
+                            reinterpret_cast<const char*>(raw_data), length);
+                } else {
+                    assert_cast<ColumnType&>(column).insert_default();
+                }
             }
         }
     } else if (arrow_array->type_id() == arrow::Type::FIXED_SIZE_BINARY) {

--- a/be/src/core/data_type_serde/data_type_string_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_string_serde.cpp
@@ -264,31 +264,37 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
 
         const uint8_t* offsets_data = concrete_array->value_offsets()->data();
         const int64_t offsets_buf_size = concrete_array->value_offsets()->size();
-        const int64_t expected_int64_size = (arrow_array->length() + 1) * sizeof(int64_t);
 
-        // Detect schema/data mismatch: sender may upgrade utf8 to large_utf8 (int64 offsets)
-        // without updating the schema. For N rows, int32 offsets need (N+1)*4 bytes while
-        // int64 offsets need (N+1)*8 bytes. These sizes never collide for N >= 0.
+        const int64_t base = arrow_array->offset();
+        // Total number of int32/int64 entries actually backing this array view.
+        const int64_t total_offsets_count = base + arrow_array->length() + 1;
+        const int64_t expected_int64_size = total_offsets_count * sizeof(int64_t);
+
+        // Detect schema/data mismatch: the sender may upgrade a utf8 builder to
+        // large_utf8 (int64 offsets) when a column exceeds MAX_ARROW_UTF8 but forget
+        // to update the schema, leaving int64 offsets behind a utf8 type tag. For N
+        // backing entries int32 offsets need N*4 bytes while int64 offsets need N*8
+        // bytes, so an exact size match is unambiguous (4N != 8N for N >= 1).
+        // Note: for arbitrarily sub-sliced arrays whose underlying buffer is larger
+        // than `total_offsets_count` entries the heuristic falls back to int32; that
+        // is safe because the sender bug we are guarding against does not slice.
         const bool offsets_are_int64 = (offsets_buf_size == expected_int64_size);
 
         if (offsets_are_int64) {
-            // Reconstruct as LargeBinaryArray to read int64 offsets correctly.
-            auto large_type = (arrow_array->type_id() == arrow::Type::STRING)
-                                      ? arrow::large_utf8()
-                                      : arrow::large_binary();
-            auto new_data = arrow::ArrayData::Make(
-                    large_type, arrow_array->length(), arrow_array->data()->buffers,
-                    arrow_array->null_count(), concrete_array->offset());
-            auto large_array = std::make_shared<arrow::LargeBinaryArray>(new_data);
-            std::shared_ptr<arrow::Buffer> large_buffer = large_array->value_data();
-
+            const size_t offset_size = sizeof(int64_t);
             for (auto offset_i = start; offset_i < end; ++offset_i) {
-                if (!large_array->IsNull(offset_i)) {
-                    const auto* raw_data =
-                            large_buffer->data() + large_array->value_offset(offset_i);
+                if (!arrow_array->IsNull(offset_i)) {
+                    int64_t start_offset = 0;
+                    int64_t end_offset = 0;
+                    memcpy(&start_offset, offsets_data + (base + offset_i) * offset_size,
+                           offset_size);
+                    memcpy(&end_offset, offsets_data + (base + offset_i + 1) * offset_size,
+                           offset_size);
+                    const int64_t length = end_offset - start_offset;
+                    DCHECK_GE(length, 0);
+                    const auto* raw_data = buffer->data() + start_offset;
                     assert_cast<ColumnType&>(column).insert_data(
-                            reinterpret_cast<const char*>(raw_data),
-                            large_array->value_length(offset_i));
+                            reinterpret_cast<const char*>(raw_data), static_cast<size_t>(length));
                 } else {
                     assert_cast<ColumnType&>(column).insert_default();
                 }
@@ -299,8 +305,10 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
                 if (!concrete_array->IsNull(offset_i)) {
                     int32_t start_offset = 0;
                     int32_t end_offset = 0;
-                    memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
-                    memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
+                    memcpy(&start_offset, offsets_data + (base + offset_i) * offset_size,
+                           offset_size);
+                    memcpy(&end_offset, offsets_data + (base + offset_i + 1) * offset_size,
+                           offset_size);
 
                     int32_t length = end_offset - start_offset;
                     const auto* raw_data = buffer->data() + start_offset;

--- a/be/src/core/data_type_serde/data_type_string_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_string_serde.cpp
@@ -262,6 +262,7 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
         const auto* concrete_array = dynamic_cast<const arrow::BinaryArray*>(arrow_array);
         std::shared_ptr<arrow::Buffer> buffer = concrete_array->value_data();
 
+        const uint8_t* offsets_data = concrete_array->value_offsets()->data();
         const int64_t offsets_buf_size = concrete_array->value_offsets()->size();
         const int64_t expected_int64_size = (arrow_array->length() + 1) * sizeof(int64_t);
 
@@ -275,10 +276,9 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
             auto large_type = (arrow_array->type_id() == arrow::Type::STRING)
                                       ? arrow::large_utf8()
                                       : arrow::large_binary();
-            auto new_data = arrow::ArrayData::Make(large_type, arrow_array->length(),
-                                                   arrow_array->data()->buffers,
-                                                   arrow_array->null_count(),
-                                                   concrete_array->offset());
+            auto new_data = arrow::ArrayData::Make(
+                    large_type, arrow_array->length(), arrow_array->data()->buffers,
+                    arrow_array->null_count(), concrete_array->offset());
             auto large_array = std::make_shared<arrow::LargeBinaryArray>(new_data);
             std::shared_ptr<arrow::Buffer> large_buffer = large_array->value_data();
 
@@ -294,11 +294,15 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
                 }
             }
         } else {
+            const size_t offset_size = sizeof(int32_t);
             for (auto offset_i = start; offset_i < end; ++offset_i) {
                 if (!concrete_array->IsNull(offset_i)) {
-                    const int32_t start_offset = concrete_array->value_offset(offset_i);
-                    const int32_t end_offset = concrete_array->value_offset(offset_i + 1);
-                    const int32_t length = end_offset - start_offset;
+                    int32_t start_offset = 0;
+                    int32_t end_offset = 0;
+                    memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
+                    memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
+
+                    int32_t length = end_offset - start_offset;
                     const auto* raw_data = buffer->data() + start_offset;
                     assert_cast<ColumnType&>(column).insert_data(
                             reinterpret_cast<const char*>(raw_data), length);

--- a/be/src/format/arrow/arrow_block_convertor.cpp
+++ b/be/src/format/arrow/arrow_block_convertor.cpp
@@ -71,9 +71,6 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
     }
 
     _arrays.resize(num_fields);
-    // Track whether any field type was changed (e.g. utf8 -> large_utf8)
-    bool schema_changed = false;
-    std::vector<std::shared_ptr<arrow::Field>> fields(num_fields);
 
     for (int idx = 0; idx < num_fields; ++idx) {
         _cur_field_idx = idx;
@@ -85,9 +82,7 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
         auto arrow_type = _schema->field(idx)->type();
         if (arrow_type->name() == "utf8" && column->byte_size() >= MAX_ARROW_UTF8) {
             arrow_type = arrow::large_utf8();
-            schema_changed = true;
         }
-        fields[idx] = _schema->field(idx)->WithType(arrow_type);
         std::unique_ptr<arrow::ArrayBuilder> builder;
         auto arrow_st = arrow::MakeBuilder(_pool, arrow_type, &builder);
         if (!arrow_st.ok()) {
@@ -108,8 +103,7 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
             return to_doris_status(arrow_st);
         }
     }
-    auto schema = schema_changed ? arrow::schema(std::move(fields)) : _schema;
-    *out = arrow::RecordBatch::Make(std::move(schema), actual_rows, std::move(_arrays));
+    *out = arrow::RecordBatch::Make(_schema, actual_rows, std::move(_arrays));
     return Status::OK();
 }
 

--- a/be/src/format/arrow/arrow_block_convertor.cpp
+++ b/be/src/format/arrow/arrow_block_convertor.cpp
@@ -71,6 +71,9 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
     }
 
     _arrays.resize(num_fields);
+    // Track whether any field type was changed (e.g. utf8 -> large_utf8)
+    bool schema_changed = false;
+    std::vector<std::shared_ptr<arrow::Field>> fields(num_fields);
 
     for (int idx = 0; idx < num_fields; ++idx) {
         _cur_field_idx = idx;
@@ -82,7 +85,9 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
         auto arrow_type = _schema->field(idx)->type();
         if (arrow_type->name() == "utf8" && column->byte_size() >= MAX_ARROW_UTF8) {
             arrow_type = arrow::large_utf8();
+            schema_changed = true;
         }
+        fields[idx] = _schema->field(idx)->WithType(arrow_type);
         std::unique_ptr<arrow::ArrayBuilder> builder;
         auto arrow_st = arrow::MakeBuilder(_pool, arrow_type, &builder);
         if (!arrow_st.ok()) {
@@ -103,7 +108,8 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
             return to_doris_status(arrow_st);
         }
     }
-    *out = arrow::RecordBatch::Make(_schema, actual_rows, std::move(_arrays));
+    auto schema = schema_changed ? arrow::schema(std::move(fields)) : _schema;
+    *out = arrow::RecordBatch::Make(std::move(schema), _block.rows(), std::move(_arrays));
     return Status::OK();
 }
 

--- a/be/src/format/arrow/arrow_block_convertor.cpp
+++ b/be/src/format/arrow/arrow_block_convertor.cpp
@@ -109,7 +109,7 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
         }
     }
     auto schema = schema_changed ? arrow::schema(std::move(fields)) : _schema;
-    *out = arrow::RecordBatch::Make(std::move(schema), _block.rows(), std::move(_arrays));
+    *out = arrow::RecordBatch::Make(std::move(schema), actual_rows, std::move(_arrays));
     return Status::OK();
 }
 

--- a/be/src/format/arrow/arrow_row_batch.h
+++ b/be/src/format/arrow/arrow_row_batch.h
@@ -39,7 +39,7 @@ class Schema;
 
 namespace doris {
 
-constexpr size_t MAX_ARROW_UTF8 = (1ULL << 21); // 2G
+constexpr size_t MAX_ARROW_UTF8 = (1ULL << 31); // 2G
 
 class RowDescriptor;
 

--- a/be/test/core/data_type_serde/data_type_serde_string_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_string_test.cpp
@@ -457,4 +457,121 @@ TEST_F(DataTypeStringSerDeTest, ArrowInt64OffsetsInUtf8Schema_ReceiverFix) {
     }
 }
 
+// Buggy schema/data combo (utf8 type tag + int64 offsets) where the offsets buffer
+// sits at a deliberately mis-aligned address. Run with UBSan to verify that the
+// receiver-side fallback uses byte-wise memcpy reads instead of dereferencing
+// raw_value_offsets_, which would trigger a misaligned-access UB on strict
+// architectures (and a UBSan diagnostic everywhere).
+TEST_F(DataTypeStringSerDeTest, ArrowInt64OffsetsInUtf8Schema_Misaligned) {
+    std::vector<std::string> strings = {"alpha", "beta", "gamma", "delta", "epsilon"};
+    const int64_t row_count = static_cast<int64_t>(strings.size());
+
+    // Build int64 offsets manually. Cumulative byte positions.
+    std::vector<int64_t> int64_offsets = {0};
+    int64_t total_length = 0;
+    for (const auto& s : strings) {
+        total_length += static_cast<int64_t>(s.size());
+        int64_offsets.push_back(total_length);
+    }
+
+    // Create an unaligned-by-1 byte buffer for offsets.
+    std::vector<uint8_t> offset_storage(int64_offsets.size() * sizeof(int64_t) + 8);
+    uint8_t* unaligned_offset_data = offset_storage.data() + 1;
+    for (size_t i = 0; i < int64_offsets.size(); ++i) {
+        memcpy(unaligned_offset_data + i * sizeof(int64_t), &int64_offsets[i], sizeof(int64_t));
+    }
+
+    // Concatenated value buffer (alignment irrelevant for byte data, but mis-align
+    // it too just to be thorough).
+    std::vector<uint8_t> value_storage(total_length + 8);
+    uint8_t* unaligned_value_data = value_storage.data() + 1;
+    int64_t cursor = 0;
+    for (const auto& s : strings) {
+        memcpy(unaligned_value_data + cursor, s.data(), s.size());
+        cursor += static_cast<int64_t>(s.size());
+    }
+
+    auto value_buffer = arrow::Buffer::Wrap(unaligned_value_data, total_length);
+    auto offset_buffer =
+            arrow::Buffer::Wrap(unaligned_offset_data, int64_offsets.size() * sizeof(int64_t));
+
+    // Wrap with utf8 schema even though offsets are int64 (the bug we are testing).
+    auto buggy_data =
+            arrow::ArrayData::Make(arrow::utf8(), row_count, {nullptr, offset_buffer, value_buffer},
+                                   /*null_count=*/0, /*offset=*/0);
+    auto buggy_array = std::make_shared<arrow::StringArray>(buggy_data);
+
+    // Sanity-check: the offsets buffer is genuinely mis-aligned to 8 bytes.
+    uintptr_t addr = reinterpret_cast<uintptr_t>(buggy_array->value_offsets()->data());
+    EXPECT_NE(addr % alignof(int64_t), 0u);
+
+    auto result_col = ColumnString::create();
+    cctz::time_zone tz;
+    auto st = serde_str->read_column_from_arrow(*result_col, buggy_array.get(), 0, row_count, tz);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(static_cast<int64_t>(result_col->size()), row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        EXPECT_EQ(result_col->get_data_at(i).to_string(), strings[i]) << "row " << i;
+    }
+}
+
+// NULL rows must be handled correctly on the int64 fallback path.
+TEST_F(DataTypeStringSerDeTest, ArrowInt64OffsetsInUtf8Schema_WithNulls) {
+    arrow::LargeStringBuilder builder;
+    ASSERT_TRUE(builder.Append("first").ok());
+    ASSERT_TRUE(builder.AppendNull().ok());
+    ASSERT_TRUE(builder.Append("third").ok());
+    ASSERT_TRUE(builder.AppendNull().ok());
+    ASSERT_TRUE(builder.Append("fifth").ok());
+    std::shared_ptr<arrow::Array> large_array;
+    ASSERT_TRUE(builder.Finish(&large_array).ok());
+
+    auto buggy_data =
+            arrow::ArrayData::Make(arrow::utf8(), large_array->length(),
+                                   large_array->data()->buffers, large_array->null_count(), 0);
+    auto buggy_array = std::make_shared<arrow::StringArray>(buggy_data);
+
+    auto col = ColumnString::create();
+    cctz::time_zone tz;
+    auto st = serde_str->read_column_from_arrow(*col, buggy_array.get(), 0, large_array->length(),
+                                                tz);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(col->size(), 5);
+    EXPECT_EQ(col->get_data_at(0).to_string(), "first");
+    EXPECT_EQ(col->get_data_at(1).to_string(), "");
+    EXPECT_EQ(col->get_data_at(2).to_string(), "third");
+    EXPECT_EQ(col->get_data_at(3).to_string(), "");
+    EXPECT_EQ(col->get_data_at(4).to_string(), "fifth");
+}
+
+// Symmetric coverage for the BINARY type id path: the fallback shares the same
+// branch in read_column_from_arrow as STRING, but only STRING was previously tested.
+TEST_F(DataTypeStringSerDeTest, ArrowInt64OffsetsInBinarySchema_ReceiverFix) {
+    std::vector<std::string> blobs = {"\x01\x02\x03", "\xff\xee\xdd\xcc", "binary_payload",
+                                      std::string(64, 'A'), std::string(80, '\0')};
+    arrow::LargeBinaryBuilder builder;
+    for (const auto& b : blobs) {
+        ASSERT_TRUE(builder.Append(b).ok());
+    }
+    std::shared_ptr<arrow::Array> large_array;
+    ASSERT_TRUE(builder.Finish(&large_array).ok());
+
+    // Re-tag with binary() while keeping int64 offsets.
+    auto buggy_data =
+            arrow::ArrayData::Make(arrow::binary(), large_array->length(),
+                                   large_array->data()->buffers, large_array->null_count(), 0);
+    auto buggy_array = std::make_shared<arrow::BinaryArray>(buggy_data);
+
+    auto col = ColumnString::create();
+    cctz::time_zone tz;
+    auto st = serde_str->read_column_from_arrow(*col, buggy_array.get(), 0, large_array->length(),
+                                                tz);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(static_cast<size_t>(col->size()), blobs.size());
+    for (size_t i = 0; i < blobs.size(); ++i) {
+        const auto sref = col->get_data_at(i);
+        EXPECT_EQ(std::string(sref.data, sref.size), blobs[i]) << "row " << i;
+    }
+}
+
 } // namespace doris

--- a/be/test/core/data_type_serde/data_type_serde_string_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_string_test.cpp
@@ -24,6 +24,7 @@
 #include <streamvbyte.h>
 
 #include <cstddef>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <type_traits>
@@ -313,6 +314,147 @@ TEST_F(DataTypeStringSerDeTest, ArrowMemNotAlignedNestedArr) {
     auto serde_list = std::make_shared<DataTypeArraySerDe>(serde_str);
     auto st = serde_list->read_column_from_arrow(*ser_col, arr.get(), 0, 1, tz);
     EXPECT_TRUE(st.ok());
+}
+
+// Simulate the sender-side bug: the sender upgrades a utf8 builder to large_utf8 (for columns
+// exceeding 2MB), producing int64 offsets in the buffer, but forgets to update the schema,
+// so the schema still says utf8. This test demonstrates that naive int32 reading of such a
+// buffer gives wrong (negative) lengths at every other row, and that our receiver-side fix
+// correctly recovers the data.
+TEST_F(DataTypeStringSerDeTest, ArrowInt64OffsetsInUtf8Schema_ShowBug) {
+    // Build a few strings that are easy to verify.
+    std::vector<std::string> strings = {"apple",      "banana",  "cherry",  "doris_db",
+                                        "arrow_data", "flight",  "segment", "row_seven",
+                                        "eighth_row", "last_row"};
+    const int64_t row_count = static_cast<int64_t>(strings.size());
+
+    // Step 1: Build a LargeStringArray — this uses int64 offsets in its buffer.
+    arrow::LargeStringBuilder builder;
+    for (const auto& s : strings) {
+        ASSERT_TRUE(builder.Append(s).ok());
+    }
+    std::shared_ptr<arrow::Array> large_array;
+    ASSERT_TRUE(builder.Finish(&large_array).ok());
+    ASSERT_EQ(large_array->type_id(), arrow::Type::LARGE_STRING);
+
+    // Step 2: Simulate the buggy sender — wrap with utf8 type but keep the int64 offsets buffer.
+    // This is exactly what block_convertor.cpp did before the sender-side fix.
+    auto buggy_data =
+            arrow::ArrayData::Make(arrow::utf8(),         // schema says utf8 (int32)
+                                   large_array->length(), // but the buffer has int64 offsets!
+                                   large_array->data()->buffers, large_array->null_count(), 0);
+    auto buggy_array = std::make_shared<arrow::StringArray>(buggy_data);
+
+    // Step 3: Verify the offsets buffer is int64-sized (the mismatch we're testing).
+    const int64_t expected_int64_buf = (row_count + 1) * static_cast<int64_t>(sizeof(int64_t));
+    const int64_t expected_int32_buf = (row_count + 1) * static_cast<int64_t>(sizeof(int32_t));
+    // Print the buffer contents so the int32/int64 mismatch is visually clear.
+    std::cout << "\n--- Offsets buffer viewed as int64 vs int32 (the bug) ---\n";
+    std::cout << std::left << std::setw(6) << "Row" << std::setw(16) << "int64 offset"
+              << std::setw(20) << "int32[2r]  (low)" << std::setw(20) << "int32[2r+1] (high)"
+              << "naive length = int32[2r+1-1] - int32[2r-1] (*)\n";
+    const int64_t* as_int64 =
+            reinterpret_cast<const int64_t*>(buggy_array->value_offsets()->data());
+    const int32_t* as_int32 =
+            reinterpret_cast<const int32_t*>(buggy_array->value_offsets()->data());
+    for (int i = 0; i <= static_cast<int>(strings.size()); ++i) {
+        std::cout << std::setw(6) << i << std::setw(16) << as_int64[i] << std::setw(20)
+                  << as_int32[2 * i]                      // lower 4 bytes
+                  << std::setw(20) << as_int32[2 * i + 1] // upper 4 bytes (always 0 here)
+                  << "\n";
+    }
+    // Show the naive int32 length computation for each row.
+    // The receiver calls value_offset(r) = as_int32[r], so:
+    //   naive_length(r) = as_int32[r+1] - as_int32[r]
+    // This reads ACROSS the int64 boundary: as_int32[2r+1] (high half of offset[r])
+    // minus as_int32[2r] (low half of offset[r]), which gives 0 - low_half = negative.
+    std::cout << "\n--- Naive int32 length per row (what the buggy receiver computes) ---\n";
+    for (int r = 0; r < static_cast<int>(strings.size()); ++r) {
+        int32_t naive_start = as_int32[r];
+        int32_t naive_end = as_int32[r + 1];
+        int32_t naive_len = naive_end - naive_start;
+        std::cout << "Row " << r << " (\"" << strings[r] << "\", real len=" << strings[r].size()
+                  << "): naive start=" << naive_start << "  end=" << naive_end
+                  << "  length=" << naive_len
+                  << (naive_len < 0 ? "  ← CRASH (negative length passed to memcpy)" : "") << "\n";
+    }
+    std::cout << "---\n\n";
+
+    EXPECT_EQ(buggy_array->value_offsets()->size(), expected_int64_buf)
+            << "Offsets buffer is int64-sized, but schema says utf8 (int32)";
+    EXPECT_NE(buggy_array->value_offsets()->size(), expected_int32_buf)
+            << "Should NOT equal int32 expected size";
+
+    // Step 4: Show the bug — naive int32 reading of the int64 buffer gives wrong lengths.
+    //
+    // The 10-row LargeStringArray has 11 int64 offsets in its buffer (row N's data spans
+    // [offset[N], offset[N+1])). With strings "apple"(5), "banana"(6), "cherry"(6), ...,
+    // the cumulative byte positions are: 0, 5, 11, 17, 25, 35, 41, 48, 57, 67, 75.
+    //
+    // These int64 values are laid out in memory (little-endian) as 8 bytes each.
+    // For small values (< 2^32), the upper 4 bytes are always 0:
+    //
+    //   Byte offset  Value  Binary (LE, 8 bytes)           As two int32 words
+    //   0            0      00 00 00 00 | 00 00 00 00  →   int32[0]=0,  int32[1]=0
+    //   8            5      05 00 00 00 | 00 00 00 00  →   int32[2]=5,  int32[3]=0
+    //   16           11     0B 00 00 00 | 00 00 00 00  →   int32[4]=11, int32[5]=0
+    //   24           17     11 00 00 00 | 00 00 00 00  →   int32[6]=17, int32[7]=0
+    //   ...
+    //
+    // The buggy receiver treats this buffer as int32 and calls value_offset(r) which returns
+    // the r-th int32 word (not the r-th int64 offset).
+    //
+    // For row 2 ("cherry", expected length 6):
+    //   start_offset = value_offset(2) = int32[2] = 5    ← lower half of int64(5)
+    //   end_offset   = value_offset(3) = int32[3] = 0    ← upper half of int64(5), always 0
+    //   length       = end_offset - start_offset = 0 - 5 = -5  ← NEGATIVE → crash
+    //
+    // The same pattern repeats for every even row (0, 2, 4, ...) where the upper-half word
+    // of the preceding int64 offset (always 0) is used as end_offset.
+    const int32_t* naive_int32_offsets =
+            reinterpret_cast<const int32_t*>(buggy_array->value_offsets()->data());
+    //   int32[2] = lower 4 bytes of int64(5)  = 5  → becomes start_offset of row 2
+    //   int32[3] = upper 4 bytes of int64(5)  = 0  → becomes end_offset of row 2 (corrupted)
+    //   naive length for row 2 = 0 - 5 = -5
+    const int32_t naive_len_row2 = naive_int32_offsets[3] - naive_int32_offsets[2];
+    EXPECT_LT(naive_len_row2, 0) << "Naive int32 reading of int64 offsets gives negative length "
+                                    "(demonstrating the crash bug): got "
+                                 << naive_len_row2;
+}
+
+TEST_F(DataTypeStringSerDeTest, ArrowInt64OffsetsInUtf8Schema_ReceiverFix) {
+    std::vector<std::string> strings = {"apple",      "banana",  "cherry",  "doris_db",
+                                        "arrow_data", "flight",  "segment", "row_seven",
+                                        "eighth_row", "last_row"};
+    const int64_t row_count = static_cast<int64_t>(strings.size());
+
+    // Build a LargeStringArray (int64 offsets), then rewrap with utf8 type — simulates bug.
+    arrow::LargeStringBuilder builder;
+    for (const auto& s : strings) {
+        ASSERT_TRUE(builder.Append(s).ok());
+    }
+    std::shared_ptr<arrow::Array> large_array;
+    ASSERT_TRUE(builder.Finish(&large_array).ok());
+
+    auto buggy_data =
+            arrow::ArrayData::Make(arrow::utf8(), large_array->length(),
+                                   large_array->data()->buffers, large_array->null_count(), 0);
+    auto buggy_array = std::make_shared<arrow::StringArray>(buggy_data);
+
+    // Our receiver-side fix: read_column_from_arrow detects int64 offsets by comparing
+    // offsets buffer size against (N+1)*8 vs (N+1)*4, and falls through to LargeBinaryArray.
+    auto result_col = ColumnString::create();
+    cctz::time_zone tz;
+    auto st = serde_str->read_column_from_arrow(*result_col, buggy_array.get(), 0, row_count, tz);
+    ASSERT_TRUE(st.ok()) << "Receiver fix should handle int64 offsets in utf8 array: "
+                         << st.to_string();
+
+    // Verify every row is correctly recovered.
+    ASSERT_EQ(static_cast<int64_t>(result_col->size()), row_count);
+    for (int64_t i = 0; i < row_count; i++) {
+        EXPECT_EQ(result_col->get_data_at(i).to_string(), strings[i])
+                << "Data mismatch at row " << i;
+    }
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

large_utf8 using OffsetType = Int64Type;
utf8() using OffsetType = Int32Type;

so if change the arrow type, read arrow offset data should use int64 instead of int32, maybe cause native offset length.
```
*** SIGSEGV invalid permissions for mapped object (@0x14a185d7c000) received by PID 589278 (TID 592608 OR 0x14a2d1447640) from PID 18446744071660093440; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/zhangsida/branch-40/be/src/common/signal_handler.h:420
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0] in /mnt/disk2/zhangsida/install_data/jdk-17.0.2/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /mnt/disk2/zhangsida/install_data/jdk-17.0.2/lib/server/libjvm.so
 3# 0x000014AAA263FC30 in /lib64/libc.so.6
 4# inline_memcpy(void*, void const*, unsigned long) at /mnt/disk2/zhangsida/branch-40/be/src/glibc-compatibility/memcpy/memcpy_x86_64.cpp:201
 5# memcpy at /mnt/disk2/zhangsida/branch-40/be/src/glibc-compatibility/memcpy/memcpy_x86_64.cpp:219
 6# doris::vectorized::ColumnStr<unsigned int>::insert_data(char const*, unsigned long) in /mnt/disk2/zhangsida/branch-40/output/be/lib/doris_be
 7# doris::vectorized::DataTypeStringSerDeBase<doris::vectorized::ColumnStr<unsigned int> >::read_column_from_arrow(doris::vectorized::IColumn&, arrow::Array const*, long, long, cctz::time_zone const&) const at /mnt/disk2/zhangsida/branch-40/be/src/vec/data_types/serde/data_type_string_serde.cpp:278
 8# doris::vectorized::DataTypeNullableSerDe::read_column_from_arrow(doris::vectorized::IColumn&, arrow::Array const*, long, long, cctz::time_zone const&) const at /mnt/disk2/zhangsida/branch-40/be/src/vec/data_types/serde/data_type_nullable_serde.cpp:351
 9# doris::vectorized::RemoteDorisReader::get_next_block(doris::vectorized::Block*, unsigned long*, bool*) at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/format/table/remote_doris_reader.cpp:91
10# doris::vectorized::FileScanner::_get_block_wrapped(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/file_scanner.cpp:468
11# doris::vectorized::FileScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/file_scanner.cpp:405
12# doris::vectorized::Scanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/scanner.cpp:110
13# doris::vectorized::Scanner::get_block_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/scanner.cpp:83
14# doris::vectorized::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>) at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/scanner_scheduler.cpp:178
15# doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/scanner_scheduler.cpp:76
16# doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}::operator()() const at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/scanner_scheduler.cpp:75
17# bool std::__invoke_impl<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>(std::__invoke_other, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63
18# std::enable_if<is_invocable_r_v<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>, bool>::type std::__invoke_r<bool, doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&>(doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:116
19# std::_Function_handler<bool (), doris::vectorized::ScannerScheduler::submit(std::shared_ptr<doris::vectorized::ScannerContext>, std::shared_ptr<doris::vectorized::ScanTask>)::$_0::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
20# std::function<bool ()>::operator()() const at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593
21# doris::vectorized::ScannerSplitRunner::process_for(std::chrono::duration<long, std::ratio<1l, 1000000000l> >) at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/scan/scanner_scheduler.cpp:419
22# doris::vectorized::PrioritizedSplitRunner::process() at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/executor/time_sharing/prioritized_split_runner.cpp:104
23# doris::vectorized::TimeSharingTaskExecutor::_dispatch_thread() at /mnt/disk2/zhangsida/branch-40/be/src/vec/exec/executor/time_sharing/time_sharing_task_executor.cpp:566
24# void std::__invoke_impl<void, void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&>(std::__invoke_memfun_deref, void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:76
25# std::__invoke_result<void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&>::type std::__invoke<void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&>(void (doris::vectorized::TimeSharingTaskExecutor::*&)(), doris::vectorized::TimeSharingTaskExecutor*&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:98
26# void std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/functional:515
27# void std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>::operator()<, void>() at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/functional:600
28# void std::__invoke_impl<void, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&>(std::__invoke_other, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63
29# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&>(std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()>&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:119
30# std::_Function_handler<void (), std::_Bind<void (doris::vectorized::TimeSharingTaskExecutor::*(doris::vectorized::TimeSharingTaskExecutor*))()> >::_M_invoke(std::_Any_data const&) at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:292
31# std::function<void ()>::operator()() const at /mnt/disk2/zhangsida/install_data/ldb_toolchain_025/ldb_toolchain/bin/../lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/std_function.h:593
32# doris::Thread::supervise_thread(void*) at /mnt/disk2/zhangsida/branch-40/be/src/util/thread.cpp:460
33# start_thread in /lib64/libc.so.6
34# clone3 in /lib64/libc.so.6
```



Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

