### PR TITLE
[Fix](version) Fix unknown doris version when build in git worktree directory

### DIFF
--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -67,7 +67,7 @@ fi
 
 cd "${DORIS_HOME}"
 
-if [[ -d '.git' ]]; then
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     revision="$(git log -1 --pretty=format:"%H")"
     short_revision="$(git log -1 --pretty=format:"%h")"
     url="git://${hostname}"


### PR DESCRIPTION
In worktree dir, `.git` is not a directory but a file.
before:
```
Version: doris-0.0.0-Unknown
```

now:
```
Version: doris-0.0.0-1f18be0330e
```
