### PR TITLE
[fix](docker) Stabilize ClickHouse external startup

### DIFF
--- a/docker/thirdparties/docker-compose/clickhouse/clickhouse.yaml.tpl
+++ b/docker/thirdparties/docker-compose/clickhouse/clickhouse.yaml.tpl
@@ -33,8 +33,9 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "clickhouse-client --password=123456 --query 'SELECT 1 FROM doris_test.deadline'"]
       interval: 30s
-      timeout: 10s
-      retries: 5
+      timeout: 30s
+      retries: 20
+      start_period: 180s
     volumes:
       - ./init:/docker-entrypoint-initdb.d
     networks:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #62664

Problem Summary: External regression can fail intermittently when ClickHouse initialization takes longer than the compose health check window. The health check depends on init SQL having created and loaded doris_test.deadline, so busy pipeline hosts can mark the container unhealthy before initialization has finished. This was observed in external regression logs such as #90767, where ClickHouse was the first unhealthy component and a later retry surfaced as a Kafka/Zookeeper cleanup race.

This PR increases the ClickHouse health check timeout, retry count, and start period so docker compose gives init scripts enough time on loaded CI agents.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Ran git diff --check for modified ClickHouse compose template
- Behavior changed: No
- Does this need documentation: No