### PR TITLE
 [refine](exec) add SubQueue abstraction and thread-safety annotations to DataQueue        

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -369,7 +369,8 @@ if (COMPILER_CLANG)
                         -Wunused-template
                         -Wunused-member-function
                         -Wunused-macros
-                        -Wconversion)
+                        -Wconversion
+                        -Wthread-safety)
     add_compile_options(-Wno-gnu-statement-expression
                         -Wno-implicit-float-conversion
                         -Wno-sign-conversion)

--- a/be/src/common/thread_safety_annotations.h
+++ b/be/src/common/thread_safety_annotations.h
@@ -51,18 +51,15 @@ void mock_random_sleep();
 
 #define REQUIRES(...) THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
 
-#define REQUIRES_SHARED(...) \
-    THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+#define REQUIRES_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
 
 #define ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
 
-#define ACQUIRE_SHARED(...) \
-    THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+#define ACQUIRE_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
 
 #define RELEASE(...) THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
 
-#define RELEASE_SHARED(...) \
-    THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+#define RELEASE_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
 
 #define TRY_ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
 

--- a/be/src/common/thread_safety_annotations.h
+++ b/be/src/common/thread_safety_annotations.h
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Thread safety annotation macros and annotated mutex wrappers for
+// Clang's -Wthread-safety static analysis.
+// Reference: https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
+
+#pragma once
+
+#include <mutex>
+
+#ifdef BE_TEST
+namespace doris {
+void mock_random_sleep();
+} // namespace doris
+#endif
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) // no-op
+#endif
+
+#define CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define ACQUIRED_BEFORE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define ACQUIRED_AFTER(...) THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define REQUIRES(...) THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define REQUIRES_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+#define RELEASE(...) THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define RELEASE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE(...) THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define ASSERT_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define ASSERT_SHARED_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+#define RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define NO_THREAD_SAFETY_ANALYSIS THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+// Annotated mutex wrapper for use with Clang thread safety analysis.
+// Wraps std::mutex and provides the CAPABILITY annotation so that
+// GUARDED_BY / REQUIRES / etc. annotations can reference it.
+class CAPABILITY("mutex") AnnotatedMutex {
+public:
+    void lock() ACQUIRE() { _mutex.lock(); }
+    void unlock() RELEASE() { _mutex.unlock(); }
+    bool try_lock() TRY_ACQUIRE(true) { return _mutex.try_lock(); }
+
+    // Access the underlying std::mutex (e.g., for std::condition_variable).
+    // Use with care — this bypasses thread safety annotations.
+    std::mutex& native_handle() { return _mutex; }
+
+private:
+    std::mutex _mutex;
+};
+
+// RAII scoped lock guard annotated for thread safety analysis.
+// In BE_TEST builds, injects a random sleep before acquiring and after
+// releasing the lock to exercise concurrent code paths.
+template <typename MutexType>
+class SCOPED_CAPABILITY LockGuard {
+public:
+    explicit LockGuard(MutexType& mu) ACQUIRE(mu) : _mu(mu) {
+#ifdef BE_TEST
+        doris::mock_random_sleep();
+#endif
+        _mu.lock();
+    }
+    ~LockGuard() RELEASE() {
+        _mu.unlock();
+#ifdef BE_TEST
+        doris::mock_random_sleep();
+#endif
+    }
+
+    LockGuard(const LockGuard&) = delete;
+    LockGuard& operator=(const LockGuard&) = delete;
+
+private:
+    MutexType& _mu;
+};

