### PR TITLE
[Fix](compile) Fix the FE compilation failure caused by mvn cache checksum composition error

### DIFF
--- a/fe/.mvn/maven-build-cache-config.xml
+++ b/fe/.mvn/maven-build-cache-config.xml
@@ -43,5 +43,18 @@ under the License.
                 <include glob="{*.sh,*.py,Makefile}" recursive="true">../../gensrc/script</include>
             </includes>
         </global>
+        <plugins>
+            <plugin groupId="org.codehaus.mojo" artifactId="exec-maven-plugin">
+                <dirScan>
+                    <excludes>
+                        <!-- DORIS_HOME points at the repository root in fe-core. Treating it as an
+                             input directory pulls unrelated top-level files (for example local large
+                             tarballs) into the checksum. Keep tracking env.sh and gensrc/script via
+                             their dedicated tags/global includes, but skip this broad directory tag. -->
+                        <exclude tagName="DORIS_HOME" />
+                    </excludes>
+                </dirScan>
+            </plugin>
+        </plugins>
     </input>
 </cache>


### PR DESCRIPTION
before we often meet error like 
```
[ERROR] Required array size too large -> [Help 1]
[ERROR] java.lang.OutOfMemoryError: Required array size too large
```
when compile FE.

This is because Maven loads all content that constitutes the signature into memory when checking whether it can reuse the cache. Since we incorrectly passed `DORIS_HOME`, any file within the project becomes part of the checksum for the cache. When loading into memory, large files (such as some core dumps or compressed packages) can easily lead to an OOM error.

This is also why disabling the cache previously could avoid this issue.

The problem has now been thoroughly fixed by removing the `DORIS_HOME` directory from the checksum cache. This does not affect the participation of `gensrc/` content in the cache identification, as they are explicitly declared through other means.