### PR TITLE
[fix](analyze) Preserve variant subfields in view definitions to fix select view result wrong when view select has variant field

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -1165,83 +1165,82 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
 
     private List<? extends Expression> bindExpressionByCatalogDbTableColumn(
             UnboundSlot unboundSlot, List<String> nameParts, Optional<Pair<Integer, Integer>> idxInSql, Scope scope) {
-        List<Slot> slots = addSqlIndexInfo(bindSingleSlotByCatalog(
-                        nameParts.get(0), nameParts.get(1), nameParts.get(2), nameParts.get(3), scope), idxInSql);
+        List<Slot> slots = bindSingleSlotByCatalog(
+                        nameParts.get(0), nameParts.get(1), nameParts.get(2), nameParts.get(3), scope);
         if (slots.isEmpty()) {
             return bindExpressionByDbTableColumn(unboundSlot, nameParts, idxInSql, scope);
         } else if (slots.size() > 1) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         if (nameParts.size() == 4) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
 
         Optional<Expression> expression = bindNestedFields(
                 unboundSlot, slots.get(0), nameParts.subList(4, nameParts.size())
         );
         if (!expression.isPresent()) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         return ImmutableList.of(expression.get());
     }
 
     private List<? extends Expression> bindExpressionByDbTableColumn(
             UnboundSlot unboundSlot, List<String> nameParts, Optional<Pair<Integer, Integer>> idxInSql, Scope scope) {
-        List<Slot> slots = addSqlIndexInfo(
-                bindSingleSlotByDb(nameParts.get(0), nameParts.get(1), nameParts.get(2), scope), idxInSql);
+        List<Slot> slots = bindSingleSlotByDb(nameParts.get(0), nameParts.get(1), nameParts.get(2), scope);
         if (slots.isEmpty()) {
             return bindExpressionByTableColumn(unboundSlot, nameParts, idxInSql, scope);
         } else if (slots.size() > 1) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         if (nameParts.size() == 3) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
 
         Optional<Expression> expression = bindNestedFields(
                 unboundSlot, slots.get(0), nameParts.subList(3, nameParts.size())
         );
         if (!expression.isPresent()) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         return ImmutableList.of(expression.get());
     }
 
     private List<? extends Expression> bindExpressionByTableColumn(
             UnboundSlot unboundSlot, List<String> nameParts, Optional<Pair<Integer, Integer>> idxInSql, Scope scope) {
-        List<Slot> slots = addSqlIndexInfo(bindSingleSlotByTable(nameParts.get(0), nameParts.get(1), scope), idxInSql);
+        List<Slot> slots = bindSingleSlotByTable(nameParts.get(0), nameParts.get(1), scope);
         if (slots.isEmpty()) {
             return bindExpressionByColumn(unboundSlot, nameParts, idxInSql, scope);
         } else if (slots.size() > 1) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         if (nameParts.size() == 2) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
 
         Optional<Expression> expression = bindNestedFields(
                 unboundSlot, slots.get(0), nameParts.subList(2, nameParts.size())
         );
         if (!expression.isPresent()) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         return ImmutableList.of(expression.get());
     }
 
     private List<? extends Expression> bindExpressionByColumn(
             UnboundSlot unboundSlot, List<String> nameParts, Optional<Pair<Integer, Integer>> idxInSql, Scope scope) {
-        List<Slot> slots = addSqlIndexInfo(bindSingleSlotByName(nameParts.get(0), scope), idxInSql);
+        List<Slot> slots = bindSingleSlotByName(nameParts.get(0), scope);
         if (slots.size() != 1) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         if (nameParts.size() == 1) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         Optional<Expression> expression = bindNestedFields(
                 unboundSlot, slots.get(0), nameParts.subList(1, nameParts.size())
         );
         if (!expression.isPresent()) {
-            return slots;
+            return addSqlIndexInfo(slots, idxInSql);
         }
         return ImmutableList.of(expression.get());
     }
@@ -1269,7 +1268,24 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
             }
             throw new AnalysisException("No such field '" + fieldName + "' in '" + lastFieldName + "'");
         }
+        addNestedFieldsSqlIndexInfo(unboundSlot, slot, fieldNames);
         return Optional.of(new Alias(expression, unboundSlot.getName(), slot.getQualifier()));
