### PR TITLE
[fix](functions)Preserve TIMESTAMPTZ in LEAD/LAG by adding TimeStampTzType signature matching

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/RequireTrivialTypes.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/RequireTrivialTypes.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.LargeIntType;
 import org.apache.doris.nereids.types.SmallIntType;
 import org.apache.doris.nereids.types.StringType;
+import org.apache.doris.nereids.types.TimeStampTzType;
 import org.apache.doris.nereids.types.TimeV2Type;
 import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.types.VarcharType;
@@ -61,6 +62,7 @@ public interface RequireTrivialTypes {
             DateV2Type.INSTANCE,
             DateTimeV2Type.WILDCARD,
             TimeV2Type.WILDCARD,
+            TimeStampTzType.WILDCARD,
             VarcharType.SYSTEM_DEFAULT,
             StringType.INSTANCE
     );

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/window/TimestampTzLeadLagSignatureTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/window/TimestampTzLeadLagSignatureTest.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.window;
+
+import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.types.TimeStampTzType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests ensuring LEAD/LAG select TimeStampTzType signatures when input is TIMESTAMPTZ.
+ */
+public class TimestampTzLeadLagSignatureTest {
+
+    @Test
+    public void testLeadSignatureMatchesTimeStampTz() {
+        SlotReference slot = SlotReference.of("ts", TimeStampTzType.of(6));
+        Lead lead = new Lead(slot);
+        FunctionSignature signature = lead.getSignature();
+
+        Assertions.assertTrue(signature.returnType instanceof TimeStampTzType,
+                "LEAD return type should be TimeStampTzType for TIMESTAMPTZ input");
+        Assertions.assertTrue(signature.getArgType(0) instanceof TimeStampTzType,
+                "LEAD first arg type should be TimeStampTzType for TIMESTAMPTZ input");
+    }
+
+    @Test
+    public void testLagSignatureMatchesTimeStampTz() {
+        SlotReference slot = SlotReference.of("ts", TimeStampTzType.of(6));
+        Lag lag = new Lag(slot);
+        FunctionSignature signature = lag.getSignature();
+
+        Assertions.assertTrue(signature.returnType instanceof TimeStampTzType,
+                "LAG return type should be TimeStampTzType for TIMESTAMPTZ input");
+        Assertions.assertTrue(signature.getArgType(0) instanceof TimeStampTzType,
+                "LAG first arg type should be TimeStampTzType for TIMESTAMPTZ input");
+    }
+}


### PR DESCRIPTION

Problem: When LEAD/LAG use ExplicitlyCastableSignature, Nereids could fail to find a TIMESTAMPTZ signature and fall back to coercion to DateTimeV2Type, causing an injected cast like cast(ts_tz as DATETIMEV2(6)) and losing the timezone suffix.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

