### PR TITLE
[fix](schema-change) Reserve watershed txn before exposing shadow indexes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudRollupJobV2.java
@@ -34,6 +34,7 @@ import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.proto.OlapFile;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
@@ -199,10 +200,16 @@ public class CloudRollupJobV2 extends RollupJobV2 {
         }
 
         // create all rollup replicas success.
-        // add rollup index to catalog
+        // reserve the watershed txn id and then add rollup index to catalog
         tbl.writeLockOrAlterCancelException();
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
+            Preconditions.checkState(watershedTxnId == -1, watershedTxnId);
+            try {
+                this.watershedTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
+            } catch (UserException e) {
+                throw new AlterCancelException(e.getMessage());
+            }
             addRollupIndexToCatalog(tbl);
         } finally {
             tbl.writeUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/CloudSchemaChangeJobV2.java
@@ -35,6 +35,7 @@ import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.proto.OlapFile;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.FrontendOptions;
@@ -207,10 +208,16 @@ public class CloudSchemaChangeJobV2 extends SchemaChangeJobV2 {
         }
 
         // create all replicas success.
-        // add all shadow indexes to catalog
+        // reserve the watershed txn id and then add all shadow indexes to catalog
         tbl.writeLockOrAlterCancelException();
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
+            Preconditions.checkState(watershedTxnId == -1, watershedTxnId);
+            try {
+                this.watershedTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
+            } catch (UserException e) {
+                throw new AlterCancelException(e.getMessage());
+            }
             addShadowIndexToCatalog(tbl);
         } finally {
             tbl.writeUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -318,10 +318,16 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             }
         }
         // create all rollup replicas success.
-        // add rollup index to catalog
+        // reserve the watershed txn id and then add rollup index to catalog
         tbl.writeLockOrAlterCancelException();
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.ROLLUP);
+            Preconditions.checkState(watershedTxnId == -1, watershedTxnId);
+            try {
+                this.watershedTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
+            } catch (UserException e) {
+                throw new AlterCancelException(e.getMessage());
+            }
             addRollupIndexToCatalog(tbl);
         } finally {
             tbl.writeUnlock();
@@ -331,9 +337,9 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
     /**
      * runPendingJob():
      * 1. Create all rollup replicas and wait them finished.
-     * 2. After creating done, add this shadow rollup index to catalog, user can not see this
-     *    rollup, but internal load process will generate data for this rollup index.
-     * 3. Get a new transaction id, then set job's state to WAITING_TXN
+     * 2. Reserve the watershed txn id while holding the table write lock.
+     * 3. Add this shadow rollup index to catalog so later transactions see it consistently.
+     * 4. Set job's state to WAITING_TXN
      */
     @Override
     protected void runPendingJob() throws Exception {
@@ -346,8 +352,6 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             return;
         }
         createRollupReplica();
-
-        this.watershedTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
         setJobState(JobState.WAITING_TXN);
 
         // write edit log

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -391,7 +391,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
         }
 
         // create all replicas success.
