### PR TITLE
[Fix](warm up) Fix warm up don't retry due to error message change

### DIFF
--- a/be/src/cloud/cloud_internal_service.cpp
+++ b/be/src/cloud/cloud_internal_service.cpp
@@ -530,7 +530,8 @@ void CloudInternalServiceImpl::warm_up_rowset(google::protobuf::RpcController* c
                                                    /* local_only = */ local_only);
         if (!res.has_value()) {
             LOG_WARNING("Warm up error ").tag("tablet_id", tablet_id).error(res.error());
-            if (res.error().msg().find("local_only=true") != std::string::npos) {
+            if (res.error().msg().find("local_only=true") != std::string::npos ||
+                res.error().msg().find("force_use_only_cached=true") != std::string::npos) {
                 res.error().set_code(ErrorCode::TABLE_NOT_FOUND);
             }
             res.error().to_protobuf(response->mutable_status());


### PR DESCRIPTION
### What problem does this PR solve?

https://github.com/apache/doris/pull/58044 changed the error message when tablet is not found in cache but don't change the condition in `CloudInternalServiceImpl::warm_up_rowset`. This will cause passive warm up don't retry because the status code is not `TABLE_NOT_FOUND`.
This PR fix it.

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

