### PR TITLE
[fix](nereids) Do not push offset-only access path for CHAR columns

### DIFF
--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -1955,6 +1955,28 @@ Status StringFileColumnIterator::set_access_paths(
     // Raw paths look like ["col_name", "OFFSET"] or ["col_name", "NULL"].
     auto sub_all_access_paths = DORIS_TRY(_get_sub_access_paths(all_access_paths));
     _check_and_set_meta_read_mode(sub_all_access_paths);
+    // OFFSET_ONLY mode is fundamentally incompatible with CHAR columns:
+    // CHAR is stored padded to its declared length (see
+    // OlapColumnDataConvertorChar::clone_and_padding), so the per-row length
+    // recorded in dict word info / page headers is always the padded length
+    // (e.g. 25 for CHAR(25)) — never the logical length expected by length().
+    // Recovering the logical length requires scanning the chars buffer with
+    // strnlen() (shrink_padding_chars), which OFFSET_ONLY by definition skips.
+    // There is no partial-benefit path: any optimization that still produces
+    // the correct length() result must read the chars buffer in full.
+    //
+    // FE (NestedColumnPruning) already filters CHAR slots out of the
+    // OFFSET-only access plan, so reaching this branch means an FE/BE
+    // contract violation. Fail loudly instead of silently falling back.
+    if (read_offset_only() && get_reader() != nullptr &&
+        get_reader()->get_meta_type() == FieldType::OLAP_FIELD_TYPE_CHAR) {
+        return Status::InternalError(
+                "OFFSET_ONLY access path is not supported on CHAR column '{}': CHAR is stored "
+                "padded so the per-row length information available without reading the chars "
+                "buffer is always the padded length, not the logical length. The FE planner "
+                "must not emit an OFFSET access path for CHAR columns.",
+                _column_name);
+    }
     if (read_offset_only()) {
         DLOG(INFO) << "String column iterator set column " << _column_name
                    << " to OFFSET_ONLY reading mode";

--- a/be/src/storage/segment/column_reader.h
+++ b/be/src/storage/segment/column_reader.h
@@ -484,6 +484,11 @@ public:
             std::map<PrefetcherInitMethod, std::vector<SegmentPrefetcher*>>& prefetchers,
             PrefetcherInitMethod init_method) override;
 
+protected:
+    // Exposed to derived iterators (e.g. StringFileColumnIterator) so they can
+    // query column metadata such as the storage field type.
+    const std::shared_ptr<ColumnReader>& get_reader() const { return _reader; }
+
 private:
     Status _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page) const;
     Status _load_next_page(bool* eos);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
@@ -156,7 +156,20 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
         // length() only needs the offset array, not the chars data.
         // Add ACCESS_STRING_OFFSET as a suffix so the path builder accumulates
         // e.g. ["str_col", "OFFSET"] or ["c_struct", "f3", "OFFSET"].
