### PR TITLE
[fix](fe) Restore delete_without_partition checks for Nereids delete

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -294,6 +294,12 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         if (olapTable.getPartitionInfo().getType().equals(PartitionType.UNPARTITIONED)) {
             return Lists.newArrayList(olapTable.getPartitions());
         }
+        if (partitionNames.isEmpty() && !canInferPartition(olapTable, filter.getPredicate())
+                && !ConnectContext.get().getSessionVariable().isDeleteWithoutPartition()) {
+            throw new AnalysisException("This is a range or list partitioned table."
+                    + " You should specify partition in delete stmt,"
+                    + " or set delete_without_partition to true");
+        }
         List<Slot> partitionSlots = Lists.newArrayList();
         for (Column c : olapTable.getPartitionColumns()) {
             Slot partitionSlot = null;
@@ -332,6 +338,31 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
                 CascadesContext.initContext(new StatementContext(), this, PhysicalProperties.ANY),
                 PartitionTableType.OLAP, sortedPartitionRanges).first;
         return prunedPartitions.stream().map(olapTable::getPartition).collect(Collectors.toList());
+    }
+
+    private boolean canInferPartition(OlapTable olapTable, Expression predicate) {
+        Set<String> partitionColumnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        partitionColumnNames.addAll(olapTable.getPartitionColumns().stream()
+                .map(Column::getName)
+                .collect(Collectors.toList()));
+        return containsSupportedPartitionPredicate(predicate, partitionColumnNames);
+    }
+
+    private boolean containsSupportedPartitionPredicate(Expression predicate, Set<String> partitionColumnNames) {
+        if (predicate instanceof And) {
+            return predicate.children().stream()
+                    .anyMatch(child -> containsSupportedPartitionPredicate(child, partitionColumnNames));
+        }
+        if (predicate instanceof ComparisonPredicate) {
+            return predicate.child(0) instanceof SlotReference
+                    && partitionColumnNames.contains(((SlotReference) predicate.child(0)).getName());
+        }
+        if (predicate instanceof InPredicate) {
+            return ((InPredicate) predicate).getCompareExpr() instanceof SlotReference
+                    && partitionColumnNames.contains(((SlotReference) ((InPredicate) predicate).getCompareExpr())
+                    .getName());
+        }
+        return false;
     }
 
     private void checkColumn(Set<String> tableColumns, SlotReference slotReference, OlapTable table) {

--- a/regression-test/suites/delete_p0/test_basic_delete_job.groovy
+++ b/regression-test/suites/delete_p0/test_basic_delete_job.groovy
@@ -39,6 +39,7 @@ suite("test_basic_delete_job") {
     qt_unpartition1 """select * from ${unpartitionTable} order by id"""
     sql """delete from ${unpartitionTable} where id < 0"""
     qt_unpartition2 """select * from ${unpartitionTable} order by id"""
+    sql """set delete_without_partition = false"""
     sql """delete from ${unpartitionTable} where id = 1"""
     qt_unpartition3 """select * from ${unpartitionTable} order by id"""
     sql """delete from ${unpartitionTable} where name = "c" """
@@ -70,6 +71,11 @@ suite("test_basic_delete_job") {
     qt_one_range4 """select * from ${oneRangeColumnTable} order by id"""
     sql """delete from ${oneRangeColumnTable} partition(p0) where id < 22"""
     qt_one_range5 """select * from ${oneRangeColumnTable} order by id"""
+    test {
+        sql """delete from ${oneRangeColumnTable} where name = "d" """
+        exception "This is a range or list partitioned table. You should specify partition in delete stmt, or set delete_without_partition to true"
+    }
+    sql """set delete_without_partition = true"""
     sql """delete from ${oneRangeColumnTable} where name = "d" """
     qt_one_range6 """select * from ${oneRangeColumnTable} order by id"""
     sql """delete from ${oneRangeColumnTable} partition(p2) where name = "g" """


### PR DESCRIPTION
## Summary
- fix CIR-12255 by restoring `delete_without_partition` enforcement for Nereids `DELETE` on range/list partitioned tables when predicates cannot infer target partitions
- keep non-partitioned `DELETE` statements working even when `delete_without_partition=false`
- add regression coverage for both the guarded partitioned path and the non-partitioned success path

## Testing
- attempted `./run-regression-test.sh --run -d delete_p0 -s test_basic_delete_job`
- blocked in the local environment before suite execution with `Unsupported class file major version 69`