### PR TITLE
[chore](format) remove the batch size in parquet/orc reader

### DIFF
--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -1232,8 +1232,7 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
         range.table_format_params.table_format_type == "iceberg") {
         // IcebergParquetReader IS-A ParquetReader (CRTP mixin), no wrapping needed
         std::unique_ptr<IcebergParquetReader> iceberg_reader = IcebergParquetReader::create_unique(
-                _kv_cache, _profile, *_params, range, _state->query_options().batch_size,
-                &_state->timezone_obj(), _io_ctx.get(), _state, file_meta_cache_ptr);
+                _kv_cache, _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr);
         iceberg_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1244,23 +1243,20 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
                range.table_format_params.table_format_type == "paimon") {
         // PaimonParquetReader IS-A ParquetReader, no wrapping needed
         auto paimon_reader = PaimonParquetReader::create_unique(
-                _profile, *_params, range, _state->query_options().batch_size,
-                &_state->timezone_obj(), _kv_cache, _io_ctx.get(), _state, file_meta_cache_ptr);
+                _profile, *_params, range, _kv_cache, _io_ctx.get(), _state, file_meta_cache_ptr);
         init_status = static_cast<GenericReader*>(paimon_reader.get())->init_reader(&pctx);
         _cur_reader = std::move(paimon_reader);
     } else if (range.__isset.table_format_params &&
                range.table_format_params.table_format_type == "hudi") {
         // HudiParquetReader IS-A ParquetReader, no wrapping needed
         auto hudi_reader = HudiParquetReader::create_unique(
-                _profile, *_params, range, _state->query_options().batch_size,
-                &_state->timezone_obj(), _io_ctx.get(), _state, file_meta_cache_ptr);
+                _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr);
         init_status = static_cast<GenericReader*>(hudi_reader.get())->init_reader(&pctx);
         _cur_reader = std::move(hudi_reader);
     } else if (range.table_format_params.table_format_type == "hive") {
         auto hive_reader = HiveParquetReader::create_unique(
-                _profile, *_params, range, _state->query_options().batch_size,
-                &_state->timezone_obj(), _io_ctx.get(), _state, &_is_file_slot, file_meta_cache_ptr,
-                _state->query_options().enable_parquet_lazy_mat);
+                _profile, *_params, range, _io_ctx.get(), _state, &_is_file_slot,
+                file_meta_cache_ptr, _state->query_options().enable_parquet_lazy_mat);
         hive_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1270,8 +1266,7 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
     } else if (range.table_format_params.table_format_type == "tvf") {
         if (!parquet_reader) {
             parquet_reader = ParquetReader::create_unique(
-                    _profile, *_params, range, _state->query_options().batch_size,
-                    &_state->timezone_obj(), _io_ctx.get(), _state, file_meta_cache_ptr,
+                    _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr,
                     _state->query_options().enable_parquet_lazy_mat);
         }
         parquet_reader->set_create_row_id_column_iterator_func(
@@ -1283,8 +1278,7 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
     } else if (_is_load) {
         if (!parquet_reader) {
             parquet_reader = ParquetReader::create_unique(
-                    _profile, *_params, range, _state->query_options().batch_size,
-                    &_state->timezone_obj(), _io_ctx.get(), _state, file_meta_cache_ptr,
+                    _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr,
                     _state->query_options().enable_parquet_lazy_mat);
         }
         init_status = static_cast<GenericReader*>(parquet_reader.get())->init_reader(&pctx);
@@ -1310,8 +1304,7 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
         range.table_format_params.table_format_type == "transactional_hive") {
         // TransactionalHiveReader IS-A OrcReader, no wrapping needed
         auto tran_orc_reader = TransactionalHiveReader::create_unique(
-                _profile, _state, *_params, range, _state->query_options().batch_size,
-                _state->timezone(), _io_ctx.get(), file_meta_cache_ptr);
+                _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr);
         tran_orc_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1323,8 +1316,7 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
                range.table_format_params.table_format_type == "iceberg") {
         // IcebergOrcReader IS-A OrcReader (CRTP mixin), no wrapping needed
         std::unique_ptr<IcebergOrcReader> iceberg_reader = IcebergOrcReader::create_unique(
-                _kv_cache, _profile, _state, *_params, range, _state->query_options().batch_size,
-                _state->timezone(), _io_ctx.get(), file_meta_cache_ptr);
+                _kv_cache, _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr);
         iceberg_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1336,26 +1328,23 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
                range.table_format_params.table_format_type == "paimon") {
         // PaimonOrcReader IS-A OrcReader, no wrapping needed
         auto paimon_reader = PaimonOrcReader::create_unique(
-                _profile, _state, *_params, range, _state->query_options().batch_size,
-                _state->timezone(), _kv_cache, _io_ctx.get(), file_meta_cache_ptr);
+                _profile, _state, *_params, range, _kv_cache, _io_ctx.get(), file_meta_cache_ptr);
         init_status = static_cast<GenericReader*>(paimon_reader.get())->init_reader(&octx);
 
         _cur_reader = std::move(paimon_reader);
     } else if (range.__isset.table_format_params &&
                range.table_format_params.table_format_type == "hudi") {
         // HudiOrcReader IS-A OrcReader, no wrapping needed
-        auto hudi_reader = HudiOrcReader::create_unique(
-                _profile, _state, *_params, range, _state->query_options().batch_size,
-                _state->timezone(), _io_ctx.get(), file_meta_cache_ptr);
+        auto hudi_reader = HudiOrcReader::create_unique(_profile, _state, *_params, range,
+                                                        _io_ctx.get(), file_meta_cache_ptr);
         init_status = static_cast<GenericReader*>(hudi_reader.get())->init_reader(&octx);
 
         _cur_reader = std::move(hudi_reader);
     } else if (range.__isset.table_format_params &&
                range.table_format_params.table_format_type == "hive") {
         auto hive_reader = HiveOrcReader::create_unique(
-                _profile, _state, *_params, range, _state->query_options().batch_size,
-                _state->timezone(), _io_ctx.get(), &_is_file_slot, file_meta_cache_ptr,
-                _state->query_options().enable_orc_lazy_mat);
+                _profile, _state, *_params, range, _io_ctx.get(), &_is_file_slot,
+                file_meta_cache_ptr, _state->query_options().enable_orc_lazy_mat);
         hive_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1366,10 +1355,9 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
     } else if (range.__isset.table_format_params &&
                range.table_format_params.table_format_type == "tvf") {
         if (!orc_reader) {
-            orc_reader = OrcReader::create_unique(
-                    _profile, _state, *_params, range, _state->query_options().batch_size,
-                    _state->timezone(), _io_ctx.get(), file_meta_cache_ptr,
-                    _state->query_options().enable_orc_lazy_mat);
+            orc_reader = OrcReader::create_unique(_profile, _state, *_params, range, _io_ctx.get(),
+                                                  file_meta_cache_ptr,
+                                                  _state->query_options().enable_orc_lazy_mat);
         }
         orc_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
@@ -1379,10 +1367,9 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
         _cur_reader = std::move(orc_reader);
     } else if (_is_load) {
         if (!orc_reader) {
-            orc_reader = OrcReader::create_unique(
-                    _profile, _state, *_params, range, _state->query_options().batch_size,
-                    _state->timezone(), _io_ctx.get(), file_meta_cache_ptr,
-                    _state->query_options().enable_orc_lazy_mat);
+            orc_reader = OrcReader::create_unique(_profile, _state, *_params, range, _io_ctx.get(),
+                                                  file_meta_cache_ptr,
+                                                  _state->query_options().enable_orc_lazy_mat);
         }
         init_status = static_cast<GenericReader*>(orc_reader.get())->init_reader(&octx);
         _cur_reader = std::move(orc_reader);
@@ -1481,9 +1468,9 @@ Status FileScanner::read_lines_from_range(const TFileRangeDesc& range,
             [&]() -> Status {
                 switch (format_type) {
                 case TFileFormatType::FORMAT_PARQUET: {
-                    std::unique_ptr<ParquetReader> parquet_reader = ParquetReader::create_unique(
-                            _profile, *_params, range, 1, &_state->timezone_obj(), _io_ctx.get(),
-                            _state, file_meta_cache_ptr, false);
+                    std::unique_ptr<ParquetReader> parquet_reader =
+                            ParquetReader::create_unique(_profile, *_params, range, _io_ctx.get(),
+                                                         _state, file_meta_cache_ptr, false);
                     RETURN_IF_ERROR(
                             _init_parquet_reader(file_meta_cache_ptr, std::move(parquet_reader)));
                     // _init_parquet_reader may create a new table-format specific reader
@@ -1493,9 +1480,9 @@ Status FileScanner::read_lines_from_range(const TFileRangeDesc& range,
                     break;
                 }
                 case TFileFormatType::FORMAT_ORC: {
-                    std::unique_ptr<OrcReader> orc_reader = OrcReader::create_unique(
-                            _profile, _state, *_params, range, 1, _state->timezone(), _io_ctx.get(),
-                            file_meta_cache_ptr, false);
+                    std::unique_ptr<OrcReader> orc_reader =
+                            OrcReader::create_unique(_profile, _state, *_params, range,
+                                                     _io_ctx.get(), file_meta_cache_ptr, false);
                     RETURN_IF_ERROR(_init_orc_reader(file_meta_cache_ptr, std::move(orc_reader)));
                     // Same as above: re-apply read_by_rows to the actual _cur_reader.
                     RETURN_IF_ERROR(_cur_reader->read_by_rows(row_ids));

--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -1067,7 +1067,7 @@ Status FileScanner::_get_next_reader() {
         case TFileFormatType::FORMAT_CSV_DEFLATE:
         case TFileFormatType::FORMAT_CSV_SNAPPYBLOCK:
         case TFileFormatType::FORMAT_PROTO: {
-            auto reader = CsvReader::create_unique(_state, _profile, &_counter, *_params, range,
+            auto reader = CsvReader::create_unique(_profile, _state, &_counter, *_params, range,
                                                    _file_slot_descs, _io_ctx.get());
             CsvInitContext csv_ctx;
             _fill_base_init_context(&csv_ctx);
@@ -1077,7 +1077,7 @@ Status FileScanner::_get_next_reader() {
             break;
         }
         case TFileFormatType::FORMAT_TEXT: {
-            auto reader = TextReader::create_unique(_state, _profile, &_counter, *_params, range,
+            auto reader = TextReader::create_unique(_profile, _state, &_counter, *_params, range,
                                                     _file_slot_descs, _io_ctx.get());
             CsvInitContext text_ctx;
             _fill_base_init_context(&text_ctx);
@@ -1088,7 +1088,7 @@ Status FileScanner::_get_next_reader() {
         }
         case TFileFormatType::FORMAT_JSON: {
             _cur_reader =
-                    NewJsonReader::create_unique(_state, _profile, &_counter, *_params, range,
+                    NewJsonReader::create_unique(_profile, _state, &_counter, *_params, range,
                                                  _file_slot_descs, &_scanner_eof, _io_ctx.get());
             JsonInitContext json_ctx;
             _fill_base_init_context(&json_ctx);
@@ -1108,7 +1108,7 @@ Status FileScanner::_get_next_reader() {
         }
         case TFileFormatType::FORMAT_NATIVE: {
             auto reader =
-                    NativeReader::create_unique(_profile, *_params, range, _io_ctx.get(), _state);
+                    NativeReader::create_unique(_profile, _state, *_params, range, _io_ctx.get());
             ReaderInitContext native_ctx;
             _fill_base_init_context(&native_ctx);
             init_status = static_cast<GenericReader*>(reader.get())->init_reader(&native_ctx);
@@ -1232,7 +1232,7 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
         range.table_format_params.table_format_type == "iceberg") {
         // IcebergParquetReader IS-A ParquetReader (CRTP mixin), no wrapping needed
         std::unique_ptr<IcebergParquetReader> iceberg_reader = IcebergParquetReader::create_unique(
-                _kv_cache, _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr);
+                _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr, _kv_cache);
         iceberg_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1243,20 +1243,21 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
                range.table_format_params.table_format_type == "paimon") {
         // PaimonParquetReader IS-A ParquetReader, no wrapping needed
         auto paimon_reader = PaimonParquetReader::create_unique(
-                _profile, *_params, range, _kv_cache, _io_ctx.get(), _state, file_meta_cache_ptr);
+                _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr,
+                /*enable_lazy_mat=*/true, _kv_cache);
         init_status = static_cast<GenericReader*>(paimon_reader.get())->init_reader(&pctx);
         _cur_reader = std::move(paimon_reader);
     } else if (range.__isset.table_format_params &&
                range.table_format_params.table_format_type == "hudi") {
         // HudiParquetReader IS-A ParquetReader, no wrapping needed
-        auto hudi_reader = HudiParquetReader::create_unique(
-                _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr);
+        auto hudi_reader = HudiParquetReader::create_unique(_profile, _state, *_params, range,
+                                                            _io_ctx.get(), file_meta_cache_ptr);
         init_status = static_cast<GenericReader*>(hudi_reader.get())->init_reader(&pctx);
         _cur_reader = std::move(hudi_reader);
     } else if (range.table_format_params.table_format_type == "hive") {
         auto hive_reader = HiveParquetReader::create_unique(
-                _profile, *_params, range, _io_ctx.get(), _state, &_is_file_slot,
-                file_meta_cache_ptr, _state->query_options().enable_parquet_lazy_mat);
+                _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr,
+                _state->query_options().enable_parquet_lazy_mat, &_is_file_slot);
         hive_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1266,7 +1267,7 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
     } else if (range.table_format_params.table_format_type == "tvf") {
         if (!parquet_reader) {
             parquet_reader = ParquetReader::create_unique(
-                    _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr,
+                    _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr,
                     _state->query_options().enable_parquet_lazy_mat);
         }
         parquet_reader->set_create_row_id_column_iterator_func(
@@ -1278,7 +1279,7 @@ Status FileScanner::_init_parquet_reader(FileMetaCache* file_meta_cache_ptr,
     } else if (_is_load) {
         if (!parquet_reader) {
             parquet_reader = ParquetReader::create_unique(
-                    _profile, *_params, range, _io_ctx.get(), _state, file_meta_cache_ptr,
+                    _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr,
                     _state->query_options().enable_parquet_lazy_mat);
         }
         init_status = static_cast<GenericReader*>(parquet_reader.get())->init_reader(&pctx);
@@ -1316,7 +1317,7 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
                range.table_format_params.table_format_type == "iceberg") {
         // IcebergOrcReader IS-A OrcReader (CRTP mixin), no wrapping needed
         std::unique_ptr<IcebergOrcReader> iceberg_reader = IcebergOrcReader::create_unique(
-                _kv_cache, _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr);
+                _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr, _kv_cache);
         iceberg_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1327,8 +1328,9 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
     } else if (range.__isset.table_format_params &&
                range.table_format_params.table_format_type == "paimon") {
         // PaimonOrcReader IS-A OrcReader, no wrapping needed
-        auto paimon_reader = PaimonOrcReader::create_unique(
-                _profile, _state, *_params, range, _kv_cache, _io_ctx.get(), file_meta_cache_ptr);
+        auto paimon_reader = PaimonOrcReader::create_unique(_profile, _state, *_params, range,
+                                                            _io_ctx.get(), file_meta_cache_ptr,
+                                                            /*enable_lazy_mat=*/true, _kv_cache);
         init_status = static_cast<GenericReader*>(paimon_reader.get())->init_reader(&octx);
 
         _cur_reader = std::move(paimon_reader);
@@ -1343,8 +1345,8 @@ Status FileScanner::_init_orc_reader(FileMetaCache* file_meta_cache_ptr,
     } else if (range.__isset.table_format_params &&
                range.table_format_params.table_format_type == "hive") {
         auto hive_reader = HiveOrcReader::create_unique(
-                _profile, _state, *_params, range, _io_ctx.get(), &_is_file_slot,
-                file_meta_cache_ptr, _state->query_options().enable_orc_lazy_mat);
+                _profile, _state, *_params, range, _io_ctx.get(), file_meta_cache_ptr,
+                _state->query_options().enable_orc_lazy_mat, &_is_file_slot);
         hive_reader->set_create_row_id_column_iterator_func(
                 [this]() -> std::shared_ptr<segment_v2::RowIdColumnIteratorV2> {
                     return _create_row_id_column_iterator();
@@ -1469,8 +1471,8 @@ Status FileScanner::read_lines_from_range(const TFileRangeDesc& range,
                 switch (format_type) {
                 case TFileFormatType::FORMAT_PARQUET: {
                     std::unique_ptr<ParquetReader> parquet_reader =
-                            ParquetReader::create_unique(_profile, *_params, range, _io_ctx.get(),
-                                                         _state, file_meta_cache_ptr, false);
+                            ParquetReader::create_unique(_profile, _state, *_params, range,
+                                                         _io_ctx.get(), file_meta_cache_ptr, false);
                     RETURN_IF_ERROR(
                             _init_parquet_reader(file_meta_cache_ptr, std::move(parquet_reader)));
                     // _init_parquet_reader may create a new table-format specific reader

--- a/be/src/exec/sink/viceberg_delete_sink.cpp
+++ b/be/src/exec/sink/viceberg_delete_sink.cpp
@@ -91,7 +91,6 @@ Status load_rewritable_delete_rows(RuntimeState* state, RuntimeProfile* profile,
     options.profile = profile;
     options.scan_params = &params;
     options.io_ctx = &delete_file_io_ctx.io_ctx;
-    options.batch_size = 102400;
 
     for (const auto& delete_file : delete_files) {
         if (is_iceberg_deletion_vector(delete_file)) {

--- a/be/src/format/csv/csv_reader.cpp
+++ b/be/src/format/csv/csv_reader.cpp
@@ -384,7 +384,7 @@ Status CsvReader::_do_get_next_block(Block* block, size_t* read_rows, bool* eof)
         return Status::OK();
     }
 
-    const int batch_size = std::max(_state->batch_size(), (int)_MIN_BATCH_SIZE);
+    const int batch_size = _state->batch_size();
     const int64_t max_block_bytes =
             (_state->query_type() == TQueryType::LOAD && config::load_reader_max_block_bytes > 0)
                     ? config::load_reader_max_block_bytes

--- a/be/src/format/csv/csv_reader.cpp
+++ b/be/src/format/csv/csv_reader.cpp
@@ -169,7 +169,7 @@ void PlainCsvTextFieldSplitter::do_split(const Slice& line, std::vector<Slice>* 
     }
 }
 
-CsvReader::CsvReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounter* counter,
+CsvReader::CsvReader(RuntimeProfile* profile, RuntimeState* state, ScannerCounter* counter,
                      const TFileScanRangeParams& params, const TFileRangeDesc& range,
                      const std::vector<SlotDescriptor*>& file_slot_descs, io::IOContext* io_ctx,
                      std::shared_ptr<io::IOContext> io_ctx_holder)

--- a/be/src/format/csv/csv_reader.h
+++ b/be/src/format/csv/csv_reader.h
@@ -174,7 +174,7 @@ class CsvReader : public TableFormatReader {
     ENABLE_FACTORY_CREATOR(CsvReader);
 
 public:
-    CsvReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounter* counter,
+    CsvReader(RuntimeProfile* profile, RuntimeState* state, ScannerCounter* counter,
               const TFileScanRangeParams& params, const TFileRangeDesc& range,
               const std::vector<SlotDescriptor*>& file_slot_descs, io::IOContext* io_ctx,
               std::shared_ptr<io::IOContext> io_ctx_holder = nullptr);

--- a/be/src/format/generic_reader.h
+++ b/be/src/format/generic_reader.h
@@ -255,8 +255,6 @@ protected:
         return Status::NotSupported("read_by_rows is not implemented for this reader.");
     }
 
-    const size_t _MIN_BATCH_SIZE = 4064; // 4094 - 32(padding)
-
     TPushAggOp::type _push_down_agg_type {};
 
 public:

--- a/be/src/format/json/new_json_reader.cpp
+++ b/be/src/format/json/new_json_reader.cpp
@@ -248,7 +248,7 @@ Status NewJsonReader::_do_get_next_block(Block* block, size_t* read_rows, bool* 
         return Status::OK();
     }
 
-    const int batch_size = std::max(_state->batch_size(), (int)_MIN_BATCH_SIZE);
+    const int batch_size = _state->batch_size();
     const int64_t max_block_bytes =
             (_state->query_type() == TQueryType::LOAD && config::load_reader_max_block_bytes > 0)
                     ? config::load_reader_max_block_bytes

--- a/be/src/format/json/new_json_reader.cpp
+++ b/be/src/format/json/new_json_reader.cpp
@@ -75,7 +75,7 @@ enum class FileCachePolicy : uint8_t;
 namespace doris {
 using namespace ErrorCode;
 
-NewJsonReader::NewJsonReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounter* counter,
+NewJsonReader::NewJsonReader(RuntimeProfile* profile, RuntimeState* state, ScannerCounter* counter,
                              const TFileScanRangeParams& params, const TFileRangeDesc& range,
                              const std::vector<SlotDescriptor*>& file_slot_descs, bool* scanner_eof,
                              io::IOContext* io_ctx, std::shared_ptr<io::IOContext> io_ctx_holder)
@@ -114,12 +114,12 @@ NewJsonReader::NewJsonReader(RuntimeState* state, RuntimeProfile* profile, Scann
     _init_file_description();
 }
 
-NewJsonReader::NewJsonReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                             const TFileRangeDesc& range,
+NewJsonReader::NewJsonReader(RuntimeProfile* profile, RuntimeState* state,
+                             const TFileScanRangeParams& params, const TFileRangeDesc& range,
                              const std::vector<SlotDescriptor*>& file_slot_descs,
                              io::IOContext* io_ctx, std::shared_ptr<io::IOContext> io_ctx_holder)
         : _vhandle_json_callback(nullptr),
-          _state(nullptr),
+          _state(state),
           _profile(profile),
           _params(params),
           _range(range),

--- a/be/src/format/json/new_json_reader.h
+++ b/be/src/format/json/new_json_reader.h
@@ -73,12 +73,12 @@ class NewJsonReader : public TableFormatReader {
     ENABLE_FACTORY_CREATOR(NewJsonReader);
 
 public:
-    NewJsonReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounter* counter,
+    NewJsonReader(RuntimeProfile* profile, RuntimeState* state, ScannerCounter* counter,
                   const TFileScanRangeParams& params, const TFileRangeDesc& range,
                   const std::vector<SlotDescriptor*>& file_slot_descs, bool* scanner_eof,
                   io::IOContext* io_ctx, std::shared_ptr<io::IOContext> io_ctx_holder = nullptr);
 
-    NewJsonReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
+    NewJsonReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
                   const TFileRangeDesc& range, const std::vector<SlotDescriptor*>& file_slot_descs,
                   io::IOContext* io_ctx, std::shared_ptr<io::IOContext> io_ctx_holder = nullptr);
     ~NewJsonReader() override = default;

--- a/be/src/format/native/native_reader.cpp
+++ b/be/src/format/native/native_reader.cpp
@@ -30,8 +30,9 @@
 
 namespace doris {
 
-NativeReader::NativeReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                           const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state)
+NativeReader::NativeReader(RuntimeProfile* profile, RuntimeState* state,
+                           const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                           io::IOContext* io_ctx)
         : _profile(profile),
           _scan_params(params),
           _scan_range(range),

--- a/be/src/format/native/native_reader.h
+++ b/be/src/format/native/native_reader.h
@@ -48,8 +48,8 @@ class NativeReader : public TableFormatReader {
 public:
     ENABLE_FACTORY_CREATOR(NativeReader);
 
-    NativeReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                 const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state);
+    NativeReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
+                 const TFileRangeDesc& range, io::IOContext* io_ctx);
 
     ~NativeReader() override;
 

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -182,19 +182,6 @@ void StripeStreamInputStream::read(void* buf, uint64_t length, uint64_t offset) 
 OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
                      const TFileScanRangeParams& params, const TFileRangeDesc& range,
                      io::IOContext* io_ctx, FileMetaCache* meta_cache, bool enable_lazy_mat)
-        : OrcReader(profile, state, params, range, io_ctx, nullptr, meta_cache, enable_lazy_mat) {}
-
-OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
-                     const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     std::shared_ptr<io::IOContext> io_ctx_holder, FileMetaCache* meta_cache,
-                     bool enable_lazy_mat)
-        : OrcReader(profile, state, params, range, io_ctx_holder ? io_ctx_holder.get() : nullptr,
-                    std::move(io_ctx_holder), meta_cache, enable_lazy_mat) {}
-
-OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
-                     const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     io::IOContext* io_ctx, std::shared_ptr<io::IOContext> io_ctx_holder,
-                     FileMetaCache* meta_cache, bool enable_lazy_mat)
         : _profile(profile),
           _state(state),
           _scan_params(params),
@@ -203,7 +190,6 @@ OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
           _range_size(range.size),
           _ctz(state->timezone()),
           _io_ctx(io_ctx),
-          _io_ctx_holder(std::move(io_ctx_holder)),
           _enable_lazy_mat(enable_lazy_mat),
           _enable_filter_by_min_max(state->query_options().enable_orc_filter_by_min_max),
           _dict_cols_has_converted(false) {
@@ -282,16 +268,9 @@ Status OrcReader::_create_file_reader() {
                 _scan_range.__isset.modification_time ? _scan_range.modification_time : 0;
         io::FileReaderOptions reader_options =
                 FileFactory::get_reader_options(_state, _file_description);
-        io::FileReaderSPtr inner_reader;
-        if (_io_ctx_holder != nullptr) {
-            inner_reader = DORIS_TRY(io::DelegateReader::create_file_reader(
-                    _profile, _system_properties, _file_description, reader_options,
-                    io::DelegateReader::AccessMode::RANDOM, _io_ctx_holder));
-        } else {
-            inner_reader = DORIS_TRY(io::DelegateReader::create_file_reader(
-                    _profile, _system_properties, _file_description, reader_options,
-                    io::DelegateReader::AccessMode::RANDOM, _io_ctx));
-        }
+        io::FileReaderSPtr inner_reader = DORIS_TRY(io::DelegateReader::create_file_reader(
+                _profile, _system_properties, _file_description, reader_options,
+                io::DelegateReader::AccessMode::RANDOM, _io_ctx));
         _file_input_stream = std::make_unique<ORCFileInputStream>(
                 _scan_range.path, std::move(inner_reader), _io_ctx, _profile,
                 _orc_once_max_read_bytes, _orc_max_merge_distance_bytes);

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -179,90 +179,38 @@ void StripeStreamInputStream::read(void* buf, uint64_t length, uint64_t offset) 
                                                length, has_read, _file_name));
     }
 }
+OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
+                     const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                     io::IOContext* io_ctx, FileMetaCache* meta_cache, bool enable_lazy_mat)
+        : OrcReader(profile, state, params, range, io_ctx, nullptr, meta_cache, enable_lazy_mat) {}
 
 OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
                      const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     size_t batch_size, const std::string& ctz, io::IOContext* io_ctx,
-                     FileMetaCache* meta_cache, bool enable_lazy_mat)
-        : _profile(profile),
-          _state(state),
-          _scan_params(params),
-          _scan_range(range),
-          _batch_size(std::max(batch_size, _MIN_BATCH_SIZE)),
-          _range_start_offset(range.start_offset),
-          _range_size(range.size),
-          _ctz(ctz),
-          _io_ctx(io_ctx),
-          _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(
-                  state == nullptr ? true : state->query_options().enable_orc_filter_by_min_max),
-          _dict_cols_has_converted(false) {
-    TimezoneUtils::find_cctz_time_zone(ctz, _time_zone);
-    _meta_cache = meta_cache;
-    _init_profile();
-    _init_system_properties();
-    _init_file_description();
-}
-
-OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
-                     const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     size_t batch_size, const std::string& ctz,
                      std::shared_ptr<io::IOContext> io_ctx_holder, FileMetaCache* meta_cache,
                      bool enable_lazy_mat)
+        : OrcReader(profile, state, params, range, io_ctx_holder ? io_ctx_holder.get() : nullptr,
+                    std::move(io_ctx_holder), meta_cache, enable_lazy_mat) {}
+
+OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
+                     const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                     io::IOContext* io_ctx, std::shared_ptr<io::IOContext> io_ctx_holder,
+                     FileMetaCache* meta_cache, bool enable_lazy_mat)
         : _profile(profile),
           _state(state),
           _scan_params(params),
           _scan_range(range),
-          _batch_size(std::max(batch_size, _MIN_BATCH_SIZE)),
           _range_start_offset(range.start_offset),
           _range_size(range.size),
-          _ctz(ctz),
-          _io_ctx(io_ctx_holder ? io_ctx_holder.get() : nullptr),
+          _ctz(state->timezone()),
+          _io_ctx(io_ctx),
           _io_ctx_holder(std::move(io_ctx_holder)),
           _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(
-                  state == nullptr ? true : state->query_options().enable_orc_filter_by_min_max),
+          _enable_filter_by_min_max(state->query_options().enable_orc_filter_by_min_max),
           _dict_cols_has_converted(false) {
-    TimezoneUtils::find_cctz_time_zone(ctz, _time_zone);
+    _batch_size = state->batch_size();
+    _time_zone = state->timezone_obj();
     _meta_cache = meta_cache;
     _init_profile();
-    _init_system_properties();
-    _init_file_description();
-}
-
-OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     const std::string& ctz, io::IOContext* io_ctx, FileMetaCache* meta_cache,
-                     bool enable_lazy_mat)
-        : _profile(nullptr),
-          _scan_params(params),
-          _scan_range(range),
-          _batch_size(_MIN_BATCH_SIZE),
-          _ctz(ctz),
-          _file_system(nullptr),
-          _io_ctx(io_ctx),
-          _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(true),
-          _dict_cols_has_converted(false) {
-    _meta_cache = meta_cache;
-    _init_system_properties();
-    _init_file_description();
-}
-
-OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     const std::string& ctz, std::shared_ptr<io::IOContext> io_ctx_holder,
-                     FileMetaCache* meta_cache, bool enable_lazy_mat)
-        : _profile(nullptr),
-          _scan_params(params),
-          _scan_range(range),
-          _batch_size(_MIN_BATCH_SIZE),
-          _ctz(ctz),
-          _file_system(nullptr),
-          _io_ctx(io_ctx_holder ? io_ctx_holder.get() : nullptr),
-          _io_ctx_holder(std::move(io_ctx_holder)),
-          _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(true),
-          _dict_cols_has_converted(false) {
-    _meta_cache = meta_cache;
     _init_system_properties();
     _init_file_description();
 }
@@ -2272,8 +2220,8 @@ Status OrcReader::_get_next_block_impl(Block* block, size_t* read_rows, bool* eo
                     : 0;
 
     if (max_block_bytes > 0 && _load_bytes_per_row > 0 && _row_reader) {
-        size_t new_batch_size = std::max(
-                (size_t)1, (size_t)((int64_t)max_block_bytes / (int64_t)_load_bytes_per_row));
+        int new_batch_size =
+                std::max(1, (int)((int64_t)max_block_bytes / (int64_t)_load_bytes_per_row));
         if (new_batch_size != _batch_size) {
             _batch_size = new_batch_size;
             _batch = _row_reader->createRowBatch(_batch_size);

--- a/be/src/format/orc/vorc_reader.h
+++ b/be/src/format/orc/vorc_reader.h
@@ -155,10 +155,6 @@ public:
               const TFileRangeDesc& range, io::IOContext* io_ctx,
               FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
 
-    OrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
-              const TFileRangeDesc& range, std::shared_ptr<io::IOContext> io_ctx_holder,
-              FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
-
     ~OrcReader() override = default;
 
     // Override to build table_info_node from ORC file type using by_orc_name.
@@ -237,12 +233,6 @@ public:
     void set_condition_cache_context(std::shared_ptr<ConditionCacheContext> ctx) override {
         _condition_cache_ctx = std::move(ctx);
     }
-
-private:
-    OrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
-              const TFileRangeDesc& range, io::IOContext* io_ctx,
-              std::shared_ptr<io::IOContext> io_ctx_holder, FileMetaCache* meta_cache,
-              bool enable_lazy_mat);
 
 protected:
     bool supports_count_pushdown() const override { return true; }
@@ -782,7 +772,6 @@ private:
     std::shared_ptr<io::FileSystem> _file_system;
 
     io::IOContext* _io_ctx = nullptr;
-    std::shared_ptr<io::IOContext> _io_ctx_holder;
     const TupleDescriptor* _tuple_descriptor = nullptr;
     const RowDescriptor* _row_descriptor = nullptr;
     bool _enable_lazy_mat = true;

--- a/be/src/format/orc/vorc_reader.h
+++ b/be/src/format/orc/vorc_reader.h
@@ -152,21 +152,11 @@ public:
     };
 
     OrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
-              const TFileRangeDesc& range, size_t batch_size, const std::string& ctz,
-              io::IOContext* io_ctx, FileMetaCache* meta_cache = nullptr,
-              bool enable_lazy_mat = true);
+              const TFileRangeDesc& range, io::IOContext* io_ctx,
+              FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
 
     OrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
-              const TFileRangeDesc& range, size_t batch_size, const std::string& ctz,
-              std::shared_ptr<io::IOContext> io_ctx_holder, FileMetaCache* meta_cache = nullptr,
-              bool enable_lazy_mat = true);
-
-    OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-              const std::string& ctz, io::IOContext* io_ctx, FileMetaCache* meta_cache = nullptr,
-              bool enable_lazy_mat = true);
-
-    OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-              const std::string& ctz, std::shared_ptr<io::IOContext> io_ctx_holder,
+              const TFileRangeDesc& range, std::shared_ptr<io::IOContext> io_ctx_holder,
               FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
 
     ~OrcReader() override = default;
@@ -248,6 +238,13 @@ public:
         _condition_cache_ctx = std::move(ctx);
     }
 
+private:
+    OrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
+              const TFileRangeDesc& range, io::IOContext* io_ctx,
+              std::shared_ptr<io::IOContext> io_ctx_holder, FileMetaCache* meta_cache,
+              bool enable_lazy_mat);
+
+protected:
     bool supports_count_pushdown() const override { return true; }
 
     int64_t get_total_rows() const override {
@@ -712,9 +709,9 @@ private:
     Status _set_read_one_line_impl() override {
         _batch_size = 1;
         // If the ORC row reader already exists, the batch was created earlier
-        // (during _do_init_reader) with the original _batch_size (capped to
-        // _MIN_BATCH_SIZE = 4064).  We must recreate it with the new size of 1
-        // so that nextBatch() returns at most 1 row per call.
+        // during _do_init_reader with the previous _batch_size. We must recreate
+        // it with the new size of 1 so that nextBatch() returns at most 1 row
+        // per call.
         if (_row_reader) {
             _batch = _row_reader->createRowBatch(_batch_size);
         }
@@ -730,15 +727,11 @@ private:
     const TFileRangeDesc& _scan_range;
     io::FileSystemProperties _system_properties;
     io::FileDescription _file_description;
-    size_t _batch_size;
     // Bytes-per-row estimate from the previous batch, used to pre-shrink _batch_size
     // before reading so that oversized blocks are prevented from the current call onward.
     // Zero means no prior data (first batch).
     size_t _load_bytes_per_row = 0;
     int64_t _range_start_offset;
-
-protected:
-    size_t get_batch_size() const { return _batch_size; }
 
 private:
     int64_t _range_size;

--- a/be/src/format/parquet/vparquet_reader.cpp
+++ b/be/src/format/parquet/vparquet_reader.cpp
@@ -81,96 +81,40 @@ class Block;
 namespace doris {
 
 ParquetReader::ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                             const TFileRangeDesc& range, size_t batch_size,
-                             const cctz::time_zone* ctz, io::IOContext* io_ctx, RuntimeState* state,
-                             FileMetaCache* meta_cache, bool enable_lazy_mat)
-        : _profile(profile),
-          _scan_params(params),
-          _scan_range(range),
-          _batch_size(std::max(batch_size, _MIN_BATCH_SIZE)),
-          _range_start_offset(range.start_offset),
-          _range_size(range.size),
-          _ctz(ctz),
-          _io_ctx(io_ctx),
-          _state(state),
-          _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_min_max),
-          _enable_filter_by_bloom_filter(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_bloom_filter) {
-    _meta_cache = meta_cache;
-    _init_profile();
-    _init_system_properties();
-    _init_file_description();
-}
+                             const TFileRangeDesc& range, io::IOContext* io_ctx,
+                             RuntimeState* state, FileMetaCache* meta_cache, bool enable_lazy_mat)
+        : ParquetReader(profile, params, range, io_ctx, nullptr, state, meta_cache,
+                        enable_lazy_mat) {}
 
 ParquetReader::ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                             const TFileRangeDesc& range, size_t batch_size,
-                             const cctz::time_zone* ctz,
+                             const TFileRangeDesc& range,
+                             std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
+                             FileMetaCache* meta_cache, bool enable_lazy_mat)
+        : ParquetReader(profile, params, range, io_ctx_holder ? io_ctx_holder.get() : nullptr,
+                        std::move(io_ctx_holder), state, meta_cache, enable_lazy_mat) {}
+
+ParquetReader::ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
+                             const TFileRangeDesc& range, io::IOContext* io_ctx,
                              std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
                              FileMetaCache* meta_cache, bool enable_lazy_mat)
         : _profile(profile),
           _scan_params(params),
           _scan_range(range),
-          _batch_size(std::max(batch_size, _MIN_BATCH_SIZE)),
           _range_start_offset(range.start_offset),
           _range_size(range.size),
-          _ctz(ctz),
-          _io_ctx(io_ctx_holder ? io_ctx_holder.get() : nullptr),
-          _io_ctx_holder(std::move(io_ctx_holder)),
-          _state(state),
-          _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_min_max),
-          _enable_filter_by_bloom_filter(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_bloom_filter) {
-    _meta_cache = meta_cache;
-    _init_profile();
-    _init_system_properties();
-    _init_file_description();
-}
-
-ParquetReader::ParquetReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                             io::IOContext* io_ctx, RuntimeState* state, FileMetaCache* meta_cache,
-                             bool enable_lazy_mat)
-        : _profile(nullptr),
-          _scan_params(params),
-          _scan_range(range),
+          _ctz(&state->timezone_obj()),
           _io_ctx(io_ctx),