-        // add all shadow indexes to catalog
+        // reserve the watershed txn id and then add all shadow indexes to catalog
         while (DebugPointUtil.isEnable("FE.SchemaChangeJobV2.createShadowIndexReplica.addShadowIndexToCatalog.block")) {
             try {
                 Thread.sleep(1000);
@@ -403,6 +403,12 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
         tbl.writeLockOrAlterCancelException();
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
+            Preconditions.checkState(watershedTxnId == -1, watershedTxnId);
+            try {
+                this.watershedTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
+            } catch (UserException e) {
+                throw new AlterCancelException(e.getMessage());
+            }
             addShadowIndexToCatalog(tbl);
         } finally {
             tbl.writeUnlock();
@@ -412,9 +418,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
     /**
      * runPendingJob():
      * 1. Create all replicas of all shadow indexes and wait them finished.
-     * 2. After creating done, add the shadow indexes to catalog, user can not see this
-     *    shadow index, but internal load process will generate data for these indexes.
-     * 3. Get a new transaction id, then set job's state to WAITING_TXN
+     * 2. Reserve the watershed txn id while holding the table write lock.
+     * 3. Add the shadow indexes to catalog so later transactions see them consistently.
+     * 4. Set job's state to WAITING_TXN
      */
     @Override
     protected void runPendingJob() throws Exception {
@@ -428,8 +434,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 implements GsonPostProcessable
         }
 
         createShadowIndexReplica();
-
-        this.watershedTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
         setJobState(JobState.WAITING_TXN);
 
         // write edit log

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -217,6 +217,32 @@ public class RollupJobV2Test {
     }
 
     @Test
+    public void testCreateRollupReplicaSetsWatershedTxnId() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        MaterializedViewHandler materializedViewHandler = Env.getCurrentEnv().getMaterializedViewHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(op);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        materializedViewHandler.process(alterOps, db, olapTable);
+        RollupJobV2 rollupJob = (RollupJobV2) materializedViewHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        Assert.assertEquals(-1L, rollupJob.getWatershedTxnId());
+        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.ALL).size());
+
+        Deencapsulation.invoke(rollupJob, "createRollupReplica");
+
+        Assert.assertTrue(rollupJob.getWatershedTxnId() > 0);
+        Assert.assertEquals(2, testPartition.getMaterializedIndices(IndexExtState.ALL).size());
+        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.SHADOW).size());
+    }
+
+    @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -218,6 +218,32 @@ public class SchemaChangeJobV2Test {
     }
 
     @Test
+    public void testCreateShadowIndexReplicaSetsWatershedTxnId() throws Exception {
+        fakeEnv = new FakeEnv();
+        fakeEditLog = new FakeEditLog();
+        FakeEnv.setEnv(masterEnv);
+        SchemaChangeHandler schemaChangeHandler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        ArrayList<AlterOp> alterOps = new ArrayList<>();
+        alterOps.add(addColumnOp);
+        Database db = masterEnv.getInternalCatalog().getDbOrDdlException(CatalogTestUtil.testDbId1);
+        OlapTable olapTable = (OlapTable) db.getTableOrDdlException(CatalogTestUtil.testTableId1);
+        Partition testPartition = olapTable.getPartition(CatalogTestUtil.testPartitionId1);
+        schemaChangeHandler.process(alterOps, db, olapTable);
+        SchemaChangeJobV2 schemaChangeJob = (SchemaChangeJobV2) schemaChangeHandler.getAlterJobsV2()
+                .values().stream().findAny().get();
+
+        Assert.assertEquals(-1L, schemaChangeJob.getWatershedTxnId());
+        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.ALL).size());
+
+        Deencapsulation.invoke(schemaChangeJob, "createShadowIndexReplica");
+
+        Assert.assertTrue(schemaChangeJob.getWatershedTxnId() > 0);
+        Assert.assertEquals(2, testPartition.getMaterializedIndices(IndexExtState.ALL).size());
+        Assert.assertEquals(1, testPartition.getMaterializedIndices(IndexExtState.SHADOW).size());
+    }
+
+    @Test
     public void testSchemaChangeWhileTabletNotStable() throws Exception {
         fakeEnv = new FakeEnv();
         fakeEditLog = new FakeEditLog();


### PR DESCRIPTION
## Summary
- reserve the alter watershed txn id while holding the table write lock immediately before exposing schema change and rollup shadow indexes
- apply the same ordering to cloud alter paths so post-watershed transactions publish against a consistent set of shadow indexes
- add FE unit tests that verify shadow and rollup replica creation assigns the watershed txn id before the new indexes are visible

## Testing
- `./run-fe-ut.sh --run org.apache.doris.alter.SchemaChangeJobV2Test,org.apache.doris.alter.RollupJobV2Test`