### PR TITLE
[fix](be) Move #include directives outside namespace blocks to avoid ODR violations

### DIFF
--- a/be/src/exec/common/sip_hash.h
+++ b/be/src/exec/common/sip_hash.h
@@ -33,6 +33,7 @@
   * (~ 700 MB/sec, 15 million strings per second)
   */
 
+#include <cstddef>
 #include <string>
 #include <type_traits>
 
@@ -208,8 +209,6 @@ public:
 
 #undef ROTL
 #undef SIPROUND
-
-#include <cstddef>
 
 inline void sip_hash128(const char* data, const size_t size, char* out) {
     SipHash hash;

--- a/be/src/exprs/table_function/vexplode_v2.cpp
+++ b/be/src/exprs/table_function/vexplode_v2.cpp
@@ -30,6 +30,7 @@
 #include "core/column/column.h"
 #include "core/column/column_array.h"
 #include "core/column/column_nothing.h"
+#include "core/column/column_struct.h"
 #include "core/column/column_variant.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
@@ -40,8 +41,6 @@
 #include "exprs/vexpr_context.h"
 
 namespace doris {
-
-#include "core/column/column_struct.h"
 
 VExplodeV2TableFunction::VExplodeV2TableFunction() {
     _fn_name = "vexplode";

--- a/be/src/storage/segment/variant/variant_doc_snpashot_compact_iterator.h
+++ b/be/src/storage/segment/variant/variant_doc_snpashot_compact_iterator.h
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-namespace doris::segment_v2 {
-
 #include "core/column/column_variant.h"
 #include "storage/segment/column_reader.h"
+
+namespace doris::segment_v2 {
 
 class VariantDocValueCompactIterator : public ColumnIterator {
 public:

--- a/be/src/util/hash/murmur_hash3.cpp
+++ b/be/src/util/hash/murmur_hash3.cpp
@@ -26,6 +26,10 @@
 
 #include "util/hash/murmur_hash3.h"
 
+#if defined(_MSC_VER)
+#include <stdlib.h>
+#endif
+
 #include "util/unaligned.h"
 
 namespace doris {
@@ -33,8 +37,6 @@ namespace doris {
 #if defined(_MSC_VER)
 
 #define FORCE_INLINE __forceinline
-
-#include <stdlib.h>
 
 #define ROTL32(x, y) _rotl(x, y)
 #define ROTL64(x, y) _rotl64(x, y)

--- a/be/src/util/simd/vstring_function.h
+++ b/be/src/util/simd/vstring_function.h
@@ -73,7 +73,6 @@ inline bool validate_ascii_fast(const char* src, size_t len) {
 }
 
 #ifdef __AVX2__
-#include <x86intrin.h>
 // The function returns true (1) if all chars passed in src are
 // 7-bit values (0x00..0x7F). Otherwise, it returns false (0).
 inline bool validate_ascii_fast_avx(const char* src, size_t len) {


### PR DESCRIPTION

Several files placed `#include` directives inside an outer `namespace { ... }` block. 

The preprocessor expands the included header verbatim at that point, so a header that opens its own `namespace doris { namespace segment_v2 { ... } }` ends up nested as `doris::segment_v2::doris::segment_v2::ColumnIterator` instead of
`doris::segment_v2::ColumnIterator`.


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