-          _state(state),
-          _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_min_max),
-          _enable_filter_by_bloom_filter(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_bloom_filter) {
-    _meta_cache = meta_cache;
-    _init_system_properties();
-    _init_file_description();
-}
-
-ParquetReader::ParquetReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                             std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
-                             FileMetaCache* meta_cache, bool enable_lazy_mat)
-        : _profile(nullptr),
-          _scan_params(params),
-          _scan_range(range),
-          _io_ctx(io_ctx_holder ? io_ctx_holder.get() : nullptr),
           _io_ctx_holder(std::move(io_ctx_holder)),
           _state(state),
           _enable_lazy_mat(enable_lazy_mat),
-          _enable_filter_by_min_max(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_min_max),
+          _enable_filter_by_min_max(state->query_options().enable_parquet_filter_by_min_max),
           _enable_filter_by_bloom_filter(
-                  state == nullptr ? true
-                                   : state->query_options().enable_parquet_filter_by_bloom_filter) {
+                  state->query_options().enable_parquet_filter_by_bloom_filter) {
+    _batch_size = state->batch_size();
     _meta_cache = meta_cache;
+    if (_profile != nullptr) {
+        _init_profile();
+    }
     _init_system_properties();
     _init_file_description();
 }
@@ -781,8 +725,7 @@ Status ParquetReader::_do_get_next_block(Block* block, size_t* read_rows, bool* 
                     ? config::load_reader_max_block_bytes
                     : 0;
     if (max_block_bytes > 0 && _load_bytes_per_row > 0) {
-        _batch_size = std::max((size_t)1,
-                               (size_t)((int64_t)max_block_bytes / (int64_t)_load_bytes_per_row));
+        _batch_size = std::max(1, (int)((int64_t)max_block_bytes / (int64_t)_load_bytes_per_row));
     }
 
     SCOPED_RAW_TIMER(&_reader_statistics.column_read_time);

--- a/be/src/format/parquet/vparquet_reader.cpp
+++ b/be/src/format/parquet/vparquet_reader.cpp
@@ -80,23 +80,9 @@ class Block;
 
 namespace doris {
 
-ParquetReader::ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                             const TFileRangeDesc& range, io::IOContext* io_ctx,
-                             RuntimeState* state, FileMetaCache* meta_cache, bool enable_lazy_mat)
-        : ParquetReader(profile, params, range, io_ctx, nullptr, state, meta_cache,
-                        enable_lazy_mat) {}
-
-ParquetReader::ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                             const TFileRangeDesc& range,
-                             std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
-                             FileMetaCache* meta_cache, bool enable_lazy_mat)
-        : ParquetReader(profile, params, range, io_ctx_holder ? io_ctx_holder.get() : nullptr,
-                        std::move(io_ctx_holder), state, meta_cache, enable_lazy_mat) {}
-
-ParquetReader::ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                             const TFileRangeDesc& range, io::IOContext* io_ctx,
-                             std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
-                             FileMetaCache* meta_cache, bool enable_lazy_mat)
+ParquetReader::ParquetReader(RuntimeProfile* profile, RuntimeState* state,
+                             const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                             io::IOContext* io_ctx, FileMetaCache* meta_cache, bool enable_lazy_mat)
         : _profile(profile),
           _scan_params(params),
           _scan_range(range),
