### PR TITLE
[fix](query) avoid missing result packet for query during master switch

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -380,7 +380,7 @@ public class AuditLogHelper {
         auditEventBuilder.setStmt(handleStmt(encryptSql, parsedStmt));
 
         if (!Env.getCurrentEnv().isMaster()) {
-            if (ctx.executor != null && ctx.executor.isForwardToMaster()) {
+            if (ctx.executor != null && ctx.executor.hasForwardedToMaster()) {
                 auditEventBuilder.setState(ctx.executor.getProxyStatus());
                 int proxyStatusCode = ctx.executor.getProxyStatusCode();
                 if (proxyStatusCode != 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -384,7 +384,7 @@ public abstract class ConnectProcessor {
                             true);
                     // execute failed, skip remaining stmts
                     if (ctx.getState().getStateType() == MysqlStateType.ERR || (!Env.getCurrentEnv().isMaster()
-                            && ctx.executor != null && ctx.executor.isForwardToMaster()
+                            && ctx.executor != null && ctx.executor.hasForwardedToMaster()
                             && ctx.executor.getProxyStatusCode() != 0)) {
                         break;
                     }
@@ -632,7 +632,7 @@ public abstract class ConnectProcessor {
         LOG.debug("Finalize command for query {}", DebugUtil.printId(ctx.queryId));
         Preconditions.checkState(connectType.equals(ConnectType.MYSQL));
         ByteBuffer packet;
-        if (executor != null && executor.isForwardToMaster()
+        if (executor != null && executor.hasForwardedToMaster()
                 && ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
             ShowResultSet resultSet = executor.getShowResultSet();
             if (resultSet == null) {
@@ -862,4 +862,3 @@ public abstract class ConnectProcessor {
         throw new NotSupportedException("Just MysqlConnectProcessor support execute");
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -475,6 +475,16 @@ public class StmtExecutor {
         }
     }
 
+    /**
+     * Whether this executor has actually forwarded to master and created a {@link MasterOpExecutor}.
+     *
+     * <p>Do not confuse with {@link #isForwardToMaster()} which is a decision (may be re-evaluated)
+     * based on current statement shape / redirect status.
+     */
+    public boolean hasForwardedToMaster() {
+        return masterOpExecutor != null;
+    }
+
     public ShowResultSet getProxyShowResultSet() {
         return proxyShowResultSet;
     }


### PR DESCRIPTION
When master switch happen, the follower will briefly enter the unknown state. 
At this time, isForwardedToMaster for every request will be determined as true, and during the finalizeCommand response packet phase, the master proxy result will be directly used as the result, leading to the loss of the real ResultPacket. Ultimately, the client remains hung while waiting for the result to return until the socket timeout.
In fact, point query will never forward to master at present.