### PR TITLE
[fix](pipeline) guard CountedFinishDependency::sub() against counter underflow

### DIFF
--- a/be/src/exec/pipeline/dependency.h
+++ b/be/src/exec/pipeline/dependency.h
@@ -194,6 +194,13 @@ public:
 
     void sub() {
         std::unique_lock<std::mutex> l(_mtx);
+        // _counter is unsigned: a stray sub() when counter is already 0 would
+        // underflow to UINT32_MAX and the dependency would never become ready,
+        // hanging the query forever. Fail loudly instead.
+        if (_counter == 0) [[unlikely]] {
+            throw Exception(ErrorCode::INTERNAL_ERROR,
+                            "CountedFinishDependency::sub() underflow on {}", debug_string());
+        }
         _counter--;
         if (!_counter) {
             set_ready();

--- a/be/test/exec/runtime_filter/sync_size_callback_test.cpp
+++ b/be/test/exec/runtime_filter/sync_size_callback_test.cpp
@@ -348,4 +348,32 @@ TEST_F(HandleErrorBrpcCallbackTest, weak_auto_release_closure_runs_with_external
     ASSERT_TRUE(ctx->is_cancelled());
 }
 
+// ==================== CountedFinishDependency::sub() underflow guard ====================
+
+TEST(CountedFinishDependencyTest, sub_with_zero_counter_throws) {
+    auto dep = std::make_shared<CountedFinishDependency>(0, 0, "TEST_DEP");
+    // Counter is 0 from construction; sub() must not silently underflow.
+    EXPECT_THROW(dep->sub(), Exception);
+}
+
+TEST(CountedFinishDependencyTest, sub_after_balanced_add_sub_throws) {
+    auto dep = std::make_shared<CountedFinishDependency>(0, 0, "TEST_DEP");
+    dep->add();
+    dep->sub(); // counter back to 0, dependency now ready
+    // A stray extra sub() must throw rather than wrap to UINT32_MAX (which would
+    // hang the query forever).
+    EXPECT_THROW(dep->sub(), Exception);
+}
+
+TEST(CountedFinishDependencyTest, balanced_add_sub_sets_ready) {
+    auto dep = std::make_shared<CountedFinishDependency>(0, 0, "TEST_DEP");
+    dep->add(3);
+    EXPECT_FALSE(dep->ready());
+    dep->sub();
+    dep->sub();
+    EXPECT_FALSE(dep->ready());
+    dep->sub();
+    EXPECT_TRUE(dep->ready());
+}
+
 } // namespace doris


### PR DESCRIPTION
Related PR: N/A

Problem Summary:

`CountedFinishDependency::sub()` decrements an unsigned `uint32_t _counter`
without checking that the counter is greater than zero. The contract is that
each `sub()` is balanced by a prior `add()`, but if the protocol is ever
violated (e.g. a duplicated `sync_filter_size` RPC from FE, double callback
on the BE side, or any future bug) the `0--` silently underflows to
`UINT32_MAX`. The condition `if (!_counter) set_ready();` is then never true
and the dependency stays blocked forever, hanging the entire query with no
log line and no crash, making the bug very hard to diagnose.

This is especially relevant because there are multiple callers of `sub()`:
- `SyncSizeCallback::call()` on RPC failure
- `SyncSizeCallback::call()` on RPC success but error response status
- `RuntimeFilterProducer::set_synced_size()` triggered by FE

Any imbalance between these and the single `add()` in
`RuntimeFilterProducer::set_dependency()` would produce the silent hang.

Add an explicit check at the top of `sub()` that throws an
`Exception(ErrorCode::INTERNAL_ERROR, ...)` carrying `debug_string()` when
`_counter == 0`. This matches the project convention of asserting
correctness and failing fast rather than letting the process limp along in
a corrupt state.

### Release note

Fix a potential silent query hang caused by an unbalanced
`CountedFinishDependency::sub()` call underflowing the counter. Such cases
now throw an explicit `INTERNAL_ERROR` instead.

### Check List (For Author)

- Test:
    - [x] Unit Test: added `CountedFinishDependencyTest` in
      `be/test/exec/runtime_filter/sync_size_callback_test.cpp` covering
      sub() on a fresh counter, sub() after balanced add/sub, and the happy
      path of multiple add() / sub() reaching ready. All pass.
    - [x] Existing `SyncSizeCallbackTest.*` re-run, no regression.

- Behavior changed: No (the only observable change is converting an existing
  silent failure into a loud error when the contract is violated)

- Does this need documentation: No