@@ -104,7 +90,6 @@ ParquetReader::ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams
           _range_size(range.size),
           _ctz(&state->timezone_obj()),
           _io_ctx(io_ctx),
-          _io_ctx_holder(std::move(io_ctx_holder)),
           _state(state),
           _enable_lazy_mat(enable_lazy_mat),
           _enable_filter_by_min_max(state->query_options().enable_parquet_filter_by_min_max),

--- a/be/src/format/parquet/vparquet_reader.h
+++ b/be/src/format/parquet/vparquet_reader.h
@@ -117,14 +117,9 @@ public:
         int64_t bloom_filter_read_time = 0;
     };
 
-    ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state,
+    ParquetReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
+                  const TFileRangeDesc& range, io::IOContext* io_ctx,
                   FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
-
-    ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, std::shared_ptr<io::IOContext> io_ctx_holder,
-                  RuntimeState* state, FileMetaCache* meta_cache = nullptr,
-                  bool enable_lazy_mat = true);
 
     ~ParquetReader() override;
 #ifdef BE_TEST
@@ -208,12 +203,6 @@ public:
 
 protected:
     void _collect_profile_before_close() override;
-
-private:
-    ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, io::IOContext* io_ctx,
-                  std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
-                  FileMetaCache* meta_cache, bool enable_lazy_mat);
 
 protected:
     // Core block reading implementation
@@ -408,7 +397,6 @@ private:
     ParquetProfile _parquet_profile;
     bool _closed = false;
     io::IOContext* _io_ctx = nullptr;
-    std::shared_ptr<io::IOContext> _io_ctx_holder;
     RuntimeState* _state = nullptr;
     const TupleDescriptor* _tuple_descriptor = nullptr;
     const RowDescriptor* _row_descriptor = nullptr;

--- a/be/src/format/parquet/vparquet_reader.h
+++ b/be/src/format/parquet/vparquet_reader.h
@@ -118,22 +118,13 @@ public:
     };
 
     ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, size_t batch_size, const cctz::time_zone* ctz,
-                  io::IOContext* io_ctx, RuntimeState* state, FileMetaCache* meta_cache = nullptr,
-                  bool enable_lazy_mat = true);
+                  const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state,
+                  FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
 
     ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, size_t batch_size, const cctz::time_zone* ctz,
-                  std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
-                  FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
-
-    ParquetReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                  io::IOContext* io_ctx, RuntimeState* state, FileMetaCache* meta_cache = nullptr,
+                  const TFileRangeDesc& range, std::shared_ptr<io::IOContext> io_ctx_holder,
+                  RuntimeState* state, FileMetaCache* meta_cache = nullptr,
                   bool enable_lazy_mat = true);
-
-    ParquetReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                  std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
-                  FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true);
 
     ~ParquetReader() override;
 #ifdef BE_TEST
@@ -218,6 +209,13 @@ public:
 protected:
     void _collect_profile_before_close() override;
 
+private:
+    ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
+                  const TFileRangeDesc& range, io::IOContext* io_ctx,
+                  std::shared_ptr<io::IOContext> io_ctx_holder, RuntimeState* state,
+                  FileMetaCache* meta_cache, bool enable_lazy_mat);
+
+protected:
     // Core block reading implementation
     Status _do_get_next_block(Block* block, size_t* read_rows, bool* eof) override;
 
@@ -227,6 +225,7 @@ protected:
         return Status::OK();
     }
 
+protected:
     // Protected accessors so CRTP mixin subclasses can reach private members
     io::IOContext* get_io_ctx() const { return _io_ctx; }
     std::unordered_map<std::string, uint32_t>*& col_name_to_block_idx_ref() {
@@ -394,7 +393,6 @@ private:
     RuntimeProfile* _profile = nullptr;
     const TFileScanRangeParams& _scan_params;
     const TFileRangeDesc& _scan_range;
-    size_t _batch_size;
     // Bytes-per-row estimate from the previous batch, used to pre-shrink _batch_size
     // before reading so that oversized blocks are prevented from the current call onward.
     // Zero means no prior data (first batch).
@@ -430,7 +428,6 @@ protected:
     // register synthesized columns in on_before_init_reader.
     RowGroupReader::LazyReadContext _lazy_read_ctx;
     bool _filter_groups = true;
-    size_t get_batch_size() const { return _batch_size; }
 
     std::function<std::shared_ptr<segment_v2::RowIdColumnIteratorV2>()>
             _create_topn_row_id_column_iterator;

--- a/be/src/format/table/hive_reader.h
+++ b/be/src/format/table/hive_reader.h
@@ -28,9 +28,8 @@ class HiveOrcReader final : public OrcReader, public TableSchemaChangeHelper {
 public:
     ENABLE_FACTORY_CREATOR(HiveOrcReader);
     HiveOrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, io::IOContext* io_ctx,
-                  const std::set<TSlotId>* is_file_slot, FileMetaCache* meta_cache = nullptr,
-                  bool enable_lazy_mat = true)
+                  const TFileRangeDesc& range, io::IOContext* io_ctx, FileMetaCache* meta_cache,
+                  bool enable_lazy_mat, const std::set<TSlotId>* is_file_slot)
             : OrcReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat),
               _is_file_slot(is_file_slot) {}
 
@@ -52,11 +51,11 @@ private:
 class HiveParquetReader final : public ParquetReader, public TableSchemaChangeHelper {
 public:
     ENABLE_FACTORY_CREATOR(HiveParquetReader);
-    HiveParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                      const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state,
-                      const std::set<TSlotId>* is_file_slot, FileMetaCache* meta_cache = nullptr,
-                      bool enable_lazy_mat = true)
-            : ParquetReader(profile, params, range, io_ctx, state, meta_cache, enable_lazy_mat),
+    HiveParquetReader(RuntimeProfile* profile, RuntimeState* state,
+                      const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                      io::IOContext* io_ctx, FileMetaCache* meta_cache, bool enable_lazy_mat,
+                      const std::set<TSlotId>* is_file_slot)
+            : ParquetReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat),
               _is_file_slot(is_file_slot) {}
 
     ~HiveParquetReader() final = default;

--- a/be/src/format/table/hive_reader.h
+++ b/be/src/format/table/hive_reader.h
@@ -28,11 +28,10 @@ class HiveOrcReader final : public OrcReader, public TableSchemaChangeHelper {
 public:
     ENABLE_FACTORY_CREATOR(HiveOrcReader);
     HiveOrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, size_t batch_size, const std::string& ctz,
-                  io::IOContext* io_ctx, const std::set<TSlotId>* is_file_slot,
-                  FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
-            : OrcReader(profile, state, params, range, batch_size, ctz, io_ctx, meta_cache,
-                        enable_lazy_mat),
+                  const TFileRangeDesc& range, io::IOContext* io_ctx,
+                  const std::set<TSlotId>* is_file_slot, FileMetaCache* meta_cache = nullptr,
+                  bool enable_lazy_mat = true)
+            : OrcReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat),
               _is_file_slot(is_file_slot) {}
 
     ~HiveOrcReader() final = default;
@@ -54,12 +53,10 @@ class HiveParquetReader final : public ParquetReader, public TableSchemaChangeHe
 public:
     ENABLE_FACTORY_CREATOR(HiveParquetReader);
     HiveParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                      const TFileRangeDesc& range, size_t batch_size, const cctz::time_zone* ctz,
-                      io::IOContext* io_ctx, RuntimeState* state,
+                      const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state,
                       const std::set<TSlotId>* is_file_slot, FileMetaCache* meta_cache = nullptr,
                       bool enable_lazy_mat = true)
-            : ParquetReader(profile, params, range, batch_size, ctz, io_ctx, state, meta_cache,
-                            enable_lazy_mat),
+            : ParquetReader(profile, params, range, io_ctx, state, meta_cache, enable_lazy_mat),
               _is_file_slot(is_file_slot) {}
 
     ~HiveParquetReader() final = default;

--- a/be/src/format/table/hudi_reader.h
+++ b/be/src/format/table/hudi_reader.h
@@ -29,11 +29,9 @@ class HudiParquetReader final : public ParquetReader, public TableSchemaChangeHe
 public:
     ENABLE_FACTORY_CREATOR(HudiParquetReader);
     HudiParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                      const TFileRangeDesc& range, size_t batch_size, const cctz::time_zone* ctz,
