### PR TITLE
[improvement](be) Restructure OLAP scan profile timers into tree hierarchy

### DIFF
--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -135,8 +135,7 @@ Status OlapScanLocalState::_init_profile() {
             ADD_COUNTER(_segment_profile, "UncompressedBytesRead", TUnit::BYTES);
     _block_load_timer = ADD_TIMER(_segment_profile, "BlockLoadTime");
     _block_load_counter = ADD_COUNTER(_segment_profile, "BlocksLoad", TUnit::UNIT);
-    _block_fetch_timer = ADD_TIMER(_scanner_profile, "BlockFetchTime");
-    _delete_bitmap_get_agg_timer = ADD_TIMER(_scanner_profile, "DeleteBitmapGetAggTime");
+    _block_fetch_timer = ADD_CHILD_TIMER(_scanner_profile, "BlockFetchTime", "ScannerGetBlockTime");
     if (config::is_cloud_mode()) {
         static const char* sync_rowset_timer_name = "SyncRowsetTime";
         _sync_rowset_timer = ADD_TIMER(_scanner_profile, sync_rowset_timer_name);
@@ -274,46 +273,55 @@ Status OlapScanLocalState::_init_profile() {
     _total_segment_counter = ADD_COUNTER(_segment_profile, "NumSegmentTotal", TUnit::UNIT);
     _tablet_counter = ADD_COUNTER(custom_profile(), "TabletNum", TUnit::UNIT);
     _key_range_counter = ADD_COUNTER(custom_profile(), "KeyRangesNum", TUnit::UNIT);
-    _tablet_reader_init_timer = ADD_TIMER(_scanner_profile, "TabletReaderInitTimer");
-    _tablet_reader_capture_rs_readers_timer =
-            ADD_TIMER(_scanner_profile, "TabletReaderCaptureRsReadersTimer");
-    _tablet_reader_init_return_columns_timer =
-            ADD_TIMER(_scanner_profile, "TabletReaderInitReturnColumnsTimer");
-    _tablet_reader_init_keys_param_timer =
-            ADD_TIMER(_scanner_profile, "TabletReaderInitKeysParamTimer");
-    _tablet_reader_init_orderby_keys_param_timer =
-            ADD_TIMER(_scanner_profile, "TabletReaderInitOrderbyKeysParamTimer");
-    _tablet_reader_init_conditions_param_timer =
-            ADD_TIMER(_scanner_profile, "TabletReaderInitConditionsParamTimer");
-    _tablet_reader_init_delete_condition_param_timer =
-            ADD_TIMER(_scanner_profile, "TabletReaderInitDeleteConditionParamTimer");
-    _block_reader_vcollect_iter_init_timer =
-            ADD_TIMER(_scanner_profile, "BlockReaderVcollectIterInitTimer");
-    _block_reader_rs_readers_init_timer =
-            ADD_TIMER(_scanner_profile, "BlockReaderRsReadersInitTimer");
-    _block_reader_build_heap_init_timer =
-            ADD_TIMER(_scanner_profile, "BlockReaderBuildHeapInitTimer");
+    _tablet_reader_init_timer =
+            ADD_CHILD_TIMER(_scanner_profile, "TabletReaderInitTimer", "ReaderInitTime");
+    _tablet_reader_capture_rs_readers_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "TabletReaderCaptureRsReadersTimer", "TabletReaderInitTimer");
+    _tablet_reader_init_return_columns_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "TabletReaderInitReturnColumnsTimer", "TabletReaderInitTimer");
+    _tablet_reader_init_keys_param_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "TabletReaderInitKeysParamTimer", "TabletReaderInitTimer");
+    _tablet_reader_init_orderby_keys_param_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "TabletReaderInitOrderbyKeysParamTimer", "TabletReaderInitTimer");
+    _tablet_reader_init_conditions_param_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "TabletReaderInitConditionsParamTimer", "TabletReaderInitTimer");
+    _tablet_reader_init_delete_condition_param_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "TabletReaderInitDeleteConditionParamTimer", "TabletReaderInitTimer");
+    _block_reader_vcollect_iter_init_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "BlockReaderVcollectIterInitTimer", "TabletReaderInitTimer");
+    _block_reader_rs_readers_init_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "BlockReaderRsReadersInitTimer", "TabletReaderInitTimer");
+    _block_reader_build_heap_init_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "BlockReaderBuildHeapInitTimer", "TabletReaderInitTimer");
 
-    _rowset_reader_get_segment_iterators_timer =
-            ADD_TIMER(_scanner_profile, "RowsetReaderGetSegmentIteratorsTimer");
+    _rowset_reader_get_segment_iterators_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "RowsetReaderGetSegmentIteratorsTimer", "ScannerGetBlockTime");
+    _delete_bitmap_get_agg_timer = ADD_CHILD_TIMER(_scanner_profile, "DeleteBitmapGetAggTime",
+                                                   "RowsetReaderGetSegmentIteratorsTimer");
     _rowset_reader_create_iterators_timer =
-            ADD_TIMER(_scanner_profile, "RowsetReaderCreateIteratorsTimer");
-    _rowset_reader_init_iterators_timer =
-            ADD_TIMER(_scanner_profile, "RowsetReaderInitIteratorsTimer");
-    _rowset_reader_load_segments_timer =
-            ADD_TIMER(_scanner_profile, "RowsetReaderLoadSegmentsTimer");
+            ADD_CHILD_TIMER(_scanner_profile, "RowsetReaderCreateIteratorsTimer",
+                            "RowsetReaderGetSegmentIteratorsTimer");
+    _rowset_reader_init_iterators_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "RowsetReaderInitIteratorsTimer", "ScannerGetBlockTime");
+    _rowset_reader_load_segments_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "RowsetReaderLoadSegmentsTimer", "ScannerGetBlockTime");
 
-    _segment_iterator_init_timer = ADD_TIMER(_scanner_profile, "SegmentIteratorInitTimer");
+    _segment_iterator_init_timer =
+            ADD_CHILD_TIMER(_scanner_profile, "SegmentIteratorInitTimer", "BlockFetchTime");
     _segment_iterator_init_return_column_iterators_timer =
-            ADD_TIMER(_scanner_profile, "SegmentIteratorInitReturnColumnIteratorsTimer");
-    _segment_iterator_init_index_iterators_timer =
-            ADD_TIMER(_scanner_profile, "SegmentIteratorInitIndexIteratorsTimer");
+            ADD_CHILD_TIMER(_scanner_profile, "SegmentIteratorInitReturnColumnIteratorsTimer",
+                            "SegmentIteratorInitTimer");
+    _segment_iterator_init_index_iterators_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "SegmentIteratorInitIndexIteratorsTimer", "SegmentIteratorInitTimer");
     _segment_iterator_init_segment_prefetchers_timer =
-            ADD_TIMER(_scanner_profile, "SegmentIteratorInitSegmentPrefetchersTimer");
+            ADD_CHILD_TIMER(_scanner_profile, "SegmentIteratorInitSegmentPrefetchersTimer",
+                            "SegmentIteratorInitTimer");
 
     _segment_create_column_readers_timer =
