### PR TITLE
[fix](sync) Treat empty cancel alter job list as all rollup jobs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -1342,7 +1342,7 @@ public class MaterializedViewHandler extends AlterHandler {
             }
 
             // find from new alter jobs first
-            if (command.getAlterJobIdList() != null) {
+            if (command.getAlterJobIdList() != null && !command.getAlterJobIdList().isEmpty()) {
                 for (Long jobId : command.getAlterJobIdList()) {
                     AlterJobV2 alterJobV2 = getUnfinishedAlterJobV2ByJobId(jobId);
                     if (alterJobV2 == null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -34,6 +34,7 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
@@ -41,6 +42,7 @@ import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.meta.MetaContext;
+import org.apache.doris.nereids.trees.plans.commands.CancelAlterTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.AddRollupOp;
 import org.apache.doris.nereids.trees.plans.commands.info.AlterOp;
 import org.apache.doris.qe.ConnectContext;
@@ -177,6 +179,37 @@ public class RollupJobV2Test {
         Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
         Assert.assertEquals(1, alterJobsV2.size());
         Assert.assertEquals(OlapTableState.ROLLUP, olapTable.getState());
+    }
+
+    @Test
+    public void testCancelRollupWithEmptyJobIdList() throws Exception {
+        if (fakeEnv != null) {
+            fakeEnv.close();
+        }
+        fakeEnv = new FakeEnv();
+        if (fakeEditLog != null) {
+            fakeEditLog.close();
+        }
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(op);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDb1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        materializedViewHandler.process(alterOps, db, olapTable);
+        Map<Long, AlterJobV2> alterJobsV2 = materializedViewHandler.getAlterJobsV2();
+        Assert.assertEquals(1, alterJobsV2.size());
+
+        RollupJobV2 rollupJob = (RollupJobV2) alterJobsV2.values().stream().findAny().get();
+        CancelAlterTableCommand cancelAlterTableCommand = new CancelAlterTableCommand(
+                new TableNameInfo(db.getFullName(), olapTable.getName()),
+                CancelAlterTableCommand.AlterType.ROLLUP,
+                Lists.newArrayList());
+        materializedViewHandler.cancel(cancelAlterTableCommand);
+
+        Assert.assertEquals(JobState.CANCELLED, rollupJob.getJobState());
     }
 
     // start a schema change, then finished

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -39,6 +39,7 @@ import org.apache.doris.nereids.trees.plans.DistributeType;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.commands.CancelAlterTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.CreateMaterializedViewCommand;
 import org.apache.doris.nereids.trees.plans.commands.CreateTableCommand;
 import org.apache.doris.nereids.trees.plans.commands.CreateViewCommand;
@@ -118,6 +119,15 @@ public class NereidsParserTest extends ParserTestBase {
         parsePlan("select * from t1 where a = 1 illegal_symbol")
                 .assertThrowsExactly(SyntaxParseException.class)
                 .assertMessageEquals("\nextraneous input 'illegal_symbol' expecting {<EOF>, ';'}(line 1, pos 29)\n");
+    }
+
+    @Test
+    public void testCancelAlterTableWithoutJobIdsBuildsEmptyJobIdList() {
+        NereidsParser nereidsParser = new NereidsParser();
+        Plan plan = nereidsParser.parseSingle("CANCEL ALTER TABLE ROLLUP FROM db1.tbl1");
+        Assertions.assertInstanceOf(CancelAlterTableCommand.class, plan);
+        CancelAlterTableCommand command = (CancelAlterTableCommand) plan;
+        Assertions.assertTrue(command.getAlterJobIdList().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:
Nereids always constructs a non-null alter job id list for `CANCEL ALTER TABLE`, using an empty list when the SQL omits explicit job ids. `SchemaChangeHandler` already treats an empty list as "cancel all unfinished jobs on the table", but `MaterializedViewHandler` only checked for `null`. As a result, `CANCEL ALTER TABLE ... ROLLUP FROM db.tbl` could incorrectly search by explicit job ids, find nothing, and throw `Table[...] is not under ROLLUP` even when the table still had unfinished rollup jobs.

This change aligns `MaterializedViewHandler` with `SchemaChangeHandler` by treating an empty job-id list the same as an omitted list, and adds regression tests for both the handler path and the Nereids parser behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. `CANCEL ALTER TABLE ROLLUP/MATERIALIZED VIEW` without explicit job ids now treats an empty job-id list the same as an omitted list.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->
