### PR TITLE
[fix](fe) Forbid adding key columns on sync-MV MOW tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1193,7 +1193,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 if (syncMvName.isPresent()) {
                     throw new DdlException(String.format(
                             "Can not add key column to merge-on-write table when table has sync materialized view[%s]. "
-                                    + "Please drop the sync materialized view first, then alter the table and recreate it.",
+                                    + "Please drop the sync materialized view first, then alter the table "
+                                    + "and recreate it.",
                             syncMvName.get()));
                 }
             }
@@ -1377,9 +1378,7 @@ public class SchemaChangeHandler extends AlterHandler {
             if (entry.getKey() == olapTable.getBaseIndexId()) {
                 continue;
             }
-            if (entry.getValue().getDefineStmt() != null) {
-                return Optional.ofNullable(olapTable.getIndexNameById(entry.getKey()));
-            }
+            return Optional.of(Preconditions.checkNotNull(olapTable.getIndexNameById(entry.getKey())));
         }
         return Optional.empty();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1188,6 +1188,14 @@ public class SchemaChangeHandler extends AlterHandler {
                 } else {
                     newColumn.setAggregationType(AggregateType.REPLACE, true);
                 }
+            } else if (olapTable.getEnableUniqueKeyMergeOnWrite()) {
+                Optional<String> syncMvName = getSyncMvName(olapTable);
+                if (syncMvName.isPresent()) {
+                    throw new DdlException(String.format(
+                            "Can not add key column to merge-on-write table when table has sync materialized view[%s]. "
+                                    + "Please drop the sync materialized view first, then alter the table and recreate it.",
+                            syncMvName.get()));
+                }
             }
         } else {
             if (newColumn.getAggregationType() != null && newColumn.isKey()) {
@@ -1362,6 +1370,18 @@ public class SchemaChangeHandler extends AlterHandler {
             checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false, rollUpNewColumnUniqueId);
         }
         return lightSchemaChange;
+    }
+
+    private Optional<String> getSyncMvName(OlapTable olapTable) {
+        for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getVisibleIndexIdToMeta().entrySet()) {
+            if (entry.getKey() == olapTable.getBaseIndexId()) {
+                continue;
+            }
+            if (entry.getValue().getDefineStmt() != null) {
+                return Optional.ofNullable(olapTable.getIndexNameById(entry.getKey()));
+            }
+        }
+        return Optional.empty();
     }
 
     /*

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -580,6 +580,23 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         expectException("alter table test.sc_uniq_sync_mv add column new_key int key default '0'",
                 "Can not add key column to merge-on-write table when table has sync materialized view[sync_mv_key_guard]");
+
+        createTable("CREATE TABLE IF NOT EXISTS test.sc_uniq_sync_rollup (\n"
+                + "user_id LARGEINT NOT NULL,\n"
+                + "username VARCHAR(50) NOT NULL,\n"
+                + "city VARCHAR(20),\n"
+                + "age SMALLINT\n"
+                + ")\n"
+                + "UNIQUE KEY(user_id, username)\n"
+                + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true',\n"
+                + "'enable_unique_key_merge_on_write' = 'true');");
+        alterTable("alter table test.sc_uniq_sync_rollup add rollup rollup_key_guard(username, user_id)",
+                connectContext);
+        waitAlterJobDone(Env.getCurrentEnv().getMaterializedViewHandler().getAlterJobsV2());
+
+        expectException("alter table test.sc_uniq_sync_rollup add column new_key int key default '0'",
+                "Can not add key column to merge-on-write table when table has sync materialized view[rollup_key_guard]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -563,6 +563,26 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     }
 
     @Test
+    public void testUniqAddKeyColumnRejectedWhenSyncMvExists() throws Exception {
+        createTable("CREATE TABLE IF NOT EXISTS test.sc_uniq_sync_mv (\n"
+                + "user_id LARGEINT NOT NULL,\n"
+                + "username VARCHAR(50) NOT NULL,\n"
+                + "city VARCHAR(20),\n"
+                + "age SMALLINT\n"
+                + ")\n"
+                + "UNIQUE KEY(user_id, username)\n"
+                + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true',\n"
+                + "'enable_unique_key_merge_on_write' = 'true');");
+        createMv("create materialized view sync_mv_key_guard as "
+                + "select username as mv_username, user_id as mv_user_id, city as mv_city "
+                + "from test.sc_uniq_sync_mv;");
+
+        expectException("alter table test.sc_uniq_sync_mv add column new_key int key default '0'",
+                "Can not add key column to merge-on-write table when table has sync materialized view[sync_mv_key_guard]");
+    }
+
+    @Test
     public void testDupAddOrDropColumn() throws Exception {
 
         LOG.info("dbName: {}", Env.getCurrentInternalCatalog().getDbNames());


### PR DESCRIPTION
## Summary
- reject add key column schema changes on merge-on-write unique tables when a sync materialized view still exists
- raise a clear remediation error instead of allowing sync MV metadata to become inconsistent after schema change
- add FE coverage for the guarded sync MV schema change path

## Testing
- Not run locally; FE UT is currently blocked by missing `thirdparty/installed/bin/protoc`