### PR TITLE
[fix](job-manager) cancelTaskById should not be blocked by unrelated streaming jobs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/manager/JobManager.java
@@ -424,10 +424,10 @@ public class JobManager<T extends AbstractJob<?, C>, C> implements Writable {
      */
     public void cancelTaskById(String jobName, Long taskId) throws JobException {
         for (T job : jobMap.values()) {
-            if (job.getJobConfig().getExecuteType().equals(JobExecuteType.STREAMING)) {
-                throw new JobException("streaming job not support cancel task by id");
-            }
             if (job.getJobName().equals(jobName)) {
+                if (job.getJobConfig().getExecuteType().equals(JobExecuteType.STREAMING)) {
+                    throw new JobException("streaming job not support cancel task by id");
+                }
                 job.cancelTaskById(taskId);
                 job.logUpdateOperation();
                 return;

--- a/fe/fe-core/src/test/java/org/apache/doris/job/manager/JobManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/manager/JobManagerTest.java
@@ -19,6 +19,11 @@ package org.apache.doris.job.manager;
 
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.job.base.AbstractJob;
+import org.apache.doris.job.base.JobExecuteType;
+import org.apache.doris.job.base.JobExecutionConfiguration;
+import org.apache.doris.job.exception.JobException;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -30,6 +35,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Map;
 
 public class JobManagerTest {
     @Test
@@ -58,6 +64,39 @@ public class JobManagerTest {
                 Assert.assertTrue(e.getMessage().contains("Admin_priv,Load_priv"));
                 Assert.assertTrue(e.getMessage().contains("table1"));
             }
+        }
+    }
+
+    private static AbstractJob mockJob(long id, String name, JobExecuteType type) {
+        AbstractJob job = Mockito.mock(AbstractJob.class);
+        Mockito.when(job.getJobId()).thenReturn(id);
+        Mockito.when(job.getJobName()).thenReturn(name);
+        JobExecutionConfiguration cfg = new JobExecutionConfiguration();
+        cfg.setExecuteType(type);
+        Mockito.when(job.getJobConfig()).thenReturn(cfg);
+        return job;
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testCancelTaskByIdNotBlockedByOtherStreamingJob() throws JobException {
+        JobManager manager = new JobManager();
+        AbstractJob streamingJob = mockJob(1L, "streaming_job", JobExecuteType.STREAMING);
+        AbstractJob batchJob = mockJob(2L, "batch_job", JobExecuteType.RECURRING);
+        Map<Long, AbstractJob> jobMap = (Map<Long, AbstractJob>) Deencapsulation.getField(manager, "jobMap");
+        jobMap.put(1L, streamingJob);
+        jobMap.put(2L, batchJob);
+
+        // Cancelling the batch job must not be blocked by the unrelated streaming job in jobMap.
+        manager.cancelTaskById("batch_job", 100L);
+        Mockito.verify(batchJob).cancelTaskById(100L);
+
+        // Cancelling the streaming job itself still rejected.
+        try {
+            manager.cancelTaskById("streaming_job", 100L);
+            Assert.fail("expected JobException for streaming job");
+        } catch (JobException e) {
+            Assert.assertTrue(e.getMessage().contains("streaming job not support"));
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`JobManager.cancelTaskById` rejects all `CANCEL TASK` calls when any streaming job exists in `jobMap`. The streaming-type check is placed before the `jobName` match, so it fires on every iteration:

```java
for (T job : jobMap.values()) {
    if (job.getJobConfig().getExecuteType().equals(JobExecuteType.STREAMING)) {
        throw new JobException("streaming job not support cancel task by id");
    }
    if (job.getJobName().equals(jobName)) { ... }
}
```

If a single streaming job exists in `jobMap`, `CANCEL TASK FOR <any-non-streaming-job>` throws "streaming job not support cancel task by id" before ever matching the actual target.

### Fix

Move the streaming-type check inside the `jobName` match, so it only fires when the matched job is actually a streaming job.

### Release note

Fix `CANCEL TASK` on non-streaming jobs incorrectly rejected when an unrelated streaming job exists in the job map.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. `CANCEL TASK` on non-streaming jobs is no longer rejected when an unrelated streaming job exists in the job map.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document