### PR TITLE
[fix](fe) Disable row-store lazy fetch for shared base columns

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -181,6 +181,7 @@ import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.StructType;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.JoinUtils;
+import org.apache.doris.nereids.util.RowStoreFetchChecker;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.planner.AggregationNode;
 import org.apache.doris.planner.AnalyticEvalNode;
@@ -2753,7 +2754,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
 
         List<Boolean> rowStoreFlags = new ArrayList<>();
         for (Relation relation : materialize.getRelations()) {
-            rowStoreFlags.add(shouldUseRowStore(relation));
+            rowStoreFlags.add(shouldUseRowStore(relation, materialize.getLazySlots(relation)));
         }
         materializeNode.setRowStoreFlags(rowStoreFlags);
 
@@ -2766,14 +2767,18 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         return inputPlanFragment;
     }
 
-    private boolean shouldUseRowStore(Relation rel) {
+    static boolean canUseRowStoreForLazySlots(List<Slot> lazySlots) {
+        return RowStoreFetchChecker.canUseRowStoreForLazySlots(lazySlots);
+    }
+
+    private boolean shouldUseRowStore(Relation rel, List<Slot> lazySlots) {
         boolean useRowStore = false;
         if (rel instanceof PhysicalOlapScan) {
             OlapTable olapTable = ((PhysicalOlapScan) rel).getTable();
             useRowStore = olapTable.storeRowColumn()
                     && CollectionUtils.isEmpty(olapTable.getTableProperty().getCopiedRowStoreColumns());
         }
-        return useRowStore;
+        return useRowStore && canUseRowStoreForLazySlots(lazySlots);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
@@ -294,4 +294,8 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
     public List<Slot> getRowIds() {
         return rowIdList;
     }
+
+    public List<Slot> getLazySlots(Relation relation) {
+        return relationToLazySlotMap.getOrDefault(relation, ImmutableList.of());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/RowStoreFetchChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/RowStoreFetchChecker.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/** Utility to determine whether FE can safely request row-store lazy fetch on BE. */
+public final class RowStoreFetchChecker {
+    private RowStoreFetchChecker() {
+    }
+
+    /**
+     * Check if we can use row-store lazy fetch for the given lazy slots. The check is based on the following criteria:
+     */
+    public static boolean canUseRowStoreForLazySlots(List<Slot> lazySlots) {
+        Set<Integer> originalColumnUniqueIds = new HashSet<>();
+        for (Slot lazySlot : lazySlots) {
+            if (!(lazySlot instanceof SlotReference)) {
+                return false;
+            }
+            SlotReference slotReference = (SlotReference) lazySlot;
+            // BE row-store fetch maps values only by col_unique_id and does not carry sub-column paths.
+            if (slotReference.hasSubColPath()) {
+                return false;
+            }
+            Optional<Column> originalColumn = slotReference.getOriginalColumn();
+            if (!originalColumn.isPresent() || !originalColumnUniqueIds.add(originalColumn.get().getUniqueId())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
@@ -265,4 +265,35 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
             return Collections.emptyList();
         }
     }
+
+    @Test
+    public void testCanUseRowStoreForLazySlots() {
+        Column distinctA = new Column("a", org.apache.doris.catalog.Type.INT);
+        distinctA.setUniqueId(1);
+        Column distinctB = new Column("b", org.apache.doris.catalog.Type.INT);
+        distinctB.setUniqueId(2);
+        Column sharedVariant = new Column("kv", org.apache.doris.catalog.Type.VARIANT);
+        sharedVariant.setUniqueId(3);
+
+        SlotReference distinctSlotA = new SlotReference(StatementScopeIdGenerator.newExprId(), "a",
+                IntegerType.INSTANCE, true, ImmutableList.of(), null, distinctA, null, distinctA);
+        SlotReference distinctSlotB = new SlotReference(StatementScopeIdGenerator.newExprId(), "b",
+                IntegerType.INSTANCE, true, ImmutableList.of(), null, distinctB, null, distinctB);
+        SlotReference variantRootSlot = new SlotReference(StatementScopeIdGenerator.newExprId(), "kv",
+                org.apache.doris.nereids.types.VariantType.INSTANCE, true, ImmutableList.of(),
+                null, sharedVariant, null, sharedVariant);
+        SlotReference singleVariantSubColumnSlot = new SlotReference(StatementScopeIdGenerator.newExprId(), "kv",
+                org.apache.doris.nereids.types.VariantType.INSTANCE, true, ImmutableList.of(),
+                null, sharedVariant, null, sharedVariant, ImmutableList.of("ssl"));
+        SlotReference variantSubColumnSlot = new SlotReference(StatementScopeIdGenerator.newExprId(), "kv",
+                org.apache.doris.nereids.types.VariantType.INSTANCE, true, ImmutableList.of(),
+                null, sharedVariant, null, sharedVariant, ImmutableList.of("ssl"));
+
+        Assertions.assertTrue(PhysicalPlanTranslator.canUseRowStoreForLazySlots(
+                ImmutableList.of(distinctSlotA, distinctSlotB)));
+        Assertions.assertFalse(PhysicalPlanTranslator.canUseRowStoreForLazySlots(
+                ImmutableList.of(singleVariantSubColumnSlot)));
+        Assertions.assertFalse(PhysicalPlanTranslator.canUseRowStoreForLazySlots(
+                ImmutableList.of(variantRootSlot, variantSubColumnSlot)));
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Prevent topn lazy materialization from using row-store fetch when multiple lazy slots share the same base column, such as variant root/subcolumn accesses. This avoids wrong results in the non-two-phase row-store path.

### Release note

None

### Check List (For Author)

- Test: No need to test (waiting for manual confirmation)
- Behavior changed: Yes (lazy materialization now falls back from row-store fetch to column fetch when lazy slots share a base column)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

