### PR TITLE
[fix](fe) Preserve JDBC external column defaults

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -402,7 +402,7 @@ public abstract class JdbcClient {
         for (JdbcFieldSchema field : jdbcTableSchema) {
             dorisTableSchema.add(new Column(field.getColumnName(),
                     jdbcTypeToDoris(field), true, null,
-                    field.isAllowNull(), field.getRemarks(),
+                    field.isAllowNull(), field.getColumnDefaultValue().orElse(null), field.getRemarks(),
                     true, -1));
         }
         return dorisTableSchema;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchema.java
@@ -38,6 +38,7 @@ public class JdbcFieldSchema {
     protected Optional<Integer> columnSize;
     protected Optional<Integer> decimalDigits;
     protected Optional<Integer> arrayDimensions;
+    protected Optional<String> columnDefaultValue;
     // Base number (usually 10 or 2)
     protected int numPrecRadix;
     // column description
@@ -55,6 +56,7 @@ public class JdbcFieldSchema {
         this.columnSize = other.columnSize;
         this.decimalDigits = other.decimalDigits;
         this.arrayDimensions = other.arrayDimensions;
+        this.columnDefaultValue = other.columnDefaultValue;
         this.numPrecRadix = other.numPrecRadix;
         this.remarks = other.remarks;
         this.charOctetLength = other.charOctetLength;
@@ -69,6 +71,7 @@ public class JdbcFieldSchema {
         this.decimalDigits = getInteger(rs, "DECIMAL_DIGITS");
         this.numPrecRadix = rs.getInt("NUM_PREC_RADIX");
         this.isAllowNull = rs.getInt("NULLABLE") != DatabaseMetaData.columnNoNulls;
+        this.columnDefaultValue = Optional.ofNullable(rs.getString("COLUMN_DEF"));
         this.remarks = rs.getString("REMARKS");
         this.charOctetLength = rs.getInt("CHAR_OCTET_LENGTH");
     }
@@ -81,6 +84,7 @@ public class JdbcFieldSchema {
         this.decimalDigits = getInteger(rs, "DECIMAL_DIGITS");
         this.numPrecRadix = rs.getInt("NUM_PREC_RADIX");
         this.isAllowNull = rs.getInt("NULLABLE") != DatabaseMetaData.columnNoNulls;
+        this.columnDefaultValue = Optional.ofNullable(rs.getString("COLUMN_DEF"));
         this.remarks = rs.getString("REMARKS");
         this.charOctetLength = rs.getInt("CHAR_OCTET_LENGTH");
         this.arrayDimensions = Optional.of(arrayDimensions);
@@ -94,6 +98,7 @@ public class JdbcFieldSchema {
         this.decimalDigits = getInteger(rs, "DECIMAL_DIGITS");
         this.numPrecRadix = rs.getInt("NUM_PREC_RADIX");
         this.isAllowNull = rs.getInt("NULLABLE") != 0;
+        this.columnDefaultValue = Optional.ofNullable(rs.getString("COLUMN_DEF"));
         this.remarks = rs.getString("REMARKS");
         this.charOctetLength = rs.getInt("CHAR_OCTET_LENGTH");
     }
@@ -108,6 +113,7 @@ public class JdbcFieldSchema {
         this.columnSize = Optional.of(metaData.getPrecision(columnIndex));
         this.decimalDigits = Optional.of(metaData.getScale(columnIndex));
         this.arrayDimensions = Optional.of(0);
+        this.columnDefaultValue = Optional.empty();
     }
 
     public int requiredColumnSize() {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchemaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/util/JdbcFieldSchemaTest.java
@@ -21,8 +21,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Types;
+import java.util.Optional;
 
 public class JdbcFieldSchemaTest {
 
@@ -53,5 +55,26 @@ public class JdbcFieldSchemaTest {
         JdbcFieldSchema schema = new JdbcFieldSchema(metaData, 1);
 
         Assert.assertEquals("username", schema.getColumnName());
+    }
+
+    @Test
+    public void testReadsColumnDefaultFromResultSet() throws Exception {
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(resultSet.getString("COLUMN_NAME")).thenReturn("pname");
+        Mockito.when(resultSet.getInt("DATA_TYPE")).thenReturn(Types.VARCHAR);
+        Mockito.when(resultSet.wasNull()).thenReturn(false);
+        Mockito.when(resultSet.getString("TYPE_NAME")).thenReturn("VARCHAR");
+        Mockito.when(resultSet.getInt("COLUMN_SIZE")).thenReturn(255);
+        Mockito.when(resultSet.getInt("DECIMAL_DIGITS")).thenReturn(0);
+        Mockito.when(resultSet.getInt("NUM_PREC_RADIX")).thenReturn(10);
+        Mockito.when(resultSet.getInt("NULLABLE")).thenReturn(ResultSetMetaData.columnNoNulls);
+        Mockito.when(resultSet.getString("COLUMN_DEF")).thenReturn("其他");
+        Mockito.when(resultSet.getString("REMARKS")).thenReturn("名字");
+        Mockito.when(resultSet.getInt("CHAR_OCTET_LENGTH")).thenReturn(255);
+
+        JdbcFieldSchema schema = new JdbcFieldSchema(resultSet);
+
+        Assert.assertEquals(Optional.of("其他"), schema.getColumnDefaultValue());
+        Assert.assertEquals("名字", schema.getRemarks());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:
JDBC external catalogs were dropping `COLUMN_DEF` when FE converted JDBC metadata into Doris `Column` objects. As a result, external JDBC tables lost their default values in Doris metadata, and downstream tools such as the Metabase Doris driver could not read `database_default` for those columns during schema sync.

### Release note

Preserve default values for JDBC external table columns in FE metadata.

### Check List (For Author)

- Test: FE unit test / Manual test
    - Unit Test: `./run-fe-ut.sh --run org.apache.doris.datasource.jdbc.util.JdbcFieldSchemaTest`
    - Unit Test: `./run-fe-ut.sh --run org.apache.doris.datasource.jdbc.client.JdbcMySQLClientTest`
    - Manual test: `./build.sh --fe`
    - Manual test: verified `SHOW FULL COLUMNS FROM doris_jdbc_catalog.regression_test_jdbc_catalog_p0.test_insert_order` returns defaults (`aid=0`, `pname=其他`)
    - Manual test: verified fresh Metabase metadata sync now shows `database_default=0` for `aid` and `database_default=其他` for `pname`
- Behavior changed: Yes (external JDBC column defaults are now preserved in FE metadata)
- Does this need documentation: No
