### PR TITLE
 [ExternalCatalog](fix) external catalog meta data inconsistent when frequent refreshing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -178,7 +178,7 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         }
     }
 
-    private List<Pair<String, String>> listTableNames() {
+    private synchronized List<Pair<String, String>> listTableNames() {
         List<Pair<String, String>> tableNames;
         lowerCaseToTableName.clear();
         if (name.equals(InfoSchemaDb.DATABASE_NAME)) {
@@ -435,9 +435,17 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             remoteTblName = lowerCaseToTableName.get(tableName.toLowerCase());
             if (remoteTblName == null) {
                 // Here we need to execute listTableNames() once to fill in lowerCaseToTableName
-                // to prevent lowerCaseToTableName from being empty in some cases
-                listTableNames();
-                remoteTblName = lowerCaseToTableName.get(tableName.toLowerCase());
+                // to prevent lowerCaseToTableName from being empty in some cases.
+                // Use double-checked locking against the same monitor used by listTableNames()
+                // so that we don't keep repeating a remote list call and don't race with
+                // a concurrent listTableNames() that is swapping the map.
+                synchronized (this) {
+                    remoteTblName = lowerCaseToTableName.get(tableName.toLowerCase());
+                    if (remoteTblName == null) {
+                        listTableNames();
+                        remoteTblName = lowerCaseToTableName.get(tableName.toLowerCase());
+                    }
+                }
                 if (remoteTblName == null) {
                     return false;
                 }
@@ -524,9 +532,17 @@ public abstract class ExternalDatabase<T extends ExternalTable>
                     return null;
                 }
                 // Here we need to execute listTableNames() once to fill in lowerCaseToTableName
-                // to prevent lowerCaseToTableName from being empty in some cases
-                listTableNames();
-                finalName = lowerCaseToTableName.get(tableName.toLowerCase());
+                // to prevent lowerCaseToTableName from being empty in some cases.
+                // Use double-checked locking against the same monitor used by listTableNames()
+                // so that concurrent callers don't wipe each other's results and don't issue
+                // redundant remote list calls.
+                synchronized (this) {
+                    finalName = lowerCaseToTableName.get(tableName.toLowerCase());
+                    if (finalName == null) {
+                        listTableNames();
+                        finalName = lowerCaseToTableName.get(tableName.toLowerCase());
+                    }
+                }
                 if (finalName == null) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("failed to get final table name from: {}.{}.{}",

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalDatabaseRefreshConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lowercase/ExternalDatabaseRefreshConcurrencyTest.java
@@ -1,0 +1,282 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.lowercase;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.datasource.ExternalDatabase;
+import org.apache.doris.datasource.test.TestExternalCatalog;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.commands.CreateCatalogCommand;
+import org.apache.doris.nereids.trees.plans.commands.DropCatalogCommand;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ExternalDatabaseRefreshConcurrencyTest extends TestWithFeService {
+    private static final String CATALOG_NAME = "test_refresh_concurrency";
+    private static final String DB_NAME = "db1";
+    // Mixed-case remote name vs. lower-case lookup forces the lowerCaseToTableName path.
+    private static final String REMOTE_TABLE_NAME = "TABLE1";
+    private static final String LOOKUP_TABLE_NAME = "table1";
+
+    private static Env env;
+    private ConnectContext rootCtx;
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        rootCtx = createDefaultCtx();
+        env = Env.getCurrentEnv();
+        String createStmt = "create catalog " + CATALOG_NAME + " properties(\n"
+                + "    \"type\" = \"test\",\n"
+                + "    \"catalog_provider.class\" "
+                + "= \"org.apache.doris.datasource.lowercase."
+                + "ExternalDatabaseRefreshConcurrencyTest$RefreshConcurrencyProvider\"\n"
+                + ");";
+
+        NereidsParser nereidsParser = new NereidsParser();
+        LogicalPlan logicalPlan = nereidsParser.parseSingle(createStmt);
+        if (logicalPlan instanceof CreateCatalogCommand) {
+            ((CreateCatalogCommand) logicalPlan).run(rootCtx, null);
+        }
+    }
+
+    @Override
+    protected void beforeCluster() {
+        // mode 2 is the case-insensitive path patched by the fix.
+        Config.lower_case_table_names = 2;
+        Config.enable_debug_points = true;
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Override
+    protected void runAfterAll() throws Exception {
+        super.runAfterAll();
+        rootCtx.setThreadLocalInfo();
+        NereidsParser nereidsParser = new NereidsParser();
+        LogicalPlan logicalPlan = nereidsParser.parseSingle("drop catalog " + CATALOG_NAME);
+        if (logicalPlan instanceof DropCatalogCommand) {
+            ((DropCatalogCommand) logicalPlan).run(rootCtx, null);
+        }
+    }
+
+    private static void enableListSleep(long sleepMs) {
+        Map<String, String> params = new HashMap<>();
+        params.put("sleepMs", String.valueOf(sleepMs));
+        DebugPointUtil.addDebugPointWithParams("ExternalDatabase.listTableNames.sleep", params);
+    }
+
+    @AfterEach
+    public void clearDebugPoints() {
+        DebugPointUtil.clearDebugPoints();
+    }
+
+    private ExternalDatabase<?> getDb() {
+        ExternalDatabase<?> db = (ExternalDatabase<?>) env.getCatalogMgr()
+                .getCatalog(CATALOG_NAME).getDbNullable(DB_NAME);
+        Assertions.assertNotNull(db, "test database should be created");
+        // Trigger first init so meta cache is built.
+        db.getTableNamesWithLock();
+        return db;
+    }
+
+    /** Sanity check: getTableNullable still works right after a reset. */
+    @Test
+    public void testGetTableAfterReset() {
+        ExternalDatabase<?> db = getDb();
+        db.resetMetaToUninitialized();
+        TableIf tbl = db.getTableNullable(LOOKUP_TABLE_NAME);
+        Assertions.assertNotNull(tbl,
+                "after reset, getTableNullable(\"" + LOOKUP_TABLE_NAME + "\") must still find the table");
+        Assertions.assertEquals(REMOTE_TABLE_NAME, tbl.getName());
+    }
+
+    /**
+     * One refresher + many readers; getTableNullable must never return null.
+     * The debug point widens the clear/refill window to make the race reproducible.
+     */
+    @Test
+    public void testGetTableNotNullUnderFrequentRefresh() throws Exception {
+        ExternalDatabase<?> db = getDb();
+
+        // Widen the clear/refill window inside listTableNames() so the race becomes reproducible.
+        enableListSleep(20L);
+
+        try {
+            final int readerCount = 8;
+            final long durationMs = 2000L;
+            ExecutorService pool = Executors.newFixedThreadPool(readerCount + 1);
+            AtomicBoolean stop = new AtomicBoolean(false);
+            CountDownLatch start = new CountDownLatch(1);
+            AtomicInteger nullCount = new AtomicInteger();
+            AtomicInteger lookupCount = new AtomicInteger();
+            AtomicReference<Throwable> firstError = new AtomicReference<>();
+
+            // Refresher: keep wiping lowerCaseToTableName.
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    rootCtx.setThreadLocalInfo();
+                    while (!stop.get()) {
+                        db.resetMetaToUninitialized();
+                        Thread.yield();
+                    }
+                } catch (Throwable t) {
+                    firstError.compareAndSet(null, t);
+                }
+            });
+
+            // Readers: getTableNullable must always find the table.
+            for (int i = 0; i < readerCount; i++) {
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        rootCtx.setThreadLocalInfo();
+                        while (!stop.get()) {
+                            TableIf tbl = db.getTableNullable(LOOKUP_TABLE_NAME);
+                            lookupCount.incrementAndGet();
+                            if (tbl == null) {
+                                nullCount.incrementAndGet();
+                            }
+                        }
+                    } catch (Throwable t) {
+                        firstError.compareAndSet(null, t);
+                    }
+                });
+            }
+
+            start.countDown();
+            Thread.sleep(durationMs);
+            stop.set(true);
+            pool.shutdown();
+            Assertions.assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS),
+                    "concurrent refresh+getTable test timed out");
+
+            Assertions.assertNull(firstError.get(),
+                    "unexpected error during concurrent run: " + firstError.get());
+            Assertions.assertTrue(lookupCount.get() > 0,
+                    "expected readers to perform at least one lookup");
+            Assertions.assertEquals(0, nullCount.get(),
+                    "regression: db.getTableNullable returned null " + nullCount.get()
+                            + " out of " + lookupCount.get()
+                            + " times under frequent refresh (lowerCaseToTableName was raced)");
+        } finally {
+            DebugPointUtil.removeDebugPoint("ExternalDatabase.listTableNames.sleep");
+        }
+    }
+
+    /**
+     * Cold-start race: many readers hit a freshly-reset db at once. Before the fix
+     * they could clear each other's refill and return null.
+     */
+    @Test
+    public void testGetTableNotNullOnConcurrentColdStart() throws Exception {
+        ExternalDatabase<?> db = getDb();
+
+        enableListSleep(20L);
+
+        try {
+            final int threadCount = 16;
+            final int rounds = 30;
+            ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+            try {
+                for (int round = 0; round < rounds; round++) {
+                    db.resetMetaToUninitialized();
+
+                    CountDownLatch start = new CountDownLatch(1);
+                    CountDownLatch done = new CountDownLatch(threadCount);
+                    AtomicInteger nullCount = new AtomicInteger();
+                    AtomicReference<Throwable> firstError = new AtomicReference<>();
+
+                    for (int i = 0; i < threadCount; i++) {
+                        pool.submit(() -> {
+                            try {
+                                start.await();
+                                rootCtx.setThreadLocalInfo();
+                                TableIf tbl = db.getTableNullable(LOOKUP_TABLE_NAME);
+                                if (tbl == null) {
+                                    nullCount.incrementAndGet();
+                                }
+                            } catch (Throwable t) {
+                                firstError.compareAndSet(null, t);
+                            } finally {
+                                done.countDown();
+                            }
+                        });
+                    }
+
+                    start.countDown();
+                    Assertions.assertTrue(done.await(30, TimeUnit.SECONDS),
+                            "round " + round + " timed out");
+                    Assertions.assertNull(firstError.get(),
+                            "round " + round + " unexpected error: " + firstError.get());
+                    Assertions.assertEquals(0, nullCount.get(),
+                            "round " + round + ": db.getTableNullable returned null on cold start"
+                                    + " (lowerCaseToTableName was raced)");
+                }
+            } finally {
+                pool.shutdownNow();
+                Assertions.assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS),
+                        "executor failed to terminate");
+            }
+        } finally {
+            DebugPointUtil.removeDebugPoint("ExternalDatabase.listTableNames.sleep");
+        }
+    }
+
+    /** Mocked provider exposing a single mixed-case table. */
+    public static class RefreshConcurrencyProvider implements TestExternalCatalog.TestCatalogProvider {
+        public static final Map<String, Map<String, List<Column>>> MOCKED_META;
+
+        static {
+            MOCKED_META = Maps.newHashMap();
+            Map<String, List<Column>> tblSchemaMap1 = Maps.newHashMap();
+            tblSchemaMap1.put(REMOTE_TABLE_NAME, Lists.newArrayList(
+                    new Column("k1", PrimitiveType.INT),
+                    new Column("k2", PrimitiveType.VARCHAR)));
+            MOCKED_META.put(DB_NAME, tblSchemaMap1);
+        }
+
+        @Override
+        public Map<String, Map<String, List<Column>>> getMetadata() {
+            return MOCKED_META;
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Race condition in lowerCaseToTableName cache:

- The catalog refresh thread clears `lowerCaseToTableName`.
- Query threads call `getLocalTableName`; on a cache miss for `finalName`, they fall back to `listTableNames` to rebuild the cache.
- `listTableNames` itself clears `lowerCaseToTableName` before repopulating it.
- If thread A has already rebuilt the cache via `listTableNames`, and thread B subsequently enters `listTableNames`, B will clear the cache again.
- Consequently, when thread A re-reads finalName from the cache, the entry is gone and the lookup fails.

```shell
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because the return value of "org.apache.doris.catalog.TableIf.getBaseSchema()" is null
        at org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation.computeOutput(LogicalCatalogRelation.java:104) ~[doris-fe.jar:1.2-SNAPSHOT]
        at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:186) ~[guava-33.2.1-jre.jar:?]
        at org.apache.doris.nereids.properties.LogicalProperties.getOutput(LogicalProperties.java:104) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.rules.analysis.BindRelation.lambda$build$0(BindRelation.java:123) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.pattern.PatternMatcher$1.transform(PatternMatcher.java:92) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.rewrite.PlanTreeRewriteJob.rewrite(PlanTreeRewriteJob.java:57) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.rewrite.PlanTreeRewriteBottomUpJob.rewriteThis(PlanTreeRewriteBottomUpJob.java:91) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.rewrite.PlanTreeRewriteBottomUpJob.execute(PlanTreeRewriteBottomUpJob.java:75) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.scheduler.SimpleJobScheduler.executeJobPool(SimpleJobScheduler.java:44) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.rewrite.RootPlanTreeRewriteJob.execute(RootPlanTreeRewriteJob.java:66) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.executor.AbstractBatchJobExecutor.execute(AbstractBatchJobExecutor.java:139) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.executor.Analyzer.analyze(Analyzer.java:83) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.rules.analysis.AnalyzeCTE.analyzeCte(AnalyzeCTE.java:98) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.rules.analysis.AnalyzeCTE.lambda$build$0(AnalyzeCTE.java:71) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.pattern.PatternMatcher$1.transform(PatternMatcher.java:92) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.rewrite.PlanTreeRewriteJob.rewrite(PlanTreeRewriteJob.java:57) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.rewrite.PlanTreeRewriteTopDownJob.execute(PlanTreeRewriteTopDownJob.java:50) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.scheduler.SimpleJobScheduler.executeJobPool(SimpleJobScheduler.java:44) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.rewrite.RootPlanTreeRewriteJob.execute(RootPlanTreeRewriteJob.java:66) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.executor.AbstractBatchJobExecutor.execute(AbstractBatchJobExecutor.java:139) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.jobs.executor.Analyzer.analyze(Analyzer.java:83) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.lambda$analyze$4(NereidsPlanner.java:365) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.keepOrShowPlanProcess(NereidsPlanner.java:898) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.analyze(NereidsPlanner.java:365) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.planWithoutLock(NereidsPlanner.java:250) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.planWithLock(NereidsPlanner.java:224) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.planWithLock(NereidsPlanner.java:180) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.planWithLock(NereidsPlanner.java:173) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.commands.CreateTableCommand.run(CreateTableCommand.java:103) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:781) ~[doris-fe.jar:1.2-SNAPSHOT]
```

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

