### PR TITLE
[refine](datatype)replace manual memcpy with unaligned_load for unaligned memory reads

### DIFF
--- a/be/src/core/data_type_serde/data_type_array_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_array_serde.cpp
@@ -327,17 +327,14 @@ Status DataTypeArraySerDe::read_column_from_arrow(IColumn& column, const arrow::
     auto prev_size = offsets_data.back();
     const auto* base_offsets_ptr = reinterpret_cast<const uint8_t*>(arrow_offsets->raw_values());
     const size_t offset_element_size = sizeof(int32_t);
-    int32_t arrow_nested_start_offset = 0;
-    int32_t arrow_nested_end_offset = 0;
     const uint8_t* start_offset_ptr = base_offsets_ptr + start * offset_element_size;
     const uint8_t* end_offset_ptr = base_offsets_ptr + end * offset_element_size;
-    memcpy(&arrow_nested_start_offset, start_offset_ptr, offset_element_size);
-    memcpy(&arrow_nested_end_offset, end_offset_ptr, offset_element_size);
+    auto arrow_nested_start_offset = unaligned_load<int32_t>(start_offset_ptr);
+    auto arrow_nested_end_offset = unaligned_load<int32_t>(end_offset_ptr);
 
     for (auto i = start + 1; i < end + 1; ++i) {
-        int32_t current_offset = 0;
         const uint8_t* current_offset_ptr = base_offsets_ptr + i * offset_element_size;
-        memcpy(&current_offset, current_offset_ptr, offset_element_size);
+        auto current_offset = unaligned_load<int32_t>(current_offset_ptr);
         // convert to doris offset, start from offsets.back()
         offsets_data.emplace_back(prev_size + current_offset - arrow_nested_start_offset);
     }

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
@@ -422,9 +422,8 @@ Status DataTypeDateTimeV2SerDe::read_column_from_arrow(IColumn& column,
         const auto* base_ptr = reinterpret_cast<const uint8_t*>(concrete_array->raw_values());
         const size_t element_size = sizeof(int64_t);
         for (auto value_i = start; value_i < end; ++value_i) {
-            int64_t date_value = 0;
             const uint8_t* raw_byte_ptr = base_ptr + value_i * element_size;
-            memcpy(&date_value, raw_byte_ptr, element_size);
+            auto date_value = unaligned_load<int64_t>(raw_byte_ptr);
             auto utc_epoch = static_cast<UInt64>(date_value);
 
             DateV2Value<DateTimeV2ValueType> v;

--- a/be/src/core/data_type_serde/data_type_datev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.cpp
@@ -115,9 +115,8 @@ Status DataTypeDateV2SerDe::read_column_from_arrow(IColumn& column, const arrow:
     const auto* base_ptr = reinterpret_cast<const uint8_t*>(concrete_array->raw_values());
     const size_t element_size = sizeof(int32_t);
     for (auto value_i = start; value_i < end; ++value_i) {
-        int32_t date_value = 0;
         const uint8_t* raw_byte_ptr = base_ptr + value_i * element_size;
-        memcpy(&date_value, raw_byte_ptr, element_size);
+        auto date_value = unaligned_load<int32_t>(raw_byte_ptr);
 
         DateV2Value<DateV2ValueType> v;
         v.get_date_from_daynr(date_value + date_threshold);

--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -341,8 +341,7 @@ Status DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
         const auto arrow_scale = arrow_decimal_type->scale();
         // TODO check precision
         for (auto value_i = start; value_i < end; ++value_i) {
-            Decimal128V2 value {};
-            memcpy(&value, concrete_array->Value(value_i), sizeof(Decimal128V2));
+            auto value = unaligned_load<Decimal128V2>(concrete_array->Value(value_i));
             // convert scale to 9;
             if (9 > arrow_scale) {
                 using MaxNativeType = typename Decimal128V2::NativeType;
@@ -366,15 +365,13 @@ Status DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
         const auto* concrete_array = dynamic_cast<const arrow::DecimalArray*>(arrow_array);
         for (auto value_i = start; value_i < end; ++value_i) {
             const auto* value = concrete_array->Value(value_i);
-            FieldType decimal_value = FieldType {};
-            memcpy(&decimal_value, value, sizeof(FieldType));
+            auto decimal_value = unaligned_load<FieldType>(value);
             column_data.emplace_back(decimal_value);
         }
     } else if constexpr (T == TYPE_DECIMAL256) {
         const auto* concrete_array = dynamic_cast<const arrow::Decimal256Array*>(arrow_array);
         for (auto value_i = start; value_i < end; ++value_i) {
-            FieldType decimal_value {};
-            memcpy(&decimal_value, concrete_array->Value(value_i), sizeof(FieldType));
+            auto decimal_value = unaligned_load<FieldType>(concrete_array->Value(value_i));
             column_data.emplace_back(decimal_value);
         }
     } else {
@@ -750,14 +747,11 @@ const uint8_t* DataTypeDecimalSerDe<T>::deserialize_binary_to_field(const uint8_
     } else if constexpr (T == TYPE_DECIMAL128I) {
         // Because __int128 in memory is not aligned, but GCC7 will generate SSE instruction
         // for __int128 load/store. This will cause segment fault.
-        PackedInt128 pack;
-        // use memcpy to avoid unaligned access
-        memcpy(&pack, data, sizeof(PackedInt128));
+        auto pack = unaligned_load<PackedInt128>(data);
         field = Field::create_field<TYPE_DECIMAL128I>(Decimal128V3(pack.value));
         data += sizeof(PackedInt128);
     } else if constexpr (T == TYPE_DECIMAL256) {
-        wide::Int256 v;
-        memcpy(&v, data, sizeof(wide::Int256));
+        auto v = unaligned_load<wide::Int256>(data);
         field = Field::create_field<TYPE_DECIMAL256>(Decimal256(v));
         data += sizeof(wide::Int256);
     } else {

--- a/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
@@ -132,10 +132,8 @@ Status DataTypeJsonbSerDe::read_column_from_arrow(IColumn& column, const arrow::
         JsonBinaryValue value;
         for (auto offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
-                int32_t start_offset = 0;
-                int32_t end_offset = 0;
-                memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
-                memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
+                auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
+                auto end_offset = unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
 
                 int32_t length = end_offset - start_offset;
                 const auto* raw_data = buffer->data() + start_offset;

--- a/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_jsonb_serde.cpp
@@ -133,7 +133,8 @@ Status DataTypeJsonbSerDe::read_column_from_arrow(IColumn& column, const arrow::
         for (auto offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
                 auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
-                auto end_offset = unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
+                auto end_offset =
+                        unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
 
                 int32_t length = end_offset - start_offset;
                 const auto* raw_data = buffer->data() + start_offset;

--- a/be/src/core/data_type_serde/data_type_map_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_map_serde.cpp
@@ -395,16 +395,13 @@ Status DataTypeMapSerDe::read_column_from_arrow(IColumn& column, const arrow::Ar
 
     const auto* base_offsets_ptr = reinterpret_cast<const uint8_t*>(arrow_offsets->raw_values());
     const size_t offset_element_size = sizeof(int32_t);
-    int32_t arrow_nested_start_offset = 0;
-    int32_t arrow_nested_end_offset = 0;
     const uint8_t* start_offset_ptr = base_offsets_ptr + start * offset_element_size;
     const uint8_t* end_offset_ptr = base_offsets_ptr + end * offset_element_size;
-    memcpy(&arrow_nested_start_offset, start_offset_ptr, offset_element_size);
-    memcpy(&arrow_nested_end_offset, end_offset_ptr, offset_element_size);
+    auto arrow_nested_start_offset = unaligned_load<int32_t>(start_offset_ptr);
+    auto arrow_nested_end_offset = unaligned_load<int32_t>(end_offset_ptr);
     for (int64_t i = start + 1; i < end + 1; ++i) {
-        int32_t current_offset = 0;
         const uint8_t* current_offset_ptr = base_offsets_ptr + i * offset_element_size;
-        memcpy(&current_offset, current_offset_ptr, offset_element_size);
+        auto current_offset = unaligned_load<int32_t>(current_offset_ptr);
         // convert to doris offset, start from offsets.back()
         offsets_data.emplace_back(prev_size + current_offset - arrow_nested_start_offset);
     }

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -255,10 +255,8 @@ Status DataTypeNumberSerDe<T>::read_column_from_arrow(IColumn& column,
         const size_t offset_size = sizeof(int32_t);
         for (size_t offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
-                int32_t start_offset = 0;
-                int32_t end_offset = 0;
-                memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
-                memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
+                auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
+                auto end_offset = unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
 
                 const auto* raw_data = buffer->data() + start_offset;
                 const auto raw_data_len = end_offset - start_offset;
@@ -981,8 +979,7 @@ const uint8_t* DataTypeNumberSerDe<T>::deserialize_binary_to_field(const uint8_t
         field = Field::create_field<TYPE_BIGINT>(v);
         data += sizeof(Int64);
     } else if constexpr (T == TYPE_LARGEINT) {
-        PackedInt128 pack;
-        memcpy(&pack, data, sizeof(PackedInt128));
+        auto pack = unaligned_load<PackedInt128>(data);
         field = Field::create_field<TYPE_LARGEINT>(Int128(pack.value));
         data += sizeof(PackedInt128);
     } else if constexpr (T == TYPE_FLOAT) {
@@ -998,8 +995,7 @@ const uint8_t* DataTypeNumberSerDe<T>::deserialize_binary_to_field(const uint8_t
         field = Field::create_field<TYPE_IPV4>(v);
         data += sizeof(IPv4);
     } else if constexpr (T == TYPE_IPV6) {
-        PackedUInt128 pack;
-        memcpy(&pack, data, sizeof(PackedUInt128));
+        auto pack = unaligned_load<PackedUInt128>(data);
         auto v = pack.value;
         field = Field::create_field<TYPE_IPV6>(v);
         data += sizeof(PackedUInt128);

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -256,7 +256,8 @@ Status DataTypeNumberSerDe<T>::read_column_from_arrow(IColumn& column,
         for (size_t offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
                 auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
-                auto end_offset = unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
+                auto end_offset =
+                        unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
 
                 const auto* raw_data = buffer->data() + start_offset;
                 const auto raw_data_len = end_offset - start_offset;

--- a/be/src/core/data_type_serde/data_type_string_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_string_serde.cpp
@@ -267,7 +267,8 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
         for (auto offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
                 auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
-                auto end_offset = unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
+                auto end_offset =
+                        unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
 
                 int32_t length = end_offset - start_offset;
                 const auto* raw_data = buffer->data() + start_offset;

--- a/be/src/core/data_type_serde/data_type_string_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_string_serde.cpp
@@ -266,10 +266,8 @@ Status DataTypeStringSerDeBase<ColumnType>::read_column_from_arrow(
 
         for (auto offset_i = start; offset_i < end; ++offset_i) {
             if (!concrete_array->IsNull(offset_i)) {
-                int32_t start_offset = 0;
-                int32_t end_offset = 0;
-                memcpy(&start_offset, offsets_data + offset_i * offset_size, offset_size);
-                memcpy(&end_offset, offsets_data + (offset_i + 1) * offset_size, offset_size);
+                auto start_offset = unaligned_load<int32_t>(offsets_data + offset_i * offset_size);
+                auto end_offset = unaligned_load<int32_t>(offsets_data + (offset_i + 1) * offset_size);
 
                 int32_t length = end_offset - start_offset;
                 const auto* raw_data = buffer->data() + start_offset;

--- a/be/src/core/packed_int128.h
+++ b/be/src/core/packed_int128.h
@@ -26,6 +26,7 @@ namespace doris {
 struct PackedInt128 {
     // PackedInt128() : value(0) {}
     PackedInt128() = default;
+    PackedInt128(const PackedInt128&) = default;
 
     PackedInt128(const __int128& value_) { value = value_; }
     PackedInt128& operator=(const __int128& value_) {
@@ -39,6 +40,7 @@ struct PackedInt128 {
 
 struct PackedUInt128 {
     PackedUInt128() = default;
+    PackedUInt128(const PackedUInt128&) = default;
 
     PackedUInt128(const unsigned __int128& value_) { value = value_; }
     PackedUInt128& operator=(const unsigned __int128& value_) {

--- a/be/src/util/unaligned.h
+++ b/be/src/util/unaligned.h
@@ -27,6 +27,7 @@ namespace doris {
 
 template <typename T>
 T unaligned_load(const void* address) {
+    static_assert(std::is_trivially_copyable_v<T>);
     T res {};
     memcpy(&res, address, sizeof(res));
     return res;


### PR DESCRIPTION
                          
  What problem does this PR solve?                                                                      
                                                                  
  Problem Summary:                                                                                      
                                                                  
  Data type serde code contains many manual memcpy calls that read scalar values (offsets, decimals,    
  timestamps, serialized fields) from potentially unaligned memory addresses (Arrow buffers, binary
  deserialization streams). These are functionally correct but obscure the intent. The codebase already 
  provides unaligned_load<T>() in util/unaligned.h which wraps the same memcpy with a clear typed
  interface.

  This change replaces all such manual memcpy(&local_var, ptr, sizeof(T)) patterns with auto local_var =
   unaligned_load<T>(ptr), making the unaligned-read semantics explicit and reducing boilerplate.
                                                                                                        
  Additionally:                                                                                         
  - unaligned_load now has static_assert(std::is_trivially_copyable_v<T>) matching the existing
  unaligned_store.                                                                                      
  - PackedInt128 / PackedUInt128 were missing explicit copy constructors, which caused a C++20
  -Wdeprecated-copy error (promoted to -Werror) when unaligned_load returned by value.                  
                  
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

