### PR TITLE
[fix](hll) shrink chars buffer in hll_to_base64 to match offsets

### DIFF
--- a/be/src/exprs/function/function_hll.cpp
+++ b/be/src/exprs/function/function_hll.cpp
@@ -303,6 +303,10 @@ struct HllToBase64 {
             encoded_offset += outlen;
             offsets[i] = cast_set<uint32_t>(encoded_offset);
         }
+        // chars was sized using max_serialized_size(); the actual encoded length
+        // can be smaller (e.g. sparse HLL), so shrink chars to keep
+        // offsets.back() == chars.size() and satisfy ColumnString::sanity_check.
+        chars.resize(encoded_offset);
         return Status::OK();
     }
 };

--- a/regression-test/data/query_p0/sql_functions/hll_functions/test_hll_functions.out
+++ b/regression-test/data/query_p0/sql_functions/hll_functions/test_hll_functions.out
@@ -33,3 +33,8 @@ AQEC5XSzrpDsdw==
 -- !const_select --
 AQEyl7yFZerf2A==
 
+-- !sparse_roundtrip --
+true
+
+-- !sparse_len_positive --
+true

--- a/regression-test/suites/query_p0/sql_functions/hll_functions/test_hll_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/hll_functions/test_hll_functions.groovy
@@ -74,4 +74,10 @@ suite("test_hll_functions") {
         sql """SELECT hll_from_base64(CAST('AgAAAAAAAABwAAAAAAAAAA==' AS VARCHAR(100))) AS result;"""
         exception "[RUNTIME_ERROR]hll_from_base64 decode failed";
     }
+
+    // Cover sparse/full HLL hll_to_base64: max_serialized_size is much larger
+    // than the real serialized size, which previously left ColumnString chars
+    // oversized vs offsets and tripped sanity_check.
+    qt_sparse_roundtrip "select hll_cardinality(hll_from_base64(hll_to_base64(hll_union(hll_hash(number))))) > 400 from numbers(\"number\"=\"500\");"
+    qt_sparse_len_positive "select length(hll_to_base64(hll_union(hll_hash(number)))) > 0 from numbers(\"number\"=\"500\");"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: N/A

Problem Summary:

`HllToBase64::vector()` in `be/src/exprs/function/function_hll.cpp` pre-allocates the output `chars` buffer using `HyperLogLog::max_serialized_size()` (for SPARSE/FULL HLL the upper bound is `1 + HLL_REGISTERS_COUNT = 16385` bytes), but the inner loop only advances `encoded_offset` by the **actual** base64-encoded length of each row's serialized HLL. After the loop, `offsets.back() == encoded_offset` reflects the real bytes written, while `chars.size()` is still the over-allocated upper bound.

This violates `ColumnString`'s invariant `chars.size() == offsets.back()`, which is asserted by `ColumnString::sanity_check_simple()` (see `be/src/core/column/column_string.cpp:153`). In debug / ASAN builds this throws `Internal error: chars.size(): X, offset[N-1]: Y`. In release builds it leaks tail bytes into memory accounting and any downstream consumer that relies on `chars.size()`.

The bug is most easily reproducible with SPARSE HLLs: `max_serialized_size()` returns 16385 but the real serialized form is `1 + 4 + 3 * num_non_zero_registers`, so the gap between allocated and used bytes is large. The existing tests only covered EXPLICIT HLL (`hll_hash('abc')`) and EMPTY HLL where `max == real`, so they did not exercise this path.

Fix: shrink `chars` to the real `encoded_offset` after the encoding loop completes.

### Release note

Fix a `ColumnString` invariant violation in `hll_to_base64` when the HLL is in SPARSE / FULL representation.

### Check List (For Author)

- Test:
    - [x] Regression Test: added two cases in `regression-test/suites/query_p0/sql_functions/hll_functions/test_hll_functions.groovy` that build a SPARSE HLL (500 distinct hashes) and exercise `hll_to_base64` round-trip and length, covering the previously untested SPARSE path.
    - [x] Manual test: rebuilt BE and reran the regression suite — passes.

- Behavior changed: No

- Does this need documentation: No
