### PR TITLE
[feat](cloud) cross compute group peer read routing with peer cache I/O optimization

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -300,10 +300,16 @@ Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
         LOG(INFO) << "set config cloud_unique_id " << master_info.cloud_unique_id << " " << st;
     }
 
-    if (master_info.__isset.cloud_cluster_info &&
-        master_info.cloud_cluster_info.__isset.isStandby) {
+    if (master_info.__isset.cloud_cluster_info) {
         auto* cloud_cluster_info = static_cast<CloudClusterInfo*>(_cluster_info);
-        cloud_cluster_info->set_is_in_standby(master_info.cloud_cluster_info.isStandby);
+        if (master_info.cloud_cluster_info.__isset.isStandby) {
+            cloud_cluster_info->set_is_in_standby(master_info.cloud_cluster_info.isStandby);
+        }
+        if (master_info.cloud_cluster_info.__isset.cloud_compute_group_id &&
+            !master_info.cloud_cluster_info.cloud_compute_group_id.empty()) {
+            cloud_cluster_info->set_cloud_compute_group_id(
+                    master_info.cloud_cluster_info.cloud_compute_group_id);
+        }
     }
 
     if (master_info.__isset.tablet_report_inactive_duration_ms) {

--- a/be/src/cloud/cloud_cluster_info.h
+++ b/be/src/cloud/cloud_cluster_info.h
@@ -85,12 +85,15 @@ public:
     // Check if this cluster should skip compaction for the given tablet
     // Returns true if should skip (i.e., another cluster should do the compaction)
     bool should_skip_compaction(CloudTablet* tablet) const;
+    const std::string& cloud_compute_group_id() const { return _cloud_compute_group_id; }
+    void set_cloud_compute_group_id(const std::string& id) { _cloud_compute_group_id = id; }
 
 private:
     void _bg_worker_func();
     void _refresh_cluster_status();
 
     bool _is_in_standby = false;
+    std::string _cloud_compute_group_id;
 
     mutable std::shared_mutex _mutex;
     std::string _my_cluster_id;

--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -293,6 +293,12 @@ bool CloudStorageEngine::stopped() {
     return _stopped;
 }
 
+#ifdef BE_TEST
+void CloudStorageEngine::set_cloud_warm_up_manager(std::unique_ptr<CloudWarmUpManager> manager) {
+    _cloud_warm_up_manager = std::move(manager);
+}
+#endif
+
 Result<BaseTabletSPtr> CloudStorageEngine::get_tablet(int64_t tablet_id,
                                                       SyncRowsetStats* sync_stats,
                                                       bool force_use_only_cached,

--- a/be/src/cloud/cloud_storage_engine.h
+++ b/be/src/cloud/cloud_storage_engine.h
@@ -193,6 +193,8 @@ public:
     void set_startup_timepoint(const std::chrono::time_point<std::chrono::system_clock>& tp) {
         _startup_timepoint = tp;
     }
+
+    void set_cloud_warm_up_manager(std::unique_ptr<CloudWarmUpManager> manager);
 #endif
 
 private:

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -396,6 +396,7 @@ void CloudTablet::add_rowsets(std::vector<RowsetSharedPtr> to_add, bool version_
 
     VLOG_DEBUG << "add_rowsets tablet_id=" << tablet_id() << " stack: " << get_stack_trace();
 
+
     if (!version_overlap) {
         _add_rowsets_directly(to_add, warmup_delta_data);
         return;

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1075,6 +1075,9 @@ DEFINE_String(tmp_file_dir, "tmp");
 DEFINE_Int32(min_s3_file_system_thread_num, "16");
 DEFINE_Int32(max_s3_file_system_thread_num, "64");
 
+DEFINE_Int32(min_peer_race_s3_thread_num, "0");
+DEFINE_Int32(max_peer_race_s3_thread_num, "64"); // aligned with default max_concurrent_peer_races
+
 DEFINE_Bool(enable_time_lut, "true");
 
 DEFINE_mBool(enable_query_like_bloom_filter, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1133,6 +1133,11 @@ DECLARE_mInt32(cold_data_compaction_score_threshold);
 DECLARE_Int32(min_s3_file_system_thread_num);
 DECLARE_Int32(max_s3_file_system_thread_num);
 
+// Thread pool for S3 reads in cross-CG peer winner race.
+// Max should match max_concurrent_peer_races so the pool never fills up under normal operation.
+DECLARE_Int32(min_peer_race_s3_thread_num);
+DECLARE_Int32(max_peer_race_s3_thread_num);
+
 DECLARE_Bool(enable_time_lut);
 
 DECLARE_mBool(enable_query_like_bloom_filter);

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -612,6 +612,7 @@ Status OlapScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
                                                              _tablets[scan_range_idx].tablet,
                                                              version,
                                                              _read_sources[scan_range_idx],
+                                                             {},
                                                              p._limit,
                                                              p._olap_scan_node.is_preaggregation,
                                                      });

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -95,7 +95,8 @@ OlapScanner::OlapScanner(ScanLocalStateBase* parent, OlapScanner::Params&& param
                                  .score_runtime {},
                                  .collection_statistics {},
                                  .ann_topn_runtime {},
-                                 .condition_cache_digest = parent->get_condition_cache_digest()}) {
+                                 .condition_cache_digest = parent->get_condition_cache_digest()}),
+          _initial_file_cache_stats(std::move(params.initial_file_cache_stats)) {
     _tablet_reader_params.set_read_source(std::move(params.read_source),
                                           _state->skip_delete_bitmap());
     _has_prepared = false;
@@ -273,6 +274,7 @@ Status OlapScanner::_open_impl(RuntimeState* state) {
                    ", backend=" + BackendOptions::get_localhost());
         return res;
     }
+    _tablet_reader->mutable_stats()->file_cache_stats.merge_from(_initial_file_cache_stats);
 
     // Do not hold rs_splits any more to release memory.
     _tablet_reader_params.rs_splits.clear();
@@ -831,6 +833,11 @@ void OlapScanner::_collect_profile_before_close() {
     InvertedIndexProfileReporter inverted_index_profile;
     inverted_index_profile.update(local_state->_index_filter_profile.get(),
                                   &stats.inverted_index_stats);
+
+    if (config::enable_file_cache) {
+        io::FileCacheProfileReporter cache_profile(local_state->_segment_profile.get());
+        cache_profile.update(&stats.file_cache_stats);
+    }
 
     // only cloud deploy mode will use file cache.
     if (config::is_cloud_mode() && config::enable_file_cache) {

--- a/be/src/exec/scan/olap_scanner.h
+++ b/be/src/exec/scan/olap_scanner.h
@@ -63,6 +63,7 @@ public:
         BaseTabletSPtr tablet;
         int64_t version;
         TabletReadSource read_source;
+        io::FileCacheStatistics initial_file_cache_stats;
         int64_t limit;
         bool aggregation;
     };
@@ -106,6 +107,7 @@ public:
     std::vector<ColumnId> _return_columns;
 
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
+    io::FileCacheStatistics _initial_file_cache_stats;
 
     // This three fields are copied from OlapScanLocalState.
     std::map<SlotId, VExprContextSPtr> _slot_id_to_virtual_column_expr;

--- a/be/src/exec/scan/parallel_scanner_builder.cpp
+++ b/be/src/exec/scan/parallel_scanner_builder.cpp
@@ -31,6 +31,21 @@
 
 namespace doris {
 
+namespace {
+
+io::FileCacheStatistics take_initial_file_cache_stats(
+        std::unordered_map<int64_t, io::FileCacheStatistics>* preload_stats, int64_t tablet_id) {
+    auto it = preload_stats->find(tablet_id);
+    if (it == preload_stats->end()) {
+        return {};
+    }
+    auto stats = it->second;
+    preload_stats->erase(it);
+    return stats;
+}
+
+} // namespace
+
 Status ParallelScannerBuilder::build_scanners(std::list<ScannerSPtr>& scanners) {
     RETURN_IF_ERROR(_load());
     if (_scan_parallelism_by_per_segment) {
@@ -112,7 +127,9 @@ Status ParallelScannerBuilder::_build_scanners_by_rowid(std::list<ScannerSPtr>& 
                                 tablet, version, _key_ranges,
                                 {.rs_splits = std::move(partitial_read_source.rs_splits),
                                  .delete_predicates = entire_read_source.delete_predicates,
-                                 .delete_bitmap = entire_read_source.delete_bitmap}));
+                                 .delete_bitmap = entire_read_source.delete_bitmap},
+                                take_initial_file_cache_stats(&_tablet_preload_file_cache_stats,
+                                                              tablet->tablet_id())));
 
                         partitial_read_source = {};
                         split = RowSetSplits(reader->clone());
@@ -157,7 +174,9 @@ Status ParallelScannerBuilder::_build_scanners_by_rowid(std::list<ScannerSPtr>& 
                     _build_scanner(tablet, version, _key_ranges,
                                    {.rs_splits = std::move(partitial_read_source.rs_splits),
                                     .delete_predicates = entire_read_source.delete_predicates,
-                                    .delete_bitmap = entire_read_source.delete_bitmap}));
+                                    .delete_bitmap = entire_read_source.delete_bitmap},
+                                   take_initial_file_cache_stats(&_tablet_preload_file_cache_stats,
+                                                                 tablet->tablet_id())));
         }
     }
 
@@ -206,7 +225,9 @@ Status ParallelScannerBuilder::_build_scanners_by_per_segment(std::list<ScannerS
                         _build_scanner(tablet, version, _key_ranges,
                                        {.rs_splits = std::move(partitial_read_source.rs_splits),
                                         .delete_predicates = entire_read_source.delete_predicates,
-                                        .delete_bitmap = entire_read_source.delete_bitmap}));
+                                        .delete_bitmap = entire_read_source.delete_bitmap},
+                                       take_initial_file_cache_stats(&_tablet_preload_file_cache_stats,
+                                                                     tablet->tablet_id())));
             }
         }
     }
@@ -234,8 +255,10 @@ Status ParallelScannerBuilder::_load() {
 
             auto beta_rowset = std::dynamic_pointer_cast<BetaRowset>(rowset);
             std::vector<uint32_t> segment_rows;
+            OlapReaderStatistics preload_stats;
             RETURN_IF_ERROR(beta_rowset->get_segment_num_rows(&segment_rows, enable_segment_cache,
-                                                              &_builder_stats));
+                                                              &preload_stats));
+            _tablet_preload_file_cache_stats[tablet_id].merge_from(preload_stats.file_cache_stats);
             auto segment_count = rowset->num_segments();
             for (int64_t i = 0; i != segment_count; i++) {
                 _all_segments_rows[rowset_id].emplace_back(segment_rows[i]);
@@ -253,9 +276,16 @@ Status ParallelScannerBuilder::_load() {
 
 std::shared_ptr<OlapScanner> ParallelScannerBuilder::_build_scanner(
         BaseTabletSPtr tablet, int64_t version, const std::vector<OlapScanRange*>& key_ranges,
-        TabletReadSource&& read_source) {
-    OlapScanner::Params params {_state,  _scanner_profile.get(), key_ranges, std::move(tablet),
-                                version, std::move(read_source), _limit,     _is_preaggregation};
+        TabletReadSource&& read_source, io::FileCacheStatistics&& initial_file_cache_stats) {
+    OlapScanner::Params params {_state,
+                                _scanner_profile.get(),
+                                key_ranges,
+                                std::move(tablet),
+                                version,
+                                std::move(read_source),
+                                std::move(initial_file_cache_stats),
+                                _limit,
+                                _is_preaggregation};
     return OlapScanner::create_shared(_parent, std::move(params));
 }
 

--- a/be/src/exec/scan/parallel_scanner_builder.h
+++ b/be/src/exec/scan/parallel_scanner_builder.h
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "exec/scan/olap_scanner.h"
+#include "io/io_common.h"
 #include "storage/rowset/rowset_fwd.h"
 #include "storage/segment/row_ranges.h"
 #include "storage/segment/segment_loader.h"
@@ -75,7 +76,8 @@ private:
 
     std::shared_ptr<OlapScanner> _build_scanner(BaseTabletSPtr tablet, int64_t version,
                                                 const std::vector<OlapScanRange*>& key_ranges,
-                                                TabletReadSource&& read_source);
+                                                TabletReadSource&& read_source,
+                                                io::FileCacheStatistics&& initial_file_cache_stats);
 
     OlapScanLocalState* _parent;
 
@@ -90,6 +92,7 @@ private:
     size_t _rows_per_scanner {_min_rows_per_scanner};
 
     std::map<RowsetId, std::vector<size_t>> _all_segments_rows;
+    std::unordered_map<int64_t, io::FileCacheStatistics> _tablet_preload_file_cache_stats;
 
     // Force building one scanner per segment when true.
     bool _scan_parallelism_by_per_segment {false};

--- a/be/src/io/fs/file_reader.cpp
+++ b/be/src/io/fs/file_reader.cpp
@@ -18,6 +18,7 @@
 #include "io/fs/file_reader.h"
 
 #include <bthread/bthread.h>
+#include <butil/iobuf.h>
 #include <glog/logging.h>
 
 #include "io/cache/cached_remote_file_reader.h"
@@ -36,6 +37,28 @@ Status FileReader::read_at(size_t offset, Slice result, size_t* bytes_read,
         LOG(WARNING) << st;
     }
     return st;
+}
+
+Status FileReader::read_at_iobuf(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                 size_t* bytes_read, const IOContext* io_ctx) {
+    DCHECK(bthread_self() == 0);
+    Status st = read_at_iobuf_impl(offset, bytes_req, out, bytes_read, io_ctx);
+    if (!st) {
+        LOG(WARNING) << st;
+    }
+    return st;
+}
+
+Status FileReader::read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                      size_t* bytes_read, const IOContext* io_ctx) {
+    if (out == nullptr || bytes_read == nullptr) {
+        return Status::InvalidArgument("read_at_iobuf requires non-null out and bytes_read");
+    }
+    *bytes_read = 0;
+    (void)offset;
+    (void)bytes_req;
+    (void)io_ctx;
+    return Status::NotSupported("read_at_iobuf is not supported by current FileReader");
 }
 
 Result<FileReaderSPtr> create_cached_file_reader(FileReaderSPtr raw_reader,

--- a/be/src/io/fs/file_reader.h
+++ b/be/src/io/fs/file_reader.h
@@ -27,6 +27,10 @@
 #include "util/profile_collector.h"
 #include "util/slice.h"
 
+namespace butil {
+class IOBuf;
+}
+
 namespace doris {
 
 namespace io {
@@ -79,6 +83,8 @@ public:
     /// the caller must ensure that the IOContext exists during the left cycle of read_at()
     Status read_at(size_t offset, Slice result, size_t* bytes_read,
                    const IOContext* io_ctx = nullptr);
+    Status read_at_iobuf(size_t offset, size_t bytes_req, butil::IOBuf* out, size_t* bytes_read,
+                         const IOContext* io_ctx = nullptr);
 
     virtual Status close() = 0;
 
@@ -96,6 +102,10 @@ public:
 protected:
     virtual Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                 const IOContext* io_ctx) = 0;
+    // Default implementation returns NotSupported. Override this in readers that can
+    // fill iobuf directly.
+    virtual Status read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                      size_t* bytes_read, const IOContext* io_ctx);
 };
 
 using FileReaderSPtr = std::shared_ptr<FileReader>;

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -18,6 +18,7 @@
 #include "io/fs/local_file_reader.h"
 
 #include <bthread/bthread.h>
+#include <butil/iobuf.h>
 // IWYU pragma: no_include <bthread/errno.h>
 #include <bvar/bvar.h>
 #include <errno.h> // IWYU pragma: keep
@@ -190,6 +191,51 @@ Status LocalFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_
             *bytes_read += res;
         }
     }
