### PR TITLE
[feat](fe) Validate authentication integration properties on DDL

### DIFF
--- a/fe/fe-authentication/fe-authentication-handler/src/main/java/org/apache/doris/authentication/handler/AuthenticationPluginManager.java
+++ b/fe/fe-authentication/fe-authentication-handler/src/main/java/org/apache/doris/authentication/handler/AuthenticationPluginManager.java
@@ -233,6 +233,27 @@ public class AuthenticationPluginManager {
     }
 
     /**
+     * Create a plugin instance and validate integration properties without initializing runtime state.
+     *
+     * @param integration authentication integration
+     * @throws AuthenticationException if validation fails
+     */
+    public void validatePlugin(AuthenticationIntegration integration) throws AuthenticationException {
+        Objects.requireNonNull(integration, "integration");
+        AuthenticationPluginFactory factory = factories.get(integration.getType());
+        if (factory == null) {
+            throw new AuthenticationException(
+                    "No AuthenticationPluginFactory found for plugin: " + integration.getType());
+        }
+        AuthenticationPlugin plugin = factory.create();
+        try {
+            plugin.validate(integration);
+        } finally {
+            plugin.close();
+        }
+    }
+
+    /**
      * Install a prepared plugin instance into the cache, replacing the old one atomically.
      *
      * @param integration authentication integration

--- a/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationMgr.java
@@ -39,6 +39,28 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Manager for AUTHENTICATION INTEGRATION metadata.
  */
 public class AuthenticationIntegrationMgr implements Writable {
+    private static final String CHECK_VALIDATION_PROPERTY = "check_validation";
+
+    private static final class ValidationConfig {
+        private final Map<String, String> properties;
+        private final boolean checkValidation;
+
+        private ValidationConfig(Map<String, String> properties, boolean checkValidation) {
+            this.properties = properties;
+            this.checkValidation = checkValidation;
+        }
+    }
+
+    private static final class UnsetValidationConfig {
+        private final Set<String> propertiesToUnset;
+        private final boolean checkValidation;
+
+        private UnsetValidationConfig(Set<String> propertiesToUnset, boolean checkValidation) {
+            this.propertiesToUnset = propertiesToUnset;
+            this.checkValidation = checkValidation;
+        }
+    }
+
     // Lock ordering across authentication metadata managers:
     // AuthenticationIntegrationMgr.lock -> RoleMappingMgr.lock.
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
@@ -66,8 +88,7 @@ public class AuthenticationIntegrationMgr implements Writable {
             String integrationName, boolean ifNotExists, Map<String, String> properties, String comment,
             String createUser)
             throws DdlException {
-        AuthenticationIntegrationMeta meta =
-                AuthenticationIntegrationMeta.fromCreateSql(integrationName, properties, comment, createUser);
+        ValidationConfig validationConfig = extractValidationConfig(properties);
         writeLock();
         try {
             if (nameToIntegration.containsKey(integrationName)) {
@@ -76,6 +97,9 @@ public class AuthenticationIntegrationMgr implements Writable {
                 }
                 throw new DdlException("Authentication integration " + integrationName + " already exists");
             }
+            AuthenticationIntegrationMeta meta = AuthenticationIntegrationMeta.fromCreateSql(
+                    integrationName, validationConfig.properties, comment, createUser);
+            validateAuthenticationIntegration(meta, validationConfig.checkValidation);
             nameToIntegration.put(integrationName, meta);
             Env.getCurrentEnv().getEditLog().logCreateAuthenticationIntegration(meta);
         } finally {
@@ -85,10 +109,13 @@ public class AuthenticationIntegrationMgr implements Writable {
 
     public void alterAuthenticationIntegrationProperties(
             String integrationName, Map<String, String> properties, String alterUser) throws DdlException {
+        ValidationConfig validationConfig = extractValidationConfig(properties);
         writeLock();
         try {
             AuthenticationIntegrationMeta current = getOrThrow(integrationName);
-            AuthenticationIntegrationMeta updated = current.withAlterProperties(properties, alterUser);
+            AuthenticationIntegrationMeta updated =
+                    current.withAlterProperties(validationConfig.properties, alterUser);
+            validateAuthenticationIntegration(updated, validationConfig.checkValidation);
             nameToIntegration.put(integrationName, updated);
             Env.getCurrentEnv().getEditLog().logAlterAuthenticationIntegration(updated);
             Env.getCurrentEnv().getAuthenticationIntegrationRuntime().markAuthenticationIntegrationDirty(
@@ -100,10 +127,13 @@ public class AuthenticationIntegrationMgr implements Writable {
 
     public void alterAuthenticationIntegrationUnsetProperties(
             String integrationName, Set<String> propertiesToUnset, String alterUser) throws DdlException {
+        UnsetValidationConfig validationConfig = extractUnsetValidationConfig(propertiesToUnset);
         writeLock();
         try {
             AuthenticationIntegrationMeta current = getOrThrow(integrationName);
-            AuthenticationIntegrationMeta updated = current.withUnsetProperties(propertiesToUnset, alterUser);
+            AuthenticationIntegrationMeta updated =
+                    current.withUnsetProperties(validationConfig.propertiesToUnset, alterUser);
+            validateAuthenticationIntegration(updated, validationConfig.checkValidation);
             nameToIntegration.put(integrationName, updated);
             Env.getCurrentEnv().getEditLog().logAlterAuthenticationIntegration(updated);
             Env.getCurrentEnv().getAuthenticationIntegrationRuntime().markAuthenticationIntegrationDirty(
@@ -213,5 +243,49 @@ public class AuthenticationIntegrationMgr implements Writable {
             throw new DdlException("Authentication integration " + integrationName + " does not exist");
         }
         return meta;
+    }
+
+    private void validateAuthenticationIntegration(AuthenticationIntegrationMeta meta, boolean checkValidation)
+            throws DdlException {
+        if (!checkValidation) {
+            return;
+        }
+        try {
+            Env.getCurrentEnv().getAuthenticationIntegrationRuntime().validateAuthenticationIntegration(meta);
+        } catch (AuthenticationException e) {
+            throw new DdlException(e.getMessage(), e);
+        }
+    }
+
+    private ValidationConfig extractValidationConfig(Map<String, String> properties) throws DdlException {
+        Map<String, String> sanitizedProperties = new LinkedHashMap<>();
+        boolean checkValidation = true;
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            if (CHECK_VALIDATION_PROPERTY.equalsIgnoreCase(key)) {
+                String value = entry.getValue();
+                if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+                    throw new DdlException(
+                            "Property '" + CHECK_VALIDATION_PROPERTY + "' must be 'true' or 'false'");
+                }
+                checkValidation = Boolean.parseBoolean(value);
+                continue;
+            }
+            sanitizedProperties.put(key, entry.getValue());
+        }
+        return new ValidationConfig(sanitizedProperties, checkValidation);
+    }
+
+    private UnsetValidationConfig extractUnsetValidationConfig(Set<String> propertiesToUnset) {
+        Set<String> sanitizedPropertiesToUnset = new java.util.LinkedHashSet<>();
+        boolean checkValidation = true;
+        for (String key : propertiesToUnset) {
+            if (CHECK_VALIDATION_PROPERTY.equalsIgnoreCase(key)) {
+                checkValidation = false;
+                continue;
+            }
+            sanitizedPropertiesToUnset.add(key);
+        }
+        return new UnsetValidationConfig(sanitizedPropertiesToUnset, checkValidation);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationRuntime.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/authentication/AuthenticationIntegrationRuntime.java
@@ -52,6 +52,11 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class AuthenticationIntegrationRuntime {
     private static final Logger LOG = LogManager.getLogger(AuthenticationIntegrationRuntime.class);
+    private static final String OIDC_INTEGRATION_TYPE = "oidc";
+    public static final String OIDC_ID_TOKEN_REJECTED_MESSAGE =
+            "OIDC ID token is not accepted; use an OAuth access token or JWT bearer access token";
+    public static final String OIDC_JIT_DISABLED_MESSAGE =
+            "OIDC authentication succeeded but no matching Doris user exists and JIT user is disabled";
 
     private static final class ResolvedAuthenticationPlugin {
         private final AuthenticationIntegration integration;
@@ -117,6 +122,18 @@ public class AuthenticationIntegrationRuntime {
         ensurePluginFactoryLoaded(integration.getType());
         AuthenticationPlugin plugin = pluginManager.createPlugin(integration);
         return new PreparedAuthenticationIntegration(integration, plugin);
+    }
+
+    public void validateAuthenticationIntegration(AuthenticationIntegrationMeta meta)
+            throws AuthenticationException {
+        validateAuthenticationIntegration(toIntegration(meta));
+    }
+
+    public void validateAuthenticationIntegration(AuthenticationIntegration integration)
+            throws AuthenticationException {
+        Objects.requireNonNull(integration, "integration");
+        ensurePluginFactoryLoaded(integration.getType());
+        pluginManager.validatePlugin(integration);
     }
 
     public void activatePreparedAuthenticationIntegration(PreparedAuthenticationIntegration prepared) {
@@ -194,6 +211,10 @@ public class AuthenticationIntegrationRuntime {
             }
             AuthenticationIntegration integration = resolved.integration;
             AuthenticationPlugin plugin = resolved.plugin;
+            if (isRejectedOidcIdTokenRequest(integration, request)) {
+                return AuthenticationOutcome.of(integration, AuthenticationResult.failure(
+                        AuthenticationFailureType.BAD_CREDENTIAL, OIDC_ID_TOKEN_REJECTED_MESSAGE));
+            }
             if (!plugin.supports(request)) {
                 continue;
             }
@@ -320,6 +341,12 @@ public class AuthenticationIntegrationRuntime {
         }
         AuthenticationException exception = result.getException();
         return exception != null && exception.getFailureType().shouldContinueInChain();
+    }
+
+    private static boolean isRejectedOidcIdTokenRequest(AuthenticationIntegration integration,
+            AuthenticationRequest request) {
+        return OIDC_INTEGRATION_TYPE.equalsIgnoreCase(integration.getType())
+                && CredentialType.OIDC_ID_TOKEN.equalsIgnoreCase(Strings.nullToEmpty(request.getCredentialType()));
     }
 
     private static RoleMappingEvaluator createDefaultRoleMappingEvaluator() {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/integration/AuthenticationIntegrationAuthenticator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/integration/AuthenticationIntegrationAuthenticator.java
@@ -22,6 +22,7 @@ import org.apache.doris.authentication.AuthenticationException;
 import org.apache.doris.authentication.AuthenticationFailureType;
 import org.apache.doris.authentication.AuthenticationIntegration;
 import org.apache.doris.authentication.AuthenticationIntegrationMeta;
+import org.apache.doris.authentication.AuthenticationIntegrationRuntime;
 import org.apache.doris.authentication.AuthenticationRequest;
 import org.apache.doris.authentication.Principal;
 import org.apache.doris.authentication.handler.AuthenticationOutcome;
@@ -176,6 +177,12 @@ public class AuthenticationIntegrationAuthenticator implements Authenticator {
         if (!Boolean.parseBoolean(integration.getProperty("enable_jit_user", "false"))) {
             LOG.info("Authentication integration '{}' authenticated user '{}' but JIT is disabled",
                     integration.getName(), qualifiedUser);
+            if ("oidc".equalsIgnoreCase(integration.getType())) {
+                return AuthenticateResponse.failed(AuthenticationFailureSummary.forClientVisibleFailure(
+                        AuthenticationFailureType.ACCESS_DENIED,
+                        AuthenticationIntegrationRuntime.OIDC_JIT_DISABLED_MESSAGE,
+                        AuthenticationIntegrationRuntime.OIDC_JIT_DISABLED_MESSAGE));
+            }
             return AuthenticateResponse.failedResponse;
         }
         UserIdentity tempUserIdentity = UserIdentity.createAnalyzedUserIdentWithIp(principal.getName(), remoteIp);
@@ -229,6 +236,7 @@ public class AuthenticationIntegrationAuthenticator implements Authenticator {
             return "OIDC access token signature validation failed";
         }
         if (detailMessage.startsWith("OIDC access token ")
+                || detailMessage.startsWith("OIDC ID token ")
                 || detailMessage.startsWith("OIDC token ")
                 || "Authentication request username does not match OIDC access token username".equals(detailMessage)
                 || "Authentication request username does not match OIDC token username".equals(detailMessage)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/plugin/AuthenticationPluginAuthenticator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/authenticate/plugin/AuthenticationPluginAuthenticator.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.authentication.AuthenticationException;
 import org.apache.doris.authentication.AuthenticationFailureType;
 import org.apache.doris.authentication.AuthenticationIntegration;
+import org.apache.doris.authentication.AuthenticationIntegrationRuntime;
 import org.apache.doris.authentication.AuthenticationRequest;
 import org.apache.doris.authentication.AuthenticationResult;
 import org.apache.doris.authentication.CredentialType;
@@ -92,10 +93,11 @@ public class AuthenticationPluginAuthenticator implements Authenticator {
     @Override
     public AuthenticateResponse authenticate(AuthenticateRequest request) throws IOException {
         AuthenticationRequest pluginRequest = toPluginRequest(request);
+        if (isRejectedOidcIdTokenRequest(pluginRequest)) {
+            return unsupportedCredentialResponse(pluginRequest);
+        }
         if (!plugin.supports(pluginRequest)) {
-            return AuthenticateResponse.failed(AuthenticationFailureSummary.forFailureType(
-                    AuthenticationFailureType.ACCESS_DENIED,
-                    "Authentication plugin '" + integration.getType() + "' does not support the supplied credential"));
+            return unsupportedCredentialResponse(pluginRequest);
         }
 
         AuthenticationResult result;
@@ -130,6 +132,18 @@ public class AuthenticationPluginAuthenticator implements Authenticator {
         return mapSuccessfulAuthentication(request.getUserName(), request.getRemoteIp(), result);
     }
 
+    private AuthenticateResponse unsupportedCredentialResponse(AuthenticationRequest pluginRequest) {
+        if (isRejectedOidcIdTokenRequest(pluginRequest)) {
+            return AuthenticateResponse.failed(AuthenticationFailureSummary.forClientVisibleFailure(
+                    AuthenticationFailureType.BAD_CREDENTIAL,
+                    AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                    AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE));
+        }
+        return AuthenticateResponse.failed(AuthenticationFailureSummary.forFailureType(
+                AuthenticationFailureType.ACCESS_DENIED,
+                "Authentication plugin '" + integration.getType() + "' does not support the supplied credential"));
+    }
+
     @Override
     public boolean canDeal(String qualifiedUser) {
         return !Auth.ROOT_USER.equals(qualifiedUser) && !Auth.ADMIN_USER.equals(qualifiedUser);
@@ -153,6 +167,12 @@ public class AuthenticationPluginAuthenticator implements Authenticator {
         if (!Boolean.parseBoolean(integration.getProperty("enable_jit_user", "false"))) {
             LOG.info("Authentication plugin '{}' authenticated user '{}' but JIT is disabled",
                     integration.getType(), qualifiedUser);
+            if ("oidc".equalsIgnoreCase(integration.getType())) {
+                return AuthenticateResponse.failed(AuthenticationFailureSummary.forClientVisibleFailure(
+                        AuthenticationFailureType.ACCESS_DENIED,
+                        AuthenticationIntegrationRuntime.OIDC_JIT_DISABLED_MESSAGE,
+                        AuthenticationIntegrationRuntime.OIDC_JIT_DISABLED_MESSAGE));
+            }
             return AuthenticateResponse.failedResponse;
         }
         UserIdentity tempUserIdentity = UserIdentity.createAnalyzedUserIdentWithIp(principal.getName(), remoteIp);
@@ -232,11 +252,18 @@ public class AuthenticationPluginAuthenticator implements Authenticator {
             return "OIDC access token signature validation failed";
         }
         if (detailMessage.startsWith("OIDC access token ")
+                || detailMessage.startsWith("OIDC ID token ")
                 || detailMessage.startsWith("OIDC token ")
                 || "Authentication request username does not match OIDC access token username".equals(detailMessage)
                 || "Authentication request username does not match OIDC token username".equals(detailMessage)) {
             return detailMessage;
         }
         return "";
+    }
+
+    private boolean isRejectedOidcIdTokenRequest(AuthenticationRequest pluginRequest) {
+        return "oidc".equalsIgnoreCase(integration.getType())
+                && CredentialType.OIDC_ID_TOKEN.equalsIgnoreCase(
+                        Strings.nullToEmpty(pluginRequest.getCredentialType()));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationMgrTest.java
@@ -106,6 +106,8 @@ class AuthenticationIntegrationMgrTest {
         mgr.dropAuthenticationIntegration("corp_ldap", false);
         Assertions.assertTrue(mgr.getAuthenticationIntegrations().isEmpty());
 
+        Mockito.verify(runtime, Mockito.times(3)).validateAuthenticationIntegration(
+                Mockito.any(AuthenticationIntegrationMeta.class));
         Mockito.verify(runtime, Mockito.times(2)).markAuthenticationIntegrationDirty("corp_ldap");
         Mockito.verify(runtime).removeAuthenticationIntegration("corp_ldap");
         Mockito.verifyNoMoreInteractions(runtime);
@@ -155,6 +157,49 @@ class AuthenticationIntegrationMgrTest {
         Mockito.verifyNoInteractions(runtime);
         Mockito.verifyNoInteractions(roleMappingMgr);
         Mockito.verifyNoInteractions(editLog);
+    }
+
+    @Test
+    void testSkipValidationPropertyIsTransient() throws Exception {
+        AuthenticationIntegrationMgr mgr = new AuthenticationIntegrationMgr();
+        mgr.createAuthenticationIntegration("corp_ldap", false, map(
+                "type", "ldap",
+                "ldap.server", "ldap://127.0.0.1:389",
+                "check_validation", "false"), null, CREATE_USER);
+
+        AuthenticationIntegrationMeta created = mgr.getAuthenticationIntegration("corp_ldap");
+        Assertions.assertNotNull(created);
+        Assertions.assertFalse(created.toSqlPropertiesView().containsKey("check_validation"));
+        Mockito.verify(runtime, Mockito.never()).validateAuthenticationIntegration(
+                Mockito.any(AuthenticationIntegrationMeta.class));
+
+        Mockito.clearInvocations(runtime, editLog, roleMappingMgr);
+
+        mgr.alterAuthenticationIntegrationProperties("corp_ldap", map(
+                "ldap.server", "ldap://127.0.0.1:1389",
+                "check_validation", "false"), ALTER_USER);
+        AuthenticationIntegrationMeta altered = mgr.getAuthenticationIntegration("corp_ldap");
+        Assertions.assertEquals("ldap://127.0.0.1:1389", altered.getProperties().get("ldap.server"));
+        Assertions.assertFalse(altered.toSqlPropertiesView().containsKey("check_validation"));
+        Mockito.verify(runtime, Mockito.never()).validateAuthenticationIntegration(
+                Mockito.any(AuthenticationIntegrationMeta.class));
+        Mockito.verify(runtime).markAuthenticationIntegrationDirty("corp_ldap");
+        Mockito.verifyNoMoreInteractions(runtime);
+        Mockito.verifyNoInteractions(roleMappingMgr);
+    }
+
+    @Test
+    void testInvalidCheckValidationPropertyThrows() {
+        AuthenticationIntegrationMgr mgr = new AuthenticationIntegrationMgr();
+
+        Assertions.assertThrows(DdlException.class,
+                () -> mgr.createAuthenticationIntegration("corp_ldap", false, map(
+                        "type", "ldap",
+                        "check_validation", "not_bool"), null, CREATE_USER));
+        Assertions.assertThrows(DdlException.class,
+                () -> mgr.alterAuthenticationIntegrationProperties("corp_ldap", map(
+                        "ldap.server", "ldap://127.0.0.1:1389",
+                        "check_validation", "not_bool"), ALTER_USER));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationRuntimeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/authentication/AuthenticationIntegrationRuntimeTest.java
@@ -297,6 +297,70 @@ class AuthenticationIntegrationRuntimeTest {
                 pluginRootsCaptor.getValue());
     }
 
+    @Test
+    void testValidateAuthenticationIntegrationOnlyRunsValidate() throws Exception {
+        List<String> lifecycle = new ArrayList<>();
+        AuthenticationPluginManager pluginManager = new AuthenticationPluginManager();
+        pluginManager.registerFactory(new ValidationOnlyPluginFactory(lifecycle));
+        AuthenticationIntegrationRuntime runtime = new AuthenticationIntegrationRuntime(pluginManager);
+
+        runtime.validateAuthenticationIntegration(meta("corp", "validation_only", map("marker", "checked")));
+
+        Assertions.assertEquals(Collections.singletonList("validate:checked"), lifecycle);
+    }
+
+    @Test
+    void testAuthenticateRejectsOidcIdTokenAsBadCredential() throws Exception {
+        AuthenticationPluginManager pluginManager = new AuthenticationPluginManager();
+        pluginManager.registerFactory(new OidcLikePluginFactory());
+        AuthenticationIntegrationRuntime runtime = new AuthenticationIntegrationRuntime(pluginManager);
+        AuthenticationIntegrationMeta integration = meta("corp_oidc", "oidc", Collections.emptyMap());
+        runtime.activatePreparedAuthenticationIntegration(runtime.prepareAuthenticationIntegration(integration));
+
+        AuthenticationRequest request = AuthenticationRequest.builder()
+                .username("alice")
+                .credentialType(CredentialType.OIDC_ID_TOKEN)
+                .credential("id-token".getBytes(StandardCharsets.UTF_8))
+                .remoteHost("127.0.0.1")
+                .clientType("mysql")
+                .build();
+
+        AuthenticationOutcome outcome = runtime.authenticate(Collections.singletonList(integration), request);
+
+        Assertions.assertTrue(outcome.isFailure());
+        Assertions.assertEquals("corp_oidc", outcome.getIntegration().getName());
+        Assertions.assertEquals(AuthenticationFailureType.BAD_CREDENTIAL,
+                outcome.getAuthResult().getException().getFailureType());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                outcome.getAuthResult().getException().getMessage());
+    }
+
+    @Test
+    void testAuthenticateRejectsOidcIdTokenEvenWhenPluginSupportsIt() throws Exception {
+        AuthenticationPluginManager pluginManager = new AuthenticationPluginManager();
+        pluginManager.registerFactory(new OidcLikePluginFactory(true));
+        AuthenticationIntegrationRuntime runtime = new AuthenticationIntegrationRuntime(pluginManager);
+        AuthenticationIntegrationMeta integration = meta("corp_oidc", "oidc", Collections.emptyMap());
+        runtime.activatePreparedAuthenticationIntegration(runtime.prepareAuthenticationIntegration(integration));
+
+        AuthenticationRequest request = AuthenticationRequest.builder()
+                .username("alice")
+                .credentialType(CredentialType.OIDC_ID_TOKEN)
+                .credential("id-token".getBytes(StandardCharsets.UTF_8))
+                .remoteHost("127.0.0.1")
+                .clientType("mysql")
+                .build();
+
+        AuthenticationOutcome outcome = runtime.authenticate(Collections.singletonList(integration), request);
+
+        Assertions.assertTrue(outcome.isFailure());
+        Assertions.assertEquals("corp_oidc", outcome.getIntegration().getName());
+        Assertions.assertEquals(AuthenticationFailureType.BAD_CREDENTIAL,
+                outcome.getAuthResult().getException().getFailureType());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                outcome.getAuthResult().getException().getMessage());
+    }
+
     private static AuthenticationIntegrationMeta meta(String name, String type, Map<String, String> properties)
             throws Exception {
         Map<String, String> createProperties = new LinkedHashMap<>();
@@ -378,6 +442,54 @@ class AuthenticationIntegrationRuntimeTest {
         }
     }
 
+    private static class OidcLikePluginFactory implements AuthenticationPluginFactory {
+        private final boolean supportsOidcIdToken;
+
+        private OidcLikePluginFactory() {
+            this(false);
+        }
+
+        private OidcLikePluginFactory(boolean supportsOidcIdToken) {
+            this.supportsOidcIdToken = supportsOidcIdToken;
+        }
+
+        @Override
+        public String name() {
+            return "oidc";
+        }
+
+        @Override
+        public AuthenticationPlugin create() {
+            return new OidcLikePlugin(supportsOidcIdToken);
+        }
+    }
+
+    private static class OidcLikePlugin implements AuthenticationPlugin {
+        private final boolean supportsOidcIdToken;
+
+        private OidcLikePlugin(boolean supportsOidcIdToken) {
+            this.supportsOidcIdToken = supportsOidcIdToken;
+        }
+
+        @Override
+        public String name() {
+            return "oidc";
+        }
+
+        @Override
+        public boolean supports(AuthenticationRequest request) {
+            return CredentialType.OAUTH_TOKEN.equals(request.getCredentialType())
+                    || CredentialType.JWT_TOKEN.equals(request.getCredentialType())
+                    || supportsOidcIdToken && CredentialType.OIDC_ID_TOKEN.equals(request.getCredentialType());
+        }
+
+        @Override
+        public AuthenticationResult authenticate(AuthenticationRequest request, AuthenticationIntegration integration) {
+            return AuthenticationResult.failure(
+                    AuthenticationFailureType.BAD_CREDENTIAL, "unexpected authentication call");
+        }
+    }
+
     private static class RecordingPluginFactory implements AuthenticationPluginFactory {
         private final List<String> initializedMarkers;
 
@@ -426,6 +538,60 @@ class AuthenticationIntegrationRuntimeTest {
             return AuthenticationResult.success(BasicPrincipal.builder()
                     .name(request.getUsername())
                     .authenticator(marker)
+                    .build());
+        }
+    }
+
+    private static class ValidationOnlyPluginFactory implements AuthenticationPluginFactory {
+        private final List<String> lifecycle;
+
+        private ValidationOnlyPluginFactory(List<String> lifecycle) {
+            this.lifecycle = lifecycle;
+        }
+
+        @Override
+        public String name() {
+            return "validation_only";
+        }
+
+        @Override
+        public AuthenticationPlugin create() {
+            return new ValidationOnlyPlugin(lifecycle);
+        }
+    }
+
+    private static class ValidationOnlyPlugin implements AuthenticationPlugin {
+        private final List<String> lifecycle;
+
+        private ValidationOnlyPlugin(List<String> lifecycle) {
+            this.lifecycle = lifecycle;
+        }
+
+        @Override
+        public String name() {
+            return "validation_only";
+        }
+
+        @Override
+        public boolean supports(AuthenticationRequest request) {
+            return true;
+        }
+
+        @Override
+        public void validate(AuthenticationIntegration integration) {
+            lifecycle.add("validate:" + integration.getProperty("marker", "missing"));
+        }
+
+        @Override
+        public void initialize(AuthenticationIntegration integration) {
+            lifecycle.add("initialize:" + integration.getProperty("marker", "missing"));
+        }
+
+        @Override
+        public AuthenticationResult authenticate(AuthenticationRequest request, AuthenticationIntegration integration) {
+            return AuthenticationResult.success(BasicPrincipal.builder()
+                    .name(request.getUsername())
+                    .authenticator(integration.getName())
                     .build());
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/AuthenticatorManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/AuthenticatorManagerTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.mysql.authenticate;
 
 import org.apache.doris.authentication.AuthenticationFailureType;
+import org.apache.doris.authentication.AuthenticationIntegrationRuntime;
 import org.apache.doris.authentication.BasicPrincipal;
 import org.apache.doris.authentication.CredentialType;
 import org.apache.doris.catalog.Env;
@@ -289,6 +290,56 @@ class AuthenticatorManagerTest {
         Assertions.assertEquals(QueryState.MysqlStateType.ERR, state.getStateType());
         Assertions.assertEquals(ErrorCode.ERR_UNKNOWN_ERROR, state.getErrorCode());
         Assertions.assertEquals("OIDC token has expired", state.getErrorMessage());
+    }
+
+    @Test
+    void testAuthenticateExposesOidcIdTokenRejectedMessageFromAuthenticationChain() throws Exception {
+        Config.authentication_chain = "corp_oidc";
+
+        Authenticator primaryAuthenticator = Mockito.mock(Authenticator.class);
+        PasswordResolver primaryResolver = Mockito.mock(PasswordResolver.class);
+        Mockito.when(primaryAuthenticator.canDeal(USER_NAME)).thenReturn(true);
+        Mockito.when(primaryAuthenticator.getPasswordResolver()).thenReturn(primaryResolver);
+        Mockito.when(primaryResolver.resolveAuthenticateRequest(Mockito.eq(USER_NAME), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(Optional.of(AuthenticateRequest.builder()
+                        .userName(USER_NAME)
+                        .password(new ClearPassword(OIDC_ID_TOKEN))
+                        .remoteHost(REMOTE_IP)
+                        .clientType("mysql")
+                        .credentialType(CredentialType.OIDC_ID_TOKEN)
+                        .credential(OIDC_ID_TOKEN.getBytes(StandardCharsets.UTF_8))
+                        .build()));
+        Mockito.when(primaryAuthenticator.authenticate(Mockito.any()))
+                .thenReturn(AuthenticateResponse.failedResponse);
+
+        Authenticator chainAuthenticator = Mockito.mock(Authenticator.class);
+        Mockito.when(chainAuthenticator.canDeal(USER_NAME)).thenReturn(true);
+        Mockito.when(chainAuthenticator.authenticate(Mockito.any()))
+                .thenReturn(AuthenticateResponse.failed(AuthenticationFailureSummary.forClientVisibleFailure(
+                        AuthenticationFailureType.BAD_CREDENTIAL,
+                        AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                        AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE)));
+
+        AuthenticatorManager manager = Mockito.spy(new AuthenticatorManager(AuthenticateType.DEFAULT.name()));
+        setStaticField("authTypeAuthenticator", primaryAuthenticator);
+        setStaticField("authTypeIdentifier", AuthenticateType.DEFAULT.name());
+        Mockito.doReturn(chainAuthenticator).when(manager).getAuthenticationChainAuthenticator();
+
+        QueryState state = new QueryState();
+        ConnectContext context = mockContext(state);
+        MysqlAuthPacket authPacket = Mockito.mock(MysqlAuthPacket.class);
+        Mockito.when(authPacket.getPluginName()).thenReturn(MysqlHandshakePacket.AUTH_PLUGIN_NAME);
+        Mockito.when(authPacket.getCapability()).thenReturn(org.apache.doris.mysql.MysqlCapability.SSL_CAPABILITY);
+
+        boolean result = manager.authenticate(context, USER_NAME, context.getMysqlChannel(),
+                Mockito.mock(MysqlSerializer.class), authPacket, Mockito.mock(MysqlHandshakePacket.class));
+
+        Assertions.assertFalse(result);
+        Assertions.assertEquals(QueryState.MysqlStateType.ERR, state.getStateType());
+        Assertions.assertEquals(ErrorCode.ERR_UNKNOWN_ERROR, state.getErrorCode());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                state.getErrorMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/integration/AuthenticationIntegrationAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/integration/AuthenticationIntegrationAuthenticatorTest.java
@@ -18,14 +18,19 @@
 package org.apache.doris.mysql.authenticate.integration;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.authentication.AuthenticationException;
+import org.apache.doris.authentication.AuthenticationFailureType;
 import org.apache.doris.authentication.AuthenticationIntegration;
 import org.apache.doris.authentication.AuthenticationIntegrationMeta;
 import org.apache.doris.authentication.AuthenticationIntegrationMgr;
 import org.apache.doris.authentication.AuthenticationIntegrationRuntime;
+import org.apache.doris.authentication.AuthenticationResult;
+import org.apache.doris.authentication.CredentialType;
 import org.apache.doris.authentication.handler.AuthenticationOutcome;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
 import org.apache.doris.mysql.authenticate.AuthenticateResponse;
+import org.apache.doris.mysql.authenticate.AuthenticationFailureSummary;
 import org.apache.doris.mysql.authenticate.password.ClearPassword;
 import org.apache.doris.mysql.privilege.Auth;
 
@@ -47,6 +52,8 @@ import java.util.Map;
 class AuthenticationIntegrationAuthenticatorTest {
     private static final String CHAIN_CONFIG = "corp_ldap,backup_ldap";
     private static final String CREATE_USER = "creator";
+    private static final String OIDC_JIT_DISABLED_MESSAGE =
+            "OIDC authentication succeeded but no matching Doris user exists and JIT user is disabled";
 
     private Env env;
     private Auth auth;
@@ -134,6 +141,61 @@ class AuthenticationIntegrationAuthenticatorTest {
                 new AuthenticateRequest("alice", new ClearPassword("secret"), "127.0.0.1"));
 
         Assertions.assertFalse(response.isSuccess());
+        Assertions.assertNull(response.getFailureSummary());
+    }
+
+    @Test
+    void testAuthenticateExposesOidcJitDisabledFailure() throws Exception {
+        mgr.replayCreateAuthenticationIntegration(meta("corp_oidc", "oidc", false));
+        Mockito.when(runtime.authenticate(Mockito.anyList(), Mockito.any()))
+                .thenReturn(AuthenticationOutcome.of(integration("corp_oidc", "oidc", false), success()));
+        Mockito.when(auth.getUserIdentityForExternalAuth("alice", "127.0.0.1"))
+                .thenReturn(Collections.emptyList());
+
+        AuthenticationIntegrationAuthenticator authenticator =
+                new AuthenticationIntegrationAuthenticator("corp_oidc", "authentication_chain");
+        AuthenticateResponse response = authenticator.authenticate(
+                new AuthenticateRequest("alice", new ClearPassword("secret"), "127.0.0.1"));
+
+        Assertions.assertFalse(response.isSuccess());
+        AuthenticationFailureSummary failureSummary = response.getFailureSummary();
+        Assertions.assertNotNull(failureSummary);
+        Assertions.assertEquals(AuthenticationFailureType.ACCESS_DENIED, failureSummary.getFailureType());
+        Assertions.assertEquals(OIDC_JIT_DISABLED_MESSAGE, failureSummary.getDetailMessage());
+        Assertions.assertTrue(failureSummary.hasClientVisibleMessage());
+        Assertions.assertEquals(OIDC_JIT_DISABLED_MESSAGE, failureSummary.getClientVisibleMessage());
+    }
+
+    @Test
+    void testAuthenticateExposesOidcIdTokenRejectedFailure() throws Exception {
+        mgr.replayCreateAuthenticationIntegration(meta("corp_oidc", "oidc", true));
+        AuthenticationException exception = new AuthenticationException(
+                AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                AuthenticationFailureType.BAD_CREDENTIAL);
+        Mockito.when(runtime.authenticate(Mockito.anyList(), Mockito.any()))
+                .thenReturn(AuthenticationOutcome.of(
+                        integration("corp_oidc", "oidc", true),
+                        AuthenticationResult.failure(exception)));
+
+        AuthenticationIntegrationAuthenticator authenticator =
+                new AuthenticationIntegrationAuthenticator("corp_oidc", "authentication_chain");
+        AuthenticateResponse response = authenticator.authenticate(AuthenticateRequest.builder()
+                .userName("alice")
+                .password(new ClearPassword("id-token"))
+                .remoteHost("127.0.0.1")
+                .credentialType(CredentialType.OIDC_ID_TOKEN)
+                .credential("id-token".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                .build());
+
+        Assertions.assertFalse(response.isSuccess());
+        AuthenticationFailureSummary failureSummary = response.getFailureSummary();
+        Assertions.assertNotNull(failureSummary);
+        Assertions.assertEquals(AuthenticationFailureType.BAD_CREDENTIAL, failureSummary.getFailureType());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                failureSummary.getDetailMessage());
+        Assertions.assertTrue(failureSummary.hasClientVisibleMessage());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                failureSummary.getClientVisibleMessage());
     }
 
     @Test
@@ -154,18 +216,26 @@ class AuthenticationIntegrationAuthenticatorTest {
     }
 
     private static AuthenticationIntegrationMeta meta(String name, boolean jitEnabled) throws Exception {
+        return meta(name, "ldap", jitEnabled);
+    }
+
+    private static AuthenticationIntegrationMeta meta(String name, String type, boolean jitEnabled) throws Exception {
         Map<String, String> properties = new LinkedHashMap<>();
-        properties.put("type", "ldap");
+        properties.put("type", type);
         properties.put("enable_jit_user", String.valueOf(jitEnabled));
         return AuthenticationIntegrationMeta.fromCreateSql(name, properties, null, CREATE_USER);
     }
 
     private static AuthenticationIntegration integration(String name, boolean jitEnabled) {
+        return integration(name, "ldap", jitEnabled);
+    }
+
+    private static AuthenticationIntegration integration(String name, String type, boolean jitEnabled) {
         Map<String, String> properties = new LinkedHashMap<>();
         properties.put("enable_jit_user", String.valueOf(jitEnabled));
         return AuthenticationIntegration.builder()
                 .name(name)
-                .type("ldap")
+                .type(type)
                 .properties(properties)
                 .build();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/plugin/AuthenticationPluginAuthenticatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/authenticate/plugin/AuthenticationPluginAuthenticatorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.mysql.authenticate.plugin;
 
+import org.apache.doris.authentication.AuthenticationFailureType;
+import org.apache.doris.authentication.AuthenticationIntegrationRuntime;
 import org.apache.doris.authentication.AuthenticationRequest;
 import org.apache.doris.authentication.AuthenticationResult;
 import org.apache.doris.authentication.BasicPrincipal;
@@ -30,6 +32,7 @@ import org.apache.doris.mysql.MysqlHandshakePacket;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.AuthenticateRequest;
 import org.apache.doris.mysql.authenticate.AuthenticateResponse;
+import org.apache.doris.mysql.authenticate.AuthenticationFailureSummary;
 import org.apache.doris.mysql.privilege.Auth;
 
 import org.junit.jupiter.api.AfterEach;
@@ -60,6 +63,8 @@ class AuthenticationPluginAuthenticatorTest {
     private static final String USER_NAME = "alice";
     private static final String REMOTE_IP = "127.0.0.1";
     private static final String OIDC_CLIENT_PLUGIN = "authentication_openid_connect_client";
+    private static final String OIDC_JIT_DISABLED_MESSAGE =
+            "OIDC authentication succeeded but no matching Doris user exists and JIT user is disabled";
 
     @BeforeEach
     void setUp() throws Exception {
@@ -107,6 +112,37 @@ class AuthenticationPluginAuthenticatorTest {
     }
 
     @Test
+    void testAuthenticateExposesOidcJitDisabledFailure() throws Exception {
+        Mockito.when(plugin.supports(Mockito.any())).thenReturn(true);
+        Mockito.when(plugin.authenticate(Mockito.any(), Mockito.any()))
+                .thenReturn(AuthenticationResult.success(BasicPrincipal.builder()
+                        .name("external_alice")
+                        .authenticator("oidc")
+                        .build()));
+        Mockito.when(auth.getUserIdentityForExternalAuth(USER_NAME, REMOTE_IP))
+                .thenReturn(Collections.emptyList());
+
+        Map<String, String> integrationProperties = new HashMap<>();
+        integrationProperties.put("enable_jit_user", "false");
+        AuthenticationPluginAuthenticator authenticator = new AuthenticationPluginAuthenticator(
+                "oidc", integrationProperties, pluginManager);
+        AuthenticateResponse response = authenticator.authenticate(AuthenticateRequest.builder()
+                .userName(USER_NAME)
+                .remoteHost(REMOTE_IP)
+                .credentialType("bearer")
+                .credential("token".getBytes(StandardCharsets.UTF_8))
+                .build());
+
+        Assertions.assertFalse(response.isSuccess());
+        AuthenticationFailureSummary failureSummary = response.getFailureSummary();
+        Assertions.assertNotNull(failureSummary);
+        Assertions.assertEquals(AuthenticationFailureType.ACCESS_DENIED, failureSummary.getFailureType());
+        Assertions.assertEquals(OIDC_JIT_DISABLED_MESSAGE, failureSummary.getDetailMessage());
+        Assertions.assertTrue(failureSummary.hasClientVisibleMessage());
+        Assertions.assertEquals(OIDC_JIT_DISABLED_MESSAGE, failureSummary.getClientVisibleMessage());
+    }
+
+    @Test
     void testOidcPluginResolverUsesOidcCredentialFromMysqlAuthPacket() throws Exception {
         Mockito.when(plugin.supports(Mockito.any())).thenReturn(true);
         Mockito.when(plugin.authenticate(Mockito.any(), Mockito.any()))
@@ -151,6 +187,59 @@ class AuthenticationPluginAuthenticatorTest {
         Assertions.assertEquals(CredentialType.OAUTH_TOKEN, requestCaptor.getValue().getCredentialType());
         Assertions.assertArrayEquals("token-from-client".getBytes(StandardCharsets.UTF_8),
                 requestCaptor.getValue().getCredential());
+    }
+
+    @Test
+    void testAuthenticateRejectsOidcIdTokenWithClientVisibleFailure() throws Exception {
+        Mockito.when(plugin.supports(Mockito.any())).thenReturn(false);
+
+        AuthenticationPluginAuthenticator authenticator = new AuthenticationPluginAuthenticator(
+                "oidc", new HashMap<>(), pluginManager);
+        AuthenticateResponse response = authenticator.authenticate(AuthenticateRequest.builder()
+                .userName(USER_NAME)
+                .remoteHost(REMOTE_IP)
+                .credentialType(CredentialType.OIDC_ID_TOKEN)
+                .credential("id-token".getBytes(StandardCharsets.UTF_8))
+                .build());
+
+        Assertions.assertFalse(response.isSuccess());
+        AuthenticationFailureSummary failureSummary = response.getFailureSummary();
+        Assertions.assertNotNull(failureSummary);
+        Assertions.assertEquals(AuthenticationFailureType.BAD_CREDENTIAL, failureSummary.getFailureType());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                failureSummary.getDetailMessage());
+        Assertions.assertTrue(failureSummary.hasClientVisibleMessage());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                failureSummary.getClientVisibleMessage());
+        Mockito.verify(plugin, Mockito.never()).authenticate(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void testAuthenticateRejectsOidcIdTokenBeforeCallingSupportingPlugin() throws Exception {
+        Mockito.when(plugin.supports(Mockito.any())).thenReturn(true);
+        Mockito.when(plugin.authenticate(Mockito.any(), Mockito.any()))
+                .thenReturn(AuthenticationResult.failure(
+                        AuthenticationFailureType.BAD_CREDENTIAL, "plugin-specific OIDC ID token failure"));
+
+        AuthenticationPluginAuthenticator authenticator = new AuthenticationPluginAuthenticator(
+                "oidc", new HashMap<>(), pluginManager);
+        AuthenticateResponse response = authenticator.authenticate(AuthenticateRequest.builder()
+                .userName(USER_NAME)
+                .remoteHost(REMOTE_IP)
+                .credentialType(CredentialType.OIDC_ID_TOKEN)
+                .credential("id-token".getBytes(StandardCharsets.UTF_8))
+                .build());
+
+        Assertions.assertFalse(response.isSuccess());
+        AuthenticationFailureSummary failureSummary = response.getFailureSummary();
+        Assertions.assertNotNull(failureSummary);
+        Assertions.assertEquals(AuthenticationFailureType.BAD_CREDENTIAL, failureSummary.getFailureType());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                failureSummary.getDetailMessage());
+        Assertions.assertTrue(failureSummary.hasClientVisibleMessage());
+        Assertions.assertEquals(AuthenticationIntegrationRuntime.OIDC_ID_TOKEN_REJECTED_MESSAGE,
+                failureSummary.getClientVisibleMessage());
+        Mockito.verify(plugin, Mockito.never()).authenticate(Mockito.any(), Mockito.any());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/service/FrontendServiceImplTest.java
@@ -274,6 +274,7 @@ public class FrontendServiceImplTest {
         properties.put("server", "ldap://127.0.0.1:389");
         properties.put("bind_password", "plain_secret");
         properties.put("secret.endpoint", "masked_by_prefix");
+        properties.put("check_validation", "false");
         Env.getCurrentEnv().getAuthenticationIntegrationMgr()
                 .createAuthenticationIntegration(
                         integrationName, false, properties, "ldap comment", connectContext.getQualifiedUser());
@@ -306,6 +307,7 @@ public class FrontendServiceImplTest {
                     "\"secret.endpoint\" = \"" + DatasourcePrintableMap.PASSWORD_MASK + "\""));
             Assert.assertFalse(rowValues.get(2).contains("plain_secret"));
             Assert.assertFalse(rowValues.get(2).contains("masked_by_prefix"));
+            Assert.assertFalse(rowValues.get(2).contains("check_validation"));
             Assert.assertEquals("ldap comment", rowValues.get(3));
             Assert.assertEquals(connectContext.getQualifiedUser(), rowValues.get(4));
             Assert.assertNotNull(rowValues.get(5));
@@ -339,7 +341,8 @@ public class FrontendServiceImplTest {
             executeCommand("CREATE ROLE " + financeReaderRole);
             executeCommand("CREATE ROLE " + financeWriterRole);
             executeCommand("CREATE AUTHENTICATION INTEGRATION " + integrationName
-                    + " PROPERTIES ('type'='ldap', 'ldap.server'='ldap://127.0.0.1:389') "
+                    + " PROPERTIES ('type'='ldap', 'ldap.server'='ldap://127.0.0.1:389', "
+                    + "'check_validation'='false') "
                     + "COMMENT 'role mapping auth'");
             executeCommand("CREATE ROLE MAPPING " + mappingName
                     + " ON AUTHENTICATION INTEGRATION " + integrationName
@@ -400,7 +403,8 @@ public class FrontendServiceImplTest {
             executeCommand("CREATE ROLE " + readerRole);
             executeCommand("CREATE USER " + normalUser);
             executeCommand("CREATE AUTHENTICATION INTEGRATION " + integrationName
-                    + " PROPERTIES ('type'='ldap', 'ldap.server'='ldap://127.0.0.1:389') "
+                    + " PROPERTIES ('type'='ldap', 'ldap.server'='ldap://127.0.0.1:389', "
+                    + "'check_validation'='false') "
                     + "COMMENT 'role mapping auth'");
             executeCommand("CREATE ROLE MAPPING " + mappingName
                     + " ON AUTHENTICATION INTEGRATION " + integrationName

--- a/regression-test/suites/auth_p0/test_authentication_integration_auth.groovy
+++ b/regression-test/suites/auth_p0/test_authentication_integration_auth.groovy
@@ -36,7 +36,8 @@ suite("test_authentication_integration_auth", "p0,auth") {
                 'type'='ldap',
                 'ldap.server'='ldap://127.0.0.1:389',
                 'ldap.admin_password'='123456',
-                'secret.endpoint'='secret_create_value'
+                'secret.endpoint'='secret_create_value',
+                'check_validation'='false'
             )
             COMMENT 'for regression test'
         """
@@ -63,7 +64,8 @@ suite("test_authentication_integration_auth", "p0,auth") {
             SET PROPERTIES (
                 'ldap.server'='ldap://127.0.0.1:1389',
                 'ldap.admin_password'='abcdef',
-                'secret.endpoint'='secret_alter_value'
+                'secret.endpoint'='secret_alter_value',
+                'check_validation'='false'
             )
         """
 

--- a/regression-test/suites/auth_p0/test_role_mapping_system_table.groovy
+++ b/regression-test/suites/auth_p0/test_role_mapping_system_table.groovy
@@ -48,7 +48,8 @@ suite("test_role_mapping_system_table", "p0,auth") {
             CREATE AUTHENTICATION INTEGRATION ${integrationName}
             PROPERTIES (
                 'type'='ldap',
-                'ldap.server'='ldap://127.0.0.1:389'
+                'ldap.server'='ldap://127.0.0.1:389',
+                'check_validation'='false'
             )
             COMMENT 'role mapping auth'
         """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Validate CREATE/ALTER AUTHENTICATION INTEGRATION properties during DDL, while allowing users to skip validation with a transient check_validation switch so plugin-less regression environments can still create test integrations.

### Release note

None

### Check List (For Author)

- Test: FE unit test
    - ./run-fe-ut.sh --run org.apache.doris.authentication.AuthenticationIntegrationMgrTest,org.apache.doris.authentication.AuthenticationIntegrationRuntimeTest,org.apache.doris.service.FrontendServiceImplTest
- Behavior changed: Yes (AUTHENTICATION INTEGRATION DDL now validates plugin properties by default, with opt-out via check_validation=false)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

