### PR TITLE
[fix](bug) Fix potential bugs

### DIFF
--- a/be/src/exec/operator/exchange_sink_buffer.cpp
+++ b/be/src/exec/operator/exchange_sink_buffer.cpp
@@ -297,6 +297,13 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
                 brpc_request->set_allocated_block(request.block.get());
             }
         }
+        Defer release_block([&]() {
+            if (!_send_multi_blocks && request.block) {
+                static_cast<void>(brpc_request->release_block());
+            } else {
+                brpc_request->clear_blocks();
+            }
+        });
 
         instance_data.seq += requests.size();
         brpc_request->set_packet_seq(instance_data.seq);
@@ -367,11 +374,6 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
             }
         }
 
-        if (!_send_multi_blocks && request.block) {
-            static_cast<void>(brpc_request->release_block());
-        } else {
-            brpc_request->clear_blocks();
-        }
         if (mem_byte) {
             COUNTER_UPDATE(channel->_parent->memory_used_counter(), -mem_byte);
         }
@@ -427,6 +429,16 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
                 brpc_request->set_allocated_block(request.block_holder->get_block());
             }
         }
+        Defer release_block([&]() {
+            if (!_send_multi_blocks && request.block_holder->get_block()) {
+                static_cast<void>(brpc_request->release_block());
+            } else {
+                for (int i = 0; i < brpc_request->mutable_blocks()->size(); ++i) {
+                    static_cast<void>(brpc_request->mutable_blocks(i)->release_column_values());
+                }
+                brpc_request->clear_blocks();
+            }
+        });
         instance_data.seq += requests.size();
         brpc_request->set_packet_seq(instance_data.seq);
         brpc_request->set_eos(requests.back().eos);
@@ -494,14 +506,6 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
             } else {
                 transmit_blockv2(channel->_brpc_stub.get(), std::move(send_remote_block_closure));
             }