+    DorisMetrics::instance()->local_bytes_read_total->increment(*bytes_read);
+    return Status::OK();
+}
+
+Status LocalFileReader::read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                                           size_t* bytes_read, const IOContext* /*io_ctx*/) {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("LocalFileReader::read_at_iobuf_impl",
+                                      Status::IOError("inject io error"));
+    if (out == nullptr || bytes_read == nullptr) {
+        return Status::InvalidArgument("read_at_iobuf requires non-null out and bytes_read");
+    }
+    if (closed()) [[unlikely]] {
+        return Status::InternalError("read closed file: ", _path.native());
+    }
+
+    if (offset > _file_size) {
+        return Status::InternalError(
+                "offset exceeds file size(offset: {}, file size: {}, path: {})", offset, _file_size,
+                _path.native());
+    }
+    bytes_req = std::min(bytes_req, _file_size - offset);
+    *bytes_read = 0;
+    if (bytes_req == 0) {
+        return Status::OK();
+    }
+
+    LIMIT_LOCAL_SCAN_IO(get_data_dir_path(), bytes_read);
+
+    butil::IOPortal portal;
+    while (bytes_req != 0) {
+        ssize_t res =
+                portal.pappend_from_file_descriptor(_fd, static_cast<off_t>(offset), bytes_req);
+        if (UNLIKELY(-1 == res && errno != EINTR)) {
+            return localfs_error(errno, fmt::format("failed to read {}", _path.native()));
+        }
+        if (UNLIKELY(res == 0)) {
+            return Status::InternalError("cannot read from {}: unexpected EOF", _path.native());
+        }
+        if (res > 0) {
+            offset += static_cast<size_t>(res);
+            bytes_req -= static_cast<size_t>(res);
+            *bytes_read += static_cast<size_t>(res);
+        }
+    }
+    out->append(portal);
     DorisMetrics::instance()->local_bytes_read_total->increment(*bytes_read);
     return Status::OK();
 }

--- a/be/src/io/fs/local_file_reader.h
+++ b/be/src/io/fs/local_file_reader.h
@@ -68,6 +68,8 @@ public:
 private:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const IOContext* io_ctx) override;
+    Status read_at_iobuf_impl(size_t offset, size_t bytes_req, butil::IOBuf* out,
+                              size_t* bytes_read, const IOContext* io_ctx) override;
 
 private:
     int _fd = -1; // owned

--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -17,6 +17,8 @@
 
 #include "io/fs/local_file_writer.h"
 
+#include <butil/iobuf.h>
+
 // IWYU pragma: no_include <bthread/errno.h>
 #include <errno.h> // IWYU pragma: keep
 #include <fcntl.h>
@@ -183,6 +185,47 @@ Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
         n_left -= res;
     }
     DCHECK_EQ(0, n_left);
+    _bytes_appended += bytes_req;
+    return Status::OK();
+}
+
+Status LocalFileWriter::append_iobuf(const butil::IOBuf& data) {
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("LocalFileWriter::append_iobuf",
+                                      Status::IOError("inject io error"));
+    if (_state != State::OPENED) [[unlikely]] {
+        return Status::InternalError("append to closed file: {}", _path.native());
+    }
+    if (data.empty()) {
+        return Status::OK();
+    }
+    _dirty = true;
+
+    butil::IOBuf payload(data);
+    const size_t bytes_req = payload.length();
+    while (!payload.empty()) {
+        const size_t size_hint = payload.length();
+        ssize_t res =
+                SYNC_POINT_HOOK_RETURN_VALUE(payload.cut_into_file_descriptor(_fd, size_hint),
+                                             "LocalFileWriter::cut_into_file_descriptor", _fd);
+        DBUG_EXECUTE_IF("LocalFileWriter::append_iobuf.io_error", {
+            auto sub_path = dp->param<std::string>("sub_path", "");
+            if ((sub_path.empty() && _path.filename().compare(kTestFilePath)) ||
+                (!sub_path.empty() && _path.native().find(sub_path) != std::string::npos)) {
+                res = -1;
+                errno = EIO;
+                LOG(WARNING) << Status::IOError("debug write io error: {}", _path.native());
+            }
+        });
+        if (UNLIKELY(res < 0)) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return localfs_error(errno, fmt::format("failed to write {}", _path.native()));
+        }
+        if (UNLIKELY(res == 0)) {
+            return Status::IOError("failed to write {}, zero bytes written", _path.native());
+        }
+    }
     _bytes_appended += bytes_req;
     return Status::OK();
 }

--- a/be/src/io/fs/local_file_writer.h
+++ b/be/src/io/fs/local_file_writer.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <butil/iobuf.h>
+
 #include <cstddef>
 
 #include "common/status.h"
@@ -32,6 +34,7 @@ public:
     ~LocalFileWriter() override;
 
     Status appendv(const Slice* data, size_t data_cnt) override;
+    Status append_iobuf(const butil::IOBuf& data);
     const Path& path() const override { return _path; }
     size_t bytes_appended() const override;
     State state() const override { return _state; }

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -72,6 +72,55 @@ struct FileCacheStatistics {
     int64_t inverted_index_remote_io_timer = 0;
     int64_t inverted_index_peer_io_timer = 0;
     int64_t inverted_index_io_timer = 0;
+
+    // Cross-CG peer read statistics
+    int64_t num_cross_cg_peer_io_total = 0;
+    int64_t bytes_read_from_cross_cg_peer = 0;
+    int64_t cross_cg_peer_io_timer = 0; // nanoseconds
+    int64_t num_peer_race_peer_win = 0;
+    int64_t num_peer_race_s3_win = 0;
+    int64_t num_peer_lazy_fetch = 0;
+    int64_t peer_lazy_fetch_timer = 0; // nanoseconds
+
+    void merge_from(const FileCacheStatistics& other) {
+        num_local_io_total += other.num_local_io_total;
+        num_remote_io_total += other.num_remote_io_total;
+        num_peer_io_total += other.num_peer_io_total;
+        local_io_timer += other.local_io_timer;
+        bytes_read_from_local += other.bytes_read_from_local;
+        bytes_read_from_remote += other.bytes_read_from_remote;
+        bytes_read_from_peer += other.bytes_read_from_peer;
+        remote_io_timer += other.remote_io_timer;
+        peer_io_timer += other.peer_io_timer;
+        remote_wait_timer += other.remote_wait_timer;
+        write_cache_io_timer += other.write_cache_io_timer;
+        bytes_write_into_cache += other.bytes_write_into_cache;
+        num_skip_cache_io_total += other.num_skip_cache_io_total;
+        read_cache_file_directly_timer += other.read_cache_file_directly_timer;
+        cache_get_or_set_timer += other.cache_get_or_set_timer;
+        lock_wait_timer += other.lock_wait_timer;
+        get_timer += other.get_timer;
+        set_timer += other.set_timer;
+
+        inverted_index_num_local_io_total += other.inverted_index_num_local_io_total;
+        inverted_index_num_remote_io_total += other.inverted_index_num_remote_io_total;
+        inverted_index_num_peer_io_total += other.inverted_index_num_peer_io_total;
+        inverted_index_bytes_read_from_local += other.inverted_index_bytes_read_from_local;
+        inverted_index_bytes_read_from_remote += other.inverted_index_bytes_read_from_remote;
+        inverted_index_bytes_read_from_peer += other.inverted_index_bytes_read_from_peer;
+        inverted_index_local_io_timer += other.inverted_index_local_io_timer;
+        inverted_index_remote_io_timer += other.inverted_index_remote_io_timer;
+        inverted_index_peer_io_timer += other.inverted_index_peer_io_timer;
+        inverted_index_io_timer += other.inverted_index_io_timer;
+
+        num_cross_cg_peer_io_total += other.num_cross_cg_peer_io_total;
+        bytes_read_from_cross_cg_peer += other.bytes_read_from_cross_cg_peer;
+        cross_cg_peer_io_timer += other.cross_cg_peer_io_timer;
+        num_peer_race_peer_win += other.num_peer_race_peer_win;
+        num_peer_race_s3_win += other.num_peer_race_s3_win;
+        num_peer_lazy_fetch += other.num_peer_lazy_fetch;
+        peer_lazy_fetch_timer += other.peer_lazy_fetch_timer;
+    }
 };
 
 struct IOContext {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -262,6 +262,7 @@ public:
     ThreadPool* s3_file_system_thread_pool() { return _s3_file_system_thread_pool.get(); }
     ThreadPool* udf_close_workers_pool() { return _udf_close_workers_thread_pool.get(); }
     ThreadPool* segment_prefetch_thread_pool() { return _segment_prefetch_thread_pool.get(); }
+    ThreadPool* peer_race_s3_thread_pool() { return _peer_race_s3_thread_pool.get(); }
 
     void init_file_cache_factory(std::vector<doris::CachePath>& cache_paths);
     io::FileCacheFactory* file_cache_factory() { return _file_cache_factory; }
@@ -492,6 +493,7 @@ private:
     std::unique_ptr<ThreadPool> _udf_close_workers_thread_pool;
     // Threadpool used to prefetch segment file cache blocks
     std::unique_ptr<ThreadPool> _segment_prefetch_thread_pool;
+    std::unique_ptr<ThreadPool> _peer_race_s3_thread_pool;
 
     FragmentMgr* _fragment_mgr = nullptr;
     WorkloadGroupMgr* _workload_group_manager = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -302,6 +302,10 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .set_min_threads(config::min_s3_file_system_thread_num)
                               .set_max_threads(config::max_s3_file_system_thread_num)
                               .build(&_s3_file_system_thread_pool));
+    static_cast<void>(ThreadPoolBuilder("PeerRaceS3ThreadPool")
+                              .set_min_threads(config::min_peer_race_s3_thread_num)
+                              .set_max_threads(config::max_peer_race_s3_thread_num)
+                              .build(&_peer_race_s3_thread_pool));
     RETURN_IF_ERROR(init_mem_env());
 
     // NOTE: runtime query statistics mgr could be visited by query and daemon thread
@@ -871,6 +875,7 @@ void ExecEnv::destroy() {
     SAFE_SHUTDOWN(_lazy_release_obj_pool);
     SAFE_SHUTDOWN(_non_block_close_thread_pool);
     SAFE_SHUTDOWN(_s3_file_system_thread_pool);
+    SAFE_SHUTDOWN(_peer_race_s3_thread_pool);
     SAFE_SHUTDOWN(_send_batch_thread_pool);
     SAFE_SHUTDOWN(_udf_close_workers_thread_pool);
     SAFE_SHUTDOWN(_send_table_stats_thread_pool);
@@ -926,6 +931,7 @@ void ExecEnv::destroy() {
     _lazy_release_obj_pool.reset(nullptr);
     _non_block_close_thread_pool.reset(nullptr);
     _s3_file_system_thread_pool.reset(nullptr);
+    _peer_race_s3_thread_pool.reset(nullptr);
     _send_table_stats_thread_pool.reset(nullptr);
     _buffered_reader_prefetch_thread_pool.reset(nullptr);
     _segment_prefetch_thread_pool.reset(nullptr);

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -524,6 +524,7 @@ void HttpService::register_cloud_handler(CloudStorageEngine& engine) {
             _pool.add(new CheckEncryptionAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ALL));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/check_tablet_encryption",
                                       check_encryption_action);
+
 }
 // NOLINTEND(readability-function-size)
 

--- a/be/src/storage/index/index_file_reader.h
+++ b/be/src/storage/index/index_file_reader.h
@@ -60,7 +60,7 @@ public:
             : _fs(std::move(fs)),
               _index_path_prefix(std::move(index_path_prefix)),
               _storage_format(storage_format),
-              _idx_file_info(idx_file_info),
+              _idx_file_info(std::move(idx_file_info)),
               _tablet_id(tablet_id) {}
     virtual ~IndexFileReader() = default;
 

--- a/be/src/storage/index/inverted/inverted_index_fs_directory.cpp
+++ b/be/src/storage/index/inverted/inverted_index_fs_directory.cpp
@@ -89,6 +89,7 @@ bool DorisFSDirectory::FSIndexInput::open(const io::FileSystemSPtr& fs, const ch
                                           IndexInput*& ret, CLuceneError& error,
                                           int32_t buffer_size, int64_t file_size,
                                           int64_t tablet_id) {
+    // no throw error
     CND_PRECONDITION(path != nullptr, "path is NULL");
 
     if (buffer_size == -1) {

--- a/be/src/storage/segment/segment.h
+++ b/be/src/storage/segment/segment.h
@@ -311,6 +311,7 @@ private:
     DorisCallOnce<Status> _index_file_reader_open;
 
     InvertedIndexFileInfo _idx_file_info;
+    std::string _seg_path;
     int64_t _tablet_id = -1;
 
     int _be_exec_version = BeExecVersionManager::get_newest_version();

--- a/be/src/storage/task/index_builder.cpp
+++ b/be/src/storage/task/index_builder.cpp
@@ -376,6 +376,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                         output_rowset_meta->rowset_id().to_string(), seg_ptr->id(),
                         output_rowset_schema->get_inverted_index_storage_format(),
                         std::move(file_writer), true /* can_use_ram_dir */, _tablet->tablet_id());
+
                 RETURN_IF_ERROR(index_file_writer->initialize(dirs));
                 // create inverted index writer
                 for (auto& index_meta : _dropped_inverted_indexes) {
@@ -447,6 +448,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
                         fs, index_path_prefix, output_rowset_meta->rowset_id().to_string(),
                         seg_ptr->id(), output_rowset_schema->get_inverted_index_storage_format(),
                         std::move(file_writer), true /* can_use_ram_dir */, _tablet->tablet_id());
+
                 RETURN_IF_ERROR(index_file_writer->initialize(dirs));
             } else {
                 index_file_writer = std::make_unique<IndexFileWriter>(

--- a/be/src/util/bthread_utils.h
+++ b/be/src/util/bthread_utils.h
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <bthread/bthread.h>
+
+#include <functional>
+#include <memory>
+
+#include "runtime/thread_context.h"
+
+namespace doris {
+
+// Launch a callable in a background bthread (fire-and-forget).
+// The callable is heap-allocated and deleted after execution.
+// Returns true on success, false if bthread creation failed (callable is still deleted).
+//
+// init_thread_ctx: when true, initialises the bthread's thread-local ThreadContext via
+// ScopedInitThreadContext before invoking fn.  Set this when the bthread needs memory-tracker
+// or workload-group context (e.g. attaches an AttachTask inside fn).  Defaults to false so
+// existing call-sites that do not need thread-context initialisation are unaffected.
+template <typename Fn>
+bool start_bthread(Fn&& fn, bool init_thread_ctx = false, const bthread_attr_t* attr = nullptr) {
+    struct Args {
+        std::function<void()> fn;
+        bool init_thread_ctx;
+    };
+    auto args = std::make_unique<Args>(Args {std::forward<Fn>(fn), init_thread_ctx});
+    auto entry = [](void* arg) -> void* {
+        // Reclaim ownership so Args is deleted when this scope exits.
+        auto a = std::unique_ptr<Args>(reinterpret_cast<Args*>(arg));
+        std::optional<ScopedInitThreadContext> scoped;
+        if (a->init_thread_ctx) {
+            scoped.emplace();
+        }
+        a->fn();
+        return nullptr;
+    };
+    bthread_t tid;
+    if (bthread_start_background(&tid, attr, entry, args.get()) != 0) {
+        return false; // args unique_ptr destructs here, no leak
+    }
+    args.release(); // bthread entry now owns the pointer
+    return true;
+}
+
+} // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -1498,6 +1498,12 @@ public class CloudTabletRebalancer extends MasterDaemon {
             req.setHost(srcBackend.getHost());
             req.setBrpcPort(srcBackend.getBrpcPort());
             req.setTabletIds(new ArrayList<>(tabletIds));
+            // Tell the receiving BE its own compute group id, so it can set _self_compute_group_id.
+            // In normal intra-CG rebalance, src and dest belong to the same compute group.
+            String srcComputeGroupId = srcBackend.getCloudClusterId();
+            if (srcComputeGroupId != null && !srcComputeGroupId.isEmpty()) {
+                req.setCloudComputeGroupId(srcComputeGroupId);
+            }
             TWarmUpCacheAsyncResponse result = client.warmUpCacheAsync(req);
             if (result.getStatus().getStatusCode() != TStatusCode.OK) {
                 LOG.warn("pre cache failed status {} {}", result.getStatus().getStatusCode(),

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -306,6 +306,10 @@ public class HeartbeatMgr extends MasterDaemon {
                     copiedMasterInfo.setTabletReportInactiveDurationMs(reportInterval);
                     TCloudClusterInfo clusterInfo = new TCloudClusterInfo();
                     clusterInfo.setIsStandby(backend.isInStandbyCluster());
+                    String computeGroupId = backend.getCloudClusterId();
+                    if (computeGroupId != null && !computeGroupId.isEmpty()) {
+                        clusterInfo.setCloudComputeGroupId(computeGroupId);
+                    }
                     copiedMasterInfo.setCloudClusterInfo(clusterInfo);
                 }
                 THeartbeatResult result;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -1154,6 +1154,18 @@ message PFetchPeerDataRequest {
     optional int64 file_size = 4;
     // PEER_FILE_CACHE_BLOCK
     repeated CacheBlockReqest cache_req = 5;
+    // Client capability for attachment payload mode.
+    // If false (default), server must return payload in datas.data for compatibility.
+    optional bool support_attachment = 6 [default = false];
+    // Client requests server to pull data from S3 and fill local cache on cache miss.
+    // Server only executes fill when this is true AND enable_peer_server_cache_fill config is true.
+    // Only set for the designated fill compute group (peer_cache_fill_compute_group_id).
+    optional bool request_cache_fill = 7 [default = false];
+    // Tablet id used by the server to look up its own storage resource and reconstruct the full
+    // remote path for S3 fill.  Sending tablet_id (rather than the raw remote path) keeps the
+    // server authoritative over its own path layout and avoids coupling client path knowledge into
+    // the protocol.  Only meaningful when request_cache_fill is true.
+    optional int64 fill_tablet_id = 8;
 }
 
 message CacheBlockPB {
@@ -1165,6 +1177,10 @@ message CacheBlockPB {
 message PFetchPeerDataResponse {
     optional PStatus status = 1;
     repeated CacheBlockPB datas = 2;
+    // Response mode flag.
+    // true: payload is in brpc response attachment; datas carries metadata only.
+    // false: payload is in datas[*].data.
+    optional bool data_in_attachment = 3 [default = false];
 }
 
 message PRequestCdcClientRequest {
@@ -1239,4 +1255,3 @@ service PBackendService {
     rpc fetch_peer_data(PFetchPeerDataRequest) returns (PFetchPeerDataResponse);
     rpc request_cdc_client(PRequestCdcClientRequest) returns (PRequestCdcClientResult);
 };
-

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -135,6 +135,7 @@ struct TWarmUpCacheAsyncRequest {
     1: required string host
     2: required i32 brpc_port
     3: required list<i64> tablet_ids
+    4: optional string cloud_compute_group_id
 }
 
 struct TWarmUpCacheAsyncResponse {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -31,6 +31,7 @@ struct TFrontendInfo {
 
 struct TCloudClusterInfo {
     1: optional bool isStandby
+    2: optional string cloud_compute_group_id
 }
 
 struct TMasterInfo {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -687,6 +687,7 @@ struct TReplicaInfo {
     5: required TReplicaId replica_id
     6: optional bool is_alive
     7: optional i64 backend_id
+    8: optional string cloud_compute_group_id
 }
 
 struct TResourceInfo {

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up.groovy
@@ -44,6 +44,12 @@ suite('test_balance_warm_up', 'docker') {
         'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
         "enable_packed_file=${enablePackedFile}",
+        'peer_candidate_cleanup_interval_s=10',
+        'peer_candidate_expiry_s=30',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98'
     ]
     options.setFeNum(1)
     options.setBeNum(1)
@@ -220,9 +226,9 @@ suite('test_balance_warm_up', 'docker') {
             "Available subdirs: ${subDirs}")
         }
 
-        sleep(105 * 1000)
-        // test expired be tablet cache info be removed
-        // after cache_read_from_peer_expired_seconds = 100s
+        // peer_candidate_expiry_s=30s, cleanup runs every 10s → entries evicted within ~40s
+        sleep(45 * 1000)
+        // test that expired peer candidate entries are removed by run_cleanup_loop
         assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "balance_tablet_be_mapping_size"))
         assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"))
         assert(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"))

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_use_peer_cache.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_use_peer_cache.groovy
@@ -44,9 +44,12 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
         'schedule_sync_tablets_interval_s=18000',
         'disable_auto_compaction=true',
         'sys_log_verbose_modules=*',
-        'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
         "enable_packed_file=${enablePackedFile}",
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98'
     ]
     options.setFeNum(1)
     options.setBeNum(1)
@@ -191,6 +194,9 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
             "Available subdirs: ${subDirs}")
         }
 
+        def peerReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read")
+        def crossCgReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "peer_cross_compute_group_read")
+
         // The query triggers reading the file cache from the peer
         profile("test_balance_warm_up_use_peer_cache_profile") {
             sql """ set enable_profile = true;"""
@@ -209,7 +215,14 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
                     total += matcher.group(1).toInteger()
                     logger.info("NumPeerIOTotal: {}", matcher.group(1))
                 }
+                def remoteMatcher = (profileString =~ /-  NumRemoteIOTotal:\s+(\d+)/)
+                def remoteTotal = 0
+                while (remoteMatcher.find()) {
+                    remoteTotal += remoteMatcher.group(1).toInteger()
+                    logger.info("NumRemoteIOTotal: {}", remoteMatcher.group(1))
+                }
                 assertTrue(total > 0)
+                assertEquals(0, remoteTotal)
             } 
         }
 
@@ -222,8 +235,12 @@ suite('test_balance_warm_up_use_peer_cache', 'docker') {
             "Expected cache file pattern ${hashFile} should found in BE ${newAddBe.Host}'s file_cache directory. " + 
             "Available subdirs: ${subDirs}")
         }
-        assert(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"))
-        assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"))
+        assert(getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read") > peerReadBeforeQuery)
+
+        // regression: same-CG rebalance warm-up must not be counted as cross-CG peer read.
+        assert crossCgReadBeforeQuery == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort,
+                "peer_cross_compute_group_read") :
+               "same-CG peer read must not increase peer_cross_compute_group_read"
     }
 
     docker(options) {

--- a/regression-test/suites/cloud_p0/balance/test_balance_warm_up_with_compaction_use_peer_cache.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_balance_warm_up_with_compaction_use_peer_cache.groovy
@@ -38,6 +38,7 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
         'cloud_pre_heating_time_limit_sec=30',
         // disable Auto Analysis Job Executor
         'auto_check_statistics_in_minutes=60',
+        'JAVA_TOOL_OPTIONS=-Djava.io.tmpdir=$LOG_DIR/tmp',
     ]
     options.beConfigs += [
         'report_tablet_interval_seconds=1',
@@ -47,7 +48,7 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
         'cumulative_compaction_min_deltas=5',
         'cache_read_from_peer_expired_seconds=100',
         'enable_cache_read_from_peer=true',
-        "enable_packed_file=${enablePackedFile}",
+        "enable_packed_file=${enablePackedFile}"
     ]
     options.setFeNum(1)
     options.setBeNum(1)
@@ -203,6 +204,9 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
             "Available subdirs: ${subDirs}")
         }
 
+        def peerReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read")
+        def crossCgReadBeforeQuery = getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "peer_cross_compute_group_read")
+
         // The query triggers reading the file cache from the peer
         profile("test_balance_warm_up_with_compaction_use_peer_cache_profile") {
             sql """ set enable_profile = true;"""
@@ -221,7 +225,14 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
                     total += matcher.group(1).toInteger()
                     logger.info("InvertedIndexNumPeerIOTotal: {}", matcher.group(1))
                 }
+                def remoteMatcher = (profileString =~ /-  InvertedIndexNumRemoteIOTotal:\s+(\d+)/)
+                def remoteTotal = 0
+                while (remoteMatcher.find()) {
+                    remoteTotal += remoteMatcher.group(1).toInteger()
+                    logger.info("InvertedIndexNumRemoteIOTotal: {}", remoteMatcher.group(1))
+                }
                 assertTrue(total > 0)
+                assertEquals(0, remoteTotal)
             } 
         }
         subDirs.clear()
@@ -233,8 +244,10 @@ suite('test_balance_warm_up_with_compaction_use_peer_cache', 'docker') {
             "Expected cache file pattern ${hashFile} should found in BE ${newAddBe.Host}'s file_cache directory. " + 
             "Available subdirs: ${subDirs}")
         }
