### PR TITLE
[fix](memory) attach MemTracker to cache background threads to fix orphan crash

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -54,7 +54,6 @@
 #include "runtime/memory/memory_reclamation.h"
 #include "runtime/process_profile.h"
 #include "runtime/runtime_query_statistics_mgr.h"
-#include "runtime/thread_context.h"
 #include "runtime/workload_group/workload_group_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet_manager.h"
@@ -508,12 +507,6 @@ void Daemon::je_reset_dirty_decay_thread() const {
 }
 
 void Daemon::cache_adjust_capacity_thread() {
-    // Attach a tracker so Block/Column destructors triggered by LRU eviction
-    // do not hit the memory_orphan_check DCHECK.
-    auto mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL,
-                                                        "CacheAdjustCapacityThread");
-    SCOPED_ATTACH_TASK(mem_tracker);
-
     do {
         std::unique_lock<std::mutex> l(doris::GlobalMemoryArbitrator::cache_adjust_capacity_lock);
         while (_stop_background_threads_latch.count() != 0 &&
@@ -557,11 +550,6 @@ void Daemon::cache_adjust_capacity_thread() {
 }
 
 void Daemon::cache_prune_stale_thread() {
-    // Same as cache_adjust_capacity_thread: attach tracker to avoid orphan check.
-    auto mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL,
-                                                        "CachePruneStaleThread");
-    SCOPED_ATTACH_TASK(mem_tracker);
-
     int32_t interval = config::cache_periodic_prune_stale_sweep_sec;
     while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(interval))) {
         if (config::cache_periodic_prune_stale_sweep_sec <= 0) {

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -54,6 +54,7 @@
 #include "runtime/memory/memory_reclamation.h"
 #include "runtime/process_profile.h"
 #include "runtime/runtime_query_statistics_mgr.h"
+#include "runtime/thread_context.h"
 #include "runtime/workload_group/workload_group_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet_manager.h"
@@ -507,6 +508,12 @@ void Daemon::je_reset_dirty_decay_thread() const {
 }
 
 void Daemon::cache_adjust_capacity_thread() {
+    // Attach a tracker so Block/Column destructors triggered by LRU eviction
+    // do not hit the memory_orphan_check DCHECK.
+    auto mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL,
+                                                        "CacheAdjustCapacityThread");
+    SCOPED_ATTACH_TASK(mem_tracker);
+
     do {
         std::unique_lock<std::mutex> l(doris::GlobalMemoryArbitrator::cache_adjust_capacity_lock);
         while (_stop_background_threads_latch.count() != 0 &&
@@ -550,6 +557,11 @@ void Daemon::cache_adjust_capacity_thread() {
 }
 
 void Daemon::cache_prune_stale_thread() {
+    // Same as cache_adjust_capacity_thread: attach tracker to avoid orphan check.
+    auto mem_tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::GLOBAL,
+                                                        "CachePruneStaleThread");
+    SCOPED_ATTACH_TASK(mem_tracker);
+
     int32_t interval = config::cache_periodic_prune_stale_sweep_sec;
     while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(interval))) {
         if (config::cache_periodic_prune_stale_sweep_sec <= 0) {

--- a/be/src/runtime/query_cache/query_cache.h
+++ b/be/src/runtime/query_cache/query_cache.h
@@ -197,20 +197,17 @@ public:
 
     // Ensure Block memory freed during eviction is tracked under query cache, not Orphan.
     int64_t adjust_capacity_weighted(double adjust_weighted) override {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
-                ExecEnv::GetInstance()->query_cache_mem_tracker());
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->query_cache_mem_tracker());
         return LRUCachePolicy::adjust_capacity_weighted(adjust_weighted);
     }
 
     int64_t reset_initial_capacity(double adjust_weighted) override {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
-                ExecEnv::GetInstance()->query_cache_mem_tracker());
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->query_cache_mem_tracker());
         return LRUCachePolicy::reset_initial_capacity(adjust_weighted);
     }
 
     void prune_stale() override {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
-                ExecEnv::GetInstance()->query_cache_mem_tracker());
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->query_cache_mem_tracker());
         LRUCachePolicy::prune_stale();
     }
 

--- a/be/src/runtime/query_cache/query_cache.h
+++ b/be/src/runtime/query_cache/query_cache.h
@@ -195,6 +195,25 @@ public:
                              /*element_count_capacity*/ 0, /*enable_prune*/ true,
                              /*is_lru_k*/ true) {}
 
+    // Ensure Block memory freed during eviction is tracked under query cache, not Orphan.
+    int64_t adjust_capacity_weighted(double adjust_weighted) override {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
+                ExecEnv::GetInstance()->query_cache_mem_tracker());
+        return LRUCachePolicy::adjust_capacity_weighted(adjust_weighted);
+    }
+
+    int64_t reset_initial_capacity(double adjust_weighted) override {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
+                ExecEnv::GetInstance()->query_cache_mem_tracker());
+        return LRUCachePolicy::reset_initial_capacity(adjust_weighted);
+    }
+
+    void prune_stale() override {
+        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
+                ExecEnv::GetInstance()->query_cache_mem_tracker());
+        LRUCachePolicy::prune_stale();
+    }
+
     bool lookup(const CacheKey& key, int64_t version, QueryCacheHandle* handle);
 
     void insert(const CacheKey& key, int64_t version, CacheResult& result,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62738

Related PR: #xxx

Problem Summary:

When `enable_memory_orphan_check=true` is set in be.conf, the Backend crashes
  with the following assertion when cache background threads are triggered under
  load:

  Check failed: limiter_mem_tracker()->label() != "Orphan"

  The affected threads are `cache_adjust_capacity_thread` and
  `cache_prune_stale_thread` created in `daemon.cpp`. These threads perform
  memory allocations without a `MemTrackerLimiter` attached, so they fall back
  to the Orphan tracker. The crash is non-deterministic — it does not happen on
  startup but fires when cache pressure activates these background threads
  (e.g. cache near capacity or stale blocks present).
  
  ##### Root Cause

  Both cache daemon threads are created without calling `SCOPED_ATTACH_TASK`.
  Any thread without an explicit `MemTrackerLimiter` inherits the Orphan tracker.
  When `enable_memory_orphan_check=true`, memory allocation on the Orphan tracker
  triggers the assertion and crashes the BE.
  
  ##### Fix

  Attach a dedicated `MemTrackerLimiter` to each cache daemon thread via
  `SCOPED_ATTACH_TASK` before the work loop begins, consistent with how other
  daemon threads in the codebase handle memory tracking.

  ##### Files Changed

  `be/src/common/daemon.cpp` — add `SCOPED_ATTACH_TASK` to
    `cache_adjust_capacity_thread` and `cache_prune_stale_thread`

  ##### Tests

  - Verified no crash with `enable_memory_orphan_check=true` and file cache
    enabled under TPC-DS query load
  - Both cache threads now have a valid memory tracking context

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [X] No need to test or manual test. Explain why:
        - [X] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