-        }
-        if (!_send_multi_blocks && request.block_holder->get_block()) {
-            static_cast<void>(brpc_request->release_block());
-        } else {
-            for (int i = 0; i < brpc_request->mutable_blocks()->size(); ++i) {
-                static_cast<void>(brpc_request->mutable_blocks(i)->release_column_values());
-            }
-            brpc_request->clear_blocks();
         }
     } else {
         instance_data.rpc_channel_is_idle = true;

--- a/be/src/exec/pipeline/pipeline_tracing.cpp
+++ b/be/src/exec/pipeline/pipeline_tracing.cpp
@@ -136,7 +136,7 @@ void PipelineTracerContext::_dump_query(TUniqueId query_id) {
 
     _last_dump_time = MonotonicSeconds();
 
-    _update([&](QueryTracesMap& new_map) { _data.load()->erase(QueryID {query_id}); });
+    _update([&](QueryTracesMap& new_map) { new_map.erase(QueryID {query_id}); });
 
     {
         std::unique_lock<std::mutex> l(_tg_lock);

--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -624,11 +624,11 @@ void VNodeChannel::_open_internal(bool is_incremental) {
     }
     SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker.get());
     auto request = std::make_shared<PTabletWriterOpenRequest>();
-    request->set_allocated_id(&_parent->_load_id);
+    request->mutable_id()->CopyFrom(_parent->_load_id);
     request->set_index_id(_index_channel->_index_id);
     request->set_txn_id(_parent->_txn_id);
     request->set_sender_id(_parent->_sender_id);
-    request->set_allocated_schema(_parent->_schema->to_protobuf());
+    request->mutable_schema()->CopyFrom(*_parent->_schema->to_protobuf());
     if (_parent->_t_sink.olap_table_sink.__isset.storage_vault_id) {
         request->set_storage_vault_id(_parent->_t_sink.olap_table_sink.storage_vault_id);
     }
@@ -1218,7 +1218,7 @@ void VNodeChannel::cancel(const std::string& cancel_msg) {
     }
 
     auto request = std::make_shared<PTabletWriterCancelRequest>();
-    request->set_allocated_id(&_parent->_load_id);
+    request->mutable_id()->CopyFrom(_parent->_load_id);
     request->set_index_id(_index_channel->_index_id);
     request->set_sender_id(_parent->_sender_id);
     request->set_cancel_reason(cancel_msg);

--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -676,9 +676,6 @@ void VNodeChannel::_open_internal(bool is_incremental) {
                               open_closure->response_.get(), open_closure.get());
     open_closure.release();
     _open_callbacks.push_back(open_callback);
-
-    static_cast<void>(request->release_id());
-    static_cast<void>(request->release_schema());
 }
 
 void VNodeChannel::open() {
@@ -1240,7 +1237,6 @@ void VNodeChannel::cancel(const std::string& cancel_msg) {
     _stub->tablet_writer_cancel(closure->cntl_.get(), closure->request_.get(),
                                 closure->response_.get(), closure.get());
     closure.release();
-    static_cast<void>(request->release_id());
 }
 
 Status VNodeChannel::close_wait(RuntimeState* state, bool* is_closed) {

--- a/be/src/exprs/function/function_json.cpp
+++ b/be/src/exprs/function/function_json.cpp
@@ -398,39 +398,6 @@ public:
     }
 };
 
-template <typename Impl>
-class FunctionJsonNullable : public IFunction {
-public:
-    static constexpr auto name = Impl::name;
-    static FunctionPtr create() { return std::make_shared<FunctionJsonNullable<Impl>>(); }
-    String get_name() const override { return name; }
-    size_t get_number_of_arguments() const override { return 0; }
-    bool is_variadic() const override { return true; }
-    DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
-        return make_nullable(std::make_shared<DataTypeString>());
-    }
-    Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                        uint32_t result, size_t input_rows_count) const override {
-        auto result_column = ColumnString::create();
-        auto null_map = ColumnUInt8::create(input_rows_count, 0);
-        std::vector<const ColumnString*> data_columns;
-        std::vector<bool> column_is_consts;
-        for (int i = 0; i < arguments.size(); i++) {
-            ColumnPtr arg_col;
-            bool arg_const;
-            std::tie(arg_col, arg_const) =
-                    unpack_if_const(block.get_by_position(arguments[i]).column);
-            column_is_consts.push_back(arg_const);
-            data_columns.push_back(assert_cast<const ColumnString*>(arg_col.get()));
-        }
-        Impl::execute(data_columns, *assert_cast<ColumnString*>(result_column.get()),
-                      null_map->get_data(), input_rows_count, column_is_consts);
-        block.replace_by_position(
-                result, ColumnNullable::create(std::move(result_column), std::move(null_map)));
-        return Status::OK();
-    }
-};
-
 class FunctionJsonValid : public IFunction {
 public:
     static constexpr auto name = "json_valid";


### PR DESCRIPTION
### What problem does this PR solve?

This commit addresses two classes of potential memory-safety bugs in the BE sink path:                                                                                                                                           
   
  1. exchange_sink_buffer.cpp — exception-safety on block release                                                                                                                                                                  
                                                                                                                                                                                                                                 
  In ExchangeSinkBuffer::_send_rpc, the cleanup logic that releases/clears blocks attached to brpc_request only ran on the normal path. If any code between set_allocated_block(...) and the cleanup threw or returned early, the  
  request would either double-free or leak the block (since protobuf took ownership via set_allocated_*).                                                                                                                        
                                                                                                                                                                                                                                   
  Fix: wrap the release/clear logic in a Defer immediately after ownership is transferred, so cleanup is guaranteed regardless of control flow. Applied to both the single-block and block_holder branches.                        
   
  2. vtablet_writer.cpp — replace set_allocated_* with CopyFrom                                                                                                                                                                    
                                                                                                                                                                                                                                 
  VNodeChannel::_open_internal and VNodeChannel::cancel were calling request->set_allocated_id(&_parent->_load_id) and set_allocated_schema(...). set_allocated_* transfers ownership to protobuf, which will delete the pointer on
   destruction — but _parent->_load_id is a member, not a heap object owned by the request, leading to a potential double-free / use-after-free when the request is destroyed.
                                                                                                                                                                                                                                   
  Fix: use mutable_id()->CopyFrom(...) and mutable_schema()->CopyFrom(...) to copy the values instead of transferring ownership.               

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

