### PR TITLE
[fix]Outdated logs cannot be unlinked if the log path is a symbolic link

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Log4jConfig.java
@@ -112,7 +112,7 @@ public class Log4jConfig extends XmlConfiguration {
             .append("        <SizeBasedTriggeringPolicy size=\"${sys_roll_maxsize}MB\"/>\n")
             .append("      </Policies>\n")
             .append("      <DefaultRolloverStrategy max=\"${sys_roll_num}\" fileIndex=\"max\">\n")
-            .append("        <Delete basePath=\"${sys_log_dir}/\" maxDepth=\"1\">\n")
+            .append("        <Delete basePath=\"${sys_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n")
             .append("          <IfFileName glob=\"fe.log.*\" />\n");
 
         getXmlConfByStrategy("info_sys_accumulated_file_size", "sys_log_delete_age");
@@ -130,7 +130,7 @@ public class Log4jConfig extends XmlConfiguration {
             .append("        <SizeBasedTriggeringPolicy size=\"${sys_roll_maxsize}MB\"/>\n")
             .append("      </Policies>\n")
             .append("      <DefaultRolloverStrategy max=\"${sys_roll_num}\" fileIndex=\"max\">\n")
-            .append("        <Delete basePath=\"${sys_log_dir}/\" maxDepth=\"1\">\n")
+            .append("        <Delete basePath=\"${sys_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n")
             .append("          <IfFileName glob=\"fe.warn.log.*\" />\n");
 
         getXmlConfByStrategy("warn_sys_accumulated_file_size", "sys_log_delete_age");
@@ -148,7 +148,7 @@ public class Log4jConfig extends XmlConfiguration {
             .append("        <SizeBasedTriggeringPolicy size=\"${audit_roll_maxsize}MB\"/>\n")
             .append("      </Policies>\n")
             .append("      <DefaultRolloverStrategy max=\"${audit_roll_num}\" fileIndex=\"max\">\n")
-            .append("        <Delete basePath=\"${audit_log_dir}/\" maxDepth=\"1\">\n")
+            .append("        <Delete basePath=\"${audit_log_dir}/\" maxDepth=\"1\" followLinks=\"true\">\n")
             .append("          <IfFileName glob=\"fe.audit.log.*\" />\n");
 
         getXmlConfByStrategy("audit_sys_accumulated_file_size", "audit_log_delete_age");


### PR DESCRIPTION
### What problem does this PR solve?

在Doris313发现，当Doris的日志的路径中包含软链接时，过期日志无法删除。

### Release note

None

### Check List (For Author)

None

- Behavior changed:
    - [ ] Yes. 日志路径存在软链接存在的情况下，过期日志可以删除

- Does this need documentation?
    - [ ] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

