### PR TITLE
branch-4.1 [fix](build) Prefer thirdparty mirror for JuiceFS downloads

### DIFF
--- a/docker/thirdparties/juicefs-helpers.sh
+++ b/docker/thirdparties/juicefs-helpers.sh
@@ -20,7 +20,20 @@
 
 JUICEFS_DEFAULT_VERSION="${JUICEFS_DEFAULT_VERSION:-1.3.1}"
 MAVEN_REPOSITORY_URL="${MAVEN_REPOSITORY_URL:-https://repo1.maven.org/maven2}"
+JUICEFS_THIRDPARTY_REPOSITORY_URL="${JUICEFS_THIRDPARTY_REPOSITORY_URL:-}"
+JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL="${JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL:-https://doris-thirdparty-repo.bj.bcebos.com/thirdparty}"
 JUICEFS_HADOOP_MAVEN_REPO="${JUICEFS_HADOOP_MAVEN_REPO:-${MAVEN_REPOSITORY_URL}/io/juicefs/juicefs-hadoop}"
+JUICEFS_CLI_RELEASE_REPO="${JUICEFS_CLI_RELEASE_REPO:-https://github.com/juicedata/juicefs/releases/download}"
+
+juicefs_thirdparty_repository_url() {
+    local repository_url="${JUICEFS_THIRDPARTY_REPOSITORY_URL:-${REPOSITORY_URL:-${JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL}}}"
+    echo "${repository_url%/}"
+}
+
+juicefs_repository_file_url() {
+    local filename="$1"
+    echo "$(juicefs_thirdparty_repository_url)/${filename}"
+}
 
 juicefs_find_hadoop_jar_by_globs() {
     local jar_glob=""
@@ -53,13 +66,71 @@ juicefs_hadoop_jar_download_url() {
     echo "${JUICEFS_HADOOP_MAVEN_REPO}/${juicefs_version}/${jar_name}"
 }
 
+juicefs_hadoop_jar_download_urls() {
+    local juicefs_version="$1"
+    local jar_name="juicefs-hadoop-${juicefs_version}.jar"
+    printf '%s\n' \
+        "$(juicefs_repository_file_url "${jar_name}")" \
+        "$(juicefs_hadoop_jar_download_url "${juicefs_version}")"
+}
+
+juicefs_cli_archive_name() {
+    local juicefs_version="$1"
+    echo "juicefs-${juicefs_version}-linux-amd64.tar.gz"
+}
+
+juicefs_cli_archive_mirror_url() {
+    local juicefs_version="$1"
+    local archive_name
+    archive_name=$(juicefs_cli_archive_name "${juicefs_version}")
+    juicefs_repository_file_url "${archive_name}"
+}
+
+juicefs_cli_archive_download_url() {
+    local juicefs_version="$1"
+    local archive_name
+    archive_name=$(juicefs_cli_archive_name "${juicefs_version}")
+    echo "${JUICEFS_CLI_RELEASE_REPO}/v${juicefs_version}/${archive_name}"
+}
+
+juicefs_cli_archive_download_urls() {
+    local juicefs_version="$1"
+    printf '%s\n' \
+        "$(juicefs_cli_archive_mirror_url "${juicefs_version}")" \
+        "$(juicefs_cli_archive_download_url "${juicefs_version}")"
+}
+
+juicefs_download_file() {
+    local target_path="$1"
+    local download_label="$2"
+    shift 2
+
+    local download_url=""
+    mkdir -p "$(dirname "${target_path}")"
+    for download_url in "$@"; do
+        [[ -n "${download_url}" ]] || continue
+        echo "Downloading ${download_label} from ${download_url}" >&2
+        if command -v curl >/dev/null 2>&1; then
+            if curl -fL --retry 3 --retry-delay 2 --connect-timeout 10 -o "${target_path}" "${download_url}"; then
+                return 0
+            fi
+        elif command -v wget >/dev/null 2>&1; then
+            if wget -q "${download_url}" -O "${target_path}"; then
+                return 0
+            fi
+        fi
+    done
+
+    rm -f "${target_path}"
+    return 1
+}
+
 juicefs_download_hadoop_jar_to_cache() {
     local juicefs_version="$1"
     local cache_dir="$2"
     local jar_name="juicefs-hadoop-${juicefs_version}.jar"
     local target_jar="${cache_dir}/${jar_name}"
-    local download_url
-    download_url=$(juicefs_hadoop_jar_download_url "${juicefs_version}")
+    local -a download_urls=()
 
     mkdir -p "${cache_dir}"
     if [[ -s "${target_jar}" ]]; then
@@ -67,19 +138,11 @@ juicefs_download_hadoop_jar_to_cache() {
         return 0
     fi
 
-    echo "Downloading JuiceFS Hadoop jar ${juicefs_version} from ${download_url}" >&2
-    if command -v curl >/dev/null 2>&1; then
-        if curl -fL --retry 3 --retry-delay 2 --connect-timeout 10 -o "${target_jar}" "${download_url}"; then
-            echo "${target_jar}"
-            return 0
-        fi
-    elif command -v wget >/dev/null 2>&1; then
-        if wget -q "${download_url}" -O "${target_jar}"; then
-            echo "${target_jar}"
-            return 0
-        fi
+    mapfile -t download_urls < <(juicefs_hadoop_jar_download_urls "${juicefs_version}")
+    if juicefs_download_file "${target_jar}" "JuiceFS Hadoop jar ${juicefs_version}" "${download_urls[@]}"; then
+        echo "${target_jar}"
+        return 0
     fi
 
-    rm -f "${target_jar}"
     return 1
 }

--- a/docker/thirdparties/juicefs-helpers.sh
+++ b/docker/thirdparties/juicefs-helpers.sh
@@ -21,12 +21,27 @@
 JUICEFS_DEFAULT_VERSION="${JUICEFS_DEFAULT_VERSION:-1.3.1}"
 MAVEN_REPOSITORY_URL="${MAVEN_REPOSITORY_URL:-https://repo1.maven.org/maven2}"
 JUICEFS_THIRDPARTY_REPOSITORY_URL="${JUICEFS_THIRDPARTY_REPOSITORY_URL:-}"
-JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL="${JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL:-https://doris-thirdparty-repo.bj.bcebos.com/thirdparty}"
+JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL="${JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL:-}"
 JUICEFS_HADOOP_MAVEN_REPO="${JUICEFS_HADOOP_MAVEN_REPO:-${MAVEN_REPOSITORY_URL}/io/juicefs/juicefs-hadoop}"
 JUICEFS_CLI_RELEASE_REPO="${JUICEFS_CLI_RELEASE_REPO:-https://github.com/juicedata/juicefs/releases/download}"
 
+juicefs_default_thirdparty_repository_url() {
+    if [[ -n "${JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL}" ]]; then
+        echo "${JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL%/}"
+        return 0
+    fi
+    if [[ -n "${s3BucketName:-}" && -n "${s3Endpoint:-}" ]]; then
+        echo "https://${s3BucketName}.${s3Endpoint}/regression/datalake/thirdparty/juicefs"
+        return 0
+    fi
+    echo "https://doris-thirdparty-repo.bj.bcebos.com/thirdparty"
+}
+
 juicefs_thirdparty_repository_url() {
-    local repository_url="${JUICEFS_THIRDPARTY_REPOSITORY_URL:-${REPOSITORY_URL:-${JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL}}}"
+    local repository_url="${JUICEFS_THIRDPARTY_REPOSITORY_URL:-${REPOSITORY_URL:-}}"
+    if [[ -z "${repository_url}" ]]; then
+        repository_url=$(juicefs_default_thirdparty_repository_url)
+    fi
     echo "${repository_url%/}"
 }
 

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -267,18 +267,19 @@ download_juicefs_hadoop_jar() {
 install_juicefs_cli() {
     local juicefs_version="$1"
     local cache_dir="${JUICEFS_RUNTIME_ROOT}/bin"
-    local archive_name="juicefs-${juicefs_version}-linux-amd64.tar.gz"
-    local download_url="https://github.com/juicedata/juicefs/releases/download/v${juicefs_version}/${archive_name}"
+    local archive_name
+    local -a download_urls=()
     local tmp_dir
     local extracted_bin
 
+    archive_name=$(juicefs_cli_archive_name "${juicefs_version}")
     mkdir -p "${cache_dir}"
     tmp_dir=$(mktemp -d "${cache_dir}/tmp.XXXXXX")
+    mapfile -t download_urls < <(juicefs_cli_archive_download_urls "${juicefs_version}")
 
-    echo "Downloading JuiceFS CLI ${juicefs_version} from ${download_url}" >&2
-    if ! curl -fL --retry 3 --retry-delay 2 -o "${tmp_dir}/${archive_name}" "${download_url}"; then
+    if ! juicefs_download_file "${tmp_dir}/${archive_name}" "JuiceFS CLI ${juicefs_version}" "${download_urls[@]}"; then
         rm -rf "${tmp_dir}"
-        echo "ERROR: failed to download JuiceFS CLI from ${download_url}" >&2
+        echo "ERROR: failed to download JuiceFS CLI ${juicefs_version}" >&2
         return 1
     fi
 

--- a/docker/thirdparties/test/juicefs-helpers-mirror-test.sh
+++ b/docker/thirdparties/test/juicefs-helpers-mirror-test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd)"
+. "${ROOT}/juicefs-helpers.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    [[ "${actual}" == "${expected}" ]] || fail "expected '${expected}', got '${actual}'"
+}
+
+assert_lines() {
+    local expected="$1"
+    shift
+    local actual
+    actual="$("$@")"
+    [[ "${actual}" == "${expected}" ]] || fail "expected lines:\n${expected}\nactual:\n${actual}"
+}
+
+assert_lines $'https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/juicefs-hadoop-1.3.1.jar\nhttps://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop/1.3.1/juicefs-hadoop-1.3.1.jar' \
+    juicefs_hadoop_jar_download_urls 1.3.1
+
+REPOSITORY_URL="https://mirror.example.com/thirdparty/" \
+assert_lines $'https://mirror.example.com/thirdparty/juicefs-hadoop-1.3.1.jar\nhttps://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop/1.3.1/juicefs-hadoop-1.3.1.jar' \
+    juicefs_hadoop_jar_download_urls 1.3.1
+
+assert_eq "https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/juicefs-1.3.1-linux-amd64.tar.gz" \
+    "$(juicefs_cli_archive_mirror_url 1.3.1)"
+
+REPOSITORY_URL="https://mirror.example.com/thirdparty/" \
+assert_lines $'https://mirror.example.com/thirdparty/juicefs-1.3.1-linux-amd64.tar.gz\nhttps://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-amd64.tar.gz' \
+    juicefs_cli_archive_download_urls 1.3.1
+
+echo "PASS"

--- a/docker/thirdparties/test/juicefs-helpers-mirror-test.sh
+++ b/docker/thirdparties/test/juicefs-helpers-mirror-test.sh
@@ -43,6 +43,17 @@ assert_lines() {
 assert_lines $'https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/juicefs-hadoop-1.3.1.jar\nhttps://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop/1.3.1/juicefs-hadoop-1.3.1.jar' \
     juicefs_hadoop_jar_download_urls 1.3.1
 
+(
+    unset JUICEFS_THIRDPARTY_REPOSITORY_URL
+    unset REPOSITORY_URL
+    unset JUICEFS_DEFAULT_THIRDPARTY_REPOSITORY_URL
+    s3BucketName="doris-regression-bj"
+    s3Endpoint="oss-cn-beijing.aliyuncs.com"
+    . "${ROOT}/juicefs-helpers.sh"
+    assert_eq "https://doris-regression-bj.oss-cn-beijing.aliyuncs.com/regression/datalake/thirdparty/juicefs" \
+        "$(juicefs_thirdparty_repository_url)"
+)
+
 REPOSITORY_URL="https://mirror.example.com/thirdparty/" \
 assert_lines $'https://mirror.example.com/thirdparty/juicefs-hadoop-1.3.1.jar\nhttps://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop/1.3.1/juicefs-hadoop-1.3.1.jar' \
     juicefs_hadoop_jar_download_urls 1.3.1

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -168,6 +168,22 @@ download_func() {
     return "${STATUS}"
 }
 
+download_with_fallbacks() {
+    local FILENAME="$1"
+    local DESC_DIR="$2"
+    local MD5SUM="$3"
+    shift 3
+
+    local DOWNLOAD_URL=""
+    for DOWNLOAD_URL in "$@"; do
+        [[ -n "${DOWNLOAD_URL}" ]] || continue
+        if download_func "${FILENAME}" "${DOWNLOAD_URL}" "${DESC_DIR}" "${MD5SUM}"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # download thirdparty archives
 echo "===== Downloading thirdparty archives..."
 for TP_ARCH in "${TP_ARCHIVES[@]}"; do
@@ -177,22 +193,19 @@ for TP_ARCH in "${TP_ARCHIVES[@]}"; do
     fi
     NAME="${TP_ARCH}_NAME"
     MD5SUM="${TP_ARCH}_MD5SUM"
-    if [[ -z "${REPOSITORY_URL}" ]]; then
-        URL="${TP_ARCH}_DOWNLOAD"
-        if ! download_func "${!NAME}" "${!URL}" "${TP_SOURCE_DIR}" "${!MD5SUM}"; then
-            echo "Failed to download ${!NAME}"
-            exit 1
-        fi
-    else
-        URL="${REPOSITORY_URL}/${!NAME}"
-        if ! download_func "${!NAME}" "${URL}" "${TP_SOURCE_DIR}" "${!MD5SUM}"; then
-            #try to download from home
-            URL="${TP_ARCH}_DOWNLOAD"
-            if ! download_func "${!NAME}" "${!URL}" "${TP_SOURCE_DIR}" "${!MD5SUM}"; then
-                echo "Failed to download ${!NAME}"
-                exit 1 # download failed again exit.
-            fi
-        fi
+    URL="${TP_ARCH}_DOWNLOAD"
+    FALLBACK_URL="${TP_ARCH}_FALLBACK_DOWNLOAD"
+    DOWNLOAD_URLS=()
+    if [[ -n "${REPOSITORY_URL}" ]]; then
+        DOWNLOAD_URLS+=("${REPOSITORY_URL%/}/${!NAME}")
+    fi
+    DOWNLOAD_URLS+=("${!URL}")
+    if [[ -n "${!FALLBACK_URL}" ]]; then
+        DOWNLOAD_URLS+=("${!FALLBACK_URL}")
+    fi
+    if ! download_with_fallbacks "${!NAME}" "${TP_SOURCE_DIR}" "${!MD5SUM}" "${DOWNLOAD_URLS[@]}"; then
+        echo "Failed to download ${!NAME}"
+        exit 1
     fi
 done
 echo "===== Downloading thirdparty archives...done"

--- a/thirdparty/test/download-thirdparty-fallback-test.sh
+++ b/thirdparty/test/download-thirdparty-fallback-test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd)"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    [[ "${actual}" == "${expected}" ]] || fail "expected '${expected}', got '${actual}'"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+stub_bin="${tmpdir}/bin"
+mkdir -p "${stub_bin}"
+download_log="${tmpdir}/wget.log"
+payload="juicefs jar payload"
+payload_md5="$(printf '%s' "${payload}" | md5sum | awk '{print $1}')"
+
+cat > "${tmpdir}/vars.sh" <<EOF
+#!/bin/bash
+export TP_SOURCE_DIR="${tmpdir}/src"
+export TP_INSTALL_DIR="${tmpdir}/installed"
+export TP_PATCH_DIR="${tmpdir}/patches"
+export TP_INCLUDE_DIR="\${TP_INSTALL_DIR}/include"
+export TP_LIB_DIR="\${TP_INSTALL_DIR}/lib"
+export TP_JAR_DIR="\${TP_INSTALL_DIR}/lib/jar"
+FOO_DOWNLOAD="https://mirror.example.com/foo.jar"
+FOO_FALLBACK_DOWNLOAD="https://official.example.com/foo.jar"
+FOO_NAME="foo.jar"
+FOO_SOURCE=
+FOO_MD5SUM="${payload_md5}"
+export TP_ARCHIVES=('FOO')
+EOF
+
+cat > "${stub_bin}/wget" <<EOF
+#!/usr/bin/env bash
+set -eo pipefail
+url=""
+output=""
+expect_output=0
+for arg in "\$@"; do
+    if [[ "\${expect_output}" -eq 1 ]]; then
+        output="\${arg}"
+        expect_output=0
+        continue
+    fi
+    if [[ "\${arg}" == "-O" ]]; then
+        expect_output=1
+        continue
+    fi
+    if [[ "\${arg}" != -* && -z "\${url}" ]]; then
+        url="\${arg}"
+    fi
+done
+echo "\${url}" >> "${download_log}"
+if [[ "\${url}" == "https://official.example.com/foo.jar" ]]; then
+    printf '%s' "${payload}" > "\${output}"
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "${stub_bin}/wget"
+
+if ! PATH="${stub_bin}:${PATH}" REPOSITORY_URL="https://repo.example.com/thirdparty" \
+    TP_DIR="${tmpdir}" DORIS_HOME="${ROOT}/.." \
+    bash "${ROOT}/download-thirdparty.sh"; then
+    fail "expected download-thirdparty.sh to fall back to FOO_FALLBACK_DOWNLOAD"
+fi
+
+[[ -f "${tmpdir}/src/foo.jar" ]] || fail "expected downloaded archive at ${tmpdir}/src/foo.jar"
+assert_eq "${payload}" "$(cat "${tmpdir}/src/foo.jar")"
+
+expected_log=$'https://repo.example.com/thirdparty/foo.jar\nhttps://repo.example.com/thirdparty/foo.jar\nhttps://mirror.example.com/foo.jar\nhttps://mirror.example.com/foo.jar\nhttps://official.example.com/foo.jar'
+assert_eq "${expected_log}" "$(cat "${download_log}")"
+
+echo "PASS"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -48,6 +48,7 @@ export TP_JAR_DIR="${TP_INSTALL_DIR}/lib/jar"
 
 # source of all dependencies, default unuse it
 # export REPOSITORY_URL=
+DORIS_THIRDPARTY_REPOSITORY_URL="${DORIS_THIRDPARTY_REPOSITORY_URL:-https://doris-thirdparty-repo.bj.bcebos.com/thirdparty}"
 
 #####################################################
 # Download url, filename and unpaced filename
@@ -548,7 +549,8 @@ JINDOFS_SOURCE=jindofs-6.10.4-libs-0.1
 JINDOFS_MD5SUM="bd30b4c5fe97c4367eeb3bb228b317d9"
 
 # juicefs
-JUICEFS_DOWNLOAD="https://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop/1.3.1/juicefs-hadoop-1.3.1.jar"
+JUICEFS_DOWNLOAD="${DORIS_THIRDPARTY_REPOSITORY_URL%/}/juicefs-hadoop-1.3.1.jar"
+JUICEFS_FALLBACK_DOWNLOAD="https://repo1.maven.org/maven2/io/juicefs/juicefs-hadoop/1.3.1/juicefs-hadoop-1.3.1.jar"
 JUICEFS_NAME=juicefs-hadoop-1.3.1.jar
 JUICEFS_SOURCE=
 JUICEFS_MD5SUM="f374dfbfbdc4b83417cfea78a6728c54"


### PR DESCRIPTION
## Summary
- prefer the datalake-owned mirror for JuiceFS Hadoop jar downloads in both docker and thirdparty build flows
- keep upstream Maven Central and JuiceFS GitHub release as the fallback path when the mirror is unavailable
- add shell regression coverage for the new default mirror path and fallback behavior

## Mirror Path
For branch-4.1, the default mirror is the Baidu Cloud BOS mirror:
- mirror root: `https://doris-thirdparty-repo.bj.bcebos.com/thirdparty`

The mirror can be customized via:
- `JUICEFS_THIRDPARTY_REPOSITORY_URL` environment variable
- `REPOSITORY_URL` environment variable
- `s3BucketName` + `s3Endpoint` for dynamic mirror construction

## Root Cause
JuiceFS downloads were hardcoded to Maven Central and GitHub release endpoints in the docker and thirdparty scripts. Network jitter on those upstream endpoints could stall or fail docker startup and thirdparty downloads.

## Impact
JuiceFS-related bootstrap paths now use the thirdparty mirror by default while preserving upstream fallback.

## Test Plan
- \`bash docker/thirdparties/test/juicefs-helpers-mirror-test.sh\`
- \`bash thirdparty/test/juicefs-default-mirror-test.sh\`
- \`bash thirdparty/test/download-thirdparty-fallback-test.sh\`
- \`bash -n docker/thirdparties/juicefs-helpers.sh thirdparty/vars.sh docker/thirdparties/test/juicefs-helpers-mirror-test.sh thirdparty/test/juicefs-default-mirror-test.sh thirdparty/test/download-thirdparty-fallback-test.sh\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cherry-picked from #61968