-            ADD_TIMER(_scanner_profile, "SegmentCreateColumnReadersTimer");
-    _segment_load_index_timer = ADD_TIMER(_scanner_profile, "SegmentLoadIndexTimer");
+            ADD_CHILD_TIMER(_scanner_profile, "SegmentCreateColumnReadersTimer",
+                            "SegmentIteratorInitReturnColumnIteratorsTimer");
+    _segment_load_index_timer = ADD_CHILD_TIMER(_scanner_profile, "SegmentLoadIndexTimer",
+                                                "SegmentIteratorInitReturnColumnIteratorsTimer");
 
     _index_filter_profile = std::make_unique<RuntimeProfile>("IndexFilter");
     _scanner_profile->add_child(_index_filter_profile.get(), true, nullptr);

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -317,11 +317,13 @@ Status OlapScanLocalState::_init_profile() {
             ADD_CHILD_TIMER(_scanner_profile, "SegmentIteratorInitSegmentPrefetchersTimer",
                             "SegmentIteratorInitTimer");
 
-    _segment_create_column_readers_timer =
-            ADD_CHILD_TIMER(_scanner_profile, "SegmentCreateColumnReadersTimer",
-                            "SegmentIteratorInitReturnColumnIteratorsTimer");
-    _segment_load_index_timer = ADD_CHILD_TIMER(_scanner_profile, "SegmentLoadIndexTimer",
-                                                "SegmentIteratorInitReturnColumnIteratorsTimer");
+    // These two timers span both iterator init and later lazy segment init paths,
+    // so their nearest stable ancestor is ScannerGetBlockTime instead of any
+    // narrower SegmentIterator/BlockFetch subphase.
+    _segment_create_column_readers_timer = ADD_CHILD_TIMER(
+            _scanner_profile, "SegmentCreateColumnReadersTimer", "ScannerGetBlockTime");
+    _segment_load_index_timer =
+            ADD_CHILD_TIMER(_scanner_profile, "SegmentLoadIndexTimer", "ScannerGetBlockTime");
 
     _index_filter_profile = std::make_unique<RuntimeProfile>("IndexFilter");
     _scanner_profile->add_child(_index_filter_profile.get(), true, nullptr);

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -837,7 +837,17 @@ void OlapScanner::_collect_profile_before_close() {
     COUNTER_UPDATE(local_state->_condition_cache_filtered_rows_counter,
                    stats.condition_cache_filtered_rows);
 
-    COUNTER_UPDATE(local_state->_tablet_reader_init_timer, stats.tablet_reader_init_timer_ns);
+    const int64_t tablet_reader_init_timer_ns =
+            stats.tablet_reader_capture_rs_readers_timer_ns +
+            stats.tablet_reader_init_return_columns_timer_ns +
+            stats.tablet_reader_init_keys_param_timer_ns +
+            stats.tablet_reader_init_orderby_keys_param_timer_ns +
+            stats.tablet_reader_init_conditions_param_timer_ns +
+            stats.tablet_reader_init_delete_condition_param_timer_ns +
+            stats.block_reader_vcollect_iter_init_timer_ns +
+            stats.block_reader_rs_readers_init_timer_ns +
+            stats.block_reader_build_heap_init_timer_ns;
+    COUNTER_UPDATE(local_state->_tablet_reader_init_timer, tablet_reader_init_timer_ns);
     COUNTER_UPDATE(local_state->_tablet_reader_capture_rs_readers_timer,
                    stats.tablet_reader_capture_rs_readers_timer_ns);
     COUNTER_UPDATE(local_state->_tablet_reader_init_return_columns_timer,
@@ -871,6 +881,8 @@ void OlapScanner::_collect_profile_before_close() {
                    stats.segment_iterator_init_return_column_iterators_timer_ns);
     COUNTER_UPDATE(local_state->_segment_iterator_init_index_iterators_timer,
                    stats.segment_iterator_init_index_iterators_timer_ns);
+    COUNTER_UPDATE(local_state->_segment_iterator_init_segment_prefetchers_timer,
+                   stats.segment_iterator_init_segment_prefetchers_timer_ns);
 
     COUNTER_UPDATE(local_state->_segment_create_column_readers_timer,
                    stats.segment_create_column_readers_timer_ns);

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -837,17 +837,7 @@ void OlapScanner::_collect_profile_before_close() {
     COUNTER_UPDATE(local_state->_condition_cache_filtered_rows_counter,
                    stats.condition_cache_filtered_rows);
 
-    const int64_t tablet_reader_init_timer_ns =
-            stats.tablet_reader_capture_rs_readers_timer_ns +
-            stats.tablet_reader_init_return_columns_timer_ns +
-            stats.tablet_reader_init_keys_param_timer_ns +
-            stats.tablet_reader_init_orderby_keys_param_timer_ns +
-            stats.tablet_reader_init_conditions_param_timer_ns +
-            stats.tablet_reader_init_delete_condition_param_timer_ns +
-            stats.block_reader_vcollect_iter_init_timer_ns +
-            stats.block_reader_rs_readers_init_timer_ns +
-            stats.block_reader_build_heap_init_timer_ns;
-    COUNTER_UPDATE(local_state->_tablet_reader_init_timer, tablet_reader_init_timer_ns);
+    COUNTER_UPDATE(local_state->_tablet_reader_init_timer, stats.tablet_reader_init_timer_ns);
     COUNTER_UPDATE(local_state->_tablet_reader_capture_rs_readers_timer,
                    stats.tablet_reader_capture_rs_readers_timer_ns);
     COUNTER_UPDATE(local_state->_tablet_reader_init_return_columns_timer,

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -126,7 +126,7 @@ static std::string read_columns_to_string(TabletSchemaSPtr tablet_schema,
     return read_columns_string;
 }
 
-Status OlapScanner::prepare() {
+Status OlapScanner::_prepare_impl() {
     auto* local_state = static_cast<OlapScanLocalState*>(_local_state);
     auto& tablet = _tablet_reader_params.tablet;
     auto& tablet_schema = _tablet_reader_params.tablet_schema;

--- a/be/src/exec/scan/olap_scanner.h
+++ b/be/src/exec/scan/olap_scanner.h
@@ -69,7 +69,7 @@ public:
 
     OlapScanner(ScanLocalStateBase* parent, Params&& params);
 
-    Status prepare() override;
+    Status _prepare_impl() override;
 
     Status _open_impl(RuntimeState* state) override;
 

--- a/be/src/exec/scan/scanner.h
+++ b/be/src/exec/scan/scanner.h
@@ -71,13 +71,15 @@ public:
     }
 
     virtual Status init(RuntimeState* state, const VExprContextSPtrs& conjuncts);
-    virtual Status prepare() {
-        _has_prepared = true;
-        return Status::OK();
+    Status prepare() {
+        SCOPED_RAW_TIMER(&_per_scanner_timer);
+        SCOPED_RAW_TIMER(&_per_scanner_prepare_timer);
+        return _prepare_impl();
     }
 
     Status open(RuntimeState* state) {
         SCOPED_RAW_TIMER(&_per_scanner_timer);
+        SCOPED_RAW_TIMER(&_per_scanner_open_timer);
         return _open_impl(state);
     }
 
@@ -96,6 +98,11 @@ public:
     virtual std::string get_current_scan_range_name() { return "not implemented"; }
 
 protected:
+    virtual Status _prepare_impl() {
+        _has_prepared = true;
+        return Status::OK();
+    }
+
     virtual Status _open_impl(RuntimeState* state) {
         _block_avg_bytes = state->batch_size() * 8;
         return Status::OK();
@@ -158,6 +165,8 @@ public:
     // that started it.
     void start_queue_wait() { _start_wait_worker_timer(); }
     int64_t get_time_cost_ns() const { return _per_scanner_timer; }
+    int64_t get_prepare_time_cost_ns() const { return _per_scanner_prepare_timer; }
+    int64_t get_open_time_cost_ns() const { return _per_scanner_open_timer; }
 
     int64_t projection_time() const { return _projection_timer; }
     int64_t get_rows_read() const { return _num_rows_read; }
@@ -265,6 +274,8 @@ protected:
 
     ScannerCounter _counter;
     int64_t _per_scanner_timer = 0;
+    int64_t _per_scanner_prepare_timer = 0;
+    int64_t _per_scanner_open_timer = 0;
     int64_t _projection_timer = 0;
 
     bool _should_stop = false;

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -490,10 +490,14 @@ void ScannerContext::stop_scanners(RuntimeState* state) {
         std::stringstream scanner_rows_read;
         std::stringstream scanner_wait_worker_time;
         std::stringstream scanner_projection;
+        std::stringstream scanner_prepare_time;
+        std::stringstream scanner_open_time;
         scanner_statistics << "[";
         scanner_rows_read << "[";
         scanner_wait_worker_time << "[";
         scanner_projection << "[";
+        scanner_prepare_time << "[";
+        scanner_open_time << "[";
         // Scanners can in 3 state
         //  state 1: in scanner context, not scheduled
         //  state 2: in scanner worker pool's queue, scheduled but not running
@@ -517,6 +521,13 @@ void ScannerContext::stop_scanners(RuntimeState* state) {
                     << PrettyPrinter::print(scanner->_scanner->get_scanner_wait_worker_timer(),
                                             TUnit::TIME_NS)
                     << ", ";
+            scanner_prepare_time << PrettyPrinter::print(
+                                            scanner->_scanner->get_prepare_time_cost_ns(),
+                                            TUnit::TIME_NS)
+                                 << ", ";
+            scanner_open_time << PrettyPrinter::print(scanner->_scanner->get_open_time_cost_ns(),
+                                                      TUnit::TIME_NS)
+                              << ", ";
             // since there are all scanners, some scanners is running, so that could not call scanner
             // close here.
         }
@@ -524,10 +535,14 @@ void ScannerContext::stop_scanners(RuntimeState* state) {
         scanner_rows_read << "]";
         scanner_wait_worker_time << "]";
         scanner_projection << "]";
+        scanner_prepare_time << "]";
+        scanner_open_time << "]";
         _scanner_profile->add_info_string("PerScannerRunningTime", scanner_statistics.str());
         _scanner_profile->add_info_string("PerScannerRowsRead", scanner_rows_read.str());
         _scanner_profile->add_info_string("PerScannerWaitTime", scanner_wait_worker_time.str());
         _scanner_profile->add_info_string("PerScannerProjectionTime", scanner_projection.str());
+        _scanner_profile->add_info_string("PerScannerPrepareTime", scanner_prepare_time.str());
+        _scanner_profile->add_info_string("PerScannerOpenTime", scanner_open_time.str());
     }
 }
 

--- a/be/src/storage/iterator/block_reader.cpp
+++ b/be/src/storage/iterator/block_reader.cpp
@@ -202,6 +202,7 @@ Status BlockReader::_init_agg_state(const ReaderParams& read_params) {
 }
 
 Status BlockReader::init(const ReaderParams& read_params) {
+    SCOPED_RAW_TIMER(&_stats.tablet_reader_init_timer_ns);
     RETURN_IF_ERROR(TabletReader::init(read_params));
 
     auto return_column_size = read_params.origin_return_columns->size();

--- a/be/src/storage/segment/segment_loader.cpp
+++ b/be/src/storage/segment/segment_loader.cpp
@@ -56,12 +56,17 @@ Status SegmentLoader::load_segment(const BetaRowsetSharedPtr& rowset, int64_t se
                                    SegmentCacheHandle* cache_handle, bool use_cache,
                                    bool need_load_pk_index_and_bf,
                                    OlapReaderStatistics* index_load_stats) {
+    auto start = MonotonicMicros();
     SegmentCache::CacheKey cache_key(rowset->rowset_id(), segment_id);
     if (_segment_cache->lookup(cache_key, cache_handle)) {
         // Has to check the segment status here, because the segment in cache may has something wrong during
         // load index or create column reader.
         // Not merge this if logic with previous to make the logic more clear.
         if (cache_handle->pop_unhealthy_segment() == nullptr) {
+            if (index_load_stats != nullptr) {
+                index_load_stats->rowset_reader_load_segments_timer_ns +=
+                        (MonotonicMicros() - start) * 1000;
+            }
             return Status::OK();
         }
     }
@@ -78,6 +83,10 @@ Status SegmentLoader::load_segment(const BetaRowsetSharedPtr& rowset, int64_t se
         _segment_cache->insert(cache_key, *cache_value, cache_handle);
     } else {
         cache_handle->push_segment(std::move(segment));
+    }
+    if (index_load_stats != nullptr) {
+        index_load_stats->rowset_reader_load_segments_timer_ns +=
+                (MonotonicMicros() - start) * 1000;
     }
 
     return Status::OK();

--- a/be/src/storage/tablet/tablet_reader.cpp
+++ b/be/src/storage/tablet/tablet_reader.cpp
@@ -67,8 +67,6 @@ void TabletReader::ReaderParams::check_validation() const {
 }
 
 Status TabletReader::init(const ReaderParams& read_params) {
-    SCOPED_RAW_TIMER(&_stats.tablet_reader_init_timer_ns);
-
     Status res = _init_params(read_params);
     if (!res.ok()) {
         LOG(WARNING) << "fail to init reader when init params. res:" << res


### PR DESCRIPTION
   ### What problem does this PR solve?

    Issue Number: N/A

    Problem Summary:
    The OLAP scanner profile timers were registered as a flat list, making
    it hard to understand parent-child timing relationships. This change:

    1. Converts all relevant timers to use ADD_CHILD_TIMER so the profile
       renders as a tree reflecting actual call containment:
       - ReaderInitTime → TabletReaderInitTimer → (TabletReader* + BlockReader* sub-timers)
       - ScannerGetBlockTime → RowsetReaderGetSegmentIteratorsTimer → (DeleteBitmapGetAggTime, RowsetReaderCreateIteratorsTimer)
       - ScannerGetBlockTime → BlockFetchTime → SegmentIteratorInitTimer → (SegmentIterator* + Segment* sub-timers)

    2. Fixes TabletReaderInitTimer inaccuracy: removes the SCOPED_RAW_TIMER
       wrapper in TabletReader::init() (which double-counted overhead) and
       instead computes the value as the sum of its sub-timers in
       olap_scanner.cpp.

    3. Adds missing COUNTER_UPDATE for SegmentIteratorInitSegmentPrefetchersTimer
       which was tracked in stats but never reported to the profile.

    ### Release note

    Profile timers for OLAP scanner are now displayed as a tree hierarchy
    showing containment relationships between init and scan phases.

    ### Check List (For Author)

    - Test: Manual test (profile structure verified via code review)
        - No functional behavior changed, only profile display structure
    - Behavior changed: No
    - Does this need documentation: No