+    }
+
+    private void addNestedFieldsSqlIndexInfo(UnboundSlot unboundSlot, Slot slot, List<String> fieldNames) {
+        Optional<Pair<Integer, Integer>> indexInSql = unboundSlot.getIndexInSqlString();
+        if (!indexInSql.isPresent()) {
+            return;
+        }
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext == null || connectContext.getStatementContext() == null) {
+            return;
+        }
+        List<String> fullName = new ArrayList<>(slot.getQualifier());
+        fullName.add(slot.getName());
+        fullName.addAll(fieldNames);
+        connectContext.getStatementContext().addIndexInSqlToString(indexInSql.get(),
+                Utils.qualifiedNameWithBackquote(fullName));
     }
 
     public static boolean sameTableName(String boundSlot, String unboundSlot, int lowerCaseTableNames) {

--- a/regression-test/suites/ddl_p0/create_view_nereids/test_create_view_variant_nested_field.groovy
+++ b/regression-test/suites/ddl_p0/create_view_nereids/test_create_view_variant_nested_field.groovy
@@ -20,16 +20,22 @@ suite("test_create_view_variant_nested_field") {
     sql "SET enable_fallback_to_original_planner=false;"
 
     String tableName = "test_create_view_variant_nested_field_events"
+    String videoMetaTableName = "test_create_view_variant_nested_field_video_meta"
     String viewName = "test_create_view_variant_nested_field_view"
+    String cteViewName = "test_create_view_variant_nested_field_cte_view"
     String bracketViewName = "test_create_view_variant_nested_field_bracket_view"
 
     sql "DROP VIEW IF EXISTS ${viewName}"
+    sql "DROP VIEW IF EXISTS ${cteViewName}"
     sql "DROP VIEW IF EXISTS ${bracketViewName}"
+    sql "DROP TABLE IF EXISTS ${videoMetaTableName}"
     sql "DROP TABLE IF EXISTS ${tableName}"
 
     sql """
         CREATE TABLE ${tableName} (
             event_key LARGEINT NOT NULL,
+            event_at DATETIME NOT NULL,
+            event_type VARCHAR(20) NOT NULL,
             event_value VARIANT<'video_id':largeint, 'duration':bigint>,
             user_connect_info VARIANT<'user_client':text>
         )
@@ -42,9 +48,22 @@ suite("test_create_view_variant_nested_field") {
     """
 
     sql """
-        INSERT INTO ${tableName} VALUES
-        (1, '{"video_id":100,"duration":15000}', '{"user_client":"ios"}')
+        CREATE TABLE ${videoMetaTableName} (
+            fid LARGEINT NOT NULL,
+            effective_duration_s BIGINT NULL
+        )
+        DUPLICATE KEY(fid)
+        DISTRIBUTED BY HASH(fid) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        )
     """
+
+    sql """
+        INSERT INTO ${tableName} VALUES
+        (1, '2026-04-21 00:00:00', 'watch_time', '{"video_id":100,"duration":15000}', '{"user_client":"ios"}')
+    """
+    sql "INSERT INTO ${videoMetaTableName} VALUES (100, 60)"
 
     sql """
         CREATE VIEW ${viewName} AS
@@ -68,6 +87,39 @@ suite("test_create_view_variant_nested_field") {
     assertFalse(createViewSql[0][1].contains("`event_value` AS LARGEINT"))
     assertFalse(createViewSql[0][1].contains("`event_value` AS INT"))
     assertFalse(createViewSql[0][1].contains("`user_connect_info` AS VARCHAR"))
+
+    sql """
+        CREATE VIEW ${cteViewName} AS
+        WITH extracted AS (
+            SELECT
+                DATE_TRUNC(event_at, 'DAY') AS event_day,
+                CAST(event_value.video_id AS LARGEINT) AS video_id,
+                TRY_CAST(event_value.duration AS INT) AS duration_ms,
+                CAST(user_connect_info.user_client AS VARCHAR) AS client
+            FROM ${tableName}
+            WHERE event_type = 'watch_time'
+        ), final AS (
+            SELECT
+                event_day,
+                video_id,
+                SUM(duration_ms) AS total_duration,
+                MIN_BY(client, event_day) AS client
+            FROM extracted e
+            JOIN ${videoMetaTableName} v ON e.video_id = v.fid
+            WHERE duration_ms > 0 AND client IS NOT NULL
+            GROUP BY 1, 2
+        )
+        SELECT * FROM final
+    """
+
+    def cteViewCount = sql "SELECT COUNT(*) FROM ${cteViewName}"
+    assertEquals("1", cteViewCount[0][0].toString())
+
+    def cteFilteredViewCount = sql """
+        SELECT COUNT(*) FROM ${cteViewName}
+        WHERE event_day >= '2026-04-20'
+    """
+    assertEquals("1", cteFilteredViewCount[0][0].toString())
 
     sql """
         ALTER VIEW ${viewName} AS
@@ -98,6 +150,8 @@ suite("test_create_view_variant_nested_field") {
     assertFalse(bracketCreateViewSql[0][1].contains("['video_id']['video_id']"))
 
     sql "DROP VIEW IF EXISTS ${viewName}"
+    sql "DROP VIEW IF EXISTS ${cteViewName}"
     sql "DROP VIEW IF EXISTS ${bracketViewName}"
+    sql "DROP TABLE IF EXISTS ${videoMetaTableName}"
     sql "DROP TABLE IF EXISTS ${tableName}"
 }

--- a/regression-test/suites/ddl_p0/create_view_nereids/test_create_view_variant_nested_field.groovy
+++ b/regression-test/suites/ddl_p0/create_view_nereids/test_create_view_variant_nested_field.groovy
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_create_view_variant_nested_field") {
+    sql "SET enable_nereids_planner=true;"
+    sql "SET enable_fallback_to_original_planner=false;"
+
+    String tableName = "test_create_view_variant_nested_field_events"
+    String viewName = "test_create_view_variant_nested_field_view"
+    String bracketViewName = "test_create_view_variant_nested_field_bracket_view"
+
+    sql "DROP VIEW IF EXISTS ${viewName}"
+    sql "DROP VIEW IF EXISTS ${bracketViewName}"
+    sql "DROP TABLE IF EXISTS ${tableName}"
+
+    sql """
+        CREATE TABLE ${tableName} (
+            event_key LARGEINT NOT NULL,
+            event_value VARIANT<'video_id':largeint, 'duration':bigint>,
+            user_connect_info VARIANT<'user_client':text>
+        )
+        DUPLICATE KEY(event_key)
+        DISTRIBUTED BY HASH(event_key) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1",
+            "storage_format" = "V3"
+        )
+    """
+
+    sql """
+        INSERT INTO ${tableName} VALUES
+        (1, '{"video_id":100,"duration":15000}', '{"user_client":"ios"}')
+    """
+
+    sql """
+        CREATE VIEW ${viewName} AS
+        SELECT
+            CAST(e.event_value.video_id AS LARGEINT) AS video_id,
+            TRY_CAST(e.event_value.duration AS INT) AS duration_ms,
+            CAST(e.user_connect_info.user_client AS VARCHAR) AS client
+        FROM ${tableName} e
+    """
+
+    def viewCount = sql """
+        SELECT COUNT(*) FROM ${viewName}
+        WHERE video_id = 100 AND duration_ms > 0 AND client = 'ios'
+    """
+    assertEquals("1", viewCount[0][0].toString())
+
+    def createViewSql = sql "SHOW CREATE VIEW ${viewName}"
+    assertTrue(createViewSql[0][1].contains("`event_value`.`video_id`"))
+    assertTrue(createViewSql[0][1].contains("`event_value`.`duration`"))
+    assertTrue(createViewSql[0][1].contains("`user_connect_info`.`user_client`"))
+    assertFalse(createViewSql[0][1].contains("`event_value` AS LARGEINT"))
+    assertFalse(createViewSql[0][1].contains("`event_value` AS INT"))
+    assertFalse(createViewSql[0][1].contains("`user_connect_info` AS VARCHAR"))
+
+    sql """
+        ALTER VIEW ${viewName} AS
+        SELECT
+            CAST(e.event_value.video_id AS LARGEINT) AS video_id,
+            TRY_CAST(e.event_value.duration AS INT) AS duration_ms,
+            CAST(e.user_connect_info.user_client AS VARCHAR) AS client
+        FROM ${tableName} e
+    """
+
+    def alterViewCount = sql """
+        SELECT COUNT(*) FROM ${viewName}
+        WHERE video_id = 100 AND duration_ms > 0 AND client = 'ios'
+    """
+    assertEquals("1", alterViewCount[0][0].toString())
+
+    sql """
+        CREATE VIEW ${bracketViewName} AS
+        SELECT CAST(event_value['video_id'] AS LARGEINT) AS video_id
+        FROM ${tableName}
+    """
+
+    def bracketViewCount = sql "SELECT COUNT(*) FROM ${bracketViewName} WHERE video_id = 100"
+    assertEquals("1", bracketViewCount[0][0].toString())
+
+    def bracketCreateViewSql = sql "SHOW CREATE VIEW ${bracketViewName}"
+    assertTrue(bracketCreateViewSql[0][1].contains("`event_value`['video_id']"))
+    assertFalse(bracketCreateViewSql[0][1].contains("['video_id']['video_id']"))
+
+    sql "DROP VIEW IF EXISTS ${viewName}"
+    sql "DROP VIEW IF EXISTS ${bracketViewName}"
+    sql "DROP TABLE IF EXISTS ${tableName}"
+}


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #57532 

Problem Summary:

`CREATE VIEW` with Nereids could persist wrong SQL when the view definition used dotted `VARIANT` subfield access such as `event_value.video_id`. The buggy persisted SQL replaced the whole subfield expression with the base column `event_value`, so querying the view could return `0` rows while the same CTE queried directly returned `1` row.

Reproduction steps:

1. Create an `events` table with `event_value VARIANT<'video_id':largeint, 'duration':bigint>` and `user_connect_info VARIANT<'user_client':text>`.
2. Insert one `watch_time` row where `event_value.video_id = 100`, `event_value.duration = 15000`, and `user_connect_info.user_client = 'ios'`.
3. Create a view with a CTE that projects `CAST(event_value.video_id AS LARGEINT)`, `TRY_CAST(event_value.duration AS INT)`, joins `video_meta`, and aggregates the result.
4. Query the view with `SELECT COUNT(*) FROM v_bug` and `SELECT COUNT(*) FROM v_bug WHERE event_day >= '2026-04-20'`.
5. On a buggy build both view queries return `0`; on the fixed build both return `1`. `SHOW CREATE VIEW` also keeps ``event_value`.`video_id`` instead of losing the subfield path.

Root cause: In `ExpressionAnalyzer.bindExpressionByColumn()` and the qualified variants (`bindExpressionByTableColumn()`, `bindExpressionByDbTableColumn()`, `bindExpressionByCatalogDbTableColumn()`), the analyzer attached SQL-index rewrite metadata to the base `SlotReference` before `bindNestedFields()` handled the dotted subfield path. After binding `event_value.video_id` into `ElementAt(SlotReference(event_value), 'video_id')`, the base slot still owned the original SQL span for the whole `event_value.video_id` text. The create-view SQL rewrite later replaced that span with the fully qualified base column only, changing the view definition semantics.

| File | Change Description |
|------|-------------------|
| `fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java` | Delays `addSqlIndexInfo()` until the analyzer knows the reference is an ordinary slot path. For successfully bound nested fields, records a fully qualified dotted replacement that includes the base column and all nested field names. |
| `regression-test/suites/ddl_p0/create_view_nereids/test_create_view_variant_nested_field.groovy` | Adds regression coverage for `CREATE VIEW`, `ALTER VIEW`, bracket-style access, and the CTE/join/aggregation shape from the JIRA reproduction. The test queries the created view directly and verifies the row count remains `1`. |

Design rationale: This is fixed in expression analysis instead of `BaseViewInfo.SlotDealer` because `ExpressionAnalyzer` is where the dotted name is resolved into a nested-field expression and where the original SQL span is still available with semantic context. `SlotDealer` only sees later slot references during view SQL rewrite, so fixing it there would require guessing whether a base slot originated from a nested-field path. Delaying base-slot rewrite metadata and adding explicit nested-field rewrite metadata keeps ordinary column behavior unchanged while preserving `VARIANT` subfield semantics in view definitions.

### Release note

Fixed an issue where `CREATE VIEW` or `ALTER VIEW` could lose dotted `VARIANT` subfield paths in persisted view SQL, causing later queries on the view to return incorrect results.

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Regression test:

```bash
./run-regression-test.sh --run -f regression-test/suites/ddl_p0/create_view_nereids/test_create_view_variant_nested_field.groovy
```

Manual test: ran the JIRA min-repro SQL against `mysql -h 127.0.0.1 -P 9030 -u root`. The manual SQL follows the reproduction steps above and validates the direct CTE result, unfiltered view result, filtered view result, and `SHOW CREATE VIEW` output.

Manual result:

```text
direct_cte    cnt = 1
view_all      cnt = 1
view_filtered cnt = 1
```

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
