### PR TITLE
[fix](function) preserve sign for negative sub-hour TIMESTAMPTZ offsets

### DIFF
--- a/be/src/core/value/timestamptz_value.cpp
+++ b/be/src/core/value/timestamptz_value.cpp
@@ -40,8 +40,10 @@ std::string TimestampTzValue::to_string(const cctz::time_zone& tz, int scale) co
     cctz::civil_second civ = lookup_result.cs;
     auto time_offset = lookup_result.offset;
 
-    int offset_hours = time_offset / 3600;
-    int offset_mins = (std::abs(time_offset) % 3600) / 60;
+    bool is_negative_offset = time_offset < 0;
+    int abs_offset = std::abs(time_offset);
+    int offset_hours = abs_offset / 3600;
+    int offset_mins = (abs_offset % 3600) / 60;
 
     /// TODO: We could directly use datetime's to_string here. In the future,
     /// when we support a function like 'show datetime with timezone',
@@ -57,13 +59,13 @@ std::string TimestampTzValue::to_string(const cctz::time_zone& tz, int scale) co
     int len = tmp_dt.to_buffer(buffer, scale);
     // timezone +03:00
     // buffer[len++] = ' ';
-    buffer[len++] = (offset_hours >= 0 ? '+' : '-');
-    buffer[len++] = static_cast<char>('0' + std::abs(offset_hours) / 10);
-    buffer[len++] = '0' + std::abs(offset_hours) % 10;
+    buffer[len++] = (is_negative_offset ? '-' : '+');
+    buffer[len++] = static_cast<char>('0' + offset_hours / 10);
+    buffer[len++] = '0' + offset_hours % 10;
     buffer[len++] = ':';
     buffer[len++] = static_cast<char>('0' + offset_mins / 10);
     buffer[len++] = '0' + offset_mins % 10;
-    return std::string(buffer, len);
+    return {buffer, static_cast<size_t>(len)};
 }
 
 bool TimestampTzValue::from_datetime(const DateV2Value<DateTimeV2ValueType>& origin_dt,

--- a/be/test/core/data_type/data_type_timestamptz_test.cpp
+++ b/be/test/core/data_type/data_type_timestamptz_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <string>
@@ -99,6 +100,17 @@ TEST_F(DataTypeTimeStampTzTest, test_serder) {
         StringRef str {"2024-01-01 12:abc:00 +08:00"};
         EXPECT_FALSE(serder->from_string_strict_mode(str, *column, options).ok());
     }
+}
+
+TEST_F(DataTypeTimeStampTzTest, test_to_string_negative_sub_hour_offset) {
+    cctz::time_zone time_zone = cctz::fixed_time_zone(std::chrono::minutes(-30));
+
+    DateV2Value<DateTimeV2ValueType> local_dt;
+    local_dt.unchecked_set_time(2023, 12, 31, 23, 45, 0, 0);
+
+    TimestampTzValue value;
+    EXPECT_TRUE(value.from_datetime(local_dt, time_zone, 6, 6));
+    EXPECT_EQ(value.to_string(time_zone), "2023-12-31 23:45:00.000000-00:30");
 }
 
 TEST_F(DataTypeTimeStampTzTest, test_sort) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When BE renders TIMESTAMPTZ values, it derives the timezone sign from the truncated hour component.
For negative sub-hour offsets such as -00:30, integer division makes the hour component 0, so the
renderer emits +00:30 instead of -00:30.

This affects both constant-folded expressions and runtime values rendered from table data.

Root cause:

- Old logic:

```cpp
int offset_hours = time_offset / 3600;
int offset_mins = (std::abs(time_offset) % 3600) / 60;
char sign = offset_hours >= 0 ? '+' : '-';
```

- For time_offset = -1800, offset_hours becomes 0, so the sign is rendered as +.

Fix:

- Determine the sign from the original second offset.
- Split hour and minute fields from the absolute offset value.
- Add a focused UT for -00:30 rendering.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

