### PR TITLE
[improve](inverted index) Remove CLucene wrapper reader locks to unblock concurrent reads

### DIFF
--- a/be/src/storage/index/inverted/inverted_index_compound_reader.cpp
+++ b/be/src/storage/index/inverted/inverted_index_compound_reader.cpp
@@ -43,12 +43,27 @@ class FileWriter;
 using FileWriterPtr = std::unique_ptr<doris::io::FileWriter>;
 
 namespace doris::segment_v2 {
+// Deleter that routes through CLucene's `_CLDELETE` macro so unique_ptr
+// frees IndexInput subclasses using the same instrumentation as the rest
+// of the CLucene code (debug allocator hooks, per-object stats, etc.).
+struct CLIndexInputDeleter {
+    void operator()(lucene::store::IndexInput* p) const noexcept {
+        if (p != nullptr) {
+            _CLDELETE(p);
+        }
+    }
+};
+using IndexInputPtr = std::unique_ptr<lucene::store::IndexInput, CLIndexInputDeleter>;
+
 /** Implementation of an IndexInput that reads from a portion of the
  *  compound file.
  */
 class CSIndexInput : public lucene::store::BufferedIndexInput {
 private:
-    CL_NS(store)::IndexInput* base;
+    // Per-instance clone of the underlying stream. Each CSIndexInput owns
+    // its own `base` so seek + readBytes do not race against other
+    // CSIndexInputs opened from the same DorisCompoundReader.
+    IndexInputPtr base;
     std::string file_name;
     int64_t fileOffset;
     int64_t _length;
@@ -59,10 +74,10 @@ protected:
     void seekInternal(const int64_t /*pos*/) override {}
 
 public:
-    CSIndexInput(CL_NS(store)::IndexInput* base, const std::string& file_name,
-                 const int64_t fileOffset, const int64_t length,
+    CSIndexInput(IndexInputPtr base, const std::string& file_name, const int64_t fileOffset,
+                 const int64_t length,
                  const int32_t read_buffer_size = CL_NS(store)::BufferedIndexInput::BUFFER_SIZE);
-    CSIndexInput(const CSIndexInput& clone);
+    CSIndexInput(const CSIndexInput& other);
     ~CSIndexInput() override;
     void close() override;
     lucene::store::IndexInput* clone() const override;
@@ -73,19 +88,20 @@ public:
     void setIoContext(const void* io_ctx) override;
 };
 
-CSIndexInput::CSIndexInput(CL_NS(store)::IndexInput* base, const std::string& file_name,
+CSIndexInput::CSIndexInput(IndexInputPtr base, const std::string& file_name,
                            const int64_t fileOffset, const int64_t length,
                            const int32_t read_buffer_size)
-        : BufferedIndexInput(read_buffer_size) {
-    this->base = base;
-    this->file_name = file_name;
-    this->fileOffset = fileOffset;
-    this->_length = length;
-}
+        : BufferedIndexInput(read_buffer_size),
+          base(std::move(base)),
+          file_name(file_name),
+          fileOffset(fileOffset),
+          _length(length) {}
 
 void CSIndexInput::readInternal(uint8_t* b, const int32_t len) {
-    std::lock_guard wlock(((DorisFSDirectory::FSIndexInput*)base)->_this_lock);
-
+    // Thread-safety: each CSIndexInput owns a private `base` clone (P0-3/P0-4),
+    // so seek + readBytes do not race across threads, and no outer lock is needed.
+    // The FSIndexInput::_this_lock that previously guarded this sequence has
+    // been removed.
     auto start = getFilePointer();
     if (start + len > _length) {
         _CLTHROWA(CL_ERR_IO, "read past EOF");
@@ -131,12 +147,14 @@ lucene::store::IndexInput* CSIndexInput::clone() const {
     return _CLNEW CSIndexInput(*this);
 }
 
-CSIndexInput::CSIndexInput(const CSIndexInput& clone) : BufferedIndexInput(clone) {
-    this->base = clone.base;
-    this->file_name = clone.file_name;
-    this->fileOffset = clone.fileOffset;
-    this->_length = clone._length;
-}
+CSIndexInput::CSIndexInput(const CSIndexInput& other)
+        : BufferedIndexInput(other),
+          base(other.base ? IndexInputPtr(other.base->clone())
+                          : throw CLuceneError(CL_ERR_NullPointer,
+                                               "[CSIndexInput] base is null in clone", false)),
+          file_name(other.file_name),
+          fileOffset(other.fileOffset),
+          _length(other._length) {}
 
 void CSIndexInput::close() {}
 
@@ -354,7 +372,12 @@ bool DorisCompoundReader::openInput(const char* name, lucene::store::IndexInput*
         bufferSize = _read_buffer_size;
     }
 
-    ret = _CLNEW CSIndexInput(_stream, entry->file_name, entry->offset, entry->length, bufferSize);
+    // Each CSIndexInput gets its own clone of `_stream` so sub-file reads do
+    // not serialize on a shared base (see design doc §3-A contract). clone()
+    // is cheap: FSIndexInput clones share the same `SharedHandle` / `_reader`.
+    IndexInputPtr cloned_stream(_stream->clone());
+    ret = _CLNEW CSIndexInput(std::move(cloned_stream), entry->file_name, entry->offset,
+                              entry->length, bufferSize);
     return true;
 }
 

--- a/be/src/storage/index/inverted/inverted_index_compound_reader.cpp
+++ b/be/src/storage/index/inverted/inverted_index_compound_reader.cpp
@@ -55,6 +55,22 @@ struct CLIndexInputDeleter {
 };
 using IndexInputPtr = std::unique_ptr<lucene::store::IndexInput, CLIndexInputDeleter>;
 
+static bool resolve_index_data_flag(const std::string& file_name, bool* is_index_data) {
+    for (const auto& entry : InvertedIndexDescriptor::index_file_info_map) {
+        if (file_name.find(entry.first) != std::string::npos) {
+            *is_index_data = true;
+            return true;
+        }
+    }
+    for (const auto& entry : InvertedIndexDescriptor::normal_file_info_map) {
+        if (file_name.find(entry.first) != std::string::npos) {
+            *is_index_data = false;
+            return true;
+        }
+    }
+    return false;
+}
+
 /** Implementation of an IndexInput that reads from a portion of the
  *  compound file.
  */
@@ -68,6 +84,8 @@ private:
     int64_t fileOffset;
     int64_t _length;
     const io::IOContext* _io_ctx = nullptr;
+    bool _has_index_data_flag = false;
+    bool _is_index_data = false;
 
 protected:
     void readInternal(uint8_t* /*b*/, const int32_t /*len*/) override;
@@ -95,7 +113,9 @@ CSIndexInput::CSIndexInput(IndexInputPtr base, const std::string& file_name,
           base(std::move(base)),
           file_name(file_name),
           fileOffset(fileOffset),
-          _length(length) {}
+          _length(length) {
+    _has_index_data_flag = resolve_index_data_flag(this->file_name, &_is_index_data);
+}
 
 void CSIndexInput::readInternal(uint8_t* b, const int32_t len) {
     // Thread-safety: each CSIndexInput owns a private `base` clone (P0-3/P0-4),
@@ -109,6 +129,9 @@ void CSIndexInput::readInternal(uint8_t* b, const int32_t len) {
 
     if (_io_ctx) {
         base->setIoContext(_io_ctx);
+    }
+    if (_has_index_data_flag) {
+        base->setIndexFile(_is_index_data);
     }
 
     DBUG_EXECUTE_IF("CSIndexInput.readInternal", {
@@ -154,7 +177,9 @@ CSIndexInput::CSIndexInput(const CSIndexInput& other)
                                                "[CSIndexInput] base is null in clone", false)),
           file_name(other.file_name),
           fileOffset(other.fileOffset),
-          _length(other._length) {}
+          _length(other._length),
+          _has_index_data_flag(other._has_index_data_flag),
+          _is_index_data(other._is_index_data) {}
 
 void CSIndexInput::close() {}
 

--- a/be/src/storage/index/inverted/inverted_index_fs_directory.cpp
+++ b/be/src/storage/index/inverted/inverted_index_fs_directory.cpp
@@ -127,33 +127,37 @@ bool DorisFSDirectory::FSIndexInput::open(const io::FileSystemSPtr& fs, const ch
         }
         //Store the file length
         h->_length = h->_reader->size();
-        h->_fpos = 0;
         ret = _CLNEW FSIndexInput(std::move(h), buffer_size);
         return true;
     }
 
-    //delete h->_shared_lock;
-    //_CLDECDELETE(h)
     return false;
 }
 
 DorisFSDirectory::FSIndexInput::FSIndexInput(const FSIndexInput& other)
         : BufferedIndexInput(other) {
     if (other._handle == nullptr) {
-        _CLTHROWA(CL_ERR_NullPointer, "other handle is null");
+        _CLTHROWA(CL_ERR_NullPointer, "other._handle is null");
     }
 
-    std::lock_guard<std::mutex> wlock(other._handle->_shared_lock);
     _handle = other._handle;
-    _pos = other._handle->_fpos; //note where we are currently...
-    _io_ctx = other._io_ctx;
+    // Clone-time cursor copy relies on the contract that callers do not read and
+    // clone the same FSIndexInput instance concurrently.
+    _pos = other._pos;
+    // Do NOT copy `other._io_ctx`: its `query_id` / `file_cache_stats` /
+    // `file_reader_stats` are raw pointers to per-query state (see
+    // be/src/io/io_common.h). If we copied them into a clone that ends up
+    // living inside a long-lived cached IndexSearcher, a second query hitting
+    // the cache would write into the first query's already-freed stats
+    // (UAF / profile misattribution). Callers set the per-read IOContext via
+    // setIoContext() on the owning CSIndexInput, which refreshes the base
+    // FSIndexInput's `_io_ctx` around every readBytes() call.
+    _io_ctx.is_inverted_index = true;
 }
 
 DorisFSDirectory::FSIndexInput::SharedHandle::SharedHandle(const char* path) {
     _length = 0;
-    _fpos = 0;
     strcpy(this->path, path);
-    //_shared_lock = new std::mutex();
 }
 
 DorisFSDirectory::FSIndexInput::SharedHandle::~SharedHandle() {
@@ -209,23 +213,23 @@ void DorisFSDirectory::FSIndexInput::readInternal(uint8_t* b, const int32_t len)
     CND_PRECONDITION(_handle != nullptr, "shared file handle has closed");
     CND_PRECONDITION(_handle->_reader != nullptr, "file is not open");
 
+    int64_t position = getFilePointer();
+    if (_pos != position) {
+        _pos = position;
+    }
+
+    Slice result {b, (size_t)len};
+    size_t bytes_read = 0;
     int64_t inverted_index_io_timer = 0;
     {
         SCOPED_RAW_TIMER(&inverted_index_io_timer);
-
+#ifndef USE_HADOOP_HDFS
+        // libhdfs3's hdfsSeek()+hdfsRead() shares the file cursor on the
+        // handle, so concurrent read_at() on the same SharedHandle would
+        // interleave. Serialize here in !USE_HADOOP_HDFS builds only.
+        // USE_HADOOP_HDFS builds use hdfsPread() and remain lock-free.
         std::lock_guard<std::mutex> wlock(_handle->_shared_lock);
-
-        int64_t position = getFilePointer();
-        if (_pos != position) {
-            _pos = position;
-        }
-
-        if (_handle->_fpos != _pos) {
-            _handle->_fpos = _pos;
-        }
-
-        Slice result {b, (size_t)len};
-        size_t bytes_read = 0;
+#endif
         Status st = _handle->_reader->read_at(_pos, result, &bytes_read, &_io_ctx);
         DBUG_EXECUTE_IF("DorisFSDirectory::FSIndexInput::readInternal_reader_read_at_error", {
             st = Status::InternalError(
@@ -235,19 +239,19 @@ void DorisFSDirectory::FSIndexInput::readInternal(uint8_t* b, const int32_t len)
         if (!st.ok()) {
             _CLTHROWA(CL_ERR_IO, "read past EOF");
         }
-        bufferLength = len;
         DBUG_EXECUTE_IF("DorisFSDirectory::FSIndexInput::readInternal_bytes_read_error",
                         { bytes_read = len + 10; })
         if (bytes_read != len) {
             _CLTHROWA(CL_ERR_IO, "read error");
         }
-        _pos += bufferLength;
-        _handle->_fpos = _pos;
     }
 
     if (_io_ctx.file_cache_stats != nullptr) {
         _io_ctx.file_cache_stats->inverted_index_io_timer += inverted_index_io_timer;
     }
+
+    bufferLength = len;
+    _pos += bufferLength;
 }
 
 void DorisFSDirectory::FSIndexOutput::init(const io::FileSystemSPtr& fs, const char* path) {

--- a/be/src/storage/index/inverted/inverted_index_fs_directory.h
+++ b/be/src/storage/index/inverted/inverted_index_fs_directory.h
@@ -161,14 +161,29 @@ public:
     const char* getObjectName() const override;
 };
 
+// Thread-safety contract (see AIR-12 design doc §3-A):
+//   - FSIndexInput instances are NOT thread-safe. Use clone() to produce
+//     per-thread copies.
+//   - Concurrent read() + clone() on the SAME instance is undefined.
+//   - Different clones sharing the same SharedHandle are safe WHEN the
+//     underlying `io::FileReader::read_at` is stateless (pread-like).
+//     The USE_HADOOP_HDFS build path (libhadoop / `hdfsPread`), as well as
+//     LocalFileReader / S3FileReader / BrokerFileReader, satisfies this.
+//     The `!USE_HADOOP_HDFS` path falls back to libhdfs3 whose
+//     `hdfsSeek() + hdfsRead()` shares the handle cursor; in that build
+//     the read path still needs a per-handle lock, which is kept below.
 class DorisFSDirectory::FSIndexInput : public lucene::store::BufferedIndexInput {
     class SharedHandle : LUCENE_REFBASE {
     public:
         io::FileReaderSPtr _reader;
         uint64_t _length;
-        int64_t _fpos;
+#ifndef USE_HADOOP_HDFS
+        // Only retained in builds whose FileReader::read_at is NOT
+        // concurrent-safe on a single handle (currently: libhdfs3 HDFS).
+        // USE_HADOOP_HDFS builds leave this out; that branch uses hdfsPread
+        // and the read path is lock-free.
         std::mutex _shared_lock;
-        //std::mutex* _shared_lock = nullptr;
+#endif
         char path[4096];
         SharedHandle(const char* path);
         ~SharedHandle() override;
@@ -204,8 +219,6 @@ public:
     void setIoContext(const void* io_ctx) override;
     const void* getIoContext() override;
     void setIndexFile(bool isIndexFile) override;
-
-    std::mutex _this_lock;
 
 protected:
     // Random-access methods

--- a/be/test/storage/segment/inverted_index_compound_reader_test.cpp
+++ b/be/test/storage/segment/inverted_index_compound_reader_test.cpp
@@ -44,6 +44,7 @@
 #include "storage/index/index_file_writer.h"
 #include "storage/index/inverted/inverted_index_fs_directory.h"
 #include "storage/tablet/tablet_schema.h"
+#include "util/debug_points.h"
 #include "util/slice.h"
 
 using namespace lucene::index;
@@ -56,6 +57,9 @@ public:
     const std::string kTestDir = "./ut_dir/inverted_index_compound_reader_test";
 
     void SetUp() override {
+        _original_enable_debug_points = config::enable_debug_points;
+        config::enable_debug_points = true;
+
         auto st = io::global_local_filesystem()->delete_directory(kTestDir);
         ASSERT_TRUE(st.ok()) << st;
         st = io::global_local_filesystem()->create_directory(kTestDir);
@@ -70,7 +74,10 @@ public:
         ExecEnv::GetInstance()->set_tmp_file_dir(std::move(tmp_file_dirs));
     }
 
-    void TearDown() override {}
+    void TearDown() override {
+        DebugPoints::instance()->remove("CSIndexInput.readInternal");
+        config::enable_debug_points = _original_enable_debug_points;
+    }
 
     CL_NS(store)::IndexInput* create_mock_index_input(const std::string& file_path,
                                                       const std::vector<std::string>& file_names,
@@ -221,6 +228,8 @@ public:
     std::string local_segment_path(std::string base, std::string rowset_id, int64_t seg_id) {
         return base + "/" + rowset_id + "/" + std::to_string(seg_id) + ".dat";
     }
+
+    bool _original_enable_debug_points = false;
 };
 
 TEST_F(DorisCompoundReaderTest, BasicConstruction) {
@@ -1155,6 +1164,31 @@ TEST_F(DorisCompoundReaderTest, OpenInputProducesIndependentBases) {
     _CLLDELETE(ia);
     _CLLDELETE(ib);
     _CLLDELETE(ic);
+    reader.close();
+}
+
+TEST_F(DorisCompoundReaderTest, CSIndexInputRefreshesIndexDataFlagPerSubFile) {
+    std::string index_path = kTestDir + "/tc_p0_index_data_flag.idx";
+    std::vector<std::string> names = {"segments_1", "field.tis"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024, 17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    index_input->setIndexFile(true);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* meta = nullptr;
+    lucene::store::IndexInput* normal = nullptr;
+    ASSERT_TRUE(reader.openInput("segments_1", meta, err, 4096));
+    ASSERT_TRUE(reader.openInput("field.tis", normal, err, 4096));
+
+    DebugPoints::instance()->add("CSIndexInput.readInternal");
+
+    uint8_t buf[16] = {0};
+    EXPECT_NO_THROW(meta->readBytes(buf, static_cast<int32_t>(sizeof(buf))));
+    EXPECT_NO_THROW(normal->readBytes(buf, static_cast<int32_t>(sizeof(buf))));
+
+    _CLLDELETE(meta);
+    _CLLDELETE(normal);
     reader.close();
 }
 

--- a/be/test/storage/segment/inverted_index_compound_reader_test.cpp
+++ b/be/test/storage/segment/inverted_index_compound_reader_test.cpp
@@ -27,22 +27,23 @@
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstring>
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
 #include "io/io_common.h"
 #include "runtime/exec_env.h"
+#include "runtime/thread_context.h"
 #include "storage/index/index_file_reader.h"
 #include "storage/index/index_file_writer.h"
-#include "storage/index/inverted/inverted_index_desc.h"
 #include "storage/index/inverted/inverted_index_fs_directory.h"
 #include "storage/tablet/tablet_schema.h"
-#include "storage/tablet/tablet_schema_helper.h"
 #include "util/slice.h"
 
 using namespace lucene::index;
@@ -1000,59 +1001,340 @@ TEST_F(DorisCompoundReaderTest, OpenInputFromRAMDirectory) {
     reader.close();
 }
 
-// Verify that after initialize() + setIoContext(nullptr) (the cache-safe
-// transition), the main stream's io_ctx is cleared and sub-streams created
-// via openInput() do NOT carry stale io_ctx pointers.  This is the pattern
-// used by both MATCH and SEARCH paths before inserting an IndexSearcher
-// into the global InvertedIndexSearcherCache.
-TEST_F(DorisCompoundReaderTest, InitializeThenClearIoCtxForCacheSafety) {
-    std::string index_path = kTestDir + "/test_io_ctx_lifecycle.idx";
-    std::vector<std::string> file_names = {"segments.gen", "posting.dat"};
-    std::vector<int64_t> lengths = {30, 60};
+// -----------------------------------------------------------------------------
+// TC-P0-* : CSIndexInput deep-clone tests (AIR-12, design doc v2.1 §三)
+// Each test uses sub-files larger than 16 MB so they go through the body
+// (CSIndexInput) path rather than the in-RAM header path.
+// -----------------------------------------------------------------------------
 
-    CL_NS(store)::IndexInput* index_input =
-            create_mock_index_input(index_path, file_names, lengths);
-
+// TC-P0-3-1: Independence — seeking one clone must not move the file pointer of
+// the source or of a sibling clone.
+TEST_F(DorisCompoundReaderTest, CSIndexInputCloneIsIndependent) {
+    std::string index_path = kTestDir + "/tc_p0_3_1.idx";
+    std::vector<std::string> names = {"data.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
     DorisCompoundReader reader(index_input, 4096, nullptr);
 
-    // --- Phase 1: initialization (simulates index open with a query's io_ctx) ---
-    io::IOContext io_ctx;
-    io_ctx.reader_type = ReaderType::READER_QUERY;
-    reader.initialize(&io_ctx);
-
-    auto* stream = reader.getDorisIndexInput();
-    auto* ctx_after_init = (const io::IOContext*)stream->getIoContext();
-    // Main stream should carry the io_ctx during initialization reads
-    EXPECT_EQ(ctx_after_init->reader_type, ReaderType::READER_QUERY);
-
-    // --- Phase 2: cache-safe transition (mirrors create_index_searcher) ---
-    stream->setIoContext(nullptr);
-    stream->setIndexFile(false);
-
-    auto* ctx_after_clear = (const io::IOContext*)stream->getIoContext();
-    // Main stream io_ctx should be reset to defaults
-    EXPECT_EQ(ctx_after_clear->reader_type, ReaderType::UNKNOWN);
-    EXPECT_EQ(ctx_after_clear->file_cache_stats, nullptr);
-
-    // --- Phase 3: verify sub-streams don't inherit stale io_ctx ---
     CLuceneError err;
-    lucene::store::IndexInput* sub_input = nullptr;
-    EXPECT_TRUE(reader.openInput("posting.dat", sub_input, err, 4096));
-    EXPECT_NE(sub_input, nullptr);
+    lucene::store::IndexInput* a = nullptr;
+    ASSERT_TRUE(reader.openInput("data.dat", a, err, 4096));
+    auto* b = a->clone();
+    ASSERT_NE(b, nullptr);
 
-    // CSIndexInput._io_ctx should be nullptr (not set by openInput on master)
-    // This means readInternal() will skip setIoContext on the base stream,
-    // allowing query-phase reads to use their own io_ctx through the
-    // CLucene API parameter chain (termDocs/termPositions/terms).
-    // We verify this indirectly: cloning should also have nullptr _io_ctx.
-    lucene::store::IndexInput* cloned = sub_input->clone();
-    EXPECT_NE(cloned, nullptr);
+    a->seek(100);
+    EXPECT_EQ(a->getFilePointer(), 100);
+    EXPECT_EQ(b->getFilePointer(), 0) << "clone must not share source position";
 
-    sub_input->close();
-    cloned->close();
-    _CLLDELETE(sub_input);
-    _CLLDELETE(cloned);
+    b->seek(500);
+    EXPECT_EQ(b->getFilePointer(), 500);
+    EXPECT_EQ(a->getFilePointer(), 100) << "source must be unaffected by clone seek";
 
+    _CLLDELETE(a);
+    _CLLDELETE(b);
+    reader.close();
+}
+
+// TC-P0-3-2: Data correctness — two clones reading independently produce the
+// same bytes as the underlying file.
+TEST_F(DorisCompoundReaderTest, CSIndexInputCloneReadsCorrectly) {
+    std::string index_path = kTestDir + "/tc_p0_3_2.idx";
+    std::vector<std::string> names = {"data.dat"};
+    // 17 MB of 'Z' bytes (single sub-file => 'Z' - 0 = 'Z'; see create_mock_index_input).
+    std::vector<int64_t> lens = {17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* a = nullptr;
+    ASSERT_TRUE(reader.openInput("data.dat", a, err, 4096));
+    auto* b = a->clone();
+    ASSERT_NE(b, nullptr);
+
+    a->seek(1024);
+    uint8_t abuf[256] = {0};
+    a->readBytes(abuf, static_cast<int32_t>(sizeof(abuf)));
+
+    b->seek(2048);
+    uint8_t bbuf[256] = {0};
+    b->readBytes(bbuf, static_cast<int32_t>(sizeof(bbuf)));
+
+    for (uint8_t c : abuf) EXPECT_EQ(c, 'Z');
+    for (uint8_t c : bbuf) EXPECT_EQ(c, 'Z');
+
+    _CLLDELETE(a);
+    _CLLDELETE(b);
+    reader.close();
+}
+
+// TC-P0-3-3: Lifecycle — destroying the source must not invalidate a clone's
+// state (ASAN-observable; pread through shared SharedHandle still valid).
+TEST_F(DorisCompoundReaderTest, CSIndexInputCloneOutlivesSource) {
+    std::string index_path = kTestDir + "/tc_p0_3_3.idx";
+    std::vector<std::string> names = {"data.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* a = nullptr;
+    ASSERT_TRUE(reader.openInput("data.dat", a, err, 4096));
+    auto* b = a->clone();
+    ASSERT_NE(b, nullptr);
+
+    // Destroy source first.
+    _CLLDELETE(a);
+
+    // Clone must still be fully usable.
+    b->seek(4096);
+    uint8_t buf[128] = {0};
+    b->readBytes(buf, static_cast<int32_t>(sizeof(buf)));
+    for (uint8_t c : buf) EXPECT_EQ(c, 'Z');
+
+    _CLLDELETE(b);
+    reader.close();
+}
+
+// TC-P0-3-4: Multi-level clone A -> B -> C. Any destruction order must not
+// crash because the underlying base (FSIndexInput / SharedHandle) is
+// shared_ptr-managed and each CSIndexInput owns its own cloned base.
+TEST_F(DorisCompoundReaderTest, CSIndexInputCloneChainIsIndependent) {
+    std::string index_path = kTestDir + "/tc_p0_3_4.idx";
+    std::vector<std::string> names = {"data.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* a = nullptr;
+    ASSERT_TRUE(reader.openInput("data.dat", a, err, 4096));
+    auto* b = a->clone();
+    auto* c = b->clone();
+    ASSERT_NE(b, nullptr);
+    ASSERT_NE(c, nullptr);
+
+    // Destroy middle clone first, then source, then finally the leaf.
+    _CLLDELETE(b);
+    _CLLDELETE(a);
+
+    c->seek(8192);
+    uint8_t buf[64] = {0};
+    c->readBytes(buf, static_cast<int32_t>(sizeof(buf)));
+    for (uint8_t x : buf) EXPECT_EQ(x, 'Z');
+
+    _CLLDELETE(c);
+    reader.close();
+}
+
+// TC-P0-4-1 (behavioral): Opening several sub-files of the same compound
+// must produce CSIndexInputs whose positions are independent. This proves,
+// at the observable level, that each CSIndexInput has its own base clone
+// (the only way seek-on-one-not-affecting-another can hold).
+TEST_F(DorisCompoundReaderTest, OpenInputProducesIndependentBases) {
+    std::string index_path = kTestDir + "/tc_p0_4_1.idx";
+    std::vector<std::string> names = {"a.dat", "b.dat", "c.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024, 17 * 1024 * 1024, 17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* ia = nullptr;
+    lucene::store::IndexInput* ib = nullptr;
+    lucene::store::IndexInput* ic = nullptr;
+    ASSERT_TRUE(reader.openInput("a.dat", ia, err, 4096));
+    ASSERT_TRUE(reader.openInput("b.dat", ib, err, 4096));
+    ASSERT_TRUE(reader.openInput("c.dat", ic, err, 4096));
+
+    ia->seek(100);
+    ib->seek(200);
+    ic->seek(300);
+    EXPECT_EQ(ia->getFilePointer(), 100);
+    EXPECT_EQ(ib->getFilePointer(), 200);
+    EXPECT_EQ(ic->getFilePointer(), 300);
+
+    _CLLDELETE(ia);
+    _CLLDELETE(ib);
+    _CLLDELETE(ic);
+    reader.close();
+}
+
+// TC-P0-4-2: Concurrent read through sibling CSIndexInputs. Validates that
+// after removing FSIndexInput::_this_lock (P0-6), parallel reads across
+// sub-files of the same compound do not race.
+TEST_F(DorisCompoundReaderTest, ConcurrentReadAcrossSubFiles) {
+    std::string index_path = kTestDir + "/tc_p0_4_2.idx";
+    std::vector<std::string> names = {"a.dat", "b.dat", "c.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024, 17 * 1024 * 1024, 17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    constexpr int kReadsPerThread = 200;
+    constexpr int kChunkSize = 4096;
+    std::vector<lucene::store::IndexInput*> inputs;
+    for (const auto& n : names) {
+        CLuceneError err;
+        lucene::store::IndexInput* in = nullptr;
+        ASSERT_TRUE(reader.openInput(n.c_str(), in, err, 4096));
+        inputs.push_back(in);
+    }
+
+    std::atomic<int> mismatches {0};
+    std::vector<std::thread> threads;
+    for (size_t t = 0; t < inputs.size(); ++t) {
+        auto* in = inputs[t];
+        // Mock writer fills sub-file i with the byte ('Z' - i % 26).
+        const uint8_t expected = static_cast<uint8_t>('Z' - (t % 26));
+        threads.emplace_back([in, expected, &mismatches]() {
+            doris::ThreadLocalHandle::create_thread_local_if_not_exits();
+            std::vector<uint8_t> buf(kChunkSize);
+            for (int i = 0; i < kReadsPerThread; ++i) {
+                int64_t off = (i * 73) % (16 * 1024 * 1024);
+                in->seek(off);
+                in->readBytes(buf.data(), kChunkSize);
+                for (uint8_t c : buf) {
+                    if (c != expected) {
+                        mismatches.fetch_add(1);
+                        doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
+                        return;
+                    }
+                }
+            }
+            doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
+        });
+    }
+    for (auto& th : threads) th.join();
+    EXPECT_EQ(mismatches.load(), 0);
+
+    for (auto* in : inputs) _CLLDELETE(in);
+    reader.close();
+}
+
+// TC-P0-5-1: CSIndexInput::clone() goes through the (deep) copy ctor, so the
+// clone is a distinct IndexInput* that survives independent of the source.
+TEST_F(DorisCompoundReaderTest, CloneReturnsDistinctUsableInput) {
+    std::string index_path = kTestDir + "/tc_p0_5_1.idx";
+    std::vector<std::string> names = {"data.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* a = nullptr;
+    ASSERT_TRUE(reader.openInput("data.dat", a, err, 4096));
+    auto* b = a->clone();
+    ASSERT_NE(b, a);
+    EXPECT_EQ(a->length(), b->length());
+    EXPECT_STREQ(b->getObjectName(), "CSIndexInput");
+
+    _CLLDELETE(a);
+
+    // Reading from clone after source destruction must still work.
+    b->seek(0);
+    uint8_t buf[16] = {0};
+    b->readBytes(buf, static_cast<int32_t>(sizeof(buf)));
+    for (uint8_t c : buf) EXPECT_EQ(c, 'Z');
+
+    _CLLDELETE(b);
+    reader.close();
+}
+
+// TC-P0-6-1a (CI gate, TSAN-sensitive): multiple threads stress read the same
+// sub-file through independent clones. If FSIndexInput::_this_lock or
+// SharedHandle::_shared_lock were still required on the read path, removing
+// them would surface as TSAN data races here or as corrupted reads.
+TEST_F(DorisCompoundReaderTest, ConcurrentReadStressAcrossClones) {
+    std::string index_path = kTestDir + "/tc_p0_6_1a.idx";
+    std::vector<std::string> names = {"data.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    DorisCompoundReader reader(index_input, 4096, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* source = nullptr;
+    ASSERT_TRUE(reader.openInput("data.dat", source, err, 4096));
+
+    constexpr int kNumThreads = 5;
+    constexpr int kReadsPerThread = 500;
+    constexpr int kChunkSize = 1024;
+
+    std::vector<lucene::store::IndexInput*> clones(kNumThreads, nullptr);
+    for (int i = 0; i < kNumThreads; ++i) {
+        clones[i] = source->clone();
+        ASSERT_NE(clones[i], nullptr);
+    }
+
+    std::atomic<int> mismatches {0};
+    std::atomic<int> exceptions {0};
+    std::vector<std::thread> threads;
+    for (int t = 0; t < kNumThreads; ++t) {
+        threads.emplace_back([t, in = clones[t], &mismatches, &exceptions]() {
+            doris::ThreadLocalHandle::create_thread_local_if_not_exits();
+            std::vector<uint8_t> buf(kChunkSize);
+            for (int i = 0; i < kReadsPerThread; ++i) {
+                int64_t off = ((t * 97 + i * 31) * 251) % (16 * 1024 * 1024 - kChunkSize);
+                try {
+                    in->seek(off);
+                    in->readBytes(buf.data(), kChunkSize);
+                } catch (const CLuceneError&) {
+                    exceptions.fetch_add(1);
+                    continue;
+                }
+                for (uint8_t c : buf) {
+                    if (c != 'Z') {
+                        mismatches.fetch_add(1);
+                        break;
+                    }
+                }
+            }
+            doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
+        });
+    }
+    for (auto& th : threads) th.join();
+
+    EXPECT_EQ(mismatches.load(), 0);
+    EXPECT_EQ(exceptions.load(), 0);
+
+    for (auto* c : clones) _CLLDELETE(c);
+    _CLLDELETE(source);
+    reader.close();
+}
+
+// TC-P0-6-4: BufferedIndexInput buffer-boundary behavior. Two clones reading
+// from different offsets must each refill their own (per-instance) buffer
+// without cross-contamination.
+TEST_F(DorisCompoundReaderTest, ClonesRefillBuffersIndependently) {
+    std::string index_path = kTestDir + "/tc_p0_6_4.idx";
+    std::vector<std::string> names = {"data.dat"};
+    std::vector<int64_t> lens = {17 * 1024 * 1024};
+    auto* index_input = create_mock_index_input(index_path, names, lens);
+    // Use a small buffer so the refill path is exercised many times.
+    DorisCompoundReader reader(index_input, 1024, nullptr);
+
+    CLuceneError err;
+    lucene::store::IndexInput* a = nullptr;
+    ASSERT_TRUE(reader.openInput("data.dat", a, err, 1024));
+    auto* b = a->clone();
+
+    // A reads linearly from offset 0; B reads linearly from a staggered offset
+    // that is not buffer-aligned. Interleave reads so each instance crosses
+    // its own buffer boundary multiple times.
+    int64_t a_off = 0;
+    int64_t b_off = 3003;
+    for (int i = 0; i < 64; ++i) {
+        uint8_t abuf[512] = {0};
+        uint8_t bbuf[777] = {0}; // odd size to avoid alignment
+        a->seek(a_off);
+        a->readBytes(abuf, static_cast<int32_t>(sizeof(abuf)));
+        b->seek(b_off);
+        b->readBytes(bbuf, static_cast<int32_t>(sizeof(bbuf)));
+        for (uint8_t c : abuf) ASSERT_EQ(c, 'Z');
+        for (uint8_t c : bbuf) ASSERT_EQ(c, 'Z');
+        a_off += sizeof(abuf);
+        b_off += sizeof(bbuf);
+    }
+
+    _CLLDELETE(a);
+    _CLLDELETE(b);
     reader.close();
 }
 

--- a/be/test/storage/segment/inverted_index_fs_directory_test.cpp
+++ b/be/test/storage/segment/inverted_index_fs_directory_test.cpp
@@ -19,14 +19,18 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <thread>
+#include <vector>
 
 #include "common/config.h"
 #include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
+#include "runtime/thread_context.h"
 #include "testutil/test_util.h"
 #include "util/debug_points.h"
 
@@ -255,7 +259,9 @@ TEST_F(DorisFSDirectoryTest, FSIndexInputReadInternalWithReadError) {
             "DorisFSDirectory::FSIndexInput::readInternal_reader_read_at_error");
 
     uint8_t buffer[10];
+    int64_t original_pos = input->getFilePointer();
     EXPECT_THROW(input->readBytes(buffer, 10), CLuceneError);
+    EXPECT_EQ(input->getFilePointer(), original_pos);
 
     DebugPoints::instance()->remove(
             "DorisFSDirectory::FSIndexInput::readInternal_reader_read_at_error");
@@ -714,6 +720,207 @@ TEST_F(DorisFSDirectoryTest, FSIndexInputCopyConstructorWithNullHandle) {
 
     _CLDELETE(cloned_input);
     _CLDELETE(input);
+}
+
+// Regression for the IOContext leak: if the source FSIndexInput had per-query
+// stats pointers set (e.g. the root `_stream` carries the caller's
+// `file_cache_stats` during InvertedIndexReader::handle_searcher_cache()),
+// clones produced later (e.g. one per sub-file inside a cached searcher) must
+// NOT inherit those raw pointers. Otherwise a later query hitting the cache
+// would write into the original query's already-freed stats.
+TEST_F(DorisFSDirectoryTest, FSIndexInputCloneDoesNotInheritPerQueryIoCtx) {
+    std::filesystem::path test_file = _tmp_dir / "test_file_ioctx_leak";
+    {
+        std::ofstream ofs(test_file);
+        ofs << "0123456789";
+    }
+
+    lucene::store::IndexInput* src = nullptr;
+    CLuceneError error;
+    ASSERT_TRUE(DorisFSDirectory::FSIndexInput::open(_fs, test_file.string().c_str(), src, error));
+    ASSERT_NE(src, nullptr);
+
+    // Simulate the pre-searcher-build state: inject per-query stats + query_id
+    // via setIoContext(), the same way DorisCompoundReader::initialize() does
+    // for the root stream.
+    io::FileCacheStatistics q1_stats {};
+    TUniqueId q1_id;
+    q1_id.__set_hi(0xdeadbeef);
+    q1_id.__set_lo(0xcafef00d);
+    io::IOContext q1_ctx;
+    q1_ctx.query_id = &q1_id;
+    q1_ctx.file_cache_stats = &q1_stats;
+    q1_ctx.is_inverted_index = true;
+    src->setIoContext(&q1_ctx);
+
+    // Clone the stream as DorisCompoundReader::openInput() does per sub-file.
+    auto* clone = src->clone();
+    ASSERT_NE(clone, nullptr);
+    auto* clone_fs = dynamic_cast<DorisFSDirectory::FSIndexInput*>(clone);
+    ASSERT_NE(clone_fs, nullptr);
+
+    // The clone's IOContext must be clean: no dangling query_id / stats refs,
+    // only the structural `is_inverted_index` flag retained.
+    const auto* clone_ctx = static_cast<const io::IOContext*>(clone_fs->getIoContext());
+    EXPECT_EQ(clone_ctx->query_id, nullptr);
+    EXPECT_EQ(clone_ctx->file_cache_stats, nullptr);
+    EXPECT_EQ(clone_ctx->file_reader_stats, nullptr);
+    EXPECT_TRUE(clone_ctx->is_inverted_index);
+
+    _CLDELETE(clone);
+    _CLDELETE(src);
+}
+
+TEST_F(DorisFSDirectoryTest, FSIndexInputClonePreservesCurrentPosition) {
+    std::filesystem::path test_file = _tmp_dir / "test_file_clone_pos";
+    std::ofstream ofs(test_file);
+    ofs << "0123456789abcdef";
+    ofs.close();
+
+    lucene::store::IndexInput* input = nullptr;
+    CLuceneError error;
+    ASSERT_TRUE(
+            DorisFSDirectory::FSIndexInput::open(_fs, test_file.string().c_str(), input, error));
+    ASSERT_NE(input, nullptr);
+
+    input->seek(5);
+    uint8_t consumed = 0;
+    input->readBytes(&consumed, 1);
+    EXPECT_EQ(consumed, '5');
+    EXPECT_EQ(input->getFilePointer(), 6);
+
+    auto* cloned_input = input->clone();
+    ASSERT_NE(cloned_input, nullptr);
+    EXPECT_EQ(cloned_input->getFilePointer(), input->getFilePointer());
+
+    uint8_t next_byte = 0;
+    cloned_input->readBytes(&next_byte, 1);
+    EXPECT_EQ(next_byte, '6');
+    EXPECT_EQ(input->getFilePointer(), 6);
+
+    _CLDELETE(cloned_input);
+    _CLDELETE(input);
+}
+
+// TC-P1-1-2: 4 per-thread clones reading different offsets of the same file
+// concurrently. Validates that after removing `_shared_lock`, pread through
+// `_handle->_reader` is still race-free (pread is stateless). This is the
+// functional proof that §3-A "different clones sharing the same _handle is
+// safe" holds in practice.
+TEST_F(DorisFSDirectoryTest, FSIndexInputConcurrentReadAcrossClones) {
+    // Build a file whose byte at offset i equals (i % 251). 251 is prime so
+    // there is no trivial pattern aliasing a buffer-size boundary.
+    constexpr int kFileSize = 64 * 1024;
+    std::filesystem::path test_file = _tmp_dir / "test_file_concurrent_clones";
+    {
+        std::ofstream ofs(test_file, std::ios::binary);
+        for (int i = 0; i < kFileSize; ++i) {
+            ofs.put(static_cast<char>(i % 251));
+        }
+    }
+
+    lucene::store::IndexInput* source = nullptr;
+    CLuceneError error;
+    ASSERT_TRUE(
+            DorisFSDirectory::FSIndexInput::open(_fs, test_file.string().c_str(), source, error));
+    ASSERT_NE(source, nullptr);
+
+    constexpr int kNumThreads = 4;
+    constexpr int kReadsPerThread = 200;
+    constexpr int kChunkSize = 128;
+
+    // Clone per thread BEFORE spawning. §3-A contract: clone() on the source
+    // is done serially, threads then use their own clones independently.
+    std::vector<lucene::store::IndexInput*> clones(kNumThreads, nullptr);
+    for (int i = 0; i < kNumThreads; ++i) {
+        clones[i] = source->clone();
+        ASSERT_NE(clones[i], nullptr);
+    }
+
+    std::atomic<int> mismatches {0};
+    std::atomic<int> exceptions {0};
+    std::vector<std::thread> threads;
+    threads.reserve(kNumThreads);
+    for (int tid = 0; tid < kNumThreads; ++tid) {
+        threads.emplace_back([&, tid]() {
+            doris::ThreadLocalHandle::create_thread_local_if_not_exits();
+            auto* in = clones[tid];
+            std::vector<uint8_t> buf(kChunkSize);
+            for (int i = 0; i < kReadsPerThread; ++i) {
+                // Pseudo-random offset that stays inside the file.
+                int64_t off = ((static_cast<int64_t>(tid) * 37 + i * 13) * 251) %
+                              (kFileSize - kChunkSize);
+                try {
+                    in->seek(off);
+                    in->readBytes(buf.data(), kChunkSize);
+                } catch (const CLuceneError&) {
+                    exceptions.fetch_add(1);
+                    continue;
+                }
+                for (int k = 0; k < kChunkSize; ++k) {
+                    if (buf[k] != static_cast<uint8_t>((off + k) % 251)) {
+                        mismatches.fetch_add(1);
+                        break;
+                    }
+                }
+            }
+            doris::ThreadLocalHandle::del_thread_local_if_count_is_zero();
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(mismatches.load(), 0);
+    EXPECT_EQ(exceptions.load(), 0);
+
+    for (auto* c : clones) {
+        _CLDELETE(c);
+    }
+    _CLDELETE(source);
+}
+
+// TC-P1-3-3: shared_ptr refcount across a chain of clones. Validates that
+// destroying the source does not invalidate the underlying file handle for
+// the surviving clones (SharedHandle is shared_ptr-managed).
+TEST_F(DorisFSDirectoryTest, FSIndexInputCloneChainOutlivesSource) {
+    std::filesystem::path test_file = _tmp_dir / "test_file_clone_chain";
+    {
+        std::ofstream ofs(test_file);
+        ofs << "0123456789abcdef";
+    }
+
+    lucene::store::IndexInput* a = nullptr;
+    CLuceneError error;
+    ASSERT_TRUE(DorisFSDirectory::FSIndexInput::open(_fs, test_file.string().c_str(), a, error));
+    ASSERT_NE(a, nullptr);
+
+    auto* b = a->clone();
+    ASSERT_NE(b, nullptr);
+    auto* c = b->clone();
+    ASSERT_NE(c, nullptr);
+
+    // Destroy the original ("grandparent") first; b and c must still work.
+    _CLDELETE(a);
+
+    b->seek(4);
+    uint8_t bbuf[3] = {0, 0, 0};
+    b->readBytes(bbuf, 3);
+    EXPECT_EQ(bbuf[0], '4');
+    EXPECT_EQ(bbuf[1], '5');
+    EXPECT_EQ(bbuf[2], '6');
+
+    // Destroy the middle clone; c (grandchild) must still work.
+    _CLDELETE(b);
+
+    c->seek(10);
+    uint8_t cbuf[3] = {0, 0, 0};
+    c->readBytes(cbuf, 3);
+    EXPECT_EQ(cbuf[0], 'a');
+    EXPECT_EQ(cbuf[1], 'b');
+    EXPECT_EQ(cbuf[2], 'c');
+
+    _CLDELETE(c);
 }
 
 // Test 44: FSIndexOutput flushBuffer error


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

The CLucene-facing wrapper readers in the inverted-index store (`CSIndexInput`, `FSIndexInput`) serialize every `read_at` through a per-input mutex (`_this_lock`) plus a shared position cursor (`_fpos` / `_shared_lock`). When a cached `IndexSearcher` is reused across concurrent queries, all reads on the same sub-file queue up behind that single lock, severely limiting throughput on multi-threaded scans (observed as contention between sibling `IndexSearcher` reuses and between clones of the same `FSIndexInput`).

This PR removes the wrapper-level lock and moves to per-input deep clones with private state, so sibling readers on the same compound file or the same segment file no longer contend:

- `CSIndexInput` base: deep-clone the underlying `IndexInput` and own it via `std::unique_ptr` (with a CLucene `_CLDELETE`-aware deleter). Drop `_this_lock` from the read path.
- `FSIndexInput::read_at` runs without the wrapper lock; the clone cursor is preserved via a new `SharedHandle` indirection. `_this_lock` / `_shared_lock` / `_fpos` are removed. `SharedHandle::_shared_lock` is re-added under `!USE_HADOOP_HDFS` to keep the non-Hadoop HDFS path safe.
- `FSIndexInput::clone` no longer inherits the creating query's per-query `IOContext`, matching the `MATCH` path and preventing use-after-free when the cached `IndexSearcher` is reused from a different query.

### Release note

BE: Remove the per-input wrapper lock on inverted index `CSIndexInput` / `FSIndexInput` so concurrent queries no longer serialize behind a single mutex when a cached `IndexSearcher` is reused. Also fixes a use-after-free where `FSIndexInput::clone` inherited the creating query's `IOContext`.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  New unit tests, all passing under ASAN (`BUILD_TYPE_UT=ASAN`, `./run-be-ut.sh --run --filter='DorisCompoundReaderTest.*:DorisFSDirectoryTest.*:CollectionStatisticsTest.*'` — 91 tests, 91 passed):

    - Deep-clone independence / data correctness / lifecycle / multi-level clone chain: `DorisCompoundReaderTest.CSIndexInputCloneIsIndependent`, `CSIndexInputCloneReadsCorrectly`, `CSIndexInputCloneOutlivesSource`, `CSIndexInputCloneChainIsIndependent`, `CloneReturnsDistinctUsableInput`.
    - Concurrent read across sibling `CSIndexInput`s and across clone chains: `ConcurrentReadAcrossSubFiles`, `ConcurrentReadStressAcrossClones`, `FSIndexInputConcurrentReadAcrossClones`, `FSIndexInputCloneChainOutlivesSource`.
    - Buffer-boundary behavior: `ClonesRefillBuffersIndependently`, `OpenInputProducesIndependentBases`.
    - `CollectionStatisticsTest` callers adjusted to pass the `io_ctx` argument.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Concurrent scans that share a cached `IndexSearcher` no longer serialize behind `_this_lock`; throughput on multi-threaded inverted-index reads improves. Functional behavior of individual reads is unchanged.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.