### PR TITLE
[fix](fe) Preserve replayed light schema job timestamps

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -202,6 +202,14 @@ public abstract class AlterJobV2 implements Writable {
         return System.currentTimeMillis() - createTimeMs > timeoutMs;
     }
 
+    public long getCreateTimeMs() {
+        return createTimeMs;
+    }
+
+    public void setCreateTimeMs(long createTimeMs) {
+        this.createTimeMs = createTimeMs;
+    }
+
     public boolean isExpire() {
         return isDone() && (System.currentTimeMillis() - finishedTimeMs) / 1000 > Config.history_job_keep_max_second;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2427,12 +2427,12 @@ public class SchemaChangeHandler extends AlterHandler {
                 long jobId = Env.getCurrentEnv().getNextId();
                 //for schema change add/drop value column optimize, direct modify table meta.
                 modifyTableLightSchemaChange(rawSql, db, olapTable, indexSchemaMap, newIndexes,
-                        null, isDropIndex, jobId, false, propertyMap);
+                        null, isDropIndex, jobId, false, propertyMap, null, null);
             } else if (Config.enable_light_index_change && lightIndexChange) {
                 long jobId = Env.getCurrentEnv().getNextId();
                 //for schema change add/drop inverted index and ngram_bf optimize, direct modify table meta firstly.
                 modifyTableLightSchemaChange(rawSql, db, olapTable, indexSchemaMap, newIndexes,
-                        alterIndexes, isDropIndex, jobId, false, propertyMap);
+                        alterIndexes, isDropIndex, jobId, false, propertyMap, null, null);
             } else if (buildIndexChange) {
                 if (alterIndexes.isEmpty()) {
                     throw new DdlException("Altered index is empty. please check your alter stmt.");
@@ -3194,7 +3194,8 @@ public class SchemaChangeHandler extends AlterHandler {
     public void modifyTableLightSchemaChange(String rawSql, Database db, OlapTable olapTable,
                                              Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes,
                                              List<Index> alterIndexes, boolean isDropIndex,
-                                             long jobId, boolean isReplay, Map<String, String> propertyMap)
+                                             long jobId, boolean isReplay, Map<String, String> propertyMap,
+                                             Long createTimeMs, Long finishedTimeMs)
             throws DdlException, AnalysisException {
 
         if (LOG.isDebugEnabled()) {
@@ -3225,6 +3226,10 @@ public class SchemaChangeHandler extends AlterHandler {
         SchemaChangeJobV2 schemaChangeJob = AlterJobV2Factory.createSchemaChangeJobV2(
                 rawSql, jobId, db.getId(), olapTable.getId(),
                 olapTable.getName(), 1000);
+        if (createTimeMs != null) {
+            schemaChangeJob.setCreateTimeMs(createTimeMs);
+        }
+        long jobFinishedTimeMs = finishedTimeMs != null ? finishedTimeMs : System.currentTimeMillis();
 
         for (Map.Entry<Long, List<Column>> entry : changedIndexIdToSchema.entrySet()) {
             long originIndexId = entry.getKey();
@@ -3251,7 +3256,8 @@ public class SchemaChangeHandler extends AlterHandler {
         if (alterIndexes != null) {
             if (!isReplay) {
                 TableAddOrDropInvertedIndicesInfo info = new TableAddOrDropInvertedIndicesInfo(rawSql, db.getId(),
-                        olapTable.getId(), indexSchemaMap, indexes, alterIndexes, isDropIndex, jobId);
+                        olapTable.getId(), indexSchemaMap, indexes, alterIndexes, isDropIndex, jobId,
+                        schemaChangeJob.getCreateTimeMs(), jobFinishedTimeMs);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("logModifyTableAddOrDropInvertedIndices info:{}", info);
                 }
@@ -3284,7 +3290,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 Map<String, Long> indexNameToId = new HashMap<>(olapTable.getIndexNameToId());
                 TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(
                         rawSql, db.getId(), olapTable.getId(), olapTable.getBaseIndexId(),
-                        indexSchemaMap, oldIndexSchemaMap, indexNameToId, indexes, jobId);
+                        indexSchemaMap, oldIndexSchemaMap, indexNameToId, indexes, jobId,
+                        schemaChangeJob.getCreateTimeMs(), jobFinishedTimeMs);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("logModifyTableAddOrDropColumns info:{}", info);
                 }
@@ -3321,7 +3328,7 @@ public class SchemaChangeHandler extends AlterHandler {
         // add job after edit log
         // set Job state then add job
         schemaChangeJob.setJobState(AlterJobV2.JobState.FINISHED);
-        schemaChangeJob.setFinishedTimeMs(System.currentTimeMillis());
+        schemaChangeJob.setFinishedTimeMs(jobFinishedTimeMs);
         this.addAlterJobV2(schemaChangeJob);
     }
 
@@ -3342,7 +3349,7 @@ public class SchemaChangeHandler extends AlterHandler {
         olapTable.writeLock();
         try {
             modifyTableLightSchemaChange("", db, olapTable, indexSchemaMap, indexes, null, false, jobId,
-                    true, new HashMap<>());
+                    true, new HashMap<>(), info.getCreateTimeMs(), info.getFinishedTimeMs());
         } catch (DdlException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop or modify columns", e);
@@ -3483,7 +3490,8 @@ public class SchemaChangeHandler extends AlterHandler {
         olapTable.writeLock();
         try {
             modifyTableLightSchemaChange("", db, olapTable, indexSchemaMap, newIndexes,
-                                             alterIndexes, isDropIndex, jobId, true, new HashMap<>());
+                                             alterIndexes, isDropIndex, jobId, true, new HashMap<>(),
+                                             info.getCreateTimeMs(), info.getFinishedTimeMs());
         } catch (UserException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop indexes", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropColumnsInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropColumnsInfo.java
@@ -52,6 +52,10 @@ public class TableAddOrDropColumnsInfo implements Writable {
     private List<Index> indexes;
     @SerializedName(value = "jobId")
     private long jobId;
+    @SerializedName(value = "createTimeMs")
+    private Long createTimeMs;
+    @SerializedName(value = "finishedTimeMs")
+    private Long finishedTimeMs;
     @SerializedName(value = "rawSql")
     private String rawSql;
 
@@ -59,7 +63,7 @@ public class TableAddOrDropColumnsInfo implements Writable {
             Map<Long, LinkedList<Column>> indexSchemaMap,
             Map<Long, List<Column>> oldIndexSchemaMap,
             Map<String, Long> indexNameToId,
-            List<Index> indexes, long jobId) {
+            List<Index> indexes, long jobId, Long createTimeMs, Long finishedTimeMs) {
         this.rawSql = rawSql;
         this.dbId = dbId;
         this.tableId = tableId;
@@ -69,6 +73,8 @@ public class TableAddOrDropColumnsInfo implements Writable {
         this.indexNameToId = indexNameToId;
         this.indexes = indexes;
         this.jobId = jobId;
+        this.createTimeMs = createTimeMs;
+        this.finishedTimeMs = finishedTimeMs;
     }
 
     public long getDbId() {
@@ -89,6 +95,14 @@ public class TableAddOrDropColumnsInfo implements Writable {
 
     public long getJobId() {
         return jobId;
+    }
+
+    public Long getCreateTimeMs() {
+        return createTimeMs;
+    }
+
+    public Long getFinishedTimeMs() {
+        return finishedTimeMs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropInvertedIndicesInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropInvertedIndicesInfo.java
@@ -50,13 +50,17 @@ public class TableAddOrDropInvertedIndicesInfo implements Writable {
     private boolean isDropInvertedIndex;
     @SerializedName(value = "jobId")
     private long jobId;
+    @SerializedName(value = "createTimeMs")
+    private Long createTimeMs;
+    @SerializedName(value = "finishedTimeMs")
+    private Long finishedTimeMs;
     @SerializedName(value = "rawSql")
     private String rawSql;
 
     public TableAddOrDropInvertedIndicesInfo(String rawSql, long dbId, long tableId,
             Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes,
             List<Index> alterInvertedIndexes, boolean isDropInvertedIndex,
-            long jobId) {
+            long jobId, Long createTimeMs, Long finishedTimeMs) {
         this.rawSql = rawSql;
         this.dbId = dbId;
         this.tableId = tableId;
@@ -65,6 +69,8 @@ public class TableAddOrDropInvertedIndicesInfo implements Writable {
         this.alterInvertedIndexes = alterInvertedIndexes;
         this.isDropInvertedIndex = isDropInvertedIndex;
         this.jobId = jobId;
+        this.createTimeMs = createTimeMs;
+        this.finishedTimeMs = finishedTimeMs;
     }
 
     public long getDbId() {
@@ -93,6 +99,14 @@ public class TableAddOrDropInvertedIndicesInfo implements Writable {
 
     public long getJobId() {
         return jobId;
+    }
+
+    public Long getCreateTimeMs() {
+        return createTimeMs;
+    }
+
+    public Long getFinishedTimeMs() {
+        return finishedTimeMs;
     }
 
     public String toJson() {

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/TableAddOrDropInvertedIndicesInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/TableAddOrDropInvertedIndicesInfoTest.java
@@ -41,12 +41,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class TableAddOrDropColumnsInfoTest {
-    private static String fileName = "./TableAddOrDropColumnsInfoTest";
+public class TableAddOrDropInvertedIndicesInfoTest {
+    private static String fileName = "./TableAddOrDropInvertedIndicesInfoTest";
 
     @Test
     public void testSerialization() throws IOException {
-        // 1. Write objects to file
         File file = new File(fileName);
         file.createNewFile();
 
@@ -60,45 +59,32 @@ public class TableAddOrDropColumnsInfoTest {
         LinkedList<Column> fullSchema = new LinkedList<>();
         fullSchema.add(new Column("testCol1", ScalarType.createType(PrimitiveType.INT)));
         fullSchema.add(new Column("testCol2", ScalarType.createType(PrimitiveType.VARCHAR)));
-        fullSchema.add(new Column("testCol3", ScalarType.createType(PrimitiveType.DATE)));
-        fullSchema.add(new Column("testCol4", ScalarType.createType(PrimitiveType.DATETIME)));
 
         Map<Long, LinkedList<Column>> indexSchemaMap = new HashMap<>();
         indexSchemaMap.put(tableId, fullSchema);
 
-        Map<Long, List<Column>> oldIndexSchemaMap = new HashMap<>();
-        oldIndexSchemaMap.put(tableId, fullSchema);
-
-        Map<String, Long> indexNameToId = new HashMap<>();
-        indexNameToId.put("index", 1L);
-
         List<Index> indexes = Lists.newArrayList(
                 new Index(0, "index", Lists.newArrayList("testCol1"), IndexType.INVERTED, null, "xxxxxx"));
+        List<Index> alterIndexes = Lists.newArrayList(
+                new Index(1, "index_1", Lists.newArrayList("testCol2"), IndexType.INVERTED, null, "yyyyyy"));
 
-        TableAddOrDropColumnsInfo tableAddOrDropColumnsInfo1 = new TableAddOrDropColumnsInfo(
-                "", dbId, tableId, tableId,
-                indexSchemaMap, oldIndexSchemaMap, indexNameToId, indexes, jobId, createTimeMs, finishedTimeMs);
+        TableAddOrDropInvertedIndicesInfo info1 = new TableAddOrDropInvertedIndicesInfo(
+                "", dbId, tableId, indexSchemaMap, indexes, alterIndexes, false, jobId, createTimeMs, finishedTimeMs);
 
-        String c1Json = GsonUtils.GSON.toJson(tableAddOrDropColumnsInfo1);
-        Text.writeString(out, c1Json);
+        Text.writeString(out, GsonUtils.GSON.toJson(info1));
         out.flush();
         out.close();
 
-        // 2. Read objects from file
         DataInputStream in = new DataInputStream(new FileInputStream(file));
-
         String readJson = Text.readString(in);
-        TableAddOrDropColumnsInfo tableAddOrDropColumnsInfo2 = GsonUtils.GSON.fromJson(readJson,
-                TableAddOrDropColumnsInfo.class);
+        TableAddOrDropInvertedIndicesInfo info2 = GsonUtils.GSON.fromJson(readJson,
+                TableAddOrDropInvertedIndicesInfo.class);
 
-        Assert.assertEquals(tableAddOrDropColumnsInfo1.getDbId(), tableAddOrDropColumnsInfo2.getDbId());
-        Assert.assertEquals(tableAddOrDropColumnsInfo1.getTableId(), tableAddOrDropColumnsInfo2.getTableId());
-        Assert.assertEquals(tableAddOrDropColumnsInfo1.getIndexSchemaMap(),
-                tableAddOrDropColumnsInfo2.getIndexSchemaMap());
-        Assert.assertEquals(tableAddOrDropColumnsInfo1.getCreateTimeMs(), tableAddOrDropColumnsInfo2.getCreateTimeMs());
-        Assert.assertEquals(tableAddOrDropColumnsInfo1.getFinishedTimeMs(),
-                tableAddOrDropColumnsInfo2.getFinishedTimeMs());
-
+        Assert.assertEquals(info1.getDbId(), info2.getDbId());
+        Assert.assertEquals(info1.getTableId(), info2.getTableId());
+        Assert.assertEquals(info1.getIndexSchemaMap(), info2.getIndexSchemaMap());
+        Assert.assertEquals(info1.getCreateTimeMs(), info2.getCreateTimeMs());
+        Assert.assertEquals(info1.getFinishedTimeMs(), info2.getFinishedTimeMs());
     }
 
     @After


### PR DESCRIPTION
## Summary
- persist original `createTimeMs` and `finishedTimeMs` in light schema change replay logs for add/drop columns and inverted indexes
- restore the original timestamps when replaying finished light schema change jobs so alter metadata remains stable after FE restart or failover
- add serialization coverage for both persisted replay info objects

## Testing
- `./run-fe-ut.sh --run org.apache.doris.persist.TableAddOrDropColumnsInfoTest,org.apache.doris.persist.TableAddOrDropInvertedIndicesInfoTest`