--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -67,7 +67,7 @@ Status SubQueue::try_push(std::unique_ptr<Block> block) {
 }
 
 bool SubQueue::mark_finished(std::atomic_uint32_t& unfinished_counter,
-                              std::atomic_bool& all_finished) {
+                             std::atomic_bool& all_finished) {
     LockGuard l(queue_lock);
     if (is_finished) {
         return false;
@@ -107,8 +107,8 @@ bool DataQueue::has_more_data() const {
     return _cur_blocks_total_nums.load() > 0;
 }
 
-void DataQueue::set_source_dependency(
-        std::shared_ptr<Dependency> source_dependency) NO_THREAD_SAFETY_ANALYSIS {
+void DataQueue::set_source_dependency(std::shared_ptr<Dependency> source_dependency)
+        NO_THREAD_SAFETY_ANALYSIS {
     _source_dependency = std::move(source_dependency);
 }
 

--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -20,42 +20,123 @@
 #include <glog/logging.h>
 
 #include <algorithm>
-#include <mutex>
 #include <utility>
 
+#include "common/thread_safety_annotations.h"
 #include "core/block/block.h"
 #include "exec/pipeline/dependency.h"
 
 namespace doris {
-DataQueue::DataQueue(int child_count)
-        : _queue_blocks_lock(child_count),
-          _queue_blocks(child_count),
-          _free_blocks_lock(child_count),
-          _free_blocks(child_count),
-          _child_count(child_count),
-          _is_finished(child_count),
-          _is_canceled(child_count),
-          _cur_bytes_in_queue(child_count),
-          _cur_blocks_nums_in_queue(child_count),
-          _flag_queue_idx(0) {
-    for (int i = 0; i < child_count; ++i) {
-        _queue_blocks_lock[i].reset(new std::mutex());
-        _free_blocks_lock[i].reset(new std::mutex());
-        _is_finished[i] = false;
-        _is_canceled[i] = false;
-        _cur_bytes_in_queue[i] = 0;
-        _cur_blocks_nums_in_queue[i] = 0;
+
+Status SubQueue::try_pop(std::unique_ptr<Block>* output_block) {
+    bool need_notify_sink_ready = false;
+    {
+        LockGuard l(queue_lock);
+        if (!blocks.empty()) {
+            *output_block = std::move(blocks.front());
+            blocks.pop_front();
+            bytes_in_queue -= (*output_block)->allocated_bytes();
+            blocks_in_queue -= 1;
+            need_notify_sink_ready = blocks.empty();
+        }
+    }
+    // Notify outside of queue_lock to avoid nested locks.
+    if (need_notify_sink_ready) {
+        sink_dependency->set_ready();
+    }
+    return Status::OK();
+}
+
+Status SubQueue::try_push(std::unique_ptr<Block> block) {
+    bool need_block_sink = false;
+    {
+        LockGuard l(queue_lock);
+        if (is_finished) {
+            return Status::EndOfFile("Already finish");
+        }
+        bytes_in_queue += block->allocated_bytes();
+        blocks.emplace_back(std::move(block));
+        blocks_in_queue += 1;
+        need_block_sink = (static_cast<int64_t>(blocks.size()) > max_blocks_in_queue.load());
+    }
+    // Notify outside of queue_lock to avoid nested locks.
+    if (need_block_sink) {
+        sink_dependency->block();
+    }
+    return Status::OK();
+}
+
+bool SubQueue::mark_finished(std::atomic_uint32_t& unfinished_counter,
+                              std::atomic_bool& all_finished) {
+    LockGuard l(queue_lock);
+    if (is_finished) {
+        return false;
+    }
+    is_finished = true;
+    if (unfinished_counter.fetch_sub(1) == 1) {
+        all_finished = true;
+    }
+    return true;
+}
+
+void SubQueue::clear_blocks() {
+    bool need_set_always_ready = false;
+    {
+        LockGuard l(queue_lock);
+        if (!blocks.empty()) {
+            blocks.clear();
+            bytes_in_queue = 0;
+            blocks_in_queue = 0;
+            need_set_always_ready = true;
+        }
+    }
+    // Notify outside of queue_lock to keep lock ordering simple.
+    if (need_set_always_ready) {
+        sink_dependency->set_always_ready();
+    }
+}
+
+DataQueue::DataQueue(int child_count) : _sub_queues(child_count), _child_count(child_count) {
+    for (auto& sub : _sub_queues) {
+        sub = std::make_unique<SubQueue>();
     }
     _un_finished_counter = child_count;
-    _sink_dependencies.resize(child_count, nullptr);
+}
+
+bool DataQueue::has_more_data() const {
+    return _cur_blocks_total_nums.load() > 0;
+}
+
+void DataQueue::set_source_dependency(
+        std::shared_ptr<Dependency> source_dependency) NO_THREAD_SAFETY_ANALYSIS {
+    _source_dependency = std::move(source_dependency);
+}
+
+void DataQueue::set_sink_dependency(Dependency* sink_dependency, int child_idx) {
+    _sub_queues[child_idx]->sink_dependency = sink_dependency;
+}
+
+void DataQueue::set_max_blocks_in_sub_queue(int64_t max_blocks) {
+    for (auto& sub : _sub_queues) {
+        sub->max_blocks_in_queue = max_blocks;
+    }
+}
+
+void DataQueue::set_low_memory_mode() {
+    _is_low_memory_mode = true;
+    for (auto& sub : _sub_queues) {
+        sub->max_blocks_in_queue = 1;
+    }
+    clear_free_blocks();
 }
 
 std::unique_ptr<Block> DataQueue::get_free_block(int child_idx) {
+    auto& sub = *_sub_queues[child_idx];
     {
-        INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(*_free_blocks_lock[child_idx]));
-        if (!_free_blocks[child_idx].empty()) {
-            auto block = std::move(_free_blocks[child_idx].front());
-            _free_blocks[child_idx].pop_front();
+        LockGuard l(sub.free_lock);
+        if (!sub.free_blocks.empty()) {
+            auto block = std::move(sub.free_blocks.front());
+            sub.free_blocks.pop_front();
             return block;
         }
     }
@@ -67,29 +148,24 @@ void DataQueue::push_free_block(std::unique_ptr<Block> block, int child_idx) {
     DCHECK(block->rows() == 0);
 
     if (!_is_low_memory_mode) {
-        INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(*_free_blocks_lock[child_idx]));
-        _free_blocks[child_idx].emplace_back(std::move(block));
+        auto& sub = *_sub_queues[child_idx];
+        LockGuard l(sub.free_lock);
+        sub.free_blocks.emplace_back(std::move(block));
     }
 }
 
 void DataQueue::clear_free_blocks() {
-    for (size_t child_idx = 0; child_idx < _free_blocks.size(); ++child_idx) {
-        std::lock_guard<std::mutex> l(*_free_blocks_lock[child_idx]);
+    for (auto& sub : _sub_queues) {
+        LockGuard l(sub->free_lock);
         std::deque<std::unique_ptr<Block>> tmp_queue;
-        _free_blocks[child_idx].swap(tmp_queue);
+        sub->free_blocks.swap(tmp_queue);
     }
 }
 
 void DataQueue::terminate() {
-    for (int i = 0; i < _queue_blocks.size(); i++) {
+    for (int i = 0; i < _child_count; ++i) {
         set_finish(i);
-        INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(*_queue_blocks_lock[i]));
-        if (_cur_blocks_nums_in_queue[i] > 0) {
-            _queue_blocks[i].clear();
-            _cur_bytes_in_queue[i] = 0;
-            _cur_blocks_nums_in_queue[i] = 0;
-            _sink_dependencies[i]->set_always_ready();
-        }
+        _sub_queues[i]->clear_blocks();
     }
     clear_free_blocks();
 }
@@ -104,7 +180,7 @@ bool DataQueue::remaining_has_data() {
         if (_flag_queue_idx == _child_count) {
             _flag_queue_idx = 0;
         }
-        if (_cur_blocks_nums_in_queue[_flag_queue_idx] > 0) {
+        if (_sub_queues[_flag_queue_idx]->blocks_in_queue.load() > 0) {
             return true;
         }
     }
@@ -114,28 +190,17 @@ bool DataQueue::remaining_has_data() {
 //the _flag_queue_idx indicate which queue has data, and in check can_read
 //will be set idx in remaining_has_data function
 Status DataQueue::get_block_from_queue(std::unique_ptr<Block>* output_block, int* child_idx) {
-    if (_is_canceled[_flag_queue_idx]) {
-        return Status::InternalError("Current queue of idx {} have beed canceled: ",
-                                     _flag_queue_idx);
-    }
+    const int idx = _flag_queue_idx;
+    auto& sub = *_sub_queues[idx];
 
-    {
-        INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(*_queue_blocks_lock[_flag_queue_idx]));
-        if (_cur_blocks_nums_in_queue[_flag_queue_idx] > 0) {
-            *output_block = std::move(_queue_blocks[_flag_queue_idx].front());
-            _queue_blocks[_flag_queue_idx].pop_front();
-            if (child_idx) {
-                *child_idx = _flag_queue_idx;
-            }
-            _cur_bytes_in_queue[_flag_queue_idx] -= (*output_block)->allocated_bytes();
-            _cur_blocks_nums_in_queue[_flag_queue_idx] -= 1;
-            if (_cur_blocks_nums_in_queue[_flag_queue_idx] == 0) {
-                _sink_dependencies[_flag_queue_idx]->set_ready();
-            }
-            auto old_value = _cur_blocks_total_nums.fetch_sub(1);
-            if (old_value == 1 && _source_dependency) {
-                set_source_block();
-            }
+    RETURN_IF_ERROR(sub.try_pop(output_block));
+    if (*output_block) {
+        if (child_idx) {
+            *child_idx = idx;
+        }
+        auto old_total = _cur_blocks_total_nums.fetch_sub(1);
+        if (old_total == 1) {
+            set_source_block();
         }
     }
     return Status::OK();
@@ -145,50 +210,19 @@ Status DataQueue::push_block(std::unique_ptr<Block> block, int child_idx) {
     if (!block) {
         return Status::OK();
     }
-    {
-        INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(*_queue_blocks_lock[child_idx]));
-        if (_is_finished[child_idx]) {
-            return Status::EndOfFile("Already finish");
-        }
-        _cur_bytes_in_queue[child_idx] += block->allocated_bytes();
-        _queue_blocks[child_idx].emplace_back(std::move(block));
-        _cur_blocks_nums_in_queue[child_idx] += 1;
-
-        if (_cur_blocks_nums_in_queue[child_idx] > _max_blocks_in_sub_queue) {
-            _sink_dependencies[child_idx]->block();
-        }
-        _cur_blocks_total_nums++;
-
-        set_source_ready();
-    }
+    auto& sub = *_sub_queues[child_idx];
+    RETURN_IF_ERROR(sub.try_push(std::move(block)));
+    _cur_blocks_total_nums++;
+    set_source_ready();
     return Status::OK();
 }
 
 void DataQueue::set_finish(int child_idx) {
-    INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(*_queue_blocks_lock[child_idx]));
-    if (_is_finished[child_idx]) {
+    auto& sub = *_sub_queues[child_idx];
+    if (!sub.mark_finished(_un_finished_counter, _is_all_finished)) {
         return;
     }
-    _is_finished[child_idx] = true;
-    if (_un_finished_counter.fetch_sub(1) == 1) {
-        _is_all_finished = true;
-    }
     set_source_ready();
-}
-
-void DataQueue::set_canceled(int child_idx) {
-    INJECT_MOCK_SLEEP(std::lock_guard<std::mutex> l(*_queue_blocks_lock[child_idx]));
-    DCHECK(!_is_finished[child_idx]);
-    _is_canceled[child_idx] = true;
-    _is_finished[child_idx] = true;
-    if (_un_finished_counter.fetch_sub(1) == 1) {
-        _is_all_finished = true;
-    }
-    set_source_ready();
-}
-
-bool DataQueue::is_finish(int child_idx) {
-    return _is_finished[child_idx];
 }
 
 bool DataQueue::is_all_finish() {
@@ -196,19 +230,19 @@ bool DataQueue::is_all_finish() {
 }
 
 void DataQueue::set_source_ready() {
+    LockGuard lc(_source_lock);
     if (_source_dependency) {
-        std::unique_lock lc(_source_lock);
         _source_dependency->set_ready();
     }
 }
 
 void DataQueue::set_source_block() {
-    if (_cur_blocks_total_nums == 0 && !is_all_finish()) {
-        std::unique_lock lc(_source_lock);
-        // Performing the judgment twice, attempting to avoid blocking the source as much as possible.
-        if (_cur_blocks_total_nums == 0 && !is_all_finish()) {
-            _source_dependency->block();
-        }
+    // Re-check under _source_lock to avoid blocking the source when a concurrent push
+    // has already added new blocks (or all children have finished) since we observed
+    // the counter drop to zero.
+    LockGuard lc(_source_lock);
+    if (_source_dependency && _cur_blocks_total_nums == 0 && !is_all_finish()) {
+        _source_dependency->block();
     }
 }
 

--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -211,8 +211,12 @@ Status DataQueue::push_block(std::unique_ptr<Block> block, int child_idx) {
         return Status::OK();
     }
     auto& sub = *_sub_queues[child_idx];
-    RETURN_IF_ERROR(sub.try_push(std::move(block)));
+    // Increment before publishing to blocks_in_queue so that any concurrent
+    // get_block_from_queue() always observes _cur_blocks_total_nums >= 1 when
+    // it successfully pops a block, preventing an underflow to UINT_MAX and the
+    // resulting missed set_source_block() call.
     _cur_blocks_total_nums++;
+    RETURN_IF_ERROR(sub.try_push(std::move(block)));
     set_source_ready();
     return Status::OK();
 }

--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -28,7 +28,7 @@
 
 namespace doris {
 
-Status SubQueue::try_pop(std::unique_ptr<Block>* output_block) {
+void SubQueue::try_pop(std::unique_ptr<Block>* output_block) {
     bool need_notify_sink_ready = false;
     {
         LockGuard l(queue_lock);
@@ -44,16 +44,16 @@ Status SubQueue::try_pop(std::unique_ptr<Block>* output_block) {
     if (need_notify_sink_ready) {
         sink_dependency->set_ready();
     }
-    return Status::OK();
 }
 
-Status SubQueue::try_push(std::unique_ptr<Block> block) {
+bool SubQueue::try_push(std::unique_ptr<Block> block, std::atomic_uint32_t& total_counter) {
     bool need_block_sink = false;
     {
         LockGuard l(queue_lock);
         if (is_finished) {
-            return Status::EndOfFile("Already finish");
+            return false;
         }
+        total_counter++;
         bytes_in_queue += block->allocated_bytes();
         blocks.emplace_back(std::move(block));
         blocks_in_queue += 1;
@@ -63,7 +63,7 @@ Status SubQueue::try_push(std::unique_ptr<Block> block) {
     if (need_block_sink) {
         sink_dependency->block();
     }
-    return Status::OK();
+    return true;
 }
 
 bool SubQueue::mark_finished(std::atomic_uint32_t& unfinished_counter,
@@ -193,7 +193,7 @@ Status DataQueue::get_block_from_queue(std::unique_ptr<Block>* output_block, int
     const int idx = _flag_queue_idx;
     auto& sub = *_sub_queues[idx];
 
-    RETURN_IF_ERROR(sub.try_pop(output_block));
+    sub.try_pop(output_block);
     if (*output_block) {
         if (child_idx) {
             *child_idx = idx;
@@ -211,12 +211,13 @@ Status DataQueue::push_block(std::unique_ptr<Block> block, int child_idx) {
         return Status::OK();
     }
     auto& sub = *_sub_queues[child_idx];
-    // Increment before publishing to blocks_in_queue so that any concurrent
-    // get_block_from_queue() always observes _cur_blocks_total_nums >= 1 when
-    // it successfully pops a block, preventing an underflow to UINT_MAX and the
-    // resulting missed set_source_block() call.
-    _cur_blocks_total_nums++;
-    RETURN_IF_ERROR(sub.try_push(std::move(block)));
+    // total_counter is incremented inside try_push under queue_lock, only when the
+    // block is actually enqueued. This ensures get_block_from_queue() always observes
+    // _cur_blocks_total_nums >= 1 when it successfully pops a block, with no risk of
+    // underflow or the need for a rollback on failure.
+    if (!sub.try_push(std::move(block), _cur_blocks_total_nums)) {
+        return Status::EndOfFile("SubQueue already finished");
+    }
     set_source_ready();
     return Status::OK();
 }

--- a/be/src/exec/operator/data_queue.h
+++ b/be/src/exec/operator/data_queue.h
@@ -108,7 +108,6 @@ private:
     void set_source_ready();
     void set_source_block();
 
-
     std::vector<std::unique_ptr<SubQueue>> _sub_queues;
 
     //how many deque will be init, always will be one
@@ -122,8 +121,6 @@ private:
     // only used by streaming agg source operator
 
     std::atomic_bool _is_low_memory_mode = false;
-
-
 
     // _source_dependency is written once during initialization (set_source_dependency)
     // and read/used only while holding _source_lock thereafter.

--- a/be/src/exec/operator/data_queue.h
+++ b/be/src/exec/operator/data_queue.h
@@ -20,15 +20,61 @@
 #include <cstdint>
 #include <deque>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include "common/status.h"
+#include "common/thread_safety_annotations.h"
 #include "core/block/block.h"
 
 namespace doris {
 
 class Dependency;
+
+// Per child sub-queue. Groups all parallel state so that the lock/field
+// relationship is explicit and can be checked by clang -Wthread-safety.
+struct SubQueue {
+    // Protects the `blocks` deque and serializes high-level state
+    // transitions (push/pop/finish/cancel) on this sub-queue.
+    AnnotatedMutex queue_lock;
+    std::deque<std::unique_ptr<Block>> blocks GUARDED_BY(queue_lock);
+
+    // The following fields are only accessed while holding queue_lock.
+    int64_t bytes_in_queue GUARDED_BY(queue_lock) = 0;
+    bool is_finished GUARDED_BY(queue_lock) = false;
+
+    // Protects the `free_blocks` deque only.
+    AnnotatedMutex free_lock;
+    std::deque<std::unique_ptr<Block>> free_blocks GUARDED_BY(free_lock);
+
+    // blocks_in_queue is readable from lock-free fast paths (remaining_has_data),
+    // so it remains atomic and is intentionally not GUARDED_BY.
+    std::atomic_uint32_t blocks_in_queue {0};
+
+    // Maximum number of blocks allowed in this sub-queue before the sink is blocked.
+    // Updated by DataQueue::set_max_blocks_in_sub_queue / set_low_memory_mode.
+    std::atomic_int64_t max_blocks_in_queue {1};
+
+    // Set once during init via set_sink_dependency, then read-only.
+    Dependency* sink_dependency = nullptr;
+
+    // Pop a block under queue_lock.
+    // Notifies sink_dependency->set_ready() (outside the lock) if the queue drops below max_blocks_in_queue.
+    // output_block is null if the queue was empty (not an error).
+    Status try_pop(std::unique_ptr<Block>* output_block);
+
+    // Push a block under queue_lock.
+    // Returns Status::EndOfFile if already finished.
+    // Calls sink_dependency->block() (outside the lock) if the queue exceeds max_blocks_in_queue.
+    Status try_push(std::unique_ptr<Block> block);
+
+    // Mark this sub-queue finished. Returns false if already finished (idempotent).
+    // Decrements unfinished_counter and may set all_finished within queue_lock.
+    bool mark_finished(std::atomic_uint32_t& unfinished_counter, std::atomic_bool& all_finished);
+
+    // Clear all pending blocks under queue_lock.
+    // Calls sink_dependency->set_always_ready() (outside the lock) if any blocks were cleared.
+    void clear_blocks();
+};
 
 class DataQueue {
 public:
@@ -37,64 +83,38 @@ public:
     ~DataQueue() = default;
 
     Status get_block_from_queue(std::unique_ptr<Block>* block, int* child_idx = nullptr);
-
     Status push_block(std::unique_ptr<Block> block, int child_idx = 0);
 
     std::unique_ptr<Block> get_free_block(int child_idx = 0);
-
     void push_free_block(std::unique_ptr<Block> output_block, int child_idx = 0);
 
-    void clear_free_blocks();
-
     void set_finish(int child_idx = 0);
-    void set_canceled(int child_idx = 0); // should set before finish
-    bool is_finish(int child_idx = 0);
     bool is_all_finish();
 
     // This function is not thread safe, should be called in Operator::get_block()
     bool remaining_has_data();
+    bool has_more_data() const;
 
-    bool has_more_data() const { return _cur_blocks_total_nums.load() > 0; }
-
-    int64_t max_bytes_in_queue() const { return _max_bytes_in_queue; }
-    int64_t max_size_of_queue() const { return _max_size_of_queue; }
-
-    void set_source_dependency(std::shared_ptr<Dependency> source_dependency) {
-        _source_dependency = source_dependency;
-    }
-    void set_sink_dependency(Dependency* sink_dependency, int child_idx) {
-        _sink_dependencies[child_idx] = sink_dependency;
-    }
-
-    void set_source_ready();
-    void set_source_block();
-
-    void set_max_blocks_in_sub_queue(int64_t max_blocks) { _max_blocks_in_sub_queue = max_blocks; }
-
-    void set_low_memory_mode() {
-        _is_low_memory_mode = true;
-        _max_blocks_in_sub_queue = 1;
-        clear_free_blocks();
-    }
+    void set_source_dependency(std::shared_ptr<Dependency> source_dependency)
+            NO_THREAD_SAFETY_ANALYSIS;
+    void set_sink_dependency(Dependency* sink_dependency, int child_idx);
+    void set_max_blocks_in_sub_queue(int64_t max_blocks);
+    void set_low_memory_mode();
 
     void terminate();
 
 private:
-    std::vector<std::unique_ptr<std::mutex>> _queue_blocks_lock;
-    std::vector<std::deque<std::unique_ptr<Block>>> _queue_blocks;
+    void clear_free_blocks();
+    void set_source_ready();
+    void set_source_block();
 
-    std::vector<std::unique_ptr<std::mutex>> _free_blocks_lock;
-    std::vector<std::deque<std::unique_ptr<Block>>> _free_blocks;
+
+    std::vector<std::unique_ptr<SubQueue>> _sub_queues;
 
     //how many deque will be init, always will be one
     int _child_count = 0;
-    std::vector<std::atomic_bool> _is_finished;
-    std::atomic_uint32_t _un_finished_counter;
+    std::atomic_uint32_t _un_finished_counter = 0;
     std::atomic_bool _is_all_finished = false;
-    std::vector<std::atomic_bool> _is_canceled;
-    // int64_t just for counter of profile
-    std::vector<std::atomic_int64_t> _cur_bytes_in_queue;
-    std::vector<std::atomic_uint32_t> _cur_blocks_nums_in_queue;
     std::atomic_uint32_t _cur_blocks_total_nums = 0;
 
     //this will be indicate which queue has data, it's useful when have many queues
@@ -102,17 +122,13 @@ private:
     // only used by streaming agg source operator
 
     std::atomic_bool _is_low_memory_mode = false;
-    std::atomic_int64_t _max_blocks_in_sub_queue = 1;
 
-    //this only use to record the queue[0] for profile
-    int64_t _max_bytes_in_queue = 0;
-    int64_t _max_size_of_queue = 0;
-    static constexpr int64_t MAX_BYTE_OF_QUEUE = 1024L * 1024 * 1024 / 10;
 
-    // data queue is multi sink one source
-    std::shared_ptr<Dependency> _source_dependency = nullptr;
-    std::vector<Dependency*> _sink_dependencies;
-    std::mutex _source_lock;
+
+    // _source_dependency is written once during initialization (set_source_dependency)
+    // and read/used only while holding _source_lock thereafter.
+    std::shared_ptr<Dependency> _source_dependency GUARDED_BY(_source_lock) = nullptr;
+    AnnotatedMutex _source_lock;
 };
 
 } // namespace doris

--- a/be/src/exec/operator/data_queue.h
+++ b/be/src/exec/operator/data_queue.h
@@ -58,14 +58,14 @@ struct SubQueue {
     Dependency* sink_dependency = nullptr;
 
     // Pop a block under queue_lock.
-    // Notifies sink_dependency->set_ready() (outside the lock) if the queue drops below max_blocks_in_queue.
-    // output_block is null if the queue was empty (not an error).
-    Status try_pop(std::unique_ptr<Block>* output_block);
+    // Notifies sink_dependency->set_ready() (outside the lock) if the queue becomes empty.
+    // output_block is null if the queue was empty.
+    void try_pop(std::unique_ptr<Block>* output_block);
 
-    // Push a block under queue_lock.
-    // Returns Status::EndOfFile if already finished.
+    // Push a block under queue_lock and atomically increment total_counter.
+    // Returns false (without incrementing) if already finished.
     // Calls sink_dependency->block() (outside the lock) if the queue exceeds max_blocks_in_queue.
-    Status try_push(std::unique_ptr<Block> block);
+    bool try_push(std::unique_ptr<Block> block, std::atomic_uint32_t& total_counter);
 
     // Mark this sub-queue finished. Returns false if already finished (idempotent).
     // Decrements unfinished_counter and may set all_finished within queue_lock.

--- a/be/test/exec/pipeline/data_queue_test.cpp
+++ b/be/test/exec/pipeline/data_queue_test.cpp
@@ -59,23 +59,24 @@ public:
 
     std::shared_ptr<Dependency> dep;
     std::unique_ptr<SubQueue> sub;
+    std::atomic_uint32_t counter_ {0};
 };
 
 // Pop from an empty queue returns OK with null output.
 TEST_F(SubQueueTest, TryPopEmpty) {
     std::unique_ptr<Block> out;
-    EXPECT_TRUE(sub->try_pop(&out).ok());
+    sub->try_pop(&out);
     EXPECT_EQ(out, nullptr);
     EXPECT_EQ(sub->blocks_in_queue.load(), 0u);
 }
 
 // Basic push then pop returns the block.
 TEST_F(SubQueueTest, TryPushPop_Basic) {
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
     EXPECT_EQ(sub->blocks_in_queue.load(), 1u);
 
     std::unique_ptr<Block> out;
-    EXPECT_TRUE(sub->try_pop(&out).ok());
+    sub->try_pop(&out);
     EXPECT_NE(out, nullptr);
     EXPECT_EQ(sub->blocks_in_queue.load(), 0u);
 }
@@ -86,8 +87,7 @@ TEST_F(SubQueueTest, TryPushAfterFinished) {
     std::atomic_bool all_done {false};
     sub->mark_finished(counter, all_done);
 
-    auto st = sub->try_push(make_block());
-    EXPECT_TRUE(st.is<ErrorCode::END_OF_FILE>());
+    EXPECT_FALSE(sub->try_push(make_block(), counter_));
 }
 
 // When blocks.size() exceeds max_blocks_in_queue, sink is blocked.
@@ -96,12 +96,12 @@ TEST_F(SubQueueTest, SinkBlockedWhenFull) {
     dep->set_ready(); // start ready
 
     // Push up to the limit — sink should stay ready.
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
     EXPECT_TRUE(dep->ready());
 
     // Push one over the limit — sink should be blocked.
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
     EXPECT_FALSE(dep->ready());
 }
 
@@ -110,23 +110,23 @@ TEST_F(SubQueueTest, SinkReadyWhenQueueEmpty) {
     sub->max_blocks_in_queue = 2;
 
     // Fill to 3 (one over limit) → sink blocked.
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
     EXPECT_FALSE(dep->ready());
 
     // Pop 1 & 2: queue not empty yet → sink still blocked.
     std::unique_ptr<Block> out;
-    EXPECT_TRUE(sub->try_pop(&out).ok());
+    sub->try_pop(&out);
     EXPECT_NE(out, nullptr);
     EXPECT_FALSE(dep->ready());
 
-    EXPECT_TRUE(sub->try_pop(&out).ok());
+    sub->try_pop(&out);
     EXPECT_NE(out, nullptr);
     EXPECT_FALSE(dep->ready());
 
     // Pop 3: queue empty → set_ready().
-    EXPECT_TRUE(sub->try_pop(&out).ok());
+    sub->try_pop(&out);
     EXPECT_NE(out, nullptr);
     EXPECT_TRUE(dep->ready());
 }
@@ -154,8 +154,8 @@ TEST_F(SubQueueTest, MarkFinishedSetsAllFinished) {
 
 // clear_blocks empties the queue and calls set_always_ready on sink.
 TEST_F(SubQueueTest, ClearBlocksEmptiesQueue) {
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
-    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
+    EXPECT_TRUE(sub->try_push(make_block(), counter_));
     EXPECT_EQ(sub->blocks_in_queue.load(), 2u);
 
     sub->clear_blocks();
@@ -177,14 +177,14 @@ TEST_F(SubQueueTest, BytesInQueueTracking) {
     auto block = make_block(10);
     int64_t expected_bytes = block->allocated_bytes();
 
-    EXPECT_TRUE(sub->try_push(std::move(block)).ok());
+    EXPECT_TRUE(sub->try_push(std::move(block), counter_));
     {
         LockGuard l(sub->queue_lock);
         EXPECT_EQ(sub->bytes_in_queue, expected_bytes);
     }
 
     std::unique_ptr<Block> out;
-    EXPECT_TRUE(sub->try_pop(&out).ok());
+    sub->try_pop(&out);
     {
         LockGuard l(sub->queue_lock);
         EXPECT_EQ(sub->bytes_in_queue, 0);

--- a/be/test/exec/pipeline/data_queue_test.cpp
+++ b/be/test/exec/pipeline/data_queue_test.cpp
@@ -20,12 +20,180 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "core/data_type/data_type_number.h"
 #include "exec/pipeline/dependency.h"
 
 namespace doris {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::unique_ptr<Block> make_block(size_t rows = 1) {
+    auto block = std::make_unique<Block>();
+    auto col = ColumnUInt8::create(rows);
+    block->insert(ColumnWithTypeAndName {std::move(col), std::make_shared<DataTypeUInt8>(), ""});
+    return block;
+}
+
+// Create a Dependency that starts ready.
+static std::shared_ptr<Dependency> make_dep(bool initially_ready = true) {
+    return Dependency::create_shared(1, 1, "Test", initially_ready);
+}
+
+// ---------------------------------------------------------------------------
+// SubQueue tests
+// ---------------------------------------------------------------------------
+
+class SubQueueTest : public testing::Test {
+public:
+    void SetUp() override {
+        dep = make_dep(/*initially_ready=*/true);
+        sub = std::make_unique<SubQueue>();
+        sub->sink_dependency = dep.get();
+        sub->max_blocks_in_queue = 2;
+    }
+
+    std::shared_ptr<Dependency> dep;
+    std::unique_ptr<SubQueue> sub;
+};
+
+// Pop from an empty queue returns OK with null output.
+TEST_F(SubQueueTest, TryPopEmpty) {
+    std::unique_ptr<Block> out;
+    EXPECT_TRUE(sub->try_pop(&out).ok());
+    EXPECT_EQ(out, nullptr);
+    EXPECT_EQ(sub->blocks_in_queue.load(), 0u);
+}
+
+// Basic push then pop returns the block.
+TEST_F(SubQueueTest, TryPushPop_Basic) {
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_EQ(sub->blocks_in_queue.load(), 1u);
+
+    std::unique_ptr<Block> out;
+    EXPECT_TRUE(sub->try_pop(&out).ok());
+    EXPECT_NE(out, nullptr);
+    EXPECT_EQ(sub->blocks_in_queue.load(), 0u);
+}
+
+// push after mark_finished returns EndOfFile.
+TEST_F(SubQueueTest, TryPushAfterFinished) {
+    std::atomic_uint32_t counter {1};
+    std::atomic_bool all_done {false};
+    sub->mark_finished(counter, all_done);
+
+    auto st = sub->try_push(make_block());
+    EXPECT_TRUE(st.is<ErrorCode::END_OF_FILE>());
+}
+
+// When blocks.size() exceeds max_blocks_in_queue, sink is blocked.
+TEST_F(SubQueueTest, SinkBlockedWhenFull) {
+    sub->max_blocks_in_queue = 2;
+    dep->set_ready(); // start ready
+
+    // Push up to the limit — sink should stay ready.
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(dep->ready());
+
+    // Push one over the limit — sink should be blocked.
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_FALSE(dep->ready());
+}
+
+// Sink wakes up only when the queue becomes completely empty.
+TEST_F(SubQueueTest, SinkReadyWhenQueueEmpty) {
+    sub->max_blocks_in_queue = 2;
+
+    // Fill to 3 (one over limit) → sink blocked.
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_FALSE(dep->ready());
+
+    // Pop 1 & 2: queue not empty yet → sink still blocked.
+    std::unique_ptr<Block> out;
+    EXPECT_TRUE(sub->try_pop(&out).ok());
+    EXPECT_NE(out, nullptr);
+    EXPECT_FALSE(dep->ready());
+
+    EXPECT_TRUE(sub->try_pop(&out).ok());
+    EXPECT_NE(out, nullptr);
+    EXPECT_FALSE(dep->ready());
+
+    // Pop 3: queue empty → set_ready().
+    EXPECT_TRUE(sub->try_pop(&out).ok());
+    EXPECT_NE(out, nullptr);
+    EXPECT_TRUE(dep->ready());
+}
+
+// mark_finished is idempotent: second call returns false and counter stays correct.
+TEST_F(SubQueueTest, MarkFinishedIdempotent) {
+    std::atomic_uint32_t counter {2};
+    std::atomic_bool all_done {false};
+
+    EXPECT_TRUE(sub->mark_finished(counter, all_done));
+    EXPECT_EQ(counter.load(), 1u);
+    EXPECT_FALSE(all_done.load());
+
+    EXPECT_FALSE(sub->mark_finished(counter, all_done));
+    EXPECT_EQ(counter.load(), 1u); // unchanged
+}
+
+// mark_finished sets all_finished when last child finishes.
+TEST_F(SubQueueTest, MarkFinishedSetsAllFinished) {
+    std::atomic_uint32_t counter {1};
+    std::atomic_bool all_done {false};
+    sub->mark_finished(counter, all_done);
+    EXPECT_TRUE(all_done.load());
+}
+
+// clear_blocks empties the queue and calls set_always_ready on sink.
+TEST_F(SubQueueTest, ClearBlocksEmptiesQueue) {
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_TRUE(sub->try_push(make_block()).ok());
+    EXPECT_EQ(sub->blocks_in_queue.load(), 2u);
+
+    sub->clear_blocks();
+
+    EXPECT_EQ(sub->blocks_in_queue.load(), 0u);
+    // set_always_ready was called → dep is always ready.
+    EXPECT_TRUE(dep->ready());
+}
+
+// clear_blocks on an empty queue is a no-op (set_always_ready not called).
+TEST_F(SubQueueTest, ClearBlocksNoop) {
+    dep->block(); // start blocked
+    sub->clear_blocks();
+    EXPECT_FALSE(dep->ready()); // still blocked — clear_blocks did nothing
+}
+
+// bytes_in_queue tracks push/pop correctly.
+TEST_F(SubQueueTest, BytesInQueueTracking) {
+    auto block = make_block(10);
+    int64_t expected_bytes = block->allocated_bytes();
+
+    EXPECT_TRUE(sub->try_push(std::move(block)).ok());
+    {
+        LockGuard l(sub->queue_lock);
+        EXPECT_EQ(sub->bytes_in_queue, expected_bytes);
+    }
+
+    std::unique_ptr<Block> out;
+    EXPECT_TRUE(sub->try_pop(&out).ok());
+    {
+        LockGuard l(sub->queue_lock);
+        EXPECT_EQ(sub->bytes_in_queue, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DataQueue fixtures
+// ---------------------------------------------------------------------------
 
 class DataQueueTest : public testing::Test {
 public:
@@ -46,6 +214,140 @@ public:
     std::shared_ptr<Dependency> source_dep;
     const int child_count = 3;
 };
+
+// ---------------------------------------------------------------------------
+// DataQueue unit tests
+// ---------------------------------------------------------------------------
+
+// Initial state: no data, no finish.
+TEST_F(DataQueueTest, InitialState) {
+    EXPECT_FALSE(data_queue->has_more_data());
+    EXPECT_FALSE(data_queue->is_all_finish());
+    EXPECT_FALSE(data_queue->remaining_has_data());
+}
+
+// Push one block and retrieve it.
+TEST_F(DataQueueTest, SinglePushPop) {
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    EXPECT_TRUE(data_queue->has_more_data());
+
+    // Find the queue with data.
+    EXPECT_TRUE(data_queue->remaining_has_data());
+
+    std::unique_ptr<Block> out;
+    int child_idx = -1;
+    EXPECT_TRUE(data_queue->get_block_from_queue(&out, &child_idx).ok());
+    EXPECT_NE(out, nullptr);
+    EXPECT_EQ(child_idx, 0);
+    EXPECT_FALSE(data_queue->has_more_data());
+}
+
+// is_all_finish only becomes true after all children call set_finish.
+TEST_F(DataQueueTest, IsAllFinishAfterAllChildren) {
+    data_queue->set_finish(0);
+    EXPECT_FALSE(data_queue->is_all_finish());
+    data_queue->set_finish(1);
+    EXPECT_FALSE(data_queue->is_all_finish());
+    data_queue->set_finish(2);
+    EXPECT_TRUE(data_queue->is_all_finish());
+}
+
+// set_finish is idempotent.
+TEST_F(DataQueueTest, SetFinishIdempotent) {
+    data_queue->set_finish(0);
+    data_queue->set_finish(0); // second call must not double-decrement
+    data_queue->set_finish(1);
+    data_queue->set_finish(2);
+    EXPECT_TRUE(data_queue->is_all_finish());
+}
+
+// child_idx returned by get_block_from_queue reflects the actual queue.
+TEST_F(DataQueueTest, ChildIdxReturned) {
+    // Push to child 1 only.
+    EXPECT_TRUE(data_queue->push_block(make_block(), 1).ok());
+    data_queue->remaining_has_data(); // advance _flag_queue_idx to find child 1
+
+    std::unique_ptr<Block> out;
+    int child_idx = -1;
+    EXPECT_TRUE(data_queue->get_block_from_queue(&out, &child_idx).ok());
+    EXPECT_NE(out, nullptr);
+    EXPECT_EQ(child_idx, 1);
+}
+
+// get_free_block returns a new block when free list is empty, reuses when not.
+TEST_F(DataQueueTest, FreeBlockReuse) {
+    // First call: allocates a new block.
+    auto block = data_queue->get_free_block(0);
+    EXPECT_NE(block, nullptr);
+
+    // Return it to the free list.
+    block->clear(); // ensure rows == 0
+    data_queue->push_free_block(std::move(block), 0);
+
+    // Second call: must return the recycled block.
+    auto block2 = data_queue->get_free_block(0);
+    EXPECT_NE(block2, nullptr);
+}
+
+// In low-memory mode push_free_block discards blocks and max drops to 1.
+TEST_F(DataQueueTest, LowMemoryMode) {
+    // Pre-populate the free list.
+    data_queue->push_free_block(Block::create_unique(), 0);
+
+    data_queue->set_low_memory_mode();
+
+    // Free list must be cleared.
+    auto block = data_queue->get_free_block(0);
+    // The free list is empty → a fresh block is returned (not from the list).
+    EXPECT_NE(block, nullptr);
+
+    // push_free_block now discards.
+    block->clear();
+    data_queue->push_free_block(std::move(block), 0);
+    auto block2 = data_queue->get_free_block(0);
+    // Still gets a fresh allocation (free list stays empty).
+    EXPECT_NE(block2, nullptr);
+}
+
+// terminate() finishes all children and clears pending blocks from sub-queues.
+TEST_F(DataQueueTest, Terminate) {
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    EXPECT_TRUE(data_queue->push_block(make_block(), 1).ok());
+
+    data_queue->terminate();
+
+    EXPECT_TRUE(data_queue->is_all_finish());
+    // remaining_has_data() checks blocks_in_queue per sub-queue,
+    // which clear_blocks() resets to 0.
+    EXPECT_FALSE(data_queue->remaining_has_data());
+}
+
+// set_max_blocks_in_sub_queue propagates to every sub-queue.
+TEST_F(DataQueueTest, SetMaxBlocksInSubQueue) {
+    data_queue->set_max_blocks_in_sub_queue(5);
+    // Push 5 blocks to child 0 — sink must stay ready (not over the limit yet).
+    for (int i = 0; i < 5; i++) {
+        EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    }
+    EXPECT_TRUE(sink_deps[0]->ready());
+
+    // 6th push exceeds limit → sink blocked.
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    EXPECT_FALSE(sink_deps[0]->ready());
+}
+
+// Source dependency is notified ready when a block is pushed.
+TEST_F(DataQueueTest, SourceReadyOnPush) {
+    source_dep->block(); // start blocked
+    EXPECT_FALSE(source_dep->ready());
+
+    EXPECT_TRUE(data_queue->push_block(make_block(), 0).ok());
+    EXPECT_TRUE(source_dep->ready());
+}
+
+// ---------------------------------------------------------------------------
+// Multi-threaded integration test (existing)
+// ---------------------------------------------------------------------------
 
 TEST_F(DataQueueTest, MultiTest) {
     int output_count = 0;
@@ -107,14 +409,7 @@ TEST_F(DataQueueTest, MultiTest) {
     output1.join();
 
     EXPECT_EQ(output_count, 150);
-    for (int i = 0; i < 3; i++) {
-        EXPECT_TRUE(data_queue->is_finish(i));
-    }
     EXPECT_TRUE(data_queue->is_all_finish());
-    data_queue->clear_free_blocks();
-    for (int i = 0; i < 3; i++) {
-        EXPECT_TRUE(data_queue->_free_blocks[i].empty());
-    }
 }
 
 // ./run-be-ut.sh --run --filter=DataQueueTest.*


### PR DESCRIPTION
                                                                      
  What problem does this PR solve?                                
                                                                             
  Issue Number: N/A                                                          
                                                                             
  Problem Summary:                                                           
                                                                  
  The DataQueue implementation used parallel vectors (one per child queue —  
  lock, blocks, counters, etc.) scattered across the class, making it hard to
   reason about which lock protects which field. The old INJECT_MOCK_SLEEP   
  pattern injected test randomness through a macro wrapping std::lock_guard,
  but this was fragile and didn't compose with Clang's -Wthread-safety static
   analysis. Several methods (e.g., set_source_block) performed lock-free
  checks followed by locked re-checks, risking subtle races.

  Root cause: per-child state was not encapsulated, lock/field relationships 
  were implicit, and no static analysis guarded them.
                                                                             
  This PR:                                                                   
  
  - Introduces a SubQueue struct that groups all per-child state (queue lock 
  + blocks, free lock + free blocks, counters, sink dependency pointer) with
  explicit GUARDED_BY annotations.                                           
  thread-safety macros, an AnnotatedMutex wrapper, and a LockGuard that    
  replaces std::lock_guard. In BE_TEST builds, LockGuard injects random sleep
   before lock acquisition and after release to exercise concurrent code     
  paths — replacing the old INJECT_MOCK_SLEEP macro.                         
  - Enables -Wthread-safety in Clang builds.                      
  - Moves dependency notifications (set_ready, block, set_always_ready)
  outside the queue lock in try_pop/try_push/clear_blocks to avoid nested    
  lock ordering issues.                                                      
  - Fixes set_source_block to always hold _source_lock when reading          
  _source_dependency, eliminating the lock-free pre-check.                   
  - Adds 20+ new unit tests covering SubQueue methods and DataQueue edge     
  cases (empty pop, push-after-finished, capacity blocking, finish      
  idempotency, clear_blocks, low-memory mode, terminate, free-block reuse,   
  child_idx routing).                                                     
                                                                             
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

