### PR TITLE
branch-4.0: [feature](be) Support hot reload for file cache microbench config (pick#58922)

### DIFF
--- a/be/src/http/action/file_cache_action.cpp
+++ b/be/src/http/action/file_cache_action.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 #include "common/status.h"
@@ -56,6 +57,7 @@ constexpr static std::string_view BASE_PATH = "base_path";
 constexpr static std::string_view RELEASED_ELEMENTS = "released_elements";
 constexpr static std::string_view DUMP = "dump";
 constexpr static std::string_view VALUE = "value";
+constexpr static std::string_view RELOAD = "reload";
 
 Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metrics) {
     const std::string header_json(HEADER_JSON);
@@ -136,6 +138,41 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
         }
     } else if (operation == DUMP) {
         io::FileCacheFactory::instance()->dump_all_caches();
+    } else if (operation == RELOAD) {
+#ifdef BE_TEST
+        std::string doris_home = getenv("DORIS_HOME");
+        std::string conffile = std::string(doris_home) + "/conf/be.conf";
+        if (!doris::config::init(conffile.c_str(), true, true, true)) {
+            return Status::InternalError("Error reading config file");
+        }
+
+        std::string custom_conffile = doris::config::custom_config_dir + "/be_custom.conf";
+        if (!doris::config::init(custom_conffile.c_str(), true, false, false)) {
+            return Status::InternalError("Error reading custom config file");
+        }
+
+        if (!doris::config::enable_file_cache) {
+            return Status::InternalError("config::enbale_file_cache should be true!");
+        }
+
+        std::unordered_set<std::string> cache_path_set;
+        std::vector<doris::CachePath> cache_paths;
+        RETURN_IF_ERROR(doris::parse_conf_cache_paths(doris::config::file_cache_path, cache_paths));
+
+        std::vector<CachePath> cache_paths_no_dup;
+        cache_paths_no_dup.reserve(cache_paths.size());
+        for (const auto& cache_path : cache_paths) {
+            if (cache_path_set.contains(cache_path.path)) {
+                LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
+                continue;
+            }
+            cache_path_set.emplace(cache_path.path);
+            cache_paths_no_dup.emplace_back(cache_path);
+        }
+        RETURN_IF_ERROR(doris::io::FileCacheFactory::instance()->reload_file_cache(cache_paths));
+#else
+        return Status::InternalError("Do not use reload in production environment!!!!");
+#endif
     } else {
         st = Status::InternalError("invalid operation: {}", operation);
     }

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -121,6 +121,42 @@ Status FileCacheFactory::create_file_cache(const std::string& cache_base_path,
     return Status::OK();
 }
 
