### PR TITLE
[fix](ci) Use actions/setup-java to install JDK 17 for BE UT macOS workflow

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -56,6 +56,13 @@ jobs:
           max-size: "5G"
           restore-keys: BE-UT-macOS-
 
+      - name: Setup JDK 17
+        if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Run UT ${{ github.ref }}
         if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
         run: |
@@ -96,5 +103,6 @@ jobs:
           tar -xvf doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
           popd
 
-          export JAVA_HOME="${JAVA_HOME_17_X64%\/}"
+          # JAVA_HOME is set by actions/setup-java@v4 above, pointing to Temurin JDK 17.
+          # The previous JAVA_HOME_17_X64 env var is unset on arm64 macOS runners.
           ./run-be-ut.sh --run -j "$(nproc)" --clean

--- a/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
@@ -552,7 +552,9 @@ private:
 
             if (curr_level > max_level) {
                 max_level = curr_level;
-                if (max_level + 1 == event_count) return event_count;
+                if (max_level + 1 == event_count) {
+                    return event_count;
+                }
             }
 
             // Prune: remaining events cannot beat current best.


### PR DESCRIPTION
## Problem

The `BE UT (macOS)` workflow on `macos-15` started failing with:

```
Check JAVA version
ERROR: The JAVA version is 25, it must be JDK-17.
```

## Root cause

The `macos-15` GitHub-hosted runner is **arm64 (Apple Silicon)**, confirmed by job logs: `Target system: Darwin; Target arch: arm64`. On arm64 macOS runners, the env var `JAVA_HOME_17_X64` is **not set** (only `JAVA_HOME_17_arm64` would be), so:

```bash
export JAVA_HOME="${JAVA_HOME_17_X64%/}"  # JAVA_HOME=""
```

ends up empty. Then `env.sh` (`check_jdk_version`) falls back to `command -v java`, which on `macos-15` is now JDK 25 by default, hence the failure.

## Fix

Use `actions/setup-java@v4` (Temurin 17) to install JDK 17 in a runner-arch-agnostic way; the action sets `JAVA_HOME` automatically. Drop the obsolete `export JAVA_HOME="${JAVA_HOME_17_X64%/}"` line.

This avoids depending on hosted-runner preinstalled JDK env vars (which differ across image versions and architectures) and matches the pattern already used by other workflows in the repo (e.g. `.github/workflows/checkstyle.yaml` and `build-extension.yml`).

## Release note

None (CI fix only).