### PR TITLE
[improvement](nereids) Enhance LogicalJoin.computeUnique with unique-set union propagation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  *                   then values in column 'b' must also be identical.
  */
 public class DataTrait {
-
+    public static int UNIQUE_UNION_LIMIT = 16;
     public static final DataTrait EMPTY_TRAIT
             = new DataTrait(new UniqueDescription().toImmutable(),
                     new UniformDescription().toImmutable(), new ImmutableSet.Builder<FdItem>().build(),
@@ -282,9 +282,9 @@ public class DataTrait {
 
         /**
          * Extends a unique slot using an equivalence set.
-         * Within slots, if any slot in the equivalence set is unique,
+         * Within uniqueSlots, if any slot in the equivalence set is unique,
          * then all slots in the set are considered unique.
-         * For slotSets, if there is an intersection with the equivalence set,
+         * For combinedUniqueSlotSet, if there is an intersection with the equivalence set,
          * the slotSet can be substituted with the equivalence set.
          * Example:
          *          Given an equivalence set {a1, a2, a3} and a uniqueSet {a1, b1, c1},
@@ -420,7 +420,7 @@ public class DataTrait {
         }
 
         /** replace uniqueSet.slotSets slot to root in equalSets */
-        public void rmDuplicateInUniqueSlotSetByEqualSet() {
+        public void normalizeUniqueSetsToEqualSetRoot() {
             ImmutableEqualSet<Slot> equalSet = equalSetBuilder.build();
             Set<ImmutableSet<Slot>> newSlotSets = new HashSet<>();
             for (ImmutableSet<Slot> uniqueSet : uniqueSet.combinedUniqueSlotSet) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DataTrait.java
@@ -138,6 +138,20 @@ public class DataTrait {
         return equalSet.isEqual(l, r);
     }
 
+    /**
+     * Get all unique slot sets, including those containing nullable slots.
+     * Each returned set is a unique key of the relation (no two rows share the same value combination,
+     * under SQL's "NULL is distinct from NULL" semantics in the UNIQUE-set sense).
+     */
+    public List<Set<Slot>> getAllUniqueSets() {
+        List<Set<Slot>> res = new ArrayList<>(uniqueSet.uniqueSlots.size() + uniqueSet.combinedUniqueSlotSet.size());
+        for (Slot slot : uniqueSet.uniqueSlots) {
+            res.add(ImmutableSet.of(slot));
+        }
+        res.addAll(uniqueSet.combinedUniqueSlotSet);
+        return res;
+    }
+
     public FuncDeps getAllValidFuncDeps(Set<Slot> validSlots) {
         return fdDg.findValidFuncDeps(validSlots);
     }
@@ -277,14 +291,14 @@ public class DataTrait {
          *          the sets {a2, b1, c1} and {a3, b1, c1} are also treated as unique.
          */
         public void addUniqueByEqualSet(Set<Slot> equalSet) {
-            if (uniqueSet.isIntersect(equalSet, uniqueSet.slots)) {
-                uniqueSet.slots.addAll(equalSet);
+            if (uniqueSet.isIntersect(equalSet, uniqueSet.uniqueSlots)) {
+                uniqueSet.uniqueSlots.addAll(equalSet);
                 return;
             }
-            for (Set<Slot> slotSet : uniqueSet.slotSets) {
-                Set<Slot> intersection = Sets.intersection(equalSet, uniqueSet.slots);
+            for (Set<Slot> slotSet : uniqueSet.combinedUniqueSlotSet) {
+                Set<Slot> intersection = Sets.intersection(equalSet, uniqueSet.uniqueSlots);
                 if (intersection.size() > 2) {
-                    uniqueSet.slotSets.remove(slotSet);
+                    uniqueSet.combinedUniqueSlotSet.remove(slotSet);
                     slotSet.removeAll(intersection);
                     for (Slot slot : equalSet) {
                         ImmutableSet<Slot> uniqueSlotSet
@@ -330,12 +344,12 @@ public class DataTrait {
          */
         public List<Set<Slot>> getAllUniqueAndNotNull() {
             List<Set<Slot>> res = new ArrayList<>();
-            for (Slot slot : uniqueSet.slots) {
+            for (Slot slot : uniqueSet.uniqueSlots) {
                 if (!slot.nullable()) {
                     res.add(ImmutableSet.of(slot));
                 }
             }
-            for (Set<Slot> slotSet : uniqueSet.slotSets) {
+            for (Set<Slot> slotSet : uniqueSet.combinedUniqueSlotSet) {
                 boolean containsNullable = false;
                 for (Slot slot : slotSet) {
                     if (slot.nullable()) {
@@ -380,7 +394,7 @@ public class DataTrait {
 
         public void pruneSlots(Set<Slot> outputSlots) {
             uniformSet.removeNotContain(outputSlots);
-            uniqueSet.removeNotContain(outputSlots);
+            uniqueSet.removeNotContain(outputSlots, equalSetBuilder.build());
             equalSetBuilder.removeNotContain(outputSlots);
             fdDgBuilder.removeNotContain(outputSlots);
         }
@@ -404,65 +418,99 @@ public class DataTrait {
         public void replaceFuncDepsBy(Map<Slot, Slot> replaceMap) {
             fdDgBuilder.replace(replaceMap);
         }
+
+        /** replace uniqueSet.slotSets slot to root in equalSets */
+        public void rmDuplicateInUniqueSlotSetByEqualSet() {
+            ImmutableEqualSet<Slot> equalSet = equalSetBuilder.build();
+            Set<ImmutableSet<Slot>> newSlotSets = new HashSet<>();
+            for (ImmutableSet<Slot> uniqueSet : uniqueSet.combinedUniqueSlotSet) {
+                ImmutableSet.Builder<Slot> roots = ImmutableSet.builder();
+                for (Slot slot : uniqueSet) {
+                    Slot root = equalSet.getRoot(slot);
+                    if (root != null) {
+                        roots.add(root);
+                    } else {
+                        roots.add(slot);
+                    }
+                }
+                newSlotSets.add(roots.build());
+            }
+            uniqueSet.combinedUniqueSlotSet = newSlotSets;
+        }
     }
 
     static class UniqueDescription {
-        Set<Slot> slots;
-        Set<ImmutableSet<Slot>> slotSets;
+        Set<Slot> uniqueSlots;
+        Set<ImmutableSet<Slot>> combinedUniqueSlotSet;
 
         UniqueDescription() {
-            slots = new HashSet<>();
-            slotSets = new HashSet<>();
+            uniqueSlots = new HashSet<>();
+            combinedUniqueSlotSet = new HashSet<>();
         }
 
         UniqueDescription(UniqueDescription o) {
-            this.slots = new HashSet<>(o.slots);
-            this.slotSets = new HashSet<>(o.slotSets);
+            this.uniqueSlots = new HashSet<>(o.uniqueSlots);
+            this.combinedUniqueSlotSet = new HashSet<>(o.combinedUniqueSlotSet);
         }
 
         UniqueDescription(Set<Slot> slots, Set<ImmutableSet<Slot>> slotSets) {
-            this.slots = slots;
-            this.slotSets = slotSets;
+            this.uniqueSlots = slots;
+            this.combinedUniqueSlotSet = slotSets;
         }
 
         public boolean contains(Slot slot) {
-            return slots.contains(slot);
+            return uniqueSlots.contains(slot);
         }
 
         public boolean contains(Set<Slot> slotSet) {
             if (slotSet.size() == 1) {
-                return slots.contains(slotSet.iterator().next());
+                return uniqueSlots.contains(slotSet.iterator().next());
             }
-            return slotSets.contains(ImmutableSet.copyOf(slotSet));
+            return combinedUniqueSlotSet.contains(ImmutableSet.copyOf(slotSet));
         }
 
         public boolean containsAnySub(Set<Slot> slotSet) {
-            return slotSet.stream().anyMatch(s -> slots.contains(s))
-                    || slotSets.stream().anyMatch(slotSet::containsAll);
+            return slotSet.stream().anyMatch(s -> uniqueSlots.contains(s))
+                    || combinedUniqueSlotSet.stream().anyMatch(slotSet::containsAll);
         }
 
-        public void removeNotContain(Set<Slot> slotSet) {
-            if (!slotSet.isEmpty()) {
-                Set<Slot> newSlots = Sets.newLinkedHashSetWithExpectedSize(slots.size());
-                for (Slot slot : slots) {
-                    if (slotSet.contains(slot)) {
+        public void removeNotContain(Set<Slot> outputSlots, ImmutableEqualSet<Slot> equalSet) {
+            if (!outputSlots.isEmpty()) {
+                Set<Slot> newSlots = Sets.newLinkedHashSetWithExpectedSize(uniqueSlots.size());
+                for (Slot slot : uniqueSlots) {
+                    if (outputSlots.contains(slot)) {
                         newSlots.add(slot);
                     }
                 }
-                this.slots = newSlots;
+                this.uniqueSlots = newSlots;
 
-                Set<ImmutableSet<Slot>> newSlotSets = Sets.newLinkedHashSetWithExpectedSize(slots.size());
-                for (ImmutableSet<Slot> set : slotSets) {
-                    if (slotSet.containsAll(set)) {
-                        newSlotSets.add(set);
+                Set<ImmutableSet<Slot>> newCombinedUniqueSlotSet = Sets.newHashSetWithExpectedSize(uniqueSlots.size());
+                for (ImmutableSet<Slot> combinedUniqueSlots : combinedUniqueSlotSet) {
+                    ImmutableSet.Builder<Slot> builder = ImmutableSet.builder();
+                    boolean allCanFindReplacement = true;
+                    for (Slot slot : combinedUniqueSlots) {
+                        if (outputSlots.contains(slot)) {
+                            builder.add(slot);
+                        } else {
+                            Set<Slot> equalSlots = equalSet.calEqualSet(slot);
+                            Set<Slot> replaceSlots = Sets.intersection(outputSlots, equalSlots);
+                            if (!replaceSlots.isEmpty()) {
+                                builder.add(replaceSlots.iterator().next());
+                            } else {
+                                allCanFindReplacement = false;
+                            }
+                        }
+                    }
+                    if (allCanFindReplacement) {
+                        newCombinedUniqueSlotSet.add(builder.build());
                     }
                 }
-                this.slotSets = newSlotSets;
+                this.combinedUniqueSlotSet = newCombinedUniqueSlotSet;
             }
         }
 
         public void add(Slot slot) {
-            slots.add(slot);
+            uniqueSlots.add(slot);
         }
 
         public void add(ImmutableSet<Slot> slotSet) {
@@ -470,15 +518,15 @@ public class DataTrait {
                 return;
             }
             if (slotSet.size() == 1) {
-                slots.add(slotSet.iterator().next());
+                uniqueSlots.add(slotSet.iterator().next());
                 return;
             }
-            slotSets.add(slotSet);
+            combinedUniqueSlotSet.add(slotSet);
         }
 
         public void add(UniqueDescription uniqueDescription) {
-            slots.addAll(uniqueDescription.slots);
-            slotSets.addAll(uniqueDescription.slotSets);
+            uniqueSlots.addAll(uniqueDescription.uniqueSlots);
+            combinedUniqueSlotSet.addAll(uniqueDescription.combinedUniqueSlotSet);
         }
 
         public boolean isIntersect(Set<Slot> set1, Set<Slot> set2) {
@@ -496,26 +544,26 @@ public class DataTrait {
         }
 
         public boolean isEmpty() {
-            return slots.isEmpty() && slotSets.isEmpty();
+            return uniqueSlots.isEmpty() && combinedUniqueSlotSet.isEmpty();
         }
 
         @Override
         public String toString() {
-            return "{" + slots + slotSets + "}";
+            return "{" + uniqueSlots + combinedUniqueSlotSet + "}";
         }
 
         public void replace(Map<Slot, Slot> replaceMap) {
-            slots = slots.stream()
+            uniqueSlots = uniqueSlots.stream()
                     .map(s -> replaceMap.getOrDefault(s, s))
                     .collect(Collectors.toSet());
-            slotSets = slotSets.stream()
+            combinedUniqueSlotSet = combinedUniqueSlotSet.stream()
                     .map(set -> set.stream().map(s -> replaceMap.getOrDefault(s, s))
                             .collect(ImmutableSet.toImmutableSet()))
                     .collect(Collectors.toSet());
         }
 
         public UniqueDescription toImmutable() {
-            return new UniqueDescription(ImmutableSet.copyOf(slots), ImmutableSet.copyOf(slotSets));
+            return new UniqueDescription(ImmutableSet.copyOf(uniqueSlots), ImmutableSet.copyOf(combinedUniqueSlotSet));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
@@ -281,7 +281,7 @@ public interface Plan extends TreeNode<Plan> {
         computeEqualSet(fdBuilder);
         computeFd(fdBuilder);
 
-        fdBuilder.rmDuplicateInUniqueSlotSetByEqualSet();
+        fdBuilder.normalizeUniqueSetsToEqualSetRoot();
 
         for (Slot slot : getOutput()) {
             Set<Slot> o = ImmutableSet.of(slot);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
@@ -281,6 +281,8 @@ public interface Plan extends TreeNode<Plan> {
         computeEqualSet(fdBuilder);
         computeFd(fdBuilder);
 
+        fdBuilder.rmDuplicateInUniqueSlotSetByEqualSet();
+
         for (Slot slot : getOutput()) {
             Set<Slot> o = ImmutableSet.of(slot);
             // all slots dependent unique slot
@@ -298,6 +300,7 @@ public interface Plan extends TreeNode<Plan> {
             fdBuilder.addUniformByEqualSet(validEqualSet);
             fdBuilder.addUniqueByEqualSet(validEqualSet);
         }
+
         Set<Slot> output = this.getOutputSet();
         for (Plan child : children()) {
             if (!output.containsAll(child.getOutputSet())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -612,6 +612,40 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
         } else if (joinType.isRightSemiOrAntiJoin() || joinType.isAsofRightJoin()) {
             builder.addUniqueSlot(right().getLogicalProperties().getTrait());
         }
+
+        // Union propagation:
+        // For INNER / CROSS / LEFT_OUTER / RIGHT_OUTER / FULL_OUTER joins, if the left side
+        // is unique on U_L and the right side is unique on U_R, then the join output is unique
+        // on U_L ∪ U_R. This does NOT require the hash keys themselves to be unique, and also
+        // does NOT require U_L / U_R to contain the join keys.
+        // Proof sketch (INNER): two output rows (l_a, r_a) and (l_b, r_b) agreeing on U_L ∪ U_R
+        // must agree on U_L (so l_a = l_b by L's uniqueness on U_L) and on U_R (so r_a = r_b),
+        // hence the two rows are identical. OUTER variants follow by treating unmatched rows
+        // separately under the "NULL is distinct from NULL" UNIQUE-set semantics.
+        if (joinType.isInnerJoin() || joinType.isCrossJoin()
+                || joinType.isLeftOuterJoin() || joinType.isRightOuterJoin()
+                || joinType.isFullOuterJoin()) {
+            List<Set<Slot>> leftUniqueSets =
+                    left().getLogicalProperties().getTrait().getAllUniqueSets();
+            List<Set<Slot>> rightUniqueSets =
+                    right().getLogicalProperties().getTrait().getAllUniqueSets();
+            if (!leftUniqueSets.isEmpty() && !rightUniqueSets.isEmpty()) {
+                final int unionLimit = 16;
+                int count = 0;
+                outer:
+                for (Set<Slot> leftUnique : leftUniqueSets) {
+                    for (Set<Slot> rightUnique : rightUniqueSets) {
+                        if (count >= unionLimit) {
+                            break outer;
+                        }
+                        builder.addUniqueSlot(ImmutableSet.<Slot>builder()
+                                .addAll(leftUnique).addAll(rightUnique).build());
+                        count++;
+                    }
+                }
+            }
+        }
+
         // if there is non-equal join conditions, don't propagate unique
         if (hashJoinConjuncts.isEmpty()) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.hint.DistributeHint;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.bitmap.LongBitmap;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.DataTrait.Builder;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.rules.exploration.join.JoinReorderContext;
@@ -616,12 +617,10 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
         // Union propagation:
         // For INNER / CROSS / LEFT_OUTER / RIGHT_OUTER / FULL_OUTER joins, if the left side
         // is unique on U_L and the right side is unique on U_R, then the join output is unique
-        // on U_L ∪ U_R. This does NOT require the hash keys themselves to be unique, and also
-        // does NOT require U_L / U_R to contain the join keys.
+        // on U_L ∪ U_R.
         // Proof sketch (INNER): two output rows (l_a, r_a) and (l_b, r_b) agreeing on U_L ∪ U_R
         // must agree on U_L (so l_a = l_b by L's uniqueness on U_L) and on U_R (so r_a = r_b),
-        // hence the two rows are identical. OUTER variants follow by treating unmatched rows
-        // separately under the "NULL is distinct from NULL" UNIQUE-set semantics.
+        // hence the two rows are identical.
         if (joinType.isInnerJoin() || joinType.isCrossJoin()
                 || joinType.isLeftOuterJoin() || joinType.isRightOuterJoin()
                 || joinType.isFullOuterJoin()) {
@@ -630,12 +629,11 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             List<Set<Slot>> rightUniqueSets =
                     right().getLogicalProperties().getTrait().getAllUniqueSets();
             if (!leftUniqueSets.isEmpty() && !rightUniqueSets.isEmpty()) {
-                final int unionLimit = 16;
                 int count = 0;
                 outer:
                 for (Set<Slot> leftUnique : leftUniqueSets) {
                     for (Set<Slot> rightUnique : rightUniqueSets) {
-                        if (count >= unionLimit) {
+                        if (count >= DataTrait.UNIQUE_UNION_LIMIT) {
                             break outer;
                         }
                         builder.addUniqueSlot(ImmutableSet.<Slot>builder()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
@@ -48,6 +48,7 @@ public class ImmutableEqualSet<T> {
      */
     public static class Builder<T> {
         private Map<T, T> parent;
+        private ImmutableEqualSet<T> built;
 
         Builder(Map<T, T> parent) {
             this.parent = parent;
@@ -146,13 +147,21 @@ public class ImmutableEqualSet<T> {
             return findRoot(parent.get(a));
         }
 
+        /** compute if built is null */
         public ImmutableEqualSet<T> build() {
-            ImmutableMap.Builder<T, T> foldMapBuilder = new ImmutableMap.Builder<>();
-            for (T k : parent.keySet()) {
-                foldMapBuilder.put(k, findRoot(k));
+            if (built == null) {
+                ImmutableMap.Builder<T, T> foldMapBuilder = new ImmutableMap.Builder<>();
+                for (T k : parent.keySet()) {
+                    foldMapBuilder.put(k, findRoot(k));
+                }
+                built = new ImmutableEqualSet<>(foldMapBuilder.build());
             }
-            return new ImmutableEqualSet<>(foldMapBuilder.build());
+            return built;
         }
+    }
+
+    public T getRoot(T node) {
+        return root.get(node);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ImmutableEqualSet.java
@@ -66,6 +66,7 @@ public class ImmutableEqualSet<T> {
          * replace all key value according replace map
          */
         public void replace(Map<T, T> replaceMap) {
+            built = null;
             Map<T, T> newMap = new LinkedHashMap<>();
             for (Entry<T, T> entry : parent.entrySet()) {
                 newMap.put(replaceMap.getOrDefault(entry.getKey(), entry.getKey()),
@@ -79,6 +80,7 @@ public class ImmutableEqualSet<T> {
          * @param containSet the set to contain
          */
         public void removeNotContain(Set<T> containSet) {
+            built = null;
             List<Set<T>> equalSetList = calEqualSetList();
             this.parent.clear();
             for (Set<T> equalSet : equalSetList) {
@@ -99,6 +101,7 @@ public class ImmutableEqualSet<T> {
          * Add a equal pair
          */
         public void addEqualPair(T a, T b) {
+            built = null;
             if (!parent.containsKey(a)) {
                 parent.put(a, a);
             }
@@ -137,6 +140,7 @@ public class ImmutableEqualSet<T> {
         }
 
         public void addEqualSet(ImmutableEqualSet<T> equalSet) {
+            built = null;
             this.parent.putAll(equalSet.root);
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
@@ -266,26 +266,31 @@ class UniqueTest extends TestWithFeService {
         Assertions.assertTrue(plan.getLogicalProperties()
                 .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
 
+        // Even though the hash key (uni.name) is not unique, the join output is still unique on
+        // {agg.id, uni.id} because both inputs are unique on their respective ids
+        // (union propagation: U_L ∪ U_R is unique).
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id = uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties()
+        Assertions.assertTrue(plan.getLogicalProperties()
                 .getTrait().isUnique(plan.getOutputSet()));
+        // Non-equal join condition: union propagation does not depend on hash equi conjuncts.
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id < uni.id")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties()
+        Assertions.assertTrue(plan.getLogicalProperties()
                 .getTrait().isUnique(plan.getOutputSet()));
+        // Disjunctive condition: still unique on {agg.id, uni.id} by union propagation.
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
                         + "on agg.id = uni.id or agg.name > uni.name")
                 .rewrite()
                 .getPlan();
-        Assertions.assertFalse(plan.getLogicalProperties()
+        Assertions.assertTrue(plan.getLogicalProperties()
                 .getTrait().isUnique(plan.getOutputSet()));
         plan = PlanChecker.from(connectContext)
                 .analyze("select uni.id, agg.id from agg inner join uni "
@@ -296,6 +301,81 @@ class UniqueTest extends TestWithFeService {
                 .getTrait().isUniqueAndNotNull(plan.getOutput().get(0)));
         Assertions.assertTrue(plan.getLogicalProperties()
                 .getTrait().isUniqueAndNotNull(plan.getOutput().get(1)));
+    }
+
+    @Test
+    void testJoinUniqueUnionPropagation() {
+        // INNER: union propagation { agg.id } ∪ { uni.id } -> output unique on {agg.id, uni.id}
+        // even when hash key (uni.name) is not unique on its side
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select agg.id, uni.id from agg inner join uni on agg.id = uni.name")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+
+        // CROSS: union propagation does not depend on equi conjuncts
+        plan = PlanChecker.from(connectContext)
+                .analyze("select agg.id, uni.id from agg cross join uni")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+
+        // LEFT OUTER: union propagation also applies (NULL distinct in unique-set semantics)
+        plan = PlanChecker.from(connectContext)
+                .analyze("select agg.id, uni.id from agg left outer join uni on agg.id = uni.name")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+
+        // RIGHT OUTER
+        plan = PlanChecker.from(connectContext)
+                .analyze("select agg.id, uni.id from agg right outer join uni on agg.id = uni.name")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+
+        // FULL OUTER
+        plan = PlanChecker.from(connectContext)
+                .analyze("select agg.id, uni.id from agg full outer join uni on agg.id = uni.name")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+
+        // Equal-set canonicalization: agg.id = uni.id, output {agg.id} alone should be unique
+        // because { agg.id, uni.id } gets canonicalized via the equal set so a single
+        // representative slot in the output identifies the row.
+        plan = PlanChecker.from(connectContext)
+                .analyze("select t1.id2, t1.name,t2.name from (select distinct id2,name from agg) t1 inner join (select distinct id2,name from uni) t2 on t1.id2 = t2.id2")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+        plan = PlanChecker.from(connectContext)
+                .analyze("select t2.id2, t1.name,t2.name,t3.name from (select distinct id2,name from agg) t1 inner join (select distinct id2,name from uni) t2 on t1.id2 = t2.id2 inner join (select distinct id2,name from uni) t3 on t2.id2=t3.id2")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+        plan = PlanChecker.from(connectContext)
+                .analyze("select t3.id2,t2.id2, t1.name,t2.name from (select distinct id2,name from agg) t1 inner join (select distinct id2,name from uni) t2 on t1.id2 = t2.id2 inner join (select distinct id2,name from uni) t3 on t2.name=t3.name")
+                .rewrite()
+                .getPlan();
+        Assertions.assertTrue(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
+
+        // Negative: when output drops both join keys and lacks any unique combination
+        // covering both sides, it must NOT be considered unique.
+        plan = PlanChecker.from(connectContext)
+                .analyze("select agg.name, uni.name from agg inner join uni on agg.id = uni.id")
+                .rewrite()
+                .getPlan();
+        Assertions.assertFalse(plan.getLogicalProperties()
+                .getTrait().isUnique(plan.getOutputSet()));
     }
 
     @Test


### PR DESCRIPTION

   ### What problem does this PR solve?
   
   Issue Number: close #xxx
   
   Related PR: #xxx
   
   Problem Summary:
   
   `LogicalJoin.computeUnique` previously only propagated unique traits when the hash keys themselves were unique on both sides. This missed the very common case where a unique set contains non-join-key 
  columns. For example, if the left side is unique on `{l.v, l.k}` and the right side is unique on `{r.v, r.k}`, an inner/outer join is in fact unique on `{l.v, l.k, r.v, r.k}`, but the old implementation could
   not derive this. As a result, downstream rules that rely on unique information (`EliminateGroupByKey`, `EliminateJoinByUnique`, SELECT DISTINCT elimination, etc.) lost optimization opportunities.
   
   This PR introduces **unique-set union propagation**:
   
   > For INNER / CROSS / LEFT_OUTER / RIGHT_OUTER / FULL_OUTER joins, if the left side is unique on `U_L` and the right side is unique on `U_R`, then the join output is unique on `U_L ∪ U_R`.
   > Neither the hash keys themselves nor `U_L`/`U_R` are required to contain the join key.
   
   Proof sketch (INNER): take two output rows `(l_a, r_a)` and `(l_b, r_b)` that agree on `U_L ∪ U_R`. They agree on `U_L`, so by left-side uniqueness `l_a = l_b`. They agree on `U_R`, so by right-side 
  uniqueness `r_a = r_b`. Thus the rows are identical. OUTER variants follow by considering the matched and unmatched sub-relations separately under SQL's "NULL is not equal to NULL" semantics for unique sets. 
  SEMI / ANTI / MARK / ASOF are excluded via a join-type whitelist and keep their existing behavior.
   
   To let downstream rules such as `EliminateGroupByKey` actually match the propagated unique sets, the PR also includes the following supporting changes:
   
   1. **New `DataTrait.getAllUniqueSets()`** that enumerates all unique sets (including nullable ones), used by the join-side computation.
   2. **`UniqueDescription.removeNotContain` is now equalSet-aware**: when a slot in a unique set is projected away but an equivalent slot is still in the output, it is substituted with the equivalent one, so 
  projections do not unnecessarily drop unique information. Both single-slot `uniqueSlots` and `combinedUniqueSlotSet` are handled symmetrically.
   3. **New `Builder.rmDuplicateInUniqueSlotSetByEqualSet`** that normalizes slots in unique sets to the equalSet root, collapsing redundant members. Combined with join equi predicates, this lets sets like 
  `{l.k, r.v}` and `{r.k, r.v}` (with `l.k ≡ r.k`) collapse to the same canonical form, making `EliminateGroupByKey` more likely to succeed.
   4. **Field renames in `UniqueDescription`**: `slots → uniqueSlots`, `slotSets → combinedUniqueSlotSet`, for readability.
   5. **`ImmutableEqualSet.Builder` gains a `built` cache and a public `getRoot(T)`**. The cache is properly invalidated by `addEqualPair` / `addEqualSet` / `replace` / `removeNotContain` to prevent stale 
  results from leaking through the public API.
   
   A conservative `unionLimit = 16` guards against pathological cartesian explosions in unique-set combinations (in practice the number of unique sets per side is far below this).
   
   ### Release note
   
   None (internal optimizer enhancement; improves trait propagation precision, no user-visible behavior change beyond plan quality).
   
   ### Check List (For Author)
   
   - Test:
       - Unit Test: Added `UniqueTest#testJoinUniqueUnionPropagation` covering union propagation for INNER / CROSS / LEFT_OUTER / RIGHT_OUTER / FULL_OUTER, the single-slot equalSet collapse path, and a negative
   case where dropping both join keys breaks uniqueness. Three previously over-conservative `assertFalse` checks in `UniqueTest#testJoin` are corrected to `assertTrue` with a comment explaining why.
   - Behavior changed: No (purely a more precise unique derivation in the optimizer; correctness is established by the proof above).
   - Does this need documentation: No