-        assert(0 != getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read"))
-        assert(0 == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_s3_read"))
+        assert(getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort, "cached_remote_reader_peer_read") > peerReadBeforeQuery)
+        assert crossCgReadBeforeQuery == getBrpcMetrics(newAddBe.Host, newAddBe.BrpcPort,
+                "peer_cross_compute_group_read") :
+               "same-CG peer read must not increase peer_cross_compute_group_read"
     }
 
     docker(options) {

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_bvar_metrics.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_bvar_metrics.groovy
@@ -1,0 +1,266 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read bvar metrics smoke tests.
+//
+// Verifies that 4 new bvar / config items land and work end-to-end:
+//
+// T_bvar1 – peer_lazy_fetch_total & peer_lazy_fetch_count
+//   CGB has no candidates for the tablet (cold miss). A cross-CG query triggers
+//   fetch_candidates_from_fe() on CGB's BE. Both counters must increase.
+//
+// T_bvar2 – peer_same_compute_group_read
+//   A second BE (BE_A2) is added to CG-A. Rebalance warmup registers BE_A1 as a
+//   same-CG peer candidate on BE_A2 (via record_balanced_tablet). A warmup segment-download
+//   debug point skips cache population while still letting warmup bookkeeping complete.
+//   Queries on CG-A that scan tablets on BE_A2 take the same-CG winner-race path.
+//   Peer should win with the configured hedge delay, so peer_same_compute_group_read
+//   increases on CG-A.
+//
+// T_bvar3 – peer_race_hedge_delay_ms → peer wins reliably
+//   peer_race_hedge_delay_ms=50 is set in beConfigs. CGA has warm cache so the peer
+//   RPC returns in ~5 ms, well within the hedge window. S3 is never submitted;
+//   peer_race_peer_win must increase on CGB's BE.
+//
+// Topology: 1 FE + CG-A (BE_A1, then BE_A2 added in T_bvar2) + CG-B (BE_B).
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.DebugPoint
+import org.apache.doris.regression.util.NodeType
+
+suite('test_cross_cg_bvar_metrics', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+        'rehash_tablet_after_be_dead_seconds=3600',
+        'cloud_warm_up_for_rebalance_type=async_warmup',
+        'cloud_pre_heating_time_limit_sec=20',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+        // Give peer a 50 ms head start before S3 is submitted (T_bvar3).
+        // Peer returns in ~5 ms when CGA cache is warm, so it wins every time.
+        'peer_race_hedge_delay_ms=50',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetric = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_bvar_metrics_tbl"
+
+        // ---- Setup: add CG-B and create table in CG-A ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends (CG-A and CG-B)"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("BE_A (CG-A): host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("BE_B (CG-B): host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b')"
+        sql "INSERT INTO ${tbl} VALUES (3, 'c'), (4, 'd')"
+        // Warm CG-A cache for all existing rows.
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+    // ==================== T_bvar1: peer_lazy_fetch_total & peer_lazy_fetch_count ====================
+        // CGB has no candidates for any tablet (cold start). The first cross-CG query
+        // triggers fetch_candidates_from_fe() on CGB's BE:
+        //   g_peer_lazy_fetch_total  << 1      (before RPC)
+        //   g_peer_lazy_fetch_latency << µs    (after RPC — LatencyRecorder exposes *_count as
+        //   peer_lazy_fetch_count in brpc_metrics / vars)
+        logger.info("=== T_bvar1: peer_lazy_fetch_total and peer_lazy_fetch_count ===")
+
+        def t1_fetchTotalBefore   = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_total")
+        def t1_latencyCountBefore = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_count")
+
+        sql "use @cross_cg_peer_cluster"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+
+        // The singleflight RPC may complete slightly after the query returns.
+        awaitUntil(15) {
+            getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_total") > t1_fetchTotalBefore
+        }
+
+        def t1_fetchTotalAfter   = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_total")
+        def t1_latencyCountAfter = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_lazy_fetch_count")
+
+        assertTrue(t1_fetchTotalAfter > t1_fetchTotalBefore,
+            "T_bvar1: peer_lazy_fetch_total should increase on CGB after cold-miss cross-CG query " +
+            "(before=${t1_fetchTotalBefore}, after=${t1_fetchTotalAfter})")
+        assertTrue(t1_latencyCountAfter > t1_latencyCountBefore,
+            "T_bvar1: peer_lazy_fetch_count should increase (LatencyRecorder recorded the FE RPC) " +
+            "(before=${t1_latencyCountBefore}, after=${t1_latencyCountAfter})")
+        logger.info("T_bvar1 PASS: lazy_fetch_total={}, latency_count={}",
+            t1_fetchTotalAfter, t1_latencyCountAfter)
+
+        // ==================== T_bvar3: peer_race_hedge_delay_ms → peer wins reliably ====================
+        // peer_race_hedge_delay_ms=50 (set in beConfigs). CGA cache is warm, so the peer
+        // RPC for the new rows returns in ~5 ms — well within the 50 ms hedge window.
+        // S3 is never submitted; peer_race_peer_win must increase on CGB.
+        logger.info("=== T_bvar3: peer_race_hedge_delay_ms=50 → peer_race_peer_win increases ===")
+
+        // Insert new rows on CG-A and warm its cache; CGB has never read them.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (5, 'e'), (6, 'f')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CGA for rows (5, 6)
+        sleep(500)
+
+        sql "use @cross_cg_peer_cluster"
+        def t3_peerWinBefore = getBrpcMetric(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // CGB has no cache for (5, 6). Peer race: CGA warm → peer returns ~5 ms;
+        // hedge delay 50 ms skips S3 entirely → peer wins.
+        def t3_result = sql "SELECT * FROM ${tbl} WHERE k1 IN (5, 6) ORDER BY k1"
+        assertEquals(2, t3_result.size(), "T_bvar3: query should return 2 rows")
+
+        assertTrue(
+            getBrpcMetric(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t3_peerWinBefore,
+            "T_bvar3: peer_race_peer_win should increase on CGB when CGA cache is warm and " +
+            "hedge delay keeps S3 submission suppressed")
+        logger.info("T_bvar3 PASS: peer_race_peer_win={}",
+            getBrpcMetric(beB.Host, beB.BrpcPort, "peer_race_peer_win"))
+
+        // ==================== T_bvar2: peer_same_compute_group_read ====================
+        // Add BE_A2 to CG-A. Skip warmup segment downloads so BE_A2's file cache stays empty.
+        // Rebalance triggers warm_up_cache_async → record_balanced_tablet on BE_A2 with
+        // BE_A1 as same-CG candidate. Once BE_A2 has tablets plus candidate mappings, queries
+        // on CG-A that hit BE_A2 should run same-CG peer-vs-S3 winner race; peer wins due to
+        // the hedge delay, so peer_same_compute_group_read increases.
+        logger.info("=== T_bvar2: peer_same_compute_group_read (same-CG winner race) ===")
+
+        // Skip warmup segment downloads to keep BE_A2's file cache empty after registration.
+        GetDebugPoint().enableDebugPointForAllBEs("FileCacheBlockDownloader::download_segment_file.skip_warmup")
+
+        setFeConfig('enable_cloud_multi_replica', true)
+        cluster.addBackend(1, "compute_cluster")
+        setFeConfig('enable_cloud_multi_replica', false)
+        sleep(5000)
+
+        def allBackends = sql_return_maparray('show backends')
+        assert allBackends.size() == 3 : "Expected 3 backends total"
+        // Identify BE_A2 by BackendId — BrpcPort is the same (8060) for all BEs in docker.
+        def beA2 = allBackends.find { it.BackendId.toLong() != beA.BackendId.toLong() &&
+                                      it.BackendId.toLong() != beB.BackendId.toLong() }
+        assert beA2 != null : "Could not identify BE_A2"
+        logger.info("T_bvar2: BE_A2 host={} brpcPort={}", beA2.Host, beA2.BrpcPort)
+        DebugPoint.enableDebugPoint(
+            beA2.Host, beA2.HttpPort.toInteger(), NodeType.BE,
+            "FileCacheBlockDownloader::download_segment_file.skip_warmup")
+
+        // Wait until BE_A2 has both accepted tablets and registered same-CG candidates.
+        awaitUntil(120) {
+            def latest = sql_return_maparray('show backends').find {
+                it.BackendId.toLong() == beA2.BackendId.toLong()
+            }
+            latest != null && latest.TabletNum.toInteger() > 0
+        }
+        awaitUntil(120) {
+            getBrpcMetric(beA2.Host, beA2.BrpcPort, "balance_tablet_be_mapping_size") > 0
+        }
+
+        // Give the rebalance warmup workflow a short window to submit and finish the skipped
+        // warmup tasks before query traffic starts.
+        sleep(2000)
+
+        sql "use @compute_cluster"
+        def t2_sameBefore_A1 = getBrpcMetric(beA.Host,  beA.BrpcPort,  "peer_same_compute_group_read")
+        def t2_sameBefore_A2 = getBrpcMetric(beA2.Host, beA2.BrpcPort, "peer_same_compute_group_read")
+
+        // Run multiple queries; full-table scans should cover tablets rebalanced to BE_A2.
+        // Those scans see: (a) same-CG candidate (BE_A1) registered, (b) empty local cache
+        // after warmup timeout → same-CG winner race with peer win → peer_same_compute_group_read++.
+        30.times {
+            sql "SELECT * FROM ${tbl} ORDER BY k1"
+        }
+        awaitUntil(30) {
+            def sameAfterA1 = getBrpcMetric(beA.Host,  beA.BrpcPort,  "peer_same_compute_group_read")
+            def sameAfterA2 = getBrpcMetric(beA2.Host, beA2.BrpcPort, "peer_same_compute_group_read")
+            ((sameAfterA1 - t2_sameBefore_A1) + (sameAfterA2 - t2_sameBefore_A2)) > 0
+        }
+
+        def t2_sameAfter_A1 = getBrpcMetric(beA.Host,  beA.BrpcPort,  "peer_same_compute_group_read")
+        def t2_sameAfter_A2 = getBrpcMetric(beA2.Host, beA2.BrpcPort, "peer_same_compute_group_read")
+        def t2_totalDelta = (t2_sameAfter_A1 - t2_sameBefore_A1) + (t2_sameAfter_A2 - t2_sameBefore_A2)
+
+        assertTrue(t2_totalDelta > 0,
+            "T_bvar2: peer_same_compute_group_read should increase on CG-A BEs " +
+            "(BE_A2 has same-CG candidate and empty local cache after skipped warmup downloads). " +
+            "BE_A1 delta=${t2_sameAfter_A1 - t2_sameBefore_A1}, " +
+            "BE_A2 delta=${t2_sameAfter_A2 - t2_sameBefore_A2}")
+        logger.info("T_bvar2 PASS: peer_same_compute_group_read total delta={}", t2_totalDelta)
+
+        DebugPoint.disableDebugPoint(
+            beA2.Host, beA2.HttpPort.toInteger(), NodeType.BE,
+            "FileCacheBlockDownloader::download_segment_file.skip_warmup")
+        GetDebugPoint().disableDebugPointForAllBEs("FileCacheBlockDownloader::download_segment_file.skip_warmup")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_candidate_management.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_candidate_management.groovy
@@ -1,0 +1,377 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read candidate management tests:
+// consecutive RPC failures → candidate eviction (P1)
+// candidate expiry via cleanup daemon (P1)
+// cache miss (NOT_FOUND from server) rotates candidate, does NOT evict (Issue 3)
+//
+// Topology:
+//   T3/1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+//   add CG-C (1 BE, "cross_cg_peer_cluster_alt") so rotate can actually move to
+//          another remote candidate after CG-A returns NOT_FOUND.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_candidate_management', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        // Eviction threshold = 1 so T3 triggers on the very first RPC failure.
+        // Threshold > 1 cannot be reliably tested in docker: after the first peer RPC failure
+        // S3 fallback fills CG-B's local file cache, so subsequent queries on the same data
+        // are local hits and never issue a second peer RPC to CG-A.
+        'peer_rpc_failure_eviction_threshold=1',
+        // Short expiry so T4 can complete in reasonable time.
+        'peer_candidate_expiry_s=60',
+        'peer_candidate_cleanup_interval_s=5',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        final String CG_A = "compute_cluster"
+        final String CG_B = "cross_cg_peer_cluster"
+        final String CG_C = "cross_cg_peer_cluster_alt"
+        def tbl = "test_cross_cg_candidate_mgmt_tbl"
+
+        // Counter for unique k1 ranges; CG-B will never have local cache for them.
+        def nextK1 = 100
+        // Insert `count` rows into CG-A, warm CG-A's file cache, then switch to CG-B context.
+        def insertAndWarmCGA = { count ->
+            def start = nextK1
+            nextK1 += count
+            def vals = (start..<nextK1).collect { i -> "(${i}, 'row${i}')" }.join(", ")
+            sql "use @${CG_A}"
+            sql "INSERT INTO ${tbl} VALUES ${vals}"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache
+            sleep(1000)
+            sql "use @${CG_B}"
+        }
+
+        def findBackendsByClusterName = { clusterName ->
+            sql_return_maparray('show backends').findAll { backend ->
+                backend.CloudClusterName == clusterName || backend.Tag?.contains(clusterName)
+            }
+        }
+
+        def getSingleBackendByClusterName = { clusterName ->
+            def backendsInCluster = findBackendsByClusterName(clusterName)
+            assertEquals(1, backendsInCluster.size(),
+                "Expected exactly 1 backend in ${clusterName}, got ${backendsInCluster.size()}")
+            backendsInCluster[0]
+        }
+
+        def getBackendNodeIndex = { backend ->
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            assertTrue(node != null, "Backend node not found for BackendId=${backend.BackendId}")
+            node.index
+        }
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, CG_B)
+        awaitUntil(30) {
+            findBackendsByClusterName(CG_A).size() == 1 &&
+                findBackendsByClusterName(CG_B).size() == 1
+        }
+
+        def beA = getSingleBackendByClusterName(CG_A)
+        def beB = getSingleBackendByClusterName(CG_B)
+        def beAIndex = getBackendNodeIndex(beA)
+        logger.info("CG-A BE: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Setup: Create table and insert data in CG-A ----
+        sql "use @${CG_A}"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b')"
+        sql "INSERT INTO ${tbl} VALUES (3, 'c'), (4, 'd')"
+        // Warm CG-A cache.
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        // Pre-warm CG-B: do a query from CG-B to trigger lazy FE fetch and populate candidates.
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} ORDER BY k1" // cold miss → lazy fetch
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+        // Insert a fresh rowset in CG-A so CG-B's local cache won't have it yet.
+        // This allows the subsequent query from CG-B to exercise the peer race path.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (5, 'e'), (6, 'f')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache for the new rowset
+        sleep(1000)
+
+        // One more query from CG-B on the new data to confirm peer wins (candidates in cache).
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        awaitUntil(10) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > 0
+        }
+        logger.info("Setup: CG-B has candidates for CG-A BE and peer wins confirmed")
+
+        // ==================== RPC failure eviction ====================
+        logger.info("=== consecutive RPC failures evict candidate ===")
+
+        def t3_evictionBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction")
+        // Use peer_lazy_fetch_success (monotonically increasing Adder) as the pre-condition signal
+        // rather than balance_tablet_be_mapping_size (an Adder<uint64_t> used as a gauge that
+        // underflows when decrements exceed increments). The setup's awaitUntil already confirmed
+        // lazy fetch succeeded, so this assertion is a documentation-level sanity check.
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0,
+            "pre-condition: candidates should exist (lazy fetch succeeded during setup)")
+
+        // Insert fresh data into CG-A (while it is still running) and warm CG-A's cache.
+        // CG-B has no local cache for these new blocks, so subsequent queries from CG-B will
+        // enter the winner race and attempt peer RPCs — which will fail once CG-A is stopped.
+        insertAndWarmCGA(4)
+
+        // Stop CG-A BE so all peer RPCs fail.
+        sql "use @${CG_A}"  // switch away so queries below route to CG-B
+        cluster.stopBackends(beAIndex)
+        sleep(2000)
+        sql "use @${CG_B}"
+
+        // With threshold=1, each tablet's first peer RPC failure triggers eviction.
+        // Table has BUCKETS 2 → 2 tablets. One query is enough; run 2 to be safe in case
+        // tablet distribution causes one tablet to be missed by a single query.
+        for (int i = 0; i < 2; i++) {
+            sql "SELECT * FROM ${tbl} ORDER BY k1" // peer RPC fails → S3 fallback
+            sleep(500)
+        }
+
+        // Eviction is incremented by the peer bthread, which runs concurrently with the S3
+        // winner path. The query may return (via S3) before the peer bthread has finished
+        // its RPC timeout and incremented the counter. Use awaitUntil to avoid a race.
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction") > t3_evictionBefore
+        }
+        logger.info("peer_rpc_failure_eviction confirmed")
+
+        // Also verify the gauge is back to 0 after eviction. This serves as a regression check
+        // for the fix that moved g_balance_tablet_be_mapping_size << 1 into the singleflight
+        // block (before operator[] creates the placeholder), ensuring increment/decrement are
+        // balanced and the gauge no longer underflows to UINT64_MAX - N.
+        assertEquals(0L,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "balance_tablet_be_mapping_size"),
+            "balance_tablet_be_mapping_size should be 0 after all candidates evicted")
+
+        // Queries should still succeed via S3 fallback.
+        def t3_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertTrue(t3_result.size() > 0, "S3 fallback should return correct data after eviction")
+
+        // Restart CG-A BE before T4.
+        cluster.startBackends(beAIndex)
+        sleep(5000)
+        logger.info("PASS")
+
+        // ==================== Candidate expiry via cleanup daemon ====================
+        logger.info("=== candidate expiry via cleanup daemon ===")
+
+        // CG-A BE is running again (restarted at end of T3).
+        // Insert fresh rows into CG-A that CG-B has NEVER cached.
+        // After T3, CG-B's local file cache already has all old data; querying the same data
+        // would be a local hit and never reach the peer path, so lazy fetch would not fire.
+        // Fresh uncached blocks force CG-B into the peer path → candidates empty (T3 evicted
+        // them) → lazy fetch fires → candidates re-populated.
+        insertAndWarmCGA(4)
+
+        def t4_lazyFetchBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success")
+        def t4_expiryBefore    = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_expiry_eviction")
+
+        sql "SELECT * FROM ${tbl} ORDER BY k1" // new uncached blocks → peer path → lazy fetch
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > t4_lazyFetchBefore
+        }
+        logger.info("candidates re-populated via lazy fetch")
+
+        // Wait for peer_candidate_expiry_s=60s + cleanup_interval=5s to fire.
+        // Total wait: 70 s to be safe.
+        logger.info("sleeping 70s for candidate expiry (expiry_s=60, cleanup_interval=5)...")
+        sleep(70 * 1000)
+
+        // peer_candidate_expiry_eviction increasing is sufficient proof that the cleanup daemon
+        // ran and removed the expired candidates.
+        // Do NOT assert balance_tablet_be_mapping_size == 0 (bvar::Adder<uint64_t> underflows).
+        // Do NOT verify via lazy fetch re-trigger after expiry: CG-B's local cache now has the
+        // fresh data, so subsequent queries are local hits and never reach the peer path.
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_expiry_eviction") > t4_expiryBefore
+        }
+        logger.info("PASS")
+
+        // ==================== cache miss rotates candidate (Issue 3) ====================
+        // After T4, CGB's candidates have all expired (expiry_s=60). Fresh setup needed.
+        //
+        // When CGA is running but its file cache is EMPTY (blocks not yet cached) and
+        // peer_cache_fill_compute_group_id is not set (this suite), CGA returns NOT_FOUND
+        // for the missing blocks.  The client (CGB) should call rotate_peer_candidate_on_cache_miss
+        // rather than incrementing the RPC-failure eviction counter — the peer_candidate_rotate
+        // bvar must increase, and the candidate must NOT be evicted.
+        logger.info("=== cache miss (NOT_FOUND) rotates candidate from CG-A to CG-C on CG-B ===")
+
+        // Step 1: Add a second remote compute group so rotate has a real next candidate.
+        cluster.addBackend(1, CG_C)
+        awaitUntil(30) {
+            findBackendsByClusterName(CG_C).size() == 1
+        }
+        def beC = getSingleBackendByClusterName(CG_C)
+        logger.info("CG-C BE: host={} brpcPort={}", beC.Host, beC.BrpcPort)
+
+        // Step 2: Prime CG-C once before CG-B's lazy fetch so FE records a primary backend for
+        // CG-C as well. Without this, the first lazy fetch may still return only CG-A, which
+        // would reduce rotate to a single-candidate noop.
+        sql "use @${CG_C}"
+        sql "SELECT * FROM ${tbl} WHERE k1 < 800 ORDER BY k1"
+        sleep(1000)
+
+        // Step 3: Trigger a fresh lazy fetch after T4 expiry so CG-B learns both remote
+        // compute groups (CG-A + CG-C) as candidates.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (800, 'fetch1'), (801, 'fetch2')"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 800 AND k1 < 810 ORDER BY k1"
+        sleep(1000)
+
+        def t5_lazyFetchBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success")
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 800 AND k1 < 810 ORDER BY k1"
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > t5_lazyFetchBefore
+        }
+        logger.info("lazy fetch refreshed candidates; CG-B should now know both CG-A and CG-C")
+
+        // Step 4: Seed CG-A as the preferred remote CG using a fresh rowset that CG-B has never
+        // cached. This ensures get_peer_candidates() stable-partitions CG-A to the front before
+        // the rotate verification below.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (820, 'pref1'), (821, 'pref2')"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 820 AND k1 < 900 ORDER BY k1"
+        sleep(1000)
+
+        def t5_peerWinSeedBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 820 AND k1 < 900 ORDER BY k1"
+        awaitUntil(10) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t5_peerWinSeedBefore
+        }
+        logger.info("CG-A became the preferred remote CG for the rotate verification")
+
+        // Step 5: Insert rotate-test rows, keep CG-A and CG-C warm, but leave CG-B cold.
+        sql "use @${CG_A}"
+        sql "INSERT INTO ${tbl} VALUES (900, 'rotate1'), (901, 'rotate2')"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"  // keep CG-A warm
+        sql "use @${CG_C}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"  // warm CG-C only
+        sleep(1000)
+
+        // Step 6: Restart CGA with cache deleted → all blocks are EMPTY after restart.
+        // trigger_peer_server_fill is NOT invoked here because peer_cache_fill_compute_group_id
+        // is empty (not configured in this suite), so request_cache_fill=false → server returns
+        // NOT_FOUND for EMPTY blocks → CGB rotate path fires.
+        cluster.stopBackends(beAIndex)
+        sleep(2000)
+        def beA_node5 = cluster.getBeByBackendId(beA.BackendId.toLong())
+        def cacheDir5 = new File("${beA_node5.path}/storage/file_cache")
+        logger.info("Deleting CGA file cache at: {}", cacheDir5.absolutePath)
+        if (cacheDir5.exists()) {
+            cacheDir5.deleteDir()
+            logger.info("CGA file cache deleted — blocks will be EMPTY after restart")
+        }
+        cluster.startBackends(beAIndex)
+        sleep(5000)
+        logger.info("CGA restarted with empty cache while CG-C remains warm")
+
+        // Step 7: CGB queries (900, 901) — CGB has NO local cache for these rows.
+        // Peer bthread first tries the preferred CG-A → EMPTY + request_fill=false → NOT_FOUND
+        // → rotate_peer_candidate_on_cache_miss. The same peer loop then advances to CG-C,
+        // which still has these blocks warm, so this is a real rotate-to-next-candidate path.
+        def t5_rotateBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_rotate")
+        def t5_evictionBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction")
+        def t5_peerWinBefore  = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        sql "use @${CG_B}"
+        sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"
+
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_rotate") > t5_rotateBefore
+        }
+        awaitUntil(15) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t5_peerWinBefore
+        }
+        logger.info("peer_candidate_rotate increased and peer still won via the next candidate")
+
+        // Key assertion: rotate occurred but eviction counter did NOT move.
+        assertEquals(t5_evictionBefore,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_rpc_failure_eviction"),
+            "NOT_FOUND (cache miss) must NOT increment peer_rpc_failure_eviction")
+
+        // Data must still be readable after rotate.
+        def t5_result = sql "SELECT * FROM ${tbl} WHERE k1 >= 900 ORDER BY k1"
+        assertEquals(2, t5_result.size(), "rotate path must return rotate-test rows")
+
+        // Restart CGA before end of suite (it was started in step 4; should still be running).
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_inverted_index.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_inverted_index.groovy
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// cross-CG peer read works correctly for tables with inverted index (.dat + .idx files).
+// CG-A warms cache for both .dat and .idx segments. CG-B lazy-fetch then reads via peer.
+// Priority: P2
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_inverted_index', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_inverted_index_tbl"
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Create table with inverted index in CG-A ----
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                id     BIGINT,
+                title  VARCHAR(256),
+                body   STRING,
+                INDEX idx_body (body) USING INVERTED PROPERTIES("parser" = "english")
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql """INSERT INTO ${tbl} VALUES
+            (1, 'hello world',  'the quick brown fox jumps over the lazy dog'),
+            (2, 'foo bar',      'pack my box with five dozen liquor jugs'),
+            (3, 'test case',    'how vexingly quick daft zebras jump')
+        """
+        sql """INSERT INTO ${tbl} VALUES
+            (4, 'more data',    'the five boxing wizards jump quickly'),
+            (5, 'last row',     'sphinx of black quartz judge my vow')
+        """
+
+        // Warm CG-A cache (both .dat segment files and .idx inverted-index files).
+        def warmResult = sql "SELECT * FROM ${tbl} ORDER BY id"
+        assertEquals(5, warmResult.size(), "Setup: CG-A warm query should return 5 rows")
+        sleep(1000)
+
+        // ==================== Cross-CG peer read with inverted index ====================
+        logger.info("=== cross-CG peer read with inverted index ===")
+
+        // Switch to CG-B, trigger cold miss → lazy fetch.
+        sql "use @cross_cg_peer_cluster"
+        def t11_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // First query: cold miss → lazy fetch fires. This populates CG-B's local cache for the
+        // existing rows and triggers async candidate registration for CG-A's BE.
+        sql "SELECT * FROM ${tbl} ORDER BY id"
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+
+        // Insert fresh rows into CG-A and warm CG-A cache (both .dat and .idx files).
+        // CG-B has no local cache for these new blocks, so the MATCH_ALL query below will
+        // enter the winner race and peer-read .dat/.idx blocks from CG-A.
+        sql "use @compute_cluster"
+        sql """INSERT INTO ${tbl} VALUES
+            (6, 'extra row', 'the quick fox is back again'),
+            (7, 'another',  'no matching keyword here')
+        """
+        sql "SELECT * FROM ${tbl} ORDER BY id"  // warm CG-A cache: .dat + .idx for new rows
+        sleep(1000)
+        sql "use @cross_cg_peer_cluster"
+
+        // Second query: new blocks not in CG-B local cache; MATCH_ALL exercises .idx files via peer.
+        def t11_result = sql """
+            SELECT id, title FROM ${tbl}
+            WHERE body MATCH_ALL 'quick'
+            ORDER BY id
+        """
+        assertTrue(t11_result.size() > 0, "MATCH_ALL query should return rows")
+        // Rows containing exact word 'quick': id=1 ("quick brown fox"), id=3 ("vexingly quick"),
+        // id=6 ("the quick fox is back again"). Row 4 has "quickly" which is a different token.
+        def ids = t11_result.collect { it[0] as long }
+        assertTrue(ids.containsAll([1L, 3L, 6L]),
+            "MATCH_ALL 'quick' should match rows 1, 3, 6; got ${ids}")
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t11_peerWinBefore,
+            "peer_race_peer_win should increase (peer served .dat and/or .idx blocks)")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > 0,
+            "peer_cross_compute_group_read should be > 0")
+
+        // Insert yet another fresh row with 'quick' into CG-A and warm CG-A, so the profile
+        // query below has uncached blocks on CG-B and will trigger a cross-CG peer read.
+        sql "use @compute_cluster"
+        sql """INSERT INTO ${tbl} VALUES (8, 'profile row', 'quick brown profile test')"""
+        sql "SELECT * FROM ${tbl} ORDER BY id"  // warm CG-A cache including new .idx blocks
+        sleep(1000)
+        sql "use @cross_cg_peer_cluster"
+
+        // Profile check: CrossCGPeerIOTotal should reflect .dat + .idx reads.
+        profile("cross_cg_inverted_index_profile") {
+            sql "set enable_profile = true"
+            sql "set profile_level = 2"
+            run {
+                sql """/* cross_cg_inverted_index */ SELECT id FROM ${tbl}
+                       WHERE body MATCH_ALL 'quick' ORDER BY id"""
+                sleep(500)
+            }
+            check { profileString, exception ->
+                logger.info("profile snippet: {}", profileString.take(2000))
+                def matcher = (profileString =~ /CrossCGPeerIOTotal:\s+(\d+)/)
+                def total = 0
+                while (matcher.find()) {
+                    total += matcher.group(1).toInteger()
+                }
+                assertTrue(total > 0,
+                    "CrossCGPeerIOTotal must be > 0 in profile for inverted-index query")
+            }
+        }
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_peer_read_core.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_peer_read_core.groovy
@@ -1,0 +1,311 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read core tests:
+// lazy FE fetch + peer wins race (P0)
+// S3 wins when peer BE is down (P0)
+// race disabled falls back to serial (P1)
+// query profile records cross-CG metrics (P0)
+// cold miss S3 first, lazy fetch, then peer wins (P0)
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_peer_read_core', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'max_concurrent_peer_races=64',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1) // CG-A starts with 1 BE
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    // Read a bvar counter from a BE's brpc_metrics endpoint. Returns 0 if the metric is not yet
+    // present (common for counters that haven't been incremented).
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_peer_read_core_tbl"
+
+        // Counter for unique k1 ranges across inserts; CG-B will never have local cache for them.
+        def nextK1 = 100
+        // Insert `count` rows into CG-A, warm CG-A's file cache, then switch to CG-B context.
+        def insertAndWarmCGA = { count ->
+            def start = nextK1
+            nextK1 += count
+            def vals = (start..<nextK1).collect { i -> "(${i}, 'row${i}')" }.join(", ")
+            sql "use @compute_cluster"
+            sql "INSERT INTO ${tbl} VALUES ${vals}"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache
+            sleep(1000)
+            sql "use @cross_cg_peer_cluster"
+        }
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        // Allow BE to register and send heartbeat before we read show backends.
+        sleep(5000)
+
+        // Backends are listed in registration order: index 0 = CG-A BE, index 1 = CG-B BE.
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends after adding CG-B"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Setup: Create table and insert data in CG-A ----
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')"
+        sql "INSERT INTO ${tbl} VALUES (4, 'delta'), (5, 'epsilon'), (6, 'zeta')"
+
+        // ---- Warm CG-A file cache by querying once in CG-A ----
+        def warmResult = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(6, warmResult.size(), "Setup: CG-A warm query should return 6 rows")
+        sleep(1000)
+
+        // ==================== Cold miss S3 first, then peer ====================
+        logger.info("=== cold miss S3 first, then peer ===")
+
+        def t10_lazyFetchBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered")
+        def t10_peerWinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // First query from CG-B: no candidates yet → cold miss → S3 wins, async lazy fetch fires.
+        sql "use @cross_cg_peer_cluster"
+        def t10_r1 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(6, t10_r1.size(), "first query (cold miss) should succeed via S3")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered") > t10_lazyFetchBefore,
+            "lazy fetch should be triggered on cold miss")
+
+        // Wait up to 30 s for lazy FE fetch to complete and populate candidate cache.
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+        logger.info("lazy fetch success confirmed")
+
+        // Insert a fresh rowset into CG-A so CG-B's local cache doesn't have it yet.
+        // Without new data, the second query would be a local cache hit (CG-B already
+        // cached everything from the first query via S3) and peer_race_peer_win would never increase.
+        insertAndWarmCGA(2)
+
+        // Second query from CG-B: new rowset not in CG-B local cache, candidates available → peer wins race.
+        def t10_r2 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertTrue(t10_r2.size() > 6, "second query (after lazy fetch) should return more than original 6 rows")
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t10_peerWinBefore,
+            "peer should win race after lazy fetch populates candidates")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_cache_hit") > 0,
+            "candidate cache should be hit on second query")
+        logger.info("PASS")
+
+        // ==================== + Peer wins, bvar + profile metrics ====================
+        logger.info("=== peer wins bvar + profile ===")
+
+        // Insert another fresh rowset so CG-B has no local cache for the new blocks.
+        insertAndWarmCGA(2)
+
+        def t1_peerWinBefore     = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        def t1_crossCgReadBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read")
+
+        profile("cross_cg_peer_win_profile") {
+            sql "set enable_profile = true"
+            sql "set profile_level = 2"
+            run {
+                sql "/* cross_cg_peer_win_profile */ SELECT * FROM ${tbl} ORDER BY k1"
+                sleep(500)
+            }
+            check { profileString, exception ->
+                logger.info("profile snippet: {}", profileString.take(2000))
+                // CrossCGPeerIOTotal should be > 0 (at least one cross-CG peer IO)
+                def crossCgMatcher = (profileString =~ /CrossCGPeerIOTotal:\s+(\d+)/)
+                def crossCgTotal = 0
+                while (crossCgMatcher.find()) {
+                    crossCgTotal += crossCgMatcher.group(1).toInteger()
+                }
+                assertTrue(crossCgTotal > 0, "CrossCGPeerIOTotal must be > 0 in profile")
+
+                // PeerRaceWin counter should reflect at least one race win
+                def raceWinMatcher = (profileString =~ /PeerRaceWin:\s+(\d+)/)
+                def raceWin = 0
+                while (raceWinMatcher.find()) {
+                    raceWin += raceWinMatcher.group(1).toInteger()
+                }
+                assertTrue(raceWin > 0, "PeerRaceWin must be > 0 in profile")
+            }
+        }
+
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t1_peerWinBefore,
+            "peer_race_peer_win bvar should increase after cross-CG peer read")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > t1_crossCgReadBefore,
+            "peer_cross_compute_group_read bvar should increase")
+        logger.info("PASS")
+
+        // ==================== Race disabled → serial peer path ====================
+        logger.info("=== race disabled, serial peer path ===")
+
+        // enable_peer_s3_race=false: cross-CG candidates go through serial peer→S3, no race counters.
+        setBeConfigTemporary(['enable_peer_s3_race': 'false']) {
+            sql "use @cross_cg_peer_cluster"
+            def t5_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+            def t5_s3WinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win")
+
+            def t5_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(t5_result.size() > 0, "serial path should return data")
+
+            // Race counters must NOT increase while race is disabled.
+            assertEquals(t5_peerWinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win"),
+                "peer_race_peer_win must not change when race disabled")
+            assertEquals(t5_s3WinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win"),
+                "peer_race_s3_win must not change when race disabled")
+        }
+        logger.info("PASS")
+
+        // ==================== S3 wins when CG-A BE is down ====================
+        logger.info("=== S3 wins when CG-A BE is unreachable ===")
+
+        // Insert fresh rows into CG-A and warm CG-A's cache BEFORE stopping CG-A.
+        // CG-B has no local cache for these new blocks. After CG-A is stopped, the
+        // winner race will try peer (fails: CG-A is down) → S3 wins → peer_race_s3_win increases.
+        // Without fresh uncached blocks, CG-B would serve all data from its own local cache
+        // (populated during T5/T1/T10) and peer_race_s3_win would never move.
+        insertAndWarmCGA(2)
+
+        def t2_s3WinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win")
+        def t2_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+
+        // Stop CG-A BE (compose index 1).
+        cluster.stopBackends(1)
+        sleep(3000)
+
+        def t2_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertTrue(t2_result.size() > 0, "S3 fallback should return data when CG-A BE is down")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win") > t2_s3WinBefore,
+            "peer_race_s3_win should increase when peer is unreachable")
+        assertEquals(t2_peerWinBefore,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win"),
+            "peer_race_peer_win should not increase when CG-A BE is down")
+
+        // Restart CG-A BE for cleanup.
+        cluster.startBackends(1)
+        sleep(5000)
+        logger.info("PASS")
+
+        // ==================== max_concurrent_peer_races=0 → degrades to serial ====================
+        logger.info("=== max_concurrent_peer_races=0 disables race ===")
+
+        // When the concurrent-race guard is saturated (limit=0), the reader falls back to the
+        // sequential peer→S3 path, so race counters must not increase.
+        setBeConfigTemporary(['max_concurrent_peer_races': '0']) {
+            sql "use @cross_cg_peer_cluster"
+            def t6_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+            def t6_s3WinBefore   = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win")
+
+            def t6_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(t6_result.size() > 0, "degraded path should still return data")
+
+            assertEquals(t6_peerWinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win"),
+                "peer_race_peer_win must not change when race is concurrency-limited to 0")
+            assertEquals(t6_s3WinBefore,
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win"),
+                "peer_race_s3_win must not change when race is concurrency-limited to 0")
+        }
+        logger.info("PASS")
+
+        // ==================== Comprehensive bvar sanity check ====================
+        // At this point the docker run has exercised all core scenarios, so we can assert
+        // the expected non-zero / zero relationship for every new bvar in aggregate.
+        logger.info("=== comprehensive bvar sanity ===")
+
+        // Candidate discovery layer (on CG-B BE).
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_cache_miss") > 0,
+            "peer_candidate_cache_miss should be > 0 (cold miss in T10)")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_triggered") > 0,
+            "peer_lazy_fetch_triggered should be > 0")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0,
+            "peer_lazy_fetch_success should be > 0")
+        assertEquals(0L, getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_failed"),
+            "peer_lazy_fetch_failed should be 0 (FE always reachable in docker)")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_candidate_cache_hit") > 0,
+            "peer_candidate_cache_hit should be > 0 (T1/T10 second query)")
+
+        // Winner race layer (on CG-B BE).
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > 0,
+            "peer_race_peer_win should be > 0")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_s3_win") > 0,
+            "peer_race_s3_win should be > 0")
+        assertTrue(getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_cross_compute_group_read") > 0,
+            "peer_cross_compute_group_read should be > 0")
+
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill.groovy
@@ -1,0 +1,299 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Cross compute group peer read server-side fill test:
+// CG-A BE cache miss → server pulls from S3 (pull-through fill) → returns data to CG-B.
+//      Second query: CG-A already cached → peer hits directly. (P1)
+// max_concurrent_peer_server_fills=0 → all fill requests rejected immediately → (Issue 5)
+//      peer_server_fill_rejected counter increases; query still succeeds via S3 fallback.
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+// CG-A BE does NOT warm its cache before the first cross-CG query, so the server-side fill path
+// is exercised.
+//
+// Note: peer_cache_fill_compute_group_id must be set to CG-A's cluster_id. In the docker
+// environment the default cluster id is "compute_cluster_id".
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_server_fill', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    // CG-A cluster id in the docker environment.
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        // Give S3 fill enough time in docker (latency can be high).
+        'peer_server_cache_fill_timeout_ms=6000',
+        // RPC timeout must exceed fill timeout.
+        // Designate CG-A as the fill compute group so client sets request_cache_fill=true only for CG-A.
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+        // Packed files would obscure per-segment file-cache inspection.
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_cross_cg_server_fill_tbl"
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE (fill server): host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B BE (requester):   host={} brpcPort={}", beB.Host, beB.BrpcPort)
+
+        // ---- Setup: Create table and insert data in CG-A. Do NOT warm CG-A cache. ----
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (10, 'foo'), (20, 'bar')"
+        sql "INSERT INTO ${tbl} VALUES (30, 'baz'), (40, 'qux')"
+        // Intentionally skip the CG-A warming step so CG-A's file cache is empty.
+        // CG-B query will trigger server-side fill on CG-A.
+        // ---- Step 1: Insert a fill-test rowset into CG-A BEFORE CG-B knows about CG-A ----
+        // CG-A's S3FileWriter will cache these blocks during write (DOWNLOADED on CG-A).
+        // CG-B has never seen this data → no local cache for it.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (50, 'fill1'), (60, 'fill2')"
+        // Warm CG-A's READ cache (the write-path cache from S3FileWriter is already populated,
+        // so this query is a local hit on CG-A — just ensures CG-A has the data accessible).
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        // ---- Step 2: Trigger lazy FE fetch from CG-B for the INITIAL rows only ----
+        // Run a SELECT before CG-A has (50,60) committed to CG-B's view... actually CG-B
+        // will read ALL rows. Insert (50,60) AFTER this cold miss to keep CG-B uncached.
+        // Restructure: trigger lazy fetch with existing rows, then insert fill-test rows.
+        //
+        // Actually, we inserted (50,60) first. The cold miss from CG-B will read ALL rows
+        // including (50,60) → CG-B caches them → can't test fill for (50,60).
+        //
+        // Correct order:
+        //   1. CG-B cold miss on initial rows (10,20,30,40) → lazy fetch, CGB caches initial
+        //   2. Insert fill-test rows (50,60) on CG-A → CGA write-caches them, CGB never reads them
+        //   3. Restart CGA → CGA file cache cleared (including write-cached (50,60))
+        //   4. CGB queries ALL: (10,20,30,40) = local hit; (50,60) = remote needed; CGA EMPTY → fill!
+
+        // Undo: we already inserted (50,60) above. Drop and recreate to get the right order.
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 2
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (10, 'foo'), (20, 'bar')"
+        sql "INSERT INTO ${tbl} VALUES (30, 'baz'), (40, 'qux')"
+        // Warm CG-A cache for initial rows.
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        sleep(1000)
+
+        // CG-B cold miss on initial rows (10,20,30,40) → triggers lazy fetch, CGB caches them.
+        sql "use @cross_cg_peer_cluster"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+        }
+        logger.info("CG-B now has CG-A BE as candidate; CG-B has (10,20,30,40) cached")
+
+        // ---- Step 3: Insert fill-test rows (50,60) into CG-A ----
+        // CG-A's S3FileWriter caches them (DOWNLOADED on CG-A). CG-B has NEVER read them.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (50, 'fill1'), (60, 'fill2')"
+        sleep(1000)
+
+        // ---- Step 4: Restart CG-A and EXPLICITLY delete its disk file cache ----
+        // S3FileWriter populates CGA's local file cache during INSERT (write-time caching).
+        // The file cache is disk-based and survives a BE process restart — blocks come back as
+        // DOWNLOADED, not EMPTY. trigger_peer_server_fill is only called when the block state
+        // is EMPTY. We must delete the cache directory after stopping the process so CGA truly
+        // starts with empty blocks after restart.
+        cluster.stopBackends(1)
+        sleep(2000)
+
+        def beA_node = cluster.getBeByBackendId(beA.BackendId.toLong())
+        def cacheDir = new File("${beA_node.path}/storage/file_cache")
+        logger.info("Deleting CGA file cache at: {}", cacheDir.absolutePath)
+        if (cacheDir.exists()) {
+            cacheDir.deleteDir()
+            logger.info("CGA file cache deleted — blocks will be EMPTY after restart")
+        } else {
+            logger.warn("CGA file cache directory not found at {}", cacheDir.absolutePath)
+        }
+
+        cluster.startBackends(1)
+        sleep(5000)
+        logger.info("CG-A restarted — file cache cleared, (50,60) blocks now EMPTY on CG-A")
+
+        // ==================== Server-side pull-through fill ====================
+        logger.info("=== server-side fill (CG-A cache miss → S3 pull-through) ===")
+
+        def t9_fillReqBefore  = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+        def t9_fillSuccBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success")
+
+        // CG-B queries ALL rows:
+        //   (10,20,30,40): CG-B local cache hit → no remote access
+        //   (50,60): CG-B has NO local cache; CG-A has EMPTY blocks (cleared by restart)
+        //            → winner race → peer bthread → RPC to CG-A with request_cache_fill=true
+        //            → CG-A EMPTY → enable_peer_server_cache_fill=true → trigger_peer_server_fill
+        //            → CG-A pulls from S3, returns data → peer_server_fill_requested++
+        sql "use @cross_cg_peer_cluster"
+        def t9_r1 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(6, t9_r1.size(), "first query should return all 6 rows")
+
+        // Verify that CG-A's server-side fill was triggered.
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested") > t9_fillReqBefore,
+            "peer_server_fill_requested should increase on CG-A after first cross-CG query")
+
+        // ---- Second query: verify peer wins now that CG-A has cached the data ----
+        // Insert another fresh rowset so CG-B has no cache for the new blocks.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (70, 'new3'), (80, 'new4')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A cache
+        sleep(1000)
+        sql "use @cross_cg_peer_cluster"
+        def t9_fillSuccBeforeSecondQuery = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success")
+
+        def t9_peerWinBefore = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win")
+        def t9_r2 = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(8, t9_r2.size(), "second query should return 8 rows")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_race_peer_win") > t9_peerWinBefore,
+            "peer should win race on second query (CG-A has data cached)")
+        // (70,80) blocks are already DOWNLOADED on CG-A — no server fill should be triggered.
+        assertEquals(t9_fillSuccBeforeSecondQuery,
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success"),
+            "peer_server_fill_success must NOT increase for (70,80) — CG-A already has them cached")
+
+        // CG-A fill success counter should be positive.
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_success") > t9_fillSuccBefore,
+            "peer_server_fill_success should increase on CG-A")
+
+        // ==================== fill concurrency limit (Issue 5) ====================
+        // Set max_concurrent_peer_server_fills=0 on CG-A → every fill request is rejected
+        // immediately (fill slot limit exceeded on the first fetch_add).
+        // CGB issues a query for blocks that CGA has NOT cached, with request_cache_fill=true.
+        // Expected: peer_server_fill_rejected increases; query succeeds via S3 winner fallback.
+        logger.info("=== max_concurrent_peer_server_fills=0 → fill rejected (Issue 5) ===")
+
+        // Insert T10-exclusive rows into CGA.  CGA's write-time caching populates them (DOWNLOADED).
+        // Then delete CGA's file cache so those blocks become EMPTY after restart.
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (200, 'limit_test1'), (201, 'limit_test2')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CGA
+        sleep(1000)
+
+        // Restart CGA with cache deleted so (200, 201) blocks are EMPTY.
+        cluster.stopBackends(1)
+        sleep(2000)
+        def beA_node10 = cluster.getBeByBackendId(beA.BackendId.toLong())
+        def cacheDir10 = new File("${beA_node10.path}/storage/file_cache")
+        if (cacheDir10.exists()) {
+            cacheDir10.deleteDir()
+            logger.info("CGA file cache deleted — blocks will be EMPTY after restart")
+        }
+        cluster.startBackends(1)
+        sleep(5000)
+        logger.info("CGA restarted with empty cache")
+
+        // Dynamically set max_concurrent_peer_server_fills=0 on CGA so all fills are rejected.
+        def beA_http_port = beA.HttpPort as int
+        def (setCode, setOut, setErr) = curl("POST",
+            "http://${beA.Host}:${beA_http_port}/api/update_config?max_concurrent_peer_server_fills=0")
+        assertTrue(setOut.contains("OK"),
+            "failed to set max_concurrent_peer_server_fills=0 on CGA: ${setOut}")
+        sleep(500)
+
+        def t10_rejectedBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_rejected")
+
+        // CGB queries (200, 201) — CGB has NO local cache; CGA EMPTY, fill rejected (limit=0).
+        // Winner race: peer RPC → CGA EMPTY + fill rejected → NOT_FOUND / error; S3 fallback wins.
+        sql "use @cross_cg_peer_cluster"
+        def t10_result = sql "SELECT * FROM ${tbl} WHERE k1 IN (200, 201) ORDER BY k1"
+        assertEquals(2, t10_result.size(), "S3 fallback must return limit-test rows")
+
+        // Verify fill was rejected on CGA.
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_rejected") > t10_rejectedBefore,
+            "peer_server_fill_rejected must increase when max_concurrent_peer_server_fills=0")
+
+        // Restore the limit to the default.
+        def (restoreCode, restoreOut, restoreErr) = curl("POST",
+            "http://${beA.Host}:${beA_http_port}/api/update_config?max_concurrent_peer_server_fills=32")
+        assertTrue(restoreOut.contains("OK"),
+            "failed to restore max_concurrent_peer_server_fills: ${restoreOut}")
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_dynamic_config.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_dynamic_config.groovy
@@ -1,0 +1,287 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Dynamic config toggle tests for cross-CG server-side fill.
+//
+// peer_cache_fill_compute_group_id and enable_peer_server_cache_fill are both
+// mutable configs — they can be changed at runtime via the HTTP API without
+// restarting BE.  This suite verifies that toggling them takes effect immediately.
+//
+// Two rounds (each a fresh docker cluster):
+//   Round 1 — enable_peer_server_cache_fill: start disabled → no fill → enable dynamically → fill works → disable → no fill
+//   Round 2 — peer_cache_fill_compute_group_id: start with wrong id → no fill → correct id dynamically → fill works → wrong id → no fill
+//
+// Topology per round: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_server_fill_dynamic_config', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A_CLUSTER_ID = "compute_cluster_id"
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    // Two rounds with different initial configs.
+    def clusterOptionsList = [
+        new ClusterOptions(),  // Round 1: enable_peer_server_cache_fill toggle
+        new ClusterOptions(),  // Round 2: peer_cache_fill_compute_group_id toggle
+    ]
+
+    def commonFeConfigs = [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    def commonBeConfigs = [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+
+    for (options in clusterOptionsList) {
+        options.feConfigs += commonFeConfigs
+        options.beConfigs += commonBeConfigs
+        options.setFeNum(1)
+        options.setBeNum(1)
+        options.cloudMode = true
+        options.enableDebugPoints()
+    }
+
+    // Round 1: fill DISABLED initially, correct CG id.
+    clusterOptionsList[0].beConfigs += [
+        'enable_peer_server_cache_fill=false',
+        "peer_cache_fill_compute_group_id=${CG_A_CLUSTER_ID}",
+    ]
+    // Round 2: fill ENABLED initially, but WRONG CG id.
+    clusterOptionsList[1].beConfigs += [
+        'enable_peer_server_cache_fill=true',
+        'peer_cache_fill_compute_group_id=nonexistent_cg_id',
+    ]
+
+    def roundLabels = [
+        "enable_peer_server_cache_fill toggle",
+        "peer_cache_fill_compute_group_id toggle",
+    ]
+
+    for (int roundIdx = 0; roundIdx < clusterOptionsList.size(); roundIdx++) {
+        def options = clusterOptionsList[roundIdx]
+        def roundLabel = roundLabels[roundIdx]
+
+        logger.info("===== Round {}: {} =====", roundIdx + 1, roundLabel)
+
+        docker(options) {
+            def tbl = "test_dyn_cfg_tbl"
+            def nextK1 = 100
+
+            // ---- Helper: update a single BE config via HTTP API ----
+            def updateBeConfig = { host, httpPort, key, value ->
+                def (code, out, err) = curl("POST",
+                    "http://${host}:${httpPort}/api/update_config?${key}=${value}")
+                assertTrue(out.contains("OK"),
+                    "failed to set ${key}=${value} on ${host}:${httpPort}: ${out}")
+            }
+
+            // ---- Helper: clear CG-A file cache (requires restart, used for setup only) ----
+            def clearCgACacheAndRestart = { beABackendId ->
+                cluster.stopBackends(1)
+                sleep(2000)
+                def node = cluster.getBeByBackendId(beABackendId as long)
+                def cacheDir = new File("${node.path}/storage/file_cache")
+                if (cacheDir.exists()) {
+                    cacheDir.deleteDir()
+                    logger.info("Deleted CG-A file cache: {}", cacheDir.absolutePath)
+                }
+                cluster.startBackends(1)
+                sleep(5000)
+            }
+
+            // ---- Helper: insert new rows into CG-A and warm its cache ----
+            def insertAndWarmCGA = { count ->
+                def start = nextK1
+                nextK1 += count
+                def vals = (start..<nextK1).collect { i -> "(${i}, 'v${i}')" }.join(", ")
+                sql "use @compute_cluster"
+                sql "INSERT INTO ${tbl} VALUES ${vals}"
+                sql "SELECT * FROM ${tbl} ORDER BY k1"
+                sleep(1000)
+            }
+
+            // ---- Setup: Add CG-B ----
+            cluster.addBackend(1, "cross_cg_peer_cluster")
+            sleep(5000)
+
+            def backends = sql_return_maparray('show backends')
+            assert backends.size() == 2 : "Expected 2 backends"
+            def beA = backends.get(0)
+            def beB = backends.get(1)
+            def beA_http = beA.HttpPort as int
+            def beB_http = beB.HttpPort as int
+            logger.info("CG-A BE: host={} brpc={} http={}", beA.Host, beA.BrpcPort, beA_http)
+            logger.info("CG-B BE: host={} brpc={} http={}", beB.Host, beB.BrpcPort, beB_http)
+
+            // ---- Setup: Create table and seed data ----
+            sql "use @compute_cluster"
+            sql "DROP TABLE IF EXISTS ${tbl}"
+            sql """
+                CREATE TABLE ${tbl} (
+                    k1 INT,
+                    v1 VARCHAR(256)
+                )
+                DUPLICATE KEY(k1)
+                DISTRIBUTED BY HASH(k1) BUCKETS 2
+                PROPERTIES ("replication_num" = "1")
+            """
+            sql "INSERT INTO ${tbl} VALUES (1, 'a'), (2, 'b')"
+            sql "INSERT INTO ${tbl} VALUES (3, 'c'), (4, 'd')"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"  // warm CG-A
+            sleep(1000)
+
+            // ---- Trigger lazy FE fetch from CG-B so CG-A becomes a candidate ----
+            sql "use @cross_cg_peer_cluster"
+            sql "SELECT * FROM ${tbl} ORDER BY k1"
+            awaitUntil(30) {
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_lazy_fetch_success") > 0
+            }
+            logger.info("CG-B lazy fetch done — CG-A is now a peer candidate")
+
+            // ==================================================================
+            // Phase 1: initial config — fill should NOT work
+            // ==================================================================
+            logger.info("--- Phase 1: fill should NOT work (initial config) ---")
+
+            insertAndWarmCGA(4)
+            clearCgACacheAndRestart(beA.BackendId)
+            // Refresh beA reference after restart.
+            backends = sql_return_maparray('show backends')
+            beA = backends.get(0)
+
+            def p1_fillBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+
+            sql "use @cross_cg_peer_cluster"
+            def p1_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(p1_result.size() >= 8, "Phase 1: query should succeed via S3 fallback")
+
+            assertEquals(p1_fillBefore,
+                getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested"),
+                "Phase 1: peer_server_fill_requested must NOT increase")
+            logger.info("Phase 1 PASS")
+
+            // ==================================================================
+            // Phase 2: dynamically enable fill — should take effect immediately
+            // ==================================================================
+            logger.info("--- Phase 2: dynamically enable fill ---")
+
+            if (roundLabel.contains("enable_peer_server_cache_fill")) {
+                updateBeConfig(beA.Host, beA_http, "enable_peer_server_cache_fill", "true")
+                logger.info("Dynamically set enable_peer_server_cache_fill=true on CG-A")
+            } else {
+                updateBeConfig(beA.Host, beA_http, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+                updateBeConfig(beB.Host, beB_http, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+                logger.info("Dynamically set peer_cache_fill_compute_group_id={}", CG_A_CLUSTER_ID)
+            }
+            sleep(500)
+
+            // Insert new data and clear CG-A cache so blocks are EMPTY.
+            insertAndWarmCGA(4)
+            clearCgACacheAndRestart(beA.BackendId)
+
+            // Re-apply the dynamic config after restart (restart resets to be_custom.conf).
+            backends = sql_return_maparray('show backends')
+            beA = backends.get(0)
+            if (roundLabel.contains("enable_peer_server_cache_fill")) {
+                updateBeConfig(beA.Host, beA_http, "enable_peer_server_cache_fill", "true")
+            } else {
+                updateBeConfig(beA.Host, beA_http, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+                updateBeConfig(beB.Host, beB_http, "peer_cache_fill_compute_group_id", CG_A_CLUSTER_ID)
+            }
+            sleep(500)
+
+            def p2_fillBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+
+            sql "use @cross_cg_peer_cluster"
+            def p2_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(p2_result.size() >= 12, "Phase 2: query should return all rows")
+
+            assertTrue(
+                getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested") > p2_fillBefore,
+                "Phase 2: peer_server_fill_requested must increase after dynamic enable")
+            logger.info("Phase 2 PASS")
+
+            // ==================================================================
+            // Phase 3: dynamically disable fill again — verify it stops
+            // ==================================================================
+            logger.info("--- Phase 3: dynamically disable fill ---")
+
+            if (roundLabel.contains("enable_peer_server_cache_fill")) {
+                updateBeConfig(beA.Host, beA_http, "enable_peer_server_cache_fill", "false")
+                logger.info("Dynamically set enable_peer_server_cache_fill=false on CG-A")
+            } else {
+                updateBeConfig(beA.Host, beA_http, "peer_cache_fill_compute_group_id", "nonexistent_cg_id")
+                updateBeConfig(beB.Host, beB_http, "peer_cache_fill_compute_group_id", "nonexistent_cg_id")
+                logger.info("Dynamically set peer_cache_fill_compute_group_id=nonexistent_cg_id")
+            }
+            sleep(500)
+
+            insertAndWarmCGA(4)
+            clearCgACacheAndRestart(beA.BackendId)
+
+            backends = sql_return_maparray('show backends')
+            beA = backends.get(0)
+
+            def p3_fillBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested")
+
+            sql "use @cross_cg_peer_cluster"
+            def p3_result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+            assertTrue(p3_result.size() >= 16, "Phase 3: query should return all rows via S3 fallback")
+
+            assertEquals(p3_fillBefore,
+                getBrpcMetrics(beA.Host, beA.BrpcPort, "peer_server_fill_requested"),
+                "Phase 3: peer_server_fill_requested must NOT increase after re-disabling")
+            logger.info("Phase 3 PASS")
+
+            logger.info("===== Round '{}' PASS =====", roundLabel)
+        }
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_three_cg.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_cross_cg_server_fill_three_cg.groovy
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_cross_cg_server_fill_three_cg', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    final String CG_A = "compute_cluster"
+    final String CG_B = "cross_cg_fill_allow_cluster"
+    final String CG_C = "cross_cg_fill_reject_cluster"
+    final String CG_B_ID = "${CG_B}_id"
+    final String CG_C_ID = "${CG_C}_id"
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'enable_peer_server_cache_fill=true',
+        'peer_server_cache_fill_timeout_ms=6000',
+        'enable_packed_file=false',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def findBackendsByClusterName = { clusterName ->
+            sql_return_maparray('show backends').findAll { backend ->
+                backend.CloudClusterName == clusterName || backend.Tag?.contains(clusterName)
+            }
+        }
+
+        def getSingleBackendByClusterName = { clusterName ->
+            def backendsInCluster = findBackendsByClusterName(clusterName)
+            assertEquals(1, backendsInCluster.size(),
+                "Expected exactly 1 backend in ${clusterName}, got ${backendsInCluster.size()}")
+            backendsInCluster[0]
+        }
+
+        def getBackendNodeIndex = { backend ->
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            assertTrue(node != null, "Backend node not found for BackendId=${backend.BackendId}")
+            node.index
+        }
+
+        def rewriteBeCustomConfigAndRestart = { backend, updates ->
+            def backendIndex = getBackendNodeIndex(backend)
+            cluster.stopBackends(backendIndex)
+            sleep(2000)
+
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            assertTrue(node != null, "Backend node not found for BackendId=${backend.BackendId}")
+            def customConf = new File("${node.path}/conf/be_custom.conf")
+            assertTrue(customConf.exists(), "be_custom.conf not found for BackendId=${backend.BackendId}")
+
+            def lines = customConf.readLines().findAll { line ->
+                def trimmed = line.trim()
+                !updates.keySet().any { key ->
+                    trimmed.startsWith("${key}=") || trimmed.startsWith("${key} =")
+                }
+            }
+            if (!lines.isEmpty() && lines[-1] != "") {
+                lines << ""
+            }
+            updates.each { key, value ->
+                lines << "${key} = ${value}"
+            }
+            customConf.text = lines.join(System.lineSeparator()) + System.lineSeparator()
+            logger.info("Updated {} with {}", customConf.absolutePath, updates)
+
+            cluster.startBackends(backendIndex)
+            sleep(5000)
+        }
+
+        def clearFileCacheAndRestart = { backend, reason ->
+            def backendIndex = getBackendNodeIndex(backend)
+            cluster.stopBackends(backendIndex)
+            sleep(2000)
+            def node = cluster.getBeByBackendId(backend.BackendId.toLong())
+            def cacheDir = new File("${node.path}/storage/file_cache")
+            logger.info("Deleting {} file cache at {}", reason, cacheDir.absolutePath)
+            if (cacheDir.exists()) {
+                cacheDir.deleteDir()
+            }
+            cluster.startBackends(backendIndex)
+            sleep(5000)
+        }
+
+        def createTable = { clusterName, tableName ->
+            sql "use @${clusterName}"
+            sql "DROP TABLE IF EXISTS ${tableName}"
+            sql """
+                CREATE TABLE ${tableName} (
+                    k1 INT,
+                    v1 VARCHAR(256)
+                )
+                DUPLICATE KEY(k1)
+                DISTRIBUTED BY HASH(k1) BUCKETS 2
+                PROPERTIES ("replication_num" = "1")
+            """
+        }
+
+        def warmRows = { clusterName, tableName, predicate ->
+            sql "use @${clusterName}"
+            sql "SELECT * FROM ${tableName} WHERE ${predicate} ORDER BY k1"
+            sleep(1000)
+        }
+
+        cluster.addBackend(1, CG_B)
+        cluster.addBackend(1, CG_C)
+        awaitUntil(30) {
+            findBackendsByClusterName(CG_A).size() == 1 &&
+                findBackendsByClusterName(CG_B).size() == 1 &&
+                findBackendsByClusterName(CG_C).size() == 1
+        }
+
+        def beA = getSingleBackendByClusterName(CG_A)
+        def beB = getSingleBackendByClusterName(CG_B)
+        def beC = getSingleBackendByClusterName(CG_C)
+        logger.info("CG-A requester: host={} brpcPort={}", beA.Host, beA.BrpcPort)
+        logger.info("CG-B fill-allow: host={} brpcPort={}", beB.Host, beB.BrpcPort)
+        logger.info("CG-C fill-reject: host={} brpcPort={}", beC.Host, beC.BrpcPort)
+
+        // Case 1: A targets B, B allows server fill.
+        def tblAllow = "test_cross_cg_server_fill_three_cg_allow_tbl"
+        // These cloud configs are startup-only in the current docker image,
+        // so switch them through be_custom.conf and a BE restart.
+        rewriteBeCustomConfigAndRestart(beA,
+            ["peer_cache_fill_compute_group_id": CG_B_ID])
+
+        createTable(CG_B, tblAllow)
+        sql "use @${CG_B}"
+        sql "INSERT INTO ${tblAllow} VALUES (10, 'b10'), (20, 'b20'), (30, 'b30'), (40, 'b40')"
+        warmRows(CG_B, tblAllow, "k1 < 50")
+
+        def bFillReqBeforeAllow = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested")
+        def bFillSuccBeforeAllow = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_success")
+        def cFillReqBeforeAllow = getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested")
+
+        sql "use @${CG_A}"
+        def allowInitial = sql "SELECT * FROM ${tblAllow} WHERE k1 < 50 ORDER BY k1"
+        assertEquals(4, allowInitial.size(), "CG-A should read initial rows from CG-B")
+        // Candidate refresh is asynchronous and does not reliably surface as a lazy-fetch
+        // counter bump after the requester BE has been restarted. Give it a short settle window
+        // and validate the real peer/server-fill behavior on the next query.
+        sleep(1000)
+
+        sql "use @${CG_B}"
+        sql "INSERT INTO ${tblAllow} VALUES (50, 'b50'), (60, 'b60')"
+        warmRows(CG_B, tblAllow, "k1 >= 50")
+        clearFileCacheAndRestart(beB, "CG-B")
+
+        sql "use @${CG_A}"
+        def allowAll = sql "SELECT * FROM ${tblAllow} ORDER BY k1"
+        assertEquals(6, allowAll.size(), "CG-A should read all rows when CG-B server fill is enabled")
+        awaitUntil(30) {
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested") > bFillReqBeforeAllow &&
+                getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_success") > bFillSuccBeforeAllow
+        }
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested") > bFillReqBeforeAllow,
+            "CG-B should receive server fill requests from CG-A")
+        assertTrue(
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_success") > bFillSuccBeforeAllow,
+            "CG-B should complete server fill successfully")
+        assertEquals(
+            cFillReqBeforeAllow,
+            getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested"),
+            "CG-C should not receive server fill requests when CG-A targets CG-B")
+
+        // Case 2: A targets C, C rejects server fill.
+        def tblReject = "test_cross_cg_server_fill_three_cg_reject_tbl"
+        rewriteBeCustomConfigAndRestart(beA,
+            ["peer_cache_fill_compute_group_id": CG_C_ID])
+        rewriteBeCustomConfigAndRestart(beC,
+            ["enable_peer_server_cache_fill": "false"])
+
+        createTable(CG_C, tblReject)
+        sql "use @${CG_C}"
+        sql "INSERT INTO ${tblReject} VALUES (110, 'c110'), (120, 'c120'), (130, 'c130'), (140, 'c140')"
+        warmRows(CG_C, tblReject, "k1 < 150")
+
+        sql "use @${CG_A}"
+        def rejectInitial = sql "SELECT * FROM ${tblReject} WHERE k1 < 150 ORDER BY k1"
+        assertEquals(4, rejectInitial.size(), "CG-A should read initial rows from CG-C")
+        sleep(1000)
+
+        sql "use @${CG_C}"
+        sql "INSERT INTO ${tblReject} VALUES (150, 'c150'), (160, 'c160')"
+        warmRows(CG_C, tblReject, "k1 >= 150")
+        clearFileCacheAndRestart(beC, "CG-C")
+
+        def cFillReqBefore = getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested")
+        def cFillSuccBefore = getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_success")
+        def bFillReqBeforeReject = getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested")
+        def rejectPeerBefore = getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_peer_read")
+        def rejectS3Before = getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_s3_read")
+
+        sql "use @${CG_A}"
+        def rejectAll = sql "SELECT * FROM ${tblReject} ORDER BY k1"
+        assertEquals(6, rejectAll.size(), "CG-A should fall back and still read all rows when CG-C rejects fill")
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_peer_read") > rejectPeerBefore,
+            "CG-A should attempt peer read against CG-C before fallback")
+        assertTrue(
+            getBrpcMetrics(beA.Host, beA.BrpcPort, "cached_remote_reader_s3_read") > rejectS3Before,
+            "CG-A should fall back to S3 when CG-C refuses server fill")
+        assertEquals(
+            cFillReqBefore,
+            getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_requested"),
+            "CG-C should not trigger server fill when enable_peer_server_cache_fill=false")
+        assertEquals(
+            cFillSuccBefore,
+            getBrpcMetrics(beC.Host, beC.BrpcPort, "peer_server_fill_success"),
+            "CG-C should not report server fill success when fill is disabled")
+        assertEquals(
+            bFillReqBeforeReject,
+            getBrpcMetrics(beB.Host, beB.BrpcPort, "peer_server_fill_requested"),
+            "CG-B should stay uninvolved when CG-A targets CG-C")
+
+        logger.info("PASS")
+    }
+}

--- a/regression-test/suites/cloud_p0/balance/test_peer_cache_http_api.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_peer_cache_http_api.groovy
@@ -1,0 +1,311 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Tests for /api/peer_cache HTTP admin endpoints:
+// 1. show_all returns empty initially
+// 2. set injects peer candidates for a tablet
+// 3. show returns the injected candidates
+// 4. reset_cooldown clears cooldown state
+// 5. remove deletes peer candidates
+// 6. peer read actually uses injected candidates (end-to-end)
+//
+// Topology: 1 FE + CG-A (1 BE, "compute_cluster") + CG-B (1 BE, "cross_cg_peer_cluster")
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+suite('test_peer_cache_http_api', 'docker') {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+        'sys_log_verbose_modules=org',
+        'heartbeat_interval_second=1',
+        'auto_check_statistics_in_minutes=60',
+    ]
+    options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'file_cache_each_block_size=131072',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
+    ]
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = true
+    options.enableDebugPoints()
+
+    def jsonSlurper = new JsonSlurper()
+
+    // Helper: call GET /api/peer_cache on a specific BE
+    def peerCacheGet = { beHost, beHttpPort, params ->
+        def result = null
+        httpTest {
+            endpoint ""
+            uri "${beHost}:${beHttpPort}/api/peer_cache?${params}"
+            op "get"
+            check { respCode, body ->
+                logger.info("GET /api/peer_cache?${params} => ${respCode}: ${body}")
+                result = [code: respCode, body: body]
+            }
+        }
+        return result
+    }
+
+    // Helper: call POST /api/peer_cache on a specific BE
+    def peerCachePost = { beHost, beHttpPort, params, jsonBody ->
+        def result = null
+        httpTest {
+            endpoint ""
+            uri "${beHost}:${beHttpPort}/api/peer_cache?${params}"
+            body jsonBody
+            check { respCode, body ->
+                logger.info("POST /api/peer_cache?${params} => ${respCode}: ${body}")
+                result = [code: respCode, body: body]
+            }
+        }
+        return result
+    }
+
+    // Read a bvar counter from a BE's brpc_metrics endpoint.
+    def getBrpcMetrics = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
+        }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
+    }
+
+    docker(options) {
+        def tbl = "test_peer_cache_http_api_tbl"
+
+        // ---- Setup: Add CG-B ----
+        cluster.addBackend(1, "cross_cg_peer_cluster")
+        sleep(5000)
+
+        def backends = sql_return_maparray('show backends')
+        assert backends.size() == 2 : "Expected 2 backends after adding CG-B"
+        def beA = backends.get(0)
+        def beB = backends.get(1)
+        logger.info("CG-A BE: host={} httpPort={} brpcPort={}", beA.Host, beA.HttpPort, beA.BrpcPort)
+        logger.info("CG-B BE: host={} httpPort={} brpcPort={}", beB.Host, beB.HttpPort, beB.BrpcPort)
+
+        def beBHost = beB.Host
+        def beBHttpPort = beB.HttpPort as int
+        def beAHost = beA.Host
+        def beABrpcPort = beA.BrpcPort as int
+
+        // ==================== T1: show_all returns empty initially ====================
+        logger.info("=== T1: show_all returns empty initially ===")
+        def t1 = peerCacheGet(beBHost, beBHttpPort, "op=show_all")
+        assertEquals(200, t1.code, "show_all should succeed")
+        def t1Json = jsonSlurper.parseText(t1.body)
+        assertEquals(0, t1Json.total, "no peer candidates should exist initially")
+        logger.info("PASS: show_all empty")
+
+        // ==================== T2: set injects peer candidates ====================
+        logger.info("=== T2: set injects peer candidates for tablet 99999 ===")
+        def setBody = """{
+            "candidates": [
+                {"host": "${beAHost}", "brpc_port": ${beABrpcPort}, "compute_group_id": "compute_cluster"},
+                {"host": "10.0.0.99", "brpc_port": 9999, "compute_group_id": "fake_cg"}
+            ],
+            "last_successful_compute_group_id": "compute_cluster",
+            "consecutive_all_miss": 0,
+            "cooldown_until_ms": 0
+        }"""
+        def t2 = peerCachePost(beBHost, beBHttpPort, "op=set&tablet_id=99999", setBody)
+        assertEquals(200, t2.code, "set should succeed")
+        logger.info("PASS: set succeeded")
+
+        // ==================== T3: show returns injected candidates ====================
+        logger.info("=== T3: show returns injected candidates ===")
+        def t3 = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=99999")
+        assertEquals(200, t3.code, "show should succeed")
+        def t3Json = jsonSlurper.parseText(t3.body)
+        assertEquals(99999L, t3Json.tablet_id as long, "tablet_id should match")
+        assertEquals(2, t3Json.candidates.size(), "should have 2 candidates")
+        assertEquals(beAHost, t3Json.candidates[0].host, "first candidate host should be CG-A")
+        assertEquals(beABrpcPort, t3Json.candidates[0].brpc_port as int, "first candidate brpc_port should match")
+        assertEquals("compute_cluster", t3Json.candidates[0].compute_group_id)
+        assertEquals("10.0.0.99", t3Json.candidates[1].host)
+        assertEquals("compute_cluster", t3Json.last_successful_compute_group_id)
+        assertEquals(0, t3Json.consecutive_all_miss)
+        assertEquals(0L, t3Json.cooldown_until_ms as long)
+        logger.info("PASS: show returns correct data")
+
+        // ==================== T4: show_all now has 1 tablet ====================
+        logger.info("=== T4: show_all has 1 tablet ===")
+        def t4 = peerCacheGet(beBHost, beBHttpPort, "op=show_all&limit=10")
+        assertEquals(200, t4.code)
+        def t4Json = jsonSlurper.parseText(t4.body)
+        assertEquals(1, t4Json.total, "should have 1 tablet after set")
+        assertEquals(99999L, t4Json.tablets[0].tablet_id as long)
+        logger.info("PASS: show_all has 1 tablet")
+
+        // ==================== T5: set cooldown then reset ====================
+        logger.info("=== T5: set cooldown then reset ===")
+        // Force-set a tablet with cooldown active
+        def cooldownBody = """{
+            "candidates": [
+                {"host": "${beAHost}", "brpc_port": ${beABrpcPort}, "compute_group_id": "cg1"}
+            ],
+            "last_successful_compute_group_id": "",
+            "consecutive_all_miss": 10,
+            "cooldown_until_ms": 9999999999999
+        }"""
+        def t5set = peerCachePost(beBHost, beBHttpPort, "op=set&tablet_id=88888", cooldownBody)
+        assertEquals(200, t5set.code)
+
+        // Verify cooldown is set
+        def t5show = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=88888")
+        def t5Json = jsonSlurper.parseText(t5show.body)
+        assertEquals(10, t5Json.consecutive_all_miss)
+        assertTrue(t5Json.cooldown_until_ms as long > 0, "cooldown should be active")
+
+        // Reset cooldown
+        def t5reset = peerCachePost(beBHost, beBHttpPort, "op=reset_cooldown&tablet_id=88888", "")
+        assertEquals(200, t5reset.code)
+
+        // Verify cooldown is cleared
+        def t5after = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=88888")
+        def t5afterJson = jsonSlurper.parseText(t5after.body)
+        assertEquals(0, t5afterJson.consecutive_all_miss, "consecutive_all_miss should be reset")
+        assertEquals(0L, t5afterJson.cooldown_until_ms as long, "cooldown_until_ms should be reset")
+        logger.info("PASS: cooldown reset works")
+
+        // ==================== T6: remove deletes peer candidates ====================
+        logger.info("=== T6: remove deletes peer candidates ===")
+        def t6rm = peerCachePost(beBHost, beBHttpPort, "op=remove&tablet_id=99999", "")
+        assertEquals(200, t6rm.code)
+
+        // show should now return error (not found)
+        def t6show = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=99999")
+        assertEquals(500, t6show.code, "show should fail for removed tablet")
+
+        // Also remove the cooldown test tablet
+        peerCachePost(beBHost, beBHttpPort, "op=remove&tablet_id=88888", "")
+        logger.info("PASS: remove works")
+
+        // ==================== T7: show for non-existent tablet returns error ====================
+        logger.info("=== T7: show non-existent tablet ===")
+        def t7 = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=11111")
+        assertEquals(500, t7.code, "show non-existent tablet should return error")
+        logger.info("PASS: show non-existent returns error")
+
+        // ==================== T8: invalid op returns error ====================
+        logger.info("=== T8: invalid op ===")
+        def t8 = peerCacheGet(beBHost, beBHttpPort, "op=invalid_op")
+        assertEquals(500, t8.code, "invalid op should return error")
+        logger.info("PASS: invalid op returns error")
+
+        // ==================== T9: end-to-end — inject candidates, then query uses peer ====================
+        logger.info("=== T9: end-to-end peer read with injected candidates ===")
+
+        // Create table and insert data in CG-A
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        sql """
+            CREATE TABLE ${tbl} (
+                k1 INT,
+                v1 VARCHAR(256)
+            )
+            DUPLICATE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO ${tbl} VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')"
+        // Warm CG-A file cache
+        def warmResult = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(3, warmResult.size())
+        sleep(1000)
+
+        // Get the tablet ID of the table
+        def tablets = sql_return_maparray("SHOW TABLETS FROM ${tbl}")
+        assertTrue(tablets.size() > 0, "table should have at least one tablet")
+        def tabletId = tablets[0].TabletId as long
+        logger.info("tablet_id for ${tbl}: ${tabletId}")
+
+        // Inject CG-A as peer candidate for this tablet on CG-B
+        def e2eBody = """{
+            "candidates": [
+                {"host": "${beAHost}", "brpc_port": ${beABrpcPort}, "compute_group_id": "compute_cluster"}
+            ],
+            "last_successful_compute_group_id": "",
+            "consecutive_all_miss": 0,
+            "cooldown_until_ms": 0
+        }"""
+        def t9set = peerCachePost(beBHost, beBHttpPort, "op=set&tablet_id=${tabletId}", e2eBody)
+        assertEquals(200, t9set.code, "inject candidate for real tablet should succeed")
+
+        // Verify it shows up
+        def t9show = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=${tabletId}")
+        assertEquals(200, t9show.code)
+        def t9showJson = jsonSlurper.parseText(t9show.body)
+        assertEquals(1, t9showJson.candidates.size())
+        logger.info("Injected candidate for tablet ${tabletId}: {}", t9showJson)
+
+        // Insert new data in CG-A to create uncached rowset for CG-B
+        sql "use @compute_cluster"
+        sql "INSERT INTO ${tbl} VALUES (4, 'delta'), (5, 'epsilon')"
+        sql "SELECT * FROM ${tbl} ORDER BY k1" // warm CG-A cache
+        sleep(1000)
+
+        // Record peer metrics before query from CG-B
+        def peerHitBefore = getBrpcMetrics(beBHost, beB.BrpcPort, "peer_candidate_cache_hit")
+
+        // Query from CG-B — new rowset not in CG-B local cache, should try peer from injected candidate
+        sql "use @cross_cg_peer_cluster"
+        def t9result = sql "SELECT * FROM ${tbl} ORDER BY k1"
+        assertEquals(5, t9result.size(), "CG-B query should return all 5 rows")
+
+        // Verify peer candidate cache was hit (the injected candidate was used)
+        def peerHitAfter = getBrpcMetrics(beBHost, beB.BrpcPort, "peer_candidate_cache_hit")
+        assertTrue(peerHitAfter > peerHitBefore,
+            "peer_candidate_cache_hit should increase after query with injected candidates")
+        logger.info("peer_candidate_cache_hit: before={} after={}", peerHitBefore, peerHitAfter)
+
+        // Verify via show that the candidate was accessed (last_access_time_ms updated)
+        def t9showAfter = peerCacheGet(beBHost, beBHttpPort, "op=show&tablet_id=${tabletId}")
+        def t9afterJson = jsonSlurper.parseText(t9showAfter.body)
+        assertTrue(t9afterJson.candidates[0].last_access_time_ms as long > 0,
+            "last_access_time_ms should be updated after access")
+        logger.info("PASS: end-to-end peer read with injected candidates works")
+
+        // Cleanup
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tbl}"
+        logger.info("=== All peer cache HTTP API tests passed ===")
+    }
+}

--- a/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
+++ b/regression-test/suites/cloud_p0/cache/read_from_peer/test_read_from_peer.groovy
@@ -16,86 +16,101 @@
 // under the License.
 
 import org.apache.doris.regression.suite.ClusterOptions
-import groovy.json.JsonSlurper
-import org.awaitility.Awaitility;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import org.apache.doris.regression.util.NodeType
 
 suite('test_read_from_peer', 'docker') {
     if (!isCloudMode()) {
-        return;
+        return
     }
+
     def options = new ClusterOptions()
     options.feConfigs += [
         'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
         'sys_log_verbose_modules=org',
         'heartbeat_interval_second=1',
-        'workload_group_check_interval_ms=1'
+        'auto_check_statistics_in_minutes=60',
     ]
     options.beConfigs += [
+        'report_tablet_interval_seconds=1',
+        'schedule_sync_tablets_interval_s=18000',
+        'disable_auto_compaction=true',
+        'enable_cache_read_from_peer=true',
+        'enable_peer_s3_race=true',
+        'max_concurrent_peer_races=64',
         'file_cache_each_block_size=131072',
-        // 'sys_log_verbose_modules=*',
-        'enable_cache_read_from_peer=true'
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'file_cache_exit_disk_resource_limit_mode_percent=98',
+        'file_cache_enter_need_evict_cache_in_advance_percent=99',
+        'file_cache_exit_need_evict_cache_in_advance_percent=98',
     ]
+    options.beConfigs.removeAll { it.startsWith('sys_log_verbose_modules=') }
     options.setFeNum(1)
     options.setBeNum(1)
     options.cloudMode = true
     options.enableDebugPoints()
-    
-    def tableName = "test_read_from_table"
 
-    def clusterBe = { clusterName ->
-        def bes = sql_return_maparray "show backends"
-        def clusterBes = bes.findAll { be -> be.Tag.contains(clusterName) }
-        logger.info("cluster {}, bes {}", clusterName, clusterBes)
-        clusterBes[0]
-    }
-
-    def testCase = { String clusterName, String runType ->
-        def startTime = System.currentTimeMillis()
-        GetDebugPoint().enableDebugPointForAllBEs("CachedRemoteFileReader.read_at_impl.change_type", [type: runType])
-        
-        try {
-            sql """
-                use @$clusterName
-            """
-
-            def be = clusterBe(clusterName)
-            def haveCacheBe = clusterBe("compute_cluster")
-
-            switch (runType) {
-                case "peer":
-                    GetDebugPoint().enableDebugPoint(be.Host, be.HttpPort as int, NodeType.BE, "PeerFileCacheReader::_fetch_from_peer_cache_blocks", 
-                        [host: haveCacheBe.Host, port: haveCacheBe.BrpcPort])
-                    break
-                case "s3":
-                    break
-                default:
-                    throw new IllegalArgumentException("Invalid type: $runType. Expected: peer, s3")
-            }
-            
-            // Execute the query and measure time
-            def queryStartTime = System.currentTimeMillis()
-            def ret = sql """
-                select count(*) from $tableName
-            """
-            logger.info("select ret={}", ret)
-            def queryTime = System.currentTimeMillis() - queryStartTime
-            logger.info("Test completed - Type:{}, Cluster: {}, Query execution time: {}ms", runType, clusterName, queryTime)
-        } catch (Exception e) {
-            def totalTime = System.currentTimeMillis() - startTime
-            logger.info("Test failed after {}ms - Type: {}, Cluster: {} Error: {}", totalTime, runType, clusterName, e.message)
-            throw e
+    def getBrpcMetric = { ip, port, name ->
+        def url = "http://${ip}:${port}/brpc_metrics"
+        if ((context.config.otherConfigs.get("enableTLS")?.toString()?.equalsIgnoreCase("true")) ?: false) {
+            url = url.replace("http://", "https://") +
+                " --cert " + context.config.otherConfigs.get("trustCert") +
+                " --cacert " + context.config.otherConfigs.get("trustCACert") +
+                " --key " + context.config.otherConfigs.get("trustCAKey")
         }
+        def metrics = new URL(url).text
+        def matcher = metrics =~ ~"${name}\\s+(\\d+)"
+        if (matcher.find()) {
+            return matcher[0][1] as long
+        }
+        return 0L
     }
 
     docker(options) {
-        // 添加一个新的cluster, 只从s3上读
-        cluster.addBackend(1, "readS3cluster")
+        def tableName = "test_read_from_table"
 
-        // 添加一个新的cluster, 只从peer上读
+        def clusterBe = { clusterName ->
+            def be = sql_return_maparray("show backends").find { backend ->
+                backend.Tag.contains(clusterName)
+            }
+            assertTrue(be != null, "backend for ${clusterName} should exist")
+            be
+        }
+
+        def insertFreshRowsOnCompute = { List<String> rows ->
+            sql "use @compute_cluster"
+            sql "INSERT INTO ${tableName} VALUES ${rows.join(', ')}"
+        }
+
+        def queryFreshRows = { clusterName, List<Long> ticketNumbers ->
+            sql "use @${clusterName}"
+            sql """
+                SELECT ss_ticket_number
+                FROM ${tableName}
+                WHERE ss_ticket_number IN (${ticketNumbers.join(',')})
+                ORDER BY ss_ticket_number
+            """
+        }
+
+        def warmFreshRowsOnCompute = { List<Long> ticketNumbers ->
+            def rows = queryFreshRows("compute_cluster", ticketNumbers)
+            assertEquals(ticketNumbers.size(), rows.size(), "compute_cluster should read all expected fresh rows")
+        }
+
+        cluster.addBackend(1, "readS3cluster")
         cluster.addBackend(1, "readPeercluster")
 
+        awaitUntil(120) {
+            def backends = sql_return_maparray("show backends")
+            backends.size() == 3 && backends.every { backend ->
+                backend.Alive.toString() == "true" && backend.TabletNum.toInteger() > 0
+            }
+        }
+
+        def beS3 = clusterBe("readS3cluster")
+        def bePeer = clusterBe("readPeercluster")
+
+        sql "use @compute_cluster"
+        sql "DROP TABLE IF EXISTS ${tableName}"
         sql """
             CREATE TABLE IF NOT EXISTS ${tableName} (
                 ss_sold_date_sk bigint,
@@ -130,28 +145,12 @@ suite('test_read_from_peer', 'docker') {
             )
         """
 
-        sql """
-            use @compute_cluster
-        """
-
-        // in compute_cluster be-1, cache all data in file cache
-        def txnId = -1;
-        // version 2
         streamLoad {
             table "${tableName}"
-
-            // default label is UUID:
-            // set 'label' UUID.randomUUID().toString()
-
-            // default column_separator is specify in doris fe config, usually is '\t'.
-            // this line change to ','
             set 'column_separator', '|'
             set 'compress_type', 'GZ'
-
             file """${getS3Url()}/regression/tpcds/sf1/store_sales.dat.gz"""
-            // file """store_sales.dat.gz"""
-
-            time 10000 // limit inflight 10s
+            time 10000
             setFeAddr cluster.getAllFrontends().get(0).host, cluster.getAllFrontends().get(0).httpPort
 
             check { res, exception, startTime, endTime ->
@@ -166,13 +165,49 @@ suite('test_read_from_peer', 'docker') {
             }
         }
 
-        def ret = sql """
-            select count(*) from $tableName
-        """
-        logger.info("ret after load, ret {}", ret)
+        sql "use @compute_cluster"
+        def computeCount = sql "SELECT count(*) FROM ${tableName}"
+        logger.info("count on compute_cluster={}", computeCount)
+        assertTrue((computeCount[0][0] as long) > 0L, "compute_cluster should have loaded rows")
 
-        testCase("compute_cluster", "s3")
-        testCase("readS3cluster", "s3")
-        testCase("readPeercluster", "peer")
+        logger.info("=== readS3cluster: first cold read succeeds ===")
+        sql "use @readS3cluster"
+        def s3Read = sql "SELECT count(*) FROM ${tableName}"
+        assertEquals(computeCount, s3Read, "readS3cluster should read loaded source data")
+
+        logger.info("=== readPeercluster: baseline read succeeds and populates peer candidates ===")
+        def peerLazyBefore = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_lazy_fetch_success")
+        sql "use @readPeercluster"
+        def baselinePeerRead = sql "SELECT count(*) FROM ${tableName}"
+        assertEquals(computeCount, baselinePeerRead, "readPeercluster baseline read should succeed")
+        awaitUntil(30) {
+            getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_lazy_fetch_success") > peerLazyBefore
+        }
+
+        logger.info("=== readPeercluster: fresh rowset should read from peer ===")
+        def freshTicketNumbers = [900000000001L, 900000000002L]
+        def freshRows = [
+            "(900001, 1, 1, 900001, 1, 1, 1, 1, 1, 900000000001, 1, 1.00, 2.00, 2.00, 0.00, 2.00, 1.00, 2.00, 0.10, 0.00, 2.10, 2.10, 1.10)",
+            "(900002, 2, 2, 900002, 2, 2, 2, 2, 2, 900000000002, 2, 2.00, 3.00, 3.00, 0.00, 6.00, 4.00, 6.00, 0.20, 0.00, 6.20, 6.20, 2.20)"
+        ]
+        insertFreshRowsOnCompute(freshRows)
+        warmFreshRowsOnCompute(freshTicketNumbers)
+
+        def peerWinBefore = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_race_peer_win")
+        def crossCgBefore = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_cross_compute_group_read")
+
+        def peerRead = queryFreshRows("readPeercluster", freshTicketNumbers)
+        assertEquals(freshTicketNumbers.size(), peerRead.size(), "readPeercluster should read fresh rows")
+
+        def peerWinAfter = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_race_peer_win")
+        def crossCgAfter = getBrpcMetric(bePeer.Host, bePeer.BrpcPort, "peer_cross_compute_group_read")
+        assertTrue(
+            peerWinAfter > peerWinBefore || crossCgAfter > crossCgBefore,
+            "peer read counters should increase on readPeercluster " +
+            "(peer_race_peer_win ${peerWinBefore}->${peerWinAfter}, " +
+            "peer_cross_compute_group_read ${crossCgBefore}->${crossCgAfter})")
+
+        logger.info("=== readPeercluster PASS ===")
+        logger.info("readS3cluster brpc={}, readPeercluster brpc={}", beS3.BrpcPort, bePeer.BrpcPort)
     }
 }


### PR DESCRIPTION
## Proposed changes

Cherry-pick of selectdb-core commit 8c9618f5c5e to the Apache Doris community.

This commit combines two related changes:

1. **Cross Compute Group Peer Read Routing**:
   - Implement peer read routing across different compute groups to enable data sharing between groups
   - Add routing logic to select optimal peer nodes for cache reads
   - Support cross-group tablet peer discovery and selection

2. **Peer Cache I/O Path Optimization**:
   - Optimize peer cache server path using IOBuf attachment for zero-copy data transfer
   - Reduce memory copies in the peer cache read path by leveraging bRPC IOBuf attachment mechanism
   - Improve peer cache read performance and reduce memory overhead

## Notes for reviewers

This is a port from selectdb-core to apache/doris. Several conflicts were resolved due to directory restructuring (`olap/` → `storage/`, `http/action/` → `service/http/action/`, `pipeline/exec/` → `exec/operator/`).

- For files renamed in apache/doris (e.g. `inverted_index_file_writer` → `index_file_writer`, `new_olap_scanner` → `olap_scanner`), the equivalent changes were applied to the new locations.
- For `cached_remote_file_reader.cpp`, the apache/doris HEAD version was kept due to substantial divergence in the peer-read implementation; the cross-CG features there will need a follow-up port.
- The `mem_file_cache_storage` sharded refactor was not brought over; the new `appendv` / `append_iobuf` methods delegate to the existing simple `_cache_map` implementation.
- `shard_mem_cache.{h,cpp}` were added as new files since they don't exist in apache/doris.
