### PR TITLE
[fix](cloud) isolate peer fetch from load heavy pool

### DIFF
--- a/be/src/cloud/config.h
+++ b/be/src/cloud/config.h
@@ -215,4 +215,7 @@ DECLARE_mBool(enable_file_cache_write_base_compaction_index_only);
 // Cumulative compaction output: only write index files to file cache, not data files
 DECLARE_mBool(enable_file_cache_write_cumu_compaction_index_only);
 
+// Reject queued peer fetch tasks that wait too long in the peer fetch pool.
+DECLARE_mInt32(peer_fetch_queue_timeout_ms);
+
 } // namespace doris::config


### PR DESCRIPTION
fetch_peer_data RPC previously shared _heavy_work_pool with the load path, so peer cache fetches starved imports when peer-read qps spiked. Move it to a dedicated _peer_fetch_pool, add per-block fail-fast dedup to reject cross-BE fan-in collisions, and an enqueue-age guard so overloaded peer fetch tasks fall back to S3 instead of blocking the new pool.

New config:

brpc_peer_fetch_pool_threads / _max_queue_size (static) peer_fetch_queue_timeout_ms (mutable, default 500ms) New bvars:

peer_fetch_work_pool_queue_size / _active_threads / _pool_max_queue_size / _max_threads file_cache_get_by_peer_duplicate_inflight_num
file_cache_get_by_peer_queue_timeout_num
Tests:

UT: 4 TEST_F in cached_remote_file_reader_peer_test.cpp covering dedup hit/miss and queue timeout hit/miss paths
Docker: test_peer_fetch_pool_isolation (metrics smoke + dynamic config + queue timeout trigger) and test_peer_fetch_dedup (cross-CG fan-in with CG-B + CG-C readers) under regression-test/suites/cloud_p0/balance

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

