### PR TITLE
[fix](mtmv) Fix incorrect result of show mv when partition by date_trunc alias (#62910)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3798,7 +3798,8 @@ public class Env {
             return;
         }
         sb.append("\n").append("PARTITION BY (");
-        if (mvPartitionInfo.getPartitionType() == MTMVPartitionType.FOLLOW_BASE_TABLE) {
+        if (mvPartitionInfo.getPartitionType() == MTMVPartitionType.FOLLOW_BASE_TABLE
+                || !mvPartitionInfo.isUserSpecifiedExpr()) {
             sb.append("`" + mvPartitionInfo.getPartitionCol() + "`");
         } else {
             sb.append(MTMVPartitionExprFactory.getExprService(mvPartitionInfo.getExpr()).toSql(mvPartitionInfo));

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionInfo.java
@@ -63,6 +63,10 @@ public class MTMVPartitionInfo implements GsonPostProcessable {
     private Expr expr;
     @SerializedName("pi")
     private List<BaseColInfo> pctInfos = Lists.newArrayList();
+    // true when user explicitly wrote date_trunc(...) in PARTITION BY, false when inferred from column definition.
+    // Defaults to true for backward compatibility with existing persisted MVs.
+    @SerializedName("use")
+    private boolean userSpecifiedExpr = true;
 
     public MTMVPartitionInfo() {
         this.pctInfos = Lists.newArrayList();
@@ -134,6 +138,14 @@ public class MTMVPartitionInfo implements GsonPostProcessable {
 
     public void setExpr(Expr expr) {
         this.expr = expr;
+    }
+
+    public boolean isUserSpecifiedExpr() {
+        return userSpecifiedExpr;
+    }
+
+    public void setUserSpecifiedExpr(boolean userSpecifiedExpr) {
+        this.userSpecifiedExpr = userSpecifiedExpr;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/MTMVPartitionDefinition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/MTMVPartitionDefinition.java
@@ -132,6 +132,9 @@ public class MTMVPartitionDefinition {
                         .map(Pair::value)
                         .collect(Collectors.toList());
                 mtmvPartitionInfo.setExpr(new FunctionCallExpr(dateTrunc.getName(), params, false));
+                if (mtmvPartitionInfo.getPartitionType() != MTMVPartitionType.EXPR) {
+                    mtmvPartitionInfo.setUserSpecifiedExpr(false);
+                }
                 mtmvPartitionInfo.setPartitionType(MTMVPartitionType.EXPR);
                 this.partitionType = MTMVPartitionType.EXPR;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionInfoTest.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mtmv;
+
+import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
+
+import com.google.gson.Gson;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MTMVPartitionInfoTest {
+
+    @Test
+    public void testUserSpecifiedExprDefaultValue() {
+        // Test that userSpecifiedExpr defaults to true
+        MTMVPartitionInfo info = new MTMVPartitionInfo(MTMVPartitionType.EXPR);
+        Assert.assertTrue(info.isUserSpecifiedExpr());
+    }
+
+    @Test
+    public void testUserSpecifiedExprSetterGetter() {
+        MTMVPartitionInfo info = new MTMVPartitionInfo(MTMVPartitionType.EXPR);
+
+        // Test setting to false
+        info.setUserSpecifiedExpr(false);
+        Assert.assertFalse(info.isUserSpecifiedExpr());
+
+        // Test setting back to true
+        info.setUserSpecifiedExpr(true);
+        Assert.assertTrue(info.isUserSpecifiedExpr());
+    }
+
+    @Test
+    public void testUserSpecifiedExprSerialization() {
+        Gson gson = new Gson();
+
+        // Test serialization with userSpecifiedExpr = false
+        MTMVPartitionInfo info = new MTMVPartitionInfo(MTMVPartitionType.EXPR);
+        info.setPartitionCol("month_dt");
+        info.setUserSpecifiedExpr(false);
+
+        String json = gson.toJson(info);
+        Assert.assertTrue(json.contains("\"use\":false"));
+
+        // Test deserialization
+        MTMVPartitionInfo deserialized = gson.fromJson(json, MTMVPartitionInfo.class);
+        Assert.assertEquals(MTMVPartitionType.EXPR, deserialized.getPartitionType());
+        Assert.assertEquals("month_dt", deserialized.getPartitionCol());
+        Assert.assertFalse(deserialized.isUserSpecifiedExpr());
+    }
+
+    @Test
+    public void testUserSpecifiedExprBackwardCompatibility() {
+        Gson gson = new Gson();
+
+        // Simulate old persisted JSON without "use" field
+        String oldJson = "{\"pt\":\"EXPR\",\"pc\":\"month_dt\",\"pi\":[]}";
+
+        // Deserialize - should default to true for backward compatibility
+        MTMVPartitionInfo deserialized = gson.fromJson(oldJson, MTMVPartitionInfo.class);
+        Assert.assertEquals(MTMVPartitionType.EXPR, deserialized.getPartitionType());
+        Assert.assertEquals("month_dt", deserialized.getPartitionCol());
+        Assert.assertTrue(deserialized.isUserSpecifiedExpr());
+    }
+}

--- a/regression-test/suites/mtmv_p0/test_show_create_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_show_create_mtmv.groovy
@@ -144,6 +144,50 @@ suite("test_show_create_mtmv","mtmv") {
     logger.info("showCreateMTMVAgainResult: " + showCreateMTMVResultAgain.toString())
     assertEquals(showCreateMTMVResult.toString(), showCreateMTMVResultAgain.toString())
 
+    // Test case: PARTITION BY (col1) where col1 is date_trunc alias - should display bare column
+    sql """drop materialized view if exists ${mvName};"""
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD DEFERRED REFRESH AUTO ON MANUAL
+        partition by (month_dt)
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1'
+        )
+        AS select date_trunc(`k2`, 'month') as month_dt, k1 from ${tableName};
+    """
+    showCreateMTMVResult = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
+    logger.info("showCreateMTMVResult (bare column): " + showCreateMTMVResult.toString())
+    // Should display PARTITION BY (`month_dt`) not PARTITION BY (date_trunc(`month_dt`, 'month'))
+    assertTrue(showCreateMTMVResult.toString().contains("PARTITION BY (`month_dt`)"))
+    assertFalse(showCreateMTMVResult.toString().contains("PARTITION BY (date_trunc(`month_dt`, 'month'))"))
+
+    // Verify re-execution produces same result
+    sql """drop materialized view if exists ${mvName};"""
+    sql """
+            ${showCreateMTMVResult[0][1]}
+        """
+    showCreateMTMVResultAgain = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
+    logger.info("showCreateMTMVAgainResult (bare column): " + showCreateMTMVResultAgain.toString())
+    assertEquals(showCreateMTMVResult.toString(), showCreateMTMVResultAgain.toString())
+
+    // Test case: explicit date_trunc in PARTITION BY - should display with date_trunc
+    sql """drop materialized view if exists ${mvName};"""
+    sql """
+        CREATE MATERIALIZED VIEW ${mvName}
+        BUILD DEFERRED REFRESH AUTO ON MANUAL
+        partition by (date_trunc(month_dt, 'month'))
+        DISTRIBUTED BY RANDOM BUCKETS 2
+        PROPERTIES (
+        'replication_num' = '1'
+        )
+        AS select date_trunc(`k2`, 'month') as month_dt, k1 from ${tableName};
+    """
+    showCreateMTMVResult = sql """show CREATE MATERIALIZED VIEW ${mvName}"""
+    logger.info("showCreateMTMVResult (explicit date_trunc): " + showCreateMTMVResult.toString())
+    // Should display PARTITION BY (date_trunc(`month_dt`, 'month'))
+    assertTrue(showCreateMTMVResult.toString().contains("PARTITION BY (date_trunc(`month_dt`, 'month'))"))
+
     sql """drop table if exists `${tableName}`"""
     sql """drop materialized view if exists ${mvName};"""
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62910

Related PR: #xxx

Problem Summary:

The result returned by show create materialized view is inconsistent with the initial creation statement.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

