### PR TITLE
[test](multi-catalog) Add lake reader unit tests.

### DIFF
--- a/be/src/format/orc/vorc_reader.h
+++ b/be/src/format/orc/vorc_reader.h
@@ -739,6 +739,7 @@ private:
 
 protected:
     size_t get_batch_size() const { return _batch_size; }
+    const std::string& ctz() const { return _ctz; }
 
 private:
     int64_t _range_size;

--- a/be/src/format/table/hudi_reader.cpp
+++ b/be/src/format/table/hudi_reader.cpp
@@ -39,7 +39,7 @@ Status HudiParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
     // Build table_info_node using field_id matching (shared with Paimon/Iceberg)
     RETURN_IF_ERROR(gen_table_info_node_by_field_id(
             get_scan_params(), get_scan_range().table_format_params.hudi_params.schema_id,
-            get_tuple_descriptor(), *field_desc));
+            ctx->tuple_descriptor, *field_desc));
     ctx->table_info_node = table_info_node_ptr;
 
     // Extract column names from descriptors
@@ -67,7 +67,7 @@ Status HudiOrcReader::on_before_init_reader(ReaderInitContext* ctx) {
     // Build table_info_node using field_id matching
     RETURN_IF_ERROR(gen_table_info_node_by_field_id(
             get_scan_params(), get_scan_range().table_format_params.hudi_params.schema_id,
-            get_tuple_descriptor(), orc_type_ptr));
+            ctx->tuple_descriptor, orc_type_ptr));
     ctx->table_info_node = table_info_node_ptr;
 
     // Extract column names from descriptors

--- a/be/src/format/table/iceberg_reader.cpp
+++ b/be/src/format/table/iceberg_reader.cpp
@@ -211,6 +211,7 @@ Status IcebergParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
                         });
                 continue;
             }
+            ctx->column_names.push_back(desc.name);
         }
     }
 
@@ -498,6 +499,7 @@ Status IcebergOrcReader::on_before_init_reader(ReaderInitContext* ctx) {
                         });
                 continue;
             }
+            ctx->column_names.push_back(desc.name);
         }
     }
 

--- a/be/src/format/table/iceberg_reader.cpp
+++ b/be/src/format/table/iceberg_reader.cpp
@@ -211,7 +211,6 @@ Status IcebergParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
                         });
                 continue;
             }
-            ctx->column_names.push_back(desc.name);
         }
     }
 
@@ -499,7 +498,6 @@ Status IcebergOrcReader::on_before_init_reader(ReaderInitContext* ctx) {
                         });
                 continue;
             }
-            ctx->column_names.push_back(desc.name);
         }
     }
 

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -456,7 +456,7 @@ Status IcebergReaderMixin<BaseReader>::_equality_delete_base(
         std::vector<int> delete_col_ids;
         std::unordered_map<std::string, uint32_t> delete_col_name_to_block_idx;
 
-        if (auto* parquet_reader = typeid_cast<ParquetReader*>(delete_reader.get())) {
+        if (auto* parquet_reader = dynamic_cast<ParquetReader*>(delete_reader.get())) {
             const FieldDescriptor* delete_field_desc = nullptr;
             RETURN_IF_ERROR(parquet_reader->get_file_metadata_schema(&delete_field_desc));
             DCHECK(delete_field_desc != nullptr);
@@ -501,7 +501,7 @@ Status IcebergReaderMixin<BaseReader>::_equality_delete_base(
             if (!st2.ok()) {
                 return st2;
             }
-        } else if (auto* orc_reader = typeid_cast<OrcReader*>(delete_reader.get())) {
+        } else if (auto* orc_reader = dynamic_cast<OrcReader*>(delete_reader.get())) {
             // For ORC: use get_parsed_schema with field_ids from delete_file
             // ORC field_ids come from the Thrift descriptor, not from ORC metadata
             RETURN_IF_ERROR(delete_reader->get_parsed_schema(&equality_delete_col_names,

--- a/be/src/format/table/paimon_reader.cpp
+++ b/be/src/format/table/paimon_reader.cpp
@@ -25,6 +25,8 @@
 
 namespace doris {
 
+static constexpr uint32_t kPaimonDeletionVectorMagicNumber = 1581511376;
+
 // ============================================================================
 // PaimonOrcReader
 // ============================================================================
@@ -47,7 +49,7 @@ Status PaimonOrcReader::on_before_init_reader(ReaderInitContext* ctx) {
 
     RETURN_IF_ERROR(gen_table_info_node_by_field_id(
             get_scan_params(), get_scan_range().table_format_params.paimon_params.schema_id,
-            get_tuple_descriptor(), orc_type_ptr));
+            ctx->tuple_descriptor, orc_type_ptr));
     ctx->table_info_node = table_info_node_ptr;
 
     for (const auto& desc : *ctx->column_descs) {
@@ -86,8 +88,6 @@ Status PaimonOrcReader::_init_deletion_vector() {
     SCOPED_TIMER(_paimon_profile.delete_files_read_time);
     using DeleteRows = std::vector<int64_t>;
     _delete_rows = _kv_cache->get<DeleteRows>(key, [&]() -> DeleteRows* {
-        auto* delete_rows = new DeleteRows;
-
         TFileRangeDesc delete_range;
         delete_range.__set_fs_name(get_scan_range().fs_name);
         delete_range.path = deletion_file.path;
@@ -127,8 +127,7 @@ Status PaimonOrcReader::_init_deletion_vector() {
         std::reverse(reinterpret_cast<char*>(&magic_number),
                      reinterpret_cast<char*>(&magic_number) + 4);
         buf += 4;
-        const static uint32_t MAGIC_NUMBER = 1581511376;
-        if (magic_number != MAGIC_NUMBER) [[unlikely]] {
+        if (magic_number != kPaimonDeletionVectorMagicNumber) [[unlikely]] {
             create_status = Status::RuntimeError(
                     "DeletionVector deserialize error: invalid magic number {}", magic_number);
             return nullptr;
@@ -144,6 +143,7 @@ Status PaimonOrcReader::_init_deletion_vector() {
                     e.what());
             return nullptr;
         }
+        auto* delete_rows = new DeleteRows;
         delete_rows->reserve(roaring_bitmap.cardinality());
         for (auto it = roaring_bitmap.begin(); it != roaring_bitmap.end(); it++) {
             delete_rows->push_back(*it);
@@ -181,7 +181,7 @@ Status PaimonParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
 
     RETURN_IF_ERROR(gen_table_info_node_by_field_id(
             get_scan_params(), get_scan_range().table_format_params.paimon_params.schema_id,
-            get_tuple_descriptor(), *field_desc));
+            ctx->tuple_descriptor, *field_desc));
     ctx->table_info_node = table_info_node_ptr;
 
     for (const auto& desc : *ctx->column_descs) {
@@ -219,8 +219,6 @@ Status PaimonParquetReader::_init_deletion_vector() {
     SCOPED_TIMER(_paimon_profile.delete_files_read_time);
     using DeleteRows = std::vector<int64_t>;
     _delete_rows = _kv_cache->get<DeleteRows>(key, [&]() -> DeleteRows* {
-        auto* delete_rows = new DeleteRows;
-
         TFileRangeDesc delete_range;
         delete_range.__set_fs_name(get_scan_range().fs_name);
         delete_range.path = deletion_file.path;
@@ -260,8 +258,7 @@ Status PaimonParquetReader::_init_deletion_vector() {
         std::reverse(reinterpret_cast<char*>(&magic_number),
                      reinterpret_cast<char*>(&magic_number) + 4);
         buf += 4;
-        const static uint32_t MAGIC_NUMBER = 1581511376;
-        if (magic_number != MAGIC_NUMBER) [[unlikely]] {
+        if (magic_number != kPaimonDeletionVectorMagicNumber) [[unlikely]] {
             create_status = Status::RuntimeError(
                     "DeletionVector deserialize error: invalid magic number {}", magic_number);
             return nullptr;
@@ -277,6 +274,7 @@ Status PaimonParquetReader::_init_deletion_vector() {
                     e.what());
             return nullptr;
         }
+        auto* delete_rows = new DeleteRows;
         delete_rows->reserve(roaring_bitmap.cardinality());
         for (auto it = roaring_bitmap.begin(); it != roaring_bitmap.end(); it++) {
             delete_rows->push_back(*it);

--- a/be/src/format/table/table_format_reader.h
+++ b/be/src/format/table/table_format_reader.h
@@ -67,10 +67,11 @@ public:
             if (it == _fill_partition_values.end()) {
                 continue;
             }
-            auto col_ptr = block->get_by_position((*_fill_col_name_to_block_idx)[col_name])
-                                   .column->assume_mutable();
+            const auto block_pos = (*_fill_col_name_to_block_idx)[col_name];
+            auto& column_with_type = block->get_by_position(block_pos);
+            auto col_ptr = column_with_type.column->assume_mutable();
             const auto& [value, slot_desc] = it->second;
-            auto text_serde = slot_desc->get_data_type_ptr()->get_serde();
+            auto text_serde = column_with_type.type->get_serde();
             Slice slice(value.data(), value.size());
             uint64_t num_deserialized = 0;
             if (text_serde->deserialize_column_from_fixed_json(

--- a/be/src/format/table/transactional_hive_reader.cpp
+++ b/be/src/format/table/transactional_hive_reader.cpp
@@ -186,8 +186,7 @@ Status TransactionalHiveReader::on_after_init_reader(ReaderInitContext* /*ctx*/)
         delete_range.file_size = -1;
 
         OrcReader delete_reader(get_profile(), get_state(), get_scan_params(), delete_range,
-                                256 /*batch_size*/, get_state()->timezone(), get_io_ctx(),
-                                _meta_cache, false);
+                                256 /*batch_size*/, ctz(), get_io_ctx(), _meta_cache, false);
 
         auto acid_info_node = std::make_shared<StructNode>();
         for (auto idx = 0; idx < TransactionalHive::DELETE_ROW_COLUMN_NAMES_LOWER_CASE.size();

--- a/be/test/exec/scan/file_scanner_conversion_test.cpp
+++ b/be/test/exec/scan/file_scanner_conversion_test.cpp
@@ -1,0 +1,194 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+
+#define private public
+#define protected public
+#include "exec/scan/file_scanner.h"
+#undef private
+#undef protected
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
+
+namespace doris {
+
+class FileScannerConversionTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _obj_pool = std::make_unique<ObjectPool>();
+        _runtime_state = std::make_unique<RuntimeState>();
+        _profile = std::make_unique<RuntimeProfile>("test_profile");
+
+        TTupleDescriptor tuple_desc;
+        tuple_desc.__set_id(0);
+        tuple_desc.__set_byteSize(16);
+        tuple_desc.__set_numNullBytes(0);
+        _tuple_desc = _obj_pool->add(new TupleDescriptor(tuple_desc));
+
+        _params = std::make_unique<TFileScanRangeParams>();
+        _params->num_of_columns_from_file = 2;
+        _scanner = std::make_unique<FileScanner>(_runtime_state.get(), _profile.get(),
+                                                 _params.get(), &_col_name_to_slot_id, _tuple_desc);
+    }
+
+    SlotDescriptor* add_slot(TSlotId slot_id, const std::string& col_name) {
+        TSlotDescriptor tslot_desc;
+        tslot_desc.id = slot_id;
+        tslot_desc.parent = _tuple_desc->id();
+
+        TTypeDesc type_desc;
+        TTypeNode node;
+        node.__set_type(TTypeNodeType::SCALAR);
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::INT);
+        node.__set_scalar_type(scalar_type);
+        type_desc.types.push_back(node);
+
+        tslot_desc.slotType = type_desc;
+        tslot_desc.columnPos = -1;
+        tslot_desc.colName = col_name;
+        tslot_desc.byteOffset = 0;
+        tslot_desc.nullIndicatorByte = 0;
+        tslot_desc.nullIndicatorBit = -1;
+        tslot_desc.slotIdx = static_cast<int>(slot_id);
+        tslot_desc.isMaterialized = true;
+
+        auto* slot_desc = _obj_pool->add(new SlotDescriptor(tslot_desc));
+        _tuple_desc->add_slot(slot_desc);
+        return slot_desc;
+    }
+
+    void add_required_slot(TSlotId slot_id, bool is_file_slot,
+                           std::optional<TColumnCategory::type> category = std::nullopt) {
+        TFileScanSlotInfo slot_info;
+        slot_info.slot_id = slot_id;
+        slot_info.is_file_slot = is_file_slot;
+        if (category.has_value()) {
+            slot_info.__set_category(*category);
+        }
+        _params->required_slots.push_back(slot_info);
+    }
+
+    const ColumnDescriptor* find_column_desc(const std::string& col_name) const {
+        for (const auto& col_desc : _scanner->_column_descs) {
+            if (col_desc.name == col_name) {
+                return &col_desc;
+            }
+        }
+        return nullptr;
+    }
+
+    std::unique_ptr<ObjectPool> _obj_pool;
+    std::unique_ptr<RuntimeState> _runtime_state;
+    std::unique_ptr<RuntimeProfile> _profile;
+    TupleDescriptor* _tuple_desc = nullptr;
+    std::unique_ptr<TFileScanRangeParams> _params;
+    std::unique_ptr<FileScanner> _scanner;
+    std::unordered_map<std::string, int> _col_name_to_slot_id;
+};
+
+TEST_F(FileScannerConversionTest, InitExprCtxesUsesThriftCategoryAndIsFileSlotDerivation) {
+    add_slot(1, "id");
+    add_slot(2, "year");
+    add_slot(3, "row_id");
+    add_slot(4, "gen_col");
+
+    _scanner->_current_range.__set_columns_from_path_keys({"year"});
+    add_required_slot(1, true, TColumnCategory::REGULAR);
+    add_required_slot(2, false, TColumnCategory::PARTITION_KEY);
+    add_required_slot(3, false, TColumnCategory::SYNTHESIZED);
+    add_required_slot(4, true, TColumnCategory::GENERATED);
+
+    Status st = _scanner->_init_expr_ctxes();
+
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(4, _scanner->_column_descs.size());
+    auto* id_col = find_column_desc("id");
+    auto* year_col = find_column_desc("year");
+    auto* row_id_col = find_column_desc("row_id");
+    auto* gen_col = find_column_desc("gen_col");
+    ASSERT_NE(nullptr, id_col);
+    ASSERT_NE(nullptr, year_col);
+    ASSERT_NE(nullptr, row_id_col);
+    ASSERT_NE(nullptr, gen_col);
+    EXPECT_EQ(ColumnCategory::REGULAR, id_col->category);
+    EXPECT_EQ(ColumnCategory::PARTITION_KEY, year_col->category);
+    EXPECT_EQ(ColumnCategory::SYNTHESIZED, row_id_col->category);
+    EXPECT_EQ(ColumnCategory::GENERATED, gen_col->category);
+
+    ASSERT_EQ(2, _scanner->_file_slot_descs.size());
+    EXPECT_EQ("id", _scanner->_file_slot_descs[0]->col_name());
+    EXPECT_EQ("gen_col", _scanner->_file_slot_descs[1]->col_name());
+    EXPECT_EQ(std::vector<std::string>({"id", "gen_col"}), _scanner->_file_col_names);
+
+    EXPECT_TRUE(_scanner->_is_file_slot.contains(1));
+    EXPECT_TRUE(_scanner->_is_file_slot.contains(4));
+    EXPECT_FALSE(_scanner->_is_file_slot.contains(2));
+    EXPECT_FALSE(_scanner->_is_file_slot.contains(3));
+
+    ASSERT_TRUE(_scanner->_partition_slot_index_map.contains(2));
+    EXPECT_EQ(0, _scanner->_partition_slot_index_map[2]);
+}
+
+TEST_F(FileScannerConversionTest, InitExprCtxesFallsBackToPartitionKeysForOldFe) {
+    add_slot(1, "data");
+    add_slot(2, "month");
+
+    _scanner->_current_range.__set_columns_from_path_keys({"month"});
+    add_required_slot(1, true);
+    add_required_slot(2, false);
+
+    Status st = _scanner->_init_expr_ctxes();
+
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(2, _scanner->_column_descs.size());
+    auto* data_col = find_column_desc("data");
+    auto* month_col = find_column_desc("month");
+    ASSERT_NE(nullptr, data_col);
+    ASSERT_NE(nullptr, month_col);
+    EXPECT_EQ(ColumnCategory::REGULAR, data_col->category);
+    EXPECT_EQ(ColumnCategory::PARTITION_KEY, month_col->category);
+
+    ASSERT_EQ(1, _scanner->_file_slot_descs.size());
+    EXPECT_EQ("data", _scanner->_file_slot_descs[0]->col_name());
+    EXPECT_TRUE(_scanner->_is_file_slot.contains(1));
+    EXPECT_FALSE(_scanner->_is_file_slot.contains(2));
+    ASSERT_TRUE(_scanner->_partition_slot_index_map.contains(2));
+    EXPECT_EQ(0, _scanner->_partition_slot_index_map[2]);
+}
+
+} // namespace doris

--- a/be/test/exec/scan/file_scanner_helpers_test.cpp
+++ b/be/test/exec/scan/file_scanner_helpers_test.cpp
@@ -1,0 +1,198 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+
+#define private public
+#define protected public
+#include "exec/scan/file_scanner.h"
+#undef private
+#undef protected
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#include "format/column_descriptor.h"
+#include "format/table/table_schema_change_helper.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
+
+namespace doris {
+
+class FileScannerHelpersTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _obj_pool = std::make_unique<ObjectPool>();
+        _runtime_state = std::make_unique<RuntimeState>();
+        _profile = std::make_unique<RuntimeProfile>("test_profile");
+
+        TTupleDescriptor tuple_desc;
+        tuple_desc.__set_id(0);
+        tuple_desc.__set_byteSize(16);
+        tuple_desc.__set_numNullBytes(0);
+        _tuple_desc = _obj_pool->add(new TupleDescriptor(tuple_desc));
+
+        _params = std::make_unique<TFileScanRangeParams>();
+        _scanner = std::make_unique<FileScanner>(_runtime_state.get(), _profile.get(),
+                                                 _params.get(), &_col_name_to_slot_id, _tuple_desc);
+    }
+
+    SlotDescriptor* add_slot(TSlotId slot_id, const std::string& col_name) {
+        TSlotDescriptor tslot_desc;
+        tslot_desc.id = slot_id;
+        tslot_desc.parent = _tuple_desc->id();
+
+        TTypeDesc type_desc;
+        TTypeNode node;
+        node.__set_type(TTypeNodeType::SCALAR);
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::INT);
+        node.__set_scalar_type(scalar_type);
+        type_desc.types.push_back(node);
+
+        tslot_desc.slotType = type_desc;
+        tslot_desc.columnPos = -1;
+        tslot_desc.colName = col_name;
+        tslot_desc.byteOffset = 0;
+        tslot_desc.nullIndicatorByte = 0;
+        tslot_desc.nullIndicatorBit = -1;
+        tslot_desc.slotIdx = static_cast<int>(slot_id);
+        tslot_desc.isMaterialized = true;
+
+        auto* slot_desc = _obj_pool->add(new SlotDescriptor(tslot_desc));
+        _tuple_desc->add_slot(slot_desc);
+        return slot_desc;
+    }
+
+    void add_column_desc(TSlotId slot_id, const std::string& col_name, ColumnCategory category) {
+        ColumnDescriptor col_desc;
+        col_desc.name = col_name;
+        col_desc.slot_desc = add_slot(slot_id, col_name);
+        col_desc.category = category;
+        _scanner->_column_descs.push_back(col_desc);
+    }
+
+    std::unique_ptr<ObjectPool> _obj_pool;
+    std::unique_ptr<RuntimeState> _runtime_state;
+    std::unique_ptr<RuntimeProfile> _profile;
+    TupleDescriptor* _tuple_desc = nullptr;
+    std::unique_ptr<TFileScanRangeParams> _params;
+    std::unique_ptr<FileScanner> _scanner;
+    std::unordered_map<std::string, int> _col_name_to_slot_id;
+};
+
+TEST_F(FileScannerHelpersTest, FillBaseInitContextUsesScannerState) {
+    add_column_desc(1, "id", ColumnCategory::REGULAR);
+    add_column_desc(2, "year", ColumnCategory::PARTITION_KEY);
+    _scanner->_src_block_name_to_idx["id"] = 0;
+    _scanner->_current_range.path = "/warehouse/data.parquet";
+    _scanner->_default_val_row_desc = std::make_unique<RowDescriptor>(_tuple_desc);
+
+    ReaderInitContext ctx;
+    _scanner->_fill_base_init_context(&ctx);
+
+    EXPECT_EQ(&_scanner->_column_descs, ctx.column_descs);
+    EXPECT_EQ(&_scanner->_src_block_name_to_idx, ctx.col_name_to_block_idx);
+    EXPECT_EQ(_runtime_state.get(), ctx.state);
+    EXPECT_EQ(_tuple_desc, ctx.tuple_descriptor);
+    EXPECT_EQ(_scanner->_default_val_row_desc.get(), ctx.row_descriptor);
+    EXPECT_EQ(_params.get(), ctx.params);
+    EXPECT_EQ(&_scanner->_current_range, ctx.range);
+    EXPECT_EQ(TableSchemaChangeHelper::ConstNode::get_instance(), ctx.table_info_node);
+    EXPECT_EQ(TPushAggOp::type::NONE, ctx.push_down_agg_type);
+}
+
+TEST_F(FileScannerHelpersTest, GeneratePartitionColumnsUsesRealHelper) {
+    _scanner->_current_range.__set_columns_from_path_keys({"year", "month", "day"});
+    _scanner->_current_range.__set_columns_from_path({"2024", "__HIVE_DEFAULT_PARTITION__"});
+    _scanner->_current_range.__set_columns_from_path_is_null({false, true});
+
+    add_column_desc(1, "id", ColumnCategory::REGULAR);
+    add_column_desc(2, "year", ColumnCategory::PARTITION_KEY);
+    add_column_desc(3, "month", ColumnCategory::PARTITION_KEY);
+    add_column_desc(4, "data", ColumnCategory::REGULAR);
+
+    Status st = _scanner->_generate_partition_columns();
+
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(2, _scanner->_partition_col_descs.size());
+    ASSERT_EQ(2, _scanner->_partition_value_is_null.size());
+
+    auto year_it = _scanner->_partition_col_descs.find("year");
+    ASSERT_NE(year_it, _scanner->_partition_col_descs.end());
+    EXPECT_EQ("2024", std::get<0>(year_it->second));
+    EXPECT_EQ("year", std::get<1>(year_it->second)->col_name());
+    EXPECT_FALSE(_scanner->_partition_value_is_null["year"]);
+
+    auto month_it = _scanner->_partition_col_descs.find("month");
+    ASSERT_NE(month_it, _scanner->_partition_col_descs.end());
+    EXPECT_EQ("__HIVE_DEFAULT_PARTITION__", std::get<0>(month_it->second));
+    EXPECT_EQ("month", std::get<1>(month_it->second)->col_name());
+    EXPECT_TRUE(_scanner->_partition_value_is_null["month"]);
+
+    EXPECT_EQ(_scanner->_partition_col_descs.end(), _scanner->_partition_col_descs.find("day"));
+    EXPECT_EQ(_scanner->_partition_col_descs.end(), _scanner->_partition_col_descs.find("id"));
+}
+
+TEST_F(FileScannerHelpersTest, GeneratePartitionColumnsWithoutPathKeysClearsState) {
+    add_column_desc(1, "year", ColumnCategory::PARTITION_KEY);
+    _scanner->_partition_col_descs.emplace("stale",
+                                           std::make_tuple("value", _tuple_desc->slots()[0]));
+    _scanner->_partition_value_is_null.emplace("stale", true);
+
+    Status st = _scanner->_generate_partition_columns();
+
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_TRUE(_scanner->_partition_col_descs.empty());
+    EXPECT_TRUE(_scanner->_partition_value_is_null.empty());
+}
+
+TEST_F(FileScannerHelpersTest, ConfigureFileScanHandlersUsesRealHelper) {
+    _scanner->_is_load = true;
+    _scanner->_configure_file_scan_handlers();
+    EXPECT_EQ(&FileScanner::_init_src_block_for_load, _scanner->_init_src_block_handler);
+    EXPECT_EQ(&FileScanner::_process_src_block_after_read_for_load,
+              _scanner->_process_src_block_after_read_handler);
+    EXPECT_EQ(&FileScanner::_should_push_down_predicates_for_load,
+              _scanner->_should_push_down_predicates_handler);
+    EXPECT_EQ(&FileScanner::_should_enable_condition_cache_for_load,
+              _scanner->_should_enable_condition_cache_handler);
+
+    _scanner->_is_load = false;
+    _scanner->_configure_file_scan_handlers();
+    EXPECT_EQ(&FileScanner::_init_src_block_for_query, _scanner->_init_src_block_handler);
+    EXPECT_EQ(&FileScanner::_process_src_block_after_read_for_query,
+              _scanner->_process_src_block_after_read_handler);
+    EXPECT_EQ(&FileScanner::_should_push_down_predicates_for_query,
+              _scanner->_should_push_down_predicates_handler);
+    EXPECT_EQ(&FileScanner::_should_enable_condition_cache_for_query,
+              _scanner->_should_enable_condition_cache_handler);
+}
+
+} // namespace doris

--- a/be/test/format/column_descriptor_test.cpp
+++ b/be/test/format/column_descriptor_test.cpp
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/column_descriptor.h"
+
+#include <gtest/gtest.h>
+
+#include "exprs/vexpr_fwd.h"
+
+namespace doris {
+
+// ============================================================================
+// Test: ColumnCategory enum values are distinct
+// ============================================================================
+TEST(ColumnCategoryTest, EnumValuesDistinct) {
+    EXPECT_NE(ColumnCategory::REGULAR, ColumnCategory::PARTITION_KEY);
+    EXPECT_NE(ColumnCategory::REGULAR, ColumnCategory::SYNTHESIZED);
+    EXPECT_NE(ColumnCategory::REGULAR, ColumnCategory::GENERATED);
+    EXPECT_NE(ColumnCategory::PARTITION_KEY, ColumnCategory::SYNTHESIZED);
+    EXPECT_NE(ColumnCategory::PARTITION_KEY, ColumnCategory::GENERATED);
+    EXPECT_NE(ColumnCategory::SYNTHESIZED, ColumnCategory::GENERATED);
+}
+
+// ============================================================================
+// Test: ColumnDescriptor default construction
+// ============================================================================
+TEST(ColumnDescriptorTest, DefaultConstruction) {
+    ColumnDescriptor desc;
+    EXPECT_TRUE(desc.name.empty());
+    EXPECT_EQ(desc.slot_desc, nullptr);
+    EXPECT_EQ(desc.category, ColumnCategory::REGULAR);
+    EXPECT_EQ(desc.default_expr, nullptr);
+}
+
+// ============================================================================
+// Test: ColumnDescriptor aggregate initialization
+// ============================================================================
+TEST(ColumnDescriptorTest, AggregateInit) {
+    ColumnDescriptor desc {"col_a", nullptr, ColumnCategory::PARTITION_KEY, nullptr};
+    EXPECT_EQ(desc.name, "col_a");
+    EXPECT_EQ(desc.category, ColumnCategory::PARTITION_KEY);
+}
+
+// ============================================================================
+// Test: ColumnDescriptor with all categories
+// ============================================================================
+TEST(ColumnDescriptorTest, AllCategories) {
+    ColumnDescriptor regular {"r", nullptr, ColumnCategory::REGULAR, nullptr};
+    ColumnDescriptor partition {"p", nullptr, ColumnCategory::PARTITION_KEY, nullptr};
+    ColumnDescriptor synthesized {"s", nullptr, ColumnCategory::SYNTHESIZED, nullptr};
+    ColumnDescriptor generated {"g", nullptr, ColumnCategory::GENERATED, nullptr};
+
+    EXPECT_EQ(regular.category, ColumnCategory::REGULAR);
+    EXPECT_EQ(partition.category, ColumnCategory::PARTITION_KEY);
+    EXPECT_EQ(synthesized.category, ColumnCategory::SYNTHESIZED);
+    EXPECT_EQ(generated.category, ColumnCategory::GENERATED);
+}
+
+// ============================================================================
+// Test: ColumnDescriptor in a vector (typical usage pattern)
+// ============================================================================
+TEST(ColumnDescriptorTest, VectorUsage) {
+    std::vector<ColumnDescriptor> descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"year", nullptr, ColumnCategory::PARTITION_KEY, nullptr},
+            {"$row_id", nullptr, ColumnCategory::SYNTHESIZED, nullptr},
+            {"_row_id", nullptr, ColumnCategory::GENERATED, nullptr},
+    };
+    EXPECT_EQ(descs.size(), 4);
+
+    // Filter REGULAR + GENERATED (as on_before_init_reader does).
+    std::vector<std::string> column_names;
+    for (auto& desc : descs) {
+        if (desc.category == ColumnCategory::REGULAR ||
+            desc.category == ColumnCategory::GENERATED) {
+            column_names.push_back(desc.name);
+        }
+    }
+    ASSERT_EQ(column_names.size(), 2);
+    EXPECT_EQ(column_names[0], "id");
+    EXPECT_EQ(column_names[1], "_row_id");
+}
+
+// ============================================================================
+// Test: ColumnDescriptor copy and move semantics
+// ============================================================================
+TEST(ColumnDescriptorTest, CopySemantics) {
+    ColumnDescriptor orig {"col_x", nullptr, ColumnCategory::SYNTHESIZED, nullptr};
+    ColumnDescriptor copy = orig;
+    EXPECT_EQ(copy.name, "col_x");
+    EXPECT_EQ(copy.category, ColumnCategory::SYNTHESIZED);
+}
+
+TEST(ColumnDescriptorTest, MoveSemantics) {
+    ColumnDescriptor orig {"col_y", nullptr, ColumnCategory::GENERATED, nullptr};
+    ColumnDescriptor moved = std::move(orig);
+    EXPECT_EQ(moved.name, "col_y");
+    EXPECT_EQ(moved.category, ColumnCategory::GENERATED);
+}
+
+} // namespace doris

--- a/be/test/format/generic_reader_test.cpp
+++ b/be/test/format/generic_reader_test.cpp
@@ -1,0 +1,722 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/generic_reader.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/column/column_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "format/column_descriptor.h"
+
+namespace doris {
+
+// ============================================================================
+// Mock Reader: Records hook call order for verifying NVI template sequence.
+// ============================================================================
+class MockReader : public GenericReader {
+public:
+    // Accumulated log of method calls for sequence verification.
+    std::vector<std::string> call_log;
+
+    // Configurable return statuses for each hook.
+    Status open_file_status = Status::OK();
+    Status before_init_status = Status::OK();
+    Status do_init_status = Status::OK();
+    Status after_init_status = Status::OK();
+    Status before_read_status = Status::OK();
+    Status do_read_status = Status::OK();
+    Status after_read_status = Status::OK();
+
+    // _do_get_next_block behavior.
+    int batches_to_emit = 1;
+    size_t rows_per_batch = 10;
+
+protected:
+    Status _open_file_reader(ReaderInitContext* ctx) override {
+        call_log.push_back("_open_file_reader");
+        return open_file_status;
+    }
+
+    Status on_before_init_reader(ReaderInitContext* ctx) override {
+        call_log.push_back("on_before_init_reader");
+        _column_descs = ctx->column_descs;
+        return before_init_status;
+    }
+
+    Status _do_init_reader(ReaderInitContext* ctx) override {
+        call_log.push_back("_do_init_reader");
+        return do_init_status;
+    }
+
+    Status on_after_init_reader(ReaderInitContext* ctx) override {
+        call_log.push_back("on_after_init_reader");
+        return after_init_status;
+    }
+
+    Status on_before_read_block(Block* block) override {
+        call_log.push_back("on_before_read_block");
+        return before_read_status;
+    }
+
+    Status _do_get_next_block(Block* block, size_t* read_rows, bool* eof) override {
+        call_log.push_back("_do_get_next_block");
+        if (batches_to_emit <= 0) {
+            *read_rows = 0;
+            *eof = true;
+            return do_read_status;
+        }
+        batches_to_emit--;
+        *read_rows = rows_per_batch;
+        *eof = (batches_to_emit == 0);
+        // Resize columns to match read_rows.
+        auto mutate_columns = block->mutate_columns();
+        for (auto& col : mutate_columns) {
+            col->resize(*read_rows);
+        }
+        block->set_columns(std::move(mutate_columns));
+        return do_read_status;
+    }
+
+    Status on_after_read_block(Block* block, size_t* read_rows) override {
+        call_log.push_back("on_after_read_block");
+        return after_read_status;
+    }
+};
+
+// A custom ReaderInitContext subclass for testing checked_context_cast.
+struct TestInitContext : public ReaderInitContext {
+    int custom_field = 42;
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+static Block make_block() {
+    Block block;
+    auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>());
+    block.insert({type->create_column(), type, "col0"});
+    return block;
+}
+
+// ============================================================================
+// Test: init_reader hook sequence with column_descs (normal path)
+// ============================================================================
+TEST(GenericReaderNVITest, InitReaderNormalSequence) {
+    MockReader reader;
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Verify exact call order: open → before → do → after
+    ASSERT_EQ(reader.call_log.size(), 4);
+    EXPECT_EQ(reader.call_log[0], "_open_file_reader");
+    EXPECT_EQ(reader.call_log[1], "on_before_init_reader");
+    EXPECT_EQ(reader.call_log[2], "_do_init_reader");
+    EXPECT_EQ(reader.call_log[3], "on_after_init_reader");
+}
+
+// ============================================================================
+// Test: init_reader standalone mode (column_descs == nullptr skips hooks)
+// ============================================================================
+TEST(GenericReaderNVITest, InitReaderStandaloneSkipsHooks) {
+    MockReader reader;
+    ReaderInitContext ctx;
+    ctx.column_descs = nullptr;
+    ctx.column_names = {"col_a", "col_b"};
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Standalone: open → do_init only (no before/after hooks)
+    ASSERT_EQ(reader.call_log.size(), 2);
+    EXPECT_EQ(reader.call_log[0], "_open_file_reader");
+    EXPECT_EQ(reader.call_log[1], "_do_init_reader");
+}
+
+// ============================================================================
+// Test: init_reader propagates push_down_agg_type from context
+// ============================================================================
+TEST(GenericReaderNVITest, InitReaderSetsPushDownAggType) {
+    MockReader reader;
+    ReaderInitContext ctx;
+    ctx.push_down_agg_type = TPushAggOp::type::COUNT;
+    ctx.column_descs = nullptr;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::COUNT);
+}
+
+// ============================================================================
+// Test: init_reader error in _open_file_reader aborts early
+// ============================================================================
+TEST(GenericReaderNVITest, InitReaderOpenFileError) {
+    MockReader reader;
+    reader.open_file_status = Status::IOError("disk failure");
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::IO_ERROR>());
+
+    // Only _open_file_reader should have been called.
+    ASSERT_EQ(reader.call_log.size(), 1);
+    EXPECT_EQ(reader.call_log[0], "_open_file_reader");
+}
+
+// ============================================================================
+// Test: init_reader error in on_before_init_reader aborts before _do_init
+// ============================================================================
+TEST(GenericReaderNVITest, InitReaderBeforeInitError) {
+    MockReader reader;
+    reader.before_init_status = Status::InternalError("schema mismatch");
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_FALSE(st.ok());
+
+    ASSERT_EQ(reader.call_log.size(), 2);
+    EXPECT_EQ(reader.call_log[0], "_open_file_reader");
+    EXPECT_EQ(reader.call_log[1], "on_before_init_reader");
+}
+
+// ============================================================================
+// Test: init_reader error in _do_init_reader aborts before on_after
+// ============================================================================
+TEST(GenericReaderNVITest, InitReaderDoInitError) {
+    MockReader reader;
+    reader.do_init_status = Status::Corruption("bad footer");
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_FALSE(st.ok());
+
+    ASSERT_EQ(reader.call_log.size(), 3);
+    EXPECT_EQ(reader.call_log[2], "_do_init_reader");
+}
+
+// ============================================================================
+// Test: init_reader error in on_after_init_reader returns error
+// ============================================================================
+TEST(GenericReaderNVITest, InitReaderAfterInitError) {
+    MockReader reader;
+    reader.after_init_status = Status::InternalError("delete file failed");
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_FALSE(st.ok());
+
+    // All 4 hooks called, but the last one returned error.
+    ASSERT_EQ(reader.call_log.size(), 4);
+    EXPECT_EQ(reader.call_log[3], "on_after_init_reader");
+}
+
+// ============================================================================
+// Test: get_next_block hook sequence
+// ============================================================================
+TEST(GenericReaderNVITest, GetNextBlockSequence) {
+    MockReader reader;
+    reader.batches_to_emit = 1;
+    reader.rows_per_batch = 5;
+
+    Block block = make_block();
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(reader.call_log.size(), 3);
+    EXPECT_EQ(reader.call_log[0], "on_before_read_block");
+    EXPECT_EQ(reader.call_log[1], "_do_get_next_block");
+    EXPECT_EQ(reader.call_log[2], "on_after_read_block");
+    EXPECT_EQ(read_rows, 5);
+    EXPECT_TRUE(eof);
+}
+
+// ============================================================================
+// Test: get_next_block error in on_before_read_block
+// ============================================================================
+TEST(GenericReaderNVITest, GetNextBlockBeforeReadError) {
+    MockReader reader;
+    reader.before_read_status = Status::InternalError("expand failed");
+
+    Block block = make_block();
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_FALSE(st.ok());
+
+    ASSERT_EQ(reader.call_log.size(), 1);
+    EXPECT_EQ(reader.call_log[0], "on_before_read_block");
+}
+
+// ============================================================================
+// Test: get_next_block error in _do_get_next_block
+// ============================================================================
+TEST(GenericReaderNVITest, GetNextBlockDoReadError) {
+    MockReader reader;
+    reader.do_read_status = Status::IOError("read error");
+    reader.batches_to_emit = 1;
+
+    Block block = make_block();
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_FALSE(st.ok());
+
+    ASSERT_EQ(reader.call_log.size(), 2);
+    EXPECT_EQ(reader.call_log[1], "_do_get_next_block");
+}
+
+// ============================================================================
+// Test: get_next_block error in on_after_read_block
+// ============================================================================
+TEST(GenericReaderNVITest, GetNextBlockAfterReadError) {
+    MockReader reader;
+    reader.after_read_status = Status::InternalError("shrink failed");
+    reader.batches_to_emit = 1;
+
+    Block block = make_block();
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_FALSE(st.ok());
+
+    ASSERT_EQ(reader.call_log.size(), 3);
+    EXPECT_EQ(reader.call_log[2], "on_after_read_block");
+}
+
+// ============================================================================
+// Test: get_next_block multi-batch reading
+// ============================================================================
+TEST(GenericReaderNVITest, GetNextBlockMultiBatch) {
+    MockReader reader;
+    reader.batches_to_emit = 3;
+    reader.rows_per_batch = 100;
+
+    size_t total_rows = 0;
+    int batch_count = 0;
+    bool eof = false;
+    while (!eof) {
+        Block block = make_block();
+        size_t read_rows = 0;
+        auto st = reader.get_next_block(&block, &read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        total_rows += read_rows;
+        batch_count++;
+    }
+    EXPECT_EQ(total_rows, 300);
+    EXPECT_EQ(batch_count, 3);
+    // Each batch triggers 3 hooks → 9 total calls.
+    EXPECT_EQ(reader.call_log.size(), 9);
+}
+
+// ============================================================================
+// Test: get_next_block with zero batches (immediate EOF)
+// ============================================================================
+TEST(GenericReaderNVITest, GetNextBlockImmediateEof) {
+    MockReader reader;
+    reader.batches_to_emit = 0;
+
+    Block block = make_block();
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(read_rows, 0);
+    EXPECT_TRUE(eof);
+}
+
+// ============================================================================
+// Test: checked_context_cast succeeds for correct type
+// ============================================================================
+TEST(GenericReaderNVITest, CheckedContextCastSuccess) {
+    TestInitContext test_ctx;
+    test_ctx.custom_field = 99;
+
+    auto* casted = checked_context_cast<TestInitContext>(&test_ctx);
+    ASSERT_NE(casted, nullptr);
+    EXPECT_EQ(casted->custom_field, 99);
+}
+
+// ============================================================================
+// Test: checked_context_cast from base pointer
+// ============================================================================
+TEST(GenericReaderNVITest, CheckedContextCastFromBase) {
+    TestInitContext test_ctx;
+    test_ctx.custom_field = 77;
+    ReaderInitContext* base_ptr = &test_ctx;
+
+    auto* casted = checked_context_cast<TestInitContext>(base_ptr);
+    ASSERT_NE(casted, nullptr);
+    EXPECT_EQ(casted->custom_field, 77);
+}
+
+// ============================================================================
+// Test: push_down_agg_type getter/setter
+// ============================================================================
+TEST(GenericReaderNVITest, PushDownAggType) {
+    MockReader reader;
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::NONE);
+
+    reader.set_push_down_agg_type(TPushAggOp::type::COUNT);
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::COUNT);
+
+    reader.set_push_down_agg_type(TPushAggOp::type::NONE);
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::NONE);
+}
+
+// ============================================================================
+// Test: has_column_descs tracks state from on_before_init_reader
+// ============================================================================
+TEST(GenericReaderNVITest, HasColumnDescs) {
+    MockReader reader;
+    EXPECT_FALSE(reader.has_column_descs());
+
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+    EXPECT_TRUE(reader.has_column_descs());
+}
+
+// ============================================================================
+// Test: has_column_descs remains false for standalone reader
+// ============================================================================
+TEST(GenericReaderNVITest, HasColumnDescsStandalone) {
+    MockReader reader;
+    ReaderInitContext ctx;
+    ctx.column_descs = nullptr;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+    // Standalone path skips on_before_init_reader → _column_descs stays null.
+    EXPECT_FALSE(reader.has_column_descs());
+}
+
+// ============================================================================
+// Test: get_columns caching behavior
+// ============================================================================
+class MockReaderWithColumns : public MockReader {
+public:
+    int get_columns_call_count = 0;
+
+    Status _get_columns_impl(std::unordered_map<std::string, DataTypePtr>* name_to_type) override {
+        get_columns_call_count++;
+        (*name_to_type)["col0"] = std::make_shared<DataTypeInt64>();
+        (*name_to_type)["col1"] = std::make_shared<DataTypeInt64>();
+        return Status::OK();
+    }
+};
+
+TEST(GenericReaderNVITest, GetColumnsCaching) {
+    MockReaderWithColumns reader;
+
+    std::unordered_map<std::string, DataTypePtr> result1;
+    auto st = reader.get_columns(&result1);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(result1.size(), 2);
+    EXPECT_EQ(reader.get_columns_call_count, 1);
+
+    // Second call should use cache.
+    std::unordered_map<std::string, DataTypePtr> result2;
+    st = reader.get_columns(&result2);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(result2.size(), 2);
+    EXPECT_EQ(reader.get_columns_call_count, 1); // Still 1, cached.
+}
+
+// ============================================================================
+// Test: default virtual method behaviors
+// ============================================================================
+TEST(GenericReaderNVITest, DefaultVirtualMethods) {
+    MockReader reader;
+
+    EXPECT_FALSE(reader.count_read_rows());
+    EXPECT_FALSE(reader.supports_count_pushdown());
+    EXPECT_EQ(reader.get_total_rows(), 0);
+    EXPECT_FALSE(reader.has_delete_operations());
+    EXPECT_TRUE(reader.close().ok());
+}
+
+// ============================================================================
+// Test: Hook that modifies block during on_before_read_block
+// ============================================================================
+class BlockModifyingReader : public MockReader {
+protected:
+    Status on_before_read_block(Block* block) override {
+        call_log.push_back("on_before_read_block");
+        // Add an extra column to the block (like Iceberg equality delete expansion).
+        auto extra_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>());
+        block->insert({extra_type->create_column(), extra_type, "extra_col"});
+        return Status::OK();
+    }
+
+    Status on_after_read_block(Block* block, size_t* read_rows) override {
+        call_log.push_back("on_after_read_block");
+        // Remove the extra column (like Iceberg shrink).
+        int pos = block->get_position_by_name("extra_col");
+        if (pos >= 0) {
+            block->erase(static_cast<size_t>(pos));
+        }
+        return Status::OK();
+    }
+};
+
+TEST(GenericReaderNVITest, HooksModifyBlockStructure) {
+    BlockModifyingReader reader;
+    reader.batches_to_emit = 1;
+    reader.rows_per_batch = 3;
+
+    Block block = make_block();
+    ASSERT_EQ(block.columns(), 1);
+
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // After the full cycle, extra_col should have been added then removed.
+    EXPECT_EQ(block.columns(), 1);
+    EXPECT_EQ(block.get_by_position(0).name, "col0");
+}
+
+// ============================================================================
+// Test: init_reader + get_next_block full lifecycle
+// ============================================================================
+TEST(GenericReaderNVITest, FullLifecycle) {
+    MockReader reader;
+    reader.batches_to_emit = 2;
+    reader.rows_per_batch = 50;
+
+    // 1) Init.
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.push_down_agg_type = TPushAggOp::type::NONE;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+    EXPECT_TRUE(reader.has_column_descs());
+
+    // 2) Read all batches.
+    size_t total_rows = 0;
+    bool eof = false;
+    while (!eof) {
+        Block block = make_block();
+        size_t read_rows = 0;
+        st = reader.get_next_block(&block, &read_rows, &eof);
+        ASSERT_TRUE(st.ok());
+        total_rows += read_rows;
+    }
+    EXPECT_EQ(total_rows, 100);
+
+    // 3) Close.
+    EXPECT_TRUE(reader.close().ok());
+
+    // 4) Verify full call sequence.
+    // Init: 4 calls. Read: 2 batches × 3 hooks = 6 calls. Total: 10.
+    EXPECT_EQ(reader.call_log.size(), 10);
+}
+
+// ============================================================================
+// Test: ReaderInitContext default values
+// ============================================================================
+TEST(GenericReaderNVITest, ReaderInitContextDefaults) {
+    ReaderInitContext ctx;
+    EXPECT_EQ(ctx.column_descs, nullptr);
+    EXPECT_EQ(ctx.col_name_to_block_idx, nullptr);
+    EXPECT_EQ(ctx.state, nullptr);
+    EXPECT_EQ(ctx.tuple_descriptor, nullptr);
+    EXPECT_EQ(ctx.row_descriptor, nullptr);
+    EXPECT_EQ(ctx.params, nullptr);
+    EXPECT_EQ(ctx.range, nullptr);
+    EXPECT_EQ(ctx.push_down_agg_type, TPushAggOp::type::NONE);
+    EXPECT_TRUE(ctx.column_names.empty());
+    EXPECT_NE(ctx.table_info_node, nullptr); // ConstNode singleton
+    EXPECT_TRUE(ctx.column_ids.empty());
+    EXPECT_TRUE(ctx.filter_column_ids.empty());
+}
+
+// ============================================================================
+// Test: Multiple init_reader calls (re-init scenario)
+// ============================================================================
+TEST(GenericReaderNVITest, MultipleInitReaderCalls) {
+    MockReader reader;
+    std::vector<ColumnDescriptor> col_descs1 = {
+            {"col_a", nullptr, ColumnCategory::REGULAR, nullptr}};
+    std::vector<ColumnDescriptor> col_descs2 = {
+            {"col_b", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"col_c", nullptr, ColumnCategory::PARTITION_KEY, nullptr}};
+
+    ReaderInitContext ctx1;
+    ctx1.column_descs = &col_descs1;
+    ASSERT_TRUE(reader.init_reader(&ctx1).ok());
+    EXPECT_EQ(reader.call_log.size(), 4);
+
+    // Second init (some readers may be re-inited for different file ranges).
+    ReaderInitContext ctx2;
+    ctx2.column_descs = &col_descs2;
+    ASSERT_TRUE(reader.init_reader(&ctx2).ok());
+    EXPECT_EQ(reader.call_log.size(), 8);
+}
+
+// ============================================================================
+// Test: get_columns error propagation
+// ============================================================================
+class ErrorColumnsReader : public MockReader {
+public:
+    Status _get_columns_impl(std::unordered_map<std::string, DataTypePtr>* name_to_type) override {
+        return Status::InternalError("schema unavailable");
+    }
+};
+
+TEST(GenericReaderNVITest, GetColumnsError) {
+    ErrorColumnsReader reader;
+    std::unordered_map<std::string, DataTypePtr> result;
+    auto st = reader.get_columns(&result);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(result.empty());
+}
+
+// ============================================================================
+// Test: get_columns error is NOT cached (retry after fix)
+// ============================================================================
+class TransientErrorColumnsReader : public MockReader {
+public:
+    int call_count = 0;
+
+    Status _get_columns_impl(std::unordered_map<std::string, DataTypePtr>* name_to_type) override {
+        call_count++;
+        if (call_count == 1) {
+            return Status::InternalError("transient error");
+        }
+        (*name_to_type)["col0"] = std::make_shared<DataTypeInt64>();
+        return Status::OK();
+    }
+};
+
+TEST(GenericReaderNVITest, GetColumnsErrorNotCached) {
+    TransientErrorColumnsReader reader;
+    std::unordered_map<std::string, DataTypePtr> result;
+
+    // First call fails.
+    auto st = reader.get_columns(&result);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(reader.call_count, 1);
+
+    // Second call succeeds (error was not cached).
+    st = reader.get_columns(&result);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(reader.call_count, 2);
+}
+
+// ============================================================================
+// Test: init_reader with all TPushAggOp types
+// ============================================================================
+TEST(GenericReaderNVITest, PushDownAggTypeAllValues) {
+    MockReader reader;
+    ReaderInitContext ctx;
+    ctx.column_descs = nullptr;
+
+    ctx.push_down_agg_type = TPushAggOp::type::COUNT;
+    ASSERT_TRUE(reader.init_reader(&ctx).ok());
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::COUNT);
+
+    ctx.push_down_agg_type = TPushAggOp::type::MINMAX;
+    ASSERT_TRUE(reader.init_reader(&ctx).ok());
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::MINMAX);
+
+    ctx.push_down_agg_type = TPushAggOp::type::NONE;
+    ASSERT_TRUE(reader.init_reader(&ctx).ok());
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::NONE);
+}
+
+// ============================================================================
+// Test: on_after_init_reader can override push_down_agg_type
+// ============================================================================
+class CountResetReader : public MockReader {
+protected:
+    Status on_after_init_reader(ReaderInitContext* ctx) override {
+        call_log.push_back("on_after_init_reader");
+        // Simulate Iceberg resetting COUNT to NONE due to equality deletes.
+        this->set_push_down_agg_type(TPushAggOp::type::NONE);
+        return Status::OK();
+    }
+};
+
+TEST(GenericReaderNVITest, AfterInitResetsCountPushdown) {
+    CountResetReader reader;
+    std::vector<ColumnDescriptor> col_descs = {{"col0", nullptr, ColumnCategory::REGULAR, nullptr}};
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.push_down_agg_type = TPushAggOp::type::COUNT;
+
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+    // COUNT was set before hooks, but on_after_init_reader reset it to NONE.
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::type::NONE);
+}
+
+// ============================================================================
+// Test: read_by_rows default returns NotSupported
+// ============================================================================
+TEST(GenericReaderNVITest, ReadByRowsDefault) {
+    MockReader reader;
+    auto st = reader.read_by_rows({1, 2, 3});
+    ASSERT_FALSE(st.ok());
+}
+
+// ============================================================================
+// Test: init_schema_reader default returns NotSupported
+// ============================================================================
+TEST(GenericReaderNVITest, InitSchemaReaderDefault) {
+    MockReader reader;
+    auto st = reader.init_schema_reader();
+    ASSERT_FALSE(st.ok());
+}
+
+// ============================================================================
+// Test: get_parsed_schema default returns NotSupported
+// ============================================================================
+TEST(GenericReaderNVITest, GetParsedSchemaDefault) {
+    MockReader reader;
+    std::vector<std::string> col_names;
+    std::vector<DataTypePtr> col_types;
+    auto st = reader.get_parsed_schema(&col_names, &col_types);
+    ASSERT_FALSE(st.ok());
+}
+
+} // namespace doris

--- a/be/test/format/jni/jni_reader_test.cpp
+++ b/be/test/format/jni/jni_reader_test.cpp
@@ -1,0 +1,414 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/data_type/data_type_bitmap.h"
+#include "core/data_type/data_type_hll.h"
+#include "core/data_type/data_type_jsonb.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_quantilestate.h"
+#include "core/data_type/data_type_string.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#define private public
+#define protected public
+#include "format/jni/jni_reader.h"
+#include "format/table/hudi_jni_reader.h"
+#include "format/table/iceberg_sys_table_jni_reader.h"
+#include "format/table/jdbc_jni_reader.h"
+#include "format/table/max_compute_jni_reader.h"
+#include "format/table/paimon_jni_reader.h"
+#include "format/table/trino_connector_jni_reader.h"
+#undef protected
+#undef private
+#pragma clang diagnostic pop
+#include "runtime/descriptors.h"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
+#include "testutil/desc_tbl_builder.h"
+#include "util/debug_util.h"
+
+namespace doris {
+
+class JniReaderTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _query_options.__set_batch_size(3);
+        _runtime_state = std::make_unique<RuntimeState>(_query_options, _query_globals);
+        _runtime_state->set_timezone("UTC");
+    }
+
+    std::vector<SlotDescriptor*> build_file_slot_descs(
+            const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        DescriptorTblBuilder builder(&_object_pool);
+        auto& tuple_builder = builder.declare_tuple();
+        for (const auto& [name, type] : columns) {
+            tuple_builder << std::make_tuple(type, name);
+        }
+        return builder.build()->get_tuple_descriptor(0)->slots();
+    }
+
+    static Block make_block(const std::vector<SlotDescriptor*>& slots) {
+        Block block;
+        for (auto* slot : slots) {
+            auto type = slot->get_data_type_ptr();
+            block.insert({type->create_column(), type, slot->col_name()});
+        }
+        return block;
+    }
+
+    TQueryOptions _query_options;
+    TQueryGlobals _query_globals;
+    ObjectPool _object_pool;
+    std::unique_ptr<RuntimeState> _runtime_state;
+    RuntimeProfile _profile {"jni_reader_test"};
+};
+
+TEST_F(JniReaderTest, MockReaderBuildsScannerParams) {
+    auto slots =
+            build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()},
+                                   {"name", make_nullable(std::make_shared<DataTypeString>())}});
+
+    MockJniReader reader(slots, _runtime_state.get(), &_profile);
+
+    EXPECT_EQ(reader._connector_class, "org/apache/doris/common/jni/MockJniScanner");
+    EXPECT_EQ(reader._connector_name, "MockJniScanner");
+    EXPECT_EQ(reader._column_names, std::vector<std::string>({"id", "name"}));
+    EXPECT_EQ(reader._scanner_params["mock_rows"], "10240");
+    EXPECT_EQ(reader._scanner_params["required_fields"], "id,name");
+    EXPECT_EQ(reader._scanner_params["columns_types"], "int#string");
+}
+
+TEST_F(JniReaderTest, HudiReaderBuildsScannerParamsAndPrefixesConfigs) {
+    auto slots = build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()},
+                                        {"name", std::make_shared<DataTypeString>()}});
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_properties({{"hoodie.datasource.query.type", "snapshot"},
+                                  {"fs.defaultFS", "hdfs://namenode:8020"}});
+
+    THudiFileDesc hudi_params;
+    hudi_params.__set_base_path("s3://warehouse/tbl");
+    hudi_params.__set_data_file_path("s3://warehouse/tbl/000.parquet");
+    hudi_params.__set_data_file_length(4096);
+    hudi_params.__set_delta_logs({"log1", "log2"});
+    hudi_params.__set_column_names({"id", "name"});
+    hudi_params.__set_column_types({"int", "string"});
+    hudi_params.__set_instant_time("20240422010101");
+    hudi_params.__set_serde("org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe");
+    hudi_params.__set_input_format("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+
+    HudiJniReader reader(scan_params, hudi_params, slots, _runtime_state.get(), &_profile);
+
+    EXPECT_EQ(reader._connector_class, "org/apache/doris/hudi/HadoopHudiJniScanner");
+    EXPECT_EQ(reader._connector_name, "HadoopHudiJniScanner");
+    EXPECT_EQ(reader._column_names, std::vector<std::string>({"id", "name"}));
+    EXPECT_EQ(reader._scanner_params["query_id"], print_id(_runtime_state->query_id()));
+    EXPECT_EQ(reader._scanner_params["base_path"], "s3://warehouse/tbl");
+    EXPECT_EQ(reader._scanner_params["data_file_path"], "s3://warehouse/tbl/000.parquet");
+    EXPECT_EQ(reader._scanner_params["data_file_length"], "4096");
+    EXPECT_EQ(reader._scanner_params["delta_file_paths"], "log1,log2");
+    EXPECT_EQ(reader._scanner_params["hudi_column_names"], "id,name");
+    EXPECT_EQ(reader._scanner_params["hudi_column_types"], "int#string");
+    EXPECT_EQ(reader._scanner_params["required_fields"], "id,name");
+    EXPECT_EQ(reader._scanner_params["instant_time"], "20240422010101");
+    EXPECT_EQ(reader._scanner_params["serde"],
+              "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe");
+    EXPECT_EQ(reader._scanner_params["input_format"],
+              "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat");
+    EXPECT_EQ(reader._scanner_params["time_zone"], _runtime_state->timezone_obj().name());
+    EXPECT_EQ(reader._scanner_params["hoodie.datasource.query.type"], "snapshot");
+    EXPECT_EQ(reader._scanner_params["hadoop_conf.fs.defaultFS"], "hdfs://namenode:8020");
+}
+
+TEST_F(JniReaderTest, PaimonReaderPrefersRangeParamsForPredicateOptionsAndProperties) {
+    auto slots = build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()},
+                                        {"name", std::make_shared<DataTypeString>()}});
+
+    TFileRangeDesc range;
+    range.__isset.self_split_weight = true;
+    range.self_split_weight = 17;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.__isset.table_level_row_count = true;
+    range.table_format_params.table_level_row_count = 5;
+    range.table_format_params.paimon_params.__set_paimon_split("encoded-split-from-range");
+    range.table_format_params.paimon_params.__set_paimon_predicate("predicate-from-range");
+    range.table_format_params.paimon_params.__set_paimon_options(
+            {{"scan.mode", "range"}, {"file.format", "orc"}});
+    range.table_format_params.paimon_params.__set_hadoop_conf({{"fs.defaultFS", "hdfs://range"}});
+
+    TFileScanRangeParams range_params;
+    range_params.__set_paimon_predicate("predicate-from-params");
+    range_params.__set_serialized_table("serialized-table-from-params");
+    range_params.__set_paimon_options({{"scan.mode", "params"}});
+    range_params.__set_properties({{"fs.defaultFS", "hdfs://params"}});
+
+    PaimonJniReader reader(slots, _runtime_state.get(), &_profile, range, &range_params);
+
+    EXPECT_EQ(reader._connector_class, "org/apache/doris/paimon/PaimonJniScanner");
+    EXPECT_EQ(reader._connector_name, "PaimonJniScanner");
+    EXPECT_EQ(reader._self_split_weight, 17);
+    EXPECT_EQ(reader._remaining_table_level_row_count, 5);
+    EXPECT_EQ(reader._scanner_params["paimon_split"], "encoded-split-from-range");
+    EXPECT_EQ(reader._scanner_params["paimon_predicate"], "predicate-from-params");
+    EXPECT_EQ(reader._scanner_params["serialized_table"], "serialized-table-from-params");
+    EXPECT_EQ(reader._scanner_params["required_fields"], "id,name");
+    EXPECT_EQ(reader._scanner_params["columns_types"], "int#string");
+    EXPECT_EQ(reader._scanner_params["time_zone"], "UTC");
+    EXPECT_EQ(reader._scanner_params["paimon.scan.mode"], "params");
+    EXPECT_EQ(reader._scanner_params["hadoop.fs.defaultFS"], "hdfs://params");
+    EXPECT_EQ(reader._scanner_params.find("paimon.file.format"), reader._scanner_params.end());
+}
+
+TEST_F(JniReaderTest, PaimonReaderFallsBackToRangeWhenRangeParamsAreUnset) {
+    auto slots = build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()}});
+
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_split("encoded-split");
+    range.table_format_params.paimon_params.__set_paimon_predicate("predicate-from-range");
+    range.table_format_params.paimon_params.__set_paimon_options(
+            {{"scan.mode", "snapshot"}, {"file.format", "parquet"}});
+    range.table_format_params.paimon_params.__set_hadoop_conf(
+            {{"fs.defaultFS", "hdfs://fallback"}});
+
+    TFileScanRangeParams range_params;
+    PaimonJniReader reader(slots, _runtime_state.get(), &_profile, range, &range_params);
+
+    EXPECT_EQ(reader._scanner_params["paimon_predicate"], "predicate-from-range");
+    EXPECT_EQ(reader._scanner_params["paimon.scan.mode"], "snapshot");
+    EXPECT_EQ(reader._scanner_params["paimon.file.format"], "parquet");
+    EXPECT_EQ(reader._scanner_params["hadoop.fs.defaultFS"], "hdfs://fallback");
+    EXPECT_EQ(reader._scanner_params.find("serialized_table"), reader._scanner_params.end());
+}
+
+TEST_F(JniReaderTest, PaimonReaderCountPushdownUsesTableLevelRowCount) {
+    auto slots = build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()},
+                                        {"name", std::make_shared<DataTypeString>()}});
+
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.table_level_row_count = true;
+    range.table_format_params.table_level_row_count = 5;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_split("encoded-split");
+
+    TFileScanRangeParams range_params;
+    PaimonJniReader reader(slots, _runtime_state.get(), &_profile, range, &range_params);
+    reader.set_push_down_agg_type(TPushAggOp::type::COUNT);
+
+    Block block = make_block(slots);
+    size_t read_rows = 0;
+    bool eof = false;
+
+    auto status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(3, read_rows);
+    EXPECT_FALSE(eof);
+    EXPECT_EQ(3, block.rows());
+
+    status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(2, read_rows);
+    EXPECT_TRUE(eof);
+    EXPECT_EQ(2, block.rows());
+
+    status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(0, read_rows);
+    EXPECT_TRUE(eof);
+    EXPECT_EQ(0, block.rows());
+}
+
+TEST_F(JniReaderTest, JdbcReaderBuildsReplaceStringForSpecialTypes) {
+    auto slots = build_file_slot_descs({{"bitmap_col", std::make_shared<DataTypeBitMap>()},
+                                        {"hll_col", std::make_shared<DataTypeHLL>()},
+                                        {"jsonb_col", std::make_shared<DataTypeJsonb>()},
+                                        {"quantile_col", std::make_shared<DataTypeQuantileState>()},
+                                        {"id", std::make_shared<DataTypeInt32>()}});
+
+    std::map<std::string, std::string> jdbc_params {{"jdbc_url", "jdbc:mysql://127.0.0.1:3306/db"},
+                                                    {"query_sql", "select 1"}};
+    JdbcJniReader reader(slots, _runtime_state.get(), &_profile, jdbc_params);
+
+    EXPECT_EQ(reader._connector_class, "org/apache/doris/jdbc/JdbcJniScanner");
+    EXPECT_EQ(reader._connector_name, "JdbcJniScanner");
+    EXPECT_EQ(reader._column_names, std::vector<std::string>({"bitmap_col", "hll_col", "jsonb_col",
+                                                              "quantile_col", "id"}));
+    EXPECT_EQ(reader._scanner_params["required_fields"],
+              "bitmap_col,hll_col,jsonb_col,quantile_col,id");
+    EXPECT_EQ(reader._scanner_params["columns_types"], "string#string#string#string#int");
+    EXPECT_EQ(reader._scanner_params["replace_string"],
+              "bitmap,hll,jsonb,quantile_state,not_replace");
+    EXPECT_EQ(reader._scanner_params["jdbc_url"], "jdbc:mysql://127.0.0.1:3306/db");
+    EXPECT_EQ(reader._scanner_params["query_sql"], "select 1");
+}
+
+TEST_F(JniReaderTest, JdbcReaderIdentifiesSpecialTypes) {
+    EXPECT_TRUE(JdbcJniReader::_is_special_type(PrimitiveType::TYPE_BITMAP));
+    EXPECT_TRUE(JdbcJniReader::_is_special_type(PrimitiveType::TYPE_HLL));
+    EXPECT_TRUE(JdbcJniReader::_is_special_type(PrimitiveType::TYPE_JSONB));
+    EXPECT_TRUE(JdbcJniReader::_is_special_type(PrimitiveType::TYPE_QUANTILE_STATE));
+    EXPECT_FALSE(JdbcJniReader::_is_special_type(PrimitiveType::TYPE_INT));
+    EXPECT_FALSE(JdbcJniReader::_is_special_type(PrimitiveType::TYPE_STRING));
+}
+
+TEST_F(JniReaderTest, TrinoReaderBuildsScannerParams) {
+    auto slots = build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()},
+                                        {"name", std::make_shared<DataTypeString>()}});
+
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.trino_connector_params = true;
+    auto& params = range.table_format_params.trino_connector_params;
+    params.__set_catalog_name("hive");
+    params.__set_db_name("db1");
+    params.__set_table_name("tbl1");
+    params.__set_trino_connector_split("serialized-split");
+    params.__set_trino_connector_table_handle("table-handle");
+    params.__set_trino_connector_column_handles("column-handles");
+    params.__set_trino_connector_column_metadata("column-metadata");
+    params.__set_trino_connector_predicate("predicate-json");
+    params.__set_trino_connector_trascation_handle("txn-handle");
+    params.__set_trino_connector_options({{"hive.metastore.uri", "thrift://127.0.0.1:9083"}});
+
+    TrinoConnectorJniReader reader(slots, _runtime_state.get(), &_profile, range);
+
+    EXPECT_EQ(reader._connector_class, "org/apache/doris/trinoconnector/TrinoConnectorJniScanner");
+    EXPECT_EQ(reader._connector_name, "TrinoConnectorJniScanner");
+    EXPECT_EQ(reader._scanner_params["catalog_name"], "hive");
+    EXPECT_EQ(reader._scanner_params["db_name"], "db1");
+    EXPECT_EQ(reader._scanner_params["table_name"], "tbl1");
+    EXPECT_EQ(reader._scanner_params["trino_connector_split"], "serialized-split");
+    EXPECT_EQ(reader._scanner_params["trino_connector_table_handle"], "table-handle");
+    EXPECT_EQ(reader._scanner_params["trino_connector_column_handles"], "column-handles");
+    EXPECT_EQ(reader._scanner_params["trino_connector_column_metadata"], "column-metadata");
+    EXPECT_EQ(reader._scanner_params["trino_connector_predicate"], "predicate-json");
+    EXPECT_EQ(reader._scanner_params["trino_connector_trascation_handle"], "txn-handle");
+    EXPECT_EQ(reader._scanner_params["required_fields"], "id,name");
+    EXPECT_EQ(reader._scanner_params["columns_types"], "int#string");
+    EXPECT_EQ(reader._scanner_params["trino.hive.metastore.uri"], "thrift://127.0.0.1:9083");
+}
+
+TEST_F(JniReaderTest, IcebergSysTableReaderValidatesRequiredRangeFields) {
+    TFileRangeDesc range;
+    auto status = IcebergSysTableJniReader::validate_scan_range(range);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("missing table_format_params"), std::string::npos);
+
+    range.__isset.table_format_params = true;
+    status = IcebergSysTableJniReader::validate_scan_range(range);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("missing iceberg_params"), std::string::npos);
+
+    range.table_format_params.__isset.iceberg_params = true;
+    status = IcebergSysTableJniReader::validate_scan_range(range);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("missing serialized_split"), std::string::npos);
+}
+
+TEST_F(JniReaderTest, IcebergSysTableReaderBuildsScannerParams) {
+    auto slots = build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()},
+                                        {"name", std::make_shared<DataTypeString>()}});
+
+    TFileRangeDesc range;
+    range.__isset.self_split_weight = true;
+    range.self_split_weight = 9;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.iceberg_params = true;
+    range.table_format_params.iceberg_params.__set_serialized_split("serialized-iceberg-split");
+
+    TFileScanRangeParams range_params;
+    range_params.__set_properties({{"fs.defaultFS", "hdfs://iceberg"}});
+
+    IcebergSysTableJniReader reader(slots, _runtime_state.get(), &_profile, range, &range_params);
+
+    EXPECT_TRUE(reader._init_status.ok());
+    EXPECT_EQ(reader._self_split_weight, 9);
+    EXPECT_EQ(reader._scanner_params["serialized_split"], "serialized-iceberg-split");
+    EXPECT_EQ(reader._scanner_params["required_fields"], "id,name");
+    EXPECT_EQ(reader._scanner_params["required_types"], "int#string");
+    EXPECT_EQ(reader._scanner_params["time_zone"], "UTC");
+    EXPECT_EQ(reader._scanner_params["hadoop.fs.defaultFS"], "hdfs://iceberg");
+}
+
+TEST_F(JniReaderTest, MaxComputeReaderBuildsScannerParamsFromDescriptorAndScanRange) {
+    auto slots = build_file_slot_descs({{"id", std::make_shared<DataTypeInt32>()},
+                                        {"name", std::make_shared<DataTypeString>()}});
+
+    TTableDescriptor table_desc;
+    table_desc.id = 1;
+    table_desc.tableType = TTableType::MAX_COMPUTE_TABLE;
+    table_desc.numCols = 2;
+    table_desc.numClusteringCols = 0;
+    table_desc.tableName = "mc_tbl";
+    table_desc.dbName = "mc_db";
+    table_desc.__isset.mcTable = true;
+    table_desc.mcTable.__set_project("mc_project");
+    table_desc.mcTable.__set_table("mc_table");
+    table_desc.mcTable.__set_endpoint("service.cn.maxcompute.aliyun.com");
+    table_desc.mcTable.__set_quota("quota_a");
+    table_desc.mcTable.__set_properties({{"mc.access_key", "ak"}, {"mc.secret_key", "sk"}});
+
+    MaxComputeTableDescriptor mc_desc(table_desc);
+    ASSERT_TRUE(mc_desc.init_status().ok()) << mc_desc.init_status();
+
+    TFileRangeDesc range;
+    range.start_offset = 128;
+    range.size = 256;
+
+    TMaxComputeFileDesc max_compute_params;
+    max_compute_params.__set_session_id("session-1");
+    max_compute_params.__set_table_batch_read_session("scan-serializer");
+    max_compute_params.__set_connect_timeout(30);
+    max_compute_params.__set_read_timeout(60);
+    max_compute_params.__set_retry_times(3);
+
+    MaxComputeJniReader reader(&mc_desc, max_compute_params, slots, range, _runtime_state.get(),
+                               &_profile);
+
+    EXPECT_EQ(reader._connector_class, "org/apache/doris/maxcompute/MaxComputeJniScanner");
+    EXPECT_EQ(reader._connector_name, "MaxComputeJniScanner");
+    EXPECT_EQ(reader._scanner_params["endpoint"], "service.cn.maxcompute.aliyun.com");
+    EXPECT_EQ(reader._scanner_params["quota"], "quota_a");
+    EXPECT_EQ(reader._scanner_params["project"], "mc_project");
+    EXPECT_EQ(reader._scanner_params["table"], "mc_table");
+    EXPECT_EQ(reader._scanner_params["session_id"], "session-1");
+    EXPECT_EQ(reader._scanner_params["scan_serializer"], "scan-serializer");
+    EXPECT_EQ(reader._scanner_params["start_offset"], "128");
+    EXPECT_EQ(reader._scanner_params["split_size"], "256");
+    EXPECT_EQ(reader._scanner_params["required_fields"], "id,name");
+    EXPECT_EQ(reader._scanner_params["columns_types"], "int#string");
+    EXPECT_EQ(reader._scanner_params["connect_timeout"], "30");
+    EXPECT_EQ(reader._scanner_params["read_timeout"], "60");
+    EXPECT_EQ(reader._scanner_params["retry_count"], "3");
+    EXPECT_EQ(reader._scanner_params["mc.access_key"], "ak");
+    EXPECT_EQ(reader._scanner_params["mc.secret_key"], "sk");
+}
+
+} // namespace doris

--- a/be/test/format/jni/paimon_jni_reader_real_test.cpp
+++ b/be/test/format/jni/paimon_jni_reader_real_test.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include "common/status.h"
@@ -76,8 +77,58 @@ protected:
         return root;
     }
 
+    static std::filesystem::path paimon_scanner_jar() {
+        return repo_root() /
+               "output/be/lib/java_extensions/paimon-scanner/"
+               "paimon-scanner-jar-with-dependencies.jar";
+    }
+
+    static std::filesystem::path hadoop_deps_root() {
+        return repo_root() / "output/be/lib/hadoop_hdfs";
+    }
+
     static std::filesystem::path paimon_warehouse_root() {
         return repo_root() / "docker/thirdparties/docker-compose/hive/scripts/paimon1";
+    }
+
+    static bool is_regular_file(const std::filesystem::path& path) {
+        std::error_code error_code;
+        return std::filesystem::is_regular_file(path, error_code);
+    }
+
+    static bool is_directory(const std::filesystem::path& path) {
+        std::error_code error_code;
+        return std::filesystem::is_directory(path, error_code);
+    }
+
+    static std::string real_test_prerequisite_error() {
+        const char* root = std::getenv("ROOT");
+        if (root == nullptr || std::string(root).empty()) {
+            return "ROOT is not set";
+        }
+        if (!is_directory(root)) {
+            return "ROOT does not point to an existing directory: " + std::string(root);
+        }
+
+        const char* java_home = std::getenv("JAVA_HOME");
+        if (java_home == nullptr || std::string(java_home).empty()) {
+            return "JAVA_HOME is not set";
+        }
+        const auto java_bin = std::filesystem::path(java_home) / "bin/java";
+        if (!is_regular_file(java_bin)) {
+            return "JAVA_HOME does not contain bin/java: " + java_bin.string();
+        }
+
+        if (!is_regular_file(paimon_scanner_jar())) {
+            return "Paimon scanner jar not found: " + paimon_scanner_jar().string();
+        }
+        if (!is_directory(hadoop_deps_root())) {
+            return "Hadoop dependency directory not found: " + hadoop_deps_root().string();
+        }
+        if (!is_directory(paimon_warehouse_root())) {
+            return "Paimon test warehouse not found: " + paimon_warehouse_root().string();
+        }
+        return "";
     }
 
     static std::string shell_quote(const std::string& value) {
@@ -104,6 +155,17 @@ protected:
         const int exit_code = pclose(pipe);
         CHECK_EQ(exit_code, 0) << output;
         return output;
+    }
+
+    static void append_jars_from_dir(std::string& classpath, const std::filesystem::path& dir) {
+        if (!is_directory(dir)) {
+            return;
+        }
+        for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+            if (entry.is_regular_file() && entry.path().extension() == ".jar") {
+                classpath.append(":").append(entry.path().string());
+            }
+        }
     }
 
     static SerializedPaimonInputs build_serialized_inputs() {
@@ -157,24 +219,9 @@ public class PaimonSerializationHelper {
         out.close();
         DORIS_CHECK(out.good());
 
-        std::string classpath = (repo_root() /
-                                 "output/be/lib/java_extensions/paimon-scanner/"
-                                 "paimon-scanner-jar-with-dependencies.jar")
-                                        .string();
-        const auto hadoop_deps_root = repo_root() / "output/be/lib/hadoop_hdfs";
-        for (const auto& entry : std::filesystem::directory_iterator(hadoop_deps_root)) {
-            if (entry.is_regular_file() && entry.path().extension() == ".jar") {
-                classpath.append(":").append(entry.path().string());
-            }
-        }
-        if (std::filesystem::exists(hadoop_deps_root / "lib")) {
-            for (const auto& entry :
-                 std::filesystem::directory_iterator(hadoop_deps_root / "lib")) {
-                if (entry.is_regular_file() && entry.path().extension() == ".jar") {
-                    classpath.append(":").append(entry.path().string());
-                }
-            }
-        }
+        std::string classpath = paimon_scanner_jar().string();
+        append_jars_from_dir(classpath, hadoop_deps_root());
+        append_jars_from_dir(classpath, hadoop_deps_root() / "lib");
 
         const auto java_bin = std::filesystem::path(std::getenv("JAVA_HOME")) / "bin/java";
         DORIS_CHECK(std::filesystem::exists(java_bin));
@@ -237,6 +284,11 @@ public class PaimonSerializationHelper {
 };
 
 TEST_F(PaimonJniReaderRealTest, ReadsFilteredRowsFromFilesystemTable) {
+    const auto prerequisite_error = real_test_prerequisite_error();
+    if (!prerequisite_error.empty()) {
+        GTEST_SKIP() << prerequisite_error;
+    }
+
     auto init_status = init_jni_runtime_once();
     ASSERT_TRUE(init_status.ok()) << init_status;
 

--- a/be/test/format/jni/paimon_jni_reader_real_test.cpp
+++ b/be/test/format/jni/paimon_jni_reader_real_test.cpp
@@ -1,0 +1,279 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "core/assert_cast.h"
+#include "core/block/block.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_vector.h"
+#include "core/data_type/data_type_number.h"
+#include "format/table/paimon_jni_reader.h"
+#include "runtime/runtime_profile.h"
+#include "runtime/runtime_state.h"
+#include "testutil/desc_tbl_builder.h"
+#include "util/jni-util.h"
+
+namespace doris {
+
+class PaimonJniReaderRealTest : public testing::Test {
+protected:
+    struct SerializedPaimonInputs {
+        std::string serialized_table;
+        std::string serialized_split;
+        std::string serialized_predicate;
+    };
+
+    void SetUp() override {
+        _query_options.__set_batch_size(16);
+        _runtime_state = std::make_unique<RuntimeState>(_query_options, _query_globals);
+        _runtime_state->set_timezone("UTC");
+    }
+
+    std::vector<SlotDescriptor*> build_file_slot_descs() {
+        DescriptorTblBuilder builder(&_object_pool);
+        builder.declare_tuple() << std::make_tuple(std::make_shared<DataTypeInt32>(), "id");
+        return builder.build()->get_tuple_descriptor(0)->slots();
+    }
+
+    static Block make_block(const std::vector<SlotDescriptor*>& slots) {
+        Block block;
+        for (auto* slot : slots) {
+            auto type = slot->get_data_type_ptr();
+            block.insert({type->create_column(), type, slot->col_name()});
+        }
+        return block;
+    }
+
+    static std::filesystem::path repo_root() {
+        const char* root = std::getenv("ROOT");
+        DORIS_CHECK(root != nullptr);
+        return root;
+    }
+
+    static std::filesystem::path paimon_warehouse_root() {
+        return repo_root() / "docker/thirdparties/docker-compose/hive/scripts/paimon1";
+    }
+
+    static std::string shell_quote(const std::string& value) {
+        std::string quoted = "'";
+        for (char ch : value) {
+            if (ch == '\'') {
+                quoted.append("'\"'\"'");
+            } else {
+                quoted.push_back(ch);
+            }
+        }
+        quoted.push_back('\'');
+        return quoted;
+    }
+
+    static std::string run_command_and_capture_output(const std::string& command) {
+        std::array<char, 4096> buffer {};
+        std::string output;
+        FILE* pipe = popen(command.c_str(), "r");
+        DORIS_CHECK(pipe != nullptr);
+        while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+            output.append(buffer.data());
+        }
+        const int exit_code = pclose(pipe);
+        CHECK_EQ(exit_code, 0) << output;
+        return output;
+    }
+
+    static SerializedPaimonInputs build_serialized_inputs() {
+        const auto helper_dir =
+                std::filesystem::temp_directory_path() / "paimon_jni_reader_real_test_helper";
+        std::filesystem::remove_all(helper_dir);
+        std::filesystem::create_directories(helper_dir);
+
+        const auto helper_source = helper_dir / "PaimonSerializationHelper.java";
+        std::ofstream out(helper_source);
+        out << R"(import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.utils.InstantiationUtil;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+public class PaimonSerializationHelper {
+    private static String encodeObject(Object value) throws Exception {
+        return Base64.getEncoder().encodeToString(InstantiationUtil.serializeObject(value));
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options options = new Options();
+        options.setString("warehouse", args[0]);
+        Catalog catalog = CatalogFactory.createCatalog(CatalogContext.create(options));
+        Table table = catalog.getTable(Identifier.create(args[1], args[2]));
+        List<Split> splits = table.newReadBuilder().newScan().plan().splits();
+        if (splits.size() != 1) {
+            throw new IllegalStateException("Expected exactly one split but got " + splits.size());
+        }
+
+        PredicateBuilder predicateBuilder = new PredicateBuilder(table.rowType());
+        Predicate predicate = predicateBuilder.greaterOrEqual(predicateBuilder.indexOf("id"), 2);
+
+        System.out.println("TABLE=" + encodeObject(table));
+        System.out.println("SPLIT=" + encodeObject(splits.get(0)));
+        System.out.println("PREDICATE=" + encodeObject(Collections.singletonList(predicate)));
+        catalog.close();
+    }
+}
+)";
+        out.close();
+        DORIS_CHECK(out.good());
+
+        std::string classpath = (repo_root() /
+                                 "output/be/lib/java_extensions/paimon-scanner/"
+                                 "paimon-scanner-jar-with-dependencies.jar")
+                                        .string();
+        const auto hadoop_deps_root = repo_root() / "output/be/lib/hadoop_hdfs";
+        for (const auto& entry : std::filesystem::directory_iterator(hadoop_deps_root)) {
+            if (entry.is_regular_file() && entry.path().extension() == ".jar") {
+                classpath.append(":").append(entry.path().string());
+            }
+        }
+        if (std::filesystem::exists(hadoop_deps_root / "lib")) {
+            for (const auto& entry :
+                 std::filesystem::directory_iterator(hadoop_deps_root / "lib")) {
+                if (entry.is_regular_file() && entry.path().extension() == ".jar") {
+                    classpath.append(":").append(entry.path().string());
+                }
+            }
+        }
+
+        const auto java_bin = std::filesystem::path(std::getenv("JAVA_HOME")) / "bin/java";
+        DORIS_CHECK(std::filesystem::exists(java_bin));
+
+        const std::string command =
+                shell_quote(java_bin.string()) + " -cp " + shell_quote(classpath) + " " +
+                shell_quote(helper_source.string()) + " " +
+                shell_quote(paimon_warehouse_root().string()) + " db1 row_jni_test";
+        const auto output = run_command_and_capture_output(command);
+
+        SerializedPaimonInputs inputs;
+        std::istringstream stream(output);
+        std::string line;
+        while (std::getline(stream, line)) {
+            if (line.rfind("TABLE=", 0) == 0) {
+                inputs.serialized_table = line.substr(sizeof("TABLE=") - 1);
+            } else if (line.rfind("SPLIT=", 0) == 0) {
+                inputs.serialized_split = line.substr(sizeof("SPLIT=") - 1);
+            } else if (line.rfind("PREDICATE=", 0) == 0) {
+                inputs.serialized_predicate = line.substr(sizeof("PREDICATE=") - 1);
+            }
+        }
+        std::filesystem::remove_all(helper_dir);
+
+        DORIS_CHECK(!inputs.serialized_table.empty());
+        DORIS_CHECK(!inputs.serialized_split.empty());
+        DORIS_CHECK(!inputs.serialized_predicate.empty());
+        return inputs;
+    }
+
+    static Status init_jni_runtime_once() {
+        static const Status init_status = Jni::Util::Init();
+        return init_status;
+    }
+
+    static SerializedPaimonInputs build_serialized_inputs_once() {
+        static const SerializedPaimonInputs inputs = build_serialized_inputs();
+        return inputs;
+    }
+
+    static std::vector<int32_t> collect_ids(const Block& block, size_t read_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name("id"));
+        const auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        DORIS_CHECK(nullable != nullptr);
+        const auto& id_col = assert_cast<const ColumnInt32&>(nullable->get_nested_column());
+        std::vector<int32_t> ids;
+        ids.reserve(read_rows);
+        for (size_t i = 0; i < read_rows; ++i) {
+            DORIS_CHECK(!nullable->is_null_at(i));
+            ids.emplace_back(id_col.get_element(i));
+        }
+        return ids;
+    }
+
+    TQueryOptions _query_options;
+    TQueryGlobals _query_globals;
+    ObjectPool _object_pool;
+    std::unique_ptr<RuntimeState> _runtime_state;
+    RuntimeProfile _profile {"paimon_jni_reader_real_test"};
+};
+
+TEST_F(PaimonJniReaderRealTest, ReadsFilteredRowsFromFilesystemTable) {
+    auto init_status = init_jni_runtime_once();
+    ASSERT_TRUE(init_status.ok()) << init_status;
+
+    const auto inputs = build_serialized_inputs_once();
+    auto slots = build_file_slot_descs();
+
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_split(inputs.serialized_split);
+
+    TFileScanRangeParams range_params;
+    range_params.__set_serialized_table(inputs.serialized_table);
+    range_params.__set_paimon_predicate(inputs.serialized_predicate);
+
+    PaimonJniReader reader(slots, _runtime_state.get(), &_profile, range, &range_params);
+
+    auto open_status = reader.init_reader();
+    ASSERT_TRUE(open_status.ok()) << open_status;
+
+    Block block = make_block(slots);
+    size_t read_rows = 0;
+    bool eof = false;
+    auto read_status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(read_status.ok()) << read_status;
+    EXPECT_EQ(2, read_rows);
+    EXPECT_FALSE(eof);
+    EXPECT_EQ(collect_ids(block, read_rows), (std::vector<int32_t> {2, 3}));
+
+    block = make_block(slots);
+    read_status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(read_status.ok()) << read_status;
+    EXPECT_EQ(0, read_rows);
+    EXPECT_TRUE(eof);
+
+    auto close_status = reader.close();
+    ASSERT_TRUE(close_status.ok()) << close_status;
+}
+
+} // namespace doris

--- a/be/test/format/orc/orc_reader_test.cpp
+++ b/be/test/format/orc/orc_reader_test.cpp
@@ -268,21 +268,22 @@ TEST_F(OrcReaderTest, test_read_orc_line_smoke) {
     bool eof = false;
     auto block_dump = read_orc_line_dump(0, &read_rows, &eof);
     EXPECT_EQ(read_rows, 1);
-    EXPECT_EQ(
-            block_dump,
-            "+----------------------+--------------------+----------------------+------------------"
-            "----+----------------------+---------------------+-------------------+----------------"
-            "--------+----------------------+\n|col1(Nullable(BIGINT))|col2(Nullable(BOOL))|col3("
-            "Nullable(String))|col4(Nullable(DateV2))|col5(Nullable(DOUBLE))|col6(Nullable(FLOAT))|"
-            "col7(Nullable(INT))|col8(Nullable(SMALLINT))|col9(Nullable(String))|\n+---------------"
-            "-------+--------------------+----------------------+----------------------+-----------"
-            "-----------+---------------------+-------------------+------------------------+-------"
-            "---------------+\n|                     0|                NULL|                 "
-            "doris|                  NULL|                 1.567|                1.567|            "
-            "  12345|                       1|                 "
-            "doris|\n+----------------------+--------------------+----------------------+----------"
-            "------------+----------------------+---------------------+-------------------+--------"
-            "----------------+----------------------+\n");
+    auto expect_contains = [&](const std::string& expected) {
+        EXPECT_NE(block_dump.find(expected), std::string::npos) << block_dump;
+    };
+    expect_contains("col1(Nullable(BIGINT))");
+    expect_contains("col2(Nullable(BOOL))");
+    expect_contains("col3(Nullable(String))");
+    expect_contains("col4(Nullable(DateV2))");
+    expect_contains("col5(Nullable(DOUBLE))");
+    expect_contains("col6(Nullable(FLOAT))");
+    expect_contains("col7(Nullable(INT))");
+    expect_contains("col8(Nullable(SMALLINT))");
+    expect_contains("col9(Nullable(String))");
+    expect_contains("NULL");
+    expect_contains("doris");
+    expect_contains("1.567");
+    expect_contains("12345");
 }
 
 } // namespace doris

--- a/be/test/format/orc/orc_reader_test.cpp
+++ b/be/test/format/orc/orc_reader_test.cpp
@@ -21,8 +21,12 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
+#include "core/block/block.h"
+#include "core/block/column_with_type_and_name.h"
+#include "core/data_type/data_type_factory.hpp"
 #include "core/data_type/define_primitive_type.h"
 #include "exec/common/util.hpp"
 #include "exprs/vexpr_context.h"
@@ -44,6 +48,84 @@ public:
 
 private:
     static constexpr const char* CANNOT_PUSH_DOWN_ERROR = "can't push down";
+
+    std::string read_orc_line_dump(int64_t line, size_t* read_rows, bool* eof) {
+        auto runtime_state = RuntimeState::create_unique();
+
+        std::vector<std::string> column_names = {"col1", "col2", "col3", "col4", "col5",
+                                                 "col6", "col7", "col8", "col9"};
+        std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
+                {"col1", 0}, {"col2", 1}, {"col3", 2}, {"col4", 3}, {"col5", 4},
+                {"col6", 5}, {"col7", 6}, {"col8", 7}, {"col9", 8},
+        };
+        ObjectPool object_pool;
+        DescriptorTblBuilder builder(&object_pool);
+        builder.declare_tuple()
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_BIGINT, true),
+                                   "col1")
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_BOOLEAN, true),
+                                   "col2")
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_VARCHAR, true),
+                                   "col3")
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_DATEV2, true),
+                                   "col4")
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_DOUBLE, true),
+                                   "col5")
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_FLOAT, true),
+                                   "col6")
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_INT, true),
+                                   "col7")
+                << std::make_tuple(
+                           DataTypeFactory::instance().create_data_type(TYPE_SMALLINT, true),
+                           "col8")
+                << std::make_tuple(DataTypeFactory::instance().create_data_type(TYPE_VARCHAR, true),
+                                   "col9");
+        DescriptorTbl* desc_tbl = builder.build();
+        auto* tuple_desc = const_cast<TupleDescriptor*>(desc_tbl->get_tuple_descriptor(0));
+        RowDescriptor row_desc(tuple_desc);
+
+        TFileScanRangeParams params;
+        params.file_type = TFileType::FILE_LOCAL;
+
+        TFileRangeDesc range;
+        range.path = "./be/test/exec/test_data/orc_scanner/my-file.orc";
+        range.start_offset = 0;
+        range.size = 2024;
+        range.table_format_params.table_format_type = "hive";
+        range.__isset.table_format_params = true;
+
+        io::IOContext io_ctx;
+        io::FileReaderStats file_reader_stats;
+        io_ctx.file_reader_stats = &file_reader_stats;
+        auto reader = OrcReader::create_unique(nullptr, runtime_state.get(), params, range, 100,
+                                               "CST", &io_ctx, nullptr, true);
+
+        auto st = reader->read_by_rows({line});
+        EXPECT_TRUE(st.ok()) << st;
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_names = column_names;
+        orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+        orc_ctx.tuple_descriptor = tuple_desc;
+        orc_ctx.row_descriptor = &row_desc;
+        orc_ctx.params = &params;
+        orc_ctx.range = &range;
+        st = reader->init_reader(&orc_ctx);
+        EXPECT_TRUE(st.ok()) << "init_reader failed: " << st.to_string();
+
+        BlockUPtr block = Block::create_unique();
+        for (const auto& slot_desc : tuple_desc->slots()) {
+            auto data_type = slot_desc->type();
+            block->insert(ColumnWithTypeAndName(data_type->create_column(), data_type,
+                                                slot_desc->col_name()));
+        }
+
+        st = reader->get_next_block(block.get(), read_rows, eof);
+        EXPECT_TRUE(st.ok()) << st;
+        EXPECT_EQ(block->rows(), *read_rows);
+        return block->dump_data(0, 1);
+    }
+
     std::string build_search_argument(const std::string& expr) {
         // build orc_reader for table orders
         std::vector<std::string> column_names = {
@@ -179,6 +261,28 @@ TEST_F(OrcReaderTest, test_build_search_argument) {
         auto search_argument = build_search_argument(exprs[i]);
         ASSERT_EQ(search_argument, result_search_arguments[i]);
     }
+}
+
+TEST_F(OrcReaderTest, test_read_orc_line_smoke) {
+    size_t read_rows = 0;
+    bool eof = false;
+    auto block_dump = read_orc_line_dump(0, &read_rows, &eof);
+    EXPECT_EQ(read_rows, 1);
+    EXPECT_EQ(
+            block_dump,
+            "+----------------------+--------------------+----------------------+------------------"
+            "----+----------------------+---------------------+-------------------+----------------"
+            "--------+----------------------+\n|col1(Nullable(BIGINT))|col2(Nullable(BOOL))|col3("
+            "Nullable(String))|col4(Nullable(DateV2))|col5(Nullable(DOUBLE))|col6(Nullable(FLOAT))|"
+            "col7(Nullable(INT))|col8(Nullable(SMALLINT))|col9(Nullable(String))|\n+---------------"
+            "-------+--------------------+----------------------+----------------------+-----------"
+            "-----------+---------------------+-------------------+------------------------+-------"
+            "---------------+\n|                     0|                NULL|                 "
+            "doris|                  NULL|                 1.567|                1.567|            "
+            "  12345|                       1|                 "
+            "doris|\n+----------------------+--------------------+----------------------+----------"
+            "------------+----------------------+---------------------+-------------------+--------"
+            "----------------+----------------------+\n");
 }
 
 } // namespace doris

--- a/be/test/format/table/equality_delete_test.cpp
+++ b/be/test/format/table/equality_delete_test.cpp
@@ -1,0 +1,737 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/table/equality_delete.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "runtime/runtime_profile.h"
+
+namespace doris {
+
+// ============================================================================
+// Helper: Build a single-column non-nullable Int32 Block.
+// ============================================================================
+static Block build_int32_block(const std::string& col_name, const std::vector<int32_t>& values) {
+    auto col = ColumnInt32::create();
+    for (auto v : values) {
+        col->insert_value(v);
+    }
+    Block block;
+    block.insert({std::move(col), std::make_shared<DataTypeInt32>(), col_name});
+    return block;
+}
+
+// ============================================================================
+// Helper: Build a single-column nullable Int32 Block.
+// null_flags[i] == true means the i-th row is NULL.
+// ============================================================================
+static Block build_nullable_int32_block(const std::string& col_name,
+                                        const std::vector<int32_t>& values,
+                                        const std::vector<bool>& null_flags) {
+    auto nested_col = ColumnInt32::create();
+    auto null_map = ColumnUInt8::create();
+    for (size_t i = 0; i < values.size(); ++i) {
+        nested_col->insert_value(values[i]);
+        null_map->insert_value(null_flags[i] ? 1 : 0);
+    }
+    auto nullable_col = ColumnNullable::create(std::move(nested_col), std::move(null_map));
+    Block block;
+    block.insert({std::move(nullable_col),
+                  std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()), col_name});
+    return block;
+}
+
+// ============================================================================
+// Helper: Build a single-column non-nullable String Block.
+// ============================================================================
+static Block build_string_block(const std::string& col_name,
+                                const std::vector<std::string>& values) {
+    auto col = ColumnString::create();
+    for (const auto& v : values) {
+        col->insert_data(v.data(), v.size());
+    }
+    Block block;
+    block.insert({std::move(col), std::make_shared<DataTypeString>(), col_name});
+    return block;
+}
+
+// ============================================================================
+// Helper: Build a two-column Block (Int32 + String).
+// ============================================================================
+static Block build_int32_string_block(const std::string& int_name,
+                                      const std::vector<int32_t>& int_vals,
+                                      const std::string& str_name,
+                                      const std::vector<std::string>& str_vals) {
+    auto int_col = ColumnInt32::create();
+    for (auto v : int_vals) {
+        int_col->insert_value(v);
+    }
+    auto str_col = ColumnString::create();
+    for (const auto& v : str_vals) {
+        str_col->insert_data(v.data(), v.size());
+    }
+    Block block;
+    block.insert({std::move(int_col), std::make_shared<DataTypeInt32>(), int_name});
+    block.insert({std::move(str_col), std::make_shared<DataTypeString>(), str_name});
+    return block;
+}
+
+// ============================================================================
+// Helper: Initialize filter to all-pass (all 1s).
+// ============================================================================
+static IColumn::Filter make_filter(size_t rows) {
+    return IColumn::Filter(rows, 1);
+}
+
+// ============================================================================
+// Factory Tests
+// ============================================================================
+class EqualityDeleteTest : public ::testing::Test {
+protected:
+    RuntimeProfile profile {"equality_delete_test"};
+};
+
+TEST_F(EqualityDeleteTest, FactorySingleColumn) {
+    auto delete_block = build_int32_block("id", {1, 2, 3});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    // Single column → SimpleEqualityDelete
+    auto* simple = dynamic_cast<SimpleEqualityDelete*>(impl.get());
+    ASSERT_NE(simple, nullptr);
+}
+
+TEST_F(EqualityDeleteTest, FactoryMultiColumn) {
+    auto delete_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    // Multi column → MultiEqualityDelete
+    auto* multi = dynamic_cast<MultiEqualityDelete*>(impl.get());
+    ASSERT_NE(multi, nullptr);
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Non-Nullable Int32
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleInt32NonNullable) {
+    // Delete rows where id ∈ {1, 3, 5}
+    auto delete_block = build_int32_block("id", {1, 3, 5});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: id = [1, 2, 3, 4, 5]
+    auto data_block = build_int32_block("id", {1, 2, 3, 4, 5});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(5);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    // Rows 0(id=1), 2(id=3), 4(id=5) should be deleted (filter=0)
+    EXPECT_EQ(filter[0], 0); // id=1 deleted
+    EXPECT_EQ(filter[1], 1); // id=2 kept
+    EXPECT_EQ(filter[2], 0); // id=3 deleted
+    EXPECT_EQ(filter[3], 1); // id=4 kept
+    EXPECT_EQ(filter[4], 0); // id=5 deleted
+}
+
+TEST_F(EqualityDeleteTest, SimpleInt32NoMatch) {
+    // Delete set: {10, 20, 30}
+    auto delete_block = build_int32_block("id", {10, 20, 30});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: [1, 2, 3]
+    auto data_block = build_int32_block("id", {1, 2, 3});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(3);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    // No matches — all kept
+    EXPECT_EQ(filter[0], 1);
+    EXPECT_EQ(filter[1], 1);
+    EXPECT_EQ(filter[2], 1);
+}
+
+TEST_F(EqualityDeleteTest, SimpleInt32AllMatch) {
+    // Delete set: {1, 2, 3}
+    auto delete_block = build_int32_block("id", {1, 2, 3});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: [1, 2, 3]
+    auto data_block = build_int32_block("id", {1, 2, 3});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(3);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0);
+    EXPECT_EQ(filter[1], 0);
+    EXPECT_EQ(filter[2], 0);
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Nullable Int32
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleNullableInt32) {
+    // Use >8 delete rows to avoid FixedContainer size check
+    // (FixedContainer<N> expects exactly N non-null elements)
+    auto delete_block = build_nullable_int32_block(
+            "id", {1, 0, 5, 10, 20, 30, 40, 50, 60},
+            {false, true, false, false, false, false, false, false, false});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: [1, 2, NULL, 4, 5]
+    auto data_block =
+            build_nullable_int32_block("id", {1, 2, 0, 4, 5}, {false, false, true, false, false});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(5);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // id=1 deleted
+    EXPECT_EQ(filter[1], 1); // id=2 kept
+    // NULL data is NOT deleted: _build_set passes null_aware=false to create_set,
+    // so contain_null() always returns false regardless of NULLs in delete set
+    EXPECT_EQ(filter[2], 1); // NULL kept (null_aware=false)
+    EXPECT_EQ(filter[3], 1); // id=4 kept
+    EXPECT_EQ(filter[4], 0); // id=5 deleted
+}
+
+TEST_F(EqualityDeleteTest, SimpleNullableNoNullInDeleteSet) {
+    // Use >8 delete rows to avoid FixedContainer size check
+    auto delete_block = build_nullable_int32_block(
+            "id", {1, 5, 10, 20, 30, 40, 50, 60, 70},
+            {false, false, false, false, false, false, false, false, false});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: [1, NULL, 5]
+    auto data_block = build_nullable_int32_block("id", {1, 0, 5}, {false, true, false});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(3);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // id=1 deleted
+    EXPECT_EQ(filter[1], 1); // NULL kept (no NULL in delete set)
+    EXPECT_EQ(filter[2], 0); // id=5 deleted
+}
+
+// ============================================================================
+// SimpleEqualityDelete — String Column
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleStringNonNullable) {
+    auto delete_block = build_string_block("name", {"alice", "charlie"});
+    std::vector<int> col_ids = {200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_string_block("name", {"alice", "bob", "charlie", "dave"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"name", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{200, "name"}};
+    auto filter = make_filter(4);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // "alice" deleted
+    EXPECT_EQ(filter[1], 1); // "bob" kept
+    EXPECT_EQ(filter[2], 0); // "charlie" deleted
+    EXPECT_EQ(filter[3], 1); // "dave" kept
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Repeated filter_data_block calls (filter reuse)
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleRepeatedFilterCalls) {
+    auto delete_block = build_int32_block("id", {2, 4});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+
+    // First batch: [1, 2, 3]
+    auto batch1 = build_int32_block("id", {1, 2, 3});
+    auto filter1 = make_filter(3);
+    ASSERT_TRUE(impl->filter_data_block(&batch1, &col_name_to_idx, id_to_name, filter1).ok());
+    EXPECT_EQ(filter1[0], 1);
+    EXPECT_EQ(filter1[1], 0); // id=2 deleted
+    EXPECT_EQ(filter1[2], 1);
+
+    // Second batch: [4, 5, 6]
+    auto batch2 = build_int32_block("id", {4, 5, 6});
+    auto filter2 = make_filter(3);
+    ASSERT_TRUE(impl->filter_data_block(&batch2, &col_name_to_idx, id_to_name, filter2).ok());
+    EXPECT_EQ(filter2[0], 0); // id=4 deleted
+    EXPECT_EQ(filter2[1], 1);
+    EXPECT_EQ(filter2[2], 1);
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Empty delete set
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleEmptyDeleteSet) {
+    auto delete_block = build_int32_block("id", {});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_block("id", {1, 2, 3});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(3);
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 1);
+    EXPECT_EQ(filter[1], 1);
+    EXPECT_EQ(filter[2], 1);
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Empty data block
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleEmptyDataBlock) {
+    auto delete_block = build_int32_block("id", {1, 2});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_block("id", {});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(0);
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Pre-filtered rows (filter already has some 0s)
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimplePreFilteredRows) {
+    auto delete_block = build_int32_block("id", {2});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_block("id", {1, 2, 3});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    // Pre-filter: row 0 already filtered out
+    IColumn::Filter filter = {0, 1, 1};
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // was already 0, stays 0
+    EXPECT_EQ(filter[1], 0); // id=2 deleted
+    EXPECT_EQ(filter[2], 1); // kept
+}
+
+// ============================================================================
+// MultiEqualityDelete — Basic Two Columns
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiTwoColumnsBasic) {
+    // Delete: (id=1, name="a"), (id=3, name="b")
+    auto delete_block = build_int32_string_block("id", {1, 3}, "name", {"a", "b"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: (1,"a"), (1,"x"), (3,"b"), (3,"x")
+    auto data_block = build_int32_string_block("id", {1, 1, 3, 3}, "name", {"a", "x", "b", "x"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(4);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // (1,"a") deleted
+    EXPECT_EQ(filter[1], 1); // (1,"x") kept
+    EXPECT_EQ(filter[2], 0); // (3,"b") deleted
+    EXPECT_EQ(filter[3], 1); // (3,"x") kept
+}
+
+TEST_F(EqualityDeleteTest, MultiTwoColumnsNoMatch) {
+    auto delete_block = build_int32_string_block("id", {10, 20}, "name", {"x", "y"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(2);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 1);
+    EXPECT_EQ(filter[1], 1);
+}
+
+TEST_F(EqualityDeleteTest, MultiTwoColumnsAllMatch) {
+    auto delete_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(2);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0);
+    EXPECT_EQ(filter[1], 0);
+}
+
+// ============================================================================
+// MultiEqualityDelete — Pre-filtered (filter[i]=0 skips _equal comparison)
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiPreFilteredSkipsEqual) {
+    auto delete_block = build_int32_string_block("id", {1}, "name", {"a"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data has (1,"a") at row 0 but pre-filtered
+    auto data_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    IColumn::Filter filter = {0, 1};
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // stayed 0 (pre-filtered → _equal skipped)
+    EXPECT_EQ(filter[1], 1); // kept
+}
+
+// ============================================================================
+// MultiEqualityDelete — Empty delete set
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiEmptyDeleteSet) {
+    auto delete_block = build_int32_string_block("id", {}, "name", {});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(2);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 1);
+    EXPECT_EQ(filter[1], 1);
+}
+
+// ============================================================================
+// MultiEqualityDelete — Empty data block
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiEmptyDataBlock) {
+    auto delete_block = build_int32_string_block("id", {1}, "name", {"a"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_string_block("id", {}, "name", {});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(0);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+}
+
+// ============================================================================
+// MultiEqualityDelete — Repeated filter calls (multiple batches)
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiRepeatedFilterCalls) {
+    auto delete_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+
+    // Batch 1
+    auto batch1 = build_int32_string_block("id", {1, 3}, "name", {"a", "c"});
+    auto filter1 = make_filter(2);
+    ASSERT_TRUE(impl->filter_data_block(&batch1, &col_name_to_idx, id_to_name, filter1).ok());
+    EXPECT_EQ(filter1[0], 0); // (1,"a") deleted
+    EXPECT_EQ(filter1[1], 1); // (3,"c") kept
+
+    // Batch 2
+    auto batch2 = build_int32_string_block("id", {2, 4}, "name", {"b", "d"});
+    auto filter2 = make_filter(2);
+    ASSERT_TRUE(impl->filter_data_block(&batch2, &col_name_to_idx, id_to_name, filter2).ok());
+    EXPECT_EQ(filter2[0], 0); // (2,"b") deleted
+    EXPECT_EQ(filter2[1], 1); // (4,"d") kept
+}
+
+// ============================================================================
+// MultiEqualityDelete — Type mismatch error
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiTypeMismatchError) {
+    // Delete: Int32 + String
+    auto delete_block = build_int32_string_block("id", {1}, "name", {"a"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: Int32 + Int32 (type mismatch for "name" column)
+    auto int_col1 = ColumnInt32::create();
+    int_col1->insert_value(1);
+    auto int_col2 = ColumnInt32::create();
+    int_col2->insert_value(42);
+    Block data_block;
+    data_block.insert({std::move(int_col1), std::make_shared<DataTypeInt32>(), "id"});
+    data_block.insert({std::move(int_col2), std::make_shared<DataTypeInt32>(), "name"});
+
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(1);
+
+    auto st = impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.to_string().find("Not support type change") != std::string::npos);
+}
+
+// ============================================================================
+// MultiEqualityDelete — Column not found error
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiColumnNotFoundError) {
+    auto delete_block = build_int32_string_block("id", {1}, "name", {"a"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data block has "id" but not "name"
+    auto data_block = build_int32_block("id", {1});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(1);
+
+    auto st = impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.to_string().find("not found in data block") != std::string::npos);
+}
+
+// ============================================================================
+// MultiEqualityDelete — Duplicate values in delete set
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiDuplicateDeleteValues) {
+    // Delete: same pair twice
+    auto delete_block = build_int32_string_block("id", {1, 1}, "name", {"a", "a"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_string_block("id", {1, 2}, "name", {"a", "b"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(2);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // (1,"a") deleted
+    EXPECT_EQ(filter[1], 1); // (2,"b") kept
+}
+
+// ============================================================================
+// Profile counter tests
+// ============================================================================
+TEST_F(EqualityDeleteTest, ProfileCountersSimple) {
+    auto delete_block = build_int32_block("id", {10, 20, 30});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+
+    RuntimeProfile test_profile("profile_test");
+    ASSERT_TRUE(impl->init(&test_profile).ok());
+
+    // Verify the profile has the EqualityDelete timer and counters
+    auto* eq_delete_timer = test_profile.get_counter("EqualityDelete");
+    ASSERT_NE(eq_delete_timer, nullptr);
+
+    auto* num_rows = test_profile.get_counter("NumRowsInDeleteFile");
+    ASSERT_NE(num_rows, nullptr);
+    EXPECT_EQ(num_rows->value(), 3); // 3 delete rows
+
+    auto* build_time = test_profile.get_counter("BuildHashSetTime");
+    ASSERT_NE(build_time, nullptr);
+
+    auto* filter_time = test_profile.get_counter("EqualityDeleteFilterTime");
+    ASSERT_NE(filter_time, nullptr);
+}
+
+TEST_F(EqualityDeleteTest, ProfileCountersMulti) {
+    auto delete_block =
+            build_int32_string_block("id", {1, 2, 3, 4, 5}, "name", {"a", "b", "c", "d", "e"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+
+    RuntimeProfile test_profile("profile_test");
+    ASSERT_TRUE(impl->init(&test_profile).ok());
+
+    auto* num_rows = test_profile.get_counter("NumRowsInDeleteFile");
+    ASSERT_NE(num_rows, nullptr);
+    EXPECT_EQ(num_rows->value(), 5);
+}
+
+// ============================================================================
+// Large batch — correctness with many rows
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleLargeBatch) {
+    // Delete every 10th value: 0, 10, 20, ..., 990
+    std::vector<int32_t> delete_vals;
+    for (int i = 0; i < 1000; i += 10) {
+        delete_vals.push_back(i);
+    }
+    auto delete_block = build_int32_block("id", delete_vals);
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: 0, 1, 2, ..., 999
+    std::vector<int32_t> data_vals;
+    for (int i = 0; i < 1000; ++i) {
+        data_vals.push_back(i);
+    }
+    auto data_block = build_int32_block("id", data_vals);
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(1000);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    for (int i = 0; i < 1000; ++i) {
+        if (i % 10 == 0) {
+            EXPECT_EQ(filter[i], 0) << "row " << i << " should be deleted";
+        } else {
+            EXPECT_EQ(filter[i], 1) << "row " << i << " should be kept";
+        }
+    }
+}
+
+TEST_F(EqualityDeleteTest, MultiLargeBatch) {
+    // Delete every 10th pair
+    std::vector<int32_t> delete_ints;
+    std::vector<std::string> delete_strs;
+    for (int i = 0; i < 1000; i += 10) {
+        delete_ints.push_back(i);
+        delete_strs.push_back(std::to_string(i));
+    }
+    auto delete_block = build_int32_string_block("id", delete_ints, "name", delete_strs);
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: 0..999 with matching strings
+    std::vector<int32_t> data_ints;
+    std::vector<std::string> data_strs;
+    for (int i = 0; i < 1000; ++i) {
+        data_ints.push_back(i);
+        data_strs.push_back(std::to_string(i));
+    }
+    auto data_block = build_int32_string_block("id", data_ints, "name", data_strs);
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(1000);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    for (int i = 0; i < 1000; ++i) {
+        if (i % 10 == 0) {
+            EXPECT_EQ(filter[i], 0) << "row " << i << " should be deleted";
+        } else {
+            EXPECT_EQ(filter[i], 1) << "row " << i << " should be kept";
+        }
+    }
+}
+
+// ============================================================================
+// MultiEqualityDelete — Partial column match (values match on one col only)
+// ============================================================================
+TEST_F(EqualityDeleteTest, MultiPartialColumnMatch) {
+    // Delete: (1, "a")
+    auto delete_block = build_int32_string_block("id", {1}, "name", {"a"});
+    std::vector<int> col_ids = {100, 200};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data: (1, "b") — id matches but name doesn't
+    auto data_block = build_int32_string_block("id", {1}, "name", {"b"});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}, {"name", 1}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}, {200, "name"}};
+    auto filter = make_filter(1);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 1); // kept (only id matches, name doesn't)
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Duplicate values in delete set
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleDuplicateDeleteValues) {
+    auto delete_block = build_int32_block("id", {1, 1, 2, 2, 3});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    auto data_block = build_int32_block("id", {1, 2, 3, 4});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(4);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // id=1 deleted
+    EXPECT_EQ(filter[1], 0); // id=2 deleted
+    EXPECT_EQ(filter[2], 0); // id=3 deleted
+    EXPECT_EQ(filter[3], 1); // id=4 kept
+}
+
+// ============================================================================
+// SimpleEqualityDelete — Single delete value matches multiple data rows
+// ============================================================================
+TEST_F(EqualityDeleteTest, SimpleSingleDeleteMatchesMultipleRows) {
+    auto delete_block = build_int32_block("id", {5});
+    std::vector<int> col_ids = {100};
+    auto impl = EqualityDeleteBase::get_delete_impl(&delete_block, col_ids);
+    ASSERT_TRUE(impl->init(&profile).ok());
+
+    // Data has multiple 5s
+    auto data_block = build_int32_block("id", {5, 1, 5, 2, 5});
+    std::unordered_map<std::string, uint32_t> col_name_to_idx = {{"id", 0}};
+    std::unordered_map<int, std::string> id_to_name = {{100, "id"}};
+    auto filter = make_filter(5);
+
+    ASSERT_TRUE(impl->filter_data_block(&data_block, &col_name_to_idx, id_to_name, filter).ok());
+    EXPECT_EQ(filter[0], 0); // id=5 deleted
+    EXPECT_EQ(filter[1], 1); // id=1 kept
+    EXPECT_EQ(filter[2], 0); // id=5 deleted
+    EXPECT_EQ(filter[3], 1); // id=2 kept
+    EXPECT_EQ(filter[4], 0); // id=5 deleted
+}
+
+} // namespace doris

--- a/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
@@ -643,8 +643,8 @@ protected:
     std::tuple<std::unique_ptr<HiveParquetReader>, const FieldDescriptor*> create_parquet_reader(
             const std::string& test_file) {
         auto local_fs = io::global_local_filesystem();
-        io::FileReaderSPtr file_reader;
-        auto st = local_fs->open_file(test_file, &file_reader);
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
         if (!st.ok()) {
             return {nullptr, nullptr};
         }
@@ -654,7 +654,7 @@ protected:
         scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
         TFileRangeDesc scan_range;
         scan_range.start_offset = 0;
-        scan_range.size = file_reader->size();
+        scan_range.size = file_size;
         scan_range.path = test_file;
         RuntimeProfile profile("test_profile");
 
@@ -667,8 +667,6 @@ protected:
         if (!hive_reader) {
             return {nullptr, nullptr};
         }
-
-        hive_reader->set_file_reader(file_reader);
 
         const FieldDescriptor* field_desc = nullptr;
         st = hive_reader->get_file_metadata_schema(&field_desc);
@@ -683,8 +681,8 @@ protected:
     std::tuple<std::unique_ptr<HiveOrcReader>, const orc::Type*> create_orc_reader(
             const std::string& test_file) {
         auto local_fs = io::global_local_filesystem();
-        io::FileReaderSPtr file_reader;
-        auto st = local_fs->open_file(test_file, &file_reader);
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
         if (!st.ok()) {
             return {nullptr, nullptr};
         }
@@ -694,7 +692,7 @@ protected:
         scan_params.format_type = TFileFormatType::FORMAT_ORC;
         TFileRangeDesc scan_range;
         scan_range.start_offset = 0;
-        scan_range.size = file_reader->size();
+        scan_range.size = file_size;
         scan_range.path = test_file;
         RuntimeProfile profile("test_profile");
 

--- a/be/test/format/table/hive/hive_reader_test.cpp
+++ b/be/test/format/table/hive/hive_reader_test.cpp
@@ -24,18 +24,21 @@
 #include <gen_cpp/Types_types.h>
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "common/consts.h"
 #include "common/object_pool.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
 #include "core/column/column_array.h"
 #include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
 #include "core/column/column_struct.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
@@ -46,6 +49,7 @@
 #include "core/data_type/data_type_struct.h"
 #include "format/orc/vorc_reader.h"
 #include "format/parquet/vparquet_reader.h"
+#include "format/table/reader_test_util.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_system.h"
@@ -53,6 +57,8 @@
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "storage/olap_scan_common.h"
+#include "storage/segment/column_reader.h"
+#include "storage/utils.h"
 #include "util/timezone_utils.h"
 
 namespace doris::table {
@@ -77,68 +83,10 @@ protected:
                                      DataTypePtr& hobby_element_struct_type,
                                      DataTypePtr& hobbies_array_type,
                                      DataTypePtr& profile_struct_type, DataTypePtr& name_type) {
-        // Create name column type (direct field)
-        name_type = make_nullable(std::make_shared<DataTypeString>());
-
-        // First create coordinates struct type
-        std::vector<DataTypePtr> coordinates_types = {
-                make_nullable(std::make_shared<DataTypeFloat64>()), // lat (field ID 10)
-                make_nullable(std::make_shared<DataTypeFloat64>())  // lng (field ID 11)
-        };
-        std::vector<std::string> coordinates_names = {"lat", "lng"};
-        coordinates_struct_type = make_nullable(
-                std::make_shared<DataTypeStruct>(coordinates_types, coordinates_names));
-
-        // Create address struct type (with street, city, coordinates)
-        std::vector<DataTypePtr> address_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // street (field ID 7)
-                make_nullable(std::make_shared<DataTypeString>()), // city (field ID 8)
-                coordinates_struct_type                            // coordinates (field ID 9)
-        };
-        std::vector<std::string> address_names = {"street", "city", "coordinates"};
-        address_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(address_types, address_names));
-
-        // Create phone struct type
-        std::vector<DataTypePtr> phone_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // country_code (field ID 14)
-                make_nullable(std::make_shared<DataTypeString>())  // number (field ID 15)
-        };
-        std::vector<std::string> phone_names = {"country_code", "number"};
-        phone_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(phone_types, phone_names));
-
-        // Create contact struct type (with email, phone)
-        std::vector<DataTypePtr> contact_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // email (field ID 12)
-                phone_struct_type                                  // phone (field ID 13)
-        };
-        std::vector<std::string> contact_names = {"email", "phone"};
-        contact_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(contact_types, contact_names));
-
-        // Create hobby element struct type for array elements
-        std::vector<DataTypePtr> hobby_element_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // name (field ID 17)
-                make_nullable(std::make_shared<DataTypeInt32>())   // level (field ID 18)
-        };
-        std::vector<std::string> hobby_element_names = {"name", "level"};
-        hobby_element_struct_type = make_nullable(
-                std::make_shared<DataTypeStruct>(hobby_element_types, hobby_element_names));
-
-        // Create hobbies array type
-        hobbies_array_type =
-                make_nullable(std::make_shared<DataTypeArray>(hobby_element_struct_type));
-
-        // Create complete profile struct type (with address, contact, hobbies)
-        std::vector<DataTypePtr> profile_types = {
-                address_struct_type, // address (field ID 4)
-                contact_struct_type, // contact (field ID 5)
-                hobbies_array_type   // hobbies (field ID 6)
-        };
-        std::vector<std::string> profile_names = {"address", "contact", "hobbies"};
-        profile_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(profile_types, profile_names));
+        doris::reader_test::create_complex_user_profile_types(
+                coordinates_struct_type, address_struct_type, phone_struct_type,
+                contact_struct_type, hobby_element_struct_type, hobbies_array_type,
+                profile_struct_type, name_type);
     }
 
     // Helper function to create tuple descriptor
@@ -381,344 +329,720 @@ protected:
 
     // Helper function to recursively print column row counts and check size > 0
     void verify_test_results(Block& block, size_t read_rows) {
-        // Verify that we read some data
-        EXPECT_GT(read_rows, 0) << "Should read at least one row";
-        EXPECT_EQ(block.rows(), read_rows);
+        doris::reader_test::verify_nested_reader_block(block, read_rows);
+    }
 
-        // Verify column count matches expected (2 columns: name, profile)
-        EXPECT_EQ(block.columns(), 2);
+    Block make_string_block(const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        Block block;
+        for (const auto& [name, type] : columns) {
+            block.insert(ColumnWithTypeAndName(type->create_column(), type, name));
+        }
+        return block;
+    }
 
-        // Verify column names and types
-        auto columns_with_names = block.get_columns_with_type_and_name();
-        std::vector<std::string> expected_column_names = {"name", "profile"};
-        for (size_t i = 0; i < expected_column_names.size(); i++) {
-            EXPECT_EQ(columns_with_names[i].name, expected_column_names[i]);
+    void verify_nullable_string_column_values(const Block& block, const std::string& column_name,
+                                              const std::vector<std::string>& expected_values) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_values.size());
+        for (size_t i = 0; i < expected_values.size(); ++i) {
+            ASSERT_FALSE(nullable->is_null_at(i));
+            EXPECT_EQ(nested.get_data_at(i).to_string(), expected_values[i]);
+        }
+    }
+
+    void verify_nullable_string_column_has_rows(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_rows);
+        ASSERT_EQ(nested.size(), expected_rows);
+        if (expected_rows > 0) {
+            EXPECT_FALSE(nullable->is_null_at(0));
+        }
+    }
+
+    void verify_nullable_string_column_all_null(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        ASSERT_EQ(nullable->size(), expected_rows);
+        for (size_t i = 0; i < expected_rows; ++i) {
+            EXPECT_TRUE(nullable->is_null_at(i));
+        }
+    }
+
+    void verify_global_rowid_column(const Block& block, const std::string& column_name,
+                                    uint8_t expected_version, int64_t expected_backend_id,
+                                    uint32_t expected_file_id) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        const auto& string_column = static_cast<const ColumnString&>(*column.column);
+        for (size_t i = 0; i < string_column.size(); ++i) {
+            ASSERT_EQ(string_column.get_data_at(i).size, sizeof(GlobalRowLoacationV2));
+            auto location = *reinterpret_cast<const GlobalRowLoacationV2*>(
+                    string_column.get_data_at(i).data);
+            EXPECT_EQ(location.version, expected_version);
+            EXPECT_EQ(location.backend_id, expected_backend_id);
+            EXPECT_EQ(location.file_id, expected_file_id);
+            EXPECT_EQ(location.row_id, static_cast<uint32_t>(i));
+        }
+    }
+
+    void read_hive_parquet_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*, RuntimeState*)>& customize_context =
+                    nullptr,
+            const std::function<void(HiveParquetReader*)>& customize_reader = nullptr) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << actual_file;
+            return;
         }
 
-        // Verify column types
-        EXPECT_TRUE(columns_with_names[0].type->get_name().find("String") !=
-                    std::string::npos); // name is STRING
-        EXPECT_TRUE(columns_with_names[1].type->get_name().find("Struct") !=
-                    std::string::npos); // profile is STRUCT
-
-        // Print row count for each column and nested subcolumns
-        std::cout << "Block rows: " << block.rows() << std::endl;
-
-        // Helper function to recursively print column row counts
-        std::function<void(const ColumnPtr&, const DataTypePtr&, const std::string&, int)>
-                print_column_rows = [&](const ColumnPtr& col, const DataTypePtr& type,
-                                        const std::string& name, int depth) {
-                    std::string indent(depth * 2, ' ');
-                    std::cout << indent << name << " row count: " << col->size() << std::endl;
-                    EXPECT_GT(col->size(), 0) << name << " column/subcolumn size should be > 0";
-
-                    // Check if it's a nullable column
-                    if (const auto* nullable_col = typeid_cast<const ColumnNullable*>(col.get())) {
-                        auto nested_type =
-                                assert_cast<const DataTypeNullable*>(type.get())->get_nested_type();
-
-                        // Only add ".nested" suffix for non-leaf (complex) nullable columns
-                        // Leaf columns like String, Int, etc. should not get the ".nested" suffix
-                        bool is_complex_type =
-                                (typeid_cast<const DataTypeStruct*>(nested_type.get()) !=
-                                 nullptr) ||
-                                (typeid_cast<const DataTypeArray*>(nested_type.get()) != nullptr) ||
-                                (typeid_cast<const DataTypeMap*>(nested_type.get()) != nullptr);
-
-                        std::string nested_name = is_complex_type ? name + ".nested" : name;
-                        print_column_rows(nullable_col->get_nested_column_ptr(), nested_type,
-                                          nested_name, depth + (is_complex_type ? 1 : 0));
-                    }
-                    // Check if it's a struct column
-                    else if (const auto* struct_col = typeid_cast<const ColumnStruct*>(col.get())) {
-                        auto struct_type = assert_cast<const DataTypeStruct*>(type.get());
-                        for (size_t i = 0; i < struct_col->tuple_size(); ++i) {
-                            std::string field_name = struct_type->get_element_name(i);
-                            auto field_type = struct_type->get_element(i);
-                            print_column_rows(struct_col->get_column_ptr(i), field_type,
-                                              name + "." + field_name, depth + 1);
-                        }
-                    }
-                    // Check if it's an array column
-                    else if (const auto* array_col = typeid_cast<const ColumnArray*>(col.get())) {
-                        auto array_type = assert_cast<const DataTypeArray*>(type.get());
-                        auto element_type = array_type->get_nested_type();
-                        print_column_rows(array_col->get_data_ptr(), element_type, name + ".data",
-                                          depth + 1);
-                    }
-                };
-
-        // Print row counts for all columns
-        for (size_t i = 0; i < block.columns(); ++i) {
-            const auto& column_with_name = block.get_by_position(i);
-            print_column_rows(column_with_name.column, column_with_name.type, column_with_name.name,
-                              0);
-            EXPECT_EQ(column_with_name.column->size(), block.rows())
-                    << "Column " << column_with_name.name << " size mismatch";
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+        if (customize_context) {
+            customize_context(&scan_params, &runtime_state);
         }
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+
+        RuntimeProfile profile("test_profile");
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        auto hive_reader =
+                std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range, 1024, &ctz,
+                                                    nullptr, &runtime_state, nullptr, cache.get());
+        ASSERT_NE(hive_reader, nullptr);
+        if (customize_reader) {
+            customize_reader(hive_reader.get());
+        }
+
+        ParquetInitContext pq_ctx;
+        pq_ctx.column_descs = &column_descs;
+        pq_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        pq_ctx.tuple_descriptor = tuple_descriptor;
+        pq_ctx.params = &scan_params;
+        pq_ctx.range = &scan_range;
+        st = hive_reader->init_reader(&pq_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        *block = make_string_block(block_columns);
+        bool eof = false;
+        st = hive_reader->get_next_block(block, read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    void read_hive_orc_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*, RuntimeState*)>& customize_context =
+                    nullptr,
+            const std::function<void(HiveOrcReader*)>& customize_reader = nullptr) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << actual_file;
+            return;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_ORC;
+        if (customize_context) {
+            customize_context(&scan_params, &runtime_state);
+        }
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+
+        RuntimeProfile profile("test_profile");
+        auto hive_reader =
+                std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params, scan_range,
+                                                1024, "CST", nullptr, nullptr, cache.get());
+        ASSERT_NE(hive_reader, nullptr);
+        if (customize_reader) {
+            customize_reader(hive_reader.get());
+        }
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_descs = &column_descs;
+        orc_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        orc_ctx.tuple_descriptor = tuple_descriptor;
+        orc_ctx.params = &scan_params;
+        orc_ctx.range = &scan_range;
+        st = hive_reader->init_reader(&orc_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        *block = make_string_block(block_columns);
+        bool eof = false;
+        st = hive_reader->get_next_block(block, read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    void read_hive_parquet_test_file(const std::string& test_file) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << test_file;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+
+        TFileRangeDesc scan_range;
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = test_file;
+
+        RuntimeProfile profile("test_profile");
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        auto hive_reader =
+                std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range, 1024, &ctz,
+                                                    nullptr, &runtime_state, nullptr, cache.get());
+        ASSERT_NE(hive_reader, nullptr);
+
+        DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
+        DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
+        DataTypePtr profile_struct_type, name_type;
+        create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
+                                    contact_struct_type, hobby_element_struct_type,
+                                    hobbies_array_type, profile_struct_type, name_type);
+
+        DescriptorTbl* desc_tbl;
+        ObjectPool obj_pool;
+        TDescriptorTable t_desc_table;
+        TTableDescriptor t_table_desc;
+        std::vector<std::string> table_column_names = {"name", "profile"};
+        std::vector<int> table_column_positions = {1, 2};
+        std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                                TPrimitiveType::STRUCT};
+        const TupleDescriptor* tuple_descriptor = create_tuple_descriptor(
+                &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+                table_column_positions, table_column_types);
+
+        std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                           {"profile", 1}};
+
+        ParquetInitContext pq_ctx;
+        pq_ctx.column_names = table_column_names;
+        pq_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+        pq_ctx.tuple_descriptor = tuple_descriptor;
+        pq_ctx.params = &scan_params;
+        pq_ctx.range = &scan_range;
+        st = hive_reader->init_reader(&pq_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        Block block = doris::reader_test::make_name_profile_block(name_type, profile_struct_type);
+        size_t read_rows = 0;
+        bool eof = false;
+        st = hive_reader->get_next_block(&block, &read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+        verify_test_results(block, read_rows);
+    }
+
+    void read_hive_orc_test_file(const std::string& test_file) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << test_file;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_ORC;
+
+        TFileRangeDesc scan_range;
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = test_file;
+
+        RuntimeProfile profile("test_profile");
+        auto hive_reader =
+                std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params, scan_range,
+                                                1024, "CST", nullptr, nullptr, cache.get());
+        ASSERT_NE(hive_reader, nullptr);
+
+        DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
+        DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
+        DataTypePtr profile_struct_type, name_type;
+        create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
+                                    contact_struct_type, hobby_element_struct_type,
+                                    hobbies_array_type, profile_struct_type, name_type);
+
+        DescriptorTbl* desc_tbl;
+        ObjectPool obj_pool;
+        TDescriptorTable t_desc_table;
+        TTableDescriptor t_table_desc;
+        std::vector<std::string> table_column_names = {"name", "profile"};
+        std::vector<int> table_column_positions = {1, 2};
+        std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                                TPrimitiveType::STRUCT};
+        const TupleDescriptor* tuple_descriptor = create_tuple_descriptor(
+                &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+                table_column_positions, table_column_types);
+
+        std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                           {"profile", 1}};
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_names = table_column_names;
+        orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+        orc_ctx.tuple_descriptor = tuple_descriptor;
+        orc_ctx.params = &scan_params;
+        orc_ctx.range = &scan_range;
+        st = hive_reader->init_reader(&orc_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        Block block = doris::reader_test::make_name_profile_block(name_type, profile_struct_type);
+        size_t read_rows = 0;
+        bool eof = false;
+        st = hive_reader->get_next_block(&block, &read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+        verify_test_results(block, read_rows);
     }
 
     std::unique_ptr<doris::FileMetaCache> cache;
     cctz::time_zone timezone_obj;
 };
 
-// Test reading real Hive Parquet file using HiveTableReader
 TEST_F(HiveReaderTest, read_hive_parquet_file) {
-    // Read only: name, profile.address.coordinates.lat, profile.address.coordinates.lng, profile.contact.email
-    // Setup table descriptor for test columns with new schema:
-    /**
-    Schema:
-    message table {
-    required int64 id = 1;
-    required binary name (STRING) = 2;
-    required group profile = 3 {
-        optional group address = 4 {
-        optional binary street (STRING) = 7;
-        optional binary city (STRING) = 8;
-        optional group coordinates = 9 {
-            optional double lat = 10;
-            optional double lng = 11;
-        }
-        }
-        optional group contact = 5 {
-        optional binary email (STRING) = 12;
-        optional group phone = 13 {
-            optional binary country_code (STRING) = 14;
-            optional binary number (STRING) = 15;
-        }
-        }
-        optional group hobbies (LIST) = 6 {
-        repeated group list {
-            optional group element = 16 {
-            optional binary name (STRING) = 17;
-            optional int32 level = 18;
-            }
-        }
-        }
-    }
-    }
-    */
-
-    // Open the Hive Parquet test file
-    auto local_fs = io::global_local_filesystem();
-    io::FileReaderSPtr file_reader;
-    std::string test_file =
+    read_hive_parquet_test_file(
             "./be/test/exec/test_data/complex_user_profiles_iceberg_parquet/data/"
-            "00000-0-a0022aad-d3b6-4e73-b181-f0a09aac7034-0-00001.parquet";
-    auto st = local_fs->open_file(test_file, &file_reader);
-    if (!st.ok()) {
-        GTEST_SKIP() << "Test file not found: " << test_file;
-        return;
-    }
-
-    // Setup runtime state
-    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
-
-    // Setup scan parameters
-    TFileScanRangeParams scan_params;
-    scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
-
-    TFileRangeDesc scan_range;
-    scan_range.start_offset = 0;
-    scan_range.size = file_reader->size(); // Read entire file
-    scan_range.path = test_file;
-
-    // Create mock profile
-    RuntimeProfile profile("test_profile");
-
-    // Create HiveParquetReader (directly inherits ParquetReader)
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-    auto hive_reader =
-            std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range, 1024, &ctz,
-                                                nullptr, &runtime_state, nullptr, cache.get());
-
-    // Set file reader for the hive reader (inherited from ParquetReader)
-    hive_reader->set_file_reader(file_reader);
-
-    // Create complex struct types using helper function
-    DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
-    DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
-    DataTypePtr profile_struct_type, name_type;
-    create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
-                                contact_struct_type, hobby_element_struct_type, hobbies_array_type,
-                                profile_struct_type, name_type);
-
-    // Create tuple descriptor using helper function
-    DescriptorTbl* desc_tbl;
-    ObjectPool obj_pool;
-    TDescriptorTable t_desc_table;
-    TTableDescriptor t_table_desc;
-    std::vector<std::string> table_column_names = {"name", "profile"};
-    std::vector<int> table_column_positions = {1, 2};
-    std::vector<TPrimitiveType::type> table_column_types = {
-            TPrimitiveType::STRING, TPrimitiveType::STRUCT // profile 用 STRUCT 类型
-    };
-    const TupleDescriptor* tuple_descriptor =
-            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
-                                    table_column_names, table_column_positions, table_column_types);
-
-    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"profile", 1}};
-
-    // Use the template method init_reader (inherited from ParquetReader)
-    // on_before_init_columns hook in HiveParquetReader will do schema matching
-    ParquetInitContext pq_ctx;
-    pq_ctx.column_names = table_column_names;
-    pq_ctx.col_name_to_block_idx = &col_name_to_block_idx;
-    pq_ctx.tuple_descriptor = tuple_descriptor;
-    pq_ctx.params = &scan_params;
-    pq_ctx.range = &scan_range;
-    st = hive_reader->init_reader(&pq_ctx);
-    ASSERT_TRUE(st.ok()) << st;
-
-    // set_fill_columns logic is now inlined in _do_init_reader,
-    // so no separate call is needed.
-
-    // Create block for reading nested structure (not flattened)
-    Block block;
-    {
-        MutableColumnPtr name_column = name_type->create_column();
-        block.insert(ColumnWithTypeAndName(std::move(name_column), name_type, "name"));
-        // Add profile column (nested struct)
-        MutableColumnPtr profile_column = profile_struct_type->create_column();
-        block.insert(
-                ColumnWithTypeAndName(std::move(profile_column), profile_struct_type, "profile"));
-    }
-
-    // Read data from the file
-    size_t read_rows = 0;
-    bool eof = false;
-    st = hive_reader->get_next_block(&block, &read_rows, &eof);
-    ASSERT_TRUE(st.ok()) << st;
-
-    // Verify test results using helper function
-    verify_test_results(block, read_rows);
+            "00000-0-a0022aad-d3b6-4e73-b181-f0a09aac7034-0-00001.parquet");
 }
 
-// Test reading real Hive Orc file using HiveTableReader
-TEST_F(HiveReaderTest, read_hive_rrc_file) {
-    // Read only: name, profile.address.coordinates.lat, profile.address.coordinates.lng, profile.contact.email
-    // Setup table descriptor for test columns with new schema:
-    /**
-    Schema:
-    message table {
-    required int64 id = 1;
-    required binary name (STRING) = 2;
-    required group profile = 3 {
-        optional group address = 4 {
-        optional binary street (STRING) = 7;
-        optional binary city (STRING) = 8;
-        optional group coordinates = 9 {
-            optional double lat = 10;
-            optional double lng = 11;
-        }
-        }
-        optional group contact = 5 {
-        optional binary email (STRING) = 12;
-        optional group phone = 13 {
-            optional binary country_code (STRING) = 14;
-            optional binary number (STRING) = 15;
-        }
-        }
-        optional group hobbies (LIST) = 6 {
-        repeated group list {
-            optional group element = 16 {
-            optional binary name (STRING) = 17;
-            optional int32 level = 18;
-            }
-        }
-        }
-    }
-    }
-    */
-    // Open the Hive Orc test file
-    auto local_fs = io::global_local_filesystem();
-    io::FileReaderSPtr file_reader;
-    std::string test_file =
+TEST_F(HiveReaderTest, read_hive_orc_file) {
+    read_hive_orc_test_file(
             "./be/test/exec/test_data/complex_user_profiles_iceberg_orc/data/"
-            "00000-0-e4897963-0081-4127-bebe-35dc7dc1edeb-0-00001.orc";
-    auto st = local_fs->open_file(test_file, &file_reader);
-    if (!st.ok()) {
-        GTEST_SKIP() << "Test file not found: " << test_file;
-        return;
-    }
+            "00000-0-e4897963-0081-4127-bebe-35dc7dc1edeb-0-00001.orc");
+}
 
-    // Setup runtime state
-    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+TEST_F(HiveReaderTest, read_nested_hive_parquet_file) {
+    read_hive_parquet_test_file(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet");
+}
 
-    // Setup scan parameters
-    TFileScanRangeParams scan_params;
-    scan_params.format_type = TFileFormatType::FORMAT_ORC;
+TEST_F(HiveReaderTest, read_nested_hive_orc_file) {
+    read_hive_orc_test_file(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc");
+}
 
-    TFileRangeDesc scan_range;
-    scan_range.start_offset = 0;
-    scan_range.size = file_reader->size(); // Read entire file
-    scan_range.path = test_file;
-
-    // Create mock profile
-    RuntimeProfile profile("test_profile");
-
-    // Create HiveOrcReader (directly inherits OrcReader)
-    auto hive_reader =
-            std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params, scan_range, 1024,
-                                            "CST", nullptr, nullptr, cache.get());
-
-    // Create complex struct types using helper function
-    DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
-    DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
-    DataTypePtr profile_struct_type, name_type;
-    create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
-                                contact_struct_type, hobby_element_struct_type, hobbies_array_type,
-                                profile_struct_type, name_type);
-
-    // Create tuple descriptor using helper function
+TEST_F(HiveReaderTest, fills_partition_column_from_scan_range_for_parquet) {
     DescriptorTbl* desc_tbl;
     ObjectPool obj_pool;
     TDescriptorTable t_desc_table;
     TTableDescriptor t_table_desc;
-    std::vector<std::string> table_column_names = {"name", "profile"};
+    std::vector<std::string> table_column_names = {"name", "year"};
     std::vector<int> table_column_positions = {1, 2};
-    std::vector<TPrimitiveType::type> table_column_types = {
-            TPrimitiveType::STRING, TPrimitiveType::STRUCT // profile 用 STRUCT 类型
-    };
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
     const TupleDescriptor* tuple_descriptor =
             create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
                                     table_column_names, table_column_positions, table_column_types);
 
-    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"profile", 1}};
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"year", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"year", tuple_descriptor->slots()[1], ColumnCategory::PARTITION_KEY, nullptr}};
 
-    OrcInitContext orc_ctx;
-    orc_ctx.column_names = table_column_names;
-    orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
-    orc_ctx.tuple_descriptor = tuple_descriptor;
-    orc_ctx.params = &scan_params;
-    orc_ctx.range = &scan_range;
-    st = hive_reader->init_reader(&orc_ctx);
-    ASSERT_TRUE(st.ok()) << st;
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "file:///warehouse/nested_user_profiles/year=2024/part-00000-64a7a390-1a03-4efc-"
+            "ab51-557e9369a1f9-c000.snappy.parquet";
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
 
-    // set_fill_columns logic is now inlined in _do_init_reader,
-    // so no separate call is needed.
-
-    // Create block for reading nested structure (not flattened)
-    Block block;
-
-    {
-        MutableColumnPtr name_column = name_type->create_column();
-        block.insert(ColumnWithTypeAndName(std::move(name_column), name_type, "name"));
-        // Add profile column (nested struct)
-        MutableColumnPtr profile_column = profile_struct_type->create_column();
-        block.insert(
-                ColumnWithTypeAndName(std::move(profile_column), profile_struct_type, "profile"));
-    }
-
-    // Read data from the file
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
     size_t read_rows = 0;
-    bool eof = false;
-    st = hive_reader->get_next_block(&block, &read_rows, &eof);
-    ASSERT_TRUE(st.ok()) << st;
+    Block block;
+    read_hive_parquet_block(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
 
-    // Verify test results using helper function
-    verify_test_results(block, read_rows);
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_values(block, "year",
+                                         std::vector<std::string>(read_rows, "2024"));
+}
+
+TEST_F(HiveReaderTest, fills_partition_column_from_scan_range_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "year"};
+    std::vector<int> table_column_positions = {1, 2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"year", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"year", tuple_descriptor->slots()[1], ColumnCategory::PARTITION_KEY, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc";
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_hive_orc_block(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_values(block, "year",
+                                         std::vector<std::string>(read_rows, "2024"));
+}
+
+TEST_F(HiveReaderTest, fills_missing_column_with_null_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "country"};
+    std::vector<int> table_column_positions = {1, 2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"country", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"country", tuple_descriptor->slots()[1], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_hive_parquet_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                            column_descs, {{"name", nullable_string}, {"country", nullable_string}},
+                            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "country", read_rows);
+}
+
+TEST_F(HiveReaderTest, fills_missing_column_with_null_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "country"};
+    std::vector<int> table_column_positions = {1, 2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"country", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"country", tuple_descriptor->slots()[1], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_hive_orc_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                        column_descs, {{"name", nullable_string}, {"country", nullable_string}},
+                        &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "country", read_rows);
+}
+
+TEST_F(HiveReaderTest, reads_generated_column_from_file_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name"};
+    std::vector<int> table_column_positions = {1};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::GENERATED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_hive_parquet_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                            column_descs, {{"name", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(HiveReaderTest, reads_generated_column_from_file_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name"};
+    std::vector<int> table_column_positions = {1};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::GENERATED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_hive_orc_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                        column_descs, {{"name", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(HiveReaderTest, uses_column_indexes_when_parquet_name_mapping_is_disabled) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"alias_name"};
+    std::vector<int> table_column_positions = {0};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"alias_name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"alias_name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_hive_parquet_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                            column_descs, {{"alias_name", nullable_string}}, &read_rows, &block,
+                            [](TFileScanRangeParams* scan_params, RuntimeState* runtime_state) {
+                                scan_params->column_idxs = {0};
+                                TQueryOptions query_options = runtime_state->query_options();
+                                query_options.__set_hive_parquet_use_column_names(false);
+                                runtime_state->set_query_options(query_options);
+                            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "alias_name", read_rows);
+}
+
+TEST_F(HiveReaderTest, uses_column_indexes_when_orc_name_mapping_is_disabled) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"alias_name"};
+    std::vector<int> table_column_positions = {0};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"alias_name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"alias_name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_hive_orc_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                        column_descs, {{"alias_name", nullable_string}}, &read_rows, &block,
+                        [](TFileScanRangeParams* scan_params, RuntimeState* runtime_state) {
+                            scan_params->column_idxs = {0};
+                            TQueryOptions query_options = runtime_state->query_options();
+                            query_options.__set_hive_orc_use_column_names(false);
+                            runtime_state->set_query_options(query_options);
+                        });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "alias_name", read_rows);
+}
+
+TEST_F(HiveReaderTest, fills_global_rowid_synthesized_column_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::string global_rowid_col_name = BeConsts::GLOBAL_ROWID_COL + "test";
+    std::vector<std::string> table_column_names = {"name", global_rowid_col_name};
+    std::vector<int> table_column_positions = {1, 2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                       {global_rowid_col_name, 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {global_rowid_col_name, tuple_descriptor->slots()[1], ColumnCategory::SYNTHESIZED,
+             nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    auto global_rowid_type = std::make_shared<DataTypeString>();
+    size_t read_rows = 0;
+    Block block;
+    constexpr uint8_t kVersion = 1;
+    constexpr int64_t kBackendId = 10020;
+    constexpr uint32_t kFileId = 31;
+    read_hive_parquet_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                            column_descs,
+                            {{"name", nullable_string}, {global_rowid_col_name, global_rowid_type}},
+                            &read_rows, &block, nullptr, [&](HiveParquetReader* reader) {
+                                reader->set_create_row_id_column_iterator_func([&]() {
+                                    return std::make_shared<segment_v2::RowIdColumnIteratorV2>(
+                                            kVersion, kBackendId, kFileId);
+                                });
+                            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+    verify_global_rowid_column(block, global_rowid_col_name, kVersion, kBackendId, kFileId);
+}
+
+TEST_F(HiveReaderTest, fills_global_rowid_synthesized_column_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::string global_rowid_col_name = BeConsts::GLOBAL_ROWID_COL + "test";
+    std::vector<std::string> table_column_names = {"name", global_rowid_col_name};
+    std::vector<int> table_column_positions = {1, 2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc,
+                                    table_column_names, table_column_positions, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                       {global_rowid_col_name, 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {global_rowid_col_name, tuple_descriptor->slots()[1], ColumnCategory::SYNTHESIZED,
+             nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    auto global_rowid_type = std::make_shared<DataTypeString>();
+    size_t read_rows = 0;
+    Block block;
+    constexpr uint8_t kVersion = 1;
+    constexpr int64_t kBackendId = 10021;
+    constexpr uint32_t kFileId = 32;
+    read_hive_orc_block(scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx,
+                        column_descs,
+                        {{"name", nullable_string}, {global_rowid_col_name, global_rowid_type}},
+                        &read_rows, &block, nullptr, [&](HiveOrcReader* reader) {
+                            reader->set_create_row_id_column_iterator_func([&]() {
+                                return std::make_shared<segment_v2::RowIdColumnIteratorV2>(
+                                        kVersion, kBackendId, kFileId);
+                            });
+                        });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+    verify_global_rowid_column(block, global_rowid_col_name, kVersion, kBackendId, kFileId);
 }
 
 } // namespace doris::table

--- a/be/test/format/table/hudi_reader_test.cpp
+++ b/be/test/format/table/hudi_reader_test.cpp
@@ -1,0 +1,600 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/table/hudi_reader.h"
+
+#include <cctz/time_zone.h>
+#include <gen_cpp/ExternalTableSchema_types.h>
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/block/column_with_type_and_name.h"
+#include "core/column/column.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_string.h"
+#include "format/column_descriptor.h"
+#include "format/orc/vorc_reader.h"
+#include "format/parquet/vparquet_reader.h"
+#include "io/fs/file_meta_cache.h"
+#include "io/fs/file_reader_writer_fwd.h"
+#include "io/fs/file_system.h"
+#include "io/fs/local_file_system.h"
+#include "runtime/runtime_state.h"
+#include "testutil/desc_tbl_builder.h"
+#include "util/timezone_utils.h"
+
+namespace doris {
+
+class HudiReaderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _cache = std::make_unique<FileMetaCache>(1024);
+        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _timezone);
+    }
+
+    const TupleDescriptor* build_tuple_descriptor(
+            ObjectPool& object_pool,
+            const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        DescriptorTblBuilder builder(&object_pool);
+        auto& tuple_builder = builder.declare_tuple();
+        for (const auto& [name, type] : columns) {
+            tuple_builder << std::make_tuple(type, name);
+        }
+        return builder.build()->get_tuple_descriptor(0);
+    }
+
+    std::unordered_map<std::string, uint32_t> build_col_name_to_block_idx(
+            const TupleDescriptor* tuple_descriptor) {
+        std::unordered_map<std::string, uint32_t> mapping;
+        for (size_t i = 0; i < tuple_descriptor->slots().size(); ++i) {
+            mapping.emplace(tuple_descriptor->slots()[i]->col_name(), static_cast<uint32_t>(i));
+        }
+        return mapping;
+    }
+
+    std::vector<ColumnDescriptor> build_column_descs(
+            const TupleDescriptor* tuple_descriptor,
+            const std::vector<ColumnCategory>& categories) {
+        std::vector<ColumnDescriptor> column_descs;
+        column_descs.reserve(tuple_descriptor->slots().size());
+        for (size_t i = 0; i < tuple_descriptor->slots().size(); ++i) {
+            column_descs.push_back({tuple_descriptor->slots()[i]->col_name(),
+                                    tuple_descriptor->slots()[i], categories[i], nullptr});
+        }
+        return column_descs;
+    }
+
+    Block make_block(const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        Block block;
+        for (const auto& [name, type] : columns) {
+            block.insert(ColumnWithTypeAndName(type->create_column(), type, name));
+        }
+        return block;
+    }
+
+    void verify_nullable_string_column_has_rows(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_rows);
+        ASSERT_EQ(nested.size(), expected_rows);
+        if (expected_rows > 0) {
+            EXPECT_FALSE(nullable->is_null_at(0));
+        }
+    }
+
+    void verify_nullable_string_column_values(const Block& block, const std::string& column_name,
+                                              const std::vector<std::string>& expected_values) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_values.size());
+        for (size_t i = 0; i < expected_values.size(); ++i) {
+            ASSERT_FALSE(nullable->is_null_at(i));
+            EXPECT_EQ(nested.get_data_at(i).to_string(), expected_values[i]);
+        }
+    }
+
+    void verify_nullable_string_column_all_null(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        ASSERT_EQ(nullable->size(), expected_rows);
+        for (size_t i = 0; i < expected_rows; ++i) {
+            EXPECT_TRUE(nullable->is_null_at(i));
+        }
+    }
+
+    schema::external::TSchema build_history_schema_with_string_field(int64_t schema_id,
+                                                                     std::string field_name,
+                                                                     int32_t field_id) {
+        schema::external::TSchema schema;
+        schema.__set_schema_id(schema_id);
+
+        TColumnType struct_type;
+        struct_type.type = TPrimitiveType::STRUCT;
+        schema::external::TStructField root_field;
+
+        TColumnType string_type;
+        string_type.type = TPrimitiveType::STRING;
+        auto string_field = std::make_shared<schema::external::TField>();
+        string_field->name = std::move(field_name);
+        string_field->id = field_id;
+        string_field->type = string_type;
+
+        schema::external::TFieldPtr string_ptr;
+        string_ptr.__set_field_ptr(string_field);
+        root_field.fields.emplace_back(string_ptr);
+
+        schema.__set_root_field(root_field);
+        return schema;
+    }
+
+    Status try_read_hudi_parquet_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            return st;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+        if (customize_scan_params != nullptr) {
+            customize_scan_params(&scan_params);
+        }
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+        scan_range.__isset.table_format_params = true;
+
+        RuntimeProfile profile("hudi_parquet_reader_test");
+        auto reader = std::make_unique<HudiParquetReader>(&profile, scan_params, scan_range, 1024,
+                                                          &_timezone, nullptr, &runtime_state,
+                                                          _cache.get());
+        if (reader == nullptr) {
+            return Status::InternalError("failed to create hudi parquet reader");
+        }
+
+        ParquetInitContext pq_ctx;
+        pq_ctx.column_descs = &column_descs;
+        pq_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        pq_ctx.tuple_descriptor = tuple_descriptor;
+        pq_ctx.params = &scan_params;
+        pq_ctx.range = &scan_range;
+        st = reader->init_reader(&pq_ctx);
+        if (!st.ok()) {
+            return st;
+        }
+
+        *block = make_block(block_columns);
+        bool eof = false;
+        st = reader->get_next_block(block, read_rows, &eof);
+        return st;
+    }
+
+    void read_hudi_parquet_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto st = try_read_hudi_parquet_block(
+                actual_file, std::move(scan_range), tuple_descriptor, col_name_to_block_idx,
+                std::move(column_descs), block_columns, read_rows, block, customize_scan_params);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    Status try_read_hudi_orc_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            return st;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_ORC;
+        if (customize_scan_params != nullptr) {
+            customize_scan_params(&scan_params);
+        }
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+        scan_range.__isset.table_format_params = true;
+
+        RuntimeProfile profile("hudi_orc_reader_test");
+        auto reader =
+                std::make_unique<HudiOrcReader>(&profile, &runtime_state, scan_params, scan_range,
+                                                1024, "CST", nullptr, _cache.get());
+        if (reader == nullptr) {
+            return Status::InternalError("failed to create hudi orc reader");
+        }
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_descs = &column_descs;
+        orc_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        orc_ctx.tuple_descriptor = tuple_descriptor;
+        orc_ctx.params = &scan_params;
+        orc_ctx.range = &scan_range;
+        st = reader->init_reader(&orc_ctx);
+        if (!st.ok()) {
+            return st;
+        }
+
+        *block = make_block(block_columns);
+        bool eof = false;
+        st = reader->get_next_block(block, read_rows, &eof);
+        return st;
+    }
+
+    void read_hudi_orc_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto st = try_read_hudi_orc_block(actual_file, std::move(scan_range), tuple_descriptor,
+                                          col_name_to_block_idx, std::move(column_descs),
+                                          block_columns, read_rows, block, customize_scan_params);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    std::unique_ptr<FileMetaCache> _cache;
+    cctz::time_zone _timezone;
+};
+
+TEST_F(HudiReaderTest, read_hudi_parquet_name_column) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_parquet_block(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"name", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(HudiReaderTest, read_hudi_orc_name_column) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_orc_block(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"name", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(HudiReaderTest, fills_partition_column_from_scan_range_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"name", nullable_string}, {"year", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(
+            tuple_descriptor, {ColumnCategory::REGULAR, ColumnCategory::PARTITION_KEY});
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_parquet_block(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_values(block, "year",
+                                         std::vector<std::string>(read_rows, "2024"));
+}
+
+TEST_F(HudiReaderTest, fills_partition_column_from_scan_range_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"name", nullable_string}, {"year", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(
+            tuple_descriptor, {ColumnCategory::REGULAR, ColumnCategory::PARTITION_KEY});
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_orc_block(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_values(block, "year",
+                                         std::vector<std::string>(read_rows, "2024"));
+}
+
+TEST_F(HudiReaderTest, fills_missing_column_with_null_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"name", nullable_string}, {"country", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor,
+                                           {ColumnCategory::REGULAR, ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_parquet_block(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"country", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "country", read_rows);
+}
+
+TEST_F(HudiReaderTest, fills_missing_column_with_null_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"name", nullable_string}, {"country", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor,
+                                           {ColumnCategory::REGULAR, ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_orc_block(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"country", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "country", read_rows);
+}
+
+TEST_F(HudiReaderTest, reads_generated_column_from_file_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::GENERATED});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_parquet_block(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"name", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(HudiReaderTest, reads_generated_column_from_file_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::GENERATED});
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_orc_block(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"name", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(HudiReaderTest, reads_renamed_column_via_history_schema_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"display_name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.hudi_params = true;
+    scan_range.table_format_params.hudi_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_parquet_block(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"display_name", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(1, "name", 2),
+                         build_history_schema_with_string_field(2, "display_name", 2)});
+            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "display_name", read_rows);
+}
+
+TEST_F(HudiReaderTest, reads_renamed_column_via_history_schema_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"display_name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.hudi_params = true;
+    scan_range.table_format_params.hudi_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    read_hudi_orc_block(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"display_name", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(1, "name", 2),
+                         build_history_schema_with_string_field(2, "display_name", 2)});
+            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "display_name", read_rows);
+}
+
+TEST_F(HudiReaderTest, missing_file_history_schema_returns_error_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"display_name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.hudi_params = true;
+    scan_range.table_format_params.hudi_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    auto st = try_read_hudi_parquet_block(
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"display_name", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(2, "display_name", 2)});
+            });
+
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("miss table/file schema info"), std::string::npos);
+}
+
+TEST_F(HudiReaderTest, missing_file_history_schema_returns_error_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"display_name", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.hudi_params = true;
+    scan_range.table_format_params.hudi_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    auto st = try_read_hudi_orc_block(
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"display_name", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(2, "display_name", 2)});
+            });
+
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("miss table/file schema info"), std::string::npos);
+}
+
+} // namespace doris

--- a/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
@@ -19,11 +19,18 @@
 
 #include <gen_cpp/Types_types.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
+#include <zlib.h>
 
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "io/fs/file_meta_cache.h"
+#include "roaring/roaring64map.hh"
 #include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
 
@@ -48,6 +55,51 @@ public:
     std::unordered_map<std::string, std::vector<int64_t>> delete_rows;
     size_t total_rows = 0;
 };
+
+void append_big_endian_u32(std::vector<char>* bytes, uint32_t value) {
+    bytes->push_back(static_cast<char>((value >> 24) & 0xFF));
+    bytes->push_back(static_cast<char>((value >> 16) & 0xFF));
+    bytes->push_back(static_cast<char>((value >> 8) & 0xFF));
+    bytes->push_back(static_cast<char>(value & 0xFF));
+}
+
+std::string write_temp_deletion_vector_file(const std::vector<uint64_t>& rows,
+                                            uint32_t magic_number = 0xD1D33964) {
+    roaring::Roaring64Map bitmap;
+    for (uint64_t row : rows) {
+        bitmap.add(row);
+    }
+
+    const size_t bitmap_size = bitmap.getSizeInBytes(true);
+    std::vector<char> bitmap_bytes(bitmap_size);
+    EXPECT_EQ(bitmap.write(bitmap_bytes.data(), true), bitmap_size);
+
+    std::vector<char> file_bytes;
+    append_big_endian_u32(&file_bytes, static_cast<uint32_t>(bitmap_size + 4));
+    append_big_endian_u32(&file_bytes, magic_number);
+    file_bytes.insert(file_bytes.end(), bitmap_bytes.begin(), bitmap_bytes.end());
+    const uint32_t crc =
+            static_cast<uint32_t>(::crc32(0, reinterpret_cast<const Bytef*>(file_bytes.data() + 4),
+                                          static_cast<uInt>(4 + bitmap_size)));
+    append_big_endian_u32(&file_bytes, crc);
+
+    auto temp_dir = std::filesystem::temp_directory_path();
+    std::string pattern = (temp_dir / "iceberg_deletion_vector_test_XXXXXX").string();
+    std::vector<char> path_buffer(pattern.begin(), pattern.end());
+    path_buffer.push_back('\0');
+    int fd = mkstemp(path_buffer.data());
+    EXPECT_GE(fd, 0);
+    if (fd >= 0) {
+        close(fd);
+    }
+
+    std::string path(path_buffer.data());
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out.write(file_bytes.data(), static_cast<std::streamsize>(file_bytes.size()));
+    out.close();
+    EXPECT_TRUE(out.good());
+    return path;
+}
 
 } // namespace
 
@@ -105,6 +157,101 @@ TEST(IcebergDeleteFileReaderHelperTest, ReadMixedEncodingParquetPositionDeleteFi
     const std::vector<int64_t> expected_positions = {0,  2,  4,  6,  8,  10, 12, 14,
                                                      16, 18, 20, 22, 24, 26, 28, 30};
     EXPECT_EQ(it->second, expected_positions);
+}
+
+TEST(IcebergDeleteFileReaderHelperTest, ReadDeletionVectorFile) {
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+    IcebergDeleteFileIOContext io_context(&runtime_state);
+
+    TFileScanRangeParams scan_params;
+    scan_params.file_type = TFileType::FILE_LOCAL;
+
+    const std::string deletion_vector_path = write_temp_deletion_vector_file({1, 5, 9, 42});
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = deletion_vector_path;
+    delete_file.__set_content(3);
+    delete_file.__set_content_offset(0);
+    delete_file.__set_content_size_in_bytes(
+            static_cast<int64_t>(std::filesystem::file_size(deletion_vector_path)));
+
+    IcebergDeleteFileReaderOptions options;
+    options.state = &runtime_state;
+    options.profile = &profile;
+    options.scan_params = &scan_params;
+    options.io_ctx = &io_context.io_ctx;
+
+    roaring::Roaring64Map rows_to_delete;
+    rows_to_delete.add(static_cast<uint64_t>(100));
+    auto st = read_iceberg_deletion_vector(delete_file, options, &rows_to_delete);
+    ASSERT_TRUE(st.ok()) << st;
+
+    EXPECT_TRUE(rows_to_delete.contains(static_cast<uint64_t>(1)));
+    EXPECT_TRUE(rows_to_delete.contains(static_cast<uint64_t>(5)));
+    EXPECT_TRUE(rows_to_delete.contains(static_cast<uint64_t>(9)));
+    EXPECT_TRUE(rows_to_delete.contains(static_cast<uint64_t>(42)));
+    EXPECT_TRUE(rows_to_delete.contains(static_cast<uint64_t>(100)));
+
+    std::error_code ec;
+    std::filesystem::remove(deletion_vector_path, ec);
+}
+
+TEST(IcebergDeleteFileReaderHelperTest, ReadDeletionVectorRejectsInvalidMagic) {
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+    IcebergDeleteFileIOContext io_context(&runtime_state);
+
+    TFileScanRangeParams scan_params;
+    scan_params.file_type = TFileType::FILE_LOCAL;
+
+    const std::string deletion_vector_path = write_temp_deletion_vector_file({3, 7}, 0x12345678);
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = deletion_vector_path;
+    delete_file.__set_content(3);
+    delete_file.__set_content_offset(0);
+    delete_file.__set_content_size_in_bytes(
+            static_cast<int64_t>(std::filesystem::file_size(deletion_vector_path)));
+
+    IcebergDeleteFileReaderOptions options;
+    options.state = &runtime_state;
+    options.profile = &profile;
+    options.scan_params = &scan_params;
+    options.io_ctx = &io_context.io_ctx;
+
+    roaring::Roaring64Map rows_to_delete;
+    auto st = read_iceberg_deletion_vector(delete_file, options, &rows_to_delete);
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("magic number mismatch"), std::string::npos);
+    EXPECT_TRUE(rows_to_delete.isEmpty());
+
+    std::error_code ec;
+    std::filesystem::remove(deletion_vector_path, ec);
+}
+
+TEST(IcebergDeleteFileReaderHelperTest, ReadDeletionVectorRequiresOffsetAndLength) {
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+    IcebergDeleteFileIOContext io_context(&runtime_state);
+
+    TFileScanRangeParams scan_params;
+    scan_params.file_type = TFileType::FILE_LOCAL;
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = "unused";
+    delete_file.__set_content(3);
+
+    IcebergDeleteFileReaderOptions options;
+    options.state = &runtime_state;
+    options.profile = &profile;
+    options.scan_params = &scan_params;
+    options.io_ctx = &io_context.io_ctx;
+
+    roaring::Roaring64Map rows_to_delete;
+    auto st = read_iceberg_deletion_vector(delete_file, options, &rows_to_delete);
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("missing content offset or length"), std::string::npos);
 }
 
 } // namespace doris

--- a/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
@@ -665,8 +665,8 @@ protected:
             const std::string& test_file) {
         // Open the Iceberg Parquet test file
         auto local_fs = io::global_local_filesystem();
-        io::FileReaderSPtr file_reader;
-        auto st = local_fs->open_file(test_file, &file_reader);
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
         if (!st.ok()) {
             return {nullptr, nullptr};
         }
@@ -680,7 +680,7 @@ protected:
 
         TFileRangeDesc scan_range;
         scan_range.start_offset = 0;
-        scan_range.size = file_reader->size(); // Read entire file
+        scan_range.size = file_size; // Read entire file
         scan_range.path = test_file;
 
         // Create mock profile
@@ -697,9 +697,6 @@ protected:
             return {nullptr, nullptr};
         }
 
-        // Set file reader directly on the iceberg reader (it IS the ParquetReader)
-        iceberg_reader->set_file_reader(file_reader);
-
         const FieldDescriptor* field_desc = nullptr;
         st = iceberg_reader->get_file_metadata_schema(&field_desc);
         if (!st.ok() || !field_desc) {
@@ -712,10 +709,9 @@ protected:
     // Helper function: create and setup OrcReader
     std::tuple<std::unique_ptr<IcebergOrcReader>, const orc::Type*> create_orc_reader(
             const std::string& test_file) {
-        // Open the Iceberg Orc test file
         auto local_fs = io::global_local_filesystem();
-        io::FileReaderSPtr file_reader;
-        auto st = local_fs->open_file(test_file, &file_reader);
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
         if (!st.ok()) {
             return {nullptr, nullptr};
         }
@@ -729,7 +725,7 @@ protected:
 
         TFileRangeDesc scan_range;
         scan_range.start_offset = 0;
-        scan_range.size = file_reader->size(); // Read entire file
+        scan_range.size = file_size; // Read entire file
         scan_range.path = test_file;
 
         // Create mock profile

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -24,18 +24,21 @@
 #include <gen_cpp/Types_types.h>
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "common/config.h"
 #include "common/object_pool.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
 #include "core/column/column_array.h"
 #include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
 #include "core/column/column_struct.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type.h"
@@ -49,6 +52,8 @@
 #include "format/orc/vorc_reader.h"
 #include "format/parquet/vparquet_column_chunk_reader.h"
 #include "format/parquet/vparquet_reader.h"
+#include "format/table/reader_test_util.h"
+#include "gen_cpp/ExternalTableSchema_types.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_system.h"
@@ -56,6 +61,9 @@
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "storage/olap_scan_common.h"
+#include "storage/segment/column_reader.h"
+#include "storage/utils.h"
+#include "util/defer_op.h"
 #include "util/timezone_utils.h"
 
 namespace doris {
@@ -84,10 +92,10 @@ protected:
 
     std::unique_ptr<ParquetReader> create_delete_file_parquet_reader(
             RuntimeProfile* profile, RuntimeState* runtime_state, TFileScanRangeParams* scan_params,
-            TFileRangeDesc* scan_range, io::FileReaderSPtr* file_reader,
-            const tparquet::FileMetaData** file_meta_data) {
+            TFileRangeDesc* scan_range, const tparquet::FileMetaData** file_meta_data) {
         auto local_fs = io::global_local_filesystem();
-        auto st = local_fs->open_file(mixed_position_delete_file(), file_reader);
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(mixed_position_delete_file(), &file_size);
         EXPECT_TRUE(st.ok()) << st;
         if (!st.ok()) {
             return nullptr;
@@ -96,7 +104,7 @@ protected:
         scan_params->format_type = TFileFormatType::FORMAT_PARQUET;
 
         scan_range->start_offset = 0;
-        scan_range->size = (*file_reader)->size();
+        scan_range->size = file_size;
         scan_range->path = mixed_position_delete_file();
 
         auto parquet_reader =
@@ -106,8 +114,6 @@ protected:
         if (parquet_reader == nullptr) {
             return nullptr;
         }
-
-        parquet_reader->set_file_reader(*file_reader);
 
         ParquetInitContext pq_ctx;
         pq_ctx.column_names = delete_file_column_names;
@@ -134,68 +140,10 @@ protected:
                                      DataTypePtr& hobby_element_struct_type,
                                      DataTypePtr& hobbies_array_type,
                                      DataTypePtr& profile_struct_type, DataTypePtr& name_type) {
-        // Create name column type (direct field)
-        name_type = make_nullable(std::make_shared<DataTypeString>());
-
-        // First create coordinates struct type
-        std::vector<DataTypePtr> coordinates_types = {
-                make_nullable(std::make_shared<DataTypeFloat64>()), // lat (field ID 10)
-                make_nullable(std::make_shared<DataTypeFloat64>())  // lng (field ID 11)
-        };
-        std::vector<std::string> coordinates_names = {"lat", "lng"};
-        coordinates_struct_type = make_nullable(
-                std::make_shared<DataTypeStruct>(coordinates_types, coordinates_names));
-
-        // Create address struct type (with street, city, coordinates)
-        std::vector<DataTypePtr> address_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // street (field ID 7)
-                make_nullable(std::make_shared<DataTypeString>()), // city (field ID 8)
-                coordinates_struct_type                            // coordinates (field ID 9)
-        };
-        std::vector<std::string> address_names = {"street", "city", "coordinates"};
-        address_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(address_types, address_names));
-
-        // Create phone struct type
-        std::vector<DataTypePtr> phone_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // country_code (field ID 14)
-                make_nullable(std::make_shared<DataTypeString>())  // number (field ID 15)
-        };
-        std::vector<std::string> phone_names = {"country_code", "number"};
-        phone_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(phone_types, phone_names));
-
-        // Create contact struct type (with email, phone)
-        std::vector<DataTypePtr> contact_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // email (field ID 12)
-                phone_struct_type                                  // phone (field ID 13)
-        };
-        std::vector<std::string> contact_names = {"email", "phone"};
-        contact_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(contact_types, contact_names));
-
-        // Create hobby element struct type for array elements
-        std::vector<DataTypePtr> hobby_element_types = {
-                make_nullable(std::make_shared<DataTypeString>()), // name (field ID 17)
-                make_nullable(std::make_shared<DataTypeInt32>())   // level (field ID 18)
-        };
-        std::vector<std::string> hobby_element_names = {"name", "level"};
-        hobby_element_struct_type = make_nullable(
-                std::make_shared<DataTypeStruct>(hobby_element_types, hobby_element_names));
-
-        // Create hobbies array type
-        hobbies_array_type =
-                make_nullable(std::make_shared<DataTypeArray>(hobby_element_struct_type));
-
-        // Create complete profile struct type (with address, contact, hobbies)
-        std::vector<DataTypePtr> profile_types = {
-                address_struct_type, // address (field ID 4)
-                contact_struct_type, // contact (field ID 5)
-                hobbies_array_type   // hobbies (field ID 6)
-        };
-        std::vector<std::string> profile_names = {"address", "contact", "hobbies"};
-        profile_struct_type =
-                make_nullable(std::make_shared<DataTypeStruct>(profile_types, profile_names));
+        reader_test::create_complex_user_profile_types(
+                coordinates_struct_type, address_struct_type, phone_struct_type,
+                contact_struct_type, hobby_element_struct_type, hobbies_array_type,
+                profile_struct_type, name_type);
     }
 
     // Helper function to create tuple descriptor
@@ -439,83 +387,482 @@ protected:
         return (*desc_tbl)->get_tuple_descriptor(0);
     }
 
+    const TupleDescriptor* create_simple_tuple_descriptor(
+            DescriptorTbl** desc_tbl, ObjectPool& obj_pool, TDescriptorTable& t_desc_table,
+            TTableDescriptor& t_table_desc, const std::vector<std::string>& column_names,
+            const std::vector<int32_t>& column_unique_ids,
+            const std::vector<TPrimitiveType::type>& column_types) {
+        t_table_desc.__set_id(0);
+        t_table_desc.__set_tableType(TTableType::OLAP_TABLE);
+        t_table_desc.__set_numCols(0);
+        t_table_desc.__set_numClusteringCols(0);
+        t_desc_table.tableDescriptors.push_back(t_table_desc);
+        t_desc_table.__isset.tableDescriptors = true;
+
+        for (size_t i = 0; i < column_names.size(); ++i) {
+            TSlotDescriptor tslot_desc;
+            tslot_desc.__set_id(static_cast<int>(i));
+            tslot_desc.__set_parent(0);
+            tslot_desc.__set_col_unique_id(column_unique_ids[i]);
+
+            TTypeDesc type;
+            if (column_types[i] == TPrimitiveType::STRUCT &&
+                column_names[i] == BeConsts::ICEBERG_ROWID_COL) {
+                TTypeNode struct_node;
+                struct_node.__set_type(TTypeNodeType::STRUCT);
+                std::vector<TStructField> struct_fields;
+                TStructField file_path_field;
+                file_path_field.__set_name("file_path");
+                file_path_field.__set_contains_null(false);
+                struct_fields.push_back(file_path_field);
+                TStructField pos_field;
+                pos_field.__set_name("pos");
+                pos_field.__set_contains_null(false);
+                struct_fields.push_back(pos_field);
+                TStructField partition_spec_id_field;
+                partition_spec_id_field.__set_name("partition_spec_id");
+                partition_spec_id_field.__set_contains_null(false);
+                struct_fields.push_back(partition_spec_id_field);
+                TStructField partition_data_field;
+                partition_data_field.__set_name("partition_data");
+                partition_data_field.__set_contains_null(false);
+                struct_fields.push_back(partition_data_field);
+                struct_node.__set_struct_fields(struct_fields);
+                type.types.push_back(struct_node);
+
+                TTypeNode file_path_node;
+                file_path_node.__set_type(TTypeNodeType::SCALAR);
+                TScalarType file_path_scalar_type;
+                file_path_scalar_type.__set_type(TPrimitiveType::STRING);
+                file_path_node.__set_scalar_type(file_path_scalar_type);
+                type.types.push_back(file_path_node);
+
+                TTypeNode pos_node;
+                pos_node.__set_type(TTypeNodeType::SCALAR);
+                TScalarType pos_scalar_type;
+                pos_scalar_type.__set_type(TPrimitiveType::BIGINT);
+                pos_node.__set_scalar_type(pos_scalar_type);
+                type.types.push_back(pos_node);
+
+                TTypeNode partition_spec_id_node;
+                partition_spec_id_node.__set_type(TTypeNodeType::SCALAR);
+                TScalarType partition_spec_id_scalar_type;
+                partition_spec_id_scalar_type.__set_type(TPrimitiveType::INT);
+                partition_spec_id_node.__set_scalar_type(partition_spec_id_scalar_type);
+                type.types.push_back(partition_spec_id_node);
+
+                TTypeNode partition_data_node;
+                partition_data_node.__set_type(TTypeNodeType::SCALAR);
+                TScalarType partition_data_scalar_type;
+                partition_data_scalar_type.__set_type(TPrimitiveType::STRING);
+                partition_data_node.__set_scalar_type(partition_data_scalar_type);
+                type.types.push_back(partition_data_node);
+            } else {
+                TTypeNode node;
+                node.__set_type(TTypeNodeType::SCALAR);
+                TScalarType scalar_type;
+                scalar_type.__set_type(column_types[i]);
+                node.__set_scalar_type(scalar_type);
+                type.types.push_back(node);
+            }
+            tslot_desc.__set_slotType(type);
+
+            tslot_desc.__set_columnPos(0);
+            tslot_desc.__set_byteOffset(0);
+            tslot_desc.__set_nullIndicatorByte(0);
+            tslot_desc.__set_nullIndicatorBit(-1);
+            tslot_desc.__set_colName(column_names[i]);
+            tslot_desc.__set_slotIdx(0);
+            tslot_desc.__set_isMaterialized(true);
+            t_desc_table.slotDescriptors.push_back(tslot_desc);
+        }
+        t_desc_table.__isset.slotDescriptors = true;
+
+        TTupleDescriptor t_tuple_desc;
+        t_tuple_desc.__set_id(0);
+        t_tuple_desc.__set_byteSize(16);
+        t_tuple_desc.__set_numNullBytes(0);
+        t_tuple_desc.__set_tableId(0);
+        t_tuple_desc.__isset.tableId = true;
+        t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
+
+        EXPECT_TRUE(DescriptorTbl::create(&obj_pool, t_desc_table, desc_tbl).ok());
+        return (*desc_tbl)->get_tuple_descriptor(0);
+    }
+
     // Helper function to verify test results
     void verify_test_results(Block& block, size_t read_rows) {
-        // Verify that we read some data
-        EXPECT_GT(read_rows, 0) << "Should read at least one row";
-        EXPECT_EQ(block.rows(), read_rows);
+        reader_test::verify_nested_reader_block(block, read_rows);
+    }
 
-        // Verify column count matches expected (2 columns: name, profile)
-        EXPECT_EQ(block.columns(), 2);
+    Block make_scalar_block(const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        Block block;
+        for (const auto& [name, type] : columns) {
+            block.insert(ColumnWithTypeAndName(type->create_column(), type, name));
+        }
+        return block;
+    }
 
-        // Verify column names and types
-        auto columns_with_names = block.get_columns_with_type_and_name();
-        std::vector<std::string> expected_column_names = {"name", "profile"};
-        for (size_t i = 0; i < expected_column_names.size(); i++) {
-            EXPECT_EQ(columns_with_names[i].name, expected_column_names[i]);
+    void verify_nullable_string_column_values(const Block& block, const std::string& column_name,
+                                              const std::vector<std::string>& expected_values) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_values.size());
+        for (size_t i = 0; i < expected_values.size(); ++i) {
+            ASSERT_FALSE(nullable->is_null_at(i));
+            EXPECT_EQ(nested.get_data_at(i).to_string(), expected_values[i]);
+        }
+    }
+
+    void verify_nullable_string_column_has_rows(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_rows);
+        ASSERT_EQ(nested.size(), expected_rows);
+        if (expected_rows > 0) {
+            EXPECT_FALSE(nullable->is_null_at(0));
+        }
+    }
+
+    void verify_nullable_string_column_all_null(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        ASSERT_EQ(nullable->size(), expected_rows);
+        for (size_t i = 0; i < expected_rows; ++i) {
+            EXPECT_TRUE(nullable->is_null_at(i));
+        }
+    }
+
+    void verify_nullable_int64_column_sequence(const Block& block, const std::string& column_name,
+                                               int64_t start_value) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnInt64&>(nullable->get_nested_column());
+        for (size_t i = 0; i < nullable->size(); ++i) {
+            ASSERT_FALSE(nullable->is_null_at(i));
+            EXPECT_EQ(nested.get_element(i), start_value + static_cast<int64_t>(i));
+        }
+    }
+
+    void verify_nullable_int64_column_constant(const Block& block, const std::string& column_name,
+                                               int64_t expected_value) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnInt64&>(nullable->get_nested_column());
+        for (size_t i = 0; i < nullable->size(); ++i) {
+            ASSERT_FALSE(nullable->is_null_at(i));
+            EXPECT_EQ(nested.get_element(i), expected_value);
+        }
+    }
+
+    void verify_iceberg_rowid_column(const Block& block, const std::string& column_name,
+                                     const std::string& expected_file_path,
+                                     int32_t expected_partition_spec_id,
+                                     const std::string& expected_partition_data_json) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* struct_column = check_and_get_column<ColumnStruct>(column.column.get());
+        ASSERT_NE(struct_column, nullptr);
+        ASSERT_EQ(struct_column->tuple_size(), 4);
+
+        const auto& file_path_column =
+                assert_cast<const ColumnString&>(struct_column->get_column(0));
+        const auto& row_pos_column = assert_cast<const ColumnInt64&>(struct_column->get_column(1));
+        const auto& spec_id_column = assert_cast<const ColumnInt32&>(struct_column->get_column(2));
+        const auto& partition_data_column =
+                assert_cast<const ColumnString&>(struct_column->get_column(3));
+
+        for (size_t i = 0; i < struct_column->size(); ++i) {
+            EXPECT_EQ(file_path_column.get_data_at(i).to_string(), expected_file_path);
+            EXPECT_EQ(row_pos_column.get_element(i), static_cast<int64_t>(i));
+            EXPECT_EQ(spec_id_column.get_element(i), expected_partition_spec_id);
+            EXPECT_EQ(partition_data_column.get_data_at(i).to_string(),
+                      expected_partition_data_json);
+        }
+    }
+
+    void verify_global_rowid_column(const Block& block, const std::string& column_name,
+                                    uint8_t expected_version, int64_t expected_backend_id,
+                                    uint32_t expected_file_id) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        const auto& string_column = assert_cast<const ColumnString&>(*column.column);
+        for (size_t i = 0; i < string_column.size(); ++i) {
+            ASSERT_EQ(string_column.get_data_at(i).size, sizeof(GlobalRowLoacationV2));
+            auto location = *reinterpret_cast<const GlobalRowLoacationV2*>(
+                    string_column.get_data_at(i).data);
+            EXPECT_EQ(location.version, expected_version);
+            EXPECT_EQ(location.backend_id, expected_backend_id);
+            EXPECT_EQ(location.file_id, expected_file_id);
+            EXPECT_EQ(location.row_id, static_cast<uint32_t>(i));
+        }
+    }
+
+    doris::schema::external::TSchema build_history_schema_with_name_field(int32_t field_id) {
+        doris::schema::external::TSchema schema;
+        schema.__set_schema_id(1);
+
+        TColumnType struct_type;
+        struct_type.type = TPrimitiveType::STRUCT;
+        doris::schema::external::TStructField root_field;
+
+        TColumnType string_type;
+        string_type.type = TPrimitiveType::STRING;
+        auto name_field = std::make_shared<doris::schema::external::TField>();
+        name_field->name = "name";
+        name_field->id = field_id;
+        name_field->type = string_type;
+
+        doris::schema::external::TFieldPtr name_ptr;
+        name_ptr.__set_field_ptr(name_field);
+        root_field.fields.emplace_back(name_ptr);
+
+        schema.__set_root_field(root_field);
+        return schema;
+    }
+
+    void read_iceberg_parquet_scalar_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const TFileScanRangeParams* custom_scan_params = nullptr,
+            const std::function<void(IcebergParquetReader*)>& customize_reader = nullptr) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << actual_file;
+            return;
         }
 
-        // Verify column types
-        EXPECT_TRUE(columns_with_names[0].type->get_name().find("String") !=
-                    std::string::npos); // name is STRING
-        EXPECT_TRUE(columns_with_names[1].type->get_name().find("Struct") !=
-                    std::string::npos); // profile is STRUCT
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params =
+                custom_scan_params ? *custom_scan_params : TFileScanRangeParams {};
+        scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
 
-        // Print row count for each column and nested subcolumns
-        std::cout << "Block rows: " << block.rows() << std::endl;
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
 
-        // Helper function to recursively print column row counts and check size > 0
-        std::function<void(const ColumnPtr&, const DataTypePtr&, const std::string&, int)>
-                print_column_rows = [&](const ColumnPtr& col, const DataTypePtr& type,
-                                        const std::string& name, int depth) {
-                    std::string indent(depth * 2, ' ');
-                    std::cout << indent << name << " row count: " << col->size() << std::endl;
-                    EXPECT_GT(col->size(), 0) << name << " column/subcolumn size should be > 0";
-
-                    // Check if it's a nullable column
-                    if (const auto* nullable_col = typeid_cast<const ColumnNullable*>(col.get())) {
-                        auto nested_type =
-                                assert_cast<const DataTypeNullable*>(type.get())->get_nested_type();
-
-                        // Only add ".nested" suffix for non-leaf (complex) nullable columns
-                        // Leaf columns like String, Int, etc. should not get the ".nested" suffix
-                        bool is_complex_type =
-                                (typeid_cast<const DataTypeStruct*>(nested_type.get()) !=
-                                 nullptr) ||
-                                (typeid_cast<const DataTypeArray*>(nested_type.get()) != nullptr) ||
-                                (typeid_cast<const DataTypeMap*>(nested_type.get()) != nullptr);
-
-                        std::string nested_name = is_complex_type ? name + ".nested" : name;
-                        print_column_rows(nullable_col->get_nested_column_ptr(), nested_type,
-                                          nested_name, depth + (is_complex_type ? 1 : 0));
-                    }
-                    // Check if it's a struct column
-                    else if (const auto* struct_col = typeid_cast<const ColumnStruct*>(col.get())) {
-                        auto struct_type = assert_cast<const DataTypeStruct*>(type.get());
-                        for (size_t i = 0; i < struct_col->tuple_size(); ++i) {
-                            std::string field_name = struct_type->get_element_name(i);
-                            auto field_type = struct_type->get_element(i);
-                            print_column_rows(struct_col->get_column_ptr(i), field_type,
-                                              name + "." + field_name, depth + 1);
-                        }
-                    }
-                    // Check if it's an array column
-                    else if (const auto* array_col = typeid_cast<const ColumnArray*>(col.get())) {
-                        auto array_type = assert_cast<const DataTypeArray*>(type.get());
-                        auto element_type = array_type->get_nested_type();
-                        print_column_rows(array_col->get_data_ptr(), element_type, name + ".data",
-                                          depth + 1);
-                    }
-                };
-
-        // Print row counts for all columns
-        for (size_t i = 0; i < block.columns(); ++i) {
-            const auto& column_with_name = block.get_by_position(i);
-            print_column_rows(column_with_name.column, column_with_name.type, column_with_name.name,
-                              0);
-            EXPECT_EQ(column_with_name.column->size(), block.rows())
-                    << "Column " << column_with_name.name << " size mismatch";
+        RuntimeProfile profile("test_profile");
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        auto iceberg_reader = std::make_unique<IcebergParquetReader>(
+                nullptr, &profile, scan_params, scan_range, 1024, &ctz, nullptr, &runtime_state,
+                cache.get());
+        ASSERT_NE(iceberg_reader, nullptr);
+        if (customize_reader) {
+            customize_reader(iceberg_reader.get());
         }
+
+        ParquetInitContext pq_ctx;
+        pq_ctx.column_descs = &column_descs;
+        pq_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        pq_ctx.tuple_descriptor = tuple_descriptor;
+        pq_ctx.params = &scan_params;
+        pq_ctx.range = &scan_range;
+        st = iceberg_reader->init_reader(&pq_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        *block = make_scalar_block(block_columns);
+        bool eof = false;
+        st = iceberg_reader->get_next_block(block, read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    void read_iceberg_orc_scalar_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const TFileScanRangeParams* custom_scan_params = nullptr,
+            const std::function<void(IcebergOrcReader*)>& customize_reader = nullptr) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << actual_file;
+            return;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params =
+                custom_scan_params ? *custom_scan_params : TFileScanRangeParams {};
+        scan_params.format_type = TFileFormatType::FORMAT_ORC;
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+
+        RuntimeProfile profile("test_profile");
+        auto iceberg_reader =
+                std::make_unique<IcebergOrcReader>(nullptr, &profile, &runtime_state, scan_params,
+                                                   scan_range, 1024, "CST", nullptr, cache.get());
+        ASSERT_NE(iceberg_reader, nullptr);
+        if (customize_reader) {
+            customize_reader(iceberg_reader.get());
+        }
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_descs = &column_descs;
+        orc_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        orc_ctx.tuple_descriptor = tuple_descriptor;
+        orc_ctx.row_descriptor = nullptr;
+        orc_ctx.params = &scan_params;
+        orc_ctx.range = &scan_range;
+        st = iceberg_reader->init_reader(&orc_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        *block = make_scalar_block(block_columns);
+        bool eof = false;
+        st = iceberg_reader->get_next_block(block, read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    void read_iceberg_parquet_test_file(const std::string& test_file) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << test_file;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+
+        TFileRangeDesc scan_range;
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = test_file;
+
+        RuntimeProfile profile("test_profile");
+
+        cctz::time_zone ctz;
+        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        auto iceberg_reader = std::make_unique<IcebergParquetReader>(
+                nullptr, &profile, scan_params, scan_range, 1024, &ctz, nullptr, &runtime_state,
+                cache.get());
+        ASSERT_NE(iceberg_reader, nullptr);
+
+        DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
+        DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
+        DataTypePtr profile_struct_type, name_type;
+        create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
+                                    contact_struct_type, hobby_element_struct_type,
+                                    hobbies_array_type, profile_struct_type, name_type);
+
+        DescriptorTbl* desc_tbl;
+        ObjectPool obj_pool;
+        TDescriptorTable t_desc_table;
+        TTableDescriptor t_table_desc;
+        const TupleDescriptor* tuple_descriptor =
+                create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc);
+
+        std::vector<std::string> table_col_names = {"name", "profile"};
+        std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                           {"profile", 1}};
+        std::vector<ColumnDescriptor> column_descs;
+        for (const auto& name : table_col_names) {
+            ColumnDescriptor desc;
+            desc.name = name;
+            column_descs.push_back(desc);
+        }
+
+        ParquetInitContext pq_ctx;
+        pq_ctx.column_descs = &column_descs;
+        pq_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+        pq_ctx.tuple_descriptor = tuple_descriptor;
+        pq_ctx.params = &scan_params;
+        pq_ctx.range = &scan_range;
+        st = iceberg_reader->init_reader(&pq_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        Block block = reader_test::make_name_profile_block(name_type, profile_struct_type);
+        size_t read_rows = 0;
+        bool eof = false;
+        st = iceberg_reader->get_next_block(&block, &read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+        verify_test_results(block, read_rows);
+    }
+
+    void read_iceberg_orc_test_file(const std::string& test_file) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(test_file, &file_size);
+        if (!st.ok()) {
+            GTEST_SKIP() << "Test file not found: " << test_file;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        TFileScanRangeParams scan_params;
+        scan_params.format_type = TFileFormatType::FORMAT_ORC;
+
+        TFileRangeDesc scan_range;
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = test_file;
+
+        RuntimeProfile profile("test_profile");
+        auto iceberg_reader =
+                std::make_unique<IcebergOrcReader>(nullptr, &profile, &runtime_state, scan_params,
+                                                   scan_range, 1024, "CST", nullptr, cache.get());
+        ASSERT_NE(iceberg_reader, nullptr);
+
+        DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
+        DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
+        DataTypePtr profile_struct_type, name_type;
+        create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
+                                    contact_struct_type, hobby_element_struct_type,
+                                    hobbies_array_type, profile_struct_type, name_type);
+
+        DescriptorTbl* desc_tbl;
+        ObjectPool obj_pool;
+        TDescriptorTable t_desc_table;
+        TTableDescriptor t_table_desc;
+        const TupleDescriptor* tuple_descriptor =
+                create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc);
+
+        std::vector<std::string> table_col_names = {"name", "profile"};
+        std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                           {"profile", 1}};
+        std::vector<ColumnDescriptor> column_descs;
+        for (const auto& name : table_col_names) {
+            ColumnDescriptor desc;
+            desc.name = name;
+            column_descs.push_back(desc);
+        }
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_descs = &column_descs;
+        orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+        orc_ctx.tuple_descriptor = tuple_descriptor;
+        orc_ctx.row_descriptor = nullptr;
+        orc_ctx.params = &scan_params;
+        orc_ctx.range = &scan_range;
+        st = iceberg_reader->init_reader(&orc_ctx);
+        ASSERT_TRUE(st.ok()) << st;
+
+        Block block = reader_test::make_name_profile_block(name_type, profile_struct_type);
+        size_t read_rows = 0;
+        bool eof = false;
+        st = iceberg_reader->get_next_block(&block, &read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st;
+        verify_test_results(block, read_rows);
     }
 
     std::unique_ptr<doris::FileMetaCache> cache;
@@ -612,10 +959,9 @@ TEST_F(IcebergReaderTest, generated_position_delete_file_is_mixed_encoded) {
     RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
     TFileScanRangeParams scan_params;
     TFileRangeDesc scan_range;
-    io::FileReaderSPtr file_reader;
     const tparquet::FileMetaData* file_meta_data = nullptr;
-    auto parquet_reader = create_delete_file_parquet_reader(
-            &profile, &runtime_state, &scan_params, &scan_range, &file_reader, &file_meta_data);
+    auto parquet_reader = create_delete_file_parquet_reader(&profile, &runtime_state, &scan_params,
+                                                            &scan_range, &file_meta_data);
     ASSERT_NE(parquet_reader, nullptr);
     ASSERT_NE(file_meta_data, nullptr);
     ASSERT_EQ(file_meta_data->row_groups.size(), 1);
@@ -638,110 +984,665 @@ TEST_F(IcebergReaderTest, generated_position_delete_file_is_mixed_encoded) {
     EXPECT_TRUE(has_dictionary_encoding);
 }
 
-// Test reading real Iceberg Parquet file using IcebergTableReader
 TEST_F(IcebergReaderTest, read_iceberg_parquet_file) {
-    // Read only: name, profile.address.coordinates.lat, profile.address.coordinates.lng, profile.contact.email
-    // Setup table descriptor for test columns with new schema:
-    /**
-    Schema:
-    message table {
-    required int64 id = 1;
-    required binary name (STRING) = 2;
-    required group profile = 3 {
-        optional group address = 4 {
-        optional binary street (STRING) = 7;
-        optional binary city (STRING) = 8;
-        optional group coordinates = 9 {
-            optional double lat = 10;
-            optional double lng = 11;
-        }
-        }
-        optional group contact = 5 {
-        optional binary email (STRING) = 12;
-        optional group phone = 13 {
-            optional binary country_code (STRING) = 14;
-            optional binary number (STRING) = 15;
-        }
-        }
-        optional group hobbies (LIST) = 6 {
-        repeated group list {
-            optional group element = 16 {
-            optional binary name (STRING) = 17;
-            optional int32 level = 18;
-            }
-        }
-        }
-    }
-    }
-    */
-
-    // Open the Iceberg Parquet test file
-    auto local_fs = io::global_local_filesystem();
-    io::FileReaderSPtr file_reader;
-    std::string test_file =
+    read_iceberg_parquet_test_file(
             "./be/test/exec/test_data/complex_user_profiles_iceberg_parquet/data/"
-            "00000-0-a0022aad-d3b6-4e73-b181-f0a09aac7034-0-00001.parquet";
-    auto st = local_fs->open_file(test_file, &file_reader);
+            "00000-0-a0022aad-d3b6-4e73-b181-f0a09aac7034-0-00001.parquet");
+}
+
+TEST_F(IcebergReaderTest, read_iceberg_orc_file) {
+    read_iceberg_orc_test_file(
+            "./be/test/exec/test_data/complex_user_profiles_iceberg_orc/data/"
+            "00000-0-e4897963-0081-4127-bebe-35dc7dc1edeb-0-00001.orc");
+}
+
+TEST_F(IcebergReaderTest, read_nested_iceberg_parquet_file) {
+    read_iceberg_parquet_test_file(
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet");
+}
+
+TEST_F(IcebergReaderTest, read_nested_iceberg_orc_file) {
+    read_iceberg_orc_test_file(
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_orc/data/"
+            "00000-8-5a144c37-16a4-47c6-96db-0007175b5c90-0-00001.orc");
+}
+
+TEST_F(IcebergReaderTest, fills_partition_column_from_scan_range_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "year"};
+    std::vector<int32_t> table_column_unique_ids = {2, 100};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"year", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"year", tuple_descriptor->slots()[1], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet";
+    scan_range.__isset.table_format_params = true;
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_parquet_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_values(block, "year",
+                                         std::vector<std::string>(read_rows, "2024"));
+}
+
+TEST_F(IcebergReaderTest, history_schema_without_field_ids_falls_back_to_name_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name"};
+    std::vector<int32_t> table_column_unique_ids = {2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_parquet/"
+            "part-00000-64a7a390-1a03-4efc-ab51-557e9369a1f9-c000.snappy.parquet";
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_current_schema_id(1);
+    scan_params.__set_history_schema_info({build_history_schema_with_name_field(2)});
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_parquet_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}}, &read_rows, &block, &scan_params);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(IcebergReaderTest, disabled_partition_fallback_keeps_missing_partition_null_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "year"};
+    std::vector<int32_t> table_column_unique_ids = {2, 100};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"year", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"year", tuple_descriptor->slots()[1], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet";
+    scan_range.__isset.table_format_params = true;
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    auto old_value = config::enable_iceberg_partition_column_fallback;
+    Defer restore_fallback =
+            Defer([&]() { config::enable_iceberg_partition_column_fallback = old_value; });
+    config::enable_iceberg_partition_column_fallback = false;
+    read_iceberg_parquet_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "year", read_rows);
+}
+
+TEST_F(IcebergReaderTest, fills_iceberg_rowid_synthesized_column_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {BeConsts::ICEBERG_ROWID_COL};
+    std::vector<int32_t> table_column_unique_ids = {200};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRUCT};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
+            {BeConsts::ICEBERG_ROWID_COL, 0}};
+    std::vector<ColumnDescriptor> column_descs = {{BeConsts::ICEBERG_ROWID_COL,
+                                                   tuple_descriptor->slots()[0],
+                                                   ColumnCategory::SYNTHESIZED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet";
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.table_format_type = "iceberg";
+    scan_range.table_format_params.iceberg_params.__set_original_file_path(scan_range.path);
+    scan_range.table_format_params.iceberg_params.__set_partition_spec_id(7);
+    scan_range.table_format_params.iceberg_params.__set_partition_data_json("{\"year\":2024}");
+
+    auto rowid_struct_type = std::make_shared<DataTypeStruct>(
+            DataTypes {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt64>(),
+                       std::make_shared<DataTypeInt32>(), std::make_shared<DataTypeString>()},
+            Strings {"file_path", "pos", "partition_spec_id", "partition_data"});
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_parquet_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{BeConsts::ICEBERG_ROWID_COL, rowid_struct_type}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_iceberg_rowid_column(block, BeConsts::ICEBERG_ROWID_COL, scan_range.path, 7,
+                                "{\"year\":2024}");
+}
+
+TEST_F(IcebergReaderTest, fills_global_rowid_synthesized_column_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::string global_rowid_col_name = BeConsts::GLOBAL_ROWID_COL + "test";
+    std::vector<std::string> table_column_names = {global_rowid_col_name};
+    std::vector<int32_t> table_column_unique_ids = {201};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{global_rowid_col_name, 0}};
+    std::vector<ColumnDescriptor> column_descs = {{global_rowid_col_name,
+                                                   tuple_descriptor->slots()[0],
+                                                   ColumnCategory::SYNTHESIZED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet";
+
+    auto global_rowid_type = std::make_shared<DataTypeString>();
+    size_t read_rows = 0;
+    Block block;
+    constexpr uint8_t kVersion = 1;
+    constexpr int64_t kBackendId = 10086;
+    constexpr uint32_t kFileId = 7;
+    read_iceberg_parquet_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{global_rowid_col_name, global_rowid_type}}, &read_rows, &block, nullptr,
+            [&](IcebergParquetReader* reader) {
+                reader->set_create_row_id_column_iterator_func([&]() {
+                    return std::make_shared<segment_v2::RowIdColumnIteratorV2>(kVersion, kBackendId,
+                                                                               kFileId);
+                });
+            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_global_rowid_column(block, global_rowid_col_name, kVersion, kBackendId, kFileId);
+}
+
+TEST_F(IcebergReaderTest, reads_generated_column_from_file_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name"};
+    std::vector<int32_t> table_column_unique_ids = {2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::GENERATED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_parquet_scalar_block(scan_range.path, scan_range, tuple_descriptor,
+                                      col_name_to_block_idx, column_descs,
+                                      {{"name", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(IcebergReaderTest, fills_partition_column_from_scan_range_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "year"};
+    std::vector<int32_t> table_column_unique_ids = {2, 100};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"year", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"year", tuple_descriptor->slots()[1], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_orc/data/"
+            "00000-8-5a144c37-16a4-47c6-96db-0007175b5c90-0-00001.orc";
+    scan_range.__isset.table_format_params = true;
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_orc_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_values(block, "year",
+                                         std::vector<std::string>(read_rows, "2024"));
+}
+
+TEST_F(IcebergReaderTest, history_schema_without_field_ids_falls_back_to_name_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name"};
+    std::vector<int32_t> table_column_unique_ids = {2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_orc/"
+            "part-00000-62614f23-05d1-4043-a533-b155ef52b720-c000.snappy.orc";
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_current_schema_id(1);
+    scan_params.__set_history_schema_info({build_history_schema_with_name_field(2)});
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_orc_scalar_block(scan_range.path, scan_range, tuple_descriptor,
+                                  col_name_to_block_idx, column_descs, {{"name", nullable_string}},
+                                  &read_rows, &block, &scan_params);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(IcebergReaderTest, disabled_partition_fallback_keeps_missing_partition_null_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "year"};
+    std::vector<int32_t> table_column_unique_ids = {2, 100};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"year", 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"year", tuple_descriptor->slots()[1], ColumnCategory::REGULAR, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_orc/data/"
+            "00000-8-5a144c37-16a4-47c6-96db-0007175b5c90-0-00001.orc";
+    scan_range.__isset.table_format_params = true;
+    scan_range.__set_columns_from_path_keys({"year"});
+    scan_range.__set_columns_from_path({"2024"});
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    auto old_value = config::enable_iceberg_partition_column_fallback;
+    Defer restore_fallback =
+            Defer([&]() { config::enable_iceberg_partition_column_fallback = old_value; });
+    config::enable_iceberg_partition_column_fallback = false;
+    read_iceberg_orc_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {"year", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "year", read_rows);
+}
+
+TEST_F(IcebergReaderTest, fills_iceberg_rowid_synthesized_column_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", BeConsts::ICEBERG_ROWID_COL};
+    std::vector<int32_t> table_column_unique_ids = {2, 200};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRUCT};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
+            {"name", 0}, {BeConsts::ICEBERG_ROWID_COL, 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {BeConsts::ICEBERG_ROWID_COL, tuple_descriptor->slots()[1], ColumnCategory::SYNTHESIZED,
+             nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_orc/data/"
+            "00000-8-5a144c37-16a4-47c6-96db-0007175b5c90-0-00001.orc";
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.table_format_type = "iceberg";
+    scan_range.table_format_params.iceberg_params.__set_original_file_path(scan_range.path);
+    scan_range.table_format_params.iceberg_params.__set_partition_spec_id(8);
+    scan_range.table_format_params.iceberg_params.__set_partition_data_json("{\"year\":2024}");
+
+    auto rowid_struct_type = std::make_shared<DataTypeStruct>(
+            DataTypes {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt64>(),
+                       std::make_shared<DataTypeInt32>(), std::make_shared<DataTypeString>()},
+            Strings {"file_path", "pos", "partition_spec_id", "partition_data"});
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_orc_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {BeConsts::ICEBERG_ROWID_COL, rowid_struct_type}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_iceberg_rowid_column(block, BeConsts::ICEBERG_ROWID_COL, scan_range.path, 8,
+                                "{\"year\":2024}");
+}
+
+TEST_F(IcebergReaderTest, fills_global_rowid_synthesized_column_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::string global_rowid_col_name = BeConsts::GLOBAL_ROWID_COL + "test";
+    std::vector<std::string> table_column_names = {"name", global_rowid_col_name};
+    std::vector<int32_t> table_column_unique_ids = {2, 201};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING,
+                                                            TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                       {global_rowid_col_name, 1}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {global_rowid_col_name, tuple_descriptor->slots()[1], ColumnCategory::SYNTHESIZED,
+             nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_orc/data/"
+            "00000-8-5a144c37-16a4-47c6-96db-0007175b5c90-0-00001.orc";
+
+    auto global_rowid_type = std::make_shared<DataTypeString>();
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    constexpr uint8_t kVersion = 1;
+    constexpr int64_t kBackendId = 10010;
+    constexpr uint32_t kFileId = 11;
+    read_iceberg_orc_scalar_block(
+            scan_range.path, scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"name", nullable_string}, {global_rowid_col_name, global_rowid_type}}, &read_rows,
+            &block, nullptr, [&](IcebergOrcReader* reader) {
+                reader->set_create_row_id_column_iterator_func([&]() {
+                    return std::make_shared<segment_v2::RowIdColumnIteratorV2>(kVersion, kBackendId,
+                                                                               kFileId);
+                });
+            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_global_rowid_column(block, global_rowid_col_name, kVersion, kBackendId, kFileId);
+}
+
+TEST_F(IcebergReaderTest, reads_generated_column_from_file_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name"};
+    std::vector<int32_t> table_column_unique_ids = {2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::GENERATED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_orc/data/"
+            "00000-8-5a144c37-16a4-47c6-96db-0007175b5c90-0-00001.orc";
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_orc_scalar_block(scan_range.path, scan_range, tuple_descriptor,
+                                  col_name_to_block_idx, column_descs, {{"name", nullable_string}},
+                                  &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "name", read_rows);
+}
+
+TEST_F(IcebergReaderTest, fills_row_lineage_columns_from_scan_range_for_parquet) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "_row_id",
+                                                   "_last_updated_sequence_number"};
+    std::vector<int32_t> table_column_unique_ids = {2, 200, 201};
+    std::vector<TPrimitiveType::type> table_column_types = {
+            TPrimitiveType::STRING, TPrimitiveType::BIGINT, TPrimitiveType::BIGINT};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
+            {"name", 0}, {"_row_id", 1}, {"_last_updated_sequence_number", 2}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"_row_id", tuple_descriptor->slots()[1], ColumnCategory::GENERATED, nullptr},
+            {"_last_updated_sequence_number", tuple_descriptor->slots()[2],
+             ColumnCategory::GENERATED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet";
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.table_format_type = "iceberg";
+    scan_range.table_format_params.iceberg_params.__set_first_row_id(1000);
+    scan_range.table_format_params.iceberg_params.__set_last_updated_sequence_number(77);
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    auto nullable_int64 = make_nullable(std::make_shared<DataTypeInt64>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_parquet_scalar_block(scan_range.path, scan_range, tuple_descriptor,
+                                      col_name_to_block_idx, column_descs,
+                                      {{"name", nullable_string},
+                                       {"_row_id", nullable_int64},
+                                       {"_last_updated_sequence_number", nullable_int64}},
+                                      &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_int64_column_sequence(block, "_row_id", 1000);
+    verify_nullable_int64_column_constant(block, "_last_updated_sequence_number", 77);
+}
+
+TEST_F(IcebergReaderTest, fills_row_lineage_columns_from_scan_range_for_orc) {
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name", "_row_id",
+                                                   "_last_updated_sequence_number"};
+    std::vector<int32_t> table_column_unique_ids = {2, 200, 201};
+    std::vector<TPrimitiveType::type> table_column_types = {
+            TPrimitiveType::STRING, TPrimitiveType::BIGINT, TPrimitiveType::BIGINT};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
+            {"name", 0}, {"_row_id", 1}, {"_last_updated_sequence_number", 2}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr},
+            {"_row_id", tuple_descriptor->slots()[1], ColumnCategory::GENERATED, nullptr},
+            {"_last_updated_sequence_number", tuple_descriptor->slots()[2],
+             ColumnCategory::GENERATED, nullptr}};
+
+    TFileRangeDesc scan_range;
+    scan_range.path =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_orc/data/"
+            "00000-8-5a144c37-16a4-47c6-96db-0007175b5c90-0-00001.orc";
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.table_format_type = "iceberg";
+    scan_range.table_format_params.iceberg_params.__set_first_row_id(2000);
+    scan_range.table_format_params.iceberg_params.__set_last_updated_sequence_number(88);
+
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    auto nullable_int64 = make_nullable(std::make_shared<DataTypeInt64>());
+    size_t read_rows = 0;
+    Block block;
+    read_iceberg_orc_scalar_block(scan_range.path, scan_range, tuple_descriptor,
+                                  col_name_to_block_idx, column_descs,
+                                  {{"name", nullable_string},
+                                   {"_row_id", nullable_int64},
+                                   {"_last_updated_sequence_number", nullable_int64}},
+                                  &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_int64_column_sequence(block, "_row_id", 2000);
+    verify_nullable_int64_column_constant(block, "_last_updated_sequence_number", 88);
+}
+
+TEST_F(IcebergReaderTest, rejects_multiple_deletion_vectors_during_parquet_init) {
+    auto local_fs = io::global_local_filesystem();
+    std::string test_file =
+            "./be/test/exec/test_data/nested_user_profiles_iceberg_parquet/data/"
+            "00000-9-a7e0135f-d581-40e4-8d56-a929aded99e4-0-00001.parquet";
+    int64_t file_size = 0;
+    auto st = local_fs->file_size(test_file, &file_size);
     if (!st.ok()) {
         GTEST_SKIP() << "Test file not found: " << test_file;
-        return;
     }
 
-    // Setup runtime state
-    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    std::vector<std::string> table_column_names = {"name"};
+    std::vector<int32_t> table_column_unique_ids = {2};
+    std::vector<TPrimitiveType::type> table_column_types = {TPrimitiveType::STRING};
+    const TupleDescriptor* tuple_descriptor = create_simple_tuple_descriptor(
+            &desc_tbl, obj_pool, t_desc_table, t_table_desc, table_column_names,
+            table_column_unique_ids, table_column_types);
 
-    // Setup scan parameters
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    std::vector<ColumnDescriptor> column_descs = {
+            {"name", tuple_descriptor->slots()[0], ColumnCategory::REGULAR, nullptr}};
+
+    RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
     TFileScanRangeParams scan_params;
     scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
 
     TFileRangeDesc scan_range;
     scan_range.start_offset = 0;
-    scan_range.size = file_reader->size(); // Read entire file
+    scan_range.size = file_size;
     scan_range.path = test_file;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.table_format_type = "iceberg";
+    scan_range.table_format_params.iceberg_params.__set_format_version(2);
+    scan_range.table_format_params.iceberg_params.__set_original_file_path(test_file);
 
-    // Create mock profile
-    RuntimeProfile profile("test_profile");
+    TIcebergDeleteFileDesc dv1;
+    dv1.path = "memory://dv-1.bin";
+    dv1.content = IcebergParquetReader::DELETION_VECTOR;
+    TIcebergDeleteFileDesc dv2;
+    dv2.path = "memory://dv-2.bin";
+    dv2.content = IcebergParquetReader::DELETION_VECTOR;
+    scan_range.table_format_params.iceberg_params.__set_delete_files({dv1, dv2});
 
-    // Create IcebergParquetReader (IS-A ParquetReader via CRTP mixin)
-    cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-
+    RuntimeProfile profile("multiple_dv_init_test");
     auto iceberg_reader = std::make_unique<IcebergParquetReader>(
-            nullptr /* kv_cache */, &profile, scan_params, scan_range, 1024, &ctz,
-            nullptr /* io_ctx */, &runtime_state, cache.get());
+            nullptr, &profile, scan_params, scan_range, 1024, &timezone_obj, nullptr,
+            &runtime_state, cache.get());
     ASSERT_NE(iceberg_reader, nullptr);
 
-    // Set file reader for the iceberg reader (it IS the ParquetReader)
-    iceberg_reader->set_file_reader(file_reader);
-
-    // Create complex struct types using helper function
-    DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
-    DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
-    DataTypePtr profile_struct_type, name_type;
-    create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
-                                contact_struct_type, hobby_element_struct_type, hobbies_array_type,
-                                profile_struct_type, name_type);
-
-    // Create tuple descriptor using helper function
-    DescriptorTbl* desc_tbl;
-    ObjectPool obj_pool;
-    TDescriptorTable t_desc_table;
-    TTableDescriptor t_table_desc;
-    const TupleDescriptor* tuple_descriptor =
-            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc);
-
-    std::vector<std::string> table_col_names = {"name", "profile"};
-    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
-            {"name", 0},
-            {"profile", 1},
-    };
-
-    std::vector<ColumnDescriptor> column_descs;
-    for (const auto& name : table_col_names) {
-        ColumnDescriptor desc;
-        desc.name = name;
-        column_descs.push_back(desc);
-    }
     ParquetInitContext pq_ctx;
     pq_ctx.column_descs = &column_descs;
     pq_ctx.col_name_to_block_idx = &col_name_to_block_idx;
@@ -749,163 +1650,9 @@ TEST_F(IcebergReaderTest, read_iceberg_parquet_file) {
     pq_ctx.params = &scan_params;
     pq_ctx.range = &scan_range;
     st = iceberg_reader->init_reader(&pq_ctx);
-    ASSERT_TRUE(st.ok()) << st;
-
-    // set_fill_columns logic is now inlined in _do_init_reader,
-    // so no separate call is needed.
-
-    // Create block for reading nested structure (not flattened)
-    Block block;
-    {
-        MutableColumnPtr name_column = name_type->create_column();
-        block.insert(ColumnWithTypeAndName(std::move(name_column), name_type, "name"));
-        // Add profile column (nested struct)
-        MutableColumnPtr profile_column = profile_struct_type->create_column();
-        block.insert(
-                ColumnWithTypeAndName(std::move(profile_column), profile_struct_type, "profile"));
-    }
-
-    // Read data from the file
-    size_t read_rows = 0;
-    bool eof = false;
-    st = iceberg_reader->get_next_block(&block, &read_rows, &eof);
-    ASSERT_TRUE(st.ok()) << st;
-
-    // Verify test results using helper function
-    verify_test_results(block, read_rows);
-}
-
-// Test reading real Iceberg Orc file using IcebergTableReader
-TEST_F(IcebergReaderTest, read_iceberg_orc_file) {
-    // Read only: name, profile.address.coordinates.lat, profile.address.coordinates.lng, profile.contact.email
-    // Setup table descriptor for test columns with new schema:
-    /**
-    Schema:
-    message table {
-    required int64 id = 1;
-    required binary name (STRING) = 2;
-    required group profile = 3 {
-        optional group address = 4 {
-        optional binary street (STRING) = 7;
-        optional binary city (STRING) = 8;
-        optional group coordinates = 9 {
-            optional double lat = 10;
-            optional double lng = 11;
-        }
-        }
-        optional group contact = 5 {
-        optional binary email (STRING) = 12;
-        optional group phone = 13 {
-            optional binary country_code (STRING) = 14;
-            optional binary number (STRING) = 15;
-        }
-        }
-        optional group hobbies (LIST) = 6 {
-        repeated group list {
-            optional group element = 16 {
-            optional binary name (STRING) = 17;
-            optional int32 level = 18;
-            }
-        }
-        }
-    }
-    }
-    */
-
-    // Open the Iceberg Orc test file
-    auto local_fs = io::global_local_filesystem();
-    io::FileReaderSPtr file_reader;
-    std::string test_file =
-            "./be/test/exec/test_data/complex_user_profiles_iceberg_orc/data/"
-            "00000-0-e4897963-0081-4127-bebe-35dc7dc1edeb-0-00001.orc";
-    auto st = local_fs->open_file(test_file, &file_reader);
-    if (!st.ok()) {
-        GTEST_SKIP() << "Test file not found: " << test_file;
-        return;
-    }
-
-    // Setup runtime state
-    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
-
-    // Setup scan parameters
-    TFileScanRangeParams scan_params;
-    scan_params.format_type = TFileFormatType::FORMAT_ORC;
-
-    TFileRangeDesc scan_range;
-    scan_range.start_offset = 0;
-    scan_range.size = file_reader->size(); // Read entire file
-    scan_range.path = test_file;
-
-    // Create mock profile
-    RuntimeProfile profile("test_profile");
-
-    // Create IcebergOrcReader (IS-A OrcReader via CRTP mixin)
-    auto iceberg_reader = std::make_unique<IcebergOrcReader>(
-            nullptr /* kv_cache */, &profile, &runtime_state, scan_params, scan_range, 1024, "CST",
-            nullptr /* io_ctx */, cache.get());
-    ASSERT_NE(iceberg_reader, nullptr);
-
-    // Create complex struct types using helper function
-    DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
-    DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
-    DataTypePtr profile_struct_type, name_type;
-    create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
-                                contact_struct_type, hobby_element_struct_type, hobbies_array_type,
-                                profile_struct_type, name_type);
-
-    // Create tuple descriptor using helper function
-    DescriptorTbl* desc_tbl;
-    ObjectPool obj_pool;
-    TDescriptorTable t_desc_table;
-    TTableDescriptor t_table_desc;
-    const TupleDescriptor* tuple_descriptor =
-            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc);
-
-    std::vector<std::string> table_col_names = {"name", "profile"};
-    const RowDescriptor* row_descriptor = nullptr;
-    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
-            {"name", 0},
-            {"profile", 1},
-    };
-
-    std::vector<ColumnDescriptor> column_descs;
-    for (const auto& name : table_col_names) {
-        ColumnDescriptor desc;
-        desc.name = name;
-        column_descs.push_back(desc);
-    }
-    OrcInitContext orc_ctx;
-    orc_ctx.column_descs = &column_descs;
-    orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
-    orc_ctx.tuple_descriptor = tuple_descriptor;
-    orc_ctx.row_descriptor = row_descriptor;
-    orc_ctx.params = &scan_params;
-    orc_ctx.range = &scan_range;
-    st = iceberg_reader->init_reader(&orc_ctx);
-    ASSERT_TRUE(st.ok()) << st;
-
-    // set_fill_columns logic is now inlined in _do_init_reader,
-    // so no separate call is needed.
-
-    // Create block for reading nested structure (not flattened)
-    Block block;
-    {
-        MutableColumnPtr name_column = name_type->create_column();
-        block.insert(ColumnWithTypeAndName(std::move(name_column), name_type, "name"));
-        // Add profile column (nested struct)
-        MutableColumnPtr profile_column = profile_struct_type->create_column();
-        block.insert(
-                ColumnWithTypeAndName(std::move(profile_column), profile_struct_type, "profile"));
-    }
-
-    // Read data from the file
-    size_t read_rows = 0;
-    bool eof = false;
-    st = iceberg_reader->get_next_block(&block, &read_rows, &eof);
-    ASSERT_TRUE(st.ok()) << st;
-
-    // Verify test results using helper function
-    verify_test_results(block, read_rows);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::DATA_QUALITY_ERROR>());
+    EXPECT_NE(st.to_string().find("multiple DVs"), std::string::npos);
 }
 
 } // namespace doris

--- a/be/test/format/table/iceberg_reader_mixin_test.cpp
+++ b/be/test/format/table/iceberg_reader_mixin_test.cpp
@@ -1,0 +1,752 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/PlanNodes_types.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <queue>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/column/column_struct.h"
+#include "core/column/column_vector.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "core/data_type/data_type_struct.h"
+#include "format/table/iceberg_reader.h"
+#include "runtime/runtime_profile.h"
+#include "storage/olap_common.h"
+
+namespace doris {
+
+// ============================================================================
+// Helper: Build the Iceberg $row_id struct type.
+//
+// The $row_id column is Nullable<Struct<file_path:String, pos:Int64,
+//   partition_spec_id:Int32, partition_data:String>>.
+// ============================================================================
+static DataTypePtr build_iceberg_rowid_type() {
+    DataTypes field_types = {
+            std::make_shared<DataTypeString>(), // file_path
+            std::make_shared<DataTypeInt64>(),  // pos (row position)
+            std::make_shared<DataTypeInt32>(),  // partition_spec_id
+            std::make_shared<DataTypeString>(), // partition_data
+    };
+    Strings field_names = {"file_path", "pos", "partition_spec_id", "partition_data"};
+    auto struct_type = std::make_shared<DataTypeStruct>(field_types, field_names);
+    return std::make_shared<DataTypeNullable>(struct_type);
+}
+
+// Non-nullable variant.
+static DataTypePtr build_iceberg_rowid_type_non_nullable() {
+    DataTypes field_types = {
+            std::make_shared<DataTypeString>(),
+            std::make_shared<DataTypeInt64>(),
+            std::make_shared<DataTypeInt32>(),
+            std::make_shared<DataTypeString>(),
+    };
+    Strings field_names = {"file_path", "pos", "partition_spec_id", "partition_data"};
+    return std::make_shared<DataTypeStruct>(field_types, field_names);
+}
+
+// Expose protected static mixin helpers through a test-only derived type.
+class IcebergReaderMixinTestAccessor : public IcebergReaderMixin<ParquetReader> {
+public:
+    using IcebergReaderMixin<ParquetReader>::_build_iceberg_rowid_column;
+    using IcebergReaderMixin<ParquetReader>::_sort_delete_rows;
+
+    void set_delete_rows() override {}
+
+protected:
+    Status on_before_init_reader(ReaderInitContext* ctx) override { return Status::OK(); }
+
+private:
+    using DeleteFile = typename IcebergReaderMixin<ParquetReader>::DeleteFile;
+
+    Status _read_position_delete_file(const TFileRangeDesc*, DeleteFile*) override {
+        return Status::OK();
+    }
+
+    std::unique_ptr<GenericReader> _create_equality_reader(
+            const TFileRangeDesc& delete_desc) override {
+        return nullptr;
+    }
+};
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column with nullable struct type
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnNullable) {
+    auto type = build_iceberg_rowid_type();
+    std::vector<segment_v2::rowid_t> row_ids = {0, 5, 10, 15};
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(
+            type, "/data/file1.parquet", row_ids, 3, "{\"region\":\"us-east-1\"}", &result);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_TRUE(static_cast<bool>(result));
+    EXPECT_EQ(result->size(), 4);
+
+    // Verify it's a nullable struct.
+    auto* nullable = check_and_get_column<ColumnNullable>(result.get());
+    ASSERT_NE(nullable, nullptr);
+    for (size_t i = 0; i < 4; i++) {
+        EXPECT_FALSE(nullable->is_null_at(i)) << "Row " << i << " should not be NULL";
+    }
+
+    auto* struct_col = check_and_get_column<ColumnStruct>(nullable->get_nested_column_ptr().get());
+    ASSERT_NE(struct_col, nullptr);
+    ASSERT_GE(struct_col->tuple_size(), 4);
+
+    // Verify file_path (field 0).
+    auto& file_path_col = struct_col->get_column(0);
+    EXPECT_EQ(file_path_col.size(), 4);
+    for (size_t i = 0; i < 4; i++) {
+        auto val = file_path_col.get_data_at(i);
+        EXPECT_EQ(std::string(val.data, val.size), "/data/file1.parquet");
+    }
+
+    // Verify row positions (field 1).
+    auto& row_pos_col = struct_col->get_column(1);
+    EXPECT_EQ(row_pos_col.size(), 4);
+    EXPECT_EQ(row_pos_col.get_int(0), 0);
+    EXPECT_EQ(row_pos_col.get_int(1), 5);
+    EXPECT_EQ(row_pos_col.get_int(2), 10);
+    EXPECT_EQ(row_pos_col.get_int(3), 15);
+
+    // Verify partition_spec_id (field 2).
+    auto& spec_id_col = struct_col->get_column(2);
+    EXPECT_EQ(spec_id_col.size(), 4);
+    for (size_t i = 0; i < 4; i++) {
+        EXPECT_EQ(spec_id_col.get_int(i), 3);
+    }
+
+    // Verify partition_data (field 3).
+    auto& partition_data_col = struct_col->get_column(3);
+    EXPECT_EQ(partition_data_col.size(), 4);
+    for (size_t i = 0; i < 4; i++) {
+        auto val = partition_data_col.get_data_at(i);
+        EXPECT_EQ(std::string(val.data, val.size), "{\"region\":\"us-east-1\"}");
+    }
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column with non-nullable struct type
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnNonNullable) {
+    auto type = build_iceberg_rowid_type_non_nullable();
+    std::vector<segment_v2::rowid_t> row_ids = {100, 200};
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(type, "/data/file2.orc",
+                                                                          row_ids, 7, "", &result);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_TRUE(static_cast<bool>(result));
+    EXPECT_EQ(result->size(), 2);
+
+    auto* struct_col = check_and_get_column<ColumnStruct>(result.get());
+    ASSERT_NE(struct_col, nullptr);
+
+    // Verify row positions.
+    auto& row_pos_col = struct_col->get_column(1);
+    EXPECT_EQ(row_pos_col.get_int(0), 100);
+    EXPECT_EQ(row_pos_col.get_int(1), 200);
+
+    // Verify spec id.
+    auto& spec_id_col = struct_col->get_column(2);
+    EXPECT_EQ(spec_id_col.get_int(0), 7);
+    EXPECT_EQ(spec_id_col.get_int(1), 7);
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column with empty row_ids
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnEmptyRows) {
+    auto type = build_iceberg_rowid_type();
+    std::vector<segment_v2::rowid_t> row_ids;
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(
+            type, "/data/empty.parquet", row_ids, 0, "", &result);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_TRUE(static_cast<bool>(result));
+    EXPECT_EQ(result->size(), 0);
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column with large row count
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnLargeBatch) {
+    auto type = build_iceberg_rowid_type();
+    const size_t num_rows = 10000;
+    std::vector<segment_v2::rowid_t> row_ids(num_rows);
+    for (size_t i = 0; i < num_rows; i++) {
+        row_ids[i] = static_cast<segment_v2::rowid_t>(i * 3);
+    }
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(
+            type, "/data/large.parquet", row_ids, 1, "{}", &result);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_TRUE(static_cast<bool>(result));
+    EXPECT_EQ(result->size(), num_rows);
+
+    auto* nullable = check_and_get_column<ColumnNullable>(result.get());
+    auto* struct_col = check_and_get_column<ColumnStruct>(nullable->get_nested_column_ptr().get());
+    auto& row_pos_col = struct_col->get_column(1);
+    // Spot check a few positions.
+    EXPECT_EQ(row_pos_col.get_int(0), 0);
+    EXPECT_EQ(row_pos_col.get_int(1), 3);
+    EXPECT_EQ(row_pos_col.get_int(9999), 29997);
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column null type returns error
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnNullTypeError) {
+    std::vector<segment_v2::rowid_t> row_ids = {0};
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(
+            nullptr, "/data/f.parquet", row_ids, 0, "", &result);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::INVALID_ARGUMENT>());
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column null output column returns error
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnNullOutputError) {
+    auto type = build_iceberg_rowid_type();
+    std::vector<segment_v2::rowid_t> row_ids = {0};
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(type, "/data/f.parquet",
+                                                                          row_ids, 0, "", nullptr);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::INVALID_ARGUMENT>());
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column with wrong type (not struct) returns error
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnWrongTypeError) {
+    auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>());
+    std::vector<segment_v2::rowid_t> row_ids = {0};
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(type, "/data/f.parquet",
+                                                                          row_ids, 0, "", &result);
+    ASSERT_FALSE(st.ok());
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column with struct having < 4 fields returns error
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnTooFewFieldsError) {
+    DataTypes field_types = {
+            std::make_shared<DataTypeString>(),
+            std::make_shared<DataTypeInt64>(),
+    };
+    Strings field_names = {"file_path", "pos"};
+    auto struct_type = std::make_shared<DataTypeStruct>(field_types, field_names);
+    auto type = std::make_shared<DataTypeNullable>(struct_type);
+
+    std::vector<segment_v2::rowid_t> row_ids = {0};
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(type, "/data/f.parquet",
+                                                                          row_ids, 0, "", &result);
+    ASSERT_FALSE(st.ok());
+}
+
+// ============================================================================
+// Test: _build_iceberg_rowid_column partition_spec_id 0 and empty partition_data
+// ============================================================================
+TEST(IcebergRowIdTest, BuildRowIdColumnZeroSpecIdEmptyPartition) {
+    auto type = build_iceberg_rowid_type();
+    std::vector<segment_v2::rowid_t> row_ids = {42};
+    MutableColumnPtr result;
+
+    auto st = IcebergReaderMixinTestAccessor::_build_iceberg_rowid_column(
+            type, "/warehouse/table/data/00000-0.parquet", row_ids, 0, "", &result);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(result->size(), 1);
+
+    auto* nullable = check_and_get_column<ColumnNullable>(result.get());
+    auto* struct_col = check_and_get_column<ColumnStruct>(nullable->get_nested_column_ptr().get());
+
+    auto& spec_id_col = struct_col->get_column(2);
+    EXPECT_EQ(spec_id_col.get_int(0), 0);
+
+    auto& partition_data_col = struct_col->get_column(3);
+    auto val = partition_data_col.get_data_at(0);
+    EXPECT_EQ(std::string(val.data, val.size), "");
+}
+
+// ============================================================================
+// Test: _sort_delete_rows merges multiple pre-sorted delete row arrays
+// ============================================================================
+TEST(IcebergSortDeleteTest, SingleArray) {
+    std::vector<int64_t> arr1 = {1, 2, 3, 4, 5};
+    std::vector<std::vector<int64_t>*> arrays = {&arr1};
+    std::vector<int64_t> result;
+
+    IcebergReaderMixinTestAccessor::_sort_delete_rows(arrays, arr1.size(), result);
+    ASSERT_EQ(result.size(), 5);
+    EXPECT_EQ(result[0], 1);
+    EXPECT_EQ(result[1], 2);
+    EXPECT_EQ(result[2], 3);
+    EXPECT_EQ(result[3], 4);
+    EXPECT_EQ(result[4], 5);
+}
+
+TEST(IcebergSortDeleteTest, TwoArraysMerged) {
+    // Both inputs must be pre-sorted.
+    std::vector<int64_t> arr1 = {1, 5, 10};
+    std::vector<int64_t> arr2 = {3, 7, 12};
+    std::vector<std::vector<int64_t>*> arrays = {&arr1, &arr2};
+    std::vector<int64_t> result;
+
+    IcebergReaderMixinTestAccessor::_sort_delete_rows(arrays, arr1.size() + arr2.size(), result);
+    // Merged: 1, 3, 5, 7, 10, 12
+    ASSERT_EQ(result.size(), 6);
+    EXPECT_EQ(result[0], 1);
+    EXPECT_EQ(result[1], 3);
+    EXPECT_EQ(result[2], 5);
+    EXPECT_EQ(result[3], 7);
+    EXPECT_EQ(result[4], 10);
+    EXPECT_EQ(result[5], 12);
+}
+
+TEST(IcebergSortDeleteTest, EmptyInput) {
+    std::vector<std::vector<int64_t>*> arrays;
+    std::vector<int64_t> result;
+
+    IcebergReaderMixinTestAccessor::_sort_delete_rows(arrays, 0, result);
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(IcebergSortDeleteTest, SingleElementArrays) {
+    std::vector<int64_t> arr1 = {100};
+    std::vector<int64_t> arr2 = {50};
+    std::vector<std::vector<int64_t>*> arrays = {&arr1, &arr2};
+    std::vector<int64_t> result;
+
+    IcebergReaderMixinTestAccessor::_sort_delete_rows(arrays, 2, result);
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_EQ(result[0], 50);
+    EXPECT_EQ(result[1], 100);
+}
+
+class FakeEqualityDeleteOrcReader : public OrcReader {
+public:
+    FakeEqualityDeleteOrcReader(std::vector<std::string> schema_names,
+                                std::vector<DataTypePtr> schema_types, std::vector<Block> batches)
+            : OrcReader(TFileScanRangeParams {}, TFileRangeDesc {}, "UTC", nullptr, nullptr, false),
+              _schema_names(std::move(schema_names)),
+              _schema_types(std::move(schema_types)),
+              _batches(std::move(batches)) {}
+
+    Status init_schema_reader() override { return Status::OK(); }
+
+    Status get_parsed_schema(std::vector<std::string>* col_names,
+                             std::vector<DataTypePtr>* col_types) override {
+        *col_names = _schema_names;
+        *col_types = _schema_types;
+        return Status::OK();
+    }
+
+protected:
+    Status _open_file_reader(ReaderInitContext* /*ctx*/) override { return Status::OK(); }
+
+    Status _do_init_reader(ReaderInitContext* /*ctx*/) override { return Status::OK(); }
+
+    Status _do_get_next_block(Block* block, size_t* read_rows, bool* eof) override {
+        if (_next_batch >= _batches.size()) {
+            *read_rows = 0;
+            *eof = true;
+            return Status::OK();
+        }
+
+        MutableBlock mutable_block(block);
+        RETURN_IF_ERROR(mutable_block.merge(_batches[_next_batch]));
+        *block = mutable_block.to_block();
+        *read_rows = block->rows();
+        ++_next_batch;
+        *eof = _next_batch >= _batches.size();
+        return Status::OK();
+    }
+
+private:
+    std::vector<std::string> _schema_names;
+    std::vector<DataTypePtr> _schema_types;
+    std::vector<Block> _batches;
+    size_t _next_batch = 0;
+};
+
+class IcebergReaderMixinOrcTestAccessor : public IcebergReaderMixin<OrcReader> {
+public:
+    IcebergReaderMixinOrcTestAccessor(RuntimeProfile* profile, const TFileScanRangeParams& params,
+                                      const TFileRangeDesc& range)
+            : IcebergReaderMixin<OrcReader>(nullptr, profile, nullptr, params, range, 1024, "UTC",
+                                            nullptr, nullptr, false) {}
+
+    using IcebergReaderMixin<OrcReader>::_init_row_filters;
+    using IcebergReaderMixin<OrcReader>::_equality_delete_base;
+    using IcebergReaderMixin<OrcReader>::on_after_read_block;
+    using IcebergReaderMixin<OrcReader>::on_before_read_block;
+
+    void set_delete_rows() override {}
+
+    void set_block_index_map(std::unordered_map<std::string, uint32_t>* col_name_to_idx) {
+        this->col_name_to_block_idx_ref() = col_name_to_idx;
+    }
+
+    const std::vector<std::string>& expand_col_names() const { return _expand_col_names; }
+
+    const std::unordered_map<int, std::string>& id_to_block_column_name() const {
+        return _id_to_block_column_name;
+    }
+
+    size_t equality_delete_impl_count() const { return _equality_delete_impls.size(); }
+
+    void enqueue_delete_reader(std::unique_ptr<GenericReader> delete_reader) {
+        _delete_readers.push(std::move(delete_reader));
+    }
+
+protected:
+    Status on_before_init_reader(ReaderInitContext* /*ctx*/) override { return Status::OK(); }
+
+private:
+    using DeleteFile = typename IcebergReaderMixin<OrcReader>::DeleteFile;
+
+    Status _read_position_delete_file(const TFileRangeDesc*, DeleteFile*) override {
+        return Status::OK();
+    }
+
+    std::unique_ptr<GenericReader> _create_equality_reader(
+            const TFileRangeDesc& /*delete_desc*/) override {
+        EXPECT_FALSE(_delete_readers.empty());
+        auto delete_reader = std::move(_delete_readers.front());
+        _delete_readers.pop();
+        return delete_reader;
+    }
+
+    std::queue<std::unique_ptr<GenericReader>> _delete_readers;
+};
+
+class UnsupportedDeleteReader : public GenericReader {
+public:
+    Status init_schema_reader() override { return Status::OK(); }
+
+protected:
+    Status _do_get_next_block(Block* /*block*/, size_t* read_rows, bool* eof) override {
+        *read_rows = 0;
+        *eof = true;
+        return Status::OK();
+    }
+};
+
+static MutableColumnPtr make_nullable_string_column(const std::vector<std::string>& values) {
+    auto column = make_nullable(std::make_shared<DataTypeString>())->create_column();
+    for (const auto& value : values) {
+        column->insert_data(value.data(), value.size());
+    }
+    return column;
+}
+
+static MutableColumnPtr make_nullable_int32_column(const std::vector<Int32>& values) {
+    auto column = make_nullable(std::make_shared<DataTypeInt32>())->create_column();
+    for (const auto value : values) {
+        column->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+    }
+    return column;
+}
+
+static std::vector<Int32> get_int32_values(const IColumn& column) {
+    const auto* int_column = check_and_get_column<ColumnInt32>(&column);
+    EXPECT_NE(int_column, nullptr);
+    if (int_column == nullptr) {
+        return {};
+    }
+    const auto& data = int_column->get_data();
+    return std::vector<Int32>(data.begin(), data.end());
+}
+
+TEST(IcebergEqualityDeleteTest, ExpandFilterAndShrinkUsingRealHooks) {
+    RuntimeProfile profile("iceberg_equality_delete_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+
+    Block delete_batch;
+    delete_batch.insert({make_nullable_string_column({"us", "jp"}),
+                         make_nullable(std::make_shared<DataTypeString>()), "region"});
+    reader.enqueue_delete_reader(std::make_unique<FakeEqualityDeleteOrcReader>(
+            std::vector<std::string> {"region"},
+            std::vector<DataTypePtr> {std::make_shared<DataTypeString>()},
+            std::vector<Block> {delete_batch}));
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = "memory://delete-region.orc";
+    delete_file.content = IcebergReaderMixinOrcTestAccessor::EQUALITY_DELETE;
+    delete_file.__set_field_ids({10});
+
+    auto st = reader._equality_delete_base({delete_file});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(reader.expand_col_names(), std::vector<std::string>({"region"}));
+    ASSERT_EQ(reader.equality_delete_impl_count(), 1);
+    ASSERT_EQ(reader.id_to_block_column_name().at(10), "region");
+
+    Block block;
+    auto id_column = ColumnInt32::create();
+    for (Int32 value : {1, 2, 3}) {
+        id_column->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+    }
+    block.insert({std::move(id_column), std::make_shared<DataTypeInt32>(), "id"});
+
+    auto block_idx = block.get_name_to_pos_map();
+    reader.set_block_index_map(&block_idx);
+
+    st = reader.on_before_read_block(&block);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(block.columns(), 2);
+    ASSERT_EQ(block_idx["region"], 1);
+
+    block.replace_by_position(block_idx["region"], make_nullable_string_column({"cn", "us", "jp"}));
+
+    size_t read_rows = block.rows();
+    st = reader.on_after_read_block(&block, &read_rows);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(read_rows, 1);
+    EXPECT_EQ(block.columns(), 1);
+    EXPECT_FALSE(block_idx.contains("region"));
+    EXPECT_EQ(get_int32_values(*block.get_by_position(0).column), std::vector<Int32>({1}));
+}
+
+TEST(IcebergEqualityDeleteTest, RejectDuplicateExpandedColumnNames) {
+    RuntimeProfile profile("iceberg_duplicate_expand_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+
+    Block delete_batch;
+    delete_batch.insert({make_nullable_int32_column({7}),
+                         make_nullable(std::make_shared<DataTypeInt32>()), "id"});
+    reader.enqueue_delete_reader(std::make_unique<FakeEqualityDeleteOrcReader>(
+            std::vector<std::string> {"id"},
+            std::vector<DataTypePtr> {std::make_shared<DataTypeInt32>()},
+            std::vector<Block> {delete_batch}));
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = "memory://delete-id.orc";
+    delete_file.content = IcebergReaderMixinOrcTestAccessor::EQUALITY_DELETE;
+    delete_file.__set_field_ids({1});
+
+    auto st = reader._equality_delete_base({delete_file});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    Block block;
+    auto id_column = ColumnInt32::create();
+    Int32 value = 7;
+    id_column->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+    block.insert({std::move(id_column), std::make_shared<DataTypeInt32>(), "id"});
+
+    auto block_idx = block.get_name_to_pos_map();
+    reader.set_block_index_map(&block_idx);
+
+    st = reader.on_before_read_block(&block);
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("Wrong expand column 'id'"), std::string::npos);
+}
+
+TEST(IcebergEqualityDeleteTest, BuildCompositeEqualityDeleteAndFilterRows) {
+    RuntimeProfile profile("iceberg_composite_delete_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+
+    Block delete_batch;
+    delete_batch.insert({make_nullable_string_column({"us", "cn"}),
+                         make_nullable(std::make_shared<DataTypeString>()), "region"});
+    delete_batch.insert({make_nullable_int32_column({7, 9}),
+                         make_nullable(std::make_shared<DataTypeInt32>()), "bucket"});
+    reader.enqueue_delete_reader(std::make_unique<FakeEqualityDeleteOrcReader>(
+            std::vector<std::string> {"region", "bucket"},
+            std::vector<DataTypePtr> {std::make_shared<DataTypeString>(),
+                                      std::make_shared<DataTypeInt32>()},
+            std::vector<Block> {delete_batch}));
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = "memory://delete-composite.orc";
+    delete_file.content = IcebergReaderMixinOrcTestAccessor::EQUALITY_DELETE;
+    delete_file.__set_field_ids({10, 20});
+
+    auto st = reader._equality_delete_base({delete_file});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(reader.expand_col_names(), std::vector<std::string>({"region", "bucket"}));
+    ASSERT_EQ(reader.equality_delete_impl_count(), 1);
+    ASSERT_EQ(reader.id_to_block_column_name().at(10), "region");
+    ASSERT_EQ(reader.id_to_block_column_name().at(20), "bucket");
+
+    Block block;
+    auto id_column = ColumnInt32::create();
+    for (Int32 value : {1, 2, 3, 4}) {
+        id_column->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+    }
+    block.insert({std::move(id_column), std::make_shared<DataTypeInt32>(), "id"});
+
+    auto block_idx = block.get_name_to_pos_map();
+    reader.set_block_index_map(&block_idx);
+
+    st = reader.on_before_read_block(&block);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(block.columns(), 3);
+
+    block.replace_by_position(block_idx["region"],
+                              make_nullable_string_column({"us", "us", "cn", "jp"}));
+    block.replace_by_position(block_idx["bucket"], make_nullable_int32_column({7, 8, 9, 7}));
+
+    size_t read_rows = block.rows();
+    st = reader.on_after_read_block(&block, &read_rows);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(read_rows, 2);
+    EXPECT_EQ(block.columns(), 1);
+    EXPECT_EQ(get_int32_values(*block.get_by_position(0).column), std::vector<Int32>({2, 4}));
+}
+
+TEST(IcebergInitRowFiltersTest, CountShortCircuitSkipsDeleteProcessing) {
+    RuntimeProfile profile("iceberg_count_short_circuit_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__set_table_level_row_count(10);
+    scan_range.table_format_params.iceberg_params.__set_format_version(2);
+
+    TIcebergDeleteFileDesc dv1;
+    dv1.path = "memory://dv-1.bin";
+    dv1.content = IcebergReaderMixinOrcTestAccessor::DELETION_VECTOR;
+    TIcebergDeleteFileDesc dv2;
+    dv2.path = "memory://dv-2.bin";
+    dv2.content = IcebergReaderMixinOrcTestAccessor::DELETION_VECTOR;
+    scan_range.table_format_params.iceberg_params.__set_delete_files({dv1, dv2});
+
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+    reader.set_push_down_agg_type(TPushAggOp::COUNT);
+
+    auto st = reader._init_row_filters();
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::COUNT);
+    EXPECT_EQ(reader.equality_delete_impl_count(), 0);
+}
+
+TEST(IcebergInitRowFiltersTest, OldFormatSkipsDeleteProcessing) {
+    RuntimeProfile profile("iceberg_old_format_skip_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.iceberg_params.__set_format_version(1);
+
+    TIcebergDeleteFileDesc dv1;
+    dv1.path = "memory://dv-1.bin";
+    dv1.content = IcebergReaderMixinOrcTestAccessor::DELETION_VECTOR;
+    TIcebergDeleteFileDesc dv2;
+    dv2.path = "memory://dv-2.bin";
+    dv2.content = IcebergReaderMixinOrcTestAccessor::DELETION_VECTOR;
+    scan_range.table_format_params.iceberg_params.__set_delete_files({dv1, dv2});
+
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+
+    auto st = reader._init_row_filters();
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::NONE);
+    EXPECT_EQ(reader.equality_delete_impl_count(), 0);
+}
+
+TEST(IcebergInitRowFiltersTest, EqualityDeleteDisablesCountPushdown) {
+    RuntimeProfile profile("iceberg_eq_delete_count_disable_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.iceberg_params.__set_format_version(2);
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = "memory://delete-region.orc";
+    delete_file.content = IcebergReaderMixinOrcTestAccessor::EQUALITY_DELETE;
+    delete_file.__set_field_ids({10});
+    scan_range.table_format_params.iceberg_params.__set_delete_files({delete_file});
+
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+    reader.set_push_down_agg_type(TPushAggOp::COUNT);
+
+    Block delete_batch;
+    delete_batch.insert({make_nullable_string_column({"us"}),
+                         make_nullable(std::make_shared<DataTypeString>()), "region"});
+    reader.enqueue_delete_reader(std::make_unique<FakeEqualityDeleteOrcReader>(
+            std::vector<std::string> {"region"},
+            std::vector<DataTypePtr> {std::make_shared<DataTypeString>()},
+            std::vector<Block> {delete_batch}));
+
+    auto st = reader._init_row_filters();
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::NONE);
+    EXPECT_EQ(reader.equality_delete_impl_count(), 1);
+    ASSERT_EQ(reader.expand_col_names(), std::vector<std::string>({"region"}));
+}
+
+TEST(IcebergEqualityDeleteTest, RejectDeleteFileWithoutFieldIds) {
+    RuntimeProfile profile("iceberg_missing_field_ids_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = "memory://delete-missing-field-ids.orc";
+    delete_file.content = IcebergReaderMixinOrcTestAccessor::EQUALITY_DELETE;
+
+    auto st = reader._equality_delete_base({delete_file});
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::INTERNAL_ERROR>());
+    EXPECT_NE(st.to_string().find("missing delete field ids"), std::string::npos);
+}
+
+TEST(IcebergEqualityDeleteTest, RejectUnsupportedDeleteReaderFormat) {
+    RuntimeProfile profile("iceberg_unsupported_delete_reader_test");
+    TFileScanRangeParams scan_params;
+    TFileRangeDesc scan_range;
+    IcebergReaderMixinOrcTestAccessor reader(&profile, scan_params, scan_range);
+    reader.enqueue_delete_reader(std::make_unique<UnsupportedDeleteReader>());
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.path = "memory://unsupported-delete-reader";
+    delete_file.content = IcebergReaderMixinOrcTestAccessor::EQUALITY_DELETE;
+    delete_file.__set_field_ids({10});
+
+    auto st = reader._equality_delete_base({delete_file});
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::INTERNAL_ERROR>());
+    EXPECT_NE(st.to_string().find("Unsupported format of delete file"), std::string::npos);
+}
+
+} // namespace doris

--- a/be/test/format/table/paimon_cpp_reader_test.cpp
+++ b/be/test/format/table/paimon_cpp_reader_test.cpp
@@ -15,16 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#define private public
 #include "format/table/paimon_cpp_reader.h"
+#undef private
+#pragma clang diagnostic pop
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "core/block/block.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "paimon/defs.h"
+#include "runtime/descriptors.h"
 #include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
+#include "testutil/desc_tbl_builder.h"
 
 namespace doris {
 
@@ -41,6 +53,14 @@ protected:
         range.table_format_params.__isset.table_level_row_count = true;
         range.table_format_params.table_level_row_count = row_count;
         return range;
+    }
+
+    std::vector<SlotDescriptor*> _build_file_slot_descs(ObjectPool* object_pool) {
+        DescriptorTblBuilder builder(object_pool);
+        auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+        builder.declare_tuple() << std::make_tuple(std::make_shared<DataTypeInt32>(), "id")
+                                << std::make_tuple(nullable_string, "name");
+        return builder.build()->get_tuple_descriptor(0)->slots();
     }
 
     TQueryOptions _query_options;
@@ -78,6 +98,24 @@ TEST_F(PaimonCppReaderTest, CountPushDownUsesTableLevelRowCount) {
     EXPECT_TRUE(eof);
 }
 
+TEST_F(PaimonCppReaderTest, CountPushDownHandlesZeroTableLevelRowCount) {
+    auto range = _build_range_with_table_level_row_count(0);
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    reader.set_push_down_agg_type(TPushAggOp::type::COUNT);
+
+    auto init_status = reader.init_reader();
+    ASSERT_TRUE(init_status.ok()) << init_status;
+
+    Block block;
+    size_t read_rows = 123;
+    bool eof = false;
+
+    auto status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(0, read_rows);
+    EXPECT_TRUE(eof);
+}
+
 TEST_F(PaimonCppReaderTest, InitReaderFailsWithoutPaimonSplit) {
     TFileRangeDesc range;
     range.__isset.table_format_params = true;
@@ -90,6 +128,182 @@ TEST_F(PaimonCppReaderTest, InitReaderFailsWithoutPaimonSplit) {
 
     ASSERT_FALSE(status.ok());
     EXPECT_NE(status.to_string().find("missing paimon_split"), std::string::npos);
+}
+
+TEST_F(PaimonCppReaderTest, InitReaderFailsWhenPaimonSplitBase64IsInvalid) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_split("not-base64");
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    auto status = reader.init_reader();
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("base64 decode paimon_split failed"), std::string::npos);
+}
+
+TEST_F(PaimonCppReaderTest, InitReaderFailsWhenPaimonSplitDeserializeFails) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_split("aGVsbG8=");
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    auto status = reader.init_reader();
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("deserialize split failed"), std::string::npos);
+}
+
+TEST_F(PaimonCppReaderTest, ReadWithoutInitializationFails) {
+    TFileRangeDesc range;
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+
+    Block block;
+    size_t read_rows = 0;
+    bool eof = false;
+    auto status = reader.get_next_block(&block, &read_rows, &eof);
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("reader is not initialized"), std::string::npos);
+}
+
+TEST_F(PaimonCppReaderTest, ResolveTablePathReturnsConfiguredPath) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_table("s3://bucket/db.tbl");
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    auto table_path = reader._resolve_table_path();
+
+    ASSERT_TRUE(table_path.has_value());
+    EXPECT_EQ(*table_path, "s3://bucket/db.tbl");
+}
+
+TEST_F(PaimonCppReaderTest, ResolveTablePathReturnsNulloptForEmptyPath) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_table("");
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    auto table_path = reader._resolve_table_path();
+
+    EXPECT_FALSE(table_path.has_value());
+}
+
+TEST_F(PaimonCppReaderTest, BuildOptionsUsesRangeFallbacksAndBackfillsFormats) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_options({{"scan.mode", "from-range"}});
+    range.table_format_params.paimon_params.__set_hadoop_conf(
+            {{"fs.oss.accessKeyId", "range-ak"},
+             {"fs.oss.accessKeySecret", "range-sk"},
+             {"fs.oss.endpoint", "oss-cn-beijing.aliyuncs.com"},
+             {"fs.s3a.path.style.access", "true"}});
+    range.table_format_params.paimon_params.__set_file_format("orc");
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    auto options = reader._build_options();
+
+    EXPECT_EQ(options["scan.mode"], "from-range");
+    EXPECT_EQ(options["AWS_ACCESS_KEY"], "range-ak");
+    EXPECT_EQ(options["AWS_SECRET_KEY"], "range-sk");
+    EXPECT_EQ(options["AWS_ENDPOINT"], "oss-cn-beijing.aliyuncs.com");
+    EXPECT_EQ(options["use_path_style"], "true");
+    EXPECT_EQ(options[paimon::Options::FILE_FORMAT], "orc");
+    EXPECT_EQ(options[paimon::Options::MANIFEST_FORMAT], "orc");
+    EXPECT_EQ(options[paimon::Options::FILE_SYSTEM], "doris");
+}
+
+TEST_F(PaimonCppReaderTest, BuildOptionsPrefersScanParamsAndKeepsExplicitFormats) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_paimon_options({{"scan.mode", "from-range"}});
+    range.table_format_params.paimon_params.__set_hadoop_conf(
+            {{"fs.oss.accessKeyId", "range-ak"}, {"fs.oss.endpoint", "range-endpoint"}});
+    range.table_format_params.paimon_params.__set_file_format("orc");
+
+    TFileScanRangeParams range_params;
+    range_params.__set_paimon_options({{"scan.mode", "from-params"},
+                                       {"file.format", "parquet"},
+                                       {"manifest.format", "avro"}});
+    range_params.__set_properties({{"AWS_ACCESS_KEY", "explicit-ak"},
+                                   {"fs.s3a.secret.key", "param-sk"},
+                                   {"fs.s3a.endpoint", "param-endpoint"}});
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, &range_params);
+    auto options = reader._build_options();
+
+    EXPECT_EQ(options["scan.mode"], "from-params");
+    EXPECT_FALSE(options.contains("fs.oss.accessKeyId"));
+    EXPECT_EQ(options["AWS_ACCESS_KEY"], "explicit-ak");
+    EXPECT_EQ(options["AWS_SECRET_KEY"], "param-sk");
+    EXPECT_EQ(options["AWS_ENDPOINT"], "param-endpoint");
+    EXPECT_EQ(options[paimon::Options::FILE_FORMAT], "parquet");
+    EXPECT_EQ(options[paimon::Options::MANIFEST_FORMAT], "avro");
+    EXPECT_EQ(options[paimon::Options::FILE_SYSTEM], "doris");
+}
+
+TEST_F(PaimonCppReaderTest, BuildOptionsCopiesSessionTokenAndRegionWhenMissing) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_hadoop_conf({{"fs.oss.sessionToken", "oss-token"},
+                                                               {"fs.oss.region", "oss-region"},
+                                                               {"fs.s3a.session.token", "s3-token"},
+                                                               {"fs.s3a.region", "s3-region"}});
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    auto options = reader._build_options();
+
+    EXPECT_EQ(options["AWS_TOKEN"], "oss-token");
+    EXPECT_EQ(options["AWS_REGION"], "oss-region");
+    EXPECT_EQ(options[paimon::Options::FILE_SYSTEM], "doris");
+}
+
+TEST_F(PaimonCppReaderTest, BuildOptionsKeepsExplicitDestinationKeys) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    range.table_format_params.__isset.paimon_params = true;
+    range.table_format_params.paimon_params.__set_hadoop_conf(
+            {{"fs.s3a.session.token", "range-token"},
+             {"fs.s3a.region", "range-region"},
+             {"fs.s3a.path.style.access", "true"}});
+
+    TFileScanRangeParams range_params;
+    range_params.__set_properties({{"AWS_TOKEN", "explicit-token"},
+                                   {"AWS_REGION", "explicit-region"},
+                                   {"use_path_style", "false"}});
+
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, &range_params);
+    auto options = reader._build_options();
+
+    EXPECT_EQ(options["AWS_TOKEN"], "explicit-token");
+    EXPECT_EQ(options["AWS_REGION"], "explicit-region");
+    EXPECT_EQ(options["use_path_style"], "false");
+    EXPECT_EQ(options[paimon::Options::FILE_SYSTEM], "doris");
+}
+
+TEST_F(PaimonCppReaderTest, BuildReadColumnsAndGetColumnsFollowFileSlots) {
+    ObjectPool object_pool;
+    auto file_slot_descs = _build_file_slot_descs(&object_pool);
+    TFileRangeDesc range;
+    PaimonCppReader reader(file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+
+    auto read_columns = reader._build_read_columns();
+    EXPECT_EQ(read_columns, (std::vector<std::string> {"id", "name"}));
+
+    std::unordered_map<std::string, DataTypePtr> name_to_type;
+    auto status = reader._get_columns_impl(&name_to_type);
+    ASSERT_TRUE(status.ok()) << status;
+    ASSERT_EQ(name_to_type.size(), 2);
+    EXPECT_EQ(name_to_type["id"]->get_name(), file_slot_descs[0]->type()->get_name());
+    EXPECT_EQ(name_to_type["name"]->get_name(), file_slot_descs[1]->type()->get_name());
 }
 
 } // namespace doris

--- a/be/test/format/table/paimon_cpp_reader_test.cpp
+++ b/be/test/format/table/paimon_cpp_reader_test.cpp
@@ -45,6 +45,7 @@ protected:
     void SetUp() override {
         _query_options.__set_batch_size(3);
         _runtime_state = std::make_unique<RuntimeState>(_query_options, _query_globals);
+        _file_slot_descs = _build_file_slot_descs(&_object_pool);
     }
 
     TFileRangeDesc _build_range_with_table_level_row_count(int64_t row_count) {
@@ -67,6 +68,7 @@ protected:
     TQueryGlobals _query_globals;
     std::unique_ptr<RuntimeState> _runtime_state;
     RuntimeProfile _profile {"paimon_cpp_reader_test"};
+    ObjectPool _object_pool;
     std::vector<SlotDescriptor*> _file_slot_descs;
 };
 
@@ -290,10 +292,8 @@ TEST_F(PaimonCppReaderTest, BuildOptionsKeepsExplicitDestinationKeys) {
 }
 
 TEST_F(PaimonCppReaderTest, BuildReadColumnsAndGetColumnsFollowFileSlots) {
-    ObjectPool object_pool;
-    auto file_slot_descs = _build_file_slot_descs(&object_pool);
     TFileRangeDesc range;
-    PaimonCppReader reader(file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
+    PaimonCppReader reader(_file_slot_descs, _runtime_state.get(), &_profile, range, nullptr);
 
     auto read_columns = reader._build_read_columns();
     EXPECT_EQ(read_columns, (std::vector<std::string> {"id", "name"}));
@@ -302,8 +302,8 @@ TEST_F(PaimonCppReaderTest, BuildReadColumnsAndGetColumnsFollowFileSlots) {
     auto status = reader._get_columns_impl(&name_to_type);
     ASSERT_TRUE(status.ok()) << status;
     ASSERT_EQ(name_to_type.size(), 2);
-    EXPECT_EQ(name_to_type["id"]->get_name(), file_slot_descs[0]->type()->get_name());
-    EXPECT_EQ(name_to_type["name"]->get_name(), file_slot_descs[1]->type()->get_name());
+    EXPECT_EQ(name_to_type["id"]->get_name(), _file_slot_descs[0]->type()->get_name());
+    EXPECT_EQ(name_to_type["name"]->get_name(), _file_slot_descs[1]->type()->get_name());
 }
 
 } // namespace doris

--- a/be/test/format/table/paimon_reader_test.cpp
+++ b/be/test/format/table/paimon_reader_test.cpp
@@ -1,0 +1,928 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cctz/time_zone.h>
+#include <gen_cpp/ExternalTableSchema_types.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <roaring/roaring.hh>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/block/column_with_type_and_name.h"
+#include "core/column/column.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_string.h"
+#include "core/data_type/primitive_type.h"
+#include "format/format_common.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#define private public
+#define protected public
+#include "format/table/paimon_reader.h"
+#undef protected
+#undef private
+#pragma clang diagnostic pop
+#include "format/column_descriptor.h"
+#include "io/fs/file_meta_cache.h"
+#include "io/fs/file_reader_writer_fwd.h"
+#include "io/fs/file_system.h"
+#include "io/fs/local_file_system.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+#include "testutil/desc_tbl_builder.h"
+#include "util/timezone_utils.h"
+
+namespace doris {
+
+static constexpr uint32_t kPaimonDeletionVectorMagicNumber = 1581511376U;
+
+class PaimonReaderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _timezone);
+        _cache = std::make_unique<FileMetaCache>(1024);
+    }
+
+    void TearDown() override {
+        for (const auto& path : _temp_files) {
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+        }
+    }
+
+    struct DeletionVectorFile {
+        std::string path;
+        int64_t payload_length = 0;
+    };
+
+    static void append_big_endian_u32(std::vector<char>* bytes, uint32_t value) {
+        bytes->push_back(static_cast<char>((value >> 24) & 0xFF));
+        bytes->push_back(static_cast<char>((value >> 16) & 0xFF));
+        bytes->push_back(static_cast<char>((value >> 8) & 0xFF));
+        bytes->push_back(static_cast<char>(value & 0xFF));
+    }
+
+    DeletionVectorFile write_valid_deletion_vector_file(const std::vector<uint32_t>& deleted_rows) {
+        roaring::Roaring bitmap;
+        for (uint32_t row : deleted_rows) {
+            bitmap.add(row);
+        }
+
+        const size_t bitmap_size = bitmap.getSizeInBytes(true);
+        std::vector<char> bitmap_bytes(bitmap_size);
+        EXPECT_EQ(bitmap.write(bitmap_bytes.data(), true), bitmap_size);
+
+        std::vector<char> file_bytes;
+        const uint32_t payload_length = static_cast<uint32_t>(4 + bitmap_size);
+        append_big_endian_u32(&file_bytes, payload_length);
+        append_big_endian_u32(&file_bytes, kPaimonDeletionVectorMagicNumber);
+        file_bytes.insert(file_bytes.end(), bitmap_bytes.begin(), bitmap_bytes.end());
+
+        return write_raw_deletion_vector_file(file_bytes, payload_length);
+    }
+
+    DeletionVectorFile write_invalid_magic_deletion_vector_file() {
+        roaring::Roaring bitmap;
+        bitmap.add(1);
+
+        const size_t bitmap_size = bitmap.getSizeInBytes(true);
+        std::vector<char> bitmap_bytes(bitmap_size);
+        EXPECT_EQ(bitmap.write(bitmap_bytes.data(), true), bitmap_size);
+
+        std::vector<char> file_bytes;
+        const uint32_t payload_length = static_cast<uint32_t>(4 + bitmap_size);
+        append_big_endian_u32(&file_bytes, payload_length);
+        append_big_endian_u32(&file_bytes, 0x12345678U);
+        file_bytes.insert(file_bytes.end(), bitmap_bytes.begin(), bitmap_bytes.end());
+
+        return write_raw_deletion_vector_file(file_bytes, payload_length);
+    }
+
+    DeletionVectorFile write_invalid_length_deletion_vector_file() {
+        roaring::Roaring bitmap;
+        bitmap.add(1);
+
+        const size_t bitmap_size = bitmap.getSizeInBytes(true);
+        std::vector<char> bitmap_bytes(bitmap_size);
+        EXPECT_EQ(bitmap.write(bitmap_bytes.data(), true), bitmap_size);
+
+        std::vector<char> file_bytes;
+        const uint32_t payload_length = static_cast<uint32_t>(4 + bitmap_size);
+        append_big_endian_u32(&file_bytes, payload_length + 1);
+        append_big_endian_u32(&file_bytes, kPaimonDeletionVectorMagicNumber);
+        file_bytes.insert(file_bytes.end(), bitmap_bytes.begin(), bitmap_bytes.end());
+
+        return write_raw_deletion_vector_file(file_bytes, payload_length);
+    }
+
+    DeletionVectorFile write_invalid_bitmap_deletion_vector_file() {
+        std::vector<char> file_bytes;
+        const uint32_t payload_length = 7;
+        append_big_endian_u32(&file_bytes, payload_length);
+        append_big_endian_u32(&file_bytes, kPaimonDeletionVectorMagicNumber);
+        file_bytes.push_back('\x01');
+        file_bytes.push_back('\x02');
+        file_bytes.push_back('\x03');
+
+        return write_raw_deletion_vector_file(file_bytes, payload_length);
+    }
+
+    DeletionVectorFile write_raw_deletion_vector_file(const std::vector<char>& bytes,
+                                                      int64_t payload_length) {
+        auto temp_dir = std::filesystem::temp_directory_path();
+        std::string pattern = (temp_dir / "paimon_reader_test_XXXXXX").string();
+        std::vector<char> path_buffer(pattern.begin(), pattern.end());
+        path_buffer.push_back('\0');
+
+        int fd = mkstemp(path_buffer.data());
+        EXPECT_GE(fd, 0);
+        if (fd >= 0) {
+            close(fd);
+        }
+
+        std::string path(path_buffer.data());
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        out.close();
+        EXPECT_TRUE(out.good());
+
+        _temp_files.push_back(path);
+        return {path, payload_length};
+    }
+
+    TFileRangeDesc build_range_with_deletion_file(const DeletionVectorFile& deletion_file) {
+        TFileRangeDesc range;
+        range.__isset.table_format_params = true;
+        range.table_format_params.__isset.paimon_params = true;
+        range.table_format_params.paimon_params.__isset.deletion_file = true;
+        range.table_format_params.paimon_params.deletion_file.path = deletion_file.path;
+        range.table_format_params.paimon_params.deletion_file.offset = 0;
+        range.table_format_params.paimon_params.deletion_file.length = deletion_file.payload_length;
+        return range;
+    }
+
+    TFileScanRangeParams build_local_params() {
+        TFileScanRangeParams params;
+        params.file_type = TFileType::FILE_LOCAL;
+        return params;
+    }
+
+    std::string paimon_parquet_test_file() const {
+        return "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+               "all_table_with_parquet/bucket-0/"
+               "data-3fe3fe10-7d88-4abd-be1f-6dc2bac84d88-0.parquet";
+    }
+
+    std::string paimon_orc_test_file() const {
+        return "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+               "all_table/bucket-0/data-12a1c2cb-6f0e-4692-996f-2d7a40a8c094-0.orc";
+    }
+
+    const TupleDescriptor* build_tuple_descriptor(
+            ObjectPool& object_pool,
+            const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        DescriptorTblBuilder builder(&object_pool);
+        auto& tuple_builder = builder.declare_tuple();
+        for (const auto& [name, type] : columns) {
+            tuple_builder << std::make_tuple(type, name);
+        }
+        return builder.build()->get_tuple_descriptor(0);
+    }
+
+    std::unordered_map<std::string, uint32_t> build_col_name_to_block_idx(
+            const TupleDescriptor* tuple_descriptor) {
+        std::unordered_map<std::string, uint32_t> mapping;
+        for (size_t i = 0; i < tuple_descriptor->slots().size(); ++i) {
+            mapping.emplace(tuple_descriptor->slots()[i]->col_name(), static_cast<uint32_t>(i));
+        }
+        return mapping;
+    }
+
+    std::vector<ColumnDescriptor> build_column_descs(
+            const TupleDescriptor* tuple_descriptor,
+            const std::vector<ColumnCategory>& categories) {
+        std::vector<ColumnDescriptor> column_descs;
+        column_descs.reserve(tuple_descriptor->slots().size());
+        for (size_t i = 0; i < tuple_descriptor->slots().size(); ++i) {
+            column_descs.push_back({tuple_descriptor->slots()[i]->col_name(),
+                                    tuple_descriptor->slots()[i], categories[i], nullptr});
+        }
+        return column_descs;
+    }
+
+    Block make_block(const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        Block block;
+        for (const auto& [name, type] : columns) {
+            block.insert(ColumnWithTypeAndName(type->create_column(), type, name));
+        }
+        return block;
+    }
+
+    void verify_nullable_string_column_has_rows(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_rows);
+        ASSERT_EQ(nested.size(), expected_rows);
+        if (expected_rows > 0) {
+            EXPECT_FALSE(nullable->is_null_at(0));
+        }
+    }
+
+    void verify_nullable_string_column_all_null(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        ASSERT_EQ(nullable->size(), expected_rows);
+        for (size_t i = 0; i < expected_rows; ++i) {
+            EXPECT_TRUE(nullable->is_null_at(i));
+        }
+    }
+
+    schema::external::TSchema build_history_schema_with_string_field(int64_t schema_id,
+                                                                     std::string field_name,
+                                                                     int32_t field_id) {
+        schema::external::TSchema schema;
+        schema.__set_schema_id(schema_id);
+
+        TColumnType struct_type;
+        struct_type.type = TPrimitiveType::STRUCT;
+        schema::external::TStructField root_field;
+
+        TColumnType string_type;
+        string_type.type = TPrimitiveType::STRING;
+        auto string_field = std::make_shared<schema::external::TField>();
+        string_field->name = std::move(field_name);
+        string_field->id = field_id;
+        string_field->type = string_type;
+
+        schema::external::TFieldPtr string_ptr;
+        string_ptr.__set_field_ptr(string_field);
+        root_field.fields.emplace_back(string_ptr);
+
+        schema.__set_root_field(root_field);
+        return schema;
+    }
+
+    Status try_read_paimon_parquet_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            return st;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        auto scan_params = build_local_params();
+        scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+        if (customize_scan_params != nullptr) {
+            customize_scan_params(&scan_params);
+        }
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+        scan_range.__isset.table_format_params = true;
+        scan_range.table_format_params.__isset.paimon_params = true;
+
+        RuntimeProfile profile("paimon_parquet_reader_test");
+        auto reader = std::make_unique<PaimonParquetReader>(&profile, scan_params, scan_range, 1024,
+                                                            &_timezone, &_kv_cache, nullptr,
+                                                            &runtime_state, _cache.get());
+        if (reader == nullptr) {
+            return Status::InternalError("failed to create paimon parquet reader");
+        }
+
+        ParquetInitContext pq_ctx;
+        pq_ctx.column_descs = &column_descs;
+        pq_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        pq_ctx.tuple_descriptor = tuple_descriptor;
+        pq_ctx.params = &scan_params;
+        pq_ctx.range = &scan_range;
+        st = reader->init_reader(&pq_ctx);
+        if (!st.ok()) {
+            return st;
+        }
+
+        *block = make_block(block_columns);
+        bool eof = false;
+        st = reader->get_next_block(block, read_rows, &eof);
+        return st;
+    }
+
+    void read_paimon_parquet_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto st = try_read_paimon_parquet_block(
+                actual_file, std::move(scan_range), tuple_descriptor, col_name_to_block_idx,
+                std::move(column_descs), block_columns, read_rows, block, customize_scan_params);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    Status try_read_paimon_orc_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        auto st = local_fs->file_size(actual_file, &file_size);
+        if (!st.ok()) {
+            return st;
+        }
+
+        RuntimeState runtime_state((TQueryOptions()), TQueryGlobals());
+        auto scan_params = build_local_params();
+        scan_params.format_type = TFileFormatType::FORMAT_ORC;
+        if (customize_scan_params != nullptr) {
+            customize_scan_params(&scan_params);
+        }
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+        scan_range.__isset.table_format_params = true;
+        scan_range.table_format_params.__isset.paimon_params = true;
+
+        RuntimeProfile profile("paimon_orc_reader_test");
+        auto reader =
+                std::make_unique<PaimonOrcReader>(&profile, &runtime_state, scan_params, scan_range,
+                                                  1024, "CST", &_kv_cache, nullptr, _cache.get());
+        if (reader == nullptr) {
+            return Status::InternalError("failed to create paimon orc reader");
+        }
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_descs = &column_descs;
+        orc_ctx.col_name_to_block_idx =
+                const_cast<std::unordered_map<std::string, uint32_t>*>(&col_name_to_block_idx);
+        orc_ctx.tuple_descriptor = tuple_descriptor;
+        orc_ctx.params = &scan_params;
+        orc_ctx.range = &scan_range;
+        st = reader->init_reader(&orc_ctx);
+        if (!st.ok()) {
+            return st;
+        }
+
+        *block = make_block(block_columns);
+        bool eof = false;
+        st = reader->get_next_block(block, read_rows, &eof);
+        return st;
+    }
+
+    void read_paimon_orc_block(
+            const std::string& actual_file, TFileRangeDesc scan_range,
+            const TupleDescriptor* tuple_descriptor,
+            const std::unordered_map<std::string, uint32_t>& col_name_to_block_idx,
+            std::vector<ColumnDescriptor> column_descs,
+            const std::vector<std::pair<std::string, DataTypePtr>>& block_columns,
+            size_t* read_rows, Block* block,
+            const std::function<void(TFileScanRangeParams*)>& customize_scan_params = {}) {
+        auto st = try_read_paimon_orc_block(actual_file, std::move(scan_range), tuple_descriptor,
+                                            col_name_to_block_idx, std::move(column_descs),
+                                            block_columns, read_rows, block, customize_scan_params);
+        ASSERT_TRUE(st.ok()) << st;
+    }
+
+    Status try_init_paimon_parquet_reader(TFileRangeDesc scan_range,
+                                          TPushAggOp::type push_down_agg_type,
+                                          std::unique_ptr<PaimonParquetReader>* reader) {
+        auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+        ObjectPool object_pool;
+        const auto* tuple_descriptor =
+                build_tuple_descriptor(object_pool, {{"c13", nullable_string}});
+        auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+        auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+        auto actual_file = paimon_parquet_test_file();
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        RETURN_IF_ERROR(local_fs->file_size(actual_file, &file_size));
+
+        auto scan_params = build_local_params();
+        scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+        scan_range.__isset.table_format_params = true;
+        scan_range.table_format_params.__isset.paimon_params = true;
+
+        auto local_reader = std::make_unique<PaimonParquetReader>(
+                &_profile, scan_params, scan_range, 1024, &_timezone, &_kv_cache, nullptr,
+                &_runtime_state, _cache.get());
+        if (local_reader == nullptr) {
+            return Status::InternalError("failed to create paimon parquet reader");
+        }
+
+        ParquetInitContext pq_ctx;
+        pq_ctx.column_descs = &column_descs;
+        pq_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+        pq_ctx.tuple_descriptor = tuple_descriptor;
+        pq_ctx.params = &scan_params;
+        pq_ctx.range = &scan_range;
+        pq_ctx.push_down_agg_type = push_down_agg_type;
+        auto st = local_reader->init_reader(&pq_ctx);
+        *reader = std::move(local_reader);
+        return st;
+    }
+
+    Status try_init_paimon_orc_reader(TFileRangeDesc scan_range,
+                                      TPushAggOp::type push_down_agg_type,
+                                      std::unique_ptr<PaimonOrcReader>* reader) {
+        auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+        ObjectPool object_pool;
+        const auto* tuple_descriptor =
+                build_tuple_descriptor(object_pool, {{"c13", nullable_string}});
+        auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+        auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+        auto actual_file = paimon_orc_test_file();
+        auto local_fs = io::global_local_filesystem();
+        int64_t file_size = 0;
+        RETURN_IF_ERROR(local_fs->file_size(actual_file, &file_size));
+
+        auto scan_params = build_local_params();
+        scan_params.format_type = TFileFormatType::FORMAT_ORC;
+
+        scan_range.start_offset = 0;
+        scan_range.size = file_size;
+        scan_range.path = actual_file;
+        scan_range.__isset.table_format_params = true;
+        scan_range.table_format_params.__isset.paimon_params = true;
+
+        auto local_reader = std::make_unique<PaimonOrcReader>(&_profile, &_runtime_state,
+                                                              scan_params, scan_range, 1024, "CST",
+                                                              &_kv_cache, nullptr, _cache.get());
+        if (local_reader == nullptr) {
+            return Status::InternalError("failed to create paimon orc reader");
+        }
+
+        OrcInitContext orc_ctx;
+        orc_ctx.column_descs = &column_descs;
+        orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+        orc_ctx.tuple_descriptor = tuple_descriptor;
+        orc_ctx.params = &scan_params;
+        orc_ctx.range = &scan_range;
+        orc_ctx.push_down_agg_type = push_down_agg_type;
+        auto st = local_reader->init_reader(&orc_ctx);
+        *reader = std::move(local_reader);
+        return st;
+    }
+
+    RuntimeState _runtime_state {(TQueryOptions()), TQueryGlobals()};
+    RuntimeProfile _profile {"paimon_reader_test"};
+    ShardedKVCache _kv_cache {8};
+    cctz::time_zone _timezone;
+    std::unique_ptr<FileMetaCache> _cache;
+    std::vector<std::string> _temp_files;
+};
+
+TEST_F(PaimonReaderTest, read_paimon_parquet_string_column) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_parquet_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table_with_parquet/bucket-0/data-3fe3fe10-7d88-4abd-be1f-6dc2bac84d88-0.parquet",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"c13", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "c13", read_rows);
+}
+
+TEST_F(PaimonReaderTest, read_paimon_orc_string_column) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_orc_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table/bucket-0/data-12a1c2cb-6f0e-4692-996f-2d7a40a8c094-0.orc",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"c13", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "c13", read_rows);
+}
+
+TEST_F(PaimonReaderTest, fills_missing_column_with_null_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"c13", nullable_string}, {"missing_col", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor,
+                                           {ColumnCategory::REGULAR, ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_parquet_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table_with_parquet/bucket-0/data-3fe3fe10-7d88-4abd-be1f-6dc2bac84d88-0.parquet",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"c13", nullable_string}, {"missing_col", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "missing_col", read_rows);
+}
+
+TEST_F(PaimonReaderTest, fills_missing_column_with_null_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"c13", nullable_string}, {"missing_col", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor,
+                                           {ColumnCategory::REGULAR, ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_orc_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table/bucket-0/data-12a1c2cb-6f0e-4692-996f-2d7a40a8c094-0.orc",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"c13", nullable_string}, {"missing_col", nullable_string}}, &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_all_null(block, "missing_col", read_rows);
+}
+
+TEST_F(PaimonReaderTest, reads_generated_column_from_file_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::GENERATED});
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_parquet_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table_with_parquet/bucket-0/data-3fe3fe10-7d88-4abd-be1f-6dc2bac84d88-0.parquet",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"c13", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "c13", read_rows);
+}
+
+TEST_F(PaimonReaderTest, reads_generated_column_from_file_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::GENERATED});
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_orc_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table/bucket-0/data-12a1c2cb-6f0e-4692-996f-2d7a40a8c094-0.orc",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"c13", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "c13", read_rows);
+}
+
+TEST_F(PaimonReaderTest, matches_uppercase_orc_columns_case_insensitively) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(object_pool, {{"val", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_orc_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "tb_with_upper_case/bucket-0/data-3eb9d575-5340-43d6-a45d-588a72a03306-0.orc",
+            {}, tuple_descriptor, col_name_to_block_idx, column_descs, {{"val", nullable_string}},
+            &read_rows, &block);
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "val", read_rows);
+}
+
+TEST_F(PaimonReaderTest, reads_renamed_column_via_history_schema_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"renamed_c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.paimon_params = true;
+    scan_range.table_format_params.paimon_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_parquet_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table_with_parquet/bucket-0/data-3fe3fe10-7d88-4abd-be1f-6dc2bac84d88-0.parquet",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"renamed_c13", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(1, "c13", 13),
+                         build_history_schema_with_string_field(2, "renamed_c13", 13)});
+            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "renamed_c13", read_rows);
+}
+
+TEST_F(PaimonReaderTest, reads_renamed_column_via_history_schema_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"renamed_c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.paimon_params = true;
+    scan_range.table_format_params.paimon_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    read_paimon_orc_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table/bucket-0/data-12a1c2cb-6f0e-4692-996f-2d7a40a8c094-0.orc",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"renamed_c13", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(1, "c13", 13),
+                         build_history_schema_with_string_field(2, "renamed_c13", 13)});
+            });
+
+    ASSERT_GT(read_rows, 0);
+    EXPECT_EQ(block.rows(), read_rows);
+    verify_nullable_string_column_has_rows(block, "renamed_c13", read_rows);
+}
+
+TEST_F(PaimonReaderTest, missing_file_history_schema_returns_error_for_parquet) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"renamed_c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.paimon_params = true;
+    scan_range.table_format_params.paimon_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    auto st = try_read_paimon_parquet_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table_with_parquet/bucket-0/data-3fe3fe10-7d88-4abd-be1f-6dc2bac84d88-0.parquet",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"renamed_c13", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(2, "renamed_c13", 13)});
+            });
+
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("miss table/file schema info"), std::string::npos);
+}
+
+TEST_F(PaimonReaderTest, missing_file_history_schema_returns_error_for_orc) {
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"renamed_c13", nullable_string}});
+    auto col_name_to_block_idx = build_col_name_to_block_idx(tuple_descriptor);
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+
+    TFileRangeDesc scan_range;
+    scan_range.__isset.table_format_params = true;
+    scan_range.table_format_params.__isset.paimon_params = true;
+    scan_range.table_format_params.paimon_params.__set_schema_id(1);
+
+    size_t read_rows = 0;
+    Block block;
+    auto st = try_read_paimon_orc_block(
+            "./docker/thirdparties/docker-compose/hive/scripts/paimon1/db1.db/"
+            "all_table/bucket-0/data-12a1c2cb-6f0e-4692-996f-2d7a40a8c094-0.orc",
+            scan_range, tuple_descriptor, col_name_to_block_idx, column_descs,
+            {{"renamed_c13", nullable_string}}, &read_rows, &block,
+            [&](TFileScanRangeParams* scan_params) {
+                scan_params->__set_current_schema_id(2);
+                scan_params->__set_history_schema_info(
+                        {build_history_schema_with_string_field(2, "renamed_c13", 13)});
+            });
+
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("miss table/file schema info"), std::string::npos);
+}
+
+TEST_F(PaimonReaderTest, parquet_deletion_vector_disables_count_pushdown_without_row_count) {
+    auto deletion_file = write_valid_deletion_vector_file({1, 3, 7});
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonParquetReader> reader;
+    auto status = try_init_paimon_parquet_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader->get_push_down_agg_type(), TPushAggOp::NONE);
+    EXPECT_TRUE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, parquet_deletion_vector_loads_expected_row_ids) {
+    auto deletion_file = write_valid_deletion_vector_file({1, 3, 7});
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonParquetReader> reader;
+    auto status = try_init_paimon_parquet_reader(range, TPushAggOp::NONE, &reader);
+
+    ASSERT_TRUE(status.ok()) << status;
+    ASSERT_NE(reader->_delete_rows, nullptr);
+    EXPECT_EQ(*reader->_delete_rows, (std::vector<int64_t> {1, 3, 7}));
+}
+
+TEST_F(PaimonReaderTest, parquet_without_deletion_vector_keeps_count_pushdown) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    std::unique_ptr<PaimonParquetReader> reader;
+    auto status = try_init_paimon_parquet_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader->get_push_down_agg_type(), TPushAggOp::COUNT);
+    EXPECT_FALSE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, orc_without_deletion_vector_keeps_count_pushdown) {
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    std::unique_ptr<PaimonOrcReader> reader;
+    auto status = try_init_paimon_orc_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader->get_push_down_agg_type(), TPushAggOp::COUNT);
+    EXPECT_FALSE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, parquet_deletion_vector_keeps_count_pushdown_with_row_count) {
+    auto deletion_file = write_valid_deletion_vector_file({2, 4});
+    auto range = build_range_with_deletion_file(deletion_file);
+    range.table_format_params.paimon_params.__set_row_count(10);
+    std::unique_ptr<PaimonParquetReader> reader;
+    auto status = try_init_paimon_parquet_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader->get_push_down_agg_type(), TPushAggOp::COUNT);
+    EXPECT_TRUE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, orc_deletion_vector_disables_count_pushdown_without_row_count) {
+    auto deletion_file = write_valid_deletion_vector_file({5, 9});
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonOrcReader> reader;
+    auto status = try_init_paimon_orc_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader->get_push_down_agg_type(), TPushAggOp::NONE);
+    EXPECT_TRUE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, orc_deletion_vector_loads_expected_row_ids) {
+    auto deletion_file = write_valid_deletion_vector_file({5, 9});
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonOrcReader> reader;
+    auto status = try_init_paimon_orc_reader(range, TPushAggOp::NONE, &reader);
+
+    ASSERT_TRUE(status.ok()) << status;
+    ASSERT_NE(reader->_delete_rows, nullptr);
+    EXPECT_EQ(*reader->_delete_rows, (std::vector<int64_t> {5, 9}));
+}
+
+TEST_F(PaimonReaderTest, orc_deletion_vector_keeps_count_pushdown_with_row_count) {
+    auto deletion_file = write_valid_deletion_vector_file({5, 9});
+    auto range = build_range_with_deletion_file(deletion_file);
+    range.table_format_params.paimon_params.__set_row_count(20);
+    std::unique_ptr<PaimonOrcReader> reader;
+    auto status = try_init_paimon_orc_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader->get_push_down_agg_type(), TPushAggOp::COUNT);
+    EXPECT_TRUE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, parquet_deletion_vector_reuses_cached_rows) {
+    auto deletion_file = write_valid_deletion_vector_file({2, 4, 8});
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonParquetReader> first_reader;
+    auto first_status = try_init_paimon_parquet_reader(range, TPushAggOp::NONE, &first_reader);
+    ASSERT_TRUE(first_status.ok()) << first_status;
+    ASSERT_NE(first_reader->_delete_rows, nullptr);
+
+    std::unique_ptr<PaimonParquetReader> second_reader;
+    auto second_status = try_init_paimon_parquet_reader(range, TPushAggOp::NONE, &second_reader);
+    ASSERT_TRUE(second_status.ok()) << second_status;
+    ASSERT_NE(second_reader->_delete_rows, nullptr);
+
+    EXPECT_EQ(first_reader->_delete_rows, second_reader->_delete_rows);
+    EXPECT_EQ(*second_reader->_delete_rows, (std::vector<int64_t> {2, 4, 8}));
+}
+
+TEST_F(PaimonReaderTest, parquet_invalid_deletion_vector_magic_returns_error) {
+    auto deletion_file = write_invalid_magic_deletion_vector_file();
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonParquetReader> reader;
+    auto status = try_init_paimon_parquet_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("invalid magic number"), std::string::npos);
+    ASSERT_NE(reader, nullptr);
+    EXPECT_FALSE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, parquet_invalid_deletion_vector_length_returns_error) {
+    auto deletion_file = write_invalid_length_deletion_vector_file();
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonParquetReader> reader;
+    auto status = try_init_paimon_parquet_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("length not match"), std::string::npos);
+    ASSERT_NE(reader, nullptr);
+    EXPECT_FALSE(reader->has_delete_operations());
+}
+
+TEST_F(PaimonReaderTest, parquet_invalid_deletion_vector_bitmap_returns_error) {
+    auto deletion_file = write_invalid_bitmap_deletion_vector_file();
+    auto range = build_range_with_deletion_file(deletion_file);
+    std::unique_ptr<PaimonParquetReader> reader;
+    auto status = try_init_paimon_parquet_reader(range, TPushAggOp::COUNT, &reader);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("failed to deserialize roaring bitmap"), std::string::npos);
+    ASSERT_NE(reader, nullptr);
+    EXPECT_FALSE(reader->has_delete_operations());
+}
+
+} // namespace doris

--- a/be/test/format/table/reader_test_util.h
+++ b/be/test/format/table/reader_test_util.h
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "core/assert_cast.h"
+#include "core/block/block.h"
+#include "core/block/column_with_type_and_name.h"
+#include "core/column/column.h"
+#include "core/column/column_array.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_struct.h"
+#include "core/data_type/data_type.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_map.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "core/data_type/data_type_struct.h"
+
+namespace doris::reader_test {
+
+inline const std::vector<std::string>& default_nested_reader_column_names() {
+    static const std::vector<std::string> names = {"name", "profile"};
+    return names;
+}
+
+inline void create_complex_user_profile_types(
+        DataTypePtr& coordinates_struct_type, DataTypePtr& address_struct_type,
+        DataTypePtr& phone_struct_type, DataTypePtr& contact_struct_type,
+        DataTypePtr& hobby_element_struct_type, DataTypePtr& hobbies_array_type,
+        DataTypePtr& profile_struct_type, DataTypePtr& name_type) {
+    name_type = make_nullable(std::make_shared<DataTypeString>());
+
+    std::vector<DataTypePtr> coordinates_types = {
+            make_nullable(std::make_shared<DataTypeFloat64>()),
+            make_nullable(std::make_shared<DataTypeFloat64>())};
+    std::vector<std::string> coordinates_names = {"lat", "lng"};
+    coordinates_struct_type =
+            make_nullable(std::make_shared<DataTypeStruct>(coordinates_types, coordinates_names));
+
+    std::vector<DataTypePtr> address_types = {make_nullable(std::make_shared<DataTypeString>()),
+                                              make_nullable(std::make_shared<DataTypeString>()),
+                                              coordinates_struct_type};
+    std::vector<std::string> address_names = {"street", "city", "coordinates"};
+    address_struct_type =
+            make_nullable(std::make_shared<DataTypeStruct>(address_types, address_names));
+
+    std::vector<DataTypePtr> phone_types = {make_nullable(std::make_shared<DataTypeString>()),
+                                            make_nullable(std::make_shared<DataTypeString>())};
+    std::vector<std::string> phone_names = {"country_code", "number"};
+    phone_struct_type = make_nullable(std::make_shared<DataTypeStruct>(phone_types, phone_names));
+
+    std::vector<DataTypePtr> contact_types = {make_nullable(std::make_shared<DataTypeString>()),
+                                              phone_struct_type};
+    std::vector<std::string> contact_names = {"email", "phone"};
+    contact_struct_type =
+            make_nullable(std::make_shared<DataTypeStruct>(contact_types, contact_names));
+
+    std::vector<DataTypePtr> hobby_element_types = {
+            make_nullable(std::make_shared<DataTypeString>()),
+            make_nullable(std::make_shared<DataTypeInt32>())};
+    std::vector<std::string> hobby_element_names = {"name", "level"};
+    hobby_element_struct_type = make_nullable(
+            std::make_shared<DataTypeStruct>(hobby_element_types, hobby_element_names));
+
+    hobbies_array_type = make_nullable(std::make_shared<DataTypeArray>(hobby_element_struct_type));
+
+    std::vector<DataTypePtr> profile_types = {address_struct_type, contact_struct_type,
+                                              hobbies_array_type};
+    std::vector<std::string> profile_names = {"address", "contact", "hobbies"};
+    profile_struct_type =
+            make_nullable(std::make_shared<DataTypeStruct>(profile_types, profile_names));
+}
+
+inline Block make_name_profile_block(const DataTypePtr& name_type,
+                                     const DataTypePtr& profile_struct_type) {
+    Block block;
+    block.insert(ColumnWithTypeAndName(name_type->create_column(), name_type, "name"));
+    block.insert(ColumnWithTypeAndName(profile_struct_type->create_column(), profile_struct_type,
+                                       "profile"));
+    return block;
+}
+
+inline void verify_nested_reader_block(Block& block, size_t read_rows,
+                                       const std::vector<std::string>& expected_column_names =
+                                               default_nested_reader_column_names()) {
+    EXPECT_GT(read_rows, 0) << "Should read at least one row";
+    EXPECT_EQ(block.rows(), read_rows);
+    EXPECT_EQ(block.columns(), expected_column_names.size());
+
+    auto columns_with_names = block.get_columns_with_type_and_name();
+    for (size_t i = 0; i < expected_column_names.size(); ++i) {
+        EXPECT_EQ(columns_with_names[i].name, expected_column_names[i]);
+    }
+
+    EXPECT_TRUE(columns_with_names[0].type->get_name().find("String") != std::string::npos);
+    EXPECT_TRUE(columns_with_names[1].type->get_name().find("Struct") != std::string::npos);
+
+    std::cout << "Block rows: " << block.rows() << std::endl;
+
+    std::function<void(const ColumnPtr&, const DataTypePtr&, const std::string&, int, bool)>
+            print_column_rows = [&](const ColumnPtr& col, const DataTypePtr& type,
+                                    const std::string& name, int depth, bool allow_empty) {
+                std::string indent(depth * 2, ' ');
+                std::cout << indent << name << " row count: " << col->size() << std::endl;
+                if (!allow_empty) {
+                    EXPECT_GT(col->size(), 0) << name << " column/subcolumn size should be > 0";
+                }
+
+                if (const auto* nullable_col = typeid_cast<const ColumnNullable*>(col.get())) {
+                    auto nested_type =
+                            assert_cast<const DataTypeNullable*>(type.get())->get_nested_type();
+                    bool is_complex_type =
+                            typeid_cast<const DataTypeStruct*>(nested_type.get()) != nullptr ||
+                            typeid_cast<const DataTypeArray*>(nested_type.get()) != nullptr ||
+                            typeid_cast<const DataTypeMap*>(nested_type.get()) != nullptr;
+                    std::string nested_name = is_complex_type ? name + ".nested" : name;
+                    print_column_rows(nullable_col->get_nested_column_ptr(), nested_type,
+                                      nested_name, depth + (is_complex_type ? 1 : 0), allow_empty);
+                    return;
+                }
+
+                if (const auto* struct_col = typeid_cast<const ColumnStruct*>(col.get())) {
+                    auto struct_type = assert_cast<const DataTypeStruct*>(type.get());
+                    for (size_t i = 0; i < struct_col->tuple_size(); ++i) {
+                        print_column_rows(struct_col->get_column_ptr(i),
+                                          struct_type->get_element(i),
+                                          name + "." + struct_type->get_element_name(i), depth + 1,
+                                          allow_empty);
+                    }
+                    return;
+                }
+
+                if (const auto* array_col = typeid_cast<const ColumnArray*>(col.get())) {
+                    auto array_type = assert_cast<const DataTypeArray*>(type.get());
+                    print_column_rows(array_col->get_data_ptr(), array_type->get_nested_type(),
+                                      name + ".data", depth + 1, true);
+                }
+            };
+
+    for (size_t i = 0; i < block.columns(); ++i) {
+        const auto& column_with_name = block.get_by_position(i);
+        print_column_rows(column_with_name.column, column_with_name.type, column_with_name.name, 0,
+                          false);
+        EXPECT_EQ(column_with_name.column->size(), block.rows())
+                << "Column " << column_with_name.name << " size mismatch";
+    }
+}
+
+} // namespace doris::reader_test

--- a/be/test/format/table/reader_test_util.h
+++ b/be/test/format/table/reader_test_util.h
@@ -20,7 +20,6 @@
 #include <gtest/gtest.h>
 
 #include <functional>
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -118,13 +117,9 @@ inline void verify_nested_reader_block(Block& block, size_t read_rows,
     EXPECT_TRUE(columns_with_names[0].type->get_name().find("String") != std::string::npos);
     EXPECT_TRUE(columns_with_names[1].type->get_name().find("Struct") != std::string::npos);
 
-    std::cout << "Block rows: " << block.rows() << std::endl;
-
-    std::function<void(const ColumnPtr&, const DataTypePtr&, const std::string&, int, bool)>
+    std::function<void(const ColumnPtr&, const DataTypePtr&, const std::string&, bool)>
             print_column_rows = [&](const ColumnPtr& col, const DataTypePtr& type,
-                                    const std::string& name, int depth, bool allow_empty) {
-                std::string indent(depth * 2, ' ');
-                std::cout << indent << name << " row count: " << col->size() << std::endl;
+                                    const std::string& name, bool allow_empty) {
                 if (!allow_empty) {
                     EXPECT_GT(col->size(), 0) << name << " column/subcolumn size should be > 0";
                 }
@@ -138,17 +133,16 @@ inline void verify_nested_reader_block(Block& block, size_t read_rows,
                             typeid_cast<const DataTypeMap*>(nested_type.get()) != nullptr;
                     std::string nested_name = is_complex_type ? name + ".nested" : name;
                     print_column_rows(nullable_col->get_nested_column_ptr(), nested_type,
-                                      nested_name, depth + (is_complex_type ? 1 : 0), allow_empty);
+                                      nested_name, allow_empty);
                     return;
                 }
 
                 if (const auto* struct_col = typeid_cast<const ColumnStruct*>(col.get())) {
                     auto struct_type = assert_cast<const DataTypeStruct*>(type.get());
                     for (size_t i = 0; i < struct_col->tuple_size(); ++i) {
-                        print_column_rows(struct_col->get_column_ptr(i),
-                                          struct_type->get_element(i),
-                                          name + "." + struct_type->get_element_name(i), depth + 1,
-                                          allow_empty);
+                        print_column_rows(
+                                struct_col->get_column_ptr(i), struct_type->get_element(i),
+                                name + "." + struct_type->get_element_name(i), allow_empty);
                     }
                     return;
                 }
@@ -156,13 +150,13 @@ inline void verify_nested_reader_block(Block& block, size_t read_rows,
                 if (const auto* array_col = typeid_cast<const ColumnArray*>(col.get())) {
                     auto array_type = assert_cast<const DataTypeArray*>(type.get());
                     print_column_rows(array_col->get_data_ptr(), array_type->get_nested_type(),
-                                      name + ".data", depth + 1, true);
+                                      name + ".data", true);
                 }
             };
 
     for (size_t i = 0; i < block.columns(); ++i) {
         const auto& column_with_name = block.get_by_position(i);
-        print_column_rows(column_with_name.column, column_with_name.type, column_with_name.name, 0,
+        print_column_rows(column_with_name.column, column_with_name.type, column_with_name.name,
                           false);
         EXPECT_EQ(column_with_name.column->size(), block.rows())
                 << "Column " << column_with_name.name << " size mismatch";

--- a/be/test/format/table/table_format_reader_test.cpp
+++ b/be/test/format/table/table_format_reader_test.cpp
@@ -1,0 +1,1149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/table/table_format_reader.h"
+
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/object_pool.h"
+#include "core/block/block.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "format/column_descriptor.h"
+#include "format/generic_reader.h"
+#include "testutil/desc_tbl_builder.h"
+
+namespace doris {
+
+// ============================================================================
+// MockTableFormatReader: A testable TableFormatReader subclass.
+// ============================================================================
+class MockTableFormatReader : public TableFormatReader {
+public:
+    // Expose protected members for testing.
+    using TableFormatReader::_extract_partition_values;
+    using TableFormatReader::_fill_col_name_to_block_idx;
+    using TableFormatReader::_fill_missing_cols;
+    using TableFormatReader::_fill_missing_defaults;
+    using TableFormatReader::_fill_partition_values;
+
+    // Fake file columns returned by get_columns().
+    std::unordered_map<std::string, DataTypePtr> fake_file_columns;
+
+    // Track calls.
+    std::vector<std::string> call_log;
+
+    // Configurable per-batch rows.
+    int batches_to_emit = 1;
+    size_t rows_per_batch = 10;
+
+protected:
+    Status _get_columns_impl(std::unordered_map<std::string, DataTypePtr>* name_to_type) override {
+        *name_to_type = fake_file_columns;
+        return Status::OK();
+    }
+
+    Status _do_init_reader(ReaderInitContext* /*ctx*/) override {
+        call_log.push_back("_do_init_reader");
+        return Status::OK();
+    }
+
+    Status _do_get_next_block(Block* block, size_t* read_rows, bool* eof) override {
+        call_log.push_back("_do_get_next_block");
+        if (batches_to_emit <= 0) {
+            *read_rows = 0;
+            *eof = true;
+            return Status::OK();
+        }
+        batches_to_emit--;
+        *read_rows = rows_per_batch;
+        *eof = (batches_to_emit == 0);
+
+        // Simulate reading data: only fill columns that are NOT partition/missing.
+        // This matches real reader behavior (Parquet/ORC only fill REGULAR file columns).
+        auto mutate_columns = block->mutate_columns();
+        for (size_t i = 0; i < mutate_columns.size(); i++) {
+            const auto& col_name = block->get_by_position(i).name;
+            // Skip columns that will be filled by on_after_read_block.
+            if (_fill_partition_values.contains(col_name) ||
+                _fill_missing_defaults.contains(col_name)) {
+                continue;
+            }
+            if (mutate_columns[i]->size() == 0) {
+                auto type = block->get_by_position(i).type;
+                if (type->is_nullable()) {
+                    auto* nullable = static_cast<ColumnNullable*>(mutate_columns[i].get());
+                    for (size_t r = 0; r < *read_rows; r++) {
+                        nullable->insert_data(nullptr, 0);
+                    }
+                } else {
+                    mutate_columns[i]->insert_many_defaults(*read_rows);
+                }
+            }
+        }
+        block->set_columns(std::move(mutate_columns));
+        return Status::OK();
+    }
+};
+
+// ============================================================================
+// Test fixture
+// ============================================================================
+class TableFormatReaderTest : public testing::Test {
+protected:
+    ObjectPool object_pool;
+
+    // Build a TupleDescriptor via DescriptorTblBuilder.
+    const TupleDescriptor* build_tuple_desc(
+            const std::vector<std::pair<std::string, DataTypePtr>>& cols) {
+        DescriptorTblBuilder builder(&object_pool);
+        auto& tuple_builder = builder.declare_tuple();
+        for (auto& [name, type] : cols) {
+            tuple_builder << std::make_tuple(type, name);
+        }
+        DescriptorTbl* desc_tbl = builder.build();
+        return desc_tbl->get_tuple_descriptor(0);
+    }
+
+    static DataTypePtr nullable_int64() {
+        return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>());
+    }
+    static DataTypePtr nullable_string() {
+        return std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
+    }
+
+    // Helper: get column by name from block (via get_position_by_name).
+    static const ColumnWithTypeAndName& get_col(const Block& block, const std::string& name) {
+        int pos = block.get_position_by_name(name);
+        EXPECT_GE(pos, 0) << "Column " << name << " not found in block";
+        return block.get_by_position(static_cast<size_t>(pos));
+    }
+
+    // Build a Block matching the given tuple descriptor.
+    static Block make_block(const TupleDescriptor* tuple_desc) {
+        Block block;
+        for (auto* slot : tuple_desc->slots()) {
+            block.insert({slot->get_data_type_ptr()->create_column(), slot->get_data_type_ptr(),
+                          slot->col_name()});
+        }
+        return block;
+    }
+
+    static std::unordered_map<std::string, uint32_t> build_col_name_to_block_idx(
+            const TupleDescriptor* tuple_desc) {
+        std::unordered_map<std::string, uint32_t> map;
+        for (size_t i = 0; i < tuple_desc->slots().size(); i++) {
+            map[tuple_desc->slots()[i]->col_name()] = i;
+        }
+        return map;
+    }
+};
+
+// ============================================================================
+// Test: ColumnOptimizationTypes bitmask operations
+// ============================================================================
+TEST_F(TableFormatReaderTest, ColumnOptimizationTypesDefault) {
+    MockTableFormatReader reader;
+    EXPECT_EQ(reader.get_column_optimizations("any_col"),
+              TableFormatReader::ColumnOptimizationTypes::DEFAULT);
+    EXPECT_TRUE(reader.has_column_optimization(
+            "any_col", TableFormatReader::ColumnOptimizationTypes::LAZY_READ));
+    EXPECT_TRUE(reader.has_column_optimization(
+            "any_col", TableFormatReader::ColumnOptimizationTypes::DICT_FILTER));
+    EXPECT_TRUE(reader.has_column_optimization(
+            "any_col", TableFormatReader::ColumnOptimizationTypes::MIN_MAX));
+    EXPECT_FALSE(reader.disable_column_opt("any_col"));
+}
+
+TEST_F(TableFormatReaderTest, ColumnOptimizationTypesSetNone) {
+    MockTableFormatReader reader;
+    reader.set_column_optimizations("col_a", TableFormatReader::ColumnOptimizationTypes::NONE);
+    EXPECT_EQ(reader.get_column_optimizations("col_a"),
+              TableFormatReader::ColumnOptimizationTypes::NONE);
+    EXPECT_FALSE(reader.has_column_optimization(
+            "col_a", TableFormatReader::ColumnOptimizationTypes::LAZY_READ));
+    EXPECT_TRUE(reader.disable_column_opt("col_a"));
+}
+
+TEST_F(TableFormatReaderTest, ColumnOptimizationTypesPartialBitmask) {
+    MockTableFormatReader reader;
+    reader.set_column_optimizations("col_b", TableFormatReader::ColumnOptimizationTypes::LAZY_READ);
+    EXPECT_TRUE(reader.has_column_optimization(
+            "col_b", TableFormatReader::ColumnOptimizationTypes::LAZY_READ));
+    EXPECT_FALSE(reader.has_column_optimization(
+            "col_b", TableFormatReader::ColumnOptimizationTypes::DICT_FILTER));
+    EXPECT_FALSE(reader.has_column_optimization(
+            "col_b", TableFormatReader::ColumnOptimizationTypes::MIN_MAX));
+    EXPECT_FALSE(reader.disable_column_opt("col_b"));
+}
+
+TEST_F(TableFormatReaderTest, ColumnOptimizationTypesResetToDefault) {
+    MockTableFormatReader reader;
+    reader.set_column_optimizations("col_c", TableFormatReader::ColumnOptimizationTypes::NONE);
+    EXPECT_TRUE(reader.disable_column_opt("col_c"));
+    // Reset by passing DEFAULT.
+    reader.set_column_optimizations("col_c", TableFormatReader::ColumnOptimizationTypes::DEFAULT);
+    EXPECT_FALSE(reader.disable_column_opt("col_c"));
+    EXPECT_EQ(reader.get_column_optimizations("col_c"),
+              TableFormatReader::ColumnOptimizationTypes::DEFAULT);
+}
+
+// ============================================================================
+// Test: Synthesized column handler registration and filling
+// ============================================================================
+TEST_F(TableFormatReaderTest, RegisterAndFillSynthesizedColumn) {
+    MockTableFormatReader reader;
+    EXPECT_FALSE(reader.has_synthesized_column_handlers());
+
+    int synth_call_count = 0;
+    reader.register_synthesized_column_handler(
+            "synth_col", [&synth_call_count](Block* block, size_t rows) -> Status {
+                synth_call_count++;
+                return Status::OK();
+            });
+    EXPECT_TRUE(reader.has_synthesized_column_handlers());
+
+    Block block;
+    auto type = nullable_int64();
+    block.insert({type->create_column(), type, "synth_col"});
+    auto st = reader.fill_synthesized_columns(&block, 5);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(synth_call_count, 1);
+}
+
+TEST_F(TableFormatReaderTest, MultipleSynthesizedColumnHandlers) {
+    MockTableFormatReader reader;
+    std::vector<std::string> called;
+
+    reader.register_synthesized_column_handler("synth_a", [&called](Block*, size_t) -> Status {
+        called.push_back("synth_a");
+        return Status::OK();
+    });
+    reader.register_synthesized_column_handler("synth_b", [&called](Block*, size_t) -> Status {
+        called.push_back("synth_b");
+        return Status::OK();
+    });
+
+    Block block;
+    auto type = nullable_int64();
+    block.insert({type->create_column(), type, "synth_a"});
+    block.insert({type->create_column(), type, "synth_b"});
+
+    auto st = reader.fill_synthesized_columns(&block, 3);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(called.size(), 2);
+    EXPECT_EQ(called[0], "synth_a");
+    EXPECT_EQ(called[1], "synth_b");
+}
+
+TEST_F(TableFormatReaderTest, SynthesizedColumnHandlerError) {
+    MockTableFormatReader reader;
+    reader.register_synthesized_column_handler("bad_synth", [](Block*, size_t) -> Status {
+        return Status::InternalError("synth computation failed");
+    });
+
+    Block block;
+    auto type = nullable_int64();
+    block.insert({type->create_column(), type, "bad_synth"});
+    auto st = reader.fill_synthesized_columns(&block, 1);
+    ASSERT_FALSE(st.ok());
+}
+
+// ============================================================================
+// Test: Generated column handler registration and optimization flags
+// ============================================================================
+TEST_F(TableFormatReaderTest, RegisterGeneratedColumnDisablesOptimizations) {
+    MockTableFormatReader reader;
+    EXPECT_FALSE(reader.has_generated_column_handlers());
+
+    reader.register_generated_column_handler("gen_col",
+                                             [](Block*, size_t) -> Status { return Status::OK(); });
+    EXPECT_TRUE(reader.has_generated_column_handlers());
+    // Generated columns must have ALL optimizations disabled.
+    EXPECT_TRUE(reader.disable_column_opt("gen_col"));
+    EXPECT_EQ(reader.get_column_optimizations("gen_col"),
+              TableFormatReader::ColumnOptimizationTypes::NONE);
+}
+
+TEST_F(TableFormatReaderTest, FillGeneratedColumns) {
+    MockTableFormatReader reader;
+    int gen_call_count = 0;
+    reader.register_generated_column_handler(
+            "gen_col", [&gen_call_count](Block* block, size_t rows) -> Status {
+                gen_call_count++;
+                return Status::OK();
+            });
+
+    Block block;
+    auto type = nullable_int64();
+    block.insert({type->create_column(), type, "gen_col"});
+    auto st = reader.fill_generated_columns(&block, 10);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(gen_call_count, 1);
+}
+
+// ============================================================================
+// Test: Clear synthesized/generated columns
+// ============================================================================
+TEST_F(TableFormatReaderTest, ClearSynthesizedColumns) {
+    MockTableFormatReader reader;
+    reader.register_synthesized_column_handler(
+            "synth_col", [](Block*, size_t) -> Status { return Status::OK(); });
+
+    Block block;
+    auto type = nullable_int64();
+    auto col = type->create_column();
+    col->assume_mutable()->insert_many_defaults(5);
+    block.insert({std::move(col), type, "synth_col"});
+    ASSERT_EQ(get_col(block, "synth_col").column->size(), 5);
+
+    auto st = reader.clear_synthesized_columns(&block);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(get_col(block, "synth_col").column->size(), 0);
+}
+
+TEST_F(TableFormatReaderTest, ClearGeneratedColumns) {
+    MockTableFormatReader reader;
+    reader.register_generated_column_handler("gen_col",
+                                             [](Block*, size_t) -> Status { return Status::OK(); });
+
+    Block block;
+    auto type = nullable_int64();
+    auto col = type->create_column();
+    col->assume_mutable()->insert_many_defaults(3);
+    block.insert({std::move(col), type, "gen_col"});
+    ASSERT_EQ(get_col(block, "gen_col").column->size(), 3);
+
+    auto st = reader.clear_generated_columns(&block);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(get_col(block, "gen_col").column->size(), 0);
+}
+
+// ============================================================================
+// Test: on_fill_partition_columns fills column with deserialized values
+// ============================================================================
+TEST_F(TableFormatReaderTest, FillPartitionColumnsInt64) {
+    auto tuple_desc =
+            build_tuple_desc({{"data_col", nullable_int64()}, {"part_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+
+    // Register partition value "2024" for part_col.
+    const SlotDescriptor* part_slot = nullptr;
+    for (auto* slot : tuple_desc->slots()) {
+        if (slot->col_name() == "part_col") {
+            part_slot = slot;
+            break;
+        }
+    }
+    ASSERT_NE(part_slot, nullptr);
+    reader._fill_partition_values["part_col"] = std::make_tuple("2024", part_slot);
+
+    Block block = make_block(tuple_desc);
+    const size_t num_rows = 5;
+
+    auto st = reader.on_fill_partition_columns(&block, num_rows, {"part_col"});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(get_col(block, "part_col").column->size(), num_rows);
+}
+
+TEST_F(TableFormatReaderTest, FillPartitionColumnsString) {
+    auto tuple_desc =
+            build_tuple_desc({{"data_col", nullable_int64()}, {"region", nullable_string()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+
+    const SlotDescriptor* region_slot = nullptr;
+    for (auto* slot : tuple_desc->slots()) {
+        if (slot->col_name() == "region") {
+            region_slot = slot;
+            break;
+        }
+    }
+    ASSERT_NE(region_slot, nullptr);
+    reader._fill_partition_values["region"] = std::make_tuple("us-east-1", region_slot);
+
+    Block block = make_block(tuple_desc);
+    const size_t num_rows = 3;
+
+    auto st = reader.on_fill_partition_columns(&block, num_rows, {"region"});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(get_col(block, "region").column->size(), num_rows);
+}
+
+TEST_F(TableFormatReaderTest, FillPartitionColumnsUnknownNameSkipped) {
+    auto tuple_desc = build_tuple_desc({{"col_a", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+    // No partition values registered.
+
+    Block block = make_block(tuple_desc);
+    // Should not fail — unknown name is simply skipped.
+    auto st = reader.on_fill_partition_columns(&block, 5, {"unknown_partition"});
+    ASSERT_TRUE(st.ok());
+}
+
+// ============================================================================
+// Test: on_fill_missing_columns with nullptr default_expr → NULL fill
+// ============================================================================
+TEST_F(TableFormatReaderTest, FillMissingColumnsNullDefault) {
+    auto tuple_desc =
+            build_tuple_desc({{"data_col", nullable_int64()}, {"missing_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+    // nullptr default_expr → fill with NULL.
+    reader._fill_missing_defaults["missing_col"] = nullptr;
+
+    Block block = make_block(tuple_desc);
+    const size_t num_rows = 5;
+
+    auto st = reader.on_fill_missing_columns(&block, num_rows, {"missing_col"});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    auto missing_col = get_col(block, "missing_col").column;
+    EXPECT_EQ(missing_col->size(), num_rows);
+    // All values should be NULL.
+    for (size_t i = 0; i < num_rows; i++) {
+        EXPECT_TRUE(missing_col->is_null_at(i)) << "Row " << i << " should be NULL";
+    }
+}
+
+TEST_F(TableFormatReaderTest, FillMissingColumnNotInBlockErrors) {
+    auto tuple_desc = build_tuple_desc({{"data_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+    reader._fill_missing_defaults["nonexistent_col"] = nullptr;
+
+    Block block = make_block(tuple_desc);
+    auto st = reader.on_fill_missing_columns(&block, 5, {"nonexistent_col"});
+    ASSERT_FALSE(st.ok());
+}
+
+// ============================================================================
+// Test: fill_remaining_columns integrates partition + missing + synthesized + generated
+// ============================================================================
+TEST_F(TableFormatReaderTest, FillRemainingColumnsIntegration) {
+    auto tuple_desc = build_tuple_desc({{"data_col", nullable_int64()},
+                                        {"part_col", nullable_int64()},
+                                        {"missing_col", nullable_int64()},
+                                        {"synth_col", nullable_int64()},
+                                        {"gen_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+
+    // Setup partition column.
+    const SlotDescriptor* part_slot = nullptr;
+    for (auto* slot : tuple_desc->slots()) {
+        if (slot->col_name() == "part_col") {
+            part_slot = slot;
+            break;
+        }
+    }
+    ASSERT_NE(part_slot, nullptr);
+    reader._fill_partition_values["part_col"] = std::make_tuple("100", part_slot);
+
+    // Setup missing column (NULL default).
+    reader._fill_missing_defaults["missing_col"] = nullptr;
+
+    // Setup synthesized column.
+    int synth_calls = 0;
+    reader.register_synthesized_column_handler(
+            "synth_col", [&synth_calls, &col_idx_map](Block* block, size_t rows) -> Status {
+                synth_calls++;
+                auto col =
+                        block->get_by_position(col_idx_map["synth_col"]).column->assume_mutable();
+                auto* nullable = static_cast<ColumnNullable*>(col.get());
+                nullable->insert_many_defaults(rows);
+                return Status::OK();
+            });
+
+    // Setup generated column.
+    int gen_calls = 0;
+    reader.register_generated_column_handler(
+            "gen_col", [&gen_calls, &col_idx_map](Block* block, size_t rows) -> Status {
+                gen_calls++;
+                auto col = block->get_by_position(col_idx_map["gen_col"]).column->assume_mutable();
+                auto* nullable = static_cast<ColumnNullable*>(col.get());
+                nullable->insert_many_defaults(rows);
+                return Status::OK();
+            });
+
+    Block block = make_block(tuple_desc);
+    const size_t num_rows = 3;
+
+    auto st = reader.fill_remaining_columns(&block, num_rows);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    EXPECT_EQ(get_col(block, "part_col").column->size(), num_rows);
+    EXPECT_EQ(get_col(block, "missing_col").column->size(), num_rows);
+    EXPECT_EQ(synth_calls, 1);
+    EXPECT_EQ(gen_calls, 1);
+}
+
+// ============================================================================
+// Test: on_after_read_block calls fill_remaining_columns when read_rows > 0
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnAfterReadBlockFillsColumnsWhenRowsGt0) {
+    auto tuple_desc =
+            build_tuple_desc({{"data_col", nullable_int64()}, {"missing_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+    reader._fill_missing_defaults["missing_col"] = nullptr;
+    reader.batches_to_emit = 1;
+    reader.rows_per_batch = 4;
+
+    Block block = make_block(tuple_desc);
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(read_rows, 4);
+    // Missing column should be filled by on_after_read_block.
+    EXPECT_EQ(get_col(block, "missing_col").column->size(), 4);
+}
+
+// ============================================================================
+// Test: on_after_read_block skips fill when read_rows == 0
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnAfterReadBlockSkipsWhenZeroRows) {
+    auto tuple_desc =
+            build_tuple_desc({{"data_col", nullable_int64()}, {"missing_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+    reader._fill_missing_defaults["missing_col"] = nullptr;
+    reader.batches_to_emit = 0; // Immediate EOF.
+
+    Block block = make_block(tuple_desc);
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(read_rows, 0);
+    EXPECT_TRUE(eof);
+    // Missing column should NOT be filled (0 rows).
+    EXPECT_EQ(get_col(block, "missing_col").column->size(), 0);
+}
+
+// ============================================================================
+// Test: on_after_read_block skips fill for COUNT pushdown
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnAfterReadBlockSkipsForCountPushDown) {
+    auto tuple_desc =
+            build_tuple_desc({{"data_col", nullable_int64()}, {"missing_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+    reader._fill_missing_defaults["missing_col"] = nullptr;
+    reader.set_push_down_agg_type(TPushAggOp::type::COUNT);
+    reader.batches_to_emit = 1;
+    reader.rows_per_batch = 4;
+
+    Block block = make_block(tuple_desc);
+    size_t read_rows = 0;
+    bool eof = false;
+    auto st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(read_rows, 4);
+    // Missing column should NOT be filled (COUNT pushdown).
+    EXPECT_EQ(get_col(block, "missing_col").column->size(), 0);
+}
+
+// ============================================================================
+// Test: _extract_partition_values from TFileRangeDesc
+// ============================================================================
+TEST_F(TableFormatReaderTest, ExtractPartitionValues) {
+    auto tuple_desc = build_tuple_desc({{"data_col", nullable_int64()},
+                                        {"year", nullable_int64()},
+                                        {"region", nullable_string()}});
+
+    TFileRangeDesc range;
+    range.__set_columns_from_path_keys({"year", "region"});
+    range.__set_columns_from_path({"2024", "us-west-2"});
+
+    std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
+            partition_values;
+    auto st = TableFormatReader::_extract_partition_values(range, tuple_desc, partition_values);
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(partition_values.size(), 2);
+
+    auto [year_val, year_slot] = partition_values["year"];
+    EXPECT_EQ(year_val, "2024");
+    EXPECT_EQ(year_slot->col_name(), "year");
+
+    auto [region_val, region_slot] = partition_values["region"];
+    EXPECT_EQ(region_val, "us-west-2");
+    EXPECT_EQ(region_slot->col_name(), "region");
+}
+
+TEST_F(TableFormatReaderTest, ExtractPartitionValuesNoPath) {
+    auto tuple_desc = build_tuple_desc({{"col_a", nullable_int64()}});
+
+    TFileRangeDesc range;
+    // No columns_from_path_keys set.
+
+    std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
+            partition_values;
+    auto st = TableFormatReader::_extract_partition_values(range, tuple_desc, partition_values);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(partition_values.size(), 0);
+}
+
+TEST_F(TableFormatReaderTest, ExtractPartitionValuesNullTupleDesc) {
+    TFileRangeDesc range;
+    range.__set_columns_from_path_keys({"year"});
+    range.__set_columns_from_path({"2024"});
+
+    std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
+            partition_values;
+    auto st = TableFormatReader::_extract_partition_values(range, nullptr, partition_values);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(partition_values.size(), 0);
+}
+
+// ============================================================================
+// Test: on_before_init_reader for simple readers (default implementation)
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnBeforeInitReaderDefaultImpl) {
+    auto tuple_desc = build_tuple_desc(
+            {{"id", nullable_int64()}, {"name", nullable_string()}, {"year", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    // Simulate file columns: file has "id" and "name" but NOT "year".
+    reader.fake_file_columns["id"] = nullable_int64();
+    reader.fake_file_columns["name"] = nullable_string();
+
+    TFileRangeDesc range;
+    range.__set_columns_from_path_keys({"year"});
+    range.__set_columns_from_path({"2024"});
+
+    // Build column_descs.
+    std::vector<ColumnDescriptor> col_descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"name", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"year", nullptr, ColumnCategory::PARTITION_KEY, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // column_names should only contain REGULAR columns (id, name), not partition (year).
+    ASSERT_EQ(ctx.column_names.size(), 2);
+    EXPECT_EQ(ctx.column_names[0], "id");
+    EXPECT_EQ(ctx.column_names[1], "name");
+
+    // table_info_node should be set (StructNode with entries).
+    EXPECT_NE(ctx.table_info_node, nullptr);
+}
+
+// ============================================================================
+// Test: on_before_init_reader detects missing columns
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnBeforeInitReaderMissingColumns) {
+    auto tuple_desc =
+            build_tuple_desc({{"id", nullable_int64()}, {"missing_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    // File only has "id".
+    reader.fake_file_columns["id"] = nullable_int64();
+
+    TFileRangeDesc range;
+
+    std::vector<ColumnDescriptor> col_descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"missing_col", nullptr, ColumnCategory::REGULAR, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // missing_col should be detected as missing.
+    EXPECT_TRUE(reader.missing_cols().count("missing_col"));
+    EXPECT_FALSE(reader.missing_cols().count("id"));
+}
+
+// ============================================================================
+// Test: on_before_init_reader case-insensitive column matching
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnBeforeInitReaderCaseInsensitive) {
+    auto tuple_desc = build_tuple_desc({{"Name", nullable_string()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    // File has column "name" (lowercase).
+    reader.fake_file_columns["name"] = nullable_string();
+
+    TFileRangeDesc range;
+
+    std::vector<ColumnDescriptor> col_descs = {
+            {"Name", nullptr, ColumnCategory::REGULAR, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    // "Name" matches "name" case-insensitively → NOT missing.
+    EXPECT_FALSE(reader.missing_cols().count("Name"));
+}
+
+// ============================================================================
+// Test: on_before_init_reader with GENERATED columns
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnBeforeInitReaderGeneratedColumn) {
+    auto tuple_desc = build_tuple_desc({{"id", nullable_int64()}, {"gen_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader.fake_file_columns["id"] = nullable_int64();
+    // gen_col NOT in file.
+
+    TFileRangeDesc range;
+
+    std::vector<ColumnDescriptor> col_descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"gen_col", nullptr, ColumnCategory::GENERATED, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+
+    // GENERATED columns appear in column_names (they may exist in file).
+    ASSERT_EQ(ctx.column_names.size(), 2);
+    EXPECT_EQ(ctx.column_names[0], "id");
+    EXPECT_EQ(ctx.column_names[1], "gen_col");
+
+    // gen_col is detected as missing because it's not in the file.
+    EXPECT_TRUE(reader.missing_cols().count("gen_col"));
+}
+
+// ============================================================================
+// Test: on_before_init_reader skips SYNTHESIZED columns from column_names
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnBeforeInitReaderSynthesizedExcluded) {
+    auto tuple_desc = build_tuple_desc({{"id", nullable_int64()}, {"synth_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader.fake_file_columns["id"] = nullable_int64();
+
+    TFileRangeDesc range;
+
+    std::vector<ColumnDescriptor> col_descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"synth_col", nullptr, ColumnCategory::SYNTHESIZED, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+
+    // Only REGULAR shows up in column_names.
+    ASSERT_EQ(ctx.column_names.size(), 1);
+    EXPECT_EQ(ctx.column_names[0], "id");
+
+    // SYNTHESIZED cols are not tracked as missing.
+    EXPECT_FALSE(reader.missing_cols().count("synth_col"));
+}
+
+// ============================================================================
+// Test: missing_cols() returns accumulated set
+// ============================================================================
+TEST_F(TableFormatReaderTest, MissingColsAccessor) {
+    MockTableFormatReader reader;
+    EXPECT_TRUE(reader.missing_cols().empty());
+
+    // Manually set for direct testing.
+    reader._fill_missing_cols.insert("col_a");
+    reader._fill_missing_cols.insert("col_b");
+    EXPECT_EQ(reader.missing_cols().size(), 2);
+    EXPECT_TRUE(reader.missing_cols().count("col_a"));
+    EXPECT_TRUE(reader.missing_cols().count("col_b"));
+}
+
+// ============================================================================
+// Test: Multi-batch get_next_block with on_after_read_block auto-fill
+// ============================================================================
+TEST_F(TableFormatReaderTest, MultiBatchWithAutoFill) {
+    auto tuple_desc =
+            build_tuple_desc({{"data_col", nullable_int64()}, {"missing_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+    reader._fill_missing_defaults["missing_col"] = nullptr;
+    reader.batches_to_emit = 3;
+    reader.rows_per_batch = 5;
+
+    size_t total_rows = 0;
+    bool eof = false;
+    int batch_count = 0;
+    while (!eof) {
+        Block block = make_block(tuple_desc);
+        size_t read_rows = 0;
+        auto st = reader.get_next_block(&block, &read_rows, &eof);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        if (read_rows > 0) {
+            // Verify missing_col was filled by on_after_read_block each batch.
+            EXPECT_EQ(get_col(block, "missing_col").column->size(), read_rows);
+            for (size_t i = 0; i < read_rows; i++) {
+                EXPECT_TRUE(get_col(block, "missing_col").column->is_null_at(i));
+            }
+        }
+        total_rows += read_rows;
+        batch_count++;
+    }
+    EXPECT_EQ(total_rows, 15);
+    EXPECT_EQ(batch_count, 3);
+}
+
+// ============================================================================
+// Test: Full lifecycle: init_reader → get_next_block → auto-fill all types
+// ============================================================================
+TEST_F(TableFormatReaderTest, FullLifecycleWithInit) {
+    auto tuple_desc = build_tuple_desc(
+            {{"id", nullable_int64()}, {"year", nullable_int64()}, {"name", nullable_string()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    // Simulate: file has "id" and "name" but NOT "year".
+    reader.fake_file_columns["id"] = nullable_int64();
+    reader.fake_file_columns["name"] = nullable_string();
+
+    TFileRangeDesc range;
+    range.__set_columns_from_path_keys({"year"});
+    range.__set_columns_from_path({"2024"});
+
+    std::vector<ColumnDescriptor> col_descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"name", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"year", nullptr, ColumnCategory::PARTITION_KEY, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    // Init should extract partition values and compute column_names.
+    auto st = reader.init_reader(&ctx);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // Verify column_names only has REGULAR columns.
+    ASSERT_EQ(ctx.column_names.size(), 2);
+    EXPECT_EQ(ctx.column_names[0], "id");
+    EXPECT_EQ(ctx.column_names[1], "name");
+
+    // Read one batch.
+    reader.batches_to_emit = 1;
+    reader.rows_per_batch = 3;
+
+    Block block = make_block(tuple_desc);
+    size_t read_rows = 0;
+    bool eof = false;
+    st = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(read_rows, 3);
+
+    // Partition column "year" should be filled with "2024" by on_after_read_block.
+    auto year_col = get_col(block, "year").column;
+    EXPECT_EQ(year_col->size(), 3);
+}
+
+// ============================================================================
+// Test: Synthesized column handler error stops fill_remaining_columns
+// ============================================================================
+TEST_F(TableFormatReaderTest, FillRemainingColumnsStopsOnSynthError) {
+    auto tuple_desc = build_tuple_desc({{"data_col", nullable_int64()},
+                                        {"synth_col", nullable_int64()},
+                                        {"gen_col", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+
+    reader.register_synthesized_column_handler("synth_col", [](Block*, size_t) -> Status {
+        return Status::InternalError("synth error");
+    });
+
+    int gen_calls = 0;
+    reader.register_generated_column_handler("gen_col", [&gen_calls](Block*, size_t) -> Status {
+        gen_calls++;
+        return Status::OK();
+    });
+
+    Block block = make_block(tuple_desc);
+    auto st = reader.fill_remaining_columns(&block, 3);
+    ASSERT_FALSE(st.ok());
+    // Generated handler should NOT have been called (synthesized error aborted early).
+    EXPECT_EQ(gen_calls, 0);
+}
+
+// ============================================================================
+// Test: Clear columns on non-existent column name does not crash
+// ============================================================================
+TEST_F(TableFormatReaderTest, ClearNonExistentColumnSafe) {
+    MockTableFormatReader reader;
+    reader.register_synthesized_column_handler(
+            "ghost_col", [](Block*, size_t) -> Status { return Status::OK(); });
+
+    Block block;
+    auto type = nullable_int64();
+    block.insert({type->create_column(), type, "other_col"});
+
+    // "ghost_col" not in block — clear should still succeed (get_position_by_name returns -1).
+    auto st = reader.clear_synthesized_columns(&block);
+    ASSERT_TRUE(st.ok());
+}
+
+// ============================================================================
+// Test: Multiple partition columns filled correctly
+// ============================================================================
+TEST_F(TableFormatReaderTest, MultiplePartitionColumns) {
+    auto tuple_desc = build_tuple_desc({{"data_col", nullable_int64()},
+                                        {"year", nullable_int64()},
+                                        {"month", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader._fill_col_name_to_block_idx = &col_idx_map;
+
+    const SlotDescriptor* year_slot = nullptr;
+    const SlotDescriptor* month_slot = nullptr;
+    for (auto* slot : tuple_desc->slots()) {
+        if (slot->col_name() == "year") year_slot = slot;
+        if (slot->col_name() == "month") month_slot = slot;
+    }
+    ASSERT_NE(year_slot, nullptr);
+    ASSERT_NE(month_slot, nullptr);
+
+    reader._fill_partition_values["year"] = std::make_tuple("2024", year_slot);
+    reader._fill_partition_values["month"] = std::make_tuple("12", month_slot);
+
+    Block block = make_block(tuple_desc);
+    const size_t num_rows = 4;
+
+    auto st = reader.on_fill_partition_columns(&block, num_rows, {"year", "month"});
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    EXPECT_EQ(get_col(block, "year").column->size(), num_rows);
+    EXPECT_EQ(get_col(block, "month").column->size(), num_rows);
+}
+
+// ============================================================================
+// Test: on_before_init_reader with all column categories mixed
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnBeforeInitReaderAllCategories) {
+    auto tuple_desc = build_tuple_desc({{"id", nullable_int64()},
+                                        {"year", nullable_int64()},
+                                        {"$row_id", nullable_int64()},
+                                        {"_row_id", nullable_int64()},
+                                        {"name", nullable_string()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader.fake_file_columns["id"] = nullable_int64();
+    reader.fake_file_columns["name"] = nullable_string();
+
+    TFileRangeDesc range;
+    range.__set_columns_from_path_keys({"year"});
+    range.__set_columns_from_path({"2024"});
+
+    std::vector<ColumnDescriptor> col_descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"year", nullptr, ColumnCategory::PARTITION_KEY, nullptr},
+            {"$row_id", nullptr, ColumnCategory::SYNTHESIZED, nullptr},
+            {"_row_id", nullptr, ColumnCategory::GENERATED, nullptr},
+            {"name", nullptr, ColumnCategory::REGULAR, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // column_names: REGULAR + GENERATED only.
+    ASSERT_EQ(ctx.column_names.size(), 3);
+    EXPECT_EQ(ctx.column_names[0], "id");
+    EXPECT_EQ(ctx.column_names[1], "_row_id");
+    EXPECT_EQ(ctx.column_names[2], "name");
+
+    // _row_id is GENERATED but not in file → detected as missing.
+    EXPECT_TRUE(reader.missing_cols().count("_row_id"));
+    // $row_id is SYNTHESIZED → not in missing.
+    EXPECT_FALSE(reader.missing_cols().count("$row_id"));
+    // year is PARTITION_KEY → not in missing.
+    EXPECT_FALSE(reader.missing_cols().count("year"));
+    // id and name are in file → not missing.
+    EXPECT_FALSE(reader.missing_cols().count("id"));
+    EXPECT_FALSE(reader.missing_cols().count("name"));
+}
+
+// ============================================================================
+// Test: _extract_partition_values ignores keys not in tuple descriptor
+// ============================================================================
+TEST_F(TableFormatReaderTest, ExtractPartitionValuesExtraKeysIgnored) {
+    auto tuple_desc = build_tuple_desc({{"year", nullable_int64()}});
+
+    TFileRangeDesc range;
+    range.__set_columns_from_path_keys({"year", "nonexistent_key"});
+    range.__set_columns_from_path({"2024", "ignored_value"});
+
+    std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
+            partition_values;
+    auto st = MockTableFormatReader::_extract_partition_values(range, tuple_desc, partition_values);
+    ASSERT_TRUE(st.ok());
+    // Only "year" matches a slot, "nonexistent_key" is ignored.
+    EXPECT_EQ(partition_values.size(), 1);
+    EXPECT_TRUE(partition_values.count("year"));
+}
+
+// ============================================================================
+// Test: ColumnOptimizationTypes bitwise OR combination
+// ============================================================================
+TEST_F(TableFormatReaderTest, ColumnOptimizationTypesCombination) {
+    MockTableFormatReader reader;
+    auto combined = TableFormatReader::ColumnOptimizationTypes::LAZY_READ |
+                    TableFormatReader::ColumnOptimizationTypes::MIN_MAX;
+    reader.set_column_optimizations("col_x", combined);
+
+    EXPECT_TRUE(reader.has_column_optimization(
+            "col_x", TableFormatReader::ColumnOptimizationTypes::LAZY_READ));
+    EXPECT_FALSE(reader.has_column_optimization(
+            "col_x", TableFormatReader::ColumnOptimizationTypes::DICT_FILTER));
+    EXPECT_TRUE(reader.has_column_optimization(
+            "col_x", TableFormatReader::ColumnOptimizationTypes::MIN_MAX));
+    EXPECT_FALSE(reader.disable_column_opt("col_x")); // Not NONE.
+}
+
+// ============================================================================
+// Test: on_before_init_reader partition column is not added to missing
+// ============================================================================
+TEST_F(TableFormatReaderTest, PartitionColumnNotMissing) {
+    auto tuple_desc = build_tuple_desc({{"id", nullable_int64()}, {"year", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader.fake_file_columns["id"] = nullable_int64();
+    // "year" is NOT in file, but it's a PARTITION_KEY column.
+
+    TFileRangeDesc range;
+    range.__set_columns_from_path_keys({"year"});
+    range.__set_columns_from_path({"2024"});
+
+    std::vector<ColumnDescriptor> col_descs = {
+            {"id", nullptr, ColumnCategory::REGULAR, nullptr},
+            {"year", nullptr, ColumnCategory::PARTITION_KEY, nullptr},
+    };
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+    // Partition columns should NOT appear in missing_cols.
+    EXPECT_FALSE(reader.missing_cols().count("year"));
+}
+
+// ============================================================================
+// Test: on_before_init_reader with empty column_descs
+// ============================================================================
+TEST_F(TableFormatReaderTest, OnBeforeInitReaderEmptyColumnDescs) {
+    auto tuple_desc = build_tuple_desc({{"id", nullable_int64()}});
+    auto col_idx_map = build_col_name_to_block_idx(tuple_desc);
+
+    MockTableFormatReader reader;
+    reader.fake_file_columns["id"] = nullable_int64();
+
+    TFileRangeDesc range;
+
+    std::vector<ColumnDescriptor> col_descs; // Empty.
+
+    ReaderInitContext ctx;
+    ctx.column_descs = &col_descs;
+    ctx.col_name_to_block_idx = &col_idx_map;
+    ctx.tuple_descriptor = tuple_desc;
+    ctx.range = &range;
+
+    auto st = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(st.ok());
+    EXPECT_TRUE(ctx.column_names.empty());
+    EXPECT_TRUE(reader.missing_cols().empty());
+}
+
+} // namespace doris

--- a/be/test/format/table/transactional_hive_common_test.cpp
+++ b/be/test/format/table/transactional_hive_common_test.cpp
@@ -1,0 +1,275 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "format/table/transactional_hive_common.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace doris {
+
+// ============================================================================
+// AcidRowID — Hash, Equality, Ordering
+// ============================================================================
+class AcidRowIDTest : public ::testing::Test {};
+
+TEST_F(AcidRowIDTest, EqualityBasic) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {100, 0, 42};
+    AcidRowID c {100, 0, 43};
+    AcidRowID::Eq eq;
+    EXPECT_TRUE(eq(a, b));
+    EXPECT_FALSE(eq(a, c));
+}
+
+TEST_F(AcidRowIDTest, EqualityDiffTransaction) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {101, 0, 42};
+    AcidRowID::Eq eq;
+    EXPECT_FALSE(eq(a, b));
+}
+
+TEST_F(AcidRowIDTest, EqualityDiffBucket) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {100, 1, 42};
+    AcidRowID::Eq eq;
+    EXPECT_FALSE(eq(a, b));
+}
+
+TEST_F(AcidRowIDTest, HashConsistency) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {100, 0, 42};
+    AcidRowID::Hash hasher;
+    EXPECT_EQ(hasher(a), hasher(b));
+}
+
+TEST_F(AcidRowIDTest, HashDistribution) {
+    AcidRowID::Hash hasher;
+    // Different row IDs should produce different hashes (probabilistic)
+    AcidRowID a {100, 0, 1};
+    AcidRowID b {100, 0, 2};
+    AcidRowID c {200, 0, 1};
+    // While hash collisions are possible, these specific inputs should differ
+    EXPECT_NE(hasher(a), hasher(b));
+    EXPECT_NE(hasher(a), hasher(c));
+}
+
+TEST_F(AcidRowIDTest, OperatorLessTransaction) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {200, 0, 42};
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+}
+
+TEST_F(AcidRowIDTest, OperatorLessBucket) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {100, 1, 42};
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+}
+
+TEST_F(AcidRowIDTest, OperatorLessRowId) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {100, 0, 43};
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+}
+
+TEST_F(AcidRowIDTest, OperatorLessEqual) {
+    AcidRowID a {100, 0, 42};
+    AcidRowID b {100, 0, 42};
+    // Equal elements: neither is less than the other
+    EXPECT_FALSE(a < b);
+    EXPECT_FALSE(b < a);
+}
+
+// ============================================================================
+// AcidRowIDSet — Insert and Lookup
+// ============================================================================
+TEST_F(AcidRowIDTest, SetInsertAndFind) {
+    AcidRowIDSet set;
+    set.insert({100, 0, 1});
+    set.insert({100, 0, 2});
+    set.insert({200, 1, 3});
+
+    EXPECT_TRUE(set.contains({100, 0, 1}));
+    EXPECT_TRUE(set.contains({100, 0, 2}));
+    EXPECT_TRUE(set.contains({200, 1, 3}));
+    EXPECT_FALSE(set.contains({100, 0, 3}));
+    EXPECT_FALSE(set.contains({300, 0, 1}));
+}
+
+TEST_F(AcidRowIDTest, SetDuplicateInsert) {
+    AcidRowIDSet set;
+    set.insert({100, 0, 1});
+    set.insert({100, 0, 1}); // duplicate
+    EXPECT_EQ(set.size(), 1);
+}
+
+TEST_F(AcidRowIDTest, SetEmpty) {
+    AcidRowIDSet set;
+    EXPECT_EQ(set.size(), 0);
+    EXPECT_FALSE(set.contains({0, 0, 0}));
+}
+
+TEST_F(AcidRowIDTest, SetLargeInsert) {
+    AcidRowIDSet set;
+    for (int i = 0; i < 10000; ++i) {
+        set.insert({static_cast<int64_t>(i / 100), static_cast<int64_t>(i % 10),
+                    static_cast<int64_t>(i)});
+    }
+    EXPECT_EQ(set.size(), 10000);
+    EXPECT_TRUE(set.contains({0, 0, 0}));
+    EXPECT_TRUE(set.contains({99, 9, 9999}));
+    EXPECT_FALSE(set.contains({100, 0, 10000}));
+}
+
+TEST_F(AcidRowIDTest, SetNegativeValues) {
+    AcidRowIDSet set;
+    set.insert({-1, -2, -3});
+    EXPECT_TRUE(set.contains({-1, -2, -3}));
+    EXPECT_FALSE(set.contains({1, 2, 3}));
+}
+
+TEST_F(AcidRowIDTest, SetZeroValues) {
+    AcidRowIDSet set;
+    set.insert({0, 0, 0});
+    EXPECT_TRUE(set.contains({0, 0, 0}));
+    EXPECT_EQ(set.size(), 1);
+}
+
+// ============================================================================
+// TransactionalHive Constants — Verification
+// ============================================================================
+class TransactionalHiveConstantsTest : public ::testing::Test {};
+
+TEST_F(TransactionalHiveConstantsTest, AcidColumnNames) {
+    // Verify all 6 ACID column names are present and in correct order
+    ASSERT_EQ(TransactionalHive::ACID_COLUMN_NAMES.size(), 6);
+    EXPECT_EQ(TransactionalHive::ACID_COLUMN_NAMES[0], "operation");
+    EXPECT_EQ(TransactionalHive::ACID_COLUMN_NAMES[1], "originalTransaction");
+    EXPECT_EQ(TransactionalHive::ACID_COLUMN_NAMES[2], "bucket");
+    EXPECT_EQ(TransactionalHive::ACID_COLUMN_NAMES[3], "rowId");
+    EXPECT_EQ(TransactionalHive::ACID_COLUMN_NAMES[4], "currentTransaction");
+    EXPECT_EQ(TransactionalHive::ACID_COLUMN_NAMES[5], "row");
+}
+
+TEST_F(TransactionalHiveConstantsTest, AcidColumnNamesLowerCase) {
+    ASSERT_EQ(TransactionalHive::ACID_COLUMN_NAMES_LOWER_CASE.size(), 6);
+    for (const auto& name : TransactionalHive::ACID_COLUMN_NAMES_LOWER_CASE) {
+        // All should be lowercase
+        std::string lower = name;
+        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+        EXPECT_EQ(name, lower) << "Column name '" << name << "' is not lowercase";
+    }
+}
+
+TEST_F(TransactionalHiveConstantsTest, RowOffset) {
+    // ROW is at index 5 in ACID columns: operation(0), originalTransaction(1),
+    // bucket(2), rowId(3), currentTransaction(4), row(5)
+    EXPECT_EQ(TransactionalHive::ROW_OFFSET, 5);
+}
+
+TEST_F(TransactionalHiveConstantsTest, DeleteRowParams) {
+    ASSERT_EQ(TransactionalHive::DELETE_ROW_PARAMS.size(), 3);
+    // originalTransaction (bigint), bucket (int), rowId (bigint)
+    EXPECT_EQ(TransactionalHive::DELETE_ROW_PARAMS[0].type, PrimitiveType::TYPE_BIGINT);
+    EXPECT_EQ(TransactionalHive::DELETE_ROW_PARAMS[1].type, PrimitiveType::TYPE_INT);
+    EXPECT_EQ(TransactionalHive::DELETE_ROW_PARAMS[2].type, PrimitiveType::TYPE_BIGINT);
+}
+
+TEST_F(TransactionalHiveConstantsTest, ReadParams) {
+    ASSERT_EQ(TransactionalHive::READ_PARAMS.size(), 3);
+    EXPECT_EQ(TransactionalHive::READ_PARAMS[0].type, PrimitiveType::TYPE_BIGINT);
+    EXPECT_EQ(TransactionalHive::READ_PARAMS[1].type, PrimitiveType::TYPE_INT);
+    EXPECT_EQ(TransactionalHive::READ_PARAMS[2].type, PrimitiveType::TYPE_BIGINT);
+}
+
+TEST_F(TransactionalHiveConstantsTest, DeleteColumnNamesConsistency) {
+    // DELETE_ROW_COLUMN_NAMES should match DELETE_ROW_PARAMS column names
+    ASSERT_EQ(TransactionalHive::DELETE_ROW_COLUMN_NAMES.size(),
+              TransactionalHive::DELETE_ROW_PARAMS.size());
+    for (size_t i = 0; i < TransactionalHive::DELETE_ROW_PARAMS.size(); ++i) {
+        EXPECT_EQ(TransactionalHive::DELETE_ROW_COLUMN_NAMES[i],
+                  TransactionalHive::DELETE_ROW_PARAMS[i].column_name);
+    }
+}
+
+TEST_F(TransactionalHiveConstantsTest, DeleteColumnNamesLowerCaseConsistency) {
+    ASSERT_EQ(TransactionalHive::DELETE_ROW_COLUMN_NAMES_LOWER_CASE.size(),
+              TransactionalHive::DELETE_ROW_PARAMS.size());
+    for (size_t i = 0; i < TransactionalHive::DELETE_ROW_PARAMS.size(); ++i) {
+        EXPECT_EQ(TransactionalHive::DELETE_ROW_COLUMN_NAMES_LOWER_CASE[i],
+                  TransactionalHive::DELETE_ROW_PARAMS[i].column_lower_case);
+    }
+}
+
+TEST_F(TransactionalHiveConstantsTest, ReadColumnNamesConsistency) {
+    ASSERT_EQ(TransactionalHive::READ_ROW_COLUMN_NAMES.size(),
+              TransactionalHive::READ_PARAMS.size());
+    for (size_t i = 0; i < TransactionalHive::READ_PARAMS.size(); ++i) {
+        EXPECT_EQ(TransactionalHive::READ_ROW_COLUMN_NAMES[i],
+                  TransactionalHive::READ_PARAMS[i].column_name);
+    }
+}
+
+TEST_F(TransactionalHiveConstantsTest, DeleteColNameToBlockIdx) {
+    ASSERT_EQ(TransactionalHive::DELETE_COL_NAME_TO_BLOCK_IDX.size(), 3);
+    // Should map lowercase names to sequential indices 0, 1, 2
+    for (size_t i = 0; i < TransactionalHive::DELETE_ROW_PARAMS.size(); ++i) {
+        auto it = TransactionalHive::DELETE_COL_NAME_TO_BLOCK_IDX.find(
+                TransactionalHive::DELETE_ROW_PARAMS[i].column_lower_case);
+        ASSERT_NE(it, TransactionalHive::DELETE_COL_NAME_TO_BLOCK_IDX.end());
+        EXPECT_EQ(it->second, i);
+    }
+}
+
+// ============================================================================
+// AcidRowID ordering for sorted operations
+// ============================================================================
+TEST_F(AcidRowIDTest, SortedOrder) {
+    std::vector<AcidRowID> rows = {
+            {200, 0, 1}, {100, 0, 1}, {100, 1, 0}, {100, 0, 2}, {100, 0, 1},
+    };
+    std::sort(rows.begin(), rows.end());
+    // Expected order: (100,0,1), (100,0,1), (100,0,2), (100,1,0), (200,0,1)
+    EXPECT_EQ(rows[0].original_transaction, 100);
+    EXPECT_EQ(rows[0].bucket, 0);
+    EXPECT_EQ(rows[0].row_id, 1);
+
+    EXPECT_EQ(rows[1].original_transaction, 100);
+    EXPECT_EQ(rows[1].bucket, 0);
+    EXPECT_EQ(rows[1].row_id, 1);
+
+    EXPECT_EQ(rows[2].original_transaction, 100);
+    EXPECT_EQ(rows[2].bucket, 0);
+    EXPECT_EQ(rows[2].row_id, 2);
+
+    EXPECT_EQ(rows[3].original_transaction, 100);
+    EXPECT_EQ(rows[3].bucket, 1);
+    EXPECT_EQ(rows[3].row_id, 0);
+
+    EXPECT_EQ(rows[4].original_transaction, 200);
+    EXPECT_EQ(rows[4].bucket, 0);
+    EXPECT_EQ(rows[4].row_id, 1);
+}
+
+} // namespace doris

--- a/be/test/format/table/transactional_hive_common_test.cpp
+++ b/be/test/format/table/transactional_hive_common_test.cpp
@@ -61,15 +61,27 @@ TEST_F(AcidRowIDTest, HashConsistency) {
     EXPECT_EQ(hasher(a), hasher(b));
 }
 
-TEST_F(AcidRowIDTest, HashDistribution) {
+TEST_F(AcidRowIDTest, HashAndEqSupportSetLookup) {
     AcidRowID::Hash hasher;
-    // Different row IDs should produce different hashes (probabilistic)
     AcidRowID a {100, 0, 1};
     AcidRowID b {100, 0, 2};
     AcidRowID c {200, 0, 1};
-    // While hash collisions are possible, these specific inputs should differ
-    EXPECT_NE(hasher(a), hasher(b));
-    EXPECT_NE(hasher(a), hasher(c));
+
+    EXPECT_EQ(hasher(a), hasher(a));
+    EXPECT_EQ(hasher(b), hasher(b));
+    EXPECT_EQ(hasher(c), hasher(c));
+
+    AcidRowIDSet set;
+    set.insert(a);
+    set.insert(b);
+    set.insert(c);
+    set.insert(a);
+
+    EXPECT_EQ(set.size(), 3);
+    EXPECT_TRUE(set.contains(a));
+    EXPECT_TRUE(set.contains(b));
+    EXPECT_TRUE(set.contains(c));
+    EXPECT_FALSE(set.contains({100, 1, 1}));
 }
 
 TEST_F(AcidRowIDTest, OperatorLessTransaction) {

--- a/be/test/format/table/transactional_hive_reader_test.cpp
+++ b/be/test/format/table/transactional_hive_reader_test.cpp
@@ -1,0 +1,691 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#define protected public
+#include "format/table/transactional_hive_reader.h"
+#undef protected
+#pragma clang diagnostic pop
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "common/consts.h"
+#include "core/block/block.h"
+#include "core/block/column_with_type_and_name.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_string.h"
+#include "format/orc/orc_memory_stream_test.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+#include "storage/segment/column_reader.h"
+#include "storage/utils.h"
+#include "testutil/desc_tbl_builder.h"
+
+namespace doris {
+
+class TransactionalHiveReaderTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        for (const auto& path : _temp_paths) {
+            std::error_code ec;
+            std::filesystem::remove_all(path, ec);
+        }
+    }
+
+    struct DeleteDeltaRow {
+        int64_t original_transaction;
+        int32_t bucket;
+        int64_t row_id;
+    };
+
+    struct AcidDataRow {
+        int32_t operation;
+        int64_t original_transaction;
+        int32_t bucket;
+        int64_t row_id;
+        int64_t current_transaction;
+        std::string name;
+    };
+
+    struct DeleteDeltaFile {
+        std::string directory;
+        std::string file_name;
+        std::string path;
+    };
+
+    Block make_name_block() {
+        auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+        Block block;
+        block.insert(
+                ColumnWithTypeAndName(nullable_string->create_column(), nullable_string, "name"));
+        return block;
+    }
+
+    DeleteDeltaFile write_delete_delta_orc_file(const std::vector<DeleteDeltaRow>& rows,
+                                                const std::string& file_name) {
+        auto temp_dir = std::filesystem::temp_directory_path();
+        std::string pattern = (temp_dir / "transactional_hive_reader_test_XXXXXX").string();
+        std::vector<char> path_buffer(pattern.begin(), pattern.end());
+        path_buffer.push_back('\0');
+
+        char* dir = mkdtemp(path_buffer.data());
+        EXPECT_NE(dir, nullptr);
+        std::string directory = dir == nullptr ? temp_dir.string() : std::string(dir);
+
+        using namespace orc;
+        MemoryOutputStream mem_stream(1024 * 1024);
+        auto type = createStructType();
+        type->addStructField(TransactionalHive::ORIGINAL_TRANSACTION,
+                             createPrimitiveType(orc::TypeKind::LONG));
+        type->addStructField(TransactionalHive::BUCKET, createPrimitiveType(orc::TypeKind::INT));
+        type->addStructField(TransactionalHive::ROW_ID, createPrimitiveType(orc::TypeKind::LONG));
+
+        WriterOptions options;
+        options.setMemoryPool(getDefaultPool());
+        auto writer = createWriter(*type, &mem_stream, options);
+        auto batch = writer->createRowBatch(rows.size());
+        auto& root_batch = dynamic_cast<StructVectorBatch&>(*batch);
+        auto& original_transaction_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[0]);
+        auto& bucket_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[1]);
+        auto& row_id_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[2]);
+
+        for (size_t i = 0; i < rows.size(); ++i) {
+            original_transaction_batch.data[i] = rows[i].original_transaction;
+            bucket_batch.data[i] = rows[i].bucket;
+            row_id_batch.data[i] = rows[i].row_id;
+        }
+        root_batch.numElements = rows.size();
+        original_transaction_batch.numElements = rows.size();
+        bucket_batch.numElements = rows.size();
+        row_id_batch.numElements = rows.size();
+        writer->add(*batch);
+        writer->close();
+
+        std::filesystem::path file_path = std::filesystem::path(directory) / file_name;
+        std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
+        out.write(mem_stream.getData(), static_cast<std::streamsize>(mem_stream.getLength()));
+        out.close();
+        EXPECT_TRUE(out.good());
+
+        _temp_paths.push_back(directory);
+        return {directory, file_name, file_path.string()};
+    }
+
+    DeleteDeltaFile write_acid_data_orc_file(const std::vector<AcidDataRow>& rows,
+                                             const std::string& file_name) {
+        auto temp_dir = std::filesystem::temp_directory_path();
+        std::string pattern = (temp_dir / "transactional_hive_reader_test_XXXXXX").string();
+        std::vector<char> path_buffer(pattern.begin(), pattern.end());
+        path_buffer.push_back('\0');
+
+        char* dir = mkdtemp(path_buffer.data());
+        EXPECT_NE(dir, nullptr);
+        std::string directory = dir == nullptr ? temp_dir.string() : std::string(dir);
+
+        using namespace orc;
+        MemoryOutputStream mem_stream(1024 * 1024);
+        auto type = createStructType();
+        type->addStructField("operation", createPrimitiveType(orc::TypeKind::INT));
+        type->addStructField("originalTransaction", createPrimitiveType(orc::TypeKind::LONG));
+        type->addStructField("bucket", createPrimitiveType(orc::TypeKind::INT));
+        type->addStructField("rowId", createPrimitiveType(orc::TypeKind::LONG));
+        type->addStructField("currentTransaction", createPrimitiveType(orc::TypeKind::LONG));
+        auto row_type = createStructType();
+        row_type->addStructField("name", createPrimitiveType(orc::TypeKind::STRING));
+        type->addStructField("row", std::move(row_type));
+
+        WriterOptions options;
+        options.setMemoryPool(getDefaultPool());
+        auto writer = createWriter(*type, &mem_stream, options);
+        auto batch = writer->createRowBatch(rows.size());
+        auto& root_batch = dynamic_cast<StructVectorBatch&>(*batch);
+        auto& operation_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[0]);
+        auto& original_transaction_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[1]);
+        auto& bucket_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[2]);
+        auto& row_id_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[3]);
+        auto& current_transaction_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[4]);
+        auto& row_batch = dynamic_cast<StructVectorBatch&>(*root_batch.fields[5]);
+        auto& name_batch = dynamic_cast<StringVectorBatch&>(*row_batch.fields[0]);
+
+        for (size_t i = 0; i < rows.size(); ++i) {
+            operation_batch.data[i] = rows[i].operation;
+            original_transaction_batch.data[i] = rows[i].original_transaction;
+            bucket_batch.data[i] = rows[i].bucket;
+            row_id_batch.data[i] = rows[i].row_id;
+            current_transaction_batch.data[i] = rows[i].current_transaction;
+            name_batch.data[i] = const_cast<char*>(rows[i].name.data());
+            name_batch.length[i] = static_cast<int64_t>(rows[i].name.size());
+        }
+        root_batch.numElements = rows.size();
+        row_batch.numElements = rows.size();
+        name_batch.numElements = rows.size();
+        writer->add(*batch);
+        writer->close();
+
+        std::filesystem::path file_path = std::filesystem::path(directory) / file_name;
+        std::ofstream out(file_path, std::ios::binary | std::ios::trunc);
+        out.write(mem_stream.getData(), static_cast<std::streamsize>(mem_stream.getLength()));
+        out.close();
+        EXPECT_TRUE(out.good());
+
+        _temp_paths.push_back(directory);
+        return {directory, file_name, file_path.string()};
+    }
+
+    const TupleDescriptor* build_tuple_descriptor(
+            ObjectPool& object_pool,
+            const std::vector<std::pair<std::string, DataTypePtr>>& columns) {
+        DescriptorTblBuilder builder(&object_pool);
+        auto& tuple_builder = builder.declare_tuple();
+        for (const auto& [name, type] : columns) {
+            tuple_builder << std::make_tuple(type, name);
+        }
+        return builder.build()->get_tuple_descriptor(0);
+    }
+
+    std::vector<ColumnDescriptor> build_column_descs(
+            const TupleDescriptor* tuple_descriptor,
+            const std::vector<ColumnCategory>& categories) {
+        std::vector<ColumnDescriptor> column_descs;
+        column_descs.reserve(tuple_descriptor->slots().size());
+        for (size_t i = 0; i < tuple_descriptor->slots().size(); ++i) {
+            column_descs.push_back({tuple_descriptor->slots()[i]->col_name(),
+                                    tuple_descriptor->slots()[i], categories[i], nullptr});
+        }
+        return column_descs;
+    }
+
+    std::unique_ptr<orc::Reader> make_acid_orc_reader_with_name(const std::string& name_value) {
+        using namespace orc;
+        MemoryOutputStream mem_stream(1024 * 1024);
+        auto type = createStructType();
+        type->addStructField("operation", createPrimitiveType(orc::TypeKind::INT));
+        type->addStructField("originalTransaction", createPrimitiveType(orc::TypeKind::LONG));
+        type->addStructField("bucket", createPrimitiveType(orc::TypeKind::INT));
+        type->addStructField("rowId", createPrimitiveType(orc::TypeKind::LONG));
+        type->addStructField("currentTransaction", createPrimitiveType(orc::TypeKind::LONG));
+        auto row_type = createStructType();
+        row_type->addStructField("name", createPrimitiveType(orc::TypeKind::STRING));
+        type->addStructField("row", std::move(row_type));
+
+        WriterOptions options;
+        options.setMemoryPool(getDefaultPool());
+        auto writer = createWriter(*type, &mem_stream, options);
+        auto batch = writer->createRowBatch(1);
+        auto& root_batch = dynamic_cast<StructVectorBatch&>(*batch);
+        auto& operation_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[0]);
+        auto& original_transaction_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[1]);
+        auto& bucket_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[2]);
+        auto& row_id_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[3]);
+        auto& current_transaction_batch = dynamic_cast<LongVectorBatch&>(*root_batch.fields[4]);
+        auto& row_batch = dynamic_cast<StructVectorBatch&>(*root_batch.fields[5]);
+        auto& name_batch = dynamic_cast<StringVectorBatch&>(*row_batch.fields[0]);
+
+        operation_batch.data[0] = 0;
+        original_transaction_batch.data[0] = 11;
+        bucket_batch.data[0] = 7;
+        row_id_batch.data[0] = 99;
+        current_transaction_batch.data[0] = 11;
+        name_batch.data[0] = const_cast<char*>(name_value.data());
+        name_batch.length[0] = static_cast<int64_t>(name_value.size());
+
+        root_batch.numElements = 1;
+        row_batch.numElements = 1;
+        name_batch.numElements = 1;
+        writer->add(*batch);
+        writer->close();
+
+        auto in_stream =
+                std::make_unique<MemoryInputStream>(mem_stream.getData(), mem_stream.getLength());
+        ReaderOptions reader_options;
+        reader_options.setMemoryPool(*getDefaultPool());
+        return createReader(std::move(in_stream), reader_options);
+    }
+
+    void verify_global_rowid_column(const Block& block, const std::string& column_name,
+                                    uint8_t expected_version, int64_t expected_backend_id,
+                                    uint32_t expected_file_id) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        const auto& string_column = static_cast<const ColumnString&>(*column.column);
+        for (size_t i = 0; i < string_column.size(); ++i) {
+            ASSERT_EQ(string_column.get_data_at(i).size, sizeof(GlobalRowLoacationV2));
+            auto location = *reinterpret_cast<const GlobalRowLoacationV2*>(
+                    string_column.get_data_at(i).data);
+            EXPECT_EQ(location.version, expected_version);
+            EXPECT_EQ(location.backend_id, expected_backend_id);
+            EXPECT_EQ(location.file_id, expected_file_id);
+            EXPECT_EQ(location.row_id, static_cast<uint32_t>(i));
+        }
+    }
+
+    void verify_nullable_string_column_values(const Block& block, const std::string& column_name,
+                                              const std::vector<std::string>& expected_values) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+        ASSERT_EQ(nullable->size(), expected_values.size());
+        for (size_t i = 0; i < expected_values.size(); ++i) {
+            ASSERT_FALSE(nullable->is_null_at(i));
+            EXPECT_EQ(nested.get_data_at(i).to_string(), expected_values[i]);
+        }
+    }
+
+    void verify_nullable_string_column_all_null(const Block& block, const std::string& column_name,
+                                                size_t expected_rows) {
+        const auto& column = block.get_by_position(block.get_position_by_name(column_name));
+        auto* nullable = check_and_get_column<ColumnNullable>(column.column.get());
+        ASSERT_NE(nullable, nullptr);
+        ASSERT_EQ(nullable->size(), expected_rows);
+        for (size_t i = 0; i < expected_rows; ++i) {
+            EXPECT_TRUE(nullable->is_null_at(i));
+        }
+    }
+
+    RuntimeProfile _profile {"transactional_hive_reader_test"};
+    RuntimeState _runtime_state {(TQueryOptions()), TQueryGlobals()};
+    std::vector<std::filesystem::path> _temp_paths;
+};
+
+TEST_F(TransactionalHiveReaderTest, expands_acid_columns_before_read) {
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    reader.col_name_to_block_idx_ref() = &col_name_to_block_idx;
+
+    Block block = make_name_block();
+    auto status = reader.on_before_read_block(&block);
+    ASSERT_TRUE(status.ok()) << status;
+
+    EXPECT_EQ(block.columns(), 1 + TransactionalHive::READ_PARAMS.size());
+    EXPECT_EQ(block.get_by_position(0).name, "name");
+    for (size_t i = 0; i < TransactionalHive::READ_PARAMS.size(); ++i) {
+        const auto& param = TransactionalHive::READ_PARAMS[i];
+        EXPECT_EQ(block.get_by_position(i + 1).name, param.column_lower_case);
+        EXPECT_EQ(col_name_to_block_idx[param.column_lower_case], i + 1);
+        EXPECT_NE(block.get_by_position(i + 1).column.get(), nullptr);
+    }
+}
+
+TEST_F(TransactionalHiveReaderTest, shrinks_acid_columns_after_read) {
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    reader.col_name_to_block_idx_ref() = &col_name_to_block_idx;
+
+    Block block = make_name_block();
+    ASSERT_TRUE(reader.on_before_read_block(&block).ok());
+
+    size_t read_rows = 0;
+    auto status = reader.on_after_read_block(&block, &read_rows);
+    ASSERT_TRUE(status.ok()) << status;
+
+    EXPECT_EQ(block.columns(), 1);
+    EXPECT_EQ(block.get_by_position(0).name, "name");
+    EXPECT_EQ(col_name_to_block_idx.size(), 1);
+    EXPECT_TRUE(col_name_to_block_idx.contains("name"));
+    for (const auto& param : TransactionalHive::READ_PARAMS) {
+        EXPECT_FALSE(col_name_to_block_idx.contains(param.column_lower_case));
+    }
+}
+
+TEST_F(TransactionalHiveReaderTest, expand_and_shrink_is_repeatable) {
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}};
+    reader.col_name_to_block_idx_ref() = &col_name_to_block_idx;
+
+    for (int i = 0; i < 2; ++i) {
+        Block block = make_name_block();
+        ASSERT_TRUE(reader.on_before_read_block(&block).ok());
+        EXPECT_EQ(block.columns(), 1 + TransactionalHive::READ_PARAMS.size());
+
+        size_t read_rows = 0;
+        ASSERT_TRUE(reader.on_after_read_block(&block, &read_rows).ok());
+        EXPECT_EQ(block.columns(), 1);
+        EXPECT_EQ(col_name_to_block_idx.size(), 1);
+        EXPECT_TRUE(col_name_to_block_idx.contains("name"));
+    }
+}
+
+TEST_F(TransactionalHiveReaderTest, no_delete_delta_keeps_existing_pushdown) {
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    reader.set_push_down_agg_type(TPushAggOp::COUNT);
+
+    auto status = reader.on_after_init_reader(nullptr);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::COUNT);
+    EXPECT_FALSE(reader.has_delete_operations());
+}
+
+TEST_F(TransactionalHiveReaderTest, unmatched_delete_delta_keeps_existing_pushdown) {
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    range.path = "/warehouse/tbl/base_0000001_v0000010/bucket_00001";
+    range.__isset.table_format_params = true;
+
+    TTransactionalHiveDeleteDeltaDesc delete_delta;
+    delete_delta.__set_directory_location("/warehouse/tbl/delete_delta_0000002_0000002_0000");
+    delete_delta.__set_file_names({"bucket_00002"});
+    range.table_format_params.transactional_hive_params.__set_delete_deltas({delete_delta});
+
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    reader.set_push_down_agg_type(TPushAggOp::COUNT);
+
+    auto status = reader.on_after_init_reader(nullptr);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::COUNT);
+    EXPECT_FALSE(reader.has_delete_operations());
+}
+
+TEST_F(TransactionalHiveReaderTest, matched_delete_delta_normalizes_bucket_attempt_id) {
+    TFileScanRangeParams params;
+    params.__isset.hdfs_params = true;
+    params.hdfs_params.__set_fs_name("hdfs://warehouse");
+
+    TFileRangeDesc range;
+    range.path = "/warehouse/tbl/base_0000001_v0000010/bucket_00001";
+    range.__isset.table_format_params = true;
+
+    TTransactionalHiveDeleteDeltaDesc delete_delta;
+    delete_delta.__set_directory_location(
+            "hdfs://warehouse/warehouse/tbl/delete_delta_0000002_0000002_0000");
+    delete_delta.__set_file_names({"bucket_00001_0"});
+    range.table_format_params.transactional_hive_params.__set_delete_deltas({delete_delta});
+
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    auto status = reader.on_after_init_reader(nullptr);
+
+    ASSERT_FALSE(status.ok());
+}
+
+TEST_F(TransactionalHiveReaderTest, matched_delete_delta_loads_delete_rows_and_disables_pushdown) {
+    auto delete_file = write_delete_delta_orc_file({{11, 7, 99}, {12, 8, 100}}, "bucket_00001");
+
+    TFileScanRangeParams params;
+    params.file_type = TFileType::FILE_LOCAL;
+
+    TFileRangeDesc range;
+    range.path = "/warehouse/tbl/base_0000001_v0000010/bucket_00001";
+    range.__isset.table_format_params = true;
+
+    TTransactionalHiveDeleteDeltaDesc delete_delta;
+    delete_delta.__set_directory_location(delete_file.directory);
+    delete_delta.__set_file_names({delete_file.file_name});
+    range.table_format_params.transactional_hive_params.__set_delete_deltas({delete_delta});
+
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    reader.set_push_down_agg_type(TPushAggOp::COUNT);
+
+    auto status = reader.on_after_init_reader(nullptr);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::NONE);
+    EXPECT_TRUE(reader.has_delete_operations());
+}
+
+TEST_F(TransactionalHiveReaderTest,
+       matched_delete_delta_attempt_id_loads_delete_rows_and_disables_pushdown) {
+    auto delete_file = write_delete_delta_orc_file({{21, 9, 101}}, "bucket_00001_0");
+
+    TFileScanRangeParams params;
+    params.file_type = TFileType::FILE_LOCAL;
+
+    TFileRangeDesc range;
+    range.path = "/warehouse/tbl/base_0000001_v0000010/bucket_00001";
+    range.__isset.table_format_params = true;
+
+    TTransactionalHiveDeleteDeltaDesc delete_delta;
+    delete_delta.__set_directory_location(delete_file.directory);
+    delete_delta.__set_file_names({delete_file.file_name});
+    range.table_format_params.transactional_hive_params.__set_delete_deltas({delete_delta});
+
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    reader.set_push_down_agg_type(TPushAggOp::COUNT);
+
+    auto status = reader.on_after_init_reader(nullptr);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(reader.get_push_down_agg_type(), TPushAggOp::NONE);
+    EXPECT_TRUE(reader.has_delete_operations());
+}
+
+TEST_F(TransactionalHiveReaderTest, reads_global_rowid_synthesized_column_from_orc_batches) {
+    auto acid_file = write_acid_data_orc_file(
+            {{0, 11, 7, 99, 11, "alice"}, {0, 12, 7, 100, 12, "bob"}}, "bucket_00001");
+
+    TFileScanRangeParams params;
+    params.file_type = TFileType::FILE_LOCAL;
+    params.format_type = TFileFormatType::FORMAT_ORC;
+
+    TFileRangeDesc range;
+    range.path = acid_file.path;
+    range.start_offset = 0;
+    range.size = static_cast<int64_t>(std::filesystem::file_size(acid_file.path));
+    range.__isset.table_format_params = true;
+
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    constexpr uint8_t kVersion = 1;
+    constexpr int64_t kBackendId = 10001;
+    constexpr uint32_t kFileId = 23;
+    reader.set_create_row_id_column_iterator_func([&]() {
+        return std::make_shared<segment_v2::RowIdColumnIteratorV2>(kVersion, kBackendId, kFileId);
+    });
+
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    auto global_rowid_type = std::make_shared<DataTypeString>();
+    std::string global_rowid_col_name = BeConsts::GLOBAL_ROWID_COL + "test";
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"name", nullable_string}, {global_rowid_col_name, global_rowid_type}});
+    auto column_descs = build_column_descs(tuple_descriptor,
+                                           {ColumnCategory::REGULAR, ColumnCategory::SYNTHESIZED});
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                       {global_rowid_col_name, 1}};
+
+    OrcInitContext ctx;
+    ctx.column_descs = &column_descs;
+    ctx.col_name_to_block_idx = &col_name_to_block_idx;
+    ctx.tuple_descriptor = tuple_descriptor;
+    ctx.params = &params;
+    ctx.range = &range;
+
+    auto status = reader.init_reader(&ctx);
+    ASSERT_TRUE(status.ok()) << status;
+
+    Block block;
+    block.insert(ColumnWithTypeAndName(nullable_string->create_column(), nullable_string, "name"));
+    block.insert(ColumnWithTypeAndName(global_rowid_type->create_column(), global_rowid_type,
+                                       global_rowid_col_name));
+
+    size_t read_rows = 0;
+    bool eof = false;
+    status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(status.ok()) << status;
+
+    ASSERT_EQ(read_rows, 2);
+    EXPECT_EQ(block.columns(), 2);
+    EXPECT_EQ(block.rows(), 2);
+    const auto& name_column = block.get_by_position(block.get_position_by_name("name"));
+    auto* nullable = check_and_get_column<ColumnNullable>(name_column.column.get());
+    ASSERT_NE(nullable, nullptr);
+    const auto& nested = static_cast<const ColumnString&>(nullable->get_nested_column());
+    EXPECT_EQ(nested.get_data_at(0).to_string(), "alice");
+    EXPECT_EQ(nested.get_data_at(1).to_string(), "bob");
+    verify_global_rowid_column(block, global_rowid_col_name, kVersion, kBackendId, kFileId);
+    EXPECT_FALSE(
+            col_name_to_block_idx.contains(TransactionalHive::ORIGINAL_TRANSACTION_LOWER_CASE));
+    EXPECT_FALSE(col_name_to_block_idx.contains(TransactionalHive::BUCKET_LOWER_CASE));
+    EXPECT_FALSE(col_name_to_block_idx.contains(TransactionalHive::ROW_ID_LOWER_CASE));
+}
+
+TEST_F(TransactionalHiveReaderTest, fills_partition_and_missing_columns_during_acid_orc_reads) {
+    auto acid_file = write_acid_data_orc_file(
+            {{0, 11, 7, 99, 11, "alice"}, {0, 12, 7, 100, 12, "bob"}}, "bucket_00001");
+
+    TFileScanRangeParams params;
+    params.file_type = TFileType::FILE_LOCAL;
+    params.format_type = TFileFormatType::FORMAT_ORC;
+
+    TFileRangeDesc range;
+    range.path = acid_file.path;
+    range.start_offset = 0;
+    range.size = static_cast<int64_t>(std::filesystem::file_size(acid_file.path));
+    range.__isset.table_format_params = true;
+    range.__set_columns_from_path_keys({"year"});
+    range.__set_columns_from_path({"2024"});
+
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"name", nullable_string},
+                                                 {"year", nullable_string},
+                                                 {"missing_col", nullable_string}});
+    auto column_descs = build_column_descs(
+            tuple_descriptor,
+            {ColumnCategory::REGULAR, ColumnCategory::PARTITION_KEY, ColumnCategory::REGULAR});
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {
+            {"name", 0}, {"year", 1}, {"missing_col", 2}};
+
+    OrcInitContext ctx;
+    ctx.column_descs = &column_descs;
+    ctx.col_name_to_block_idx = &col_name_to_block_idx;
+    ctx.tuple_descriptor = tuple_descriptor;
+    ctx.params = &params;
+    ctx.range = &range;
+
+    auto status = reader.init_reader(&ctx);
+    ASSERT_TRUE(status.ok()) << status;
+
+    Block block;
+    block.insert(ColumnWithTypeAndName(nullable_string->create_column(), nullable_string, "name"));
+    block.insert(ColumnWithTypeAndName(nullable_string->create_column(), nullable_string, "year"));
+    block.insert(ColumnWithTypeAndName(nullable_string->create_column(), nullable_string,
+                                       "missing_col"));
+
+    size_t read_rows = 0;
+    bool eof = false;
+    status = reader.get_next_block(&block, &read_rows, &eof);
+    ASSERT_TRUE(status.ok()) << status;
+
+    ASSERT_EQ(read_rows, 2);
+    EXPECT_EQ(block.columns(), 3);
+    EXPECT_EQ(block.rows(), 2);
+    verify_nullable_string_column_values(block, "name", {"alice", "bob"});
+    verify_nullable_string_column_values(block, "year", {"2024", "2024"});
+    verify_nullable_string_column_all_null(block, "missing_col", read_rows);
+    EXPECT_FALSE(
+            col_name_to_block_idx.contains(TransactionalHive::ORIGINAL_TRANSACTION_LOWER_CASE));
+    EXPECT_FALSE(col_name_to_block_idx.contains(TransactionalHive::BUCKET_LOWER_CASE));
+    EXPECT_FALSE(col_name_to_block_idx.contains(TransactionalHive::ROW_ID_LOWER_CASE));
+}
+
+TEST_F(TransactionalHiveReaderTest, on_before_init_reader_maps_row_columns_and_missing_columns) {
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    reader._reader = make_acid_orc_reader_with_name("alice");
+
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor = build_tuple_descriptor(
+            object_pool, {{"name", nullable_string}, {"missing_col", nullable_string}});
+    auto column_descs = build_column_descs(tuple_descriptor,
+                                           {ColumnCategory::REGULAR, ColumnCategory::REGULAR});
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0},
+                                                                       {"missing_col", 1}};
+
+    OrcInitContext ctx;
+    ctx.column_descs = &column_descs;
+    ctx.col_name_to_block_idx = &col_name_to_block_idx;
+    ctx.tuple_descriptor = tuple_descriptor;
+    ctx.range = &range;
+
+    auto status = reader.on_before_init_reader(&ctx);
+    ASSERT_TRUE(status.ok()) << status;
+
+    EXPECT_EQ(ctx.column_names.size(), 5);
+    EXPECT_EQ(ctx.column_names[0], "name");
+    EXPECT_EQ(ctx.column_names[1], "missing_col");
+    EXPECT_EQ(ctx.column_names[2], TransactionalHive::ORIGINAL_TRANSACTION_LOWER_CASE);
+    EXPECT_EQ(ctx.column_names[3], TransactionalHive::BUCKET_LOWER_CASE);
+    EXPECT_EQ(ctx.column_names[4], TransactionalHive::ROW_ID_LOWER_CASE);
+    ASSERT_NE(ctx.table_info_node, nullptr);
+    EXPECT_TRUE(ctx.table_info_node->children_column_exists("name"));
+    EXPECT_EQ(ctx.table_info_node->children_file_column_name("name"), "row.name");
+    EXPECT_FALSE(ctx.table_info_node->children_column_exists("missing_col"));
+}
+
+TEST_F(TransactionalHiveReaderTest, on_before_init_reader_rejects_acid_metadata_conflict) {
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    range.__isset.table_format_params = true;
+    TransactionalHiveReader reader(&_profile, &_runtime_state, params, range, 1024, "CST", nullptr,
+                                   nullptr);
+    reader._reader = make_acid_orc_reader_with_name("alice");
+
+    ObjectPool object_pool;
+    auto nullable_string = make_nullable(std::make_shared<DataTypeString>());
+    const auto* tuple_descriptor =
+            build_tuple_descriptor(object_pool, {{"bucket", nullable_string}});
+    auto column_descs = build_column_descs(tuple_descriptor, {ColumnCategory::REGULAR});
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"bucket", 0}};
+
+    OrcInitContext ctx;
+    ctx.column_descs = &column_descs;
+    ctx.col_name_to_block_idx = &col_name_to_block_idx;
+    ctx.tuple_descriptor = tuple_descriptor;
+    ctx.range = &range;
+
+    auto status = reader.on_before_init_reader(&ctx);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("conflicts with ACID metadata column"), std::string::npos);
+}
+
+} // namespace doris

--- a/be/test/io/fs/buffered_reader_test.cpp
+++ b/be/test/io/fs/buffered_reader_test.cpp
@@ -358,8 +358,8 @@ TEST_F(BufferedReaderTest, test_merged_io) {
         random_access_ranges.emplace_back(start_offset, end_offset);
     }
     io::MergeRangeFileReader merge_reader(nullptr, offset_reader, random_access_ranges);
-    char data[2 * 1024 * 1024]; // 2MB;
-    Slice result(data, 1 * 1024 * 1024);
+    std::vector<char> data(2 * 1024 * 1024); // 2MB
+    Slice result(data.data(), 1 * 1024 * 1024);
     size_t bytes_read = 0;
 
     // read column 0
@@ -403,21 +403,21 @@ TEST_F(BufferedReaderTest, test_merged_io) {
                 size_t start_offset = 4 * 1024 * 1024 * col;
                 size_t to_read = 729 * 1024; // read 729KB
                 static_cast<void>(static_cast<void>(merge_reader.read_at(
-                        start_offset, Slice(data, to_read), &bytes_read, nullptr)));
+                        start_offset, Slice(data.data(), to_read), &bytes_read, nullptr)));
                 EXPECT_EQ(to_read, bytes_read);
                 EXPECT_EQ(start_offset % UCHAR_MAX, (uint8_t)data[0]);
             } else if (i == 1) {
                 size_t start_offset = 4 * 1024 * 1024 * col + 729 * 1024;
                 size_t to_read = 1872 * 1024; // read 1872KB
                 static_cast<void>(static_cast<void>(merge_reader.read_at(
-                        start_offset, Slice(data, to_read), &bytes_read, nullptr)));
+                        start_offset, Slice(data.data(), to_read), &bytes_read, nullptr)));
                 EXPECT_EQ(to_read, bytes_read);
                 EXPECT_EQ(start_offset % UCHAR_MAX, (uint8_t)data[0]);
             } else if (i == 2) {
                 size_t start_offset = 4 * 1024 * 1024 * col + 729 * 1024 + 1872 * 1024;
                 size_t to_read = 471 * 1024; // read 471KB
                 static_cast<void>(static_cast<void>(merge_reader.read_at(
-                        start_offset, Slice(data, to_read), &bytes_read, nullptr)));
+                        start_offset, Slice(data.data(), to_read), &bytes_read, nullptr)));
                 EXPECT_EQ(to_read, bytes_read);
                 EXPECT_EQ(start_offset % UCHAR_MAX, (uint8_t)data[0]);
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -458,6 +458,57 @@ public class PaimonScanNodeTest {
     }
 
     @Test
+    public void testMixedNativeAndJniSplits() throws UserException {
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(3));
+        PaimonScanNode paimonScanNode = new PaimonScanNode(new PlanNodeId(1), desc, false, sv, ScanContext.EMPTY);
+        PaimonScanNode spyPaimonScanNode = Mockito.spy(paimonScanNode);
+
+        DataSplit nativeSplit = createDataSplit("native.parquet", true);
+        DataSplit jniSplit = createDataSplit("jni.binary", false);
+        Mockito.doReturn(new ArrayList<org.apache.paimon.table.source.Split>() {
+            {
+                add(nativeSplit);
+                add(jniSplit);
+            }
+        }).when(spyPaimonScanNode).getPaimonSplitFromAPI();
+
+        PaimonSource source = Mockito.mock(PaimonSource.class);
+        Mockito.when(source.getFileFormatFromTableProperties()).thenReturn("parquet");
+        spyPaimonScanNode.setSource(source);
+
+        long maxInitialSplitSize = 32L * 1024L * 1024L;
+        long maxSplitSize = 64L * 1024L * 1024L;
+        FileSplitter fileSplitter = new FileSplitter(maxInitialSplitSize, maxSplitSize, 0);
+        try {
+            java.lang.reflect.Field field = FileQueryScanNode.class.getDeclaredField("fileSplitter");
+            field.setAccessible(true);
+            field.set(spyPaimonScanNode, fileSplitter);
+
+            java.lang.reflect.Field storagePropertiesField =
+                    PaimonScanNode.class.getDeclaredField("storagePropertiesMap");
+            storagePropertiesField.setAccessible(true);
+            storagePropertiesField.set(spyPaimonScanNode, Collections.emptyMap());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to inject test fields into PaimonScanNode", e);
+        }
+
+        Mockito.when(sv.isForceJniScanner()).thenReturn(false);
+        Mockito.when(sv.getIgnoreSplitType()).thenReturn("NONE");
+        Mockito.when(sv.isEnableRuntimeFilterPartitionPrune()).thenReturn(false);
+        Mockito.when(sv.getFileSplitSize()).thenReturn(128L * 1024L * 1024L);
+
+        List<org.apache.doris.spi.Split> splits = spyPaimonScanNode.getSplits(1);
+        Assert.assertEquals(2, splits.size());
+
+        PaimonSplit firstSplit = (PaimonSplit) splits.get(0);
+        PaimonSplit secondSplit = (PaimonSplit) splits.get(1);
+        Assert.assertNull(firstSplit.getSplit());
+        Assert.assertNotNull(secondSplit.getSplit());
+        Assert.assertTrue(firstSplit.getPathString().endsWith("native.parquet"));
+        Assert.assertEquals(jniSplit, secondSplit.getSplit());
+    }
+
+    @Test
     public void testDetermineTargetFileSplitSizeHonorsMaxFileSplitNum() throws Exception {
         SessionVariable sv = new SessionVariable();
         sv.setMaxFileSplitNum(100);
@@ -565,11 +616,15 @@ public class PaimonScanNodeTest {
     }
 
     private DataSplit createDataSplit(String fileName) {
+        return createDataSplit(fileName, true);
+    }
+
+    private DataSplit createDataSplit(String fileName, boolean rawConvertible) {
         DataFileMeta dataFileMeta = DataFileMeta.forAppend(fileName, 64L * 1024 * 1024, 1L, SimpleStats.EMPTY_STATS,
                 1L, 1L, 1L, Collections.<String>emptyList(), null, FileSource.APPEND,
                 Collections.<String>emptyList(), null, null, Collections.<String>emptyList());
         return DataSplit.builder()
-                .rawConvertible(true)
+                .rawConvertible(rawConvertible)
                 .withPartition(BinaryRow.singleColumn(1))
                 .withBucket(1)
                 .withBucketPath("file://b1")

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -51,6 +51,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -100,12 +101,8 @@ public class PaimonScanNodeTest {
 
         // Mock PaimonScanNode to return test data splits
         PaimonScanNode spyPaimonScanNode = Mockito.spy(paimonScanNode);
-        Mockito.doReturn(new ArrayList<org.apache.paimon.table.source.Split>() {
-            {
-                add(ds1);
-                add(ds2);
-            }
-        }).when(spyPaimonScanNode).getPaimonSplitFromAPI();
+        Mockito.doReturn(new ArrayList<>(Arrays.asList(ds1, ds2)))
+                .when(spyPaimonScanNode).getPaimonSplitFromAPI();
 
         long maxInitialSplitSize = 32L * 1024L * 1024L;
         long maxSplitSize = 64L * 1024L * 1024L;
@@ -465,12 +462,8 @@ public class PaimonScanNodeTest {
 
         DataSplit nativeSplit = createDataSplit("native.parquet", true);
         DataSplit jniSplit = createDataSplit("jni.binary", false);
-        Mockito.doReturn(new ArrayList<org.apache.paimon.table.source.Split>() {
-            {
-                add(nativeSplit);
-                add(jniSplit);
-            }
-        }).when(spyPaimonScanNode).getPaimonSplitFromAPI();
+        Mockito.doReturn(new ArrayList<>(Arrays.asList(nativeSplit, jniSplit)))
+                .when(spyPaimonScanNode).getPaimonSplitFromAPI();
 
         PaimonSource source = Mockito.mock(PaimonSource.class);
         Mockito.when(source.getFileFormatFromTableProperties()).thenReturn("parquet");

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -363,14 +363,45 @@ touch "${UT_TMP_DIR}/tmp_file"
 
 # prepare java jars
 LIB_DIR="${DORIS_TEST_BINARY_DIR}/lib/"
+JAVA_EXT_DIR="${LIB_DIR}/java_extensions"
 rm -rf "${LIB_DIR}"
 mkdir "${LIB_DIR}"
+mkdir "${JAVA_EXT_DIR}"
 if [[ -d "${DORIS_THIRDPARTY}/installed/lib/hadoop_hdfs/" ]]; then
     cp -r "${DORIS_THIRDPARTY}/installed/lib/hadoop_hdfs/" "${LIB_DIR}"
 fi
-if [[ -f "${DORIS_HOME}/output/be/lib/java-udf-jar-with-dependencies.jar" ]]; then
+if [[ -d "${DORIS_HOME}/output/be/lib/java_extensions/" ]]; then
+    cp -r "${DORIS_HOME}/output/be/lib/java_extensions/." "${JAVA_EXT_DIR}/"
+fi
+if [[ -f "${DORIS_HOME}/output/be/lib/java_extensions/java-udf/java-udf-jar-with-dependencies.jar" ]]; then
+    cp "${DORIS_HOME}/output/be/lib/java_extensions/java-udf/java-udf-jar-with-dependencies.jar" \
+        "${LIB_DIR}/"
+elif [[ -f "${DORIS_HOME}/output/be/lib/java-udf-jar-with-dependencies.jar" ]]; then
     cp "${DORIS_HOME}/output/be/lib/java-udf-jar-with-dependencies.jar" "${LIB_DIR}/"
 fi
+
+# add preload java libs first to match BE startup classpath ordering
+DORIS_PRELOAD_JAR=
+preload_jars=("preload-extensions")
+preload_jars+=("java-udf")
+for preload_jar_dir in "${preload_jars[@]}"; do
+    if [[ ! -d "${JAVA_EXT_DIR}/${preload_jar_dir}" ]]; then
+        continue
+    fi
+    for f in "${JAVA_EXT_DIR}/${preload_jar_dir}"/*.jar; do
+        if [[ ! -f "${f}" ]]; then
+            continue
+        fi
+        if [[ "${f}" == *"preload-extensions-project.jar" ]]; then
+            DORIS_PRELOAD_JAR="${f}"
+            continue
+        elif [[ -z "${DORIS_CLASSPATH}" ]]; then
+            export DORIS_CLASSPATH="${f}"
+        else
+            export DORIS_CLASSPATH="${DORIS_CLASSPATH}:${f}"
+        fi
+    done
+done
 
 # add java libs
 for f in "${LIB_DIR}"/*.jar; do
@@ -397,9 +428,13 @@ if [[ -d "${LIB_DIR}/hadoop_hdfs/" ]]; then
     done
 fi
 
+if [[ -n "${DORIS_PRELOAD_JAR}" ]]; then
+    DORIS_CLASSPATH="${DORIS_PRELOAD_JAR}:${DORIS_CLASSPATH}"
+fi
+
 # the CLASSPATH and LIBHDFS_OPTS is used for hadoop libhdfs
 # and conf/ dir so that hadoop libhdfs can read .xml config file in conf/
-export CLASSPATH="${DORIS_CLASSPATH}"
+export CLASSPATH="${DORIS_TEST_BINARY_DIR}/conf:${DORIS_CLASSPATH}"
 # DORIS_CLASSPATH is for self-managed jni
 export DORIS_CLASSPATH="-Djava.class.path=${DORIS_CLASSPATH}"
 
@@ -463,7 +498,7 @@ if [[ "${MACHINE_OS}" == "Darwin" ]]; then
 fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs
-export LIBHDFS_OPTS="${final_java_opt}"
+export LIBHDFS_OPTS="${final_java_opt} ${DORIS_CLASSPATH}"
 
 # set ORC_EXAMPLE_DIR for orc unit tests
 export ORC_EXAMPLE_DIR="${DORIS_HOME}/contrib/apache-orc/examples"

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -429,12 +429,20 @@ if [[ -d "${LIB_DIR}/hadoop_hdfs/" ]]; then
 fi
 
 if [[ -n "${DORIS_PRELOAD_JAR}" ]]; then
-    DORIS_CLASSPATH="${DORIS_PRELOAD_JAR}:${DORIS_CLASSPATH}"
+    if [[ -z "${DORIS_CLASSPATH}" ]]; then
+        DORIS_CLASSPATH="${DORIS_PRELOAD_JAR}"
+    else
+        DORIS_CLASSPATH="${DORIS_PRELOAD_JAR}:${DORIS_CLASSPATH}"
+    fi
 fi
 
 # the CLASSPATH and LIBHDFS_OPTS is used for hadoop libhdfs
 # and conf/ dir so that hadoop libhdfs can read .xml config file in conf/
-export CLASSPATH="${DORIS_TEST_BINARY_DIR}/conf:${DORIS_CLASSPATH}"
+if [[ -z "${DORIS_CLASSPATH}" ]]; then
+    export CLASSPATH="${DORIS_TEST_BINARY_DIR}/conf"
+else
+    export CLASSPATH="${DORIS_TEST_BINARY_DIR}/conf:${DORIS_CLASSPATH}"
+fi
 # DORIS_CLASSPATH is for self-managed jni
 export DORIS_CLASSPATH="-Djava.class.path=${DORIS_CLASSPATH}"
 
@@ -505,8 +513,13 @@ export ORC_EXAMPLE_DIR="${DORIS_HOME}/contrib/apache-orc/examples"
 
 # set asan and ubsan env to generate core file
 export DORIS_HOME="${DORIS_TEST_BINARY_DIR}/"
+if [[ -n "${LSAN_OPTIONS}" ]]; then
+    export LSAN_OPTIONS="suppressions=${ROOT}/conf/lsan_suppr.conf:${LSAN_OPTIONS}"
+else
+    export LSAN_OPTIONS="suppressions=${ROOT}/conf/lsan_suppr.conf"
+fi
 ## detect_container_overflow=0, https://github.com/google/sanitizers/issues/193
-export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0:check_malloc_usable_size=0
+export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0:check_malloc_usable_size=0:suppressions=${ROOT}/conf/asan_suppr.conf
 export UBSAN_OPTIONS=print_stacktrace=1
 export JAVA_OPTS="-Xmx1024m -DlogPath=${DORIS_HOME}/log/jni.log -Xloggc:${DORIS_HOME}/log/be.gc.log.${CUR_DATE} -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -DJDBC_MIN_POOL=1 -DJDBC_MAX_POOL=100 -DJDBC_MAX_IDLE_TIME=300000"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

- Fix several data lake reader edge cases around initialization ordering and column handling:
  - Use ReaderInitContext tuple descriptors during pre-init schema mapping instead of
  reader-local descriptors that are initialized later.
  - Use the actual block column type when deserializing partition values.
  - Avoid leaking Paimon deletion-vector row buffers on parse failures.
  - Align small reader cleanups for deletion-vector magic numbers, equality delete
  reader casting, and timezone propagation.

- Add lake reader unit tests.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

