### PR TITLE
[fix](streaming-job) recompute derived fields after replay and ALTER

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -297,19 +297,33 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         try {
             this.jobProperties = new StreamingJobProperties(properties);
             jobProperties.validate();
-            this.sampleWindowMs = jobProperties.getMaxIntervalSecond() * 10 * 1000;
             resolveCloudCluster();
             // build time definition
             JobExecutionConfiguration execConfig = getJobConfig();
             TimerDefinition timerDefinition = new TimerDefinition();
-            timerDefinition.setInterval(jobProperties.getMaxIntervalSecond());
             timerDefinition.setIntervalUnit(IntervalUnit.SECOND);
             timerDefinition.setStartTimeMs(execConfig.getTimerDefinition().getStartTimeMs());
             execConfig.setTimerDefinition(timerDefinition);
+            recomputeDerivedFields();
         } catch (AnalysisException ae) {
             log.warn("parse streaming insert job failed, props: {}", properties, ae);
             throw new RuntimeException(ae.getMessage());
         }
+    }
+
+    private void recomputeDerivedFields() {
+        if (jobProperties == null) {
+            return;
+        }
+        long maxIntervalSec = jobProperties.getMaxIntervalSecond();
+        this.sampleWindowMs = maxIntervalSec * 10 * 1000;
+        JobExecutionConfiguration execConfig = getJobConfig();
+        if (execConfig != null && execConfig.getTimerDefinition() != null) {
+            execConfig.getTimerDefinition().setInterval(maxIntervalSec);
+        }
+        this.sampleStartTime = System.currentTimeMillis();
+        this.sampleWindowScannedRows = 0L;
+        this.sampleWindowFilteredRows = 0L;
     }
 
     private void resolveCloudCluster() throws AnalysisException {
@@ -938,6 +952,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         }
         this.properties.putAll(inputProperties);
         this.jobProperties = new StreamingJobProperties(this.properties);
+        recomputeDerivedFields();
     }
 
     private void resetCloudProgress(Offset offset) throws JobException {
@@ -1317,6 +1332,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         if (jobProperties == null && properties != null) {
             jobProperties = new StreamingJobProperties(properties);
         }
+        recomputeDerivedFields();
 
         if (null == getSucceedTaskCount()) {
             setSucceedTaskCount(new AtomicLong(0));

--- a/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobCheckDataQualityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobCheckDataQualityTest.java
@@ -18,6 +18,8 @@
 package org.apache.doris.job.extensions.insert.streaming;
 
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.job.base.JobExecutionConfiguration;
+import org.apache.doris.job.base.TimerDefinition;
 import org.apache.doris.job.cdc.request.CommitOffsetRequest;
 import org.apache.doris.job.common.JobStatus;
 import org.apache.doris.job.exception.JobException;
@@ -142,6 +144,58 @@ public class StreamingInsertJobCheckDataQualityTest {
         Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowScannedRows"));
         Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowFilteredRows"));
         Assert.assertTrue((long) Deencapsulation.getField(job, "sampleStartTime") > oldStartTime);
+    }
+
+    private static StreamingInsertJob jobWithProperties(String maxIntervalSec) {
+        StreamingInsertJob job = Deencapsulation.newInstance(StreamingInsertJob.class);
+        Map<String, String> props = new HashMap<>();
+        props.put(StreamingJobProperties.MAX_INTERVAL_SECOND_PROPERTY, maxIntervalSec);
+        Deencapsulation.setField(job, "properties", props);
+        Deencapsulation.setField(job, "jobProperties", new StreamingJobProperties(props));
+
+        JobExecutionConfiguration cfg = new JobExecutionConfiguration();
+        cfg.setTimerDefinition(new TimerDefinition());
+        Deencapsulation.setField(job, "jobConfig", cfg);
+        return job;
+    }
+
+    @Test
+    public void testRecomputeDerivedFieldsRebuildsSampleWindowMs() throws Exception {
+        StreamingInsertJob job = jobWithProperties("10");
+        Deencapsulation.setField(job, "sampleWindowMs", 0L);
+        Deencapsulation.setField(job, "sampleStartTime", 0L);
+
+        Deencapsulation.invoke(job, "recomputeDerivedFields");
+
+        Assert.assertEquals(100_000L, (long) Deencapsulation.getField(job, "sampleWindowMs"));
+        Assert.assertTrue((long) Deencapsulation.getField(job, "sampleStartTime") > 0L);
+    }
+
+    @Test
+    public void testModifyPropertiesInternalRefreshesDerivedFields() throws Exception {
+        StreamingInsertJob job = jobWithProperties("10");
+        JobExecutionConfiguration cfg = (JobExecutionConfiguration) Deencapsulation.getField(job, "jobConfig");
+        cfg.getTimerDefinition().setInterval(10L);
+        Deencapsulation.setField(job, "sampleWindowMs", 100_000L);
+
+        Map<String, String> alter = new HashMap<>();
+        alter.put(StreamingJobProperties.MAX_INTERVAL_SECOND_PROPERTY, "30");
+        Deencapsulation.invoke(job, "modifyPropertiesInternal", alter);
+
+        Assert.assertEquals(300_000L, (long) Deencapsulation.getField(job, "sampleWindowMs"));
+        Assert.assertEquals(30L, cfg.getTimerDefinition().getInterval().longValue());
+    }
+
+    @Test
+    public void testRecomputeDerivedFieldsResetsSampleCounters() throws Exception {
+        StreamingInsertJob job = jobWithProperties("10");
+        Deencapsulation.setField(job, "sampleWindowScannedRows", 1000L);
+        Deencapsulation.setField(job, "sampleWindowFilteredRows", 100L);
+
+        Deencapsulation.invoke(job, "recomputeDerivedFields");
+
+        Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowScannedRows"));
+        Assert.assertEquals(0L, (long) Deencapsulation.getField(job, "sampleWindowFilteredRows"));
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`StreamingInsertJob` initializes two derived fields from `jobProperties.max_interval` in `init()`:
- `sampleWindowMs` = `max_interval * 10 * 1000` — used by `checkDataQuality()` for the `load.max_filter_ratio` time window
- `jobConfig.timerDefinition.interval` = `max_interval` — used by `JobScheduler` to compute next trigger time

Neither is persisted in the gson image, and neither is refreshed in two paths:

1. **gson replay (`gsonPostProcess`)**: after FE checkpoint restart, `sampleWindowMs` stays at default `0`. The time-window check `(now - sampleStartTime) > sampleWindowMs` is then always true, so the sample window expires on every commit. The window-accumulation contract used by `load.max_filter_ratio` degrades to single-batch judgment, and a job recovered from image can be wrongly paused on a small bad batch that should be diluted by the surrounding window.

2. **ALTER PROPERTIES (`modifyPropertiesInternal`)**: changing `max_interval` only updates `properties` and `jobProperties`. Neither `sampleWindowMs` nor `timerDefinition.interval` is refreshed. The scheduler keeps reading the old interval (the new value never reaches `JobExecutionConfiguration.getTriggerDelayTimes`), so ALTER `max_interval` never takes effect — not even after FE restart, since image carries the stale `interval` too.

### Fix

Extract a single `recomputeDerivedFields()` that re-derives all transient state from `jobProperties`:
- `sampleWindowMs = maxIntervalSec * 10 * 1000`
- `timerDefinition.interval = maxIntervalSec`
- reset `sampleStartTime` / `sampleWindowScannedRows` / `sampleWindowFilteredRows`

Call it at every entry point where `jobProperties` is rebuilt:
- `init()` (job creation)
- `gsonPostProcess()` (image replay)
- `modifyPropertiesInternal()` (ALTER PROPERTIES)

Resetting the sample counters on ALTER is intentional: changing `max_interval` redefines the window itself, so accumulated counts from the old window have no meaningful interpretation in the new one.

### Release note

Fix streaming insert job sample window and scheduler interval not being restored after FE checkpoint replay or ALTER PROPERTIES.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. (1) Streaming jobs recovered from FE image no longer wrongly pause on the first bad batch under `load.max_filter_ratio`. (2) ALTER `max_interval` now takes effect on the scheduler within the next batch tick (~10 minutes); previously it was silently ignored.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document