### PR TITLE
[Bug](profile) move watcher.stop() into locked code block

### DIFF
--- a/be/src/exec/pipeline/dependency.cpp
+++ b/be/src/exec/pipeline/dependency.cpp
@@ -66,13 +66,13 @@ void Dependency::set_ready() {
     if (_ready) {
         return;
     }
-    _watcher.stop();
     std::vector<std::weak_ptr<PipelineTask>> local_block_task {};
     {
         std::unique_lock<std::mutex> lc(_task_lock);
         if (_ready) {
             return;
         }
+        _watcher.stop();
         _ready = true;
         local_block_task.swap(_blocked_task);
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #56462

Problem Summary:

Backport of #56462 to this branch.

`Dependency::set_ready()` previously called `_watcher.stop()` outside `_task_lock`. A concurrent `is_blocked_by()` (which acquires `_task_lock`, checks `_ready`, and calls `start_watcher()`) could re-start the watcher right after `stop()` but before `_ready = true` was published; nothing stops it again. As a result `watcher_elapse_time()` accumulates wall-clock time from the first block until the operator closes, making `WaitForDependency` / `WaitForRuntimeFilter` profile counters appear hugely inflated (e.g. ~12s on a 20s query while each individual RF `WaitTime` is only tens of ms).

Move `_watcher.stop()` inside the `_task_lock` block, before setting `_ready = true`, matching the master fix.

### Release note

None

### Check List (For Author)

- Test:
    - No need to test (profile-only fix; identical to merged master change #56462)
- Behavior changed: No
- Does this need documentation: No
