### PR TITLE
[refine](function) unify use_default_implementation_for_constants interface

### DIFF
--- a/be/src/exprs/function/array/varray_match_function.cpp
+++ b/be/src/exprs/function/array/varray_match_function.cpp
@@ -47,8 +47,6 @@ public:
 
     size_t get_number_of_arguments() const override { return 1; }
 
-    bool is_use_default_implementation_for_constants() const override { return false; }
-
     bool use_default_implementation_for_nulls() const override { return false; }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
@@ -58,8 +56,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         // here is executed by array_map filtered and arg[0] is bool result column
-        const auto& [src_column, src_const] =
-                unpack_if_const(block.get_by_position(arguments[0]).column);
+        const auto& src_column = block.get_by_position(arguments[0]).column;
         const ColumnArray* array_column = nullptr;
         const UInt8* array_null_map = nullptr;
         if (src_column->is_nullable()) {

--- a/be/src/exprs/function/cast/function_cast.cpp
+++ b/be/src/exprs/function/cast/function_cast.cpp
@@ -351,7 +351,7 @@ public:
 
     String get_name() const override { return name; }
 
-    bool is_use_default_implementation_for_constants() const override { return true; }
+    bool use_default_implementation_for_constants() const override { return true; }
 
 private:
     const char* name = nullptr;

--- a/be/src/exprs/function/function.h
+++ b/be/src/exprs/function/function.h
@@ -219,7 +219,7 @@ public:
         return Status::OK();
     }
 
-    virtual bool is_use_default_implementation_for_constants() const = 0;
+    virtual bool use_default_implementation_for_constants() const = 0;
 
     virtual bool is_udf_function() const { return false; }
 
@@ -395,8 +395,10 @@ public:
     /// all constancy check should use this function to do automatically
     ColumnNumbers get_arguments_that_are_always_constant() const override { return {}; }
 
-    bool is_use_default_implementation_for_constants() const override {
-        return use_default_implementation_for_constants();
+    // Resolve ambiguity: IFunctionBase and PreparedFunctionImpl both declare
+    // use_default_implementation_for_constants(). Subclasses override this directly.
+    bool use_default_implementation_for_constants() const override {
+        return PreparedFunctionImpl::use_default_implementation_for_constants();
     }
 
     using PreparedFunctionImpl::execute;
@@ -484,8 +486,8 @@ public:
                                                  analyzer_ctx, bitmap_result);
     }
 
-    bool is_use_default_implementation_for_constants() const override {
-        return function->is_use_default_implementation_for_constants();
+    bool use_default_implementation_for_constants() const override {
+        return function->use_default_implementation_for_constants();
     }
 
     bool can_push_down_to_index() const override { return function->can_push_down_to_index(); }

--- a/be/src/exprs/function/function_java_udf.h
+++ b/be/src/exprs/function/function_java_udf.h
@@ -101,7 +101,7 @@ public:
 
     Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override;
 
-    bool is_use_default_implementation_for_constants() const override { return true; }
+    bool use_default_implementation_for_constants() const override { return true; }
 
     bool is_udf_function() const override { return true; }
 

--- a/be/src/exprs/function/function_python_udf.h
+++ b/be/src/exprs/function/function_python_udf.h
@@ -95,7 +95,7 @@ public:
 
     Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override;
 
-    bool is_use_default_implementation_for_constants() const override { return true; }
+    bool use_default_implementation_for_constants() const override { return true; }
 
     bool is_udf_function() const override { return true; }
 

--- a/be/src/exprs/function/function_rpc.h
+++ b/be/src/exprs/function/function_rpc.h
@@ -108,7 +108,7 @@ public:
 
     Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override;
 
-    bool is_use_default_implementation_for_constants() const override { return true; }
+    bool use_default_implementation_for_constants() const override { return true; }
 
 private:
     DataTypes _argument_types;

--- a/be/src/exprs/function/function_search.h
+++ b/be/src/exprs/function/function_search.h
@@ -141,8 +141,6 @@ public:
 
     // We manage nulls explicitly for index pushdown only.
     bool use_default_implementation_for_nulls() const override { return false; }
-    bool is_use_default_implementation_for_constants() const override { return false; }
-
     bool use_default_implementation_for_constants() const override { return false; }
 
     DataTypePtr get_return_type_impl(const DataTypes& /*arguments*/) const override {

--- a/be/src/exprs/vectorized_fn_call.h
+++ b/be/src/exprs/vectorized_fn_call.h
@@ -72,7 +72,7 @@ public:
                            [](VExprSPtr child) { return child->is_blockable(); });
     }
     bool is_constant() const override {
-        if (!_function->is_use_default_implementation_for_constants() ||
+        if (!_function->use_default_implementation_for_constants() ||
             // udf function with no argument, can't sure it's must return const column
             (_fn.binary_type == TFunctionBinaryType::JAVA_UDF && _children.empty())) {
             return false;

--- a/be/test/exprs/function/function_search_test.cpp
+++ b/be/test/exprs/function/function_search_test.cpp
@@ -450,7 +450,6 @@ TEST_F(FunctionSearchTest, TestBasicProperties) {
     EXPECT_TRUE(function_search->is_variadic());
     EXPECT_EQ(0, function_search->get_number_of_arguments());
     EXPECT_FALSE(function_search->use_default_implementation_for_nulls());
-    EXPECT_FALSE(function_search->is_use_default_implementation_for_constants());
     EXPECT_FALSE(function_search->use_default_implementation_for_constants());
     EXPECT_TRUE(function_search->can_push_down_to_index());
 


### PR DESCRIPTION
## Problem

`IFunctionBase` declared a pure virtual method `is_use_default_implementation_for_constants()`,
while `PreparedFunctionImpl` declared a separate method `use_default_implementation_for_constants()`
with the same semantics but different name.

`IFunction` bridged them with a forwarding override, but this caused confusion:
- Subclasses that directly overrode `is_use_default_implementation_for_constants()` on `IFunction`
  bypassed the `PreparedFunctionImpl` method, causing the two to return inconsistent values.
- For example, `ArrayMatchFunction` overrode `is_use_default_implementation_for_constants()` to
  return `false`, but `use_default_implementation_for_constants()` still returned `true` (default),
  so the execution framework still unpacked const columns, while `execute_impl` also called
  `unpack_if_const` redundantly.

## Solution

- Rename `IFunctionBase::is_use_default_implementation_for_constants()` to
  `use_default_implementation_for_constants()` to unify the two interfaces into one name.
- Add an explicit override in `IFunction` to resolve the multiple-inheritance ambiguity between
  `IFunctionBase` and `PreparedFunctionImpl`.
- Remove the redundant `is_use_default_implementation_for_constants()` bridge in `IFunction`.
- Fix `ArrayMatchFunction`: remove the incorrect `is_use_default_implementation_for_constants()`
  override and the unused `unpack_if_const` call, letting the framework handle const columns via
  the default `use_default_implementation_for_constants() = true` path.
- Remove the duplicate override in `FunctionSearch`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

