### PR TITLE
[fix](streaming-job) bound cdc_client RPCs with per-category timeouts

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1155,6 +1155,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int streaming_task_timeout_multiplier = 10;
 
+    @ConfField(mutable = true, masterOnly = true)
+    public static int streaming_cdc_light_rpc_timeout_sec = 90;
+
+    @ConfField(mutable = true, masterOnly = true)
+    public static int streaming_cdc_heavy_rpc_timeout_sec = 600;
+
     /**
      * the max timeout of get kafka meta.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingMultiTblTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingMultiTblTask.java
@@ -60,6 +60,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * In PostgreSQL/MySQL, multi-table writes are performed by tasks that only make calls.
@@ -134,9 +136,9 @@ public class StreamingMultiTblTask extends AbstractStreamingTask {
         TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
         InternalService.PRequestCdcClientResult result = null;
         try {
-            Future<PRequestCdcClientResult> future =
-                    BackendServiceProxy.getInstance().requestCdcClient(address, request);
-            result = future.get();
+            Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                    .requestCdcClient(address, request, Config.streaming_cdc_heavy_rpc_timeout_sec);
+            result = future.get(Config.streaming_cdc_heavy_rpc_timeout_sec, TimeUnit.SECONDS);
             TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
             if (code != TStatusCode.OK) {
                 log.error("Failed to send write records request, {}", result.getStatus().getErrorMsgs(0));
@@ -160,6 +162,11 @@ public class StreamingMultiTblTask extends AbstractStreamingTask {
                 throw new JobException("Failed to parse write records response: " + response);
             }
             throw new JobException("Failed to send write records request , error message: " + response);
+        } catch (TimeoutException te) {
+            log.warn("cdc_client RPC timeout api=/api/writeRecords taskId={} jobId={} backend={}:{} timeout_sec={}",
+                    taskId, getJobId(), backend.getHost(), backend.getBrpcPort(),
+                    Config.streaming_cdc_heavy_rpc_timeout_sec);
+            throw new JobException("cdc_client RPC timeout: /api/writeRecords taskId=" + taskId);
         } catch (ExecutionException | InterruptedException ex) {
             log.error("Send write request failed: ", ex);
             throw new JobException(ex);
@@ -331,20 +338,20 @@ public class StreamingMultiTblTask extends AbstractStreamingTask {
      * such as a data quality error, and needs to expose it to the user.
      */
     public String getTimeoutReason() {
+        if (runningBackendId <= 0) {
+            log.info("No running backend for task {}", runningBackendId);
+            return "";
+        }
+        Backend backend = Env.getCurrentSystemInfo().getBackend(runningBackendId);
         try {
-            if (runningBackendId <= 0) {
-                log.info("No running backend for task {}", runningBackendId);
-                return "";
-            }
-            Backend backend = Env.getCurrentSystemInfo().getBackend(runningBackendId);
             InternalService.PRequestCdcClientRequest request = InternalService.PRequestCdcClientRequest.newBuilder()
                     .setApi("/api/getFailReason/" + getTaskId())
                     .build();
             TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
             InternalService.PRequestCdcClientResult result = null;
-            Future<PRequestCdcClientResult> future =
-                    BackendServiceProxy.getInstance().requestCdcClient(address, request);
-            result = future.get();
+            Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                    .requestCdcClient(address, request, Config.streaming_cdc_light_rpc_timeout_sec);
+            result = future.get(Config.streaming_cdc_light_rpc_timeout_sec, TimeUnit.SECONDS);
             TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
             if (code != TStatusCode.OK) {
                 log.warn("Failed to get task timeout reason, {}", result.getStatus().getErrorMsgs(0));
@@ -363,6 +370,11 @@ public class StreamingMultiTblTask extends AbstractStreamingTask {
             } catch (JsonProcessingException e) {
                 log.warn("Failed to get task timeout reason, response: {}", response);
             }
+        } catch (TimeoutException te) {
+            log.warn("cdc_client RPC timeout api=/api/getFailReason jobId={} taskId={} backend={}:{} "
+                            + "timeout_sec={}",
+                    getJobId(), getTaskId(), backend.getHost(), backend.getBrpcPort(),
+                    Config.streaming_cdc_light_rpc_timeout_sec);
         } catch (ExecutionException | InterruptedException ex) {
             log.warn("Send get task fail reason request failed: ", ex);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
@@ -19,6 +19,7 @@ package org.apache.doris.job.offset.jdbc;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.rest.RestApiStatusCode;
 import org.apache.doris.job.cdc.DataSourceConfigKeys;
@@ -64,6 +65,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 @Getter
@@ -229,9 +232,9 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
         InternalService.PRequestCdcClientResult result = null;
         try {
-            Future<PRequestCdcClientResult> future =
-                    BackendServiceProxy.getInstance().requestCdcClient(address, request);
-            result = future.get();
+            Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                    .requestCdcClient(address, request, Config.streaming_cdc_light_rpc_timeout_sec);
+            result = future.get(Config.streaming_cdc_light_rpc_timeout_sec, TimeUnit.SECONDS);
             TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
             if (code != TStatusCode.OK) {
                 log.warn("Failed to get end offset from backend, {}", result.getStatus().getErrorMsgs(0));
@@ -256,6 +259,11 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
                 log.warn("Failed to parse end offset response: {}", response);
                 throw new JobException(response);
             }
+        } catch (TimeoutException te) {
+            log.warn("cdc_client RPC timeout api=/api/fetchEndOffset jobId={} backend={}:{} timeout_sec={}",
+                    getJobId(), backend.getHost(), backend.getBrpcPort(),
+                    Config.streaming_cdc_light_rpc_timeout_sec);
+            throw new JobException("cdc_client RPC timeout: /api/fetchEndOffset jobId=" + getJobId());
         } catch (ExecutionException | InterruptedException ex) {
             log.warn("Get end offset error: ", ex);
             throw new JobException(ex);
@@ -316,9 +324,9 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
         InternalService.PRequestCdcClientResult result = null;
         try {
-            Future<PRequestCdcClientResult> future =
-                    BackendServiceProxy.getInstance().requestCdcClient(address, request);
-            result = future.get();
+            Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                    .requestCdcClient(address, request, Config.streaming_cdc_light_rpc_timeout_sec);
+            result = future.get(Config.streaming_cdc_light_rpc_timeout_sec, TimeUnit.SECONDS);
             TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
             if (code != TStatusCode.OK) {
                 log.warn("Failed to compare offset , {}", result.getStatus().getErrorMsgs(0));
@@ -338,6 +346,11 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
                 log.warn("Failed to parse compare offset response: {}", response);
                 throw new JobException("Failed to parse compare offset response: " + response);
             }
+        } catch (TimeoutException te) {
+            log.warn("cdc_client RPC timeout api=/api/compareOffset jobId={} backend={}:{} timeout_sec={}",
+                    getJobId(), backend.getHost(), backend.getBrpcPort(),
+                    Config.streaming_cdc_light_rpc_timeout_sec);
+            throw new JobException("cdc_client RPC timeout: /api/compareOffset jobId=" + getJobId());
         } catch (ExecutionException | InterruptedException ex) {
             log.warn("Compare offset error: ", ex);
             throw new JobException(ex);
@@ -559,9 +572,9 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
         InternalService.PRequestCdcClientResult result = null;
         try {
-            Future<PRequestCdcClientResult> future =
-                    BackendServiceProxy.getInstance().requestCdcClient(address, request);
-            result = future.get();
+            Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                    .requestCdcClient(address, request, Config.streaming_cdc_heavy_rpc_timeout_sec);
+            result = future.get(Config.streaming_cdc_heavy_rpc_timeout_sec, TimeUnit.SECONDS);
             TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
             if (code != TStatusCode.OK) {
                 log.warn("Failed to get split from backend, {}", result.getStatus().getErrorMsgs(0));
@@ -582,6 +595,11 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
                 log.warn("Failed to parse split response: {}", response);
                 throw new JobException("Failed to parse split response: " + response);
             }
+        } catch (TimeoutException te) {
+            log.warn("cdc_client RPC timeout api=/api/fetchSplits jobId={} backend={}:{} table={} timeout_sec={}",
+                    getJobId(), backend.getHost(), backend.getBrpcPort(), table,
+                    Config.streaming_cdc_heavy_rpc_timeout_sec);
+            throw new JobException("cdc_client RPC timeout: /api/fetchSplits jobId=" + getJobId() + " table=" + table);
         } catch (ExecutionException | InterruptedException ex) {
             log.warn("Get splits error: ", ex);
             throw new JobException(ex);
@@ -673,9 +691,9 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
         InternalService.PRequestCdcClientResult result = null;
         try {
-            Future<PRequestCdcClientResult> future =
-                    BackendServiceProxy.getInstance().requestCdcClient(address, request);
-            result = future.get();
+            Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                    .requestCdcClient(address, request, Config.streaming_cdc_heavy_rpc_timeout_sec);
+            result = future.get(Config.streaming_cdc_heavy_rpc_timeout_sec, TimeUnit.SECONDS);
             TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
             if (code != TStatusCode.OK) {
                 log.warn("Failed to init job {} reader, {}", getJobId(), result.getStatus().getErrorMsgs(0));
@@ -703,6 +721,11 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
                 log.warn("Failed to init {} source reader, {}", getJobId(), response);
                 throw new JobException("Failed to init source reader, cause " + e.getMessage());
             }
+        } catch (TimeoutException te) {
+            log.warn("cdc_client RPC timeout api=/api/initReader jobId={} backend={}:{} timeout_sec={}",
+                    getJobId(), backend.getHost(), backend.getBrpcPort(),
+                    Config.streaming_cdc_heavy_rpc_timeout_sec);
+            throw new JobException("cdc_client RPC timeout: /api/initReader jobId=" + getJobId());
         } catch (ExecutionException | InterruptedException ex) {
             log.warn("init source reader: ", ex);
             throw new JobException(ex);
@@ -721,13 +744,17 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
         InternalService.PRequestCdcClientResult result = null;
         try {
-            Future<PRequestCdcClientResult> future =
-                    BackendServiceProxy.getInstance().requestCdcClient(address, request);
-            result = future.get();
+            Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                    .requestCdcClient(address, request, Config.streaming_cdc_light_rpc_timeout_sec);
+            result = future.get(Config.streaming_cdc_light_rpc_timeout_sec, TimeUnit.SECONDS);
             TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
             if (code != TStatusCode.OK) {
                 log.warn("Failed to close job {} source {}", jobId, result.getStatus().getErrorMsgs(0));
             }
+        } catch (TimeoutException te) {
+            log.warn("cdc_client RPC timeout api=/api/close jobId={} backend={}:{} timeout_sec={}",
+                    jobId, backend.getHost(), backend.getBrpcPort(),
+                    Config.streaming_cdc_light_rpc_timeout_sec);
         } catch (ExecutionException | InterruptedException ex) {
             log.warn("Close job error: ", ex);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcTvfSourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcTvfSourceOffsetProvider.java
@@ -58,6 +58,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -203,9 +205,10 @@ public class JdbcTvfSourceOffsetProvider extends JdbcSourceOffsetProvider {
             String rawResponse = null;
             try {
                 TNetworkAddress address = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
-                Future<PRequestCdcClientResult> future =
-                        BackendServiceProxy.getInstance().requestCdcClient(address, request);
-                InternalService.PRequestCdcClientResult result = future.get();
+                Future<PRequestCdcClientResult> future = BackendServiceProxy.getInstance()
+                        .requestCdcClient(address, request, Config.streaming_cdc_light_rpc_timeout_sec);
+                InternalService.PRequestCdcClientResult result =
+                        future.get(Config.streaming_cdc_light_rpc_timeout_sec, TimeUnit.SECONDS);
                 TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
                 if (code != TStatusCode.OK) {
                     log.warn("Failed to get task {} offset from BE {}: {}", taskId,
@@ -221,6 +224,11 @@ public class JdbcTvfSourceOffsetProvider extends JdbcSourceOffsetProvider {
                     log.info("Fetched task {} offset from BE {}: {}", taskId, backend.getHost(), data);
                     return data;
                 }
+            } catch (TimeoutException te) {
+                log.warn("cdc_client RPC timeout api=/api/getTaskOffset jobId={} taskId={} backend={}:{} "
+                                + "timeout_sec={}",
+                        jobId, taskId, backend.getHost(), backend.getBrpcPort(),
+                        Config.streaming_cdc_light_rpc_timeout_sec);
             } catch (Exception ex) {
                 log.warn("Get task offset error for task {} from BE {}, raw response: {}",
                         taskId, backend.getHost(), rawResponse, ex);

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -227,6 +227,11 @@ public class BackendServiceClient {
         return stub.requestCdcClient(request);
     }
 
+    public Future<InternalService.PRequestCdcClientResult> requestCdcClient(
+            InternalService.PRequestCdcClientRequest request, int timeoutSec) {
+        return stub.withDeadlineAfter(timeoutSec, TimeUnit.SECONDS).requestCdcClient(request);
+    }
+
     public void shutdown() {
         ConnectivityState state = channel.getState(false);
         LOG.warn("shut down backend service client: {}, channel state: {}", address, state);

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -608,4 +608,15 @@ public class BackendServiceProxy {
         }
         return null;
     }
+
+    public Future<InternalService.PRequestCdcClientResult> requestCdcClient(TNetworkAddress address,
+            InternalService.PRequestCdcClientRequest request, int timeoutSec) {
+        try {
+            final BackendServiceClient client = getProxy(address);
+            return client.requestCdcClient(request, timeoutSec);
+        } catch (Throwable e) {
+            LOG.warn("request cdc client failed, address={}:{}", address.getHostname(), address.getPort(), e);
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`JdbcSourceOffsetProvider.cleanMeta()` and several other cdc_client RPCs called `future.get()` with no timeout. When the cdc_client (or PG/MySQL behind it) hangs, the call blocks forever. For `cleanMeta()` this is fatal because it runs inside `JobManager.dropJobInternal()` while holding `JobManager.writeLock()` — any subsequent `CREATE / DROP / SHOW JOB` on streaming jobs is then serialized behind the dead lock, effectively freezing the streaming-job control plane.

### Fix

Introduce two configurable timeouts (mirroring the BE `brpc_light/heavy_work_pool` naming) and apply them to all 8 cdc_client RPC call sites:

- `streaming_cdc_light_rpc_timeout_sec = 90` for `/api/close`, `/api/compareOffset`, `/api/fetchEndOffset`, `/api/getTaskOffset`, `/api/getFailReason` (server-side single-statement queries / cache lookups, expected sub-second). Default is 90s rather than 30s to absorb cdc_client cold-start: when the BE-spawned cdc_client process is not yet running, `start_cdc_client` performs a health-check loop (worst case ~45s) before serving the request — 90s gives enough headroom to avoid spurious timeouts during this window while still bounding `JobManager.writeLock` hold time.
- `streaming_cdc_heavy_rpc_timeout_sec = 600` for `/api/initReader`, `/api/fetchSplits`, `/api/writeRecords` (may legitimately take minutes for replication slot creation, large snapshot split computation, or batch writes).

Both configs are `mutable = true` so they can be tuned via `ADMIN SET FRONTEND CONFIG` without restarting FE.

`BackendServiceClient.requestCdcClient` gains a timeout overload that applies a gRPC `withDeadlineAfter`; the per-call-site `future.get(...)` also passes the same timeout so the deadline is enforced on both sides.

On timeout we WARN with a uniform line carrying `api / jobId / backend / timeout_sec` for easy log aggregation. `cleanMeta` keeps its existing swallow-on-failure semantics (a cleanup hiccup must not fail `DROP JOB`); the other seven sites throw `JobException` consistent with their existing `ExecutionException` handling.

### Release note

Add streaming-job FE configs `streaming_cdc_light_rpc_timeout_sec` (default 90s) and `streaming_cdc_heavy_rpc_timeout_sec` (default 600s) to bound cdc_client RPCs.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason: defensive timeout — main path behavior is unchanged, the new branch only triggers when cdc_client itself is misbehaving (which is hard to reproduce in CI).

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label