### PR TITLE
[Fix](decimal) Fix unaligned memory access in read_column_from_arrow

### DIFF
--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -341,7 +341,8 @@ Status DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
         const auto arrow_scale = arrow_decimal_type->scale();
         // TODO check precision
         for (auto value_i = start; value_i < end; ++value_i) {
-            auto value = *reinterpret_cast<const Decimal128V2*>(concrete_array->Value(value_i));
+            Decimal128V2 value {};
+            memcpy(&value, concrete_array->Value(value_i), sizeof(Decimal128V2));
             // convert scale to 9;
             if (9 > arrow_scale) {
                 using MaxNativeType = typename Decimal128V2::NativeType;

--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -372,8 +372,9 @@ Status DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
     } else if constexpr (T == TYPE_DECIMAL256) {
         const auto* concrete_array = dynamic_cast<const arrow::Decimal256Array*>(arrow_array);
         for (auto value_i = start; value_i < end; ++value_i) {
-            column_data.emplace_back(
-                    *reinterpret_cast<const FieldType*>(concrete_array->Value(value_i)));
+            FieldType decimal_value {};
+            memcpy(&decimal_value, concrete_array->Value(value_i), sizeof(FieldType));
+            column_data.emplace_back(decimal_value);
         }
     } else {
         return Status::Error(ErrorCode::NOT_IMPLEMENTED_ERROR,

--- a/be/test/core/data_type_serde/data_type_serde_decimal_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_decimal_test.cpp
@@ -23,6 +23,8 @@
 #include <streamvbyte.h>
 
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <type_traits>
 
@@ -403,4 +405,92 @@ TEST_F(DataTypeDecimalSerDeTest, ArrowMemNotAlignedDecimal256) {
     EXPECT_EQ(column->get_element(1).to_string(20), decimal_strings[1]);
 }
 
+template <typename T>
+uint8_t* find_misaligned_address(std::vector<uint8_t>& storage) {
+    auto base = reinterpret_cast<uintptr_t>(storage.data());
+    for (size_t offset = 1; offset <= alignof(T); ++offset) {
+        if ((base + offset) % alignof(T) != 0) {
+            return storage.data() + offset;
+        }
+    }
+    return storage.data() + 1;
+}
+
+TEST_F(DataTypeDecimalSerDeTest, ArrowMemNotAlignedDecimalV2TypeAlignment) {
+    arrow::Decimal128Builder builder(arrow::decimal(27, 9));
+    std::vector<std::string> decimal_strings = {"1.000000000", "-123456789012345678.123456789"};
+
+    for (const auto& str : decimal_strings) {
+        EXPECT_TRUE(builder.Append(arrow::Decimal128(str)).ok());
+    }
+
+    std::shared_ptr<arrow::Array> aligned_array;
+    EXPECT_TRUE(builder.Finish(&aligned_array).ok());
+    auto decimal_array = std::static_pointer_cast<arrow::DecimalArray>(aligned_array);
+
+    const int64_t num_elements = decimal_array->length();
+    const int64_t element_size = decimal_array->byte_width();
+
+    std::vector<uint8_t> data_storage(num_elements * element_size + alignof(Decimal128V2) + 1);
+    uint8_t* unaligned_data = find_misaligned_address<Decimal128V2>(data_storage);
+
+    const uint8_t* original_data = decimal_array->raw_values();
+    memcpy(unaligned_data, original_data, num_elements * element_size);
+
+    auto unaligned_buffer = arrow::Buffer::Wrap(unaligned_data, num_elements * element_size);
+    auto arr = std::make_shared<arrow::DecimalArray>(arrow::decimal(27, 9), num_elements,
+                                                     unaligned_buffer);
+
+    const auto* raw_values_ptr = arr->raw_values();
+    uintptr_t address = reinterpret_cast<uintptr_t>(raw_values_ptr);
+    EXPECT_NE(address % alignof(Decimal128V2), 0);
+
+    cctz::time_zone tz;
+    auto column = ColumnDecimal128V2::create(0, 9);
+    auto st = serde_decimal128v2->read_column_from_arrow(*column, arr.get(), 0, num_elements, tz);
+    EXPECT_TRUE(st.ok());
+    ASSERT_EQ(column->size(), num_elements);
+    EXPECT_EQ(column->get_element(0).to_string(9), decimal_strings[0]);
+    EXPECT_EQ(column->get_element(1).to_string(9), decimal_strings[1]);
+}
+
+TEST_F(DataTypeDecimalSerDeTest, ArrowMemNotAlignedDecimal256TypeAlignment) {
+    arrow::Decimal256Builder builder(arrow::decimal256(76, 20));
+    std::vector<std::string> decimal_strings = {"1.00000000000000000000",
+                                                "-12345678901234567890.12345678901234567890"};
+
+    for (const auto& str : decimal_strings) {
+        EXPECT_TRUE(builder.Append(arrow::Decimal256(str)).ok());
+    }
+
+    std::shared_ptr<arrow::Array> aligned_array;
+    EXPECT_TRUE(builder.Finish(&aligned_array).ok());
+    auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(aligned_array);
+
+    const int64_t num_elements = decimal_array->length();
+    const int64_t element_size = decimal_array->byte_width();
+
+    std::vector<uint8_t> data_storage(num_elements * element_size + alignof(Decimal256) + 1);
+    uint8_t* unaligned_data = find_misaligned_address<Decimal256>(data_storage);
+
+    const uint8_t* original_data = decimal_array->raw_values();
+    memcpy(unaligned_data, original_data, num_elements * element_size);
+
+    auto unaligned_buffer = arrow::Buffer::Wrap(unaligned_data, num_elements * element_size);
+    auto arr = std::make_shared<arrow::Decimal256Array>(arrow::decimal256(76, 20), num_elements,
+                                                        unaligned_buffer);
+
+    const auto* raw_values_ptr = arr->raw_values();
+    uintptr_t address = reinterpret_cast<uintptr_t>(raw_values_ptr);
+    EXPECT_NE(address % alignof(Decimal256), 0);
+
+    cctz::time_zone tz;
+    DataTypeDecimalSerDe<TYPE_DECIMAL256> serde_decimal256_20(76, 20);
+    auto column = ColumnDecimal256::create(0, 20);
+    auto st = serde_decimal256_20.read_column_from_arrow(*column, arr.get(), 0, num_elements, tz);
+    EXPECT_TRUE(st.ok());
+    ASSERT_EQ(column->size(), num_elements);
+    EXPECT_EQ(column->get_element(0).to_string(20), decimal_strings[0]);
+    EXPECT_EQ(column->get_element(1).to_string(20), decimal_strings[1]);
+}
 } // namespace doris

--- a/be/test/core/data_type_serde/data_type_serde_decimal_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_decimal_test.cpp
@@ -359,4 +359,48 @@ TEST_F(DataTypeDecimalSerDeTest, JsonDeserializeKeepsUnderflowCompatibility) {
     EXPECT_EQ(vector_column->get_element(0), expected);
 }
 
+TEST_F(DataTypeDecimalSerDeTest, ArrowMemNotAlignedDecimal256) {
+    // 1.Prepare the data.
+    arrow::Decimal256Builder builder(arrow::decimal256(76, 20));
+    std::vector<std::string> decimal_strings = {"1.00000000000000000000",
+                                                "-12345678901234567890.12345678901234567890"};
+
+    for (const auto& str : decimal_strings) {
+        EXPECT_TRUE(builder.Append(arrow::Decimal256(str)).ok());
+    }
+
+    std::shared_ptr<arrow::Array> aligned_array;
+    EXPECT_TRUE(builder.Finish(&aligned_array).ok());
+    auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(aligned_array);
+
+    // 2.Create an unaligned memory buffer.
+    const int64_t num_elements = decimal_array->length();
+    const int64_t element_size = decimal_array->byte_width();
+
+    std::vector<uint8_t> data_storage(num_elements * element_size + 10);
+    uint8_t* unaligned_data = data_storage.data() + 1;
+
+    // 3.Copy data to unaligned memory.
+    const uint8_t* original_data = decimal_array->raw_values();
+    memcpy(unaligned_data, original_data, num_elements * element_size);
+
+    // 4.Create Arrow array with unaligned memory.
+    auto unaligned_buffer = arrow::Buffer::Wrap(unaligned_data, num_elements * element_size);
+    auto arr = std::make_shared<arrow::Decimal256Array>(arrow::decimal256(76, 20), num_elements,
+                                                        unaligned_buffer);
+
+    const auto* raw_values_ptr = arr->raw_values();
+    uintptr_t address = reinterpret_cast<uintptr_t>(raw_values_ptr);
+    EXPECT_EQ(address % alignof(Decimal256), 1);
+
+    // 5.Test read_column_from_arrow.
+    cctz::time_zone tz;
+    auto column = ColumnDecimal256::create(0, 20);
+    auto st = serde_decimal256_2->read_column_from_arrow(*column, arr.get(), 0, num_elements, tz);
+    EXPECT_TRUE(st.ok());
+    ASSERT_EQ(column->size(), num_elements);
+    EXPECT_EQ(column->get_element(0).to_string(20), decimal_strings[0]);
+    EXPECT_EQ(column->get_element(1).to_string(20), decimal_strings[1]);
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #58002

Problem Summary:

`arrow::Decimal256Array::Value()` returns raw bytes (`const uint8_t*`), we previously reinterpret_cast it to `Decimal256*` which is a misaligned access .

```text
../src/core/data_type_serde/data_type_decimal_serde.cpp:376:21: runtime error: reference binding to misaligned address 0x1338f3345b12 for type 'const FieldType' (aka 'const Decimal<integer<256, int>>'), which requires 8 byte alignment
0x1338f3345b12: note: pointer points here
 00 c2  3e 20 00 00 10 63 2d 5e  c7 6b 05 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00
              ^ 
    #0 0x56203d1eb751 in doris::DataTypeDecimalSerDe<(doris::PrimitiveType)35>::read_column_from_arrow(doris::IColumn&, arrow::Array const*, long, long, cctz::time_zone const&) const be/build_ASAN/../src/core/data_type_serde/data_type_decimal_serde.cpp:375:25
    #1 0x56203d9c6d6b in doris::DataTypeNullableSerDe::read_column_from_arrow(doris::IColumn&, arrow::Array const*, long, long, cctz::time_zone const&) const be/build_ASAN/../src/core/data_type_serde/data_type_nullable_serde.cpp:350:26
    #2 0x562055dd83b5 in doris::FromRecordBatchToBlockConverter::convert(doris::Block*) be/build_ASAN/../src/format/arrow/arrow_block_convertor.cpp:131:9
    #3 0x562055dd9229 in doris::convert_from_arrow_batch(std::shared_ptr<arrow::RecordBatch> const&, std::vector<std::shared_ptr<doris::IDataType const>, 
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