-                      io::IOContext* io_ctx, RuntimeState* state,
+                      const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state,
                       FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
-            : ParquetReader(profile, params, range, batch_size, ctz, io_ctx, state, meta_cache,
-                            enable_lazy_mat) {}
+            : ParquetReader(profile, params, range, io_ctx, state, meta_cache, enable_lazy_mat) {}
     ~HudiParquetReader() final = default;
 
 protected:
@@ -45,11 +43,9 @@ class HudiOrcReader final : public OrcReader, public TableSchemaChangeHelper {
 public:
     ENABLE_FACTORY_CREATOR(HudiOrcReader);
     HudiOrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
-                  const TFileRangeDesc& range, size_t batch_size, const std::string& ctz,
-                  io::IOContext* io_ctx, FileMetaCache* meta_cache = nullptr,
-                  bool enable_lazy_mat = true)
-            : OrcReader(profile, state, params, range, batch_size, ctz, io_ctx, meta_cache,
-                        enable_lazy_mat) {}
+                  const TFileRangeDesc& range, io::IOContext* io_ctx,
+                  FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
+            : OrcReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat) {}
     ~HudiOrcReader() final = default;
 
 protected:

--- a/be/src/format/table/hudi_reader.h
+++ b/be/src/format/table/hudi_reader.h
@@ -28,10 +28,11 @@ namespace doris {
 class HudiParquetReader final : public ParquetReader, public TableSchemaChangeHelper {
 public:
     ENABLE_FACTORY_CREATOR(HudiParquetReader);
-    HudiParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                      const TFileRangeDesc& range, io::IOContext* io_ctx, RuntimeState* state,
-                      FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
-            : ParquetReader(profile, params, range, io_ctx, state, meta_cache, enable_lazy_mat) {}
+    HudiParquetReader(RuntimeProfile* profile, RuntimeState* state,
+                      const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                      io::IOContext* io_ctx, FileMetaCache* meta_cache = nullptr,
+                      bool enable_lazy_mat = true)
+            : ParquetReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat) {}
     ~HudiParquetReader() final = default;
 
 protected:

--- a/be/src/format/table/iceberg_delete_file_reader_helper.cpp
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.cpp
@@ -233,9 +233,9 @@ Status read_iceberg_position_delete_file(const TIcebergDeleteFileDesc& delete_fi
     RETURN_IF_ERROR(validate_position_delete_file_format(delete_file, &file_format));
 
     if (file_format == TFileFormatType::FORMAT_PARQUET) {
-        ParquetReader reader(options.profile, *options.scan_params, delete_range,
-                             options.batch_size, &options.state->timezone_obj(), options.io_ctx,
+        ParquetReader reader(options.profile, *options.scan_params, delete_range, options.io_ctx,
                              options.state, options.meta_cache);
+        reader.use_delete_file_batch_size();
         bool dictionary_coded = false;
         RETURN_IF_ERROR(init_parquet_delete_reader(&reader, &dictionary_coded));
 
@@ -262,8 +262,8 @@ Status read_iceberg_position_delete_file(const TIcebergDeleteFileDesc& delete_fi
 
     if (file_format == TFileFormatType::FORMAT_ORC) {
         OrcReader reader(options.profile, options.state, *options.scan_params, delete_range,
-                         options.batch_size, options.state->timezone(), options.io_ctx,
-                         options.meta_cache);
+                         options.io_ctx, options.meta_cache);
+        reader.use_delete_file_batch_size();
         RETURN_IF_ERROR(init_orc_delete_reader(&reader));
 
         bool eof = false;

--- a/be/src/format/table/iceberg_delete_file_reader_helper.cpp
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.cpp
@@ -233,8 +233,8 @@ Status read_iceberg_position_delete_file(const TIcebergDeleteFileDesc& delete_fi
     RETURN_IF_ERROR(validate_position_delete_file_format(delete_file, &file_format));
 
     if (file_format == TFileFormatType::FORMAT_PARQUET) {
-        ParquetReader reader(options.profile, *options.scan_params, delete_range, options.io_ctx,
-                             options.state, options.meta_cache);
+        ParquetReader reader(options.profile, options.state, *options.scan_params, delete_range,
+                             options.io_ctx, options.meta_cache);
         reader.use_delete_file_batch_size();
         bool dictionary_coded = false;
         RETURN_IF_ERROR(init_parquet_delete_reader(&reader, &dictionary_coded));

--- a/be/src/format/table/iceberg_delete_file_reader_helper.h
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.h
@@ -50,7 +50,6 @@ struct IcebergDeleteFileReaderOptions {
     io::IOContext* io_ctx = nullptr;
     FileMetaCache* meta_cache = nullptr;
     const std::string* fs_name = nullptr;
-    size_t batch_size = 102400;
 };
 
 class IcebergPositionDeleteVisitor {

--- a/be/src/format/table/iceberg_reader.cpp
+++ b/be/src/format/table/iceberg_reader.cpp
@@ -369,8 +369,8 @@ ColumnIdResult IcebergParquetReader::_create_column_ids(const FieldDescriptor* f
 Status IcebergParquetReader::_read_position_delete_file(const TFileRangeDesc* delete_range,
                                                         DeleteFile* position_delete) {
     ParquetReader parquet_delete_reader(get_profile(), get_scan_params(), *delete_range,
-                                        READ_DELETE_FILE_BATCH_SIZE, &get_state()->timezone_obj(),
                                         get_io_ctx(), get_state(), _meta_cache);
+    parquet_delete_reader.use_delete_file_batch_size();
     // The delete file range has size=-1 (read whole file). We must disable
     // row group filtering before init; otherwise _do_init_reader returns EndOfFile
     // when _filter_groups && _range_size < 0.
@@ -644,8 +644,8 @@ ColumnIdResult IcebergOrcReader::_create_column_ids(const orc::Type* orc_type,
 Status IcebergOrcReader::_read_position_delete_file(const TFileRangeDesc* delete_range,
                                                     DeleteFile* position_delete) {
     OrcReader orc_delete_reader(get_profile(), get_state(), get_scan_params(), *delete_range,
-                                READ_DELETE_FILE_BATCH_SIZE, get_state()->timezone(), get_io_ctx(),
-                                _meta_cache);
+                                get_io_ctx(), _meta_cache);
+    orc_delete_reader.use_delete_file_batch_size();
     OrcInitContext delete_ctx;
     delete_ctx.column_names = delete_file_col_names;
     delete_ctx.col_name_to_block_idx =

--- a/be/src/format/table/iceberg_reader.cpp
+++ b/be/src/format/table/iceberg_reader.cpp
@@ -368,8 +368,8 @@ ColumnIdResult IcebergParquetReader::_create_column_ids(const FieldDescriptor* f
 // ============================================================================
 Status IcebergParquetReader::_read_position_delete_file(const TFileRangeDesc* delete_range,
                                                         DeleteFile* position_delete) {
-    ParquetReader parquet_delete_reader(get_profile(), get_scan_params(), *delete_range,
-                                        get_io_ctx(), get_state(), _meta_cache);
+    ParquetReader parquet_delete_reader(get_profile(), get_state(), get_scan_params(),
+                                        *delete_range, get_io_ctx(), _meta_cache);
     parquet_delete_reader.use_delete_file_batch_size();
     // The delete file range has size=-1 (read whole file). We must disable
     // row group filtering before init; otherwise _do_init_reader returns EndOfFile

--- a/be/src/format/table/iceberg_reader.h
+++ b/be/src/format/table/iceberg_reader.h
@@ -69,10 +69,10 @@ class IcebergParquetReader final : public IcebergReaderMixin<ParquetReader> {
 public:
     ENABLE_FACTORY_CREATOR(IcebergParquetReader);
 
-    IcebergParquetReader(ShardedKVCache* kv_cache, RuntimeProfile* profile,
+    IcebergParquetReader(RuntimeProfile* profile, RuntimeState* state,
                          const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                         io::IOContext* io_ctx, RuntimeState* state, FileMetaCache* meta_cache)
-            : IcebergReaderMixin<ParquetReader>(kv_cache, profile, params, range, io_ctx, state,
+                         io::IOContext* io_ctx, FileMetaCache* meta_cache, ShardedKVCache* kv_cache)
+            : IcebergReaderMixin<ParquetReader>(kv_cache, profile, state, params, range, io_ctx,
                                                 meta_cache) {}
 
     void set_delete_rows() final {
@@ -86,9 +86,9 @@ protected:
 
     std::unique_ptr<GenericReader> _create_equality_reader(
             const TFileRangeDesc& delete_desc) final {
-        auto reader = ParquetReader::create_unique(this->get_profile(), this->get_scan_params(),
-                                                   delete_desc, this->get_io_ctx(),
-                                                   this->get_state(), this->_meta_cache);
+        auto reader = ParquetReader::create_unique(this->get_profile(), this->get_state(),
+                                                   this->get_scan_params(), delete_desc,
+                                                   this->get_io_ctx(), this->_meta_cache);
         reader->use_delete_file_batch_size();
         return reader;
     }
@@ -106,9 +106,9 @@ class IcebergOrcReader final : public IcebergReaderMixin<OrcReader> {
 public:
     ENABLE_FACTORY_CREATOR(IcebergOrcReader);
 
-    IcebergOrcReader(ShardedKVCache* kv_cache, RuntimeProfile* profile, RuntimeState* state,
+    IcebergOrcReader(RuntimeProfile* profile, RuntimeState* state,
                      const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     io::IOContext* io_ctx, FileMetaCache* meta_cache)
+                     io::IOContext* io_ctx, FileMetaCache* meta_cache, ShardedKVCache* kv_cache)
             : IcebergReaderMixin<OrcReader>(kv_cache, profile, state, params, range, io_ctx,
                                             meta_cache) {}
 

--- a/be/src/format/table/iceberg_reader.h
+++ b/be/src/format/table/iceberg_reader.h
@@ -71,10 +71,9 @@ public:
 
     IcebergParquetReader(ShardedKVCache* kv_cache, RuntimeProfile* profile,
                          const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                         size_t batch_size, const cctz::time_zone* ctz, io::IOContext* io_ctx,
-                         RuntimeState* state, FileMetaCache* meta_cache)
-            : IcebergReaderMixin<ParquetReader>(kv_cache, profile, params, range, batch_size, ctz,
-                                                io_ctx, state, meta_cache) {}
+                         io::IOContext* io_ctx, RuntimeState* state, FileMetaCache* meta_cache)
+            : IcebergReaderMixin<ParquetReader>(kv_cache, profile, params, range, io_ctx, state,
+                                                meta_cache) {}
 
     void set_delete_rows() final {
         // Call ParquetReader's set_delete_rows(const vector<int64_t>*)
@@ -87,10 +86,11 @@ protected:
 
     std::unique_ptr<GenericReader> _create_equality_reader(
             const TFileRangeDesc& delete_desc) final {
-        return ParquetReader::create_unique(this->get_profile(), this->get_scan_params(),
-                                            delete_desc, READ_DELETE_FILE_BATCH_SIZE,
-                                            &this->get_state()->timezone_obj(), this->get_io_ctx(),
-                                            this->get_state(), this->_meta_cache);
+        auto reader = ParquetReader::create_unique(this->get_profile(), this->get_scan_params(),
+                                                   delete_desc, this->get_io_ctx(),
+                                                   this->get_state(), this->_meta_cache);
+        reader->use_delete_file_batch_size();
+        return reader;
     }
 
     static ColumnIdResult _create_column_ids(const FieldDescriptor* field_desc,
@@ -108,10 +108,9 @@ public:
 
     IcebergOrcReader(ShardedKVCache* kv_cache, RuntimeProfile* profile, RuntimeState* state,
                      const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                     size_t batch_size, const std::string& ctz, io::IOContext* io_ctx,
-                     FileMetaCache* meta_cache)
-            : IcebergReaderMixin<OrcReader>(kv_cache, profile, state, params, range, batch_size,
-                                            ctz, io_ctx, meta_cache) {}
+                     io::IOContext* io_ctx, FileMetaCache* meta_cache)
+            : IcebergReaderMixin<OrcReader>(kv_cache, profile, state, params, range, io_ctx,
+                                            meta_cache) {}
 
     void set_delete_rows() final {
         // Call OrcReader's set_position_delete_rowids
@@ -124,10 +123,11 @@ protected:
 
     std::unique_ptr<GenericReader> _create_equality_reader(
             const TFileRangeDesc& delete_desc) override {
-        return OrcReader::create_unique(this->get_profile(), this->get_state(),
-                                        this->get_scan_params(), delete_desc,
-                                        READ_DELETE_FILE_BATCH_SIZE, this->get_state()->timezone(),
-                                        this->get_io_ctx(), this->_meta_cache);
+        auto reader = OrcReader::create_unique(this->get_profile(), this->get_state(),
+                                               this->get_scan_params(), delete_desc,
+                                               this->get_io_ctx(), this->_meta_cache);
+        reader->use_delete_file_batch_size();
+        return reader;
     }
 
     static ColumnIdResult _create_column_ids(const orc::Type* orc_type,

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -327,8 +327,6 @@ protected:
             {ICEBERG_FILE_PATH, 0}, {ICEBERG_ROW_POS, 1}};
     const int ICEBERG_FILE_PATH_INDEX = 0;
     const int ICEBERG_FILE_POS_INDEX = 1;
-    const int READ_DELETE_FILE_BATCH_SIZE = 102400;
-
     // all ids that need read for eq delete (from all eq delete files)
     std::set<int> _equality_delete_col_ids;
     // eq delete column ids -> location of _equality_delete_blocks / _equality_delete_impls

--- a/be/src/format/table/paimon_reader.h
+++ b/be/src/format/table/paimon_reader.h
@@ -34,8 +34,8 @@ public:
     ENABLE_FACTORY_CREATOR(PaimonOrcReader);
     PaimonOrcReader(RuntimeProfile* profile, RuntimeState* state,
                     const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                    ShardedKVCache* kv_cache, io::IOContext* io_ctx,
-                    FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
+                    io::IOContext* io_ctx, FileMetaCache* meta_cache, bool enable_lazy_mat,
+                    ShardedKVCache* kv_cache)
             : OrcReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat),
               _kv_cache(kv_cache) {
         _init_paimon_profile();
@@ -66,11 +66,11 @@ private:
 class PaimonParquetReader final : public ParquetReader, public TableSchemaChangeHelper {
 public:
     ENABLE_FACTORY_CREATOR(PaimonParquetReader);
-    PaimonParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                        const TFileRangeDesc& range, ShardedKVCache* kv_cache,
-                        io::IOContext* io_ctx, RuntimeState* state,
-                        FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
-            : ParquetReader(profile, params, range, io_ctx, state, meta_cache, enable_lazy_mat),
+    PaimonParquetReader(RuntimeProfile* profile, RuntimeState* state,
+                        const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                        io::IOContext* io_ctx, FileMetaCache* meta_cache, bool enable_lazy_mat,
+                        ShardedKVCache* kv_cache)
+            : ParquetReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat),
               _kv_cache(kv_cache) {
         _init_paimon_profile();
     }

--- a/be/src/format/table/paimon_reader.h
+++ b/be/src/format/table/paimon_reader.h
@@ -34,11 +34,9 @@ public:
     ENABLE_FACTORY_CREATOR(PaimonOrcReader);
     PaimonOrcReader(RuntimeProfile* profile, RuntimeState* state,
                     const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                    size_t batch_size, const std::string& ctz, ShardedKVCache* kv_cache,
-                    io::IOContext* io_ctx, FileMetaCache* meta_cache = nullptr,
-                    bool enable_lazy_mat = true)
-            : OrcReader(profile, state, params, range, batch_size, ctz, io_ctx, meta_cache,
-                        enable_lazy_mat),
+                    ShardedKVCache* kv_cache, io::IOContext* io_ctx,
+                    FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
+            : OrcReader(profile, state, params, range, io_ctx, meta_cache, enable_lazy_mat),
               _kv_cache(kv_cache) {
         _init_paimon_profile();
     }
@@ -69,11 +67,10 @@ class PaimonParquetReader final : public ParquetReader, public TableSchemaChange
 public:
     ENABLE_FACTORY_CREATOR(PaimonParquetReader);
     PaimonParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
-                        const TFileRangeDesc& range, size_t batch_size, const cctz::time_zone* ctz,
-                        ShardedKVCache* kv_cache, io::IOContext* io_ctx, RuntimeState* state,
+                        const TFileRangeDesc& range, ShardedKVCache* kv_cache,
+                        io::IOContext* io_ctx, RuntimeState* state,
                         FileMetaCache* meta_cache = nullptr, bool enable_lazy_mat = true)
-            : ParquetReader(profile, params, range, batch_size, ctz, io_ctx, state, meta_cache,
-                            enable_lazy_mat),
+            : ParquetReader(profile, params, range, io_ctx, state, meta_cache, enable_lazy_mat),
               _kv_cache(kv_cache) {
         _init_paimon_profile();
     }

--- a/be/src/format/table/table_format_reader.h
+++ b/be/src/format/table/table_format_reader.h
@@ -56,6 +56,10 @@ public:
     /// Get missing columns computed by on_before_init_reader / get_columns().
     const std::unordered_set<std::string>& missing_cols() const { return _fill_missing_cols; }
 
+    /// Override _batch_size to DELETE_FILE_BATCH_SIZE.
+    /// Must be called immediately after construction, before init_reader().
+    void use_delete_file_batch_size() { _batch_size = DELETE_FILE_BATCH_SIZE; }
+
     // ---- Fill-column hooks (called by RowGroupReader and ORC per-batch reading) ----
 
     /// Fill partition columns from metadata values.
@@ -267,6 +271,17 @@ protected:
             const TFileRangeDesc& range, const TupleDescriptor* tuple_descriptor,
             std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>&
                     partition_values);
+
+    /// Base batch size initialized from RuntimeState::batch_size()
+    /// in derived-class constructors.  May be increased by use_delete_file_batch_size()
+    /// when this reader is serving as a delete-file reader (Iceberg, Hive ACID).
+    int _batch_size = 0;
+
+    /// Convenience accessor.
+    int get_batch_size() const { return _batch_size; }
+
+    /// Larger batch size for delete file reads to amortize per-batch overhead.
+    static constexpr int DELETE_FILE_BATCH_SIZE = 102400;
 
     // ---- Fill column data (set by on_before_init_reader / _do_init_reader) ----
     std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>

--- a/be/src/format/table/transactional_hive_reader.cpp
+++ b/be/src/format/table/transactional_hive_reader.cpp
@@ -36,10 +36,9 @@ namespace doris {
 
 TransactionalHiveReader::TransactionalHiveReader(RuntimeProfile* profile, RuntimeState* state,
                                                  const TFileScanRangeParams& params,
-                                                 const TFileRangeDesc& range, size_t batch_size,
-                                                 const std::string& ctz, io::IOContext* io_ctx,
+                                                 const TFileRangeDesc& range, io::IOContext* io_ctx,
                                                  FileMetaCache* meta_cache)
-        : OrcReader(profile, state, params, range, batch_size, ctz, io_ctx, meta_cache, false) {
+        : OrcReader(profile, state, params, range, io_ctx, meta_cache, false) {
     static const char* transactional_hive_profile = "TransactionalHiveProfile";
     ADD_TIMER(get_profile(), transactional_hive_profile);
     _transactional_orc_profile.num_delete_files = ADD_CHILD_COUNTER(
@@ -186,8 +185,8 @@ Status TransactionalHiveReader::on_after_init_reader(ReaderInitContext* /*ctx*/)
         delete_range.file_size = -1;
 
         OrcReader delete_reader(get_profile(), get_state(), get_scan_params(), delete_range,
-                                256 /*batch_size*/, get_state()->timezone(), get_io_ctx(),
-                                _meta_cache, false);
+                                get_io_ctx(), _meta_cache, false);
+        delete_reader.use_delete_file_batch_size();
 
         auto acid_info_node = std::make_shared<StructNode>();
         for (auto idx = 0; idx < TransactionalHive::DELETE_ROW_COLUMN_NAMES_LOWER_CASE.size();

--- a/be/src/format/table/transactional_hive_reader.h
+++ b/be/src/format/table/transactional_hive_reader.h
@@ -51,8 +51,7 @@ class TransactionalHiveReader final : public OrcReader, public TableSchemaChange
 public:
     TransactionalHiveReader(RuntimeProfile* profile, RuntimeState* state,
                             const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                            size_t batch_size, const std::string& ctz, io::IOContext* io_ctx,
-                            FileMetaCache* meta_cache = nullptr);
+                            io::IOContext* io_ctx, FileMetaCache* meta_cache = nullptr);
     ~TransactionalHiveReader() final = default;
 
 protected:

--- a/be/src/format/text/text_reader.cpp
+++ b/be/src/format/text/text_reader.cpp
@@ -110,10 +110,10 @@ void HiveTextFieldSplitter::_split_field_multi_char(const Slice& line,
     process_value_func(data, start, size - start, _trimming_char, splitted_values);
 }
 
-TextReader::TextReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounter* counter,
+TextReader::TextReader(RuntimeProfile* profile, RuntimeState* state, ScannerCounter* counter,
                        const TFileScanRangeParams& params, const TFileRangeDesc& range,
                        const std::vector<SlotDescriptor*>& file_slot_descs, io::IOContext* io_ctx)
-        : CsvReader(state, profile, counter, params, range, file_slot_descs, io_ctx) {}
+        : CsvReader(profile, state, counter, params, range, file_slot_descs, io_ctx) {}
 
 Status TextReader::_init_options() {
     // get column_separator and line_delimiter

--- a/be/src/format/text/text_reader.h
+++ b/be/src/format/text/text_reader.h
@@ -53,7 +53,7 @@ class TextReader : public CsvReader {
     ENABLE_FACTORY_CREATOR(TextReader);
 
 public:
-    TextReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounter* counter,
+    TextReader(RuntimeProfile* profile, RuntimeState* state, ScannerCounter* counter,
                const TFileScanRangeParams& params, const TFileRangeDesc& range,
                const std::vector<SlotDescriptor*>& file_slot_descs, io::IOContext* io_ctx);
 

--- a/be/src/load/delta_writer/push_handler.cpp
+++ b/be/src/load/delta_writer/push_handler.cpp
@@ -634,7 +634,7 @@ Status PushBrokerReader::_get_next_reader() {
     switch (_file_params.format_type) {
     case TFileFormatType::FORMAT_PARQUET: {
         std::unique_ptr<ParquetReader> parquet_reader = ParquetReader::create_unique(
-                _runtime_profile, _file_params, range, _io_ctx.get(), _runtime_state.get());
+                _runtime_profile, _runtime_state.get(), _file_params, range, _io_ctx.get());
 
         ParquetInitContext ctx;
         ctx.column_names = _all_col_names;

--- a/be/src/load/delta_writer/push_handler.cpp
+++ b/be/src/load/delta_writer/push_handler.cpp
@@ -634,8 +634,7 @@ Status PushBrokerReader::_get_next_reader() {
     switch (_file_params.format_type) {
     case TFileFormatType::FORMAT_PARQUET: {
         std::unique_ptr<ParquetReader> parquet_reader = ParquetReader::create_unique(
-                _runtime_profile, _file_params, range, _runtime_state->query_options().batch_size,
-                &_runtime_state->timezone_obj(), _io_ctx.get(), _runtime_state.get());
+                _runtime_profile, _file_params, range, _io_ctx.get(), _runtime_state.get());
 
         ParquetInitContext ctx;
         ctx.column_names = _all_col_names;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -823,8 +823,9 @@ void PInternalService::fetch_table_schema(google::protobuf::RpcController* contr
         // might asynchronouslly access the profile
         std::unique_ptr<RuntimeProfile> profile =
                 std::make_unique<RuntimeProfile>("FetchTableSchema");
-        std::unique_ptr<GenericReader> reader(nullptr);
+        // io_ctx must outlive reader because reader holds a raw pointer to it.
         auto io_ctx = std::make_shared<io::IOContext>();
+        std::unique_ptr<GenericReader> reader(nullptr);
         auto file_cache_statis = std::make_shared<io::FileCacheStatistics>();
         auto file_reader_stats = std::make_shared<io::FileReaderStats>();
         io_ctx->file_cache_stats = file_cache_statis.get();
@@ -841,30 +842,31 @@ void PInternalService::fetch_table_schema(google::protobuf::RpcController* contr
         case TFileFormatType::FORMAT_CSV_SNAPPYBLOCK:
         case TFileFormatType::FORMAT_CSV_LZOP:
         case TFileFormatType::FORMAT_CSV_DEFLATE: {
-            reader = CsvReader::create_unique(nullptr, profile.get(), nullptr, params, range,
+            reader = CsvReader::create_unique(profile.get(), &state, nullptr, params, range,
                                               file_slots, io_ctx.get(), io_ctx);
             break;
         }
         case TFileFormatType::FORMAT_TEXT: {
-            reader = TextReader::create_unique(nullptr, profile.get(), nullptr, params, range,
+            reader = TextReader::create_unique(profile.get(), &state, nullptr, params, range,
                                                file_slots, io_ctx.get());
             break;
         }
         case TFileFormatType::FORMAT_PARQUET: {
-            reader = ParquetReader::create_unique(profile.get(), params, range, io_ctx, &state);
+            reader = ParquetReader::create_unique(profile.get(), &state, params, range,
+                                                  io_ctx.get());
             break;
         }
         case TFileFormatType::FORMAT_ORC: {
-            reader = OrcReader::create_unique(profile.get(), &state, params, range, io_ctx);
+            reader = OrcReader::create_unique(profile.get(), &state, params, range, io_ctx.get());
             break;
         }
         case TFileFormatType::FORMAT_NATIVE: {
-            reader = NativeReader::create_unique(profile.get(), params, range, io_ctx.get(),
-                                                 nullptr);
+            reader =
+                    NativeReader::create_unique(profile.get(), &state, params, range, io_ctx.get());
             break;
         }
         case TFileFormatType::FORMAT_JSON: {
-            reader = NewJsonReader::create_unique(profile.get(), params, range, file_slots,
+            reader = NewJsonReader::create_unique(profile.get(), &state, params, range, file_slots,
                                                   io_ctx.get(), io_ctx);
             break;
         }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -97,6 +97,7 @@
 #include "runtime/result_block_buffer.h"
 #include "runtime/result_buffer_mgr.h"
 #include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
 #include "runtime/thread_context.h"
 #include "runtime/workload_group/workload_group.h"
 #include "runtime/workload_group/workload_group_manager.h"
@@ -828,6 +829,7 @@ void PInternalService::fetch_table_schema(google::protobuf::RpcController* contr
         auto file_reader_stats = std::make_shared<io::FileReaderStats>();
         io_ctx->file_cache_stats = file_cache_statis.get();
         io_ctx->file_reader_stats = file_reader_stats.get();
+        RuntimeState state;
         // file_slots is no use, but the lifetime should be longer than reader
         std::vector<SlotDescriptor*> file_slots;
         switch (params.format_type) {
@@ -849,11 +851,11 @@ void PInternalService::fetch_table_schema(google::protobuf::RpcController* contr
             break;
         }
         case TFileFormatType::FORMAT_PARQUET: {
-            reader = ParquetReader::create_unique(params, range, io_ctx, nullptr);
+            reader = ParquetReader::create_unique(profile.get(), params, range, io_ctx, &state);
             break;
         }
         case TFileFormatType::FORMAT_ORC: {
-            reader = OrcReader::create_unique(params, range, "", io_ctx);
+            reader = OrcReader::create_unique(profile.get(), &state, params, range, io_ctx);
             break;
         }
         case TFileFormatType::FORMAT_NATIVE: {

--- a/be/test/format/condition_cache_test.cpp
+++ b/be/test/format/condition_cache_test.cpp
@@ -39,8 +39,8 @@ std::unique_ptr<ParquetReader> create_test_parquet_reader(RuntimeProfile* profil
                                                           RuntimeState* state,
                                                           const TFileScanRangeParams& params,
                                                           const TFileRangeDesc& range) {
-    return ParquetReader::create_unique(profile, params, range,
-                                        static_cast<io::IOContext*>(nullptr), state);
+    return ParquetReader::create_unique(profile, state, params, range,
+                                        static_cast<io::IOContext*>(nullptr));
 }
 
 std::unique_ptr<OrcReader> create_test_orc_reader(RuntimeProfile* profile, RuntimeState* state,

--- a/be/test/format/condition_cache_test.cpp
+++ b/be/test/format/condition_cache_test.cpp
@@ -28,10 +28,27 @@
 #include "format/orc/vorc_reader.h"
 #include "format/parquet/vparquet_reader.h"
 #include "format/table/transactional_hive_common.h"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
 
 namespace doris::vectorized {
 
 constexpr int GS = ConditionCacheContext::GRANULE_SIZE; // 2048
+
+std::unique_ptr<ParquetReader> create_test_parquet_reader(RuntimeProfile* profile,
+                                                          RuntimeState* state,
+                                                          const TFileScanRangeParams& params,
+                                                          const TFileRangeDesc& range) {
+    return ParquetReader::create_unique(profile, params, range,
+                                        static_cast<io::IOContext*>(nullptr), state);
+}
+
+std::unique_ptr<OrcReader> create_test_orc_reader(RuntimeProfile* profile, RuntimeState* state,
+                                                  const TFileScanRangeParams& params,
+                                                  const TFileRangeDesc& range) {
+    return OrcReader::create_unique(profile, state, params, range,
+                                    static_cast<io::IOContext*>(nullptr));
+}
 
 class FilterRangesByCacheTest : public testing::Test {};
 
@@ -442,7 +459,9 @@ protected:
 TEST_F(ConditionCacheDeleteOpsTest, ParquetNoDeletes_CachePopulated) {
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = ParquetReader::create_unique(params, range, nullptr, nullptr);
+    RuntimeProfile profile("test");
+    RuntimeState state;
+    auto reader = create_test_parquet_reader(&profile, &state, params, range);
 
     bool hit = false;
     std::shared_ptr<std::vector<bool>> cache;
@@ -459,7 +478,9 @@ TEST_F(ConditionCacheDeleteOpsTest, ParquetNoDeletes_CachePopulated) {
 TEST_F(ConditionCacheDeleteOpsTest, ParquetWithPositionDeletes_CacheSkipped) {
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = ParquetReader::create_unique(params, range, nullptr, nullptr);
+    RuntimeProfile profile("test");
+    RuntimeState state;
+    auto reader = create_test_parquet_reader(&profile, &state, params, range);
     std::vector<int64_t> deletes = {1, 5, 10};
     reader->set_delete_rows(&deletes);
 
@@ -476,7 +497,9 @@ TEST_F(ConditionCacheDeleteOpsTest, ParquetWithPositionDeletes_CacheSkipped) {
 TEST_F(ConditionCacheDeleteOpsTest, OrcNoDeletes_CachePopulated) {
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = OrcReader::create_unique(params, range, "", nullptr);
+    RuntimeProfile profile("test");
+    RuntimeState state;
+    auto reader = create_test_orc_reader(&profile, &state, params, range);
 
     bool hit = false;
     std::shared_ptr<std::vector<bool>> cache;
@@ -493,7 +516,9 @@ TEST_F(ConditionCacheDeleteOpsTest, OrcNoDeletes_CachePopulated) {
 TEST_F(ConditionCacheDeleteOpsTest, OrcWithPositionDeletes_CacheSkipped) {
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = OrcReader::create_unique(params, range, "", nullptr);
+    RuntimeProfile profile("test");
+    RuntimeState state;
+    auto reader = create_test_orc_reader(&profile, &state, params, range);
     std::vector<int64_t> pos_deletes = {0, 3, 7};
     reader->set_position_delete_rowids(&pos_deletes);
 
@@ -510,7 +535,9 @@ TEST_F(ConditionCacheDeleteOpsTest, OrcWithPositionDeletes_CacheSkipped) {
 TEST_F(ConditionCacheDeleteOpsTest, OrcWithAcidDeletes_CacheSkipped) {
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = OrcReader::create_unique(params, range, "", nullptr);
+    RuntimeProfile profile("test");
+    RuntimeState state;
+    auto reader = create_test_orc_reader(&profile, &state, params, range);
     AcidRowIDSet acid_deletes;
     acid_deletes.insert({1, 0, 5});
     reader->set_delete_rows(&acid_deletes);
@@ -569,7 +596,9 @@ TEST_F(ConditionCacheDeleteOpsTest, CacheHitSkippedWhenDeletesExist) {
     {
         TFileScanRangeParams params;
         TFileRangeDesc range;
-        auto reader = ParquetReader::create_unique(params, range, nullptr, nullptr);
+        RuntimeProfile profile("test");
+        RuntimeState state;
+        auto reader = create_test_parquet_reader(&profile, &state, params, range);
 
         bool hit = false;
         std::shared_ptr<std::vector<bool>> cache;
@@ -587,7 +616,9 @@ TEST_F(ConditionCacheDeleteOpsTest, CacheHitSkippedWhenDeletesExist) {
     {
         TFileScanRangeParams params;
         TFileRangeDesc range;
-        auto reader = ParquetReader::create_unique(params, range, nullptr, nullptr);
+        RuntimeProfile profile("test");
+        RuntimeState state;
+        auto reader = create_test_parquet_reader(&profile, &state, params, range);
         std::vector<int64_t> deletes = {1, 2, 3};
         reader->set_delete_rows(&deletes);
 
@@ -606,7 +637,9 @@ TEST_F(ConditionCacheDeleteOpsTest, CacheHitSkippedWhenDeletesExist) {
 TEST_F(ConditionCacheDeleteOpsTest, ZeroDigest_CacheAlwaysSkipped) {
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = ParquetReader::create_unique(params, range, nullptr, nullptr);
+    RuntimeProfile profile("test");
+    RuntimeState state;
+    auto reader = create_test_parquet_reader(&profile, &state, params, range);
 
     bool hit = false;
     std::shared_ptr<std::vector<bool>> cache;

--- a/be/test/format/native/native_reader_writer_test.cpp
+++ b/be/test/format/native/native_reader_writer_test.cpp
@@ -309,7 +309,7 @@ TEST_F(NativeReaderWriterTest, round_trip_native_file) {
     TFileRangeDesc scan_range;
     scan_range.__set_path(file_path);
     scan_range.__set_file_type(TFileType::FILE_LOCAL);
-    NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+    NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
     Block dst_block;
     size_t read_rows = 0;
@@ -382,7 +382,7 @@ TEST_F(NativeReaderWriterTest, round_trip_empty_and_single_row) {
         TFileRangeDesc scan_range;
         scan_range.__set_path(file_path);
         scan_range.__set_file_type(TFileType::FILE_LOCAL);
-        NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+        NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
         Block dst_block;
         size_t read_rows = 0;
@@ -426,7 +426,7 @@ TEST_F(NativeReaderWriterTest, round_trip_empty_and_single_row) {
         TFileRangeDesc scan_range;
         scan_range.__set_path(file_path);
         scan_range.__set_file_type(TFileType::FILE_LOCAL);
-        NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+        NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
         Block dst_block;
         size_t read_rows = 0;
@@ -509,7 +509,7 @@ TEST_F(NativeReaderWriterTest, round_trip_native_file_large_rows) {
     TFileRangeDesc scan_range;
     scan_range.__set_path(file_path);
     scan_range.__set_file_type(TFileType::FILE_LOCAL);
-    NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+    NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
     // Read back in multiple blocks and merge into a single result block.
     Block merged_block;
@@ -619,7 +619,7 @@ TEST_F(NativeReaderWriterTest, non_nullable_columns_forced_nullable) {
     TFileRangeDesc scan_range;
     scan_range.__set_path(file_path);
     scan_range.__set_file_type(TFileType::FILE_LOCAL);
-    NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+    NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
     Block dst_block;
     size_t read_rows = 0;
@@ -707,7 +707,7 @@ TEST_F(NativeReaderWriterTest, transformer_writes_header_and_reader_handles_it) 
     TFileRangeDesc scan_range;
     scan_range.__set_path(file_path);
     scan_range.__set_file_type(TFileType::FILE_LOCAL);
-    NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+    NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
     Block dst_block;
     size_t read_rows = 0;
@@ -754,7 +754,7 @@ TEST_F(NativeReaderWriterTest, get_columns_and_parsed_schema) {
     TFileRangeDesc scan_range;
     scan_range.__set_path(file_path);
     scan_range.__set_file_type(TFileType::FILE_LOCAL);
-    NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+    NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
     std::unordered_map<std::string, DataTypePtr> name_to_type;
     st = reader_impl.get_columns(&name_to_type);
@@ -1226,7 +1226,7 @@ TEST_F(NativeReaderWriterTest, read_all_types_from_pregenerated_file) {
     TFileRangeDesc scan_range;
     scan_range.__set_path(file_path);
     scan_range.__set_file_type(TFileType::FILE_LOCAL);
-    NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+    NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
     Block dst_block;
     size_t read_rows = 0;
@@ -1300,7 +1300,7 @@ TEST_F(NativeReaderWriterTest, round_trip_all_types_single_row) {
     TFileRangeDesc scan_range;
     scan_range.__set_path(file_path);
     scan_range.__set_file_type(TFileType::FILE_LOCAL);
-    NativeReader reader_impl(nullptr, scan_params, scan_range, nullptr, &state);
+    NativeReader reader_impl(nullptr, &state, scan_params, scan_range, nullptr);
 
     Block dst_block;
     size_t read_rows = 0;

--- a/be/test/format/orc/orc_convert_dict_test.cpp
+++ b/be/test/format/orc/orc_convert_dict_test.cpp
@@ -25,6 +25,8 @@
 #include "core/column/column_struct.h"
 #include "format/orc/vorc_reader.h"
 #include "orc/ColumnPrinter.hh"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
 
 namespace doris {
 class OrcReaderConvertDictTest : public ::testing::Test {
@@ -32,6 +34,17 @@ protected:
     void SetUp() override {}
 
     void TearDown() override {}
+
+    std::unique_ptr<OrcReader> create_reader(const TFileScanRangeParams& params,
+                                             const TFileRangeDesc& range,
+                                             bool enable_lazy_mat = true) {
+        return OrcReader::create_unique(&profile, &state, params, range,
+                                        static_cast<io::IOContext*>(nullptr), nullptr,
+                                        enable_lazy_mat);
+    }
+
+    RuntimeProfile profile {"test"};
+    RuntimeState state;
 };
 
 std::unique_ptr<orc::EncodedStringVectorBatch> create_encoded_string_batch(
@@ -81,7 +94,7 @@ TEST_F(OrcReaderConvertDictTest, ConvertDictColumnToStringColumnBasic) {
 
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto reader = create_reader(params, range);
 
     // Execute conversion
     auto result_column = reader->_convert_dict_column_to_string_column(
@@ -118,7 +131,7 @@ TEST_F(OrcReaderConvertDictTest, ConvertDictColumnToStringColumnWithNulls) {
 
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto _reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto _reader = create_reader(params, range);
 
     // Execute conversion
     auto result_column = _reader->_convert_dict_column_to_string_column(
@@ -150,7 +163,7 @@ TEST_F(OrcReaderConvertDictTest, ConvertDictColumnToStringColumnChar) {
     auto orc_type_ptr = createPrimitiveType(orc::TypeKind::CHAR);
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto _reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto _reader = create_reader(params, range);
 
     // Execute conversion
     auto result_column = _reader->_convert_dict_column_to_string_column(
@@ -181,7 +194,7 @@ TEST_F(OrcReaderConvertDictTest, ConvertDictColumnToStringColumnEmpty) {
     auto orc_type_ptr = createPrimitiveType(orc::TypeKind::STRING);
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto _reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto _reader = create_reader(params, range);
     // Execute conversion
     auto result_column = _reader->_convert_dict_column_to_string_column(
             dict_column.get(), nullptr, string_batch.get(), orc_type_ptr.get());
@@ -213,7 +226,7 @@ TEST_F(OrcReaderConvertDictTest, ConvertDictColumnToStringColumnMixed) {
     auto orc_type_ptr = createPrimitiveType(orc::TypeKind::STRING);
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto _reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto _reader = create_reader(params, range);
     // Execute conversion
     auto result_column = _reader->_convert_dict_column_to_string_column(
             dict_column.get(), &null_map, string_batch.get(), orc_type_ptr.get());

--- a/be/test/format/orc/orc_read_lines.cpp
+++ b/be/test/format/orc/orc_read_lines.cpp
@@ -28,7 +28,6 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "common/object_pool.h"
@@ -120,8 +119,9 @@ static void read_orc_line(int64_t line, std::string block_dump,
     io::IOContext io_ctx;
     io::FileReaderStats file_reader_stats;
     io_ctx.file_reader_stats = &file_reader_stats;
-    auto reader = OrcReader::create_unique(nullptr, runtime_state.get(), params, range, 100,
-                                           time_zone, &io_ctx, nullptr, true);
+    runtime_state->set_timezone(time_zone);
+    auto reader = OrcReader::create_unique(nullptr, runtime_state.get(), params, range, &io_ctx,
+                                           nullptr, true);
     auto local_fs = io::global_local_filesystem();
     io::FileReaderSPtr file_reader;
     static_cast<void>(reader->read_by_rows({line}));

--- a/be/test/format/orc/orc_reader_fill_data_test.cpp
+++ b/be/test/format/orc/orc_reader_fill_data_test.cpp
@@ -30,6 +30,8 @@
 #include "format/orc/orc_memory_stream_test.h"
 #include "format/orc/vorc_reader.h"
 #include "orc/ColumnPrinter.hh"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
 
 namespace doris {
 class OrcReaderFillDataTest : public ::testing::Test {
@@ -38,8 +40,18 @@ protected:
 
     void TearDown() override {}
 
+    std::unique_ptr<OrcReader> create_reader(const TFileScanRangeParams& params,
+                                             const TFileRangeDesc& range,
+                                             bool enable_lazy_mat = true) {
+        return OrcReader::create_unique(&profile, &state, params, range,
+                                        static_cast<io::IOContext*>(nullptr), nullptr,
+                                        enable_lazy_mat);
+    }
+
     std::shared_ptr<TableSchemaChangeHelper::ConstNode> const_node =
             std::make_shared<TableSchemaChangeHelper::ConstNode>();
+    RuntimeProfile profile {"test"};
+    RuntimeState state;
 };
 
 std::unique_ptr<orc::LongVectorBatch> create_long_batch(size_t size,
@@ -80,7 +92,7 @@ TEST_F(OrcReaderFillDataTest, TestFillLongColumn) {
 
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto reader = create_reader(params, range);
 
     MutableColumnPtr xx = column->assume_mutable();
 
@@ -106,7 +118,7 @@ TEST_F(OrcReaderFillDataTest, TestFillLongColumnWithNull) {
 
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto reader = create_reader(params, range);
 
     MutableColumnPtr xx = column->assume_mutable();
 
@@ -160,7 +172,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
 
         TFileScanRangeParams params;
         TFileRangeDesc range;
-        auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+        auto reader = create_reader(params, range);
 
         auto doris_struct_type = std::make_shared<DataTypeStruct>(
                 std::vector<DataTypePtr> {
@@ -246,7 +258,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
 
         TFileScanRangeParams params;
         TFileRangeDesc range;
-        auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+        auto reader = create_reader(params, range);
 
         auto doris_struct_type = std::make_shared<DataTypeStruct>(
                 std::vector<DataTypePtr> {std::make_shared<DataTypeInt32>(),
@@ -332,7 +344,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
 
         TFileScanRangeParams params;
         TFileRangeDesc range;
-        auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+        auto reader = create_reader(params, range);
 
         auto doris_struct_type = std::make_shared<DataTypeStruct>(
                 std::vector<DataTypePtr> {std::make_shared<DataTypeDecimal64>(18, 5)},
@@ -446,7 +458,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
 
         TFileScanRangeParams params;
         TFileRangeDesc range;
-        auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+        auto reader = create_reader(params, range);
 
         auto doris_struct_type = std::make_shared<DataTypeMap>(std::make_shared<DataTypeInt32>(),
                                                                std::make_shared<DataTypeFloat32>());

--- a/be/test/format/orc/orc_reader_init_column_test.cpp
+++ b/be/test/format/orc/orc_reader_init_column_test.cpp
@@ -23,6 +23,8 @@
 #include "format/orc/orc_memory_stream_test.h"
 #include "format/orc/vorc_reader.h"
 #include "orc/ColumnPrinter.hh"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
 
 namespace doris {
 class OrcReaderInitColumnTest : public ::testing::Test {
@@ -30,6 +32,17 @@ protected:
     void SetUp() override {}
 
     void TearDown() override {}
+
+    std::unique_ptr<OrcReader> create_reader(const TFileScanRangeParams& params,
+                                             const TFileRangeDesc& range,
+                                             bool enable_lazy_mat = true) {
+        return OrcReader::create_unique(&profile, &state, params, range,
+                                        static_cast<io::IOContext*>(nullptr), nullptr,
+                                        enable_lazy_mat);
+    }
+
+    RuntimeProfile profile {"test"};
+    RuntimeState state;
 };
 TEST_F(OrcReaderInitColumnTest, InitReadColumn) {
     {
@@ -53,7 +66,7 @@ TEST_F(OrcReaderInitColumnTest, InitReadColumn) {
 
         TFileScanRangeParams params;
         TFileRangeDesc range;
-        auto reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+        auto reader = create_reader(params, range);
         reader->_reader = std::move(orc_reader);
         std::vector<std::string> tmp;
         tmp.emplace_back("col1");
@@ -72,7 +85,7 @@ TEST_F(OrcReaderInitColumnTest, CheckAcidSchemaTest) {
     using namespace orc;
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto _reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto _reader = create_reader(params, range);
     // 1. Test standard ACID schema
     {
         // Create standard ACID structure
@@ -139,7 +152,7 @@ TEST_F(OrcReaderInitColumnTest, RemoveAcidTest) {
     using namespace orc;
     TFileScanRangeParams params;
     TFileRangeDesc range;
-    auto _reader = OrcReader::create_unique(params, range, "", nullptr, nullptr, true);
+    auto _reader = create_reader(params, range);
     // 1. Test removing ACID info from ACID schema
     {
         // Create ACID schema

--- a/be/test/format/orc/orc_reader_test.cpp
+++ b/be/test/format/orc/orc_reader_test.cpp
@@ -32,6 +32,7 @@
 #include "io/fs/file_meta_cache.h"
 #include "orc/sargs/SearchArgument.hh"
 #include "runtime/exec_env.h"
+#include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
 #include "testutil/desc_tbl_builder.h"
 namespace doris {
@@ -83,7 +84,11 @@ private:
         range.path = "./be/test/exec/test_data/orc_scanner/orders.orc";
         range.start_offset = 0;
         range.size = 1293;
-        auto reader = OrcReader::create_unique(params, range, "UTC", nullptr, &cache, true);
+        RuntimeProfile profile("test");
+        RuntimeState state;
+        state.set_timezone("UTC");
+        auto reader = OrcReader::create_unique(&profile, &state, params, range,
+                                               static_cast<io::IOContext*>(nullptr), &cache, true);
         OrcInitContext orc_ctx;
         orc_ctx.column_names = column_names;
         orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
@@ -101,7 +106,6 @@ private:
         EXPECT_TRUE(status.ok());
 
         // prepare expr context
-        RuntimeState state;
         state.set_desc_tbl(desc_tbl);
         status = context->prepare(&state, row_desc);
         EXPECT_TRUE(status.ok()) << status.to_string();

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -38,13 +38,10 @@
 #include <sys/types.h>
 
 #include <algorithm>
-#include <cmath>
 #include <cstdint>
 #include <memory>
-#include <new>
 #include <ostream>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -53,7 +50,6 @@
 #include "common/status.h"
 #include "core/column/column.h"
 #include "core/data_type/define_primitive_type.h"
-#include "core/value/decimalv2_value.h"
 #include "exprs/aggregate/aggregate_function.h"
 #include "exprs/create_predicate_function.h"
 #include "exprs/hybrid_set.h"
@@ -66,13 +62,11 @@
 #include "format/parquet/vparquet_file_metadata.h"
 #include "format/parquet/vparquet_page_index.h"
 #include "format/parquet/vparquet_reader.h"
-#include "gtest/gtest_pred_impl.h"
 #include "information_schema/schema_scanner.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
 #include "storage/predicate/comparison_predicate.h"
 #include "storage/predicate/in_list_predicate.h"
-#include "storage/predicate/null_predicate.h"
 #include "testutil/mock/mock_fn_call.h"
 #include "testutil/mock/mock_literal_expr.h"
 #include "testutil/mock/mock_slot_ref.h"
@@ -275,8 +269,8 @@ public:
             scan_range.size = local_file_reader->size();
         }
 
-        p_reader = ParquetReader::create_unique(nullptr, scan_params, scan_range, scan_range.size,
-                                                &ctz, nullptr, nullptr);
+        p_reader = ParquetReader::create_unique(nullptr, scan_params, scan_range, nullptr, &state,
+                                                nullptr);
         p_reader->set_file_reader(local_file_reader);
         colname_to_slot_id.emplace("int64_col", 2);
         ParquetInitContext pq_ctx;
@@ -327,8 +321,9 @@ public:
         scan_range.start_offset = 0;
         scan_range.size = local_file_reader->size();
 
-        auto local_reader = ParquetReader::create_unique(
-                nullptr, scan_params, scan_range, scan_range.size, &local_ctz, nullptr, nullptr);
+        RuntimeState local_state;
+        auto local_reader = ParquetReader::create_unique(nullptr, scan_params, scan_range, nullptr,
+                                                         &local_state, nullptr);
         local_reader->set_file_reader(local_file_reader);
         ParquetInitContext pq_ctx2;
         pq_ctx2.column_names = column_names;
@@ -428,6 +423,7 @@ public:
     std::unique_ptr<FileMetaData> doris_file_metadata;
     tparquet::FileMetaData doris_metadata;
     cctz::time_zone ctz = cctz::utc_time_zone();
+    RuntimeState state;
     std::unordered_map<std::string, int> colname_to_slot_id;
 };
 

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -269,7 +269,7 @@ public:
             scan_range.size = local_file_reader->size();
         }
 
-        p_reader = ParquetReader::create_unique(nullptr, scan_params, scan_range, nullptr, &state,
+        p_reader = ParquetReader::create_unique(nullptr, &state, scan_params, scan_range, nullptr,
                                                 nullptr);
         p_reader->set_file_reader(local_file_reader);
         colname_to_slot_id.emplace("int64_col", 2);
@@ -322,8 +322,8 @@ public:
         scan_range.size = local_file_reader->size();
 
         RuntimeState local_state;
-        auto local_reader = ParquetReader::create_unique(nullptr, scan_params, scan_range, nullptr,
-                                                         &local_state, nullptr);
+        auto local_reader = ParquetReader::create_unique(nullptr, &local_state, scan_params,
+                                                         scan_range, nullptr, nullptr);
         local_reader->set_file_reader(local_file_reader);
         ParquetInitContext pq_ctx2;
         pq_ctx2.column_names = column_names;

--- a/be/test/format/parquet/parquet_read_lines.cpp
+++ b/be/test/format/parquet/parquet_read_lines.cpp
@@ -131,7 +131,7 @@ static void read_parquet_lines(std::vector<std::string> numeric_types,
     }
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
-    auto p_reader = new ParquetReader(nullptr, scan_params, scan_range, nullptr, &runtime_state);
+    auto p_reader = new ParquetReader(nullptr, &runtime_state, scan_params, scan_range, nullptr);
 
     auto iter = std::make_shared<RowIdColumnIteratorV2>(IdManager::ID_VERSION,
                                                         BackendOptions::get_backend_id(), 10);

--- a/be/test/format/parquet/parquet_read_lines.cpp
+++ b/be/test/format/parquet/parquet_read_lines.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cctz/time_zone.h>
 #include <gen_cpp/Descriptors_types.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
@@ -26,7 +25,6 @@
 
 #include <memory>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -42,14 +40,11 @@
 #include "exprs/vexpr_context.h"
 #include "format/orc/vorc_reader.h"
 #include "format/parquet/vparquet_reader.h"
-#include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
-#include "orc/sargs/SearchArgument.hh"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "storage/segment/column_reader.h"
-#include "util/timezone_utils.h"
 
 namespace doris {
 class VExprContext;
@@ -120,8 +115,6 @@ static void read_parquet_lines(std::vector<std::string> numeric_types,
                                 "parquet_scanner/type-decoder.parquet",
                                 &reader));
 
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -136,8 +129,9 @@ static void read_parquet_lines(std::vector<std::string> numeric_types,
         scan_range.start_offset = 0;
         scan_range.size = 100000;
     }
-    auto p_reader =
-            new ParquetReader(nullptr, scan_params, scan_range, 992, &ctz, nullptr, nullptr);
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    runtime_state.set_desc_tbl(desc_tbl);
+    auto p_reader = new ParquetReader(nullptr, scan_params, scan_range, nullptr, &runtime_state);
 
     auto iter = std::make_shared<RowIdColumnIteratorV2>(IdManager::ID_VERSION,
                                                         BackendOptions::get_backend_id(), 10);
@@ -147,9 +141,6 @@ static void read_parquet_lines(std::vector<std::string> numeric_types,
             });
     p_reader->set_file_reader(reader);
     static_cast<void>(p_reader->read_by_rows(read_lines));
-
-    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
-    runtime_state.set_desc_tbl(desc_tbl);
 
     std::unordered_map<std::string, ColumnValueRangeType> colname_to_value_range;
     ParquetInitContext pq_ctx;

--- a/be/test/format/parquet/parquet_reader_test.cpp
+++ b/be/test/format/parquet/parquet_reader_test.cpp
@@ -103,8 +103,8 @@ public:
         auto q_options = TQueryOptions();
         q_options.__set_enable_adjust_conjunct_order_by_cost(true);
         RuntimeState runtime_state = RuntimeState(q_options, TQueryGlobals());
-        auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
-                                                        &runtime_state, &cache, enable_lazy);
+        auto p_reader = std::make_unique<ParquetReader>(nullptr, &runtime_state, scan_params,
+                                                        scan_range, nullptr, &cache, enable_lazy);
         p_reader->set_file_reader(reader);
         runtime_state.set_desc_tbl(desc_tbl);
         auto conjuncts = create_predicates(desc_tbl, &runtime_state);
@@ -203,8 +203,8 @@ public:
         auto q_options = TQueryOptions();
         q_options.__set_enable_adjust_conjunct_order_by_cost(true);
         RuntimeState runtime_state = RuntimeState(q_options, TQueryGlobals());
-        auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
-                                                        &runtime_state, &cache, enable_lazy);
+        auto p_reader = std::make_unique<ParquetReader>(nullptr, &runtime_state, scan_params,
+                                                        scan_range, nullptr, &cache, enable_lazy);
         p_reader->set_file_reader(reader);
         runtime_state.set_desc_tbl(desc_tbl);
 
@@ -350,7 +350,7 @@ TEST_F(ParquetReaderTest, normal) {
     RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
     auto p_reader =
-            new ParquetReader(nullptr, scan_params, scan_range, nullptr, &runtime_state, &cache);
+            new ParquetReader(nullptr, &runtime_state, scan_params, scan_range, nullptr, &cache);
     p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
@@ -413,8 +413,8 @@ TEST_F(ParquetReaderTest, uuid_varbinary) {
     }
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
-                                                    &runtime_state, &cache);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, &runtime_state, scan_params,
+                                                    scan_range, nullptr, &cache);
     p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
@@ -485,8 +485,8 @@ TEST_F(ParquetReaderTest, varbinary_varbinary) {
     }
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
-                                                    &runtime_state, &cache);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, &runtime_state, scan_params,
+                                                    scan_range, nullptr, &cache);
     p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
@@ -559,8 +559,8 @@ TEST_F(ParquetReaderTest, varbinary_string) {
     }
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
-                                                    &runtime_state, &cache);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, &runtime_state, scan_params,
+                                                    scan_range, nullptr, &cache);
     p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
@@ -633,8 +633,8 @@ TEST_F(ParquetReaderTest, varbinary_string2) {
     }
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
-                                                    &runtime_state, &cache);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, &runtime_state, scan_params,
+                                                    scan_range, nullptr, &cache);
     p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
@@ -962,8 +962,8 @@ TEST_F(ParquetReaderTest, only_partition_column) {
     auto q_options = TQueryOptions();
     q_options.__set_enable_adjust_conjunct_order_by_cost(true);
     RuntimeState runtime_state = RuntimeState(q_options, TQueryGlobals());
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
-                                                    &runtime_state, &cache);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, &runtime_state, scan_params,
+                                                    scan_range, nullptr, &cache);
     p_reader->set_file_reader(reader);
     runtime_state.set_desc_tbl(desc_tbl);
 

--- a/be/test/format/parquet/parquet_reader_test.cpp
+++ b/be/test/format/parquet/parquet_reader_test.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cctz/time_zone.h>
 #include <gen_cpp/Descriptors_types.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
@@ -26,7 +25,6 @@
 
 #include <memory>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -36,19 +34,14 @@
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
 #include "core/data_type/data_type.h"
-#include "core/data_type/data_type_factory.hpp"
 #include "core/string_view.h"
 #include "format/column_descriptor.h"
 #include "format/parquet/vparquet_reader.h"
-#include "gtest/gtest_pred_impl.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
-#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "storage/olap_scan_common.h"
-#include "util/timezone_utils.h"
 
 namespace doris {
 class VExprContext;
@@ -94,8 +87,6 @@ public:
                 "./be/test/exec/test_data/parquet_scanner/test_string_null.zst.parquet", &reader);
         EXPECT_TRUE(st.ok()) << st;
 
-        cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
         auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
         std::vector<std::string> column_names;
         std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -112,9 +103,8 @@ public:
         auto q_options = TQueryOptions();
         q_options.__set_enable_adjust_conjunct_order_by_cost(true);
         RuntimeState runtime_state = RuntimeState(q_options, TQueryGlobals());
-        auto p_reader =
-                std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
-                                                nullptr, &runtime_state, &cache, enable_lazy);
+        auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
+                                                        &runtime_state, &cache, enable_lazy);
         p_reader->set_file_reader(reader);
         runtime_state.set_desc_tbl(desc_tbl);
         auto conjuncts = create_predicates(desc_tbl, &runtime_state);
@@ -196,8 +186,6 @@ public:
                 "./be/test/exec/test_data/parquet_scanner/test_string_null.zst.parquet", &reader);
         EXPECT_TRUE(st.ok()) << st;
 
-        cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
         auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
         std::vector<std::string> column_names;
         std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -215,9 +203,8 @@ public:
         auto q_options = TQueryOptions();
         q_options.__set_enable_adjust_conjunct_order_by_cost(true);
         RuntimeState runtime_state = RuntimeState(q_options, TQueryGlobals());
-        auto p_reader =
-                std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
-                                                nullptr, &runtime_state, &cache, enable_lazy);
+        auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
+                                                        &runtime_state, &cache, enable_lazy);
         p_reader->set_file_reader(reader);
         runtime_state.set_desc_tbl(desc_tbl);
 
@@ -347,8 +334,6 @@ TEST_F(ParquetReaderTest, normal) {
     static_cast<void>(local_fs->open_file(
             "./be/test/exec/test_data/parquet_scanner/type-decoder.parquet", &reader));
 
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -362,11 +347,11 @@ TEST_F(ParquetReaderTest, normal) {
         scan_range.start_offset = 0;
         scan_range.size = 1000;
     }
-    auto p_reader = new ParquetReader(nullptr, scan_params, scan_range, 992, &ctz, nullptr, nullptr,
-                                      &cache);
-    p_reader->set_file_reader(reader);
     RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
+    auto p_reader =
+            new ParquetReader(nullptr, scan_params, scan_range, nullptr, &runtime_state, &cache);
+    p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
     pq_ctx.column_names = column_names;
@@ -412,8 +397,6 @@ TEST_F(ParquetReaderTest, uuid_varbinary) {
     st = local_fs->open_file("./be/test/exec/test_data/parquet_scanner/test_uuid.parquet", &reader);
     EXPECT_TRUE(st.ok()) << st;
 
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -428,11 +411,11 @@ TEST_F(ParquetReaderTest, uuid_varbinary) {
         scan_range.start_offset = 0;
         scan_range.size = 1000;
     }
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
-                                                    nullptr, nullptr, &cache);
-    p_reader->set_file_reader(reader);
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
+                                                    &runtime_state, &cache);
+    p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
     pq_ctx.column_names = column_names;
@@ -486,8 +469,6 @@ TEST_F(ParquetReaderTest, varbinary_varbinary) {
     st = local_fs->open_file("./be/test/exec/test_data/parquet_scanner/test_uuid.parquet", &reader);
     EXPECT_TRUE(st.ok()) << st;
 
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -502,11 +483,11 @@ TEST_F(ParquetReaderTest, varbinary_varbinary) {
         scan_range.start_offset = 0;
         scan_range.size = 1000;
     }
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
-                                                    nullptr, nullptr, &cache);
-    p_reader->set_file_reader(reader);
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
+                                                    &runtime_state, &cache);
+    p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
     pq_ctx.column_names = column_names;
@@ -560,8 +541,6 @@ TEST_F(ParquetReaderTest, varbinary_string) {
     st = local_fs->open_file("./be/test/exec/test_data/parquet_scanner/test_uuid.parquet", &reader);
     EXPECT_TRUE(st.ok()) << st;
 
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -578,11 +557,11 @@ TEST_F(ParquetReaderTest, varbinary_string) {
         scan_range.start_offset = 0;
         scan_range.size = 1000;
     }
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
-                                                    nullptr, nullptr, &cache);
-    p_reader->set_file_reader(reader);
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
+                                                    &runtime_state, &cache);
+    p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
     pq_ctx.column_names = column_names;
@@ -636,8 +615,6 @@ TEST_F(ParquetReaderTest, varbinary_string2) {
     st = local_fs->open_file("./be/test/exec/test_data/parquet_scanner/test_uuid.parquet", &reader);
     EXPECT_TRUE(st.ok()) << st;
 
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -654,11 +631,11 @@ TEST_F(ParquetReaderTest, varbinary_string2) {
         scan_range.start_offset = 0;
         scan_range.size = 1000;
     }
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
-                                                    nullptr, nullptr, &cache);
-    p_reader->set_file_reader(reader);
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     runtime_state.set_desc_tbl(desc_tbl);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
+                                                    &runtime_state, &cache);
+    p_reader->set_file_reader(reader);
 
     ParquetInitContext pq_ctx;
     pq_ctx.column_names = column_names;
@@ -968,8 +945,6 @@ TEST_F(ParquetReaderTest, only_partition_column) {
             "./be/test/exec/test_data/parquet_scanner/test_string_null.zst.parquet", &reader);
     EXPECT_TRUE(st.ok()) << st;
 
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -987,8 +962,8 @@ TEST_F(ParquetReaderTest, only_partition_column) {
     auto q_options = TQueryOptions();
     q_options.__set_enable_adjust_conjunct_order_by_cost(true);
     RuntimeState runtime_state = RuntimeState(q_options, TQueryGlobals());
-    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, 992, &ctz,
-                                                    nullptr, &runtime_state, &cache);
+    auto p_reader = std::make_unique<ParquetReader>(nullptr, scan_params, scan_range, nullptr,
+                                                    &runtime_state, &cache);
     p_reader->set_file_reader(reader);
     runtime_state.set_desc_tbl(desc_tbl);
 

--- a/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
@@ -634,8 +634,8 @@ protected:
         RuntimeProfile profile("test_profile");
 
         auto hive_reader = std::make_unique<HiveParquetReader>(
-                &profile, scan_params, scan_range, nullptr /* io_ctx */, &runtime_state,
-                nullptr /* is_file_slot */, cache.get());
+                &profile, &runtime_state, scan_params, scan_range, nullptr /* io_ctx */,
+                cache.get(), true /* enable_lazy_mat */, nullptr /* is_file_slot */);
         if (!hive_reader) {
             return {nullptr, nullptr};
         }
@@ -670,9 +670,9 @@ protected:
         scan_range.path = test_file;
         RuntimeProfile profile("test_profile");
 
-        auto hive_reader = std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params,
-                                                           scan_range, nullptr /* io_ctx */,
-                                                           nullptr /* is_file_slot */, cache.get());
+        auto hive_reader = std::make_unique<HiveOrcReader>(
+                &profile, &runtime_state, scan_params, scan_range, nullptr /* io_ctx */,
+                cache.get(), true /* enable_lazy_mat */, nullptr /* is_file_slot */);
         if (!hive_reader) {
             return {nullptr, nullptr};
         }

--- a/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
@@ -15,43 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cctz/time_zone.h>
 #include <gen_cpp/Descriptors_types.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
 #include <gen_cpp/Types_types.h>
 #include <gtest/gtest.h>
 
-#include <iostream>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "common/object_pool.h"
 #include "core/block/block.h"
-#include "core/block/column_with_type_and_name.h"
-#include "core/column/column.h"
-#include "core/column/column_array.h"
-#include "core/column/column_nullable.h"
-#include "core/column/column_struct.h"
-#include "core/data_type/data_type.h"
-#include "core/data_type/data_type_array.h"
-#include "core/data_type/data_type_factory.hpp"
-#include "core/data_type/data_type_nullable.h"
-#include "core/data_type/data_type_number.h"
-#include "core/data_type/data_type_string.h"
-#include "core/data_type/data_type_struct.h"
 #include "format/parquet/vparquet_reader.h"
 #include "format/table/hive_reader.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
-#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "storage/olap_scan_common.h"
-#include "util/timezone_utils.h"
 
 namespace doris {
 
@@ -159,13 +141,7 @@ struct ColumnAccessPathConfig {
 
 class HiveReaderCreateColumnIdsTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        cache = std::make_unique<doris::FileMetaCache>(1024);
-
-        // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
-    }
+    void SetUp() override { cache = std::make_unique<doris::FileMetaCache>(1024); }
 
     void TearDown() override { cache.reset(); }
 
@@ -637,7 +613,6 @@ protected:
     }
 
     std::unique_ptr<doris::FileMetaCache> cache;
-    cctz::time_zone timezone_obj;
 
     // Helper function: Create and setup ParquetReader
     std::tuple<std::unique_ptr<HiveParquetReader>, const FieldDescriptor*> create_parquet_reader(
@@ -658,12 +633,9 @@ protected:
         scan_range.path = test_file;
         RuntimeProfile profile("test_profile");
 
-        cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-
-        auto hive_reader =
-                std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range, 1024, &ctz,
-                                                    nullptr, &runtime_state, nullptr, cache.get());
+        auto hive_reader = std::make_unique<HiveParquetReader>(
+                &profile, scan_params, scan_range, nullptr /* io_ctx */, &runtime_state,
+                nullptr /* is_file_slot */, cache.get());
         if (!hive_reader) {
             return {nullptr, nullptr};
         }
@@ -698,12 +670,9 @@ protected:
         scan_range.path = test_file;
         RuntimeProfile profile("test_profile");
 
-        cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-
-        auto hive_reader =
-                std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params, scan_range,
-                                                1024, "CST", nullptr, nullptr, cache.get());
+        auto hive_reader = std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params,
+                                                           scan_range, nullptr /* io_ctx */,
+                                                           nullptr /* is_file_slot */, cache.get());
         if (!hive_reader) {
             return {nullptr, nullptr};
         }

--- a/be/test/format/table/hive/hive_reader_test.cpp
+++ b/be/test/format/table/hive/hive_reader_test.cpp
@@ -17,7 +17,6 @@
 
 #include "format/table/hive_reader.h"
 
-#include <cctz/time_zone.h>
 #include <gen_cpp/Descriptors_types.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
@@ -39,33 +38,22 @@
 #include "core/column/column_struct.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
-#include "core/data_type/data_type_factory.hpp"
 #include "core/data_type/data_type_nullable.h"
-#include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_struct.h"
 #include "format/orc/vorc_reader.h"
 #include "format/parquet/vparquet_reader.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
-#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "storage/olap_scan_common.h"
-#include "util/timezone_utils.h"
 
 namespace doris::table {
 
 class HiveReaderTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        cache = std::make_unique<doris::FileMetaCache>(1024);
-
-        // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
-    }
+    void SetUp() override { cache = std::make_unique<doris::FileMetaCache>(1024); }
 
     void TearDown() override { cache.reset(); }
 
@@ -459,7 +447,6 @@ protected:
     }
 
     std::unique_ptr<doris::FileMetaCache> cache;
-    cctz::time_zone timezone_obj;
 };
 
 // Test reading real Hive Parquet file using HiveTableReader
@@ -527,11 +514,9 @@ TEST_F(HiveReaderTest, read_hive_parquet_file) {
     RuntimeProfile profile("test_profile");
 
     // Create HiveParquetReader (directly inherits ParquetReader)
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-    auto hive_reader =
-            std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range, 1024, &ctz,
-                                                nullptr, &runtime_state, nullptr, cache.get());
+    auto hive_reader = std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range,
+                                                           nullptr /* io_ctx */, &runtime_state,
+                                                           nullptr /* is_file_slot */, cache.get());
 
     // Set file reader for the hive reader (inherited from ParquetReader)
     hive_reader->set_file_reader(file_reader);
@@ -643,8 +628,10 @@ TEST_F(HiveReaderTest, read_hive_rrc_file) {
         return;
     }
 
-    // Setup runtime state
-    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    // Setup runtime state (use UTC to avoid ORC timezone lookup failures)
+    TQueryGlobals query_globals;
+    query_globals.__set_time_zone("UTC");
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), query_globals);
 
     // Setup scan parameters
     TFileScanRangeParams scan_params;
@@ -659,9 +646,9 @@ TEST_F(HiveReaderTest, read_hive_rrc_file) {
     RuntimeProfile profile("test_profile");
 
     // Create HiveOrcReader (directly inherits OrcReader)
-    auto hive_reader =
-            std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params, scan_range, 1024,
-                                            "CST", nullptr, nullptr, cache.get());
+    auto hive_reader = std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params,
+                                                       scan_range, nullptr /* io_ctx */,
+                                                       nullptr /* is_file_slot */, cache.get());
 
     // Create complex struct types using helper function
     DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;

--- a/be/test/format/table/hive/hive_reader_test.cpp
+++ b/be/test/format/table/hive/hive_reader_test.cpp
@@ -514,9 +514,9 @@ TEST_F(HiveReaderTest, read_hive_parquet_file) {
     RuntimeProfile profile("test_profile");
 
     // Create HiveParquetReader (directly inherits ParquetReader)
-    auto hive_reader = std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range,
-                                                           nullptr /* io_ctx */, &runtime_state,
-                                                           nullptr /* is_file_slot */, cache.get());
+    auto hive_reader = std::make_unique<HiveParquetReader>(
+            &profile, &runtime_state, scan_params, scan_range, nullptr /* io_ctx */, cache.get(),
+            true /* enable_lazy_mat */, nullptr /* is_file_slot */);
 
     // Set file reader for the hive reader (inherited from ParquetReader)
     hive_reader->set_file_reader(file_reader);
@@ -646,9 +646,9 @@ TEST_F(HiveReaderTest, read_hive_rrc_file) {
     RuntimeProfile profile("test_profile");
 
     // Create HiveOrcReader (directly inherits OrcReader)
-    auto hive_reader = std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params,
-                                                       scan_range, nullptr /* io_ctx */,
-                                                       nullptr /* is_file_slot */, cache.get());
+    auto hive_reader = std::make_unique<HiveOrcReader>(
+            &profile, &runtime_state, scan_params, scan_range, nullptr /* io_ctx */, cache.get(),
+            true /* enable_lazy_mat */, nullptr /* is_file_slot */);
 
     // Create complex struct types using helper function
     DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;

--- a/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
@@ -92,7 +92,6 @@ TEST(IcebergDeleteFileReaderHelperTest, ReadMixedEncodingParquetPositionDeleteFi
     options.scan_params = &scan_params;
     options.io_ctx = &io_context.io_ctx;
     options.meta_cache = &meta_cache;
-    options.batch_size = 1024;
 
     CollectPositionDeleteVisitor visitor;
     auto st = read_iceberg_position_delete_file(delete_file, options, &visitor);

--- a/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
@@ -665,8 +665,8 @@ protected:
         // Create IcebergParquetReader (IS-A ParquetReader via CRTP mixin)
 
         auto iceberg_reader = std::make_unique<IcebergParquetReader>(
-                nullptr /* kv_cache */, &profile, scan_params, scan_range, nullptr /* io_ctx */,
-                &runtime_state, cache.get());
+                &profile, &runtime_state, scan_params, scan_range, nullptr /* io_ctx */,
+                cache.get(), nullptr /* kv_cache */);
         if (!iceberg_reader) {
             return {nullptr, nullptr};
         }
@@ -711,8 +711,8 @@ protected:
 
         // Create IcebergOrcReader (IS-A OrcReader via CRTP mixin)
         auto iceberg_reader = std::make_unique<IcebergOrcReader>(
-                nullptr /* kv_cache */, &profile, &runtime_state, scan_params, scan_range,
-                nullptr /* io_ctx */, cache.get());
+                &profile, &runtime_state, scan_params, scan_range, nullptr /* io_ctx */,
+                cache.get(), nullptr /* kv_cache */);
         if (!iceberg_reader) {
             return {nullptr, nullptr};
         }

--- a/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
@@ -15,14 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cctz/time_zone.h>
 #include <gen_cpp/Descriptors_types.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
 #include <gen_cpp/Types_types.h>
 #include <gtest/gtest.h>
 
-#include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -30,28 +28,13 @@
 
 #include "common/object_pool.h"
 #include "core/block/block.h"
-#include "core/block/column_with_type_and_name.h"
-#include "core/column/column.h"
-#include "core/column/column_array.h"
-#include "core/column/column_nullable.h"
-#include "core/column/column_struct.h"
-#include "core/data_type/data_type.h"
-#include "core/data_type/data_type_array.h"
-#include "core/data_type/data_type_factory.hpp"
-#include "core/data_type/data_type_nullable.h"
-#include "core/data_type/data_type_number.h"
-#include "core/data_type/data_type_string.h"
-#include "core/data_type/data_type_struct.h"
 #include "format/parquet/vparquet_reader.h"
 #include "format/table/iceberg_reader.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
-#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "storage/olap_scan_common.h"
-#include "util/timezone_utils.h"
 
 namespace doris {
 
@@ -158,13 +141,7 @@ struct ColumnAccessPathConfig {
 
 class IcebergReaderCreateColumnIdsTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        cache = std::make_unique<doris::FileMetaCache>(1024);
-
-        // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
-    }
+    void SetUp() override { cache = std::make_unique<doris::FileMetaCache>(1024); }
 
     void TearDown() override { cache.reset(); }
 
@@ -658,7 +635,6 @@ protected:
     }
 
     std::unique_ptr<doris::FileMetaCache> cache;
-    cctz::time_zone timezone_obj;
 
     // Helper function: create and setup ParquetReader
     std::tuple<std::unique_ptr<IcebergParquetReader>, const FieldDescriptor*> create_parquet_reader(
@@ -687,12 +663,10 @@ protected:
         RuntimeProfile profile("test_profile");
 
         // Create IcebergParquetReader (IS-A ParquetReader via CRTP mixin)
-        cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
 
         auto iceberg_reader = std::make_unique<IcebergParquetReader>(
-                nullptr /* kv_cache */, &profile, scan_params, scan_range, 1024, &ctz,
-                nullptr /* io_ctx */, &runtime_state, cache.get());
+                nullptr /* kv_cache */, &profile, scan_params, scan_range, nullptr /* io_ctx */,
+                &runtime_state, cache.get());
         if (!iceberg_reader) {
             return {nullptr, nullptr};
         }
@@ -737,8 +711,8 @@ protected:
 
         // Create IcebergOrcReader (IS-A OrcReader via CRTP mixin)
         auto iceberg_reader = std::make_unique<IcebergOrcReader>(
-                nullptr /* kv_cache */, &profile, &runtime_state, scan_params, scan_range, 1024,
-                "CST", nullptr /* io_ctx */, cache.get());
+                nullptr /* kv_cache */, &profile, &runtime_state, scan_params, scan_range,
+                nullptr /* io_ctx */, cache.get());
         if (!iceberg_reader) {
             return {nullptr, nullptr};
         }

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -17,7 +17,6 @@
 
 #include "format/table/iceberg_reader.h"
 
-#include <cctz/time_zone.h>
 #include <gen_cpp/Descriptors_types.h>
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gen_cpp/PlanNodes_types.h>
@@ -37,12 +36,9 @@
 #include "core/column/column_array.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_struct.h"
-#include "core/column/column_vector.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
-#include "core/data_type/data_type_factory.hpp"
 #include "core/data_type/data_type_nullable.h"
-#include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_struct.h"
 #include "format/column_descriptor.h"
@@ -51,12 +47,9 @@
 #include "format/parquet/vparquet_reader.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
-#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "storage/olap_scan_common.h"
-#include "util/timezone_utils.h"
 
 namespace doris {
 
@@ -67,13 +60,7 @@ public:
 
 class IcebergReaderTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        cache = std::make_unique<doris::FileMetaCache>(1024);
-
-        // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
-    }
+    void SetUp() override { cache = std::make_unique<doris::FileMetaCache>(1024); }
 
     void TearDown() override { cache.reset(); }
 
@@ -100,8 +87,8 @@ protected:
         scan_range->path = mixed_position_delete_file();
 
         auto parquet_reader =
-                ParquetReader::create_unique(profile, *scan_params, *scan_range, 1024,
-                                             &timezone_obj, nullptr, runtime_state, cache.get());
+                ParquetReader::create_unique(profile, *scan_params, *scan_range,
+                                             nullptr /* io_ctx */, runtime_state, cache.get());
         EXPECT_NE(parquet_reader, nullptr);
         if (parquet_reader == nullptr) {
             return nullptr;
@@ -519,7 +506,6 @@ protected:
     }
 
     std::unique_ptr<doris::FileMetaCache> cache;
-    cctz::time_zone timezone_obj;
     std::vector<std::string> delete_file_column_names = {"file_path", "pos"};
     std::unordered_map<std::string, uint32_t> delete_file_col_name_to_block_idx = {{"file_path", 0},
                                                                                    {"pos", 1}};
@@ -703,12 +689,9 @@ TEST_F(IcebergReaderTest, read_iceberg_parquet_file) {
     RuntimeProfile profile("test_profile");
 
     // Create IcebergParquetReader (IS-A ParquetReader via CRTP mixin)
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-
     auto iceberg_reader = std::make_unique<IcebergParquetReader>(
-            nullptr /* kv_cache */, &profile, scan_params, scan_range, 1024, &ctz,
-            nullptr /* io_ctx */, &runtime_state, cache.get());
+            nullptr /* kv_cache */, &profile, scan_params, scan_range, nullptr /* io_ctx */,
+            &runtime_state, cache.get());
     ASSERT_NE(iceberg_reader, nullptr);
 
     // Set file reader for the iceberg reader (it IS the ParquetReader)
@@ -824,8 +807,10 @@ TEST_F(IcebergReaderTest, read_iceberg_orc_file) {
         return;
     }
 
-    // Setup runtime state
-    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    // Setup runtime state (use UTC to avoid ORC timezone lookup failures)
+    TQueryGlobals query_globals;
+    query_globals.__set_time_zone("UTC");
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), query_globals);
 
     // Setup scan parameters
     TFileScanRangeParams scan_params;
@@ -841,7 +826,7 @@ TEST_F(IcebergReaderTest, read_iceberg_orc_file) {
 
     // Create IcebergOrcReader (IS-A OrcReader via CRTP mixin)
     auto iceberg_reader = std::make_unique<IcebergOrcReader>(
-            nullptr /* kv_cache */, &profile, &runtime_state, scan_params, scan_range, 1024, "CST",
+            nullptr /* kv_cache */, &profile, &runtime_state, scan_params, scan_range,
             nullptr /* io_ctx */, cache.get());
     ASSERT_NE(iceberg_reader, nullptr);
 

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -87,8 +87,8 @@ protected:
         scan_range->path = mixed_position_delete_file();
 
         auto parquet_reader =
-                ParquetReader::create_unique(profile, *scan_params, *scan_range,
-                                             nullptr /* io_ctx */, runtime_state, cache.get());
+                ParquetReader::create_unique(profile, runtime_state, *scan_params, *scan_range,
+                                             nullptr /* io_ctx */, cache.get());
         EXPECT_NE(parquet_reader, nullptr);
         if (parquet_reader == nullptr) {
             return nullptr;
@@ -690,8 +690,8 @@ TEST_F(IcebergReaderTest, read_iceberg_parquet_file) {
 
     // Create IcebergParquetReader (IS-A ParquetReader via CRTP mixin)
     auto iceberg_reader = std::make_unique<IcebergParquetReader>(
-            nullptr /* kv_cache */, &profile, scan_params, scan_range, nullptr /* io_ctx */,
-            &runtime_state, cache.get());
+            &profile, &runtime_state, scan_params, scan_range, nullptr /* io_ctx */, cache.get(),
+            nullptr /* kv_cache */);
     ASSERT_NE(iceberg_reader, nullptr);
 
     // Set file reader for the iceberg reader (it IS the ParquetReader)
@@ -825,9 +825,9 @@ TEST_F(IcebergReaderTest, read_iceberg_orc_file) {
     RuntimeProfile profile("test_profile");
 
     // Create IcebergOrcReader (IS-A OrcReader via CRTP mixin)
-    auto iceberg_reader = std::make_unique<IcebergOrcReader>(
-            nullptr /* kv_cache */, &profile, &runtime_state, scan_params, scan_range,
-            nullptr /* io_ctx */, cache.get());
+    auto iceberg_reader = std::make_unique<IcebergOrcReader>(&profile, &runtime_state, scan_params,
+                                                             scan_range, nullptr /* io_ctx */,
+                                                             cache.get(), nullptr /* kv_cache */);
     ASSERT_NE(iceberg_reader, nullptr);
 
     // Create complex struct types using helper function


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

before the reader use _MIN_BATCH_SIZE  as batch size, 
now use the batch size from runtime state.
so OrcReader/ParquetReader c'tor pass the runtime_state object, and remove the batch_size, ctz params.
Unified constructor order as 
(profile, state, params, range, io_ctx, meta_cache=null, enable_lazy_mat=true, [subclass-specific parameters])


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