-        if (arg.getDataType().isStringLikeType() && context.accessPathBuilder.isEmpty()) {
+        //
+        // CHAR is excluded: CHAR(N) is stored padded to N bytes per row (see BE
+        // OlapColumnDataConvertorChar::clone_and_padding), so the per-row length
+        // information available without reading the chars buffer is the padded
+        // length (always N), not the logical post-trim length expected by
+        // length(). There is no way to recover the logical length from offsets
+        // alone — the chars buffer must be scanned with strnlen() (BE
+        // shrink_padding_chars). Falling through to the default visit causes
+        // length() to read the column normally, which is correct.
+        // NOTE: arg.getDataType() is the resolved type at the leaf of any
+        // chained access (struct field, map subscript, array index), so this
+        // single check covers nested CHAR cases too.
+        if (arg.getDataType().isStringLikeType() && !arg.getDataType().isCharType()
+                && context.accessPathBuilder.isEmpty()) {
             CollectorContext offsetContext =
                     new CollectorContext(context.statementContext, context.bottomFilter);
             offsetContext.accessPathBuilder.addSuffix(AccessPathInfo.ACCESS_STRING_OFFSET);

--- a/regression-test/data/nereids_rules_p0/column_pruning/string_length_column_pruning.out
+++ b/regression-test/data/nereids_rules_p0/column_pruning/string_length_column_pruning.out
@@ -7,3 +7,52 @@
 -- !map_element_with_map_values --
 1	x
 
+-- !length_top_char --
+1	1
+2	2
+3	3
+4	4
+5	5
+
+-- !length_top_char_only --
+1
+2
+3
+4
+5
+
+-- !length_top_char_groupby --
+1	1
+2	1
+3	1
+4	1
+5	1
+
+-- !length_struct_char --
+2
+2
+3
+3
+4
+
+-- !length_map_char_value --
+2
+2
+2
+3
+3
+
+-- !length_array_char_element --
+1
+1
+2
+3
+4
+
+-- !length_varchar --
+1
+2
+3
+4
+5
+

--- a/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
+++ b/regression-test/suites/nereids_rules_p0/column_pruning/string_length_column_pruning.groovy
@@ -477,4 +477,104 @@ suite("string_length_column_pruning") {
         notContains "OFFSET"
         notContains "bigint"
     }
+
+    // ─── CHAR(N) correctness ────────────────────────────────────────────────────
+    //
+    // CHAR(N) is stored padded to N bytes per row on BE
+    // (OlapColumnDataConvertorChar::clone_and_padding). The per-row length recorded
+    // in dict word info / page headers is therefore always the padded length N,
+    // never the logical post-trim length expected by length(). Also, when the BE
+    // SegmentIterator runs shrink_char_type_column_suffix_zero on a CHAR column
+    // that was read in OFFSET_ONLY mode, it scans the (only-resized, never-
+    // initialized) chars buffer with strnlen() and corrupts the offsets with
+    // non-deterministic values.
+    //
+    // Therefore the FE must NOT emit the OFFSET access path for CHAR columns,
+    // top-level or nested (struct.char_field, map<X, char>['k'], array<char>[i]).
+    // The BE additionally hard-fails (Status::InternalError) if a CHAR column
+    // ever receives an OFFSET access path, to catch planner regressions.
+
+    sql """ DROP TABLE IF EXISTS slcp_char_tbl """
+    sql """
+        CREATE TABLE slcp_char_tbl (
+            id        INT,
+            char_col  CHAR(25) NOT NULL,
+            str_col   STRING,
+            struct_col STRUCT<f1: INT, f3: CHAR(10)>,
+            arr_char  ARRAY<CHAR(8)>,
+            map_col_char MAP<STRING, CHAR(12)>
+        ) ENGINE = OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1")
+    """
+    sql """
+        INSERT INTO slcp_char_tbl VALUES
+            (1, 'a',     'a',     named_struct('f1', 10, 'f3', 'aa'),   ['x',   'yy'],   {'k1': 'v1'}),
+            (2, 'bb',    'bb',    named_struct('f1', 20, 'f3', 'bbb'),  ['xxx', 'yy'],   {'k2': 'vv2'}),
+            (3, 'ccc',   'ccc',   named_struct('f1', 30, 'f3', 'cccc'), ['x'],           {'k3': 'vvv'}),
+            (4, 'dddd',  'dddd',  named_struct('f1', 40, 'f3', 'ddd'),  ['xx',  'y'],    {'k4': 'v4'}),
+            (5, 'eeeee', 'eeeee', named_struct('f1', 50, 'f3', 'ee'),   ['xxxx'],        {'k5': 'vv'})
+    """
+
+    // Top-level CHAR: length() must NOT use the OFFSET path (FE source-level filter).
+    explain {
+        sql "select length(char_col) from slcp_char_tbl"
+        notContains "OFFSET"
+    }
+    // Top-level CHAR: result must equal the logical post-trim length, not the
+    // padded length 25. Compare against length() applied to the equivalent
+    // STRING column to exercise the same rows.
+    order_qt_length_top_char "select length(char_col), length(str_col) from slcp_char_tbl"
+    order_qt_length_top_char_only "select length(char_col) from slcp_char_tbl"
+    order_qt_length_top_char_groupby """
+        select length(char_col), count(*) from slcp_char_tbl group by length(char_col)
+    """
+
+    // Nested CHAR inside a STRUCT: length(struct.char_field) must also skip OFFSET.
+    explain {
+        sql "select length(struct_element(struct_col, 'f3')) from slcp_char_tbl"
+        notContains "OFFSET"
+    }
+    order_qt_length_struct_char """
+        select length(struct_element(struct_col, 'f3')) from slcp_char_tbl
+    """
+
+    // Nested CHAR as MAP value: length(map<X, char>['k']) must also skip OFFSET.
+    explain {
+        sql "select length(map_col_char['k1']) from slcp_char_tbl"
+        notContains "OFFSET"
+    }
+    order_qt_length_map_char_value """
+        select length(map_col_char[concat('k', cast(id as string))]) from slcp_char_tbl
+    """
+
+    // Nested CHAR as ARRAY element: length(array<char>[i]) must also skip OFFSET.
+    explain {
+        sql "select length(arr_char[1]) from slcp_char_tbl"
+        notContains "OFFSET"
+    }
+    order_qt_length_array_char_element """
+        select length(arr_char[1]) from slcp_char_tbl
+    """
+
+    // VARCHAR / STRING are not padded; the OFFSET optimization remains active and
+    // results stay correct. (Existing tests above already cover plain STRING; this
+    // case asserts they still produce the right values alongside the CHAR fix.)
+    sql """ DROP TABLE IF EXISTS slcp_varchar_tbl """
+    sql """
+        CREATE TABLE slcp_varchar_tbl (
+            id  INT,
+            v   VARCHAR(25) NOT NULL
+        ) ENGINE = OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1")
+    """
+    sql """ INSERT INTO slcp_varchar_tbl VALUES (1,'a'), (2,'bb'), (3,'ccc'), (4,'dddd'), (5,'eeeee') """
+    explain {
+        sql "select length(v) from slcp_varchar_tbl"
+        contains "OFFSET"
+    }
+    order_qt_length_varchar "select length(v) from slcp_varchar_tbl"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #62205

#### Problem Summary

PR #62205 optimizes `length(str_col)` by pushing an OFFSET access path to BE so the chars buffer can be skipped. The optimization predicate is `isStringLikeType()`, which incorrectly includes CHAR(N).

CHAR is stored padded to its declared length on BE (see `OlapColumnDataConvertorChar::clone_and_padding`). The per-row length recorded in dict word info / page headers is therefore always the padded length (e.g. 25 for CHAR(25)), never the logical length expected by `length()`. Recovering the logical length requires scanning the chars buffer with `strnlen()` (`shrink_padding_chars`), which OFFSET_ONLY by definition skips.

In addition, when `SegmentIterator` runs `shrink_char_type_column_suffix_zero` on the CHAR column, it reads the (only-resized, never-initialized) chars buffer with `strnlen` and rewrites the offsets, corrupting them with non-deterministic values. As a result, `select length(c) from t` on a CHAR column returns garbage (mix of `0` / random small numbers / padded length `25`), depending on what was previously in heap memory.

#### Reproduction

```sql
CREATE TABLE t (
    pk INT,
    c CHAR(25) NOT NULL
) DUPLICATE KEY(pk) DISTRIBUTED BY HASH(pk) BUCKETS 1
PROPERTIES('replication_num'='1');

INSERT INTO t VALUES (1,'a'), (2,'bb'), (3,'ccc');

-- Wrong (mix of 0 / 25 / random):
SELECT length(c) FROM t;
-- Correct (1, 2, 3):
SELECT c, length(c) FROM t;
```

#### Fix

1. **FE**: in `AccessPathExpressionCollector.visitLength`, skip the OFFSET suffix when the resolved leaf type is CHAR. Because the check is on `arg.getDataType()` (the type after struct field / map subscript / array index resolution), a single guard covers top-level CHAR as well as nested CHAR (`struct.char_field`, `map<X,char>['k']`, `array<char>[i]`).
2. **BE**: in `StringFileColumnIterator::set_access_paths`, hard-fail with `Status::InternalError` when an OFFSET access path is received for a CHAR column. This catches any future planner regression that breaks the contract above. A small protected accessor `get_reader()` is added to `FileColumnIterator` so the derived string iterator can inspect the storage field type.

VARCHAR / STRING are not padded, so OFFSET_ONLY remains correct for them. Other types (VARBINARY, JSONB, HLL, BITMAP, Variant) are not `isStringLikeType()`, so FE never emits OFFSET for them. Container length / cardinality (`length(arr)` / `cardinality(map)`) use their own offset stream as canonical metadata and are unaffected.

### Release note

Fix wrong / non-deterministic result of `length()` on CHAR columns when no other column from the same row is projected (e.g. `select length(c) from t` or `select length(c), count(*) from t group by length(c)`).

### Check List (For Author)

- Test:
    - [x] Manual test (mysql client, repro from a 200-row CHAR(25) table)
    - [ ] Regression Test — to be added in a follow-up
- Behavior changed: Yes — `length(CHAR)` now returns the correct logical length; previously it could return `0`, the padded length, or other garbage.
- Does this need documentation: No
