### PR TITLE
[fix](fe) Preserve AWS role props in ObjectInfo adapter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/ObjectInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/ObjectInfo.java
@@ -55,7 +55,8 @@ public class ObjectInfo {
     public ObjectInfo(Cloud.ObjectStoreInfoPB objectStoreInfoPB) {
         this(objectStoreInfoPB.getProvider(), objectStoreInfoPB.getAk(), objectStoreInfoPB.getSk(),
                 objectStoreInfoPB.getBucket(), objectStoreInfoPB.getEndpoint(), objectStoreInfoPB.getRegion(),
-                objectStoreInfoPB.getPrefix());
+                objectStoreInfoPB.getPrefix(), null, objectStoreInfoPB.getRoleArn(),
+                objectStoreInfoPB.getExternalId(), null);
     }
 
     public ObjectInfo(Cloud.ObjectStoreInfoPB objectStoreInfoPB, String roleName, String arn,

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/ObjectInfoAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/storage/ObjectInfoAdapter.java
@@ -171,6 +171,8 @@ public class ObjectInfoAdapter {
         putIfNotBlank(props, STS_ROLE_NAME_KEY,    obj.getRoleName());
         putIfNotBlank(props, STS_ROLE_ARN_KEY,     obj.getArn());
         putIfNotBlank(props, STS_EXTERNAL_ID_KEY,  obj.getExternalId());
+        putIfNotBlank(props, "AWS_ROLE_ARN", obj.getArn());
+        putIfNotBlank(props, "AWS_EXTERNAL_ID", obj.getExternalId());
         return props;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/storage/ObjectInfoAdapterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/storage/ObjectInfoAdapterTest.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cloud.storage;
+
+import org.apache.doris.cloud.proto.Cloud;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+import org.apache.doris.fs.StoragePropertiesConverter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class ObjectInfoAdapterTest {
+
+    @Test
+    public void testToStoragePropertiesPreservesAwsRoleFields() {
+        ObjectInfo objectInfo = new ObjectInfo(
+                Cloud.ObjectStoreInfoPB.Provider.S3,
+                "",
+                "",
+                "snapshot-bucket",
+                "s3.us-west-2.amazonaws.com",
+                "us-west-2",
+                "snapshot/prefix",
+                "snapshot-session",
+                "arn:aws:iam::123456789012:role/snapshot-role",
+                "snapshot-external-id",
+                null);
+
+        StorageProperties storageProperties = ObjectInfoAdapter.toStorageProperties(objectInfo);
+        Map<String, String> backendProps = StoragePropertiesConverter.toMap(storageProperties);
+
+        Assert.assertEquals("S3", backendProps.get("_STORAGE_TYPE_"));
+        Assert.assertEquals("s3.us-west-2.amazonaws.com", backendProps.get("AWS_ENDPOINT"));
+        Assert.assertEquals("us-west-2", backendProps.get("AWS_REGION"));
+        Assert.assertEquals("snapshot-bucket", backendProps.get("AWS_BUCKET"));
+        Assert.assertEquals("arn:aws:iam::123456789012:role/snapshot-role",
+                backendProps.get("AWS_ROLE_ARN"));
+        Assert.assertEquals("snapshot-external-id", backendProps.get("AWS_EXTERNAL_ID"));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62584

Problem Summary: Preserve AWS role ARN and external ID when building ObjectInfo for internal-stage usage and when converting ObjectInfo to storage properties, so snapshot-related S3 access keeps the expected IAM role context.

### Release note

None

### Check List (For Author)


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

