### PR TITLE
[fix](cloud) Generate unique cloudUniqueId per backend node in addBackends

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
@@ -603,8 +603,6 @@ public class CloudSystemInfoService extends SystemInfoService {
         String instanceId = Config.cluster_id == -1 ? ((CloudEnv) Env.getCurrentEnv()).getCloudInstanceId()
                 : String.valueOf(Config.cluster_id);
 
-        String cloudUniqueId = "1:" + instanceId + ":" + RandomIdentifierGenerator.generateRandomIdentifier(8);
-
         String publicEndpoint = tagMap.getOrDefault(Tag.PUBLIC_ENDPOINT, "");
         String privateEndpoint = tagMap.getOrDefault(Tag.PRIVATE_ENDPOINT, "");
 
@@ -614,6 +612,7 @@ public class CloudSystemInfoService extends SystemInfoService {
                 .build();
 
         for (HostInfo hostInfo : hostInfos) {
+            String cloudUniqueId = "1:" + instanceId + ":" + RandomIdentifierGenerator.generateRandomIdentifier(8);
             Cloud.NodeInfoPB nodeInfoPB = Cloud.NodeInfoPB.newBuilder()
                     .setCloudUniqueId(cloudUniqueId)
                     .setIp(hostInfo.getHost())

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/system/CloudSystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/system/CloudSystemInfoServiceTest.java
@@ -19,19 +19,28 @@ package org.apache.doris.cloud.system;
 
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.cloud.catalog.CloudEnv;
 import org.apache.doris.cloud.catalog.ComputeGroup;
+import org.apache.doris.cloud.proto.Cloud;
+import org.apache.doris.cloud.rpc.MetaServiceProxy;
 import org.apache.doris.common.Config;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class CloudSystemInfoServiceTest {
     private CloudSystemInfoService infoService;
@@ -40,6 +49,7 @@ public class CloudSystemInfoServiceTest {
     public void setUp() {
         // Enable cloud mode for testing
         Config.cloud_unique_id = "test_cloud_unique_id";
+        Config.meta_service_endpoint = "127.0.0.1:5000";
     }
 
     @Test
@@ -971,6 +981,52 @@ public class CloudSystemInfoServiceTest {
             // Clean up ConnectContext
             ConnectContext.remove();
         }
+    }
+
+    @Test
+    public void testAddBackendsGenerateUniqueCloudUniqueIdPerBackend() throws Exception {
+        infoService = new CloudSystemInfoService();
+
+        CloudEnv cloudEnv = Mockito.mock(CloudEnv.class);
+        MetaServiceProxy metaServiceProxy = Mockito.mock(MetaServiceProxy.class);
+        AtomicReference<Cloud.AlterClusterRequest> addNodeRequestRef = new AtomicReference<>();
+
+        Mockito.when(cloudEnv.getCloudInstanceId()).thenReturn("instance-test");
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class);
+                MockedStatic<MetaServiceProxy> mockedMetaServiceProxy = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(cloudEnv);
+            mockedMetaServiceProxy.when(MetaServiceProxy::getInstance).thenReturn(metaServiceProxy);
+
+            Mockito.when(metaServiceProxy.alterCluster(Mockito.any())).thenAnswer(invocation -> {
+                Cloud.AlterClusterRequest request = invocation.getArgument(0);
+                if (request.getOp() == Cloud.AlterClusterRequest.Operation.ADD_NODE) {
+                    addNodeRequestRef.set(request);
+                }
+                return Cloud.AlterClusterResponse.newBuilder()
+                        .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                                .setCode(Cloud.MetaServiceCode.OK)
+                                .setMsg("OK"))
+                        .build();
+            });
+
+            Map<String, String> tagMap = Tag.DEFAULT_BACKEND_TAG.toMap();
+            tagMap.put(Tag.COMPUTE_GROUP_NAME, "test_compute_group");
+
+            List<HostInfo> hostInfos = new ArrayList<>();
+            hostInfos.add(new HostInfo("192.168.1.189", 9050));
+            hostInfos.add(new HostInfo("192.168.1.189", 9052));
+
+            infoService.addBackends(hostInfos, tagMap);
+        }
+
+        Cloud.AlterClusterRequest addNodeRequest = addNodeRequestRef.get();
+        Assert.assertNotNull(addNodeRequest);
+        Assert.assertEquals(2, addNodeRequest.getCluster().getNodesCount());
+
+        Set<String> cloudUniqueIds = new HashSet<>();
+        addNodeRequest.getCluster().getNodesList().forEach(node -> cloudUniqueIds.add(node.getCloudUniqueId()));
+        Assert.assertEquals(2, cloudUniqueIds.size());
     }
 
     /**


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Problem Summary: When multiple backends are added simultaneously via
`ALTER SYSTEM ADD BACKEND "host1:port1", "host2:port2"`, all nodes were
assigned the same `cloudUniqueId` because the ID was generated once
before the loop. Move the generation inside the loop so each node gets
its own unique ID.

#### Before
<img width="2139" height="1159" alt="before" src="https://github.com/user-attachments/assets/763cabeb-bc5d-4b6d-8a22-6a8d60fe6feb" />

#### After
<img width="2139" height="1159" alt="Paste" src="https://github.com/user-attachments/assets/9a5b5338-4c97-49e4-a8bd-96f6f508b757" />




### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

