### PR TITLE
[fix](be) destroy ExecEnv before startup failure exit

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -614,6 +614,7 @@ int main(int argc, char** argv) {
         if (!status.ok()) {
             std::cerr << msg << '\n';
             service->stop_works();
+            exec_env->destroy();
             exit(-1);
         }
     };


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When BE fails to start after `ExecEnv` has already been initialized, for example because the thrift backend port is already in use, the current startup error path calls `exit(-1)` directly.

That leaves `ExecEnv` to be destroyed later by the C++ static object cleanup path. `ExecEnv` owns the storage engine, which owns `StreamLoadRecorder`, which owns a RocksDB `DBWithTTL`. During process exit, RocksDB static resources such as the default Env/background thread pool may already be in teardown before `StreamLoadRecorder` destroys its RocksDB instance, causing a crash in RocksDB `DBImpl::CloseHelper()`.

This patch explicitly calls `exec_env->destroy()` before exiting from the BE service startup failure path, so storage resources are cleaned up while the process is still in the controlled Doris shutdown path instead of relying on late static destruction.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

