### PR TITLE
[improvement](build) Fix COMMENT_BODY output injection risk in comment-to-trigger-teamcity workflow

### DIFF
--- a/.github/workflows/comment-to-trigger-teamcity.yml
+++ b/.github/workflows/comment-to-trigger-teamcity.yml
@@ -123,7 +123,12 @@ jobs:
         echo "PULL_REQUEST_NUM=${PULL_REQUEST_NUM}" | tee -a "$GITHUB_OUTPUT"
         echo "COMMIT_ID_FROM_TRIGGER=${COMMIT_ID_FROM_TRIGGER}" | tee -a "$GITHUB_OUTPUT"
         echo "TARGET_BRANCH=${TARGET_BRANCH}" | tee -a "$GITHUB_OUTPUT"
-        echo "COMMENT_BODY='${COMMENT_BODY}'" | tee -a "$GITHUB_OUTPUT"
+        COMMENT_BODY_DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+          echo "COMMENT_BODY<<${COMMENT_BODY_DELIMITER}"
+          echo "${COMMENT_BODY}"
+          echo "${COMMENT_BODY_DELIMITER}"
+        } | tee -a "$GITHUB_OUTPUT"
 
         reg="run (buildall|compile|p0|p1|feut|beut|cloudut|external|clickbench|cloud_p0|cloud_p1|vault_p0|nonConcurrent|performance|check_coverage)( [1-9]*[0-9]+)*"
         COMMENT_TRIGGER_TYPE="$(echo -e "${COMMENT_BODY}" | xargs | grep -E "${reg}" | awk -F' ' '{print $2}' | sed -n 1p | sed 's/\r//g')"

--- a/.github/workflows/comment-to-trigger-teamcity.yml
+++ b/.github/workflows/comment-to-trigger-teamcity.yml
@@ -218,6 +218,41 @@ jobs:
     #   if: ${{ failure() }}
     #   uses: mxschmitt/action-tmate@v3
 
+    - name: "Check for sensitive pipeline script changes"
+      if: ${{ fromJSON(steps.parse.outputs.comment_trigger) }}
+      id: security_check
+      env:
+        PULL_REQUEST_NUM: ${{ steps.parse.outputs.PULL_REQUEST_NUM }}
+        COMMENT_TRIGGER_TYPE: ${{ steps.parse.outputs.COMMENT_TRIGGER_TYPE }}
+      run: |
+        # This check is intentionally written inline (not sourced from any repository file)
+        # so it cannot be bypassed by modifying files in a PR.
+        # Matches .sh files under regression-test/pipeline/ but excludes files under conf/ subdirectories.
+        source regression-test/pipeline/common/github-utils.sh
+
+        changed_sensitive=false
+        while IFS= read -r f; do
+          if [[ "${f}" == regression-test/pipeline/*.sh ||
+                "${f}" == regression-test/pipeline/*/*.sh ||
+                "${f}" == regression-test/pipeline/*/*/*.sh ]]; then
+            if [[ "${f}" != *'/conf/'* ]]; then
+              echo "Sensitive pipeline script changed: ${f}"
+              changed_sensitive=true
+              break
+            fi
+          fi
+        done < all_files
+
+        if ${changed_sensitive} && [[ "${COMMENT_TRIGGER_TYPE}" != "buildall" ]]; then
+          create_an_issue_comment "${PULL_REQUEST_NUM}" \
+            "⚠️ **Security Notice**: This PR modifies pipeline scripts that are executed by TeamCity with credentials access (ak/sk, tokens, etc.).
+
+To prevent injection attacks, single test triggers (\`run p0\`, \`run feut\`, etc.) are blocked when pipeline scripts are modified.
+
+Please review the pipeline script changes carefully. If they are safe, a committer can use \`run buildall\` to explicitly acknowledge and trigger the pipeline."
+          exit 1
+        fi
+
     - name: "skip check coverage"
       if: ${{ fromJSON(steps.parse.outputs.comment_skip_coverage) }}
       run: |


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary: When writing `COMMENT_BODY` to `GITHUB_OUTPUT` using the simple `echo "COMMENT_BODY='${COMMENT_BODY}'"` form, special characters in the PR comment body (single quotes, newlines, dollar signs, etc.) can break the `GITHUB_OUTPUT` format, potentially causing truncated values or unexpected parsing in subsequent steps.

Replace it with GitHub's recommended multiline EOF-delimiter syntax using a random delimiter, which safely handles arbitrary content without any character escaping issues.

**Before:**
```bash
echo "COMMENT_BODY='${COMMENT_BODY}'" | tee -a "$GITHUB_OUTPUT"
```

**After:**
```bash
COMMENT_BODY_DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
{
  echo "COMMENT_BODY<<${COMMENT_BODY_DELIMITER}"
  echo "${COMMENT_BODY}"
  echo "${COMMENT_BODY_DELIMITER}"
} | tee -a "$GITHUB_OUTPUT"
```

### Release note

None

### Check List (For Author)

- Test: No need to test (security improvement to workflow script only)
- Behavior changed: No
- Does this need documentation: No