### PR TITLE
[refactor](fe) Remove enable_nereids_load switch

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2216,10 +2216,6 @@ public class Config extends ConfigBase {
     public static boolean enable_hms_events_incremental_sync = false;
 
     /**
-     * If set to true, doris will try to parse the ddl of a hive view and try to execute the query
-     * otherwise it will throw an AnalysisException.
-     */
-    /**
      * the plan cache num which can be reused for the next query
      */
     @ConfField(

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2219,12 +2219,6 @@ public class Config extends ConfigBase {
      * If set to true, doris will try to parse the ddl of a hive view and try to execute the query
      * otherwise it will throw an AnalysisException.
      */
-    @ConfField(mutable = true, varType = VariableAnnotation.EXPERIMENTAL, description = {
-            "Currently defaults to true. After this function is enabled, the load statement of "
-                    + "the new optimizer can be used to import data. If this function fails, "
-                    + "the system will fall back to the old load statement."})
-    public static boolean enable_nereids_load = false;
-
     /**
      * the plan cache num which can be reused for the next query
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/OlapInsertExecutor.java
@@ -320,7 +320,7 @@ public class OlapInsertExecutor extends AbstractInsertExecutor {
     }
 
     private void recordLoadJob(UserIdentity userIdentity) {
-        if (!Config.enable_nereids_load && jobId != -1) {
+        if (jobId != -1) {
             try {
                 ctx.getEnv().getLoadManager()
                         .recordFinishedLoadJob(labelName, txnId, database.getFullName(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutor.java
@@ -304,7 +304,7 @@ public class RemoteOlapInsertExecutor extends OlapInsertExecutor {
         // we will record the load job info for these 2 cases
         try {
             // Do not register job if job id is -1.
-            if (!Config.enable_nereids_load && jobId != -1) {
+            if (jobId != -1) {
                 ((RemoteOlapTable) table).getCatalog().getFeServiceClient().recordFinishedLoadJob(
                         labelName, txnId, database.getCatalog().getName(), database.getFullName(), table.getName(),
                         createTime, errMsg, coordinator.getTrackingUrl(), coordinator.getFirstErrorMsg(), jobId);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutor.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.plans.commands.insert;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AuthenticationException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.MetaNotFoundException;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.profile.Profile;
 import org.apache.doris.datasource.InternalCatalog;
@@ -72,8 +71,6 @@ public class EncryptSQLTest extends ParserTestBase {
                 })) {
             ctx.setEnv(env);
             ctx.setCurrentUserIdentity(UserIdentity.ROOT);
-            Config.enable_nereids_load = true;
-
             String sql = "EXPORT TABLE export_table TO \"s3://abc/aaa\" "
                     + "PROPERTIES("
                     + " \"format\" = \"csv\","


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Remove the obsolete enable_nereids_load config and keep Nereids insert/load job recording on the existing loadv2 path unconditionally.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - Attempted run-fe-ut.sh --run org.apache.doris.nereids.parser.EncryptSQLTest after rebasing to origin/master; the first run failed due sandboxed Maven cache writes, the rerun reached FE module compilation including fe-common and fe-core generation/compile stages before being stopped because the script builds a broad FE dependency graph.
- Behavior changed: No
- Does this need documentation: No
