### PR TITLE
[improve](memory) Improve BE memory profile accuracy for jemalloc internal memory, segment metadata memory, and BloomFilter memory tracking

### DIFF
--- a/be/src/runtime/memory/global_memory_arbitrator.cpp
+++ b/be/src/runtime/memory/global_memory_arbitrator.cpp
@@ -68,10 +68,10 @@ std::atomic<bool> GlobalMemoryArbitrator::memtable_memory_refresh_notify {false}
 void GlobalMemoryArbitrator::refresh_memory_bvar() {
     memory_jemalloc_cache_bytes << JemallocControl::je_cache_bytes() -
                                            memory_jemalloc_cache_bytes.get_value();
-    memory_jemalloc_dirty_pages_bytes << JemallocControl::je_dirty_pages_mem() -
-                                                 memory_jemalloc_dirty_pages_bytes.get_value();
+    memory_jemalloc_dirty_pages_bytes
+            << JemallocControl::je_dirty_bytes() - memory_jemalloc_dirty_pages_bytes.get_value();
     memory_jemalloc_metadata_bytes
-            << JemallocControl::je_metadata_mem() - memory_jemalloc_metadata_bytes.get_value();
+            << JemallocControl::je_metadata_bytes() - memory_jemalloc_metadata_bytes.get_value();
     memory_jemalloc_virtual_bytes << JemallocControl::je_virtual_memory_used() -
                                              memory_jemalloc_virtual_bytes.get_value();
 

--- a/be/src/runtime/memory/jemalloc_control.cpp
+++ b/be/src/runtime/memory/jemalloc_control.cpp
@@ -29,10 +29,15 @@ std::atomic<bool> JemallocControl::je_enable_dirty_page {true};
 std::condition_variable JemallocControl::je_reset_dirty_decay_cv;
 std::atomic<bool> JemallocControl::je_reset_dirty_decay_notify {false};
 
+std::atomic<int64_t> JemallocControl::je_resident_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_allocated_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_active_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_tcache_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_metadata_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_dirty_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_muzzy_bytes_ = 0;
+std::atomic<int64_t> JemallocControl::je_internal_bytes_ = 0;
 std::atomic<int64_t> JemallocControl::je_cache_bytes_ = 0;
-std::atomic<int64_t> JemallocControl::je_tcache_mem_ = 0;
-std::atomic<int64_t> JemallocControl::je_metadata_mem_ = 0;
-std::atomic<int64_t> JemallocControl::je_dirty_pages_mem_ = std::numeric_limits<int64_t>::min();
 std::atomic<int64_t> JemallocControl::je_virtual_memory_used_ = 0;
 
 void JemallocControl::refresh_allocator_mem() {
@@ -49,23 +54,42 @@ void JemallocControl::refresh_allocator_mem() {
     size_t sz = sizeof(epoch);
     jemallctl("epoch", &epoch, &sz, &epoch, sz);
 
+    auto resident_bytes = get_jemallctl_value<int64_t>("stats.resident");
+    auto allocated_bytes = get_jemallctl_value<int64_t>("stats.allocated");
+    auto active_bytes = get_jemallctl_value<int64_t>("stats.active");
+    auto tcache_bytes = get_je_all_arena_metrics("tcache_bytes");
+    auto metadata_bytes = get_jemallctl_value<int64_t>("stats.metadata");
+    je_resident_bytes_.store(resident_bytes, std::memory_order_relaxed);
+    je_allocated_bytes_.store(allocated_bytes, std::memory_order_relaxed);
+    je_active_bytes_.store(active_bytes, std::memory_order_relaxed);
+    je_tcache_bytes_.store(tcache_bytes, std::memory_order_relaxed);
+    // Total number of bytes dedicated to metadata, which comprise base allocations used
+    // for bootstrap-sensitive allocator metadata structures.
+    je_metadata_bytes_.store(metadata_bytes, std::memory_order_relaxed);
+
     // Number of extents of the given type in this arena in the bucket corresponding to page size index.
     // Large size class starts at 16384, the extents have three sizes before 16384: 4096, 8192, and 12288, so + 3
     int64_t dirty_pages_bytes = 0;
+    int64_t muzzy_pages_bytes = 0;
     for (unsigned i = 0; i < get_jemallctl_value<unsigned>("arenas.nlextents") + 3; i++) {
         dirty_pages_bytes += get_je_all_arena_extents_metrics(i, "dirty_bytes");
+        muzzy_pages_bytes += get_je_all_arena_extents_metrics(i, "muzzy_bytes");
     }
-    je_dirty_pages_mem_.store(dirty_pages_bytes, std::memory_order_relaxed);
-    je_tcache_mem_.store(get_je_all_arena_metrics("tcache_bytes"));
+    je_dirty_bytes_.store(dirty_pages_bytes, std::memory_order_relaxed);
+    je_muzzy_bytes_.store(muzzy_pages_bytes, std::memory_order_relaxed);
 
-    // Doris uses Jemalloc as default Allocator, Jemalloc Cache consists of two parts:
-    // - Thread Cache, cache a specified number of Pages in Thread Cache.
-    // - Dirty Page, memory Page that can be reused in all Arenas.
-    je_cache_bytes_.store(je_tcache_mem_ + dirty_pages_bytes, std::memory_order_relaxed);
-    // Total number of bytes dedicated to metadata, which comprise base allocations used
-    // for bootstrap-sensitive allocator metadata structures.
-    je_metadata_mem_.store(get_jemallctl_value<int64_t>("stats.metadata"),
-                           std::memory_order_relaxed);
+    je_cache_bytes_.store(resident_bytes - allocated_bytes - metadata_bytes,
+                          std::memory_order_relaxed);
+    // For physical memory occupied by jemalloc itself, don’t calculate it as:
+    // tcache + dirty + muzzy + metadata
+    // That can be misleading and can double count or include memory that is not actually resident.
+    // For memory overview, the best calculation is based on jemalloc’s own resident total and allocated total:
+    // stats.allocated is application live allocation bytes already represented by Doris MemTrackers where allocations
+    // go through Doris Allocator.
+    // `stats.resident - stats.allocated` is the allocator-side resident delta: metadata, dirty reusable memory, tcache/cache effects,
+    // fragmentation/slack, and page-size rounding. That is the number we want for
+    // physical memory occupied by jemalloc itself beyond application live allocation.
+    je_internal_bytes_.store(resident_bytes - allocated_bytes, std::memory_order_relaxed);
     je_virtual_memory_used_.store(get_jemallctl_value<int64_t>("stats.mapped"),
                                   std::memory_order_relaxed);
 #else
@@ -132,7 +156,7 @@ void JemallocControl::je_decay_all_arena_dirty_pages() {
 
 void JemallocControl::je_thread_tcache_flush() {
     constexpr size_t TCACHE_LIMIT = (1ULL << 30); // 1G
-    if (je_tcache_mem() > TCACHE_LIMIT) {
+    if (je_tcache_bytes() > TCACHE_LIMIT) {
         action_jemallctl("thread.tcache.flush");
     }
 }

--- a/be/src/runtime/memory/jemalloc_control.h
+++ b/be/src/runtime/memory/jemalloc_control.h
@@ -47,7 +47,7 @@ public:
     template <typename T>
     static inline T get_jemallctl_value(const std::string& name) {
 #ifdef USE_JEMALLOC
-        T value;
+        T value = 0;
         size_t value_size = sizeof(T);
         if (jemallctl(name.c_str(), &value, &value_size, nullptr, 0) != 0) {
             LOG(WARNING) << fmt::format("Failed, jemallctl get {}", name);
@@ -94,17 +94,34 @@ public:
     // obtained by the process malloc, not the physical memory actually used by the process in the OS.
     static void refresh_allocator_mem();
 
-    static inline size_t je_cache_bytes() {
+    static inline int64_t je_resident_bytes() {
+        return je_resident_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_allocated_bytes() {
+        return je_allocated_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_active_bytes() {
+        return je_active_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_tcache_bytes() {
+        return je_tcache_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_metadata_bytes() {
+        return je_metadata_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_dirty_bytes() {
+        return je_dirty_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_muzzy_bytes() {
+        return je_muzzy_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_internal_bytes() {
+        return je_internal_bytes_.load(std::memory_order_relaxed);
+    }
+    static inline int64_t je_cache_bytes() {
         return je_cache_bytes_.load(std::memory_order_relaxed);
     }
-    static inline size_t je_tcache_mem() { return je_tcache_mem_.load(std::memory_order_relaxed); }
-    static inline size_t je_metadata_mem() {
-        return je_metadata_mem_.load(std::memory_order_relaxed);
-    }
-    static inline int64_t je_dirty_pages_mem() {
-        return je_dirty_pages_mem_.load(std::memory_order_relaxed);
-    }
-    static inline size_t je_virtual_memory_used() {
+    static inline int64_t je_virtual_memory_used() {
         return je_virtual_memory_used_.load(std::memory_order_relaxed);
     }
 
@@ -124,10 +141,16 @@ public:
     }
 
 private:
+    static std::atomic<int64_t> je_resident_bytes_;
+    static std::atomic<int64_t> je_allocated_bytes_;
+    static std::atomic<int64_t> je_active_bytes_;
+    static std::atomic<int64_t> je_tcache_bytes_;
+    static std::atomic<int64_t> je_metadata_bytes_;
+    static std::atomic<int64_t> je_dirty_bytes_;
+    static std::atomic<int64_t> je_muzzy_bytes_;
+
+    static std::atomic<int64_t> je_internal_bytes_;
     static std::atomic<int64_t> je_cache_bytes_;
-    static std::atomic<int64_t> je_tcache_mem_;
-    static std::atomic<int64_t> je_metadata_mem_;
-    static std::atomic<int64_t> je_dirty_pages_mem_;
     static std::atomic<int64_t> je_virtual_memory_used_;
 };
 

--- a/be/src/runtime/memory/memory_profile.cpp
+++ b/be/src/runtime/memory/memory_profile.cpp
@@ -104,8 +104,21 @@ void MemoryProfile::init_memory_overview_counter() {
             jemalloc_memory_profile->AddHighWaterMarkCounter("Memory", TUnit::BYTES);
     _jemalloc_cache_usage_counter =
             jemalloc_memory_details_profile->AddHighWaterMarkCounter("Cache", TUnit::BYTES);
+    // jemalloc details, refer to https://jemalloc.net/jemalloc.3.html
+    _jemalloc_resident_usage_counter =
+            jemalloc_memory_details_profile->AddHighWaterMarkCounter("Resident", TUnit::BYTES);
+    _jemalloc_allocated_usage_counter =
+            jemalloc_memory_details_profile->AddHighWaterMarkCounter("Allocated", TUnit::BYTES);
+    _jemalloc_active_usage_counter =
+            jemalloc_memory_details_profile->AddHighWaterMarkCounter("Active", TUnit::BYTES);
+    _jemalloc_tcache_usage_counter =
+            jemalloc_memory_details_profile->AddHighWaterMarkCounter("TCache", TUnit::BYTES);
     _jemalloc_metadata_usage_counter =
             jemalloc_memory_details_profile->AddHighWaterMarkCounter("Metadata", TUnit::BYTES);
+    _jemalloc_dirty_usage_counter =
+            jemalloc_memory_details_profile->AddHighWaterMarkCounter("Dirty", TUnit::BYTES);
+    _jemalloc_muzzy_usage_counter =
+            jemalloc_memory_details_profile->AddHighWaterMarkCounter("Muzzy", TUnit::BYTES);
 
     // 4 add global/metadata/cache/Jvm memory counter
     _global_usage_counter =
@@ -255,15 +268,18 @@ void MemoryProfile::refresh_memory_overview_profile() {
     memory_reserved_memory_bytes << GlobalMemoryArbitrator::process_reserved_memory() -
                                             memory_reserved_memory_bytes.get_value();
 
-    all_tracked_mem_sum += JemallocControl::je_cache_bytes();
-    COUNTER_SET(_jemalloc_cache_usage_counter,
-                static_cast<int64_t>(JemallocControl::je_cache_bytes()));
-    all_tracked_mem_sum += JemallocControl::je_metadata_mem();
-    COUNTER_SET(_jemalloc_metadata_usage_counter,
-                static_cast<int64_t>(JemallocControl::je_metadata_mem()));
-    COUNTER_SET(_jemalloc_memory_usage_counter,
-                _jemalloc_cache_usage_counter->current_value() +
-                        _jemalloc_metadata_usage_counter->current_value());
+    all_tracked_mem_sum += JemallocControl::je_internal_bytes();
+    COUNTER_SET(_jemalloc_memory_usage_counter, JemallocControl::je_internal_bytes());
+    COUNTER_SET(_jemalloc_cache_usage_counter, JemallocControl::je_cache_bytes());
+    // jemalloc details, refer to https://jemalloc.net/jemalloc.3.html
+    COUNTER_SET(_jemalloc_resident_usage_counter, JemallocControl::je_resident_bytes());
+    COUNTER_SET(_jemalloc_allocated_usage_counter, JemallocControl::je_allocated_bytes());
+    COUNTER_SET(_jemalloc_active_usage_counter, JemallocControl::je_active_bytes());
+    COUNTER_SET(_jemalloc_tcache_usage_counter, JemallocControl::je_tcache_bytes());
+    COUNTER_SET(_jemalloc_metadata_usage_counter, JemallocControl::je_metadata_bytes());
+    COUNTER_SET(_jemalloc_dirty_usage_counter, JemallocControl::je_dirty_bytes());
+    COUNTER_SET(_jemalloc_muzzy_usage_counter, JemallocControl::je_muzzy_bytes());
+
     int64_t jvm_heap_bytes = 0;
     int64_t jvm_non_heap_bytes = 0;
     // JvmMetrics only inited when enable_java_support == true, or it is nullptr

--- a/be/src/runtime/memory/memory_profile.h
+++ b/be/src/runtime/memory/memory_profile.h
@@ -85,9 +85,15 @@ private:
     RuntimeProfile::HighWaterMarkCounter* _tracked_memory_usage_counter;
 
     // Jemalloc memory counter
+    RuntimeProfile::HighWaterMarkCounter* _jemalloc_resident_usage_counter;
+    RuntimeProfile::HighWaterMarkCounter* _jemalloc_allocated_usage_counter;
+    RuntimeProfile::HighWaterMarkCounter* _jemalloc_active_usage_counter;
+    RuntimeProfile::HighWaterMarkCounter* _jemalloc_tcache_usage_counter;
+    RuntimeProfile::HighWaterMarkCounter* _jemalloc_metadata_usage_counter;
+    RuntimeProfile::HighWaterMarkCounter* _jemalloc_dirty_usage_counter;
+    RuntimeProfile::HighWaterMarkCounter* _jemalloc_muzzy_usage_counter;
     RuntimeProfile::HighWaterMarkCounter* _jemalloc_memory_usage_counter;
     RuntimeProfile::HighWaterMarkCounter* _jemalloc_cache_usage_counter;
-    RuntimeProfile::HighWaterMarkCounter* _jemalloc_metadata_usage_counter;
 
     // JVM memory counter
     RuntimeProfile::HighWaterMarkCounter* _jvm_heap_memory_usage_counter;

--- a/be/src/storage/index/bloom_filter/bloom_filter.h
+++ b/be/src/storage/index/bloom_filter/bloom_filter.h
@@ -27,6 +27,8 @@
 #include <memory>
 
 #include "common/status.h"
+#include "core/allocator.h"
+#include "core/allocator_fwd.h"
 #include "util/hash/murmur_hash3.h"
 
 namespace doris::segment_v2 {
@@ -89,7 +91,7 @@ public:
                 g_read_bloom_filter_num << -1;
             }
             g_total_bloom_filter_total_bytes << -static_cast<int64_t>(_size);
-            delete[] _data;
+            _allocator.free(_data, _size);
         }
         g_total_bloom_filter_num << -1;
     }
@@ -112,8 +114,8 @@ public:
         _num_bytes = filter_size;
         DCHECK((_num_bytes & (_num_bytes - 1)) == 0);
         _size = _num_bytes + 1;
-        // reserve last byte for null flag
-        _data = new char[_size];
+        DCHECK(_data == nullptr);
+        _data = reinterpret_cast<char*>(_allocator.alloc(_size));
         memset(_data, 0, _size);
         _has_null = (bool*)(_data + _num_bytes);
         *_has_null = false;
@@ -142,7 +144,8 @@ public:
         if (((size - 1) & (size - 2)) != 0) {
             return Status::InvalidArgument("size - 1 must be power of two");
         }
-        _data = new char[size];
+        DCHECK(_data == nullptr);
+        _data = reinterpret_cast<char*>(_allocator.alloc(size));
         memcpy(_data, buf, size);
         _size = size;
         _num_bytes = _size - 1;
@@ -239,6 +242,7 @@ protected:
     bool _is_write = false;
 
     std::function<void(const void*, const int64_t, const uint64_t, void*)> _hash_func;
+    Allocator<false> _allocator;
 };
 
 } // namespace doris::segment_v2

--- a/be/src/storage/index/bloom_filter/ngram_bloom_filter.h
+++ b/be/src/storage/index/bloom_filter/ngram_bloom_filter.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "core/custom_allocator.h"
 #include "storage/index/bloom_filter/bloom_filter.h"
 
 namespace doris {
@@ -58,7 +59,7 @@ private:
 #pragma clang diagnostic pop
 #endif
     size_t words = 0;
-    std::vector<uint64_t> filter;
+    DorisVector<uint64_t> filter;
 };
 
 } // namespace segment_v2

--- a/be/src/storage/metadata_adder.h
+++ b/be/src/storage/metadata_adder.h
@@ -123,6 +123,7 @@ public:
         return g_rowset_meta_mem_bytes.get_value() + g_rowset_mem_bytes.get_value();
     }
 
+#ifdef BE_TEST
     static int64_t get_all_segments_size() {
         return g_segment_mem_bytes.get_value() + g_column_reader_mem_bytes.get_value() +
                g_bloom_filter_index_reader_mem_bytes.get_value() +
@@ -132,6 +133,7 @@ public:
                g_ordinal_index_reader_mem_bytes.get_value() +
                g_zone_map_index_reader_mem_bytes.get_value();
     }
+#endif
 
     // Doris currently uses the estimated segments memory as the basis, maybe it is more realistic.
     static int64_t get_all_segments_estimate_size() {
@@ -153,7 +155,7 @@ protected:
         int64_t old_size = this->_current_meta_size;
         this->_current_meta_size = other._current_meta_size;
         int64_t size_diff = this->_current_meta_size - old_size;
-        add_mem_size(size_diff);
+        _add_mem_size(size_diff);
 
         return *this;
     }
@@ -162,56 +164,57 @@ protected:
         int64_t old_size = this->_current_meta_size;
         this->_current_meta_size = other._current_meta_size;
         int64_t size_diff = this->_current_meta_size - old_size;
-        add_mem_size(size_diff);
+        _add_mem_size(size_diff);
 
-        other.clear_memory();
+        other._clear_memory();
 
         return *this;
     }
 
-    void clear_memory();
-
+private:
     int64_t _current_meta_size {0};
 
-    void add_mem_size(int64_t val);
+    void _add_mem_size(int64_t val);
 
-    void add_num(int64_t val);
+    void _add_num(int64_t val);
+
+    void _clear_memory();
 };
 
 template <typename T>
 MetadataAdder<T>::MetadataAdder(const MetadataAdder<T>& other) {
     this->_current_meta_size = other._current_meta_size;
-    add_num(1);
-    add_mem_size(this->_current_meta_size);
+    _add_num(1);
+    _add_mem_size(this->_current_meta_size);
 }
 
 template <typename T>
 MetadataAdder<T>::MetadataAdder(MetadataAdder&& other) {
     this->_current_meta_size = other._current_meta_size;
-    add_num(1);
-    add_mem_size(this->_current_meta_size);
+    _add_num(1);
+    _add_mem_size(this->_current_meta_size);
 
-    other.clear_memory();
+    other._clear_memory();
 }
 
 template <typename T>
 MetadataAdder<T>::MetadataAdder() {
     this->_current_meta_size = sizeof(T);
-    add_mem_size(this->_current_meta_size);
-    add_num(1);
+    _add_mem_size(this->_current_meta_size);
+    _add_num(1);
 }
 
 template <typename T>
 MetadataAdder<T>::~MetadataAdder() {
-    add_mem_size(-_current_meta_size);
-    add_num(-1);
+    _add_mem_size(-_current_meta_size);
+    _add_num(-1);
 }
 
 template <typename T>
-void MetadataAdder<T>::clear_memory() {
+void MetadataAdder<T>::_clear_memory() {
     int64_t old_size = _current_meta_size;
     _current_meta_size = sizeof(T);
-    add_mem_size(_current_meta_size - old_size);
+    _add_mem_size(_current_meta_size - old_size);
 }
 
 template <typename T>
@@ -220,11 +223,11 @@ void MetadataAdder<T>::update_metadata_size() {
     _current_meta_size = get_metadata_size();
     int64_t size_diff = _current_meta_size - old_size;
 
-    add_mem_size(size_diff);
+    _add_mem_size(size_diff);
 }
 
 template <typename T>
-void MetadataAdder<T>::add_mem_size(int64_t val) {
+void MetadataAdder<T>::_add_mem_size(int64_t val) {
     if (val == 0) {
         return;
     }
@@ -257,13 +260,13 @@ void MetadataAdder<T>::add_mem_size(int64_t val) {
     } else if constexpr (std::is_same_v<T, segment_v2::ZoneMapIndexReader>) {
         g_zone_map_index_reader_mem_bytes << val;
     } else {
-        LOG(FATAL) << "add_mem_size not match class type: " << typeid(T).name() << ", " << val;
+        LOG(FATAL) << "_add_mem_size not match class type: " << typeid(T).name() << ", " << val;
         __builtin_unreachable();
     }
 }
 
 template <typename T>
-void MetadataAdder<T>::add_num(int64_t val) {
+void MetadataAdder<T>::_add_num(int64_t val) {
     if (val == 0) {
         return;
     }
@@ -296,7 +299,7 @@ void MetadataAdder<T>::add_num(int64_t val) {
     } else if constexpr (std::is_same_v<T, segment_v2::ZoneMapIndexReader>) {
         g_zone_map_index_reader_num << val;
     } else {
-        LOG(FATAL) << "add_num not match class type: " << typeid(T).name() << ", " << val;
+        LOG(FATAL) << "_add_num not match class type: " << typeid(T).name() << ", " << val;
         __builtin_unreachable();
     }
 }

--- a/be/src/storage/segment/segment.cpp
+++ b/be/src/storage/segment/segment.cpp
@@ -195,7 +195,7 @@ int64_t Segment::get_metadata_size() const {
            (footer_pb_shared ? footer_pb_shared->ByteSizeLong() : 0);
 }
 
-void Segment::update_metadata_size() {
+void Segment::_update_metadata_size() {
     MetadataAdder::update_metadata_size();
     g_segment_estimate_mem_bytes << _meta_mem_usage - _tracked_meta_mem_usage;
     _tracked_meta_mem_usage = _meta_mem_usage;
@@ -226,12 +226,11 @@ Status Segment::_open(OlapReaderStatistics* stats) {
                                 config::max_segment_partial_column_cache_size) *
                        config::estimated_mem_per_column_reader;
 
-    // 1024 comes from SegmentWriterOptions
-    _meta_mem_usage += (_num_rows + 1023) / 1024 * (36 + 4);
-    // 0.01 comes from PrimaryKeyIndexBuilder::init
-    _meta_mem_usage += BloomFilter::optimal_bit_num(_num_rows, 0.01) / 8;
-
-    update_metadata_size();
+    if (footer_pb_shared->has_short_key_index_page()) {
+        // 1024 comes from SegmentWriterOptions.
+        _meta_mem_usage += (_num_rows + 1023) / 1024 * (36 + 4);
+    }
+    _update_metadata_size();
 
     return Status::OK();
 }
@@ -488,7 +487,7 @@ Status Segment::_load_pk_bloom_filter(OlapReaderStatistics* stats) {
         // for BE UT "segment_cache_test"
         return _load_pk_bf_once.call([this] {
             _meta_mem_usage += 100;
-            update_metadata_size();
+            _update_metadata_size();
             return Status::OK();
         });
     }

--- a/be/src/storage/segment/segment.h
+++ b/be/src/storage/segment/segment.h
@@ -104,7 +104,6 @@ public:
     ~Segment() override;
 
     int64_t get_metadata_size() const override;
-    void update_metadata_size();
 
     Status new_iterator(SchemaSPtr schema, const StorageReadOptions& read_options,
                         std::unique_ptr<RowwiseIterator>* iter);
@@ -245,6 +244,8 @@ private:
                                        OlapReaderStatistics* stats);
 
     StoragePageCache::CacheKey get_segment_footer_cache_key() const;
+
+    void _update_metadata_size();
 
     friend class SegmentIterator;
     friend class ColumnReaderCache;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

BE memory overview could overstate tracked memory and report misleading
 jemalloc/segment memory details.

 The main issues were:
 1. Segment metadata accounting estimated primary-key BloomFilter bytes in `Segment::_open()`, even though BloomFilter buffers are now allocated
 through Doris `Allocator` and tracked by MemTracker. This could double
count PK BloomFilter memory.
 2. Segment metadata accounting estimated short-key index memory unconditionally, even when a segment footer has no short-key index page.
 3. Jemalloc “cache” memory was calculated from `tcache + dirty pages`, which misses allocator resident overhead such as fragmentation/slack and
 page rounding, and does not represent physical jemalloc overhead
accurately.
 4. BloomFilter buffers used raw allocation paths, so large BloomFilter memory could bypass Doris MemTracker accounting.

 This change improves memory accounting by:
 - Computing jemalloc internal resident overhead from `stats.resident - stats.allocated`, while exposing detailed jemalloc counters including resident, allocated, active, tcache, metadata, dirty, and muzzy bytes.
 - Removing PK BloomFilter bytes from Segment metadata estimation because the actual BloomFilter buffer is now allocator-tracked.
 - Counting short-key index estimate only when the footer has a short-key index page.
 - Refactoring BloomFilter buffer allocation to use Doris `Allocator`, and changing NGramBloomFilter storage to allocator-aware `DorisVector`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

