### PR TITLE
[fix](insert) Avoid formatting generated insert errors

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -201,8 +201,8 @@ public abstract class AbstractInsertExecutor {
             coordinator.cancel(new Status(TStatusCode.CANCELLED, "insert timeout"));
             if (notTimeout) {
                 errMsg = coordinator.getExecStatus().getErrorMsg();
-                ErrorReport.reportDdlException("there exists unhealthy backend. "
-                        + errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
+                ErrorReport.reportDdlException("%s", ErrorCode.ERR_FAILED_WHEN_INSERT,
+                        "there exists unhealthy backend. " + errMsg);
             } else {
                 ErrorReport.reportDdlException(ErrorCode.ERR_EXECUTE_TIMEOUT);
             }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The unhealthy-backend insert failure path passed a generated error message as the String.format pattern to ErrorReport. If the generated message contains percent signs, reporting can throw a secondary formatting exception and hide the original insert failure. Use a fixed "%s" pattern and pass the generated message as data.
