### PR TITLE
[fix](mtmv) Avoid mutating excluded trigger tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPartitionUtil.java
@@ -94,6 +94,7 @@ public class MTMVPartitionUtil {
             Set<TableNameInfo> excludedTriggerTables) throws AnalysisException {
         MTMV mtmv = refreshContext.getMtmv();
         Map<MTMVRelatedTableIf, Set<String>> partitionMappings = refreshContext.getByPartitionName(partitionName);
+        Set<TableNameInfo> excludedTriggerTablesToCheck = Sets.newHashSet(excludedTriggerTables);
         if (mtmv.getMvPartitionInfo().getPartitionType() != MTMVPartitionType.SELF_MANAGE) {
             if (MapUtils.isEmpty(partitionMappings)) {
                 LOG.warn("can not found pct partition, partitionName: {}, mtmvName: {}",
@@ -104,7 +105,7 @@ public class MTMVPartitionUtil {
             for (MTMVRelatedTableIf pctTable : pctTables) {
                 Set<String> relatedPartitionNames = partitionMappings.getOrDefault(pctTable, Sets.newHashSet());
                 // if follow base table, not need compare with related table, only should compare with related partition
-                excludedTriggerTables.add(TableNameInfoUtils.fromCatalogDb(
+                excludedTriggerTablesToCheck.add(TableNameInfoUtils.fromCatalogDb(
                         pctTable.getDatabase().getCatalog(),
                         pctTable.getDatabase(), pctTable));
                 if (!isSyncWithPartitions(refreshContext, partitionName, relatedPartitionNames, pctTable)) {
@@ -114,7 +115,7 @@ public class MTMVPartitionUtil {
 
         }
         return isSyncWithAllBaseTables(refreshContext, partitionName, tables,
-                excludedTriggerTables);
+                excludedTriggerTablesToCheck);
 
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVPartitionUtilTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.mtmv.MTMVPartitionInfo.MTMVPartitionType;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -169,6 +170,22 @@ public class MTMVPartitionUtilTest {
         boolean isSyncWithPartition = MTMVPartitionUtil
                 .isSyncWithPartitions(context, "name1", Sets.newHashSet("name2"), baseOlapTable);
         Assert.assertFalse(isSyncWithPartition);
+    }
+
+    @Test
+    public void testIsMTMVPartitionSyncWithImmutableExcludedTriggerTables() throws AnalysisException {
+        Map<MTMVRelatedTableIf, Set<String>> partitionMappings = Maps.newHashMap();
+        partitionMappings.put(baseOlapTable, Sets.newHashSet("name2"));
+        Mockito.when(context.getByPartitionName("name1")).thenReturn(partitionMappings);
+        Mockito.when(mtmvPartitionInfo.getPartitionType()).thenReturn(MTMVPartitionType.FOLLOW_BASE_TABLE);
+        Mockito.when(mtmvPartitionInfo.getPctTables()).thenReturn(Sets.newHashSet(baseOlapTable));
+
+        Set<TableNameInfo> excludedTriggerTables = ImmutableSet.of();
+        boolean isMTMVPartitionSync = MTMVPartitionUtil.isMTMVPartitionSync(context, "name1", baseTables,
+                excludedTriggerTables);
+
+        Assert.assertTrue(isMTMVPartitionSync);
+        Assert.assertTrue(excludedTriggerTables.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
intro by #56745

Problem Summary:

isMTMVPartitionSync adds followed PCT tables into the excluded trigger table set while checking partition sync. Some callers pass immutable sets, such as the force-consistent rewrite path using ImmutableSet.of(), so partitioned MTMVs can fail with UnsupportedOperationException before the sync check finishes. Copy the input set into a local mutable set before adding derived PCT tables, avoiding mutation of caller-owned state and supporting immutable inputs.