### PR TITLE
[fix](function)fix map_contains_key/map_contains_value/array_contains for TIMESTAMPTZ and other   non-numeric scalar types 

### DIFF
--- a/be/src/exprs/function/array/function_array_index.h
+++ b/be/src/exprs/function/array/function_array_index.h
@@ -351,20 +351,6 @@ private:
         return ColumnNullable::create(std::move(dst), std::move(dst_null_column));
     }
 
-    template <typename NestedColumnType>
-    ColumnPtr _execute_number_expanded(const ColumnArray::Offsets64& offsets,
-                                       const UInt8* nested_null_map, const IColumn& nested_column,
-                                       const IColumn& right_column,
-                                       const UInt8* right_nested_null_map,
-                                       const UInt8* outer_null_map) const {
-        if (is_column<NestedColumnType>(right_column)) {
-            return _execute_number<NestedColumnType, NestedColumnType>(
-                    offsets, nested_null_map, nested_column, right_column, right_nested_null_map,
-                    outer_null_map);
-        }
-        return nullptr;
-    }
-
     Status _execute_dispatch(Block& block, const ColumnNumbers& arguments, uint32_t result,
                              size_t input_rows_count) const {
         // extract array offsets and nested data
@@ -377,7 +363,7 @@ private:
         const ColumnArray* array_column = nullptr;
         const UInt8* array_null_map = nullptr;
         if (left_column->is_nullable()) {
-            auto nullable_array = reinterpret_cast<const ColumnNullable*>(left_column.get());
+            const auto* nullable_array = reinterpret_cast<const ColumnNullable*>(left_column.get());
             array_column =
                     reinterpret_cast<const ColumnArray*>(&nullable_array->get_nested_column());
             array_null_map = nullable_array->get_null_map_column().get_data().data();
@@ -413,12 +399,12 @@ private:
         auto right_type = remove_nullable(block.get_by_position(arguments[1]).type);
 
         ColumnPtr return_column = nullptr;
-        if (is_string_type(right_type->get_primitive_type()) &&
-            is_string_type(left_element_type->get_primitive_type())) {
+        auto left_element_ptype = left_element_type->get_primitive_type();
+        auto right_ptype = right_type->get_primitive_type();
+        if (is_string_type(right_ptype) && is_string_type(left_element_ptype)) {
             return_column = _execute_string(offsets, nested_null_map, *nested_column, *right_column,
                                             right_nested_null_map, array_null_map);
-        } else if (is_number(right_type->get_primitive_type()) &&
-                   is_number(left_element_type->get_primitive_type())) {
+        } else if (left_element_ptype == right_ptype) {
             auto call = [&](const auto& type) -> bool {
                 using DispatchType = std::decay_t<decltype(type)>;
                 return_column = _execute_number<typename DispatchType::ColumnType,
@@ -427,37 +413,9 @@ private:
                         right_nested_null_map, array_null_map);
                 return true;
             };
-            if (!dispatch_switch_number(right_type->get_primitive_type(), call)) {
-                return Status::InternalError(get_name() + " not support right type " +
-                                             right_type->get_name());
-            }
-        } else if ((is_date_v2_or_datetime_v2(right_type->get_primitive_type()) ||
-                    right_type->get_primitive_type() == TYPE_TIMEV2) &&
-                   (is_date_v2_or_datetime_v2(left_element_type->get_primitive_type()) ||
-                    left_element_type->get_primitive_type() == TYPE_TIMEV2)) {
-            if (left_element_type->get_primitive_type() == TYPE_DATEV2) {
-                return_column = _execute_number_expanded<ColumnDateV2>(
-                        offsets, nested_null_map, *nested_column, *right_column,
-                        right_nested_null_map, array_null_map);
-            } else if (left_element_type->get_primitive_type() == TYPE_DATETIMEV2) {
-                return_column = _execute_number_expanded<ColumnDateTimeV2>(
-                        offsets, nested_null_map, *nested_column, *right_column,
-                        right_nested_null_map, array_null_map);
-            } else if (left_element_type->get_primitive_type() == TYPE_TIMEV2) {
-                return_column = _execute_number_expanded<ColumnTimeV2>(
-                        offsets, nested_null_map, *nested_column, *right_column,
-                        right_nested_null_map, array_null_map);
-            }
-        } else if (is_ip(right_type->get_primitive_type()) &&
-                   is_ip(left_element_type->get_primitive_type())) {
-            if (left_element_type->get_primitive_type() == TYPE_IPV4) {
-                return_column = _execute_number_expanded<ColumnIPv4>(
-                        offsets, nested_null_map, *nested_column, *right_column,
-                        right_nested_null_map, array_null_map);
-            } else if (left_element_type->get_primitive_type() == TYPE_IPV6) {
-                return_column = _execute_number_expanded<ColumnIPv6>(
-                        offsets, nested_null_map, *nested_column, *right_column,
-                        right_nested_null_map, array_null_map);
+            if (!dispatch_switch_scalar(left_element_ptype, call)) {
+                return Status::InternalError(get_name() + " not support type " +
+                                             left_element_type->get_name());
             }
         }
 

--- a/be/test/exprs/function/function_array_index_test.cpp
+++ b/be/test/exprs/function/function_array_index_test.cpp
@@ -17,12 +17,33 @@
 
 #include <string>
 
+#include "core/column/column_array.h"
+#include "core/column/column_nullable.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_timestamptz.h"
 #include "core/field.h"
 #include "core/types.h"
 #include "exprs/function/function_test_util.h"
+#include "exprs/function/simple_function_factory.h"
+#include "testutil/datetime_ut_util.h"
 
 namespace doris {
+
+namespace {
+
+ColumnPtr create_nullable_timestamptz_column(std::initializer_list<TimestampTzValue> values) {
+    auto nested = ColumnTimeStampTz::create();
+    auto null_map = ColumnUInt8::create();
+    for (const auto& value : values) {
+        nested->insert_value(value);
+        null_map->insert_value(0);
+    }
+    return ColumnNullable::create(std::move(nested), std::move(null_map));
+}
+
+} // namespace
 
 TEST(function_array_index_test, array_contains) {
     std::string func_name = "array_contains";
@@ -141,6 +162,42 @@ TEST(function_array_index_test, array_contains) {
 
         static_cast<void>(check_function<DataTypeUInt8, true>(func_name, input_types, data_set));
     }
+}
+
+TEST(function_array_index_test, array_contains_timestamptz) {
+    const std::string func_name = "array_contains";
+    auto element_type = std::make_shared<DataTypeTimeStampTz>(6);
+    auto array_type = std::make_shared<DataTypeArray>(make_nullable(element_type));
+    auto return_type = std::make_shared<DataTypeBool>();
+    auto arguments_template = ColumnsWithTypeAndName {{nullptr, array_type, "array"},
+                                                      {nullptr, element_type, "item"}};
+
+    auto function = SimpleFunctionFactory::instance().get_function(
+            func_name, arguments_template, return_type, {true},
+            BeExecVersionManager::get_newest_version());
+    ASSERT_TRUE(function != nullptr);
+
+    auto pre = make_timestamptz(2024, 11, 3, 1, 5, 0, 0);
+    auto post = make_timestamptz(2024, 11, 3, 1, 5, 0, 0);
+
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert_value(2);
+
+    auto probe_column = ColumnTimeStampTz::create();
+    probe_column->insert_value(post);
+
+    Block block;
+    block.insert({ColumnArray::create(create_nullable_timestamptz_column({pre, post}),
+                                      std::move(offsets)),
+                  array_type, "array"});
+    block.insert({std::move(probe_column), element_type, "item"});
+    block.insert({nullptr, return_type, "result"});
+
+    auto status = function->execute(nullptr, block, {0, 1}, 2, 1);
+    ASSERT_TRUE(status.ok()) << status.to_string();
+
+    const auto& result_column = assert_cast<const ColumnUInt8&>(*block.get_by_position(2).column);
+    EXPECT_EQ(result_column.get_element(0), 1);
 }
 
 TEST(function_array_index_test, array_position) {

--- a/be/test/exprs/function/function_map_test.cpp
+++ b/be/test/exprs/function/function_map_test.cpp
@@ -22,11 +22,49 @@
 
 #include "core/column/column_array.h"
 #include "core/column/column_map.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
 #include "core/data_type/data_type_map.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "core/data_type/data_type_timestamptz.h"
 #include "core/types.h"
 #include "exprs/function/function_test_util.h"
+#include "exprs/function/simple_function_factory.h"
+#include "testutil/datetime_ut_util.h"
 
 namespace doris {
+
+namespace {
+
+ColumnPtr create_nullable_timestamptz_column(std::initializer_list<TimestampTzValue> values) {
+    auto nested = ColumnTimeStampTz::create();
+    auto null_map = ColumnUInt8::create();
+    for (const auto& value : values) {
+        nested->insert_value(value);
+        null_map->insert_value(0);
+    }
+    return ColumnNullable::create(std::move(nested), std::move(null_map));
+}
+
+ColumnPtr create_nullable_string_column(std::initializer_list<std::string> values) {
+    auto nested = ColumnString::create();
+    auto null_map = ColumnUInt8::create();
+    for (const auto& value : values) {
+        nested->insert_data(value.data(), value.size());
+        null_map->insert_value(0);
+    }
+    return ColumnNullable::create(std::move(nested), std::move(null_map));
+}
+
+ColumnArray::ColumnOffsets::MutablePtr create_offsets(ColumnArray::Offset64 offset) {
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert_value(offset);
+    return offsets;
+}
+
+} // namespace
 
 TEST(FunctionMapTest, deduplicate_map) {
     const std::string func_name = "deduplicate_map";
@@ -79,6 +117,76 @@ TEST(FunctionMapTest, deduplicate_map) {
         auto map_size = result_map_column.get_offsets()[i] -
                         (i == 0 ? 0 : result_map_column.get_offsets()[i - 1]);
         ASSERT_EQ(map_size, 8) << "deduplicate map failed at row " << i;
+    }
+}
+
+TEST(FunctionMapTest, map_contains_timestamptz) {
+    auto timestamptz_type = std::make_shared<DataTypeTimeStampTz>(6);
+    auto nullable_timestamptz_type = make_nullable(timestamptz_type);
+    auto nullable_string_type = make_nullable(std::make_shared<DataTypeString>());
+    auto return_type = std::make_shared<DataTypeBool>();
+
+    auto pre = make_timestamptz(2024, 11, 3, 1, 5, 0, 0);
+    auto post = make_timestamptz(2024, 11, 3, 1, 5, 0, 0);
+
+    {
+        const std::string func_name = "map_contains_key";
+        auto map_type =
+                std::make_shared<DataTypeMap>(nullable_timestamptz_type, nullable_string_type);
+        auto arguments_template = ColumnsWithTypeAndName {{nullptr, map_type, "map"},
+                                                          {nullptr, timestamptz_type, "key"}};
+        auto function = SimpleFunctionFactory::instance().get_function(
+                func_name, arguments_template, return_type, {true},
+                BeExecVersionManager::get_newest_version());
+        ASSERT_TRUE(function != nullptr);
+
+        auto probe_column = ColumnTimeStampTz::create();
+        probe_column->insert_value(post);
+
+        Block block;
+        block.insert({ColumnMap::create(create_nullable_timestamptz_column({pre, post}),
+                                        create_nullable_string_column({"pre", "post"}),
+                                        create_offsets(2)),
+                      map_type, "map"});
+        block.insert({std::move(probe_column), timestamptz_type, "key"});
+        block.insert({nullptr, return_type, "result"});
+
+        auto status = function->execute(nullptr, block, {0, 1}, 2, 1);
+        ASSERT_TRUE(status.ok()) << status.to_string();
+
+        const auto& result_column =
+                assert_cast<const ColumnUInt8&>(*block.get_by_position(2).column);
+        EXPECT_EQ(result_column.get_element(0), 1);
+    }
+
+    {
+        const std::string func_name = "map_contains_value";
+        auto map_type =
+                std::make_shared<DataTypeMap>(nullable_string_type, nullable_timestamptz_type);
+        auto arguments_template = ColumnsWithTypeAndName {{nullptr, map_type, "map"},
+                                                          {nullptr, timestamptz_type, "value"}};
+        auto function = SimpleFunctionFactory::instance().get_function(
+                func_name, arguments_template, return_type, {true},
+                BeExecVersionManager::get_newest_version());
+        ASSERT_TRUE(function != nullptr);
+
+        auto probe_column = ColumnTimeStampTz::create();
+        probe_column->insert_value(post);
+
+        Block block;
+        block.insert({ColumnMap::create(create_nullable_string_column({"pre", "post"}),
+                                        create_nullable_timestamptz_column({pre, post}),
+                                        create_offsets(2)),
+                      map_type, "map"});
+        block.insert({std::move(probe_column), timestamptz_type, "value"});
+        block.insert({nullptr, return_type, "result"});
+
+        auto status = function->execute(nullptr, block, {0, 1}, 2, 1);
+        ASSERT_TRUE(status.ok()) << status.to_string();
+
+        const auto& result_column =
+                assert_cast<const ColumnUInt8&>(*block.get_by_position(2).column);
+        EXPECT_EQ(result_column.get_element(0), 1);
     }
 }
 } // namespace doris

--- a/regression-test/data/datatype_p0/timestamptz/test_timestamptz_complext_type.out
+++ b/regression-test/data/datatype_p0/timestamptz/test_timestamptz_complext_type.out
@@ -17,3 +17,15 @@
 -- !parse_struct --
 {"first":"2020-01-01 05:00:00+08:00", "second":"2020-06-01 15:00:00+08:00", "third":"2020-01-01 07:59:59+08:00"}
 
+-- !element_at_key --
+post
+
+-- !map_contains_key --
+1
+
+-- !element_at_value --
+2024-11-03 06:05:00.000000+00:00
+
+-- !map_contains_value --
+1
+

--- a/regression-test/suites/datatype_p0/timestamptz/test_timestamptz_complext_type.groovy
+++ b/regression-test/suites/datatype_p0/timestamptz/test_timestamptz_complext_type.groovy
@@ -65,4 +65,49 @@ suite("test_timestamptz_complext_type") {
             cast('{"first": "2020-01-01 00:00:00 +03:00", "second": "2020-06-01 12:00:00 +05:00", "third": "2019-12-31 23:59:59 +00:00"}' as struct<first:timestamptz, second:timestamptz, third:timestamptz>) as tz_struct;
     """
 
+    sql " set enable_nereids_planner = true; "
+    sql " set enable_fallback_to_original_planner = false; "
+    sql " set debug_skip_fold_constant = false; "
+    sql " set time_zone = '+00:00'; "
+
+    qt_element_at_key """
+        select cast(element_at(
+            map(
+                cast('2024-11-03 01:05:00 -04:00' as timestamptz(6)), 'pre',
+                cast('2024-11-03 01:05:00 -05:00' as timestamptz(6)), 'post'
+            ),
+            cast('2024-11-03 01:05:00 -05:00' as timestamptz(6))
+        ) as string);
+    """
+
+    qt_map_contains_key """
+        select cast(map_contains_key(
+            map(
+                cast('2024-11-03 01:05:00 -04:00' as timestamptz(6)), 'pre',
+                cast('2024-11-03 01:05:00 -05:00' as timestamptz(6)), 'post'
+            ),
+            cast('2024-11-03 01:05:00 -05:00' as timestamptz(6))
+        ) as int);
+    """
+
+    qt_element_at_value """
+        select cast(element_at(
+            map(
+                'pre', cast('2024-11-03 01:05:00 -04:00' as timestamptz(6)),
+                'post', cast('2024-11-03 01:05:00 -05:00' as timestamptz(6))
+            ),
+            'post'
+        ) as string);
+    """
+
+    qt_map_contains_value """
+        select cast(map_contains_value(
+            map(
+                'pre', cast('2024-11-03 01:05:00 -04:00' as timestamptz(6)),
+                'post', cast('2024-11-03 01:05:00 -05:00' as timestamptz(6))
+            ),
+            cast('2024-11-03 01:05:00 -05:00' as timestamptz(6))
+        ) as int);
+    """
+
 }


### PR DESCRIPTION
What problem does this PR solve?                                                     
                                                                                       
  Issue Number: N/A                                                                    
                                                                                       
  Problem Summary:                                                                     
                                                                  
  map_contains_key, map_contains_value, and array_contains failed to match TIMESTAMPTZ 
  keys/values (and potentially other non-numeric scalar types like IPV4/IPV6/DATEV2
  etc.) because _execute_dispatch in function_array_index.h used                       
  dispatch_switch_number() which only dispatches numeric types. Separate hardcoded
  branches existed for DATEV2/DATETIMEV2/TIMEV2 and IPV4/IPV6, but TIMESTAMPTZ was
  missing. When a TIMESTAMPTZ value was used as the search key, no branch matched and
  the function returned null/error.

  Root cause: The dispatch logic enumerated supported types instead of using a generic 
  dispatch that covers all scalar types via dispatch_switch_scalar().
                                                                                       
  Fix: Replace is_number + date-v2 + ip branches with a single left_element_ptype ==   
  right_ptype condition that delegates to dispatch_switch_scalar(), which covers all
  scalar primitive types uniformly. Remove the now-dead _execute_number_expanded       
  helper.          

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