+Status FileCacheFactory::reload_file_cache(const std::vector<CachePath>& cache_base_paths) {
+    {
+        std::unique_lock lock(_mtx);
+        for (const auto& cache_path : cache_base_paths) {
+            if (_path_to_cache.find(cache_path.path) == _path_to_cache.end()) {
+                return Status::InternalError(
+                        "Current file cache not support file cache num changes");
+            }
+        }
+
+        for (const auto& cache_path : cache_base_paths) {
+            auto cache_map_iter = _path_to_cache.find(cache_path.path);
+            auto cache_iter = std::find_if(_caches.begin(), _caches.end(),
+                                           [cache_map_iter](const auto& cache_uptr) {
+                                               return cache_uptr.get() == cache_map_iter->second;
+                                           });
+
+            if (cache_iter == _caches.end()) {
+                return Status::InternalError("Target relaod cache in path {} may has been released",
+                                             cache_path.path);
+            }
+
+            // deconstruct target reload first
+            *cache_iter = std::unique_ptr<BlockFileCache>();
+            // after deconstruct the BlockFileCache, construct the BlockFileCache again
+            *cache_iter =
+                    std::make_unique<BlockFileCache>(cache_path.path, cache_path.init_settings());
+            cache_map_iter->second = cache_iter->get();
+
+            RETURN_IF_ERROR(cache_iter->get()->initialize());
+        }
+    }
+
+    return Status::OK();
+}
+
 std::vector<doris::CacheBlockPB> FileCacheFactory::get_cache_data_by_path(const std::string& path) {
     auto cache_hash = BlockFileCache::hash(path);
     return get_cache_data_by_path(cache_hash);

--- a/be/src/io/cache/block_file_cache_factory.h
+++ b/be/src/io/cache/block_file_cache_factory.h
@@ -30,6 +30,7 @@
 #include "gen_cpp/internal_service.pb.h"
 #include "io/cache/block_file_cache.h"
 #include "io/cache/file_cache_common.h"
+#include "olap/options.h"
 namespace doris {
 class TUniqueId;
 
@@ -48,6 +49,8 @@ public:
 
     Status create_file_cache(const std::string& cache_base_path,
                              FileCacheSettings file_cache_settings);
+
+    Status reload_file_cache(const std::vector<CachePath>& cache_base_paths);
 
     size_t try_release();
 

--- a/be/src/io/tools/file_cache_microbench.cpp
+++ b/be/src/io/tools/file_cache_microbench.cpp
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#include "io/cache/file_cache_common.h"
 #if defined(BE_TEST) && defined(BUILD_FILE_CACHE_MICROBENCH_TOOL)
 #include <brpc/controller.h>
 #include <brpc/http_status_code.h>
@@ -23,6 +24,7 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -39,6 +41,7 @@
 #include <string>
 #include <thread>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "build/proto/microbench.pb.h"
@@ -274,7 +277,7 @@ public:
         for (const auto& pair : records_) {
             const std::vector<FileInfo>& file_infos = pair.second;
             for (const auto& file_info : file_infos) {
-                if (file_info.filename.compare(0, file_prefix.length(), file_prefix) == 0) {
+                if (file_info.filename.starts_with(file_prefix)) {
                     if (file_number == -1 || result.size() < file_number) {
                         result.push_back(file_info.filename);
                     }
@@ -291,7 +294,7 @@ public:
         for (const auto& pair : records_) {
             const std::vector<FileInfo>& file_infos = pair.second;
             for (const auto& file_info : file_infos) {
-                if (file_info.filename.compare(0, file_prefix.length(), file_prefix) == 0) {
+                if (file_info.filename.starts_with(file_prefix)) {
                     return pair.first;
                 }
             }
@@ -313,7 +316,7 @@ public:
                            const std::string& bucket, const std::string& key,
                            const doris::io::FileWriterOptions* options,
                            std::shared_ptr<doris::S3RateLimiterHolder> rate_limiter)
-            : _writer(client, bucket, key, options), _rate_limiter(rate_limiter) {}
+            : _writer(client, bucket, key, options), _rate_limiter(std::move(rate_limiter)) {}
 
     doris::Status appendv(const doris::Slice* slices, size_t slices_size,
                           const std::shared_ptr<bvar::LatencyRecorder>& write_bvar) {
@@ -339,7 +342,7 @@ class MicrobenchFileReader {
 public:
     MicrobenchFileReader(std::shared_ptr<doris::io::FileReader> base_reader,
                          std::shared_ptr<doris::S3RateLimiterHolder> rate_limiter)
-            : _base_reader(std::move(base_reader)), _rate_limiter(rate_limiter) {}
+            : _base_reader(std::move(base_reader)), _rate_limiter(std::move(rate_limiter)) {}
 
     doris::Status read_at(size_t offset, const doris::Slice& result, size_t* bytes_read,
                           const doris::io::IOContext* io_ctx,
@@ -850,10 +853,284 @@ private:
     }
 };
 
-// Job manager
+namespace microbenchService {
+class JobManager;
+
+class BenchEnvManager : public std::enable_shared_from_this<BenchEnvManager> {
+public:
+    BenchEnvManager(std::string_view doris_home) : _doris_home(doris_home) {}
+
+    ~BenchEnvManager() { stop_reload_worker(); }
+
+    doris::Status load_config() {
+        std::string conffile = std::string(_doris_home) + "/conf/be.conf";
+        if (!doris::config::init(conffile.c_str(), true, true, true)) {
+            return Status::InternalError("Error reading config file");
+        }
+
+        std::string custom_conffile = doris::config::custom_config_dir + "/be_custom.conf";
+        if (!doris::config::init(custom_conffile.c_str(), true, false, false)) {
+            return Status::InternalError("Error reading custom config file");
+        }
+
+        if (!doris::config::enable_file_cache) {
+            return Status::InternalError("config::enbale_file_cache should be true!");
+        }
+
+        config::group_commit_wal_max_disk_limit = "100M";
+        LOG(INFO) << "Obj config. ak=" << doris::config::test_s3_ak
+                  << " sk=" << doris::config::test_s3_sk
+                  << " region=" << doris::config::test_s3_region
+                  << " endpoint=" << doris::config::test_s3_endpoint
+                  << " bucket=" << doris::config::test_s3_bucket;
+
+        LOG(INFO) << "File cache config. enable_file_cache=" << doris::config::enable_file_cache
+                  << " file_cache_path=" << doris::config::file_cache_path
+                  << " file_cache_each_block_size=" << doris::config::file_cache_each_block_size
+                  << " clear_file_cache=" << doris::config::clear_file_cache
+                  << " enable_file_cache_query_limit="
+                  << doris::config::enable_file_cache_query_limit
+                  << " file_cache_enter_disk_resource_limit_mode_percent="
+                  << doris::config::file_cache_enter_disk_resource_limit_mode_percent
+                  << " file_cache_exit_disk_resource_limit_mode_percent="
+                  << doris::config::file_cache_exit_disk_resource_limit_mode_percent
+                  << " enable_read_cache_file_directly="
+                  << doris::config::enable_read_cache_file_directly
+                  << " file_cache_enable_evict_from_other_queue_by_size="
+                  << doris::config::file_cache_enable_evict_from_other_queue_by_size
+                  << " file_cache_error_log_limit_bytes="
+                  << doris::config::file_cache_error_log_limit_bytes
+                  << " cache_lock_wait_long_tail_threshold_us="
+                  << doris::config::cache_lock_wait_long_tail_threshold_us
+                  << " cache_lock_held_long_tail_threshold_us="
+                  << doris::config::cache_lock_held_long_tail_threshold_us
+                  << " file_cache_remove_block_qps_limit="
+                  << doris::config::file_cache_remove_block_qps_limit
+                  << " enable_evict_file_cache_in_advance="
+                  << doris::config::enable_evict_file_cache_in_advance
+                  << " file_cache_enter_need_evict_cache_in_advance_percent="
+                  << doris::config::file_cache_enter_need_evict_cache_in_advance_percent
+                  << " file_cache_exit_need_evict_cache_in_advance_percent="
+                  << doris::config::file_cache_exit_need_evict_cache_in_advance_percent
+                  << " file_cache_evict_in_advance_interval_ms="
+                  << doris::config::file_cache_evict_in_advance_interval_ms
+                  << " file_cache_evict_in_advance_batch_bytes="
+                  << doris::config::file_cache_evict_in_advance_batch_bytes;
+
+        LOG(INFO) << "S3 writer config. s3_file_writer_log_interval_second="
+                  << doris::config::s3_file_writer_log_interval_second
+                  << " s3_write_buffer_size=" << doris::config::s3_write_buffer_size
+                  << " enable_flush_file_cache_async="
+                  << doris::config::enable_flush_file_cache_async;
+
+        return Status::OK();
+    }
+
+    doris::Status load_bench_exec_env() {
+        SCOPED_INIT_THREAD_CONTEXT();
+
+        doris::CpuInfo::init();
+        doris::DiskInfo::init();
+        doris::MemInfo::init();
+
+        LOG(INFO) << doris::CpuInfo::debug_string();
+        LOG(INFO) << doris::DiskInfo::debug_string();
+        LOG(INFO) << doris::MemInfo::debug_string();
+
+        std::vector<doris::StorePath> paths;
+        auto olap_res = doris::parse_conf_store_paths(doris::config::storage_root_path, &paths);
+        if (!olap_res) {
+            LOG(ERROR) << "parse config storage path failed, path="
+                       << doris::config::storage_root_path;
+            exit(-1);
+        }
+
+        std::vector<doris::StorePath> spill_paths;
+        if (doris::config::spill_storage_root_path.empty()) {
+            doris::config::spill_storage_root_path = doris::config::storage_root_path;
+        }
+        olap_res =
+                doris::parse_conf_store_paths(doris::config::spill_storage_root_path, &spill_paths);
+        if (!olap_res) {
+            LOG(ERROR) << "parse config spill storage path failed, path="
+                       << doris::config::spill_storage_root_path;
+            exit(-1);
+        }
+        std::set<std::string> broken_paths;
+        doris::parse_conf_broken_store_paths(doris::config::broken_storage_path, &broken_paths);
+
+        auto it = paths.begin();
+        for (; it != paths.end();) {
+            if (broken_paths.contains(it->path)) {
+                if (doris::config::ignore_broken_disk) {
+                    LOG(WARNING) << "ignore broken disk, path = " << it->path;
+                    it = paths.erase(it);
+                } else {
+                    LOG(ERROR) << "a broken disk is found " << it->path;
+                    exit(-1);
+                }
+            } else if (!doris::check_datapath_rw(it->path)) {
+                if (doris::config::ignore_broken_disk) {
+                    LOG(WARNING) << "read write test file failed, path=" << it->path;
+                    it = paths.erase(it);
+                } else {
+                    LOG(ERROR) << "read write test file failed, path=" << it->path;
+                    // if only one disk and the disk is full, also need exit because rocksdb will open failed
+                    exit(-1);
+                }
+            } else {
+                ++it;
+            }
+        }
+
+        if (paths.empty()) {
+            LOG(ERROR) << "All disks are broken, exit.";
+            exit(-1);
+        }
+
+        it = spill_paths.begin();
+        for (; it != spill_paths.end();) {
+            if (!doris::check_datapath_rw(it->path)) {
+                if (doris::config::ignore_broken_disk) {
+                    LOG(WARNING) << "read write test file failed, path=" << it->path;
+                    it = spill_paths.erase(it);
+                } else {
+                    LOG(ERROR) << "read write test file failed, path=" << it->path;
+                    exit(-1);
+                }
+            } else {
+                ++it;
+            }
+        }
+        if (spill_paths.empty()) {
+            LOG(ERROR) << "All spill disks are broken, exit.";
+            exit(-1);
+        }
+
+        auto* exec_env = doris::ExecEnv::GetInstance();
+        auto status = doris::ExecEnv::init(exec_env, paths, spill_paths, broken_paths);
+        if (!status.ok()) {
+            return status;
+        }
+
+        std::unique_ptr<doris::ThreadPool> s3_upload_pool;
+        static_cast<void>(doris::ThreadPoolBuilder("MicrobenchS3FileUploadThreadPool")
+                                  .set_min_threads(256)
+                                  .set_max_threads(512)
+                                  .build(&s3_upload_pool));
+        exec_env->set_s3_file_upload_thread_pool(std::move(s3_upload_pool));
+        exec_env->set_file_cache_open_fd_cache(std::make_unique<doris::io::FDCache>());
+        return Status::OK();
+    }
+
+    doris::Status reload_cache_in_config() {
+        std::unordered_set<std::string> cache_path_set;
+        std::vector<doris::CachePath> cache_paths;
+        RETURN_IF_ERROR(doris::parse_conf_cache_paths(doris::config::file_cache_path, cache_paths));
+
+        std::vector<CachePath> cache_paths_no_dup;
+        cache_paths_no_dup.reserve(cache_paths.size());
+        for (const auto& cache_path : cache_paths) {
+            if (cache_path_set.contains(cache_path.path)) {
+                LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
+                continue;
+            }
+            cache_path_set.emplace(cache_path.path);
+            cache_paths_no_dup.emplace_back(cache_path);
+        }
+        RETURN_IF_ERROR(doris::io::FileCacheFactory::instance()->reload_file_cache(cache_paths));
+        return Status::OK();
+    }
+
+    std::unique_ptr<JobManager> create_job_manager_from_current_config() {
+        return std::make_unique<JobManager>(shared_from_this());
+    }
+
+    void start_reload_worker() {
+        std::lock_guard<std::mutex> lock(_reload_mt);
+        if (_reload_thread.joinable()) {
+            return;
+        }
+
+        _reloading.store(false);
+        _stop_thread = false;
+        _reload_thread = std::thread(&BenchEnvManager::_reload_worker_func, this);
+        LOG(INFO) << "Reload worker thread started";
+    }
+
+    void stop_reload_worker() {
+        {
+            std::unique_lock<std::mutex> lock(_reload_mt);
+            if (_stop_thread) {
+                return;
+            }
+
+            _stop_thread = true;
+            _reload_cv.notify_all();
+        }
+        if (_reload_thread.joinable()) {
+            _reload_thread.join();
+        }
+    }
+
+    void reload_request() {
+        _reloading.store(true);
+        _reload_cv.notify_one();
+    }
+
+    std::string reload_details_stat() {
+        return _reloading.load() ? "Reloading config" : "Reload finished or not started";
+    }
+
+private:
+    void _reload_worker_func() {
+        while (true) {
+            std::unique_lock<std::mutex> l(_reload_mt);
+            // Wait until stopped or safe to reload (State == Reloading && JobCount == 0)
+            _reload_cv.wait(l, [this]() { return _stop_thread; });
+
+            if (_stop_thread) {
+                break;
+            }
+
+            LOG(INFO) << "Starting configuration reload sequence...";
+
+            l.unlock();
+
+            doris::Status status;
+            try {
+                status = load_config();
+                if (!status) {
+                    LOG(ERROR) << "Failed to load config!";
+                    throw std::runtime_error(status.to_string().c_str());
+                }
+                status = reload_cache_in_config();
+                if (!status) {
+                    LOG(ERROR) << "Failed to reload file cache!";
+                    throw std::runtime_error(status.to_string().c_str());
+                }
+            } catch (const std::exception& e) {
+                _reloading.store(false);
+                LOG(ERROR) << "Exception during reload: " << e.what();
+            }
+            _reloading.store(false);
+        }
+    }
+
+    std::string _doris_home;
+    std::mutex _reload_mt;
+    std::condition_variable _reload_cv;
+    std::thread _reload_thread;
+    bool _stop_thread {false};
+    std::atomic<bool> _reloading {false};
+};
+
 class JobManager {
 public:
-    JobManager() : _next_job_id(0), _job_executor_pool(std::thread::hardware_concurrency()) {
+    JobManager(std::shared_ptr<BenchEnvManager> env_mgr)
+            : _next_job_id(0),
+              _env_mgr(std::move(env_mgr)),
+              _job_executor_pool(std::thread::hardware_concurrency()) {
         LOG(INFO) << "Initialized JobManager with " << std::thread::hardware_concurrency()
                   << " executor threads";
     }
@@ -932,7 +1209,7 @@ public:
         std::lock_guard<std::mutex> lock(_mutex);
         auto it = _jobs.find(job_id);
         if (it != _jobs.end()) {
-            FileInfo file_info = {key, data_size, job_id};
+            FileInfo file_info = {.filename = key, .data_size = data_size, .job_id = job_id};
             it->second->file_records.push_back(file_info);
             s3_file_records.add_file_info(job_id, file_info);
         } else {
@@ -1048,7 +1325,6 @@ private:
         LOG(INFO) << "Job " << job_id << " execution completed";
     }
 
-private:
     doris::S3ClientConf create_s3_client_conf(const JobConfig& config) {
         doris::S3ClientConf s3_conf;
         s3_conf.max_connections = std::max(256, config.num_threads * 4);
@@ -1197,9 +1473,15 @@ private:
         LOG(INFO) << "job_id = " << job.job_id << " read_files size = " << read_files.size();
 
         read_stopwatch.start();
+        std::vector<std::string> read_buffers(read_files.size());
+
+        for (auto& buffer : read_buffers) {
+            buffer.resize(config.read_length_right);
+        }
+
         for (int i = 0; i < read_files.size(); ++i) {
             const auto& key = read_files[i];
-            read_futures.push_back(read_pool.enqueue([&, key]() {
+            read_futures.push_back(read_pool.enqueue([&, &buffer = read_buffers[i], key]() {
                 try {
                     if (job.completion_tracker) {
                         job.completion_tracker->wait_for_completion(
@@ -1242,16 +1524,16 @@ private:
                             std::this_thread::sleep_for(std::chrono::seconds(1));
                             continue;
                         }
+                        auto reader = std::make_unique<MicrobenchFileReader>(
+                                status_or_reader.value(), job.read_limiter);
 
-                        for (int i = 0; i < config.repeat; i++) {
-                            auto reader = std::make_unique<MicrobenchFileReader>(
-                                    status_or_reader.value(), job.read_limiter);
-                            doris::Defer defer {[&]() {
-                                if (auto status = reader->close(); !status.ok()) {
-                                    LOG(ERROR) << "close file reader failed" << status.to_string();
-                                }
-                            }};
+                        doris::Defer defer {[&]() {
+                            if (auto status = reader->close(); !status.ok()) {
+                                LOG(ERROR) << "close file reader failed" << status.to_string();
+                            }
+                        }};
 
+                        for (int j = 0; j < config.repeat; j++) {
                             size_t read_offset = 0;
                             size_t read_length = 0;
 
@@ -1261,12 +1543,10 @@ private:
                             }
                             if (exist_job_perfile_size != -1) {
                                 // read exist files
-                                if (config.read_offset_right > exist_job_perfile_size) {
-                                    config.read_offset_right = exist_job_perfile_size;
-                                }
-                                if (config.read_length_right > exist_job_perfile_size) {
-                                    config.read_length_right = exist_job_perfile_size;
-                                }
+                                config.read_offset_right =
+                                        std::min(config.read_offset_right, exist_job_perfile_size);
+                                config.read_length_right =
+                                        std::min(config.read_length_right, exist_job_perfile_size);
 
                                 if (use_random) {
                                     std::random_device rd;
@@ -1301,16 +1581,13 @@ private:
                             CHECK(read_length >= 0)
                                     << "Calculated read_length is negative: " << read_length;
 
-                            std::string read_buffer;
-                            read_buffer.resize(read_length);
-
                             size_t total_bytes_read = 0;
                             while (total_bytes_read < read_length) {
                                 size_t bytes_to_read = std::min(
                                         read_length - total_bytes_read,
                                         static_cast<size_t>(4 * 1024 * 1024)); // 4MB chunks
 
-                                doris::Slice read_slice(read_buffer.data() + total_bytes_read,
+                                doris::Slice read_slice(buffer.data() + total_bytes_read,
                                                         bytes_to_read);
                                 size_t bytes_read = 0;
 
@@ -1339,7 +1616,7 @@ private:
                             }
 
                             // Verify read data
-                            if (!DataVerifier::verify_data(key, file_size, read_offset, read_buffer,
+                            if (!DataVerifier::verify_data(key, file_size, read_offset, buffer,
                                                            read_length)) {
                                 throw std::runtime_error("Data verification failed for key: " +
                                                          key);
@@ -1400,15 +1677,107 @@ private:
     std::mutex _mutex;
     std::atomic<int> _next_job_id;
     std::map<std::string, std::shared_ptr<Job>> _jobs;
+    std::shared_ptr<BenchEnvManager> _env_mgr;
     BenchThreadPool _job_executor_pool;
 };
 
-namespace microbenchService {
-
 class MicrobenchServiceImpl : public microbench::MicrobenchService {
 public:
-    MicrobenchServiceImpl(JobManager& job_manager) : _job_manager(job_manager) {}
-    virtual ~MicrobenchServiceImpl() {}
+    MicrobenchServiceImpl(std::string_view doris_home_path)
+            : _bench_env_mgr(std::make_shared<BenchEnvManager>(doris_home_path)) {}
+
+    ~MicrobenchServiceImpl() override {
+        if (_job_manager) {
+            _job_manager->stop();
+        }
+        if (_bench_env_mgr) {
+            _bench_env_mgr->stop_reload_worker();
+        }
+    }
+
+    doris::Status init_microbench_service() {
+        auto status = _bench_env_mgr->load_config();
+        if (!status) {
+            return status;
+        }
+
+        status = _bench_env_mgr->load_bench_exec_env();
+        if (!status) {
+            return status;
+        }
+        _job_manager = _bench_env_mgr->create_job_manager_from_current_config();
+        _bench_env_mgr->start_reload_worker();
+
+        return Status::OK();
+    }
+
+    void show_reload_status(google::protobuf::RpcController* cntl_base,
+                            const microbench::HttpRequest* request,
+                            microbench::HttpResponse* response,
+                            google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+
+        rapidjson::StringBuffer buffer;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+        writer.StartObject();
+        writer.Key("status");
+        writer.String("OK");
+        writer.Key("ReloadStat");
+
+        writer.String(_bench_env_mgr->reload_details_stat().c_str());
+
+        writer.EndObject();
+
+        cntl->http_response().set_content_type("application/json");
+        cntl->response_attachment().append(buffer.GetString());
+    }
+
+    void reload_config(google::protobuf::RpcController* cntl_base,
+                       const microbench::HttpRequest* request, microbench::HttpResponse* response,
+                       google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+
+        LOG(INFO) << "Hot reload config of microbench service";
+
+        try {
+            LOG(INFO) << "Request reload. May be execute after";
+            _bench_env_mgr->reload_request();
+
+            rapidjson::StringBuffer buffer;
+            rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+            writer.StartObject();
+            writer.Key("status");
+            writer.String("OK");
+            writer.Key("message");
+            writer.String("Reload requested");
+            writer.EndObject();
+            cntl->http_response().set_content_type("application/json");
+            cntl->response_attachment().append(buffer.GetString());
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "Error reloading config job: " << e.what();
+
+            // Set error status code and response
+            cntl->http_response().set_status_code(brpc::HTTP_STATUS_BAD_REQUEST);
+            cntl->http_response().set_content_type("application/json");
+
+            // Build error response
+            rapidjson::Document error_doc;
+            error_doc.SetObject();
+            rapidjson::Document::AllocatorType& allocator = error_doc.GetAllocator();
+            error_doc.AddMember("status", "error", allocator);
+            error_doc.AddMember("message", rapidjson::Value(e.what(), allocator), allocator);
+
+            // Serialize to string
+            rapidjson::StringBuffer buffer;
+            rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+            error_doc.Accept(writer);
+
+            cntl->response_attachment().append(buffer.GetString());
+        }
+    }
 
     /**
      * Submit a job
@@ -1418,7 +1787,7 @@ public:
      */
     void submit_job(google::protobuf::RpcController* cntl_base,
                     const microbench::HttpRequest* request, microbench::HttpResponse* response,
-                    google::protobuf::Closure* done) {
+                    google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
 
@@ -1431,7 +1800,7 @@ public:
 
             LOG(INFO) << "Parsed JobConfig: " << config.to_string();
 
-            std::string job_id = _job_manager.submit_job(config);
+            std::string job_id = _job_manager->submit_job(config);
             LOG(INFO) << "Job submitted successfully with ID: " << job_id;
 
             // Set response headers
@@ -1482,7 +1851,7 @@ public:
      */
     void get_job_status(google::protobuf::RpcController* cntl_base,
                         const microbench::HttpRequest* request, microbench::HttpResponse* response,
-                        google::protobuf::Closure* done) {
+                        google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
 
@@ -1503,7 +1872,7 @@ public:
                   << ", max_files=" << max_files;
 
         try {
-            const Job& job = _job_manager.get_job_status(job_id);
+            const Job& job = _job_manager->get_job_status(job_id);
 
             // Set response headers
             cntl->http_response().set_content_type("application/json");
@@ -1575,14 +1944,14 @@ public:
      */
     void list_jobs(google::protobuf::RpcController* cntl_base,
                    const microbench::HttpRequest* request, microbench::HttpResponse* response,
-                   google::protobuf::Closure* done) {
+                   google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
 
         LOG(INFO) << "Received list_jobs request";
 
         try {
-            std::vector<std::shared_ptr<Job>> jobs = _job_manager.list_jobs();
+            std::vector<std::shared_ptr<Job>> jobs = _job_manager->list_jobs();
 
             // Set response headers
             cntl->http_response().set_content_type("application/json");
@@ -1658,7 +2027,7 @@ public:
      */
     void cancel_job(google::protobuf::RpcController* cntl_base,
                     const microbench::HttpRequest* request, microbench::HttpResponse* response,
-                    google::protobuf::Closure* done) {
+                    google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
 
@@ -1691,7 +2060,7 @@ public:
      */
     void get_help(google::protobuf::RpcController* cntl_base,
                   const microbench::HttpRequest* request, microbench::HttpResponse* response,
-                  google::protobuf::Closure* done) {
+                  google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
 
@@ -1711,7 +2080,8 @@ public:
      */
     void file_cache_clear(google::protobuf::RpcController* cntl_base,
                           const microbench::HttpRequest* request,
-                          microbench::HttpResponse* response, google::protobuf::Closure* done) {
+                          microbench::HttpResponse* response,
+                          google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
 
@@ -1785,7 +2155,8 @@ public:
      */
     void file_cache_reset(google::protobuf::RpcController* cntl_base,
                           const microbench::HttpRequest* request,
-                          microbench::HttpResponse* response, google::protobuf::Closure* done) {
+                          microbench::HttpResponse* response,
+                          google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
         LOG(INFO) << "Received file_cache_reset request";
@@ -1853,7 +2224,8 @@ public:
      */
     void file_cache_release(google::protobuf::RpcController* cntl_base,
                             const microbench::HttpRequest* request,
-                            microbench::HttpResponse* response, google::protobuf::Closure* done) {
+                            microbench::HttpResponse* response,
+                            google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
         LOG(INFO) << "Received file_cache_release request";
@@ -1913,7 +2285,7 @@ public:
      */
     void update_config(google::protobuf::RpcController* cntl_base,
                        const microbench::HttpRequest* request, microbench::HttpResponse* response,
-                       google::protobuf::Closure* done) {
+                       google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
         LOG(INFO) << "Received update_config request";
@@ -1925,8 +2297,8 @@ public:
                 need_persist = true;
             }
             cntl->http_request().uri().RemoveQuery("persist");
-            std::string key = "";
-            std::string value = "";
+            std::string key;
+            std::string value;
             for (brpc::URI::QueryIterator it = cntl->http_request().uri().QueryBegin();
                  it != cntl->http_request().uri().QueryEnd(); ++it) {
                 key = it->first;
@@ -1987,7 +2359,7 @@ public:
      */
     void show_config(google::protobuf::RpcController* cntl_base,
                      const microbench::HttpRequest* request, microbench::HttpResponse* response,
-                     google::protobuf::Closure* done) {
+                     google::protobuf::Closure* done) override {
         brpc::ClosureGuard done_guard(done);
         brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
         LOG(INFO) << "Received show_config request";
@@ -2221,18 +2593,24 @@ private:
         doc.AddMember("file_records_total", static_cast<uint64_t>(file_records.size()), allocator);
     }
 
-    JobManager& _job_manager;
+    std::shared_ptr<BenchEnvManager> _bench_env_mgr;
+    std::unique_ptr<JobManager> _job_manager;
 };
 } // namespace microbenchService
 
 // HTTP server handling
 class HttpServer {
 public:
-    HttpServer(JobManager& job_manager) : _job_manager(job_manager), _server(nullptr) {}
+    HttpServer() = default;
 
-    void start() {
+    void start(std::string_view doris_home_path) {
         _server = new brpc::Server();
-        microbenchService::MicrobenchServiceImpl http_svc(_job_manager);
+        microbenchService::MicrobenchServiceImpl http_svc(doris_home_path);
+        auto status = http_svc.init_microbench_service();
+        if (!status) {
+            LOG(ERROR) << status.to_string();
+            return;
+        }
 
         LOG(INFO) << "Starting HTTP server on port " << FLAGS_port;
 
@@ -2262,96 +2640,8 @@ public:
     }
 
 private:
-    JobManager& _job_manager;
-    brpc::Server* _server;
+    brpc::Server* _server {nullptr};
 };
-
-void init_exec_env() {
-    SCOPED_INIT_THREAD_CONTEXT();
-    std::vector<doris::StorePath> paths;
-    auto olap_res = doris::parse_conf_store_paths(doris::config::storage_root_path, &paths);
-    if (!olap_res) {
-        LOG(ERROR) << "parse config storage path failed, path=" << doris::config::storage_root_path;
-        exit(-1);
-    }
-
-    std::vector<doris::StorePath> spill_paths;
-    if (doris::config::spill_storage_root_path.empty()) {
-        doris::config::spill_storage_root_path = doris::config::storage_root_path;
-    }
-    olap_res = doris::parse_conf_store_paths(doris::config::spill_storage_root_path, &spill_paths);
-    if (!olap_res) {
-        LOG(ERROR) << "parse config spill storage path failed, path="
-                   << doris::config::spill_storage_root_path;
-        exit(-1);
-    }
-    std::set<std::string> broken_paths;
-    doris::parse_conf_broken_store_paths(doris::config::broken_storage_path, &broken_paths);
-
-    auto it = paths.begin();
-    for (; it != paths.end();) {
-        if (broken_paths.count(it->path) > 0) {
-            if (doris::config::ignore_broken_disk) {
-                LOG(WARNING) << "ignore broken disk, path = " << it->path;
-                it = paths.erase(it);
-            } else {
-                LOG(ERROR) << "a broken disk is found " << it->path;
-                exit(-1);
-            }
-        } else if (!doris::check_datapath_rw(it->path)) {
-            if (doris::config::ignore_broken_disk) {
-                LOG(WARNING) << "read write test file failed, path=" << it->path;
-                it = paths.erase(it);
-            } else {
-                LOG(ERROR) << "read write test file failed, path=" << it->path;
-                // if only one disk and the disk is full, also need exit because rocksdb will open failed
-                exit(-1);
-            }
-        } else {
-            ++it;
-        }
-    }
-
-    if (paths.empty()) {
-        LOG(ERROR) << "All disks are broken, exit.";
-        exit(-1);
-    }
-
-    it = spill_paths.begin();
-    for (; it != spill_paths.end();) {
-        if (!doris::check_datapath_rw(it->path)) {
-            if (doris::config::ignore_broken_disk) {
-                LOG(WARNING) << "read write test file failed, path=" << it->path;
-                it = spill_paths.erase(it);
-            } else {
-                LOG(ERROR) << "read write test file failed, path=" << it->path;
-                exit(-1);
-            }
-        } else {
-            ++it;
-        }
-    }
-    if (spill_paths.empty()) {
-        LOG(ERROR) << "All spill disks are broken, exit.";
-        exit(-1);
-    }
-
-    auto* exec_env = doris::ExecEnv::GetInstance();
-    auto status = exec_env->init_mem_env();
-
-    std::unique_ptr<doris::ThreadPool> s3_upload_pool;
-    static_cast<void>(doris::ThreadPoolBuilder("MicrobenchS3FileUploadThreadPool")
-                              .set_min_threads(256)
-                              .set_max_threads(512)
-                              .build(&s3_upload_pool));
-    exec_env->set_s3_file_upload_thread_pool(std::move(s3_upload_pool));
-
-    exec_env->set_file_cache_factory(new FileCacheFactory());
-    std::vector<doris::CachePath> cache_paths;
-    exec_env->init_file_cache_factory(cache_paths);
-    exec_env->set_file_cache_open_fd_cache(std::make_unique<doris::io::FDCache>());
-}
-
 int main(int argc, char* argv[]) {
     google::ParseCommandLineFlags(&argc, &argv, true);
     FLAGS_minloglevel = google::GLOG_INFO;
@@ -2366,68 +2656,12 @@ int main(int argc, char* argv[]) {
     }
     google::InitGoogleLogging(argv[0]);
 
-    if (-1 == setenv("DORIS_HOME", ".", 0)) {
-        LOG(WARNING) << "set DORIS_HOME error";
+    std::string doris_home = getenv("DORIS_HOME");
+    if (doris_home.empty()) {
+        LOG(ERROR) << "DORIS_HOME environment variable not set";
     }
-    const char* doris_home = getenv("DORIS_HOME");
-    if (doris_home == nullptr) {
-        LOG(INFO) << "DORIS_HOME environment variable not set";
-    }
+
     LOG(INFO) << "env=" << doris_home;
-    std::string conffile = std::string(doris_home) + "/conf/be.conf";
-    if (!doris::config::init(conffile.c_str(), true, true, true)) {
-        LOG(ERROR) << "Error reading config file";
-        return -1;
-    }
-    std::string custom_conffile = doris::config::custom_config_dir + "/be_custom.conf";
-    if (!doris::config::init(custom_conffile.c_str(), true, false, false)) {
-        LOG(ERROR) << "Error reading custom config file";
-        return -1;
-    }
-
-    LOG(INFO) << "Obj config. ak=" << doris::config::test_s3_ak
-              << " sk=" << doris::config::test_s3_sk << " region=" << doris::config::test_s3_region
-              << " endpoint=" << doris::config::test_s3_endpoint
-              << " bucket=" << doris::config::test_s3_bucket;
-    LOG(INFO) << "File cache config. enable_file_cache=" << doris::config::enable_file_cache
-              << " file_cache_path=" << doris::config::file_cache_path
-              << " file_cache_each_block_size=" << doris::config::file_cache_each_block_size
-              << " clear_file_cache=" << doris::config::clear_file_cache
-              << " enable_file_cache_query_limit=" << doris::config::enable_file_cache_query_limit
-              << " file_cache_enter_disk_resource_limit_mode_percent="
-              << doris::config::file_cache_enter_disk_resource_limit_mode_percent
-              << " file_cache_exit_disk_resource_limit_mode_percent="
-              << doris::config::file_cache_exit_disk_resource_limit_mode_percent
-              << " enable_read_cache_file_directly="
-              << doris::config::enable_read_cache_file_directly
-              << " file_cache_enable_evict_from_other_queue_by_size="
-              << doris::config::file_cache_enable_evict_from_other_queue_by_size
-              << " file_cache_error_log_limit_bytes="
-              << doris::config::file_cache_error_log_limit_bytes
-              << " cache_lock_wait_long_tail_threshold_us="
-              << doris::config::cache_lock_wait_long_tail_threshold_us
-              << " cache_lock_held_long_tail_threshold_us="
-              << doris::config::cache_lock_held_long_tail_threshold_us
-              << " file_cache_remove_block_qps_limit="
-              << doris::config::file_cache_remove_block_qps_limit
-              << " enable_evict_file_cache_in_advance="
-              << doris::config::enable_evict_file_cache_in_advance
-              << " file_cache_enter_need_evict_cache_in_advance_percent="
-              << doris::config::file_cache_enter_need_evict_cache_in_advance_percent
-              << " file_cache_exit_need_evict_cache_in_advance_percent="
-              << doris::config::file_cache_exit_need_evict_cache_in_advance_percent
-              << " file_cache_evict_in_advance_interval_ms="
-              << doris::config::file_cache_evict_in_advance_interval_ms
-              << " file_cache_evict_in_advance_batch_bytes="
-              << doris::config::file_cache_evict_in_advance_batch_bytes;
-    LOG(INFO) << "S3 writer config. s3_file_writer_log_interval_second="
-              << doris::config::s3_file_writer_log_interval_second
-              << " s3_write_buffer_size=" << doris::config::s3_write_buffer_size
-              << " enable_flush_file_cache_async=" << doris::config::enable_flush_file_cache_async;
-
-    init_exec_env();
-    JobManager job_manager;
-
     std::thread periodiccally_log_thread;
     std::mutex periodiccally_log_thread_lock;
     std::condition_variable periodiccally_log_thread_cv;
@@ -2441,8 +2675,12 @@ int main(int argc, char* argv[]) {
     };
     periodiccally_log_thread = std::thread {periodiccally_log};
 
-    HttpServer http_server;
-    http_server.start(doris_home);
+    try {
+        HttpServer http_server;
+        http_server.start(doris_home);
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Error in HTTP server: " << e.what();
+    }
 
     if (periodiccally_log_thread.joinable()) {
         {

--- a/be/src/io/tools/proto/microbench.proto
+++ b/be/src/io/tools/proto/microbench.proto
@@ -36,4 +36,6 @@ service MicrobenchService {
       rpc file_cache_release(HttpRequest) returns (HttpResponse);
       rpc update_config(HttpRequest) returns (HttpResponse);
       rpc show_config(HttpRequest) returns (HttpResponse);
+      rpc reload_config(HttpRequest) returns (HttpResponse);
+      rpc show_reload_status(HttpRequest) returns (HttpResponse);
 };


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: apache/doris#58922

Problem Summary: Backport the file cache microbench config hot reload support to branch-4.0, including the file cache reload API and the supporting microbench service changes.

### Release note

Support hot reload for the BE test file cache microbench configuration.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->
              Cherry-pick and conflict resolution only in this workspace. Local build/test was not run because `hooks/setup_worktree.sh` is unavailable here and `thirdparty/installed` is missing.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Adds hot reload support for the file cache microbench test tool.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->