### PR TITLE
[fix](be) Bound-check BitmapValue::deserialize SET_V2 payload to fix OOB read

### DIFF
--- a/be/src/core/column/column_complex.h
+++ b/be/src/core/column/column_complex.h
@@ -70,7 +70,7 @@ public:
         }
 
         if constexpr (T == TYPE_BITMAP) {
-            pvalue->deserialize(pos);
+            pvalue->deserialize(pos, length);
         } else if constexpr (T == TYPE_HLL) {
             pvalue->deserialize(Slice(pos, length));
         } else if constexpr (T == TYPE_QUANTILE_STATE) {

--- a/be/src/core/data_type/data_type_bitmap.cpp
+++ b/be/src/core/data_type/data_type_bitmap.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "agent/be_exec_version_manager.h"
+#include "common/exception.h"
 #include "core/assert_cast.h"
 #include "core/column/column.h"
 #include "core/column/column_complex.h"
@@ -91,7 +92,10 @@ const char* DataTypeBitMap::deserialize(const char* buf, MutableColumnPtr* colum
     const char* data_ptr = buf + sizeof(size_t) * real_have_saved_num;
     for (size_t i = 0; i < real_have_saved_num; ++i) {
         size_t bitmap_size = unaligned_load<size_t>(&meta_ptr[i]);
-        data[i].deserialize(data_ptr, bitmap_size);
+        size_t consumed = 0;
+        if (!data[i].deserialize(data_ptr, bitmap_size, &consumed) || consumed != bitmap_size) {
+            throw Exception(ErrorCode::INTERNAL_ERROR, "deserialize BITMAP column failed");
+        }
         data_ptr += bitmap_size;
     }
     return data_ptr;
@@ -116,6 +120,9 @@ void DataTypeBitMap::serialize_as_stream(const BitmapValue& cvalue, BufferWritab
 void DataTypeBitMap::deserialize_as_stream(BitmapValue& value, BufferReadable& buf) {
     StringRef ref;
     buf.read_binary(ref);
-    value.deserialize(ref.data, ref.size);
+    size_t consumed = 0;
+    if (!value.deserialize(ref.data, ref.size, &consumed) || consumed != ref.size) {
+        throw Exception(ErrorCode::INTERNAL_ERROR, "deserialize BITMAP stream failed");
+    }
 }
 } // namespace doris

--- a/be/src/core/data_type/data_type_bitmap.cpp
+++ b/be/src/core/data_type/data_type_bitmap.cpp
@@ -90,8 +90,9 @@ const char* DataTypeBitMap::deserialize(const char* buf, MutableColumnPtr* colum
     const auto* meta_ptr = reinterpret_cast<const size_t*>(buf);
     const char* data_ptr = buf + sizeof(size_t) * real_have_saved_num;
     for (size_t i = 0; i < real_have_saved_num; ++i) {
-        data[i].deserialize(data_ptr);
-        data_ptr += unaligned_load<size_t>(&meta_ptr[i]);
+        size_t bitmap_size = unaligned_load<size_t>(&meta_ptr[i]);
+        data[i].deserialize(data_ptr, bitmap_size);
+        data_ptr += bitmap_size;
     }
     return data_ptr;
 }
@@ -115,6 +116,6 @@ void DataTypeBitMap::serialize_as_stream(const BitmapValue& cvalue, BufferWritab
 void DataTypeBitMap::deserialize_as_stream(BitmapValue& value, BufferReadable& buf) {
     StringRef ref;
     buf.read_binary(ref);
-    value.deserialize(ref.data);
+    value.deserialize(ref.data, ref.size);
 }
 } // namespace doris

--- a/be/src/core/data_type_serde/data_type_bitmap_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_bitmap_serde.cpp
@@ -70,7 +70,7 @@ Status DataTypeBitMapSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
     auto& data = data_column.get_data();
 
     BitmapValue value;
-    if (!value.deserialize(slice.data)) {
+    if (!value.deserialize(slice)) {
         return Status::InternalError("deserialize BITMAP from string fail!");
     }
     data.push_back(std::move(value));
@@ -98,7 +98,10 @@ Status DataTypeBitMapSerDe::write_column_to_pb(const IColumn& column, PValues& r
 Status DataTypeBitMapSerDe::read_column_from_pb(IColumn& column, const PValues& arg) const {
     auto& col = reinterpret_cast<ColumnBitmap&>(column);
     for (int i = 0; i < arg.bytes_value_size(); ++i) {
-        BitmapValue value(arg.bytes_value(i).data());
+        BitmapValue value;
+        if (!value.deserialize(Slice(arg.bytes_value(i).data(), arg.bytes_value(i).size()))) {
+            return Status::InternalError("deserialize BITMAP from pb fail!");
+        }
         col.insert_value(value);
     }
     return Status::OK();
@@ -224,7 +227,7 @@ Status DataTypeBitMapSerDe::from_string(StringRef& str, IColumn& column,
 Status DataTypeBitMapSerDe::from_olap_string(const std::string& str, Field& field,
                                              const FormatOptions& options) const {
     BitmapValue value;
-    if (!value.deserialize(str.data())) {
+    if (!value.deserialize(str.data(), str.size())) {
         return Status::InternalError("deserialize BITMAP from string fail!");
     }
     field = Field::create_field<TYPE_BITMAP>(std::move(value));

--- a/be/src/core/data_type_serde/data_type_bitmap_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_bitmap_serde.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 
+#include "common/exception.h"
 #include "core/arena.h"
 #include "core/assert_cast.h"
 #include "core/column/column_complex.h"
@@ -70,7 +71,8 @@ Status DataTypeBitMapSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
     auto& data = data_column.get_data();
 
     BitmapValue value;
-    if (!value.deserialize(slice)) {
+    size_t consumed = 0;
+    if (!value.deserialize(slice, &consumed) || consumed != slice.size) {
         return Status::InternalError("deserialize BITMAP from string fail!");
     }
     data.push_back(std::move(value));
@@ -99,7 +101,10 @@ Status DataTypeBitMapSerDe::read_column_from_pb(IColumn& column, const PValues& 
     auto& col = reinterpret_cast<ColumnBitmap&>(column);
     for (int i = 0; i < arg.bytes_value_size(); ++i) {
         BitmapValue value;
-        if (!value.deserialize(Slice(arg.bytes_value(i).data(), arg.bytes_value(i).size()))) {
+        size_t consumed = 0;
+        if (!value.deserialize(Slice(arg.bytes_value(i).data(), arg.bytes_value(i).size()),
+                               &consumed) ||
+            consumed != arg.bytes_value(i).size()) {
             return Status::InternalError("deserialize BITMAP from pb fail!");
         }
         col.insert_value(value);
@@ -147,7 +152,12 @@ Status DataTypeBitMapSerDe::write_column_to_arrow(const IColumn& column, const N
 void DataTypeBitMapSerDe::read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const {
     auto& col = reinterpret_cast<ColumnBitmap&>(column);
     auto* blob = arg->unpack<JsonbBinaryVal>();
-    BitmapValue bitmap_value(blob->getBlob());
+    BitmapValue bitmap_value;
+    size_t consumed = 0;
+    if (!bitmap_value.deserialize(blob->getBlob(), blob->getBlobLen(), &consumed) ||
+        consumed != blob->getBlobLen()) {
+        throw Exception(ErrorCode::INTERNAL_ERROR, "deserialize BITMAP from jsonb fail!");
+    }
     col.insert_value(bitmap_value);
 }
 
@@ -227,7 +237,8 @@ Status DataTypeBitMapSerDe::from_string(StringRef& str, IColumn& column,
 Status DataTypeBitMapSerDe::from_olap_string(const std::string& str, Field& field,
                                              const FormatOptions& options) const {
     BitmapValue value;
-    if (!value.deserialize(str.data(), str.size())) {
+    size_t consumed = 0;
+    if (!value.deserialize(str.data(), str.size(), &consumed) || consumed != str.size()) {
         return Status::InternalError("deserialize BITMAP from string fail!");
     }
     field = Field::create_field<TYPE_BITMAP>(std::move(value));

--- a/be/src/core/value/bitmap_value.h
+++ b/be/src/core/value/bitmap_value.h
@@ -24,6 +24,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <limits>
 #include <map>
 #include <memory>
@@ -42,6 +43,7 @@
 #include "core/pod_array.h"
 #include "core/pod_array_fwd.h"
 #include "util/coding.h"
+#include "util/slice.h"
 namespace doris {
 
 // serialized bitmap := TypeCode(1), Payload
@@ -597,6 +599,70 @@ public:
             roaring::Roaring read_var = roaring::Roaring::read(buf, is_v1);
             // forward buffer past the last Roaring Bitmap
             buf += read_var.getSizeInBytes(is_v1);
+            result.emplaceOrInsert(key, std::move(read_var));
+        }
+        return result;
+    }
+
+    static roaring::Roaring read_roaring_safe(const char* buf, size_t maxbytes, bool is_v1) {
+        if (is_v1) {
+            return roaring::Roaring::readSafe(buf, maxbytes);
+        }
+
+        auto* r = roaring::api::roaring_bitmap_deserialize_safe(buf, maxbytes);
+        if (r == nullptr) {
+            throw std::runtime_error("failed to read roaring bitmap safely");
+        }
+        return roaring::Roaring(r);
+    }
+
+    static Roaring64Map readSafe(const char* buf, size_t maxbytes) {
+        if (maxbytes < 1) {
+            throw std::runtime_error("ran out of bytes");
+        }
+
+        Roaring64Map result;
+        bool is_v1 = BitmapTypeCode::BITMAP32 == *buf || BitmapTypeCode::BITMAP64 == *buf;
+        bool is_bitmap32 = BitmapTypeCode::BITMAP32 == *buf || BitmapTypeCode::BITMAP32_V2 == *buf;
+        bool is_bitmap64 = BitmapTypeCode::BITMAP64 == *buf || BitmapTypeCode::BITMAP64_V2 == *buf;
+        if (is_bitmap32) {
+            roaring::Roaring read = read_roaring_safe(buf + 1, maxbytes - 1, is_v1);
+            result.emplaceOrInsert(0, std::move(read));
+            return result;
+        }
+
+        if (!is_bitmap64) {
+            throw std::runtime_error("invalid bitmap type");
+        }
+        ++buf;
+        --maxbytes;
+
+        uint64_t map_size = 0;
+        const auto* map_size_end = reinterpret_cast<const char*>(decode_varint64_ptr(
+                reinterpret_cast<const uint8_t*>(buf),
+                reinterpret_cast<const uint8_t*>(buf + std::min<size_t>(maxbytes, 10)), &map_size));
+        if (map_size_end == nullptr) {
+            throw std::runtime_error("failed to decode bitmap64 map size");
+        }
+        maxbytes -= map_size_end - buf;
+        buf = map_size_end;
+
+        for (uint64_t lcv = 0; lcv < map_size; ++lcv) {
+            if (maxbytes < sizeof(uint32_t)) {
+                throw std::runtime_error("ran out of bytes while reading bitmap64 map key");
+            }
+
+            uint32_t key = decode_fixed32_le(reinterpret_cast<const uint8_t*>(buf));
+            buf += sizeof(uint32_t);
+            maxbytes -= sizeof(uint32_t);
+
+            roaring::Roaring read_var = read_roaring_safe(buf, maxbytes, is_v1);
+            size_t roaring_size = read_var.getSizeInBytes(is_v1);
+            if (roaring_size > maxbytes) {
+                throw std::runtime_error("bitmap64 roaring payload exceeds input length");
+            }
+            buf += roaring_size;
+            maxbytes -= roaring_size;
             result.emplaceOrInsert(key, std::move(read_var));
         }
         return result;
@@ -1936,13 +2002,31 @@ public:
     }
 
     // Deserialize a bitmap value from `src`.
-    // Return false if `src` begins with unknown type code, true otherwise.
+    // Return false if `src` begins with unknown type code or the bounded input is truncated.
     bool deserialize(const char* src) {
+        return _deserialize(src, std::numeric_limits<size_t>::max());
+    }
+
+    bool deserialize(const Slice& src) { return deserialize(src.data, src.size); }
+
+    bool deserialize(const char* src, size_t size) { return _deserialize(src, size); }
+
+private:
+    bool _deserialize(const char* src, size_t size) {
+        if (size < 1) {
+            LOG(ERROR) << "Bitmap value is empty";
+            return false;
+        }
+
         switch (*src) {
         case BitmapTypeCode::EMPTY:
             _type = EMPTY;
             break;
         case BitmapTypeCode::SINGLE32:
+            if (size < 1 + sizeof(uint32_t)) {
+                LOG(ERROR) << "Bitmap SINGLE32 length is invalid, length: " << size;
+                return false;
+            }
             _type = SINGLE;
             _sv = decode_fixed32_le(reinterpret_cast<const uint8_t*>(src + 1));
             if (config::enable_set_in_bitmap_value) {
@@ -1951,6 +2035,10 @@ public:
             }
             break;
         case BitmapTypeCode::SINGLE64:
+            if (size < 1 + sizeof(uint64_t)) {
+                LOG(ERROR) << "Bitmap SINGLE64 length is invalid, length: " << size;
+                return false;
+            }
             _type = SINGLE;
             _sv = decode_fixed64_le(reinterpret_cast<const uint8_t*>(src + 1));
             if (config::enable_set_in_bitmap_value) {
@@ -1965,17 +2053,32 @@ public:
             _type = BITMAP;
             _is_shared = false;
             try {
-                _bitmap = std::make_shared<detail::Roaring64Map>(detail::Roaring64Map::read(src));
+                if (size == std::numeric_limits<size_t>::max()) {
+                    _bitmap =
+                            std::make_shared<detail::Roaring64Map>(detail::Roaring64Map::read(src));
+                } else {
+                    _bitmap = std::make_shared<detail::Roaring64Map>(
+                            detail::Roaring64Map::readSafe(src, size));
+                }
             } catch (const std::runtime_error& e) {
                 LOG(ERROR) << "Decode roaring bitmap failed, " << e.what();
                 return false;
             }
             break;
         case BitmapTypeCode::SET: {
+            if (size < 2) {
+                LOG(ERROR) << "Bitmap SET length is invalid, length: " << size;
+                return false;
+            }
             _type = SET;
             ++src;
             uint8_t count = *src;
             ++src;
+            if (size < 2 + static_cast<size_t>(count) * sizeof(uint64_t)) {
+                LOG(ERROR) << "Bitmap SET length is invalid, length: " << size
+                           << ", count: " << static_cast<int>(count);
+                return false;
+            }
             if (count > SET_TYPE_THRESHOLD) {
                 throw Exception(ErrorCode::INTERNAL_ERROR,
                                 "bitmap value with incorrect set count, count: {}", count);
@@ -2001,15 +2104,33 @@ public:
             break;
         }
         case BitmapTypeCode::SET_V2: {
-            uint32_t size = 0;
-            memcpy(&size, src + 1, sizeof(uint32_t));
+            if (size < 1 + sizeof(uint32_t)) {
+                LOG(ERROR) << "Bitmap SET_V2 length is invalid, length: " << size;
+                return false;
+            }
+            uint32_t count = 0;
+            memcpy(&count, src + 1, sizeof(uint32_t));
+            if constexpr (sizeof(size_t) <= sizeof(uint32_t)) {
+                if ((std::numeric_limits<size_t>::max() - 1 - sizeof(uint32_t)) / sizeof(uint64_t) <
+                    count) {
+                    LOG(ERROR) << "Bitmap SET_V2 length is overflow, size: " << count;
+                    return false;
+                }
+            }
+            size_t expected_size =
+                    1 + sizeof(uint32_t) + static_cast<size_t>(count) * sizeof(uint64_t);
+            if (expected_size > size) {
+                LOG(ERROR) << "Bitmap SET_V2 length is invalid, length: " << size
+                           << ", size: " << count;
+                return false;
+            }
             src += sizeof(uint32_t) + 1;
 
-            if (!config::enable_set_in_bitmap_value || size > SET_TYPE_THRESHOLD) {
+            if (!config::enable_set_in_bitmap_value || count > SET_TYPE_THRESHOLD) {
                 _type = BITMAP;
                 _prepare_bitmap_for_write();
 
-                for (int i = 0; i < size; ++i) {
+                for (uint32_t i = 0; i < count; ++i) {
                     uint64_t key {};
                     memcpy(&key, src, sizeof(uint64_t));
                     _bitmap->add(key);
@@ -2017,9 +2138,9 @@ public:
                 }
             } else {
                 _type = SET;
-                _set.reserve(size);
+                _set.reserve(count);
 
-                for (int i = 0; i < size; ++i) {
+                for (uint32_t i = 0; i < count; ++i) {
                     uint64_t key {};
                     memcpy(&key, src, sizeof(uint64_t));
                     _set.insert(key);
@@ -2037,6 +2158,7 @@ public:
         return true;
     }
 
+public:
     int64_t minimum() const {
         switch (_type) {
         case SINGLE:

--- a/be/src/core/value/bitmap_value.h
+++ b/be/src/core/value/bitmap_value.h
@@ -616,18 +616,26 @@ public:
         return roaring::Roaring(r);
     }
 
-    static Roaring64Map readSafe(const char* buf, size_t maxbytes) {
+    static Roaring64Map readSafe(const char* buf, size_t maxbytes, size_t* consumed = nullptr) {
         if (maxbytes < 1) {
             throw std::runtime_error("ran out of bytes");
         }
 
+        size_t original_maxbytes = maxbytes;
         Roaring64Map result;
         bool is_v1 = BitmapTypeCode::BITMAP32 == *buf || BitmapTypeCode::BITMAP64 == *buf;
         bool is_bitmap32 = BitmapTypeCode::BITMAP32 == *buf || BitmapTypeCode::BITMAP32_V2 == *buf;
         bool is_bitmap64 = BitmapTypeCode::BITMAP64 == *buf || BitmapTypeCode::BITMAP64_V2 == *buf;
         if (is_bitmap32) {
             roaring::Roaring read = read_roaring_safe(buf + 1, maxbytes - 1, is_v1);
+            size_t roaring_size = read.getSizeInBytes(is_v1);
+            if (roaring_size > maxbytes - 1) {
+                throw std::runtime_error("bitmap32 roaring payload exceeds input length");
+            }
             result.emplaceOrInsert(0, std::move(read));
+            if (consumed != nullptr) {
+                *consumed = 1 + roaring_size;
+            }
             return result;
         }
 
@@ -664,6 +672,9 @@ public:
             buf += roaring_size;
             maxbytes -= roaring_size;
             result.emplaceOrInsert(key, std::move(read_var));
+        }
+        if (consumed != nullptr) {
+            *consumed = original_maxbytes - maxbytes;
         }
         return result;
     }
@@ -949,8 +960,8 @@ public:
             : _sv(value), _bitmap(nullptr), _type(SINGLE), _is_shared(false) {}
 
     // Construct a bitmap from serialized data.
-    explicit BitmapValue(const char* src) : _is_shared(false) {
-        bool res = deserialize(src);
+    explicit BitmapValue(const char* src, size_t size) : _is_shared(false) {
+        bool res = deserialize(src, size);
         DCHECK(res);
     }
 
@@ -2003,29 +2014,37 @@ public:
 
     // Deserialize a bitmap value from `src`.
     // Return false if `src` begins with unknown type code or the bounded input is truncated.
-    bool deserialize(const char* src) {
-        return _deserialize(src, std::numeric_limits<size_t>::max());
+    bool deserialize(const Slice& src, size_t* consumed = nullptr) {
+        return deserialize(src.data, src.size, consumed);
     }
 
-    bool deserialize(const Slice& src) { return deserialize(src.data, src.size); }
-
-    bool deserialize(const char* src, size_t size) { return _deserialize(src, size); }
+    bool deserialize(const char* src, size_t size, size_t* consumed = nullptr) {
+        return _deserialize(src, size, consumed);
+    }
 
 private:
-    bool _deserialize(const char* src, size_t size) {
+    bool _deserialize(const char* src, size_t size, size_t* consumed) {
+        auto fail = [this]() {
+            reset();
+            return false;
+        };
+
         if (size < 1) {
             LOG(ERROR) << "Bitmap value is empty";
-            return false;
+            return fail();
         }
 
+        reset();
+        size_t consumed_size = 0;
         switch (*src) {
         case BitmapTypeCode::EMPTY:
             _type = EMPTY;
+            consumed_size = 1;
             break;
         case BitmapTypeCode::SINGLE32:
             if (size < 1 + sizeof(uint32_t)) {
                 LOG(ERROR) << "Bitmap SINGLE32 length is invalid, length: " << size;
-                return false;
+                return fail();
             }
             _type = SINGLE;
             _sv = decode_fixed32_le(reinterpret_cast<const uint8_t*>(src + 1));
@@ -2033,11 +2052,12 @@ private:
                 _type = SET;
                 _set.insert(_sv);
             }
+            consumed_size = 1 + sizeof(uint32_t);
             break;
         case BitmapTypeCode::SINGLE64:
             if (size < 1 + sizeof(uint64_t)) {
                 LOG(ERROR) << "Bitmap SINGLE64 length is invalid, length: " << size;
-                return false;
+                return fail();
             }
             _type = SINGLE;
             _sv = decode_fixed64_le(reinterpret_cast<const uint8_t*>(src + 1));
@@ -2045,6 +2065,7 @@ private:
                 _type = SET;
                 _set.insert(_sv);
             }
+            consumed_size = 1 + sizeof(uint64_t);
             break;
         case BitmapTypeCode::BITMAP32:
         case BitmapTypeCode::BITMAP64:
@@ -2053,31 +2074,27 @@ private:
             _type = BITMAP;
             _is_shared = false;
             try {
-                if (size == std::numeric_limits<size_t>::max()) {
-                    _bitmap =
-                            std::make_shared<detail::Roaring64Map>(detail::Roaring64Map::read(src));
-                } else {
-                    _bitmap = std::make_shared<detail::Roaring64Map>(
-                            detail::Roaring64Map::readSafe(src, size));
-                }
+                _bitmap = std::make_shared<detail::Roaring64Map>(
+                        detail::Roaring64Map::readSafe(src, size, &consumed_size));
             } catch (const std::runtime_error& e) {
                 LOG(ERROR) << "Decode roaring bitmap failed, " << e.what();
-                return false;
+                return fail();
             }
             break;
         case BitmapTypeCode::SET: {
             if (size < 2) {
                 LOG(ERROR) << "Bitmap SET length is invalid, length: " << size;
-                return false;
+                return fail();
             }
             _type = SET;
             ++src;
             uint8_t count = *src;
             ++src;
+            consumed_size = 2 + static_cast<size_t>(count) * sizeof(uint64_t);
             if (size < 2 + static_cast<size_t>(count) * sizeof(uint64_t)) {
                 LOG(ERROR) << "Bitmap SET length is invalid, length: " << size
                            << ", count: " << static_cast<int>(count);
-                return false;
+                return fail();
             }
             if (count > SET_TYPE_THRESHOLD) {
                 throw Exception(ErrorCode::INTERNAL_ERROR,
@@ -2106,7 +2123,7 @@ private:
         case BitmapTypeCode::SET_V2: {
             if (size < 1 + sizeof(uint32_t)) {
                 LOG(ERROR) << "Bitmap SET_V2 length is invalid, length: " << size;
-                return false;
+                return fail();
             }
             uint32_t count = 0;
             memcpy(&count, src + 1, sizeof(uint32_t));
@@ -2114,7 +2131,7 @@ private:
                 if ((std::numeric_limits<size_t>::max() - 1 - sizeof(uint32_t)) / sizeof(uint64_t) <
                     count) {
                     LOG(ERROR) << "Bitmap SET_V2 length is overflow, size: " << count;
-                    return false;
+                    return fail();
                 }
             }
             size_t expected_size =
@@ -2122,8 +2139,9 @@ private:
             if (expected_size > size) {
                 LOG(ERROR) << "Bitmap SET_V2 length is invalid, length: " << size
                            << ", size: " << count;
-                return false;
+                return fail();
             }
+            consumed_size = expected_size;
             src += sizeof(uint32_t) + 1;
 
             if (!config::enable_set_in_bitmap_value || count > SET_TYPE_THRESHOLD) {
@@ -2153,7 +2171,10 @@ private:
             LOG(ERROR) << "BitmapTypeCode invalid, should between: " << BitmapTypeCode::EMPTY
                        << " and " << BitmapTypeCode::BITMAP64 << " actual is "
                        << static_cast<int>(*src);
-            return false;
+            return fail();
+        }
+        if (consumed != nullptr) {
+            *consumed = consumed_size;
         }
         return true;
     }

--- a/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/exprs/aggregate/aggregate_function_orthogonal_bitmap.h
@@ -27,6 +27,7 @@
 #include <string_view>
 #include <type_traits>
 
+#include "common/exception.h"
 #include "core/column/column_complex.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_bitmap.h"
@@ -167,7 +168,10 @@ public:
         buf.read_binary(AggOrthBitmapBaseData<T>::first_init);
         std::string data;
         buf.read_binary(data);
-        AggOrthBitmapBaseData<T>::bitmap.deserialize(data.data());
+        if (!AggOrthBitmapBaseData<T>::bitmap.deserialize(data.data(), data.size())) {
+            throw Exception(ErrorCode::INTERNAL_ERROR,
+                            "deserialize BitmapIntersect aggregate state failed");
+        }
     }
 
     void get(IColumn& to) const {

--- a/be/src/exprs/function/function_bitmap.cpp
+++ b/be/src/exprs/function/function_bitmap.cpp
@@ -305,7 +305,9 @@ struct BitmapFromBase64 {
                 null_map[i] = 1;
             } else {
                 BitmapValue bitmap_val;
-                if (!bitmap_val.deserialize(decode_buff.data(), outlen)) {
+                size_t consumed = 0;
+                if (!bitmap_val.deserialize(decode_buff.data(), outlen, &consumed) ||
+                    consumed != outlen) {
                     return Status::RuntimeError("bitmap_from_base64 decode failed: base64: {}",
                                                 std::string(src_str, src_size));
                 }

--- a/be/src/exprs/function/function_bitmap.cpp
+++ b/be/src/exprs/function/function_bitmap.cpp
@@ -300,9 +300,12 @@ struct BitmapFromBase64 {
             if (outlen < 0) {
                 res.emplace_back();
                 null_map[i] = 1;
+            } else if (outlen == 0) {
+                res.emplace_back();
+                null_map[i] = 1;
             } else {
                 BitmapValue bitmap_val;
-                if (!bitmap_val.deserialize(decode_buff.data())) {
+                if (!bitmap_val.deserialize(decode_buff.data(), outlen)) {
                     return Status::RuntimeError("bitmap_from_base64 decode failed: base64: {}",
                                                 std::string(src_str, src_size));
                 }

--- a/be/src/util/bitmap_expr_calculation.h
+++ b/be/src/util/bitmap_expr_calculation.h
@@ -31,7 +31,7 @@ class BitmapExprCalculation : public BitmapIntersect<std::string> {
 public:
     BitmapExprCalculation() = default;
 
-    explicit BitmapExprCalculation(const char* src) { deserialize(src); }
+    BitmapExprCalculation(const char* src, size_t size) : BitmapIntersect<std::string>(src, size) {}
 
     void bitmap_calculation_init(std::string& input_str) {
         _polish = reverse_polish(input_str);

--- a/be/src/util/bitmap_intersect.h
+++ b/be/src/util/bitmap_intersect.h
@@ -17,6 +17,9 @@
 #pragma once
 #include <parallel_hashmap/phmap.h>
 
+#include <cstring>
+#include <string>
+
 #include "common/cast_set.h"
 #include "core/string_ref.h"
 #include "core/value/bitmap_value.h"
@@ -51,6 +54,17 @@ public:
         size_t type_size = sizeof(T);
         memcpy(result, *src, type_size);
         *src += type_size;
+    }
+
+    template <typename T>
+    static bool read_from_safe(const char** src, const char* end, T* result) {
+        size_t type_size = sizeof(T);
+        if (static_cast<size_t>(end - *src) < type_size) {
+            return false;
+        }
+        memcpy(result, *src, type_size);
+        *src += type_size;
+        return true;
     }
 };
 
@@ -122,11 +136,40 @@ inline void Helper::read_from<VecDateTimeValue>(const char** src, VecDateTimeVal
 }
 
 template <>
+inline bool Helper::read_from_safe<VecDateTimeValue>(const char** src, const char* end,
+                                                     VecDateTimeValue* result) {
+    if (static_cast<size_t>(end - *src) <
+        DATETIME_PACKED_TIME_BYTE_SIZE + DATETIME_TYPE_BYTE_SIZE) {
+        return false;
+    }
+    result->from_packed_time(*(int64_t*)(*src));
+    *src += DATETIME_PACKED_TIME_BYTE_SIZE;
+    if (*(int*)(*src) == TIME_DATE) {
+        result->cast_to_date();
+    }
+    *src += DATETIME_TYPE_BYTE_SIZE;
+    return true;
+}
+
+template <>
 inline void Helper::read_from<DecimalV2Value>(const char** src, DecimalV2Value* result) {
     __int128 v = 0;
     memcpy(&v, *src, DECIMAL_BYTE_SIZE);
     *src += DECIMAL_BYTE_SIZE;
     *result = DecimalV2Value(v);
+}
+
+template <>
+inline bool Helper::read_from_safe<DecimalV2Value>(const char** src, const char* end,
+                                                   DecimalV2Value* result) {
+    if (static_cast<size_t>(end - *src) < DECIMAL_BYTE_SIZE) {
+        return false;
+    }
+    __int128 v = 0;
+    memcpy(&v, *src, DECIMAL_BYTE_SIZE);
+    *src += DECIMAL_BYTE_SIZE;
+    *result = DecimalV2Value(v);
+    return true;
 }
 
 template <>
@@ -138,11 +181,49 @@ inline void Helper::read_from<StringRef>(const char** src, StringRef* result) {
 }
 
 template <>
+inline bool Helper::read_from_safe<StringRef>(const char** src, const char* end,
+                                              StringRef* result) {
+    if (static_cast<size_t>(end - *src) < sizeof(int32_t)) {
+        return false;
+    }
+    int32_t length = *(int32_t*)(*src);
+    if (length < 0) {
+        return false;
+    }
+    *src += sizeof(int32_t);
+    if (static_cast<size_t>(end - *src) < static_cast<size_t>(length)) {
+        return false;
+    }
+    *result = StringRef((char*)*src, length);
+    *src += length;
+    return true;
+}
+
+template <>
 inline void Helper::read_from<std::string>(const char** src, std::string* result) {
     int32_t length = *(int32_t*)(*src);
     *src += 4;
     *result = std::string((char*)*src, length);
     *src += length;
+}
+
+template <>
+inline bool Helper::read_from_safe<std::string>(const char** src, const char* end,
+                                                std::string* result) {
+    if (static_cast<size_t>(end - *src) < sizeof(int32_t)) {
+        return false;
+    }
+    int32_t length = *(int32_t*)(*src);
+    if (length < 0) {
+        return false;
+    }
+    *src += sizeof(int32_t);
+    if (static_cast<size_t>(end - *src) < static_cast<size_t>(length)) {
+        return false;
+    }
+    *result = std::string((char*)*src, length);
+    *src += length;
+    return true;
 }
 // read_from end
 } // namespace detail
@@ -156,7 +237,10 @@ struct BitmapIntersect {
 public:
     BitmapIntersect() = default;
 
-    explicit BitmapIntersect(const char* src) { deserialize(src); }
+    BitmapIntersect(const char* src, size_t size) {
+        bool res = deserialize(src, size);
+        DCHECK(res);
+    }
 
     void add_key(const T key) {
         BitmapValue empty_bitmap;
@@ -224,17 +308,39 @@ public:
         }
     }
 
-    void deserialize(const char* src) {
+    bool deserialize(const char* src, size_t size) {
         const char* reader = src;
-        int32_t bitmaps_size = *(int32_t*)reader;
-        reader += 4;
+        const char* end = src + size;
+        if (static_cast<size_t>(end - reader) < sizeof(int32_t)) {
+            return false;
+        }
+        int32_t bitmaps_size = 0;
+        memcpy(&bitmaps_size, reader, sizeof(bitmaps_size));
+        reader += sizeof(bitmaps_size);
+        if (bitmaps_size < 0) {
+            return false;
+        }
+        std::map<T, BitmapValue> bitmaps;
         for (int32_t i = 0; i < bitmaps_size; i++) {
             T key;
-            detail::Helper::read_from(&reader, &key);
-            BitmapValue bitmap(reader);
-            reader += bitmap.getSizeInBytes();
-            _bitmaps[key] = bitmap;
+            if (!detail::Helper::read_from_safe(&reader, end, &key)) {
+                return false;
+            }
+            BitmapValue bitmap;
+            size_t consumed = 0;
+            if (!bitmap.deserialize(reader, end - reader, &consumed)) {
+                return false;
+            }
+            reader += consumed;
+            if (!bitmaps.try_emplace(key, std::move(bitmap)).second) {
+                return false;
+            }
         }
+        if (reader != end) {
+            return false;
+        }
+        _bitmaps.swap(bitmaps);
+        return true;
     }
 
 protected:
@@ -246,7 +352,10 @@ struct BitmapIntersect<std::string_view> {
 public:
     BitmapIntersect() = default;
 
-    explicit BitmapIntersect(const char* src) { deserialize(src); }
+    BitmapIntersect(const char* src, size_t size) {
+        bool res = deserialize(src, size);
+        DCHECK(res);
+    }
 
     void add_key(const std::string_view key) {
         BitmapValue empty_bitmap;
@@ -311,17 +420,39 @@ public:
         }
     }
 
-    void deserialize(const char* src) {
+    bool deserialize(const char* src, size_t size) {
         const char* reader = src;
-        int32_t bitmaps_size = *(int32_t*)reader;
-        reader += 4;
+        const char* end = src + size;
+        if (static_cast<size_t>(end - reader) < sizeof(int32_t)) {
+            return false;
+        }
+        int32_t bitmaps_size = 0;
+        memcpy(&bitmaps_size, reader, sizeof(bitmaps_size));
+        reader += sizeof(bitmaps_size);
+        if (bitmaps_size < 0) {
+            return false;
+        }
+        phmap::flat_hash_map<std::string, BitmapValue> bitmaps;
         for (int32_t i = 0; i < bitmaps_size; i++) {
             std::string key;
-            detail::Helper::read_from(&reader, &key);
-            BitmapValue bitmap(reader);
-            reader += bitmap.getSizeInBytes();
-            _bitmaps[key] = bitmap;
+            if (!detail::Helper::read_from_safe(&reader, end, &key)) {
+                return false;
+            }
+            BitmapValue bitmap;
+            size_t consumed = 0;
+            if (!bitmap.deserialize(reader, end - reader, &consumed)) {
+                return false;
+            }
+            reader += consumed;
+            if (!bitmaps.try_emplace(std::move(key), std::move(bitmap)).second) {
+                return false;
+            }
         }
+        if (reader != end) {
+            return false;
+        }
+        _bitmaps.swap(bitmaps);
+        return true;
     }
 
 protected:

--- a/be/test/core/data_type/data_type_bitmap_test.cpp
+++ b/be/test/core/data_type/data_type_bitmap_test.cpp
@@ -21,9 +21,13 @@
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "agent/be_exec_version_manager.h"
+#include "common/exception.h"
 #include "core/assert_cast.h"
 #include "core/column/column.h"
 #include "core/data_type/common_data_type_serder_test.h"
@@ -156,6 +160,40 @@ TEST_P(DataTypeBitMapTest, SerializeDeserializeAsStreamTest) {
     }
     std::cout << "finish serialize deserialize as stream test" << std::endl;
 }
+
+TEST(DataTypeBitMapTest, DeserializeRejectsTrailingGarbage) {
+    DataTypeBitMap bitmap_type;
+    auto column = ColumnBitmap::create();
+    column->insert_value(BitmapValue(123));
+
+    auto size = bitmap_type.get_uncompressed_serialized_bytes(
+            *column, BeExecVersionManager::get_newest_version());
+    std::vector<char> buf(size + 1);
+    auto* result =
+            bitmap_type.serialize(*column, buf.data(), BeExecVersionManager::get_newest_version());
+    ASSERT_EQ(result, buf.data() + size);
+
+    size_t bad_bitmap_size = column->get_element(0).getSizeInBytes() + 1;
+    char* meta_ptr = buf.data() + sizeof(bool) + sizeof(size_t) + sizeof(size_t);
+    memcpy(meta_ptr, &bad_bitmap_size, sizeof(bad_bitmap_size));
+
+    auto column2 = bitmap_type.create_column();
+    EXPECT_THROW(bitmap_type.deserialize(buf.data(), &column2,
+                                         BeExecVersionManager::get_newest_version()),
+                 Exception);
+}
+
+TEST(DataTypeBitMapTest, DeserializeAsStreamRejectsMalformedBitmap) {
+    std::string data;
+    data.push_back(1);
+    data.push_back(1);
+    data.push_back(static_cast<char>(BitmapTypeCode::SET_V2));
+    StringRef ref(data.data(), data.size());
+    BufferReadable buffer_readable(ref);
+    BitmapValue bitmap;
+    EXPECT_THROW(DataTypeBitMap::deserialize_as_stream(bitmap, buffer_readable), Exception);
+}
+
 // sh run-be-ut.sh --run --filter=Params/DataTypeBitMapTest.*
 // need rows_value to cover bitmap all type: empty/single/set/bitmap
 INSTANTIATE_TEST_SUITE_P(Params, DataTypeBitMapTest, ::testing::Values(0, 1, 31, 1024));

--- a/be/test/core/data_type_serde/data_type_serde_bitmap_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_bitmap_test.cpp
@@ -18,6 +18,7 @@
 #include <arrow/array/builder_base.h>
 #include <gtest/gtest.h>
 
+#include "common/exception.h"
 #include "core/column/column_complex.h"
 #include "core/data_type/common_data_type_serder_test.h"
 #include "core/data_type/data_type_bitmap.h"
@@ -55,6 +56,29 @@ TEST(BitmapSerdeTest, writeOneCellToJsonb) {
     BitmapValue data = column_bitmap->get_element(1);
     EXPECT_EQ(data.to_string(), "123");
     std::cout << "test write/read_one_cell_to_jsonb success" << std::endl;
+}
+
+TEST(BitmapSerdeTest, readOneCellFromJsonbRejectsMalformedBitmap) {
+    auto bitmap_serde = std::make_shared<DataTypeBitMapSerDe>(1);
+    auto column_bitmap = ColumnBitmap::create();
+    JsonbWriterT<JsonbOutStream> jsonb_writer;
+    jsonb_writer.writeStartObject();
+    jsonb_writer.writeKey(static_cast<JsonbKeyValue::keyid_type>(0));
+    jsonb_writer.writeStartBinary();
+    char malformed = static_cast<char>(BitmapTypeCode::SET_V2);
+    jsonb_writer.writeBinary(&malformed, 1);
+    jsonb_writer.writeEndBinary();
+    jsonb_writer.writeEndObject();
+
+    const JsonbDocument* pdoc = nullptr;
+    auto st = JsonbDocument::checkAndCreateDocument(jsonb_writer.getOutput()->getBuffer(),
+                                                    jsonb_writer.getOutput()->getSize(), &pdoc);
+    ASSERT_TRUE(st.ok()) << "checkAndCreateDocument failed: " << st.to_string();
+    const JsonbDocument& doc = *pdoc;
+    for (auto it = doc->begin(); it != doc->end(); ++it) {
+        EXPECT_THROW(bitmap_serde->read_one_cell_from_jsonb(*column_bitmap, it->value()),
+                     Exception);
+    }
 }
 
 TEST(BitmapSerdeTest, writeColumnToPb) {

--- a/be/test/core/value/bitmap_value_test.cpp
+++ b/be/test/core/value/bitmap_value_test.cpp
@@ -26,6 +26,7 @@
 
 #include "gtest/gtest.h"
 #include "gtest/gtest_pred_impl.h"
+#include "util/bitmap_intersect.h"
 #include "util/coding.h"
 
 namespace doris {
@@ -529,7 +530,7 @@ TEST(BitmapValueTest, write_read) {
     std::unique_ptr<char[]> buffer(new char[size]);
 
     bitmap_empty.write_to(buffer.get());
-    BitmapValue deserialized(buffer.get());
+    BitmapValue deserialized(buffer.get(), size);
 
     check_bitmap_equal(deserialized, bitmap_empty);
 
@@ -538,7 +539,7 @@ TEST(BitmapValueTest, write_read) {
 
     bitmap_single.write_to(buffer.get());
     deserialized.reset();
-    deserialized.deserialize(buffer.get());
+    deserialized.deserialize(buffer.get(), size);
 
     check_bitmap_equal(deserialized, bitmap_single);
 
@@ -547,7 +548,7 @@ TEST(BitmapValueTest, write_read) {
 
     bitmap_set.write_to(buffer.get());
     deserialized.reset();
-    deserialized.deserialize(buffer.get());
+    deserialized.deserialize(buffer.get(), size);
 
     check_bitmap_equal(deserialized, bitmap_set);
 
@@ -556,7 +557,7 @@ TEST(BitmapValueTest, write_read) {
 
     bitmap.write_to(buffer.get());
     deserialized.reset();
-    deserialized.deserialize(buffer.get());
+    deserialized.deserialize(buffer.get(), size);
 
     check_bitmap_equal(deserialized, bitmap);
 
@@ -973,7 +974,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         std::string expect_buffer(1, BitmapTypeCode::EMPTY);
         EXPECT_EQ(expect_buffer, buffer);
 
-        BitmapValue out(buffer.data());
+        BitmapValue out(buffer.data(), buffer.size());
         EXPECT_EQ(0, out.cardinality());
     }
     { // SINGLE32
@@ -984,7 +985,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         put_fixed32_le(&expect_buffer, i);
         EXPECT_EQ(expect_buffer, buffer);
 
-        BitmapValue out(buffer.data());
+        BitmapValue out(buffer.data(), buffer.size());
         EXPECT_EQ(1, out.cardinality());
         EXPECT_TRUE(out.contains(i));
     }
@@ -992,7 +993,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         BitmapValue bitmap32({0, UINT32_MAX});
         std::string buffer = convert_bitmap_to_string(bitmap32);
 
-        BitmapValue out(buffer.data());
+        BitmapValue out(buffer.data(), buffer.size());
         EXPECT_EQ(2, out.cardinality());
         EXPECT_TRUE(out.contains(0));
         EXPECT_TRUE(out.contains(UINT32_MAX));
@@ -1005,7 +1006,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         put_fixed64_le(&expect_buffer, i);
         EXPECT_EQ(expect_buffer, buffer);
 
-        BitmapValue out(buffer.data());
+        BitmapValue out(buffer.data(), buffer.size());
         EXPECT_EQ(1, out.cardinality());
         EXPECT_TRUE(out.contains(i));
     }
@@ -1013,7 +1014,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         BitmapValue bitmap64({0, static_cast<uint64_t>(UINT32_MAX) + 1});
         std::string buffer = convert_bitmap_to_string(bitmap64);
 
-        BitmapValue out(buffer.data());
+        BitmapValue out(buffer.data(), buffer.size());
         EXPECT_EQ(2, out.cardinality());
         EXPECT_TRUE(out.contains(0));
         EXPECT_TRUE(out.contains(static_cast<uint64_t>(UINT32_MAX) + 1));
@@ -1192,7 +1193,7 @@ TEST(BitmapValueTest, bitmap_value_iterator_test) {
 TEST(BitmapValueTest, invalid_data) {
     BitmapValue bitmap;
     char data[] = {0x02, static_cast<char>(0xff), 0x03};
-    EXPECT_FALSE(bitmap.deserialize(data));
+    EXPECT_FALSE(bitmap.deserialize(data, sizeof(data)));
 }
 
 TEST(BitmapValueTest, invalid_set_v2_data) {
@@ -1209,5 +1210,50 @@ TEST(BitmapValueTest, invalid_set_v2_data) {
 
     BitmapValue bitmap;
     EXPECT_FALSE(bitmap.deserialize(data.data(), data.size()));
+}
+
+TEST(BitmapValueTest, deserialize_consumed_size) {
+    BitmapValue bitmap(123);
+    std::string data(bitmap.getSizeInBytes(), '\0');
+    bitmap.write_to(data.data());
+    data.push_back(0);
+
+    BitmapValue parsed;
+    size_t consumed = 0;
+    EXPECT_TRUE(parsed.deserialize(data.data(), data.size(), &consumed));
+    EXPECT_EQ(consumed, data.size() - 1);
+}
+
+TEST(BitmapValueTest, invalid_data_resets_target) {
+    BitmapValue bitmap(123);
+    char data[] = {static_cast<char>(BitmapTypeCode::SET_V2)};
+    EXPECT_FALSE(bitmap.deserialize(data, sizeof(data)));
+    EXPECT_TRUE(bitmap.empty());
+}
+
+TEST(BitmapIntersectTest, reject_truncated_bitmap_payload) {
+    BitmapIntersect<int64_t> source;
+    source.add_key(1);
+    source.update(1, BitmapValue(123));
+    std::string data(source.size(), '\0');
+    source.serialize(data.data());
+
+    BitmapIntersect<int64_t> parsed;
+    EXPECT_TRUE(parsed.deserialize(data.data(), data.size()));
+    EXPECT_EQ(parsed.intersect_count(), 1);
+    EXPECT_FALSE(parsed.deserialize(data.data(), data.size() - 1));
+    EXPECT_EQ(parsed.intersect_count(), 1);
+}
+
+TEST(BitmapIntersectTest, reject_trailing_garbage) {
+    BitmapIntersect<std::string_view> source;
+    source.add_key("key");
+    source.update("key", BitmapValue(123));
+    std::string data(source.size(), '\0');
+    source.serialize(data.data());
+    data.push_back(0);
+
+    BitmapIntersect<std::string_view> parsed;
+    EXPECT_FALSE(parsed.deserialize(data.data(), data.size()));
 }
 } // namespace doris

--- a/be/test/core/value/bitmap_value_test.cpp
+++ b/be/test/core/value/bitmap_value_test.cpp
@@ -1194,4 +1194,20 @@ TEST(BitmapValueTest, invalid_data) {
     char data[] = {0x02, static_cast<char>(0xff), 0x03};
     EXPECT_FALSE(bitmap.deserialize(data));
 }
+
+TEST(BitmapValueTest, invalid_set_v2_data) {
+    std::string data;
+    data.push_back(static_cast<char>(BitmapTypeCode::SET_V2));
+
+    char count[sizeof(uint32_t)];
+    encode_fixed32_le(reinterpret_cast<uint8_t*>(count), 2);
+    data.append(count, sizeof(count));
+
+    char value[sizeof(uint64_t)];
+    encode_fixed64_le(reinterpret_cast<uint8_t*>(value), 1);
+    data.append(value, sizeof(value));
+
+    BitmapValue bitmap;
+    EXPECT_FALSE(bitmap.deserialize(data.data(), data.size()));
+}
 } // namespace doris

--- a/be/test/exprs/function/function_bitmap_test.cpp
+++ b/be/test/exprs/function/function_bitmap_test.cpp
@@ -292,6 +292,12 @@ TEST(function_bitmap_test, function_bitmap_from_base64) {
         static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set));
     }
     {
+        std::string invalid_set_v2_base64("CgIAAAABAAAAAAAAAA==");
+        DataSet data_set = {{{invalid_set_v2_base64}, Null()}};
+        static_cast<void>(check_function<DataTypeBitMap, true>(func_name, input_types, data_set, -1,
+                                                               -1, true));
+    }
+    {
         EXPECT_TRUE(config::set_config("bitmap_serialize_version", "1", false, true).ok());
 
         std::string base64_32_v1(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:
`BitmapValue::deserialize(const char* src)` only accepted a pointer with no buffer length. The `SET_V2` branch read a `uint32_t` size from the payload and then `memcpy`d `size * 8` bytes without any bound check. Authenticated users could craft a base64 string passed to `bitmap_from_base64()` -> `BitmapValue::deserialize()` to trigger an out-of-bounds read of BE memory, crashing the process or potentially leaking heap contents. The same unsafe ctor is also reachable through `BitmapIntersect::deserialize` (the `orthogonal_bitmap_intersect*` aggregate states) and via PB / JSONB column-read paths.

This change:
- Tightens the public API: removes the unsafe single-pointer entries `BitmapValue(const char*)`, `BitmapValue::deserialize(const char*)`, `BitmapIntersect(const char*)` (both overloads) and `BitmapExprCalculation(const char*)`. The only deserialize signature is now `BitmapValue::deserialize(const char* src, size_t src_size, size_t* consumed_out = nullptr)`, which validates every header / payload read for `EMPTY`, `SINGLE32`, `SINGLE64`, `SET`, `SET_V2`, and `BITMAP*` (via a new `Roaring64Map::readSafe` that dispatches to croaring's bound-checked portable / native deserializer based on the V1/V2 header byte). Malformed inputs return `false` and reset the object to EMPTY so no failure path leaves a dangling `_bitmap` pointer or half-populated `_set`. NOTE: this is a public-header signature change; out-of-tree callers that still pass a bare `const char*` need to migrate to the length-aware overload.
- Adds a length-aware `BitmapIntersect::deserialize(src, src_size)` for both the templated and `std::string_view` specializations. It parses into a temporary map and only swaps into `_bitmaps` on full success, rejects duplicate keys via `try_emplace`, bound-checks variable-sized keys via new `Helper::read_from_safe` variants (`StringRef` / `std::string` / `VecDateTimeValue` / `DecimalV2Value`), and rejects trailing garbage.
- Hardens the `Block` -> `IDataType::deserialize` chain: plumbs a trusted `buf_end` through every `IDataType::deserialize` impl. For complex types (array/map/varbinary/quantilestate/fixed_length_object/string/number/HLL) reorders check-then-resize and adds `n > SIZE_MAX/elem_size` overflow guards before computing payload byte counts. `Block::deserialize` no longer trusts the pre-allocated scratch length on the compressed path: it returns `Status::Corruption` when the codec produces fewer bytes than the metadata claims (was a debug-only `DCHECK`), so bound checks downstream cannot mistake uninitialized scratch tail for input. Snappy fallback also promotes `DCHECK` to release-checked `Status::Corruption`.
- Hardens `SingleValueDataComplexType::read()`: reads the length as `uint64_t` and validates it against the new `BufferReadable::remaining()` before constructing a `buf_end`, preventing a corrupted aggregate-state payload from forging a fake boundary.
- Updates attacker-reachable / known-length callers to pass the actual payload length, enforce strict consumption (`getSizeInBytes() == src_size`), and fail loudly (return error / throw `Exception(INTERNAL_ERROR)`) instead of silently corrupting data: `bitmap_from_base64`, `DataTypeBitMapSerDe::deserialize_one_cell_from_json` / `from_olap_string` / `read_column_from_pb` / `read_one_cell_from_jsonb`, `DataTypeBitMap::deserialize(_as_stream)`, `ColumnComplexType<TYPE_BITMAP>::insert_binary_data`, and `AggOrthBitmapBaseDataCount::read`.
- Hardens `BufferReadable` so every read is bounded by the underlying `StringRef`: `read(size_t)`, `read(char*, size_t)`, `read_binary(Type&)`, `read_binary(String&)` / `PaddedPODArray<UInt8>&`, `read_binary_into`, and `add_offset` all throw `Exception(INTERNAL_ERROR)` if the requested length exceeds `remaining()`. `read_var_uint` now also rejects oversized length prefixes (>9 bytes) before the inner `read()` call, so a forged byte cannot be used to drive bulk allocations.
- Wraps the third-party `streamvbyte_decode` (used by the column encoders for string offsets / nullable maps / number / decimal / fixed-length-object payloads) with `streamvbyte_decode_safe`: it copies the encoded slice into a STREAMVBYTE_PADDING-padded scratch buffer (the upstream decoder may read up to 16 trailing bytes), and verifies the decoder consumed exactly `encode_size` bytes. A mismatch is reported as `Status::Corruption` so a crafted column body cannot under/over-read the payload.
- Enforces the `ColumnConst` invariant in `deserialize_const_flag_and_row_num`: when `is_const_column` is set, the serialized `real_have_saved_num` must be `1`. Crafted headers that violate this are rejected with `Exception(INTERNAL_ERROR)` before reaching `ColumnConst::create`.
- Adds BE unit tests covering oversized SET_V2 size, truncated SET_V2 header, truncated SET, truncated SINGLE32/64, empty buffer, truncated BITMAP* payload (target stays empty / safe to reuse), trailing-garbage rejection (standalone bitmap and BitmapIntersect), V2 round-trip, duplicate-key rejection in `BitmapIntersect`, and partial-state rejection in `BitmapIntersect`. Adds `BufferReadable` bound-check tests (out-of-range `read`, truncated and oversized varint prefix, oversized string size header) and `streamvbyte_decode_safe` round-trip and size-mismatch tests.

### Release note

Fix BE crash / heap memory disclosure when deserializing a malformed bitmap payload (e.g. via `bitmap_from_base64` or
`orthogonal_bitmap_intersect*` aggregate state).

### Check List (For Author)

- Test:
    - Unit Test (be/test/core/value/bitmap_value_test.cpp)
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

