### PR TITLE
[fix](statistics) Fix missing Mockito import in AnalysisManagerTest

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
@@ -42,6 +42,7 @@ import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #62710

Problem Summary: `AnalysisManagerTest` in the `adaptive_batch_size` branch is missing the `import org.mockito.Mockito;` statement needed by the Mockito-based test methods introduced in #62686/#62710. Without this import the FE build fails at compilation with `cannot find symbol: variable Mockito`.

### Release note

None

### Check List (For Author)

- Test: No need to test (compile fix only, import statement only)
- Behavior changed: No
- Does this need documentation: No