### PR TITLE
[refactor](cloud) Extract snapshot integration hooks

### DIFF
--- a/cloud/src/meta-service/meta_server.cpp
+++ b/cloud/src/meta-service/meta_server.cpp
@@ -42,6 +42,7 @@
 #include "meta-store/txn_kv_error.h"
 #include "rate-limiter/rate_limiter.h"
 #include "resource-manager/resource_manager.h"
+#include "snapshot/snapshot_manager_factory.h"
 
 namespace doris::cloud {
 
@@ -78,7 +79,7 @@ int MetaServer::start(brpc::Server* server) {
     }
 
     auto rate_limiter = std::make_shared<RateLimiter>();
-    auto snapshot_mgr = std::make_shared<SnapshotManager>(txn_kv_);
+    auto snapshot_mgr = create_snapshot_manager(txn_kv_);
 
     // Add service
     auto meta_service = std::make_unique<MetaServiceImpl>(txn_kv_, rc_mgr, rate_limiter,

--- a/cloud/src/recycler/checker.cpp
+++ b/cloud/src/recycler/checker.cpp
@@ -53,7 +53,7 @@
 #include "meta-store/blob_message.h"
 #include "meta-store/keys.h"
 #include "meta-store/txn_kv.h"
-#include "snapshot/snapshot_manager.h"
+#include "snapshot/snapshot_manager_factory.h"
 #ifdef ENABLE_HDFS_STORAGE_VAULT
 #include "recycler/hdfs_accessor.h"
 #endif
@@ -464,7 +464,7 @@ int key_exist(TxnKv* txn_kv, std::string_view key) {
 
 InstanceChecker::InstanceChecker(std::shared_ptr<TxnKv> txn_kv, const std::string& instance_id)
         : txn_kv_(txn_kv), instance_id_(instance_id) {
-    snapshot_manager_ = std::make_shared<SnapshotManager>(txn_kv);
+    snapshot_manager_ = create_snapshot_manager(txn_kv);
     resource_mgr_ = std::make_shared<ResourceManager>(std::move(txn_kv));
     resource_mgr_->init();
 }

--- a/cloud/src/recycler/meta_checker.cpp
+++ b/cloud/src/recycler/meta_checker.cpp
@@ -38,11 +38,12 @@
 #include "meta-store/blob_message.h"
 #include "meta-store/keys.h"
 #include "meta-store/txn_kv.h"
+#include "snapshot/snapshot_manager_factory.h"
 
 namespace doris::cloud {
 
 MetaChecker::MetaChecker(std::shared_ptr<TxnKv> txn_kv) : txn_kv_(txn_kv) {
-    snapshot_manager_ = std::make_shared<SnapshotManager>(std::move(txn_kv));
+    snapshot_manager_ = create_snapshot_manager(std::move(txn_kv));
 }
 
 bool MetaChecker::scan_and_handle_kv(

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -76,6 +76,7 @@
 #include "recycler/recycler_service.h"
 #include "recycler/sync_executor.h"
 #include "recycler/util.h"
+#include "snapshot/snapshot_manager_factory.h"
 
 namespace doris::cloud {
 
@@ -231,7 +232,7 @@ Recycler::Recycler(std::shared_ptr<TxnKv> txn_kv) : txn_kv_(std::move(txn_kv)) {
 
     auto resource_mgr = std::make_shared<ResourceManager>(txn_kv_);
     txn_lazy_committer_ = std::make_shared<TxnLazyCommitter>(txn_kv_, std::move(resource_mgr));
-    snapshot_manager_ = std::make_shared<SnapshotManager>(txn_kv_);
+    snapshot_manager_ = create_snapshot_manager(txn_kv_);
 }
 
 Recycler::~Recycler() {
@@ -591,7 +592,8 @@ InstanceRecycler::InstanceRecycler(std::shared_ptr<TxnKv> txn_kv, const Instance
           resource_mgr_(std::make_shared<ResourceManager>(txn_kv_)) {
     delete_bitmap_lock_white_list_->init();
     resource_mgr_->init();
-    snapshot_manager_ = std::make_shared<SnapshotManager>(txn_kv_);
+
+    snapshot_manager_ = create_snapshot_manager(txn_kv_);
 
     // Since the recycler's resource manager could not be notified when instance info changes,
     // we need to refresh the instance info here to ensure the resource manager has the latest info.

--- a/cloud/src/recycler/snapshot_chain_compactor.cpp
+++ b/cloud/src/recycler/snapshot_chain_compactor.cpp
@@ -27,6 +27,7 @@
 #include "recycler/hdfs_accessor.h"
 #include "recycler/s3_accessor.h"
 #include "recycler/util.h"
+#include "snapshot/snapshot_manager_factory.h"
 
 namespace doris::cloud {
 
@@ -391,8 +392,8 @@ int InstanceChainCompactor::do_compact() {
                 .tag("cost(sec)", stop_watch.elapsed_seconds());
     };
 
-    SnapshotManager snapshot_mgr(txn_kv_);
-    int res = snapshot_mgr.compact_snapshot_chains(this);
+    auto snapshot_mgr = create_snapshot_manager(txn_kv_);
+    int res = snapshot_mgr->compact_snapshot_chains(this);
     if (res != 0) {
         LOG_WARNING("failed to compact snapshot chains").tag("instance_id", instance_id_);
         return res;

--- a/cloud/src/recycler/snapshot_data_migrator.cpp
+++ b/cloud/src/recycler/snapshot_data_migrator.cpp
@@ -28,6 +28,7 @@
 #include "recycler/hdfs_accessor.h"
 #include "recycler/s3_accessor.h"
 #include "recycler/util.h"
+#include "snapshot/snapshot_manager_factory.h"
 
 namespace doris::cloud {
 
@@ -303,8 +304,8 @@ int InstanceDataMigrator::do_migrate() {
                 .tag("cost(sec)", stop_watch.elapsed_seconds());
     };
 
-    SnapshotManager snapshot_mgr(txn_kv_);
-    int res = snapshot_mgr.migrate_to_versioned_keys(this);
+    auto snapshot_mgr = create_snapshot_manager(txn_kv_);
+    int res = snapshot_mgr->migrate_to_versioned_keys(this);
     if (res != 0) {
         LOG_WARNING("failed to migrate snapshot keys").tag("instance_id", instance_id_);
         return res;

--- a/cloud/src/snapshot/CMakeLists.txt
+++ b/cloud/src/snapshot/CMakeLists.txt
@@ -18,4 +18,4 @@
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/snapshot")
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/snapshot")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lfdb_c -L${THIRDPARTY_DIR}/lib")
-add_library(Snapshot snapshot_manager.cpp)
+add_library(Snapshot snapshot_manager.cpp snapshot_manager_factory.cpp)

--- a/cloud/src/snapshot/snapshot_manager.h
+++ b/cloud/src/snapshot/snapshot_manager.h
@@ -110,7 +110,7 @@ public:
     // Return 0 for success otherwise error.
     virtual int compact_snapshot_chains(InstanceChainCompactor* compactor);
 
-private:
+protected:
     SnapshotManager(const SnapshotManager&) = delete;
     SnapshotManager& operator=(const SnapshotManager&) = delete;
 

--- a/cloud/src/snapshot/snapshot_manager_factory.cpp
+++ b/cloud/src/snapshot/snapshot_manager_factory.cpp
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "snapshot/snapshot_manager_factory.h"
+
+namespace doris::cloud {
+
+std::shared_ptr<SnapshotManager> create_snapshot_manager(std::shared_ptr<TxnKv> txn_kv) {
+    return std::make_shared<SnapshotManager>(std::move(txn_kv));
+}
+
+} // namespace doris::cloud

--- a/cloud/src/snapshot/snapshot_manager_factory.h
+++ b/cloud/src/snapshot/snapshot_manager_factory.h
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "snapshot/snapshot_manager.h"
+
+namespace doris::cloud {
+
+std::shared_ptr<SnapshotManager> create_snapshot_manager(std::shared_ptr<TxnKv> txn_kv);
+
+} // namespace doris::cloud


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Isolate snapshot-specific integrations behind a dedicated snapshot manager factory so doris/master can merge the narrow cloud hook layer first and dev/snapshot can override the isolated factory file later.

### Release note

None

### Check List (For Author)

- Test: Cloud build
    - Build
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

