### PR TITLE
[fix](pipeline) avoid data queue sink dependency lost wakeup

### DIFF
--- a/be/src/exec/operator/data_queue.cpp
+++ b/be/src/exec/operator/data_queue.cpp
@@ -29,38 +29,28 @@
 namespace doris {
 
 void SubQueue::try_pop(std::unique_ptr<Block>* output_block) {
-    bool need_notify_sink_ready = false;
-    {
-        LockGuard l(queue_lock);
-        if (!blocks.empty()) {
-            *output_block = std::move(blocks.front());
-            blocks.pop_front();
-            bytes_in_queue -= (*output_block)->allocated_bytes();
-            blocks_in_queue -= 1;
-            need_notify_sink_ready = blocks.empty();
+    LockGuard l(queue_lock);
+    if (!blocks.empty()) {
+        *output_block = std::move(blocks.front());
+        blocks.pop_front();
+        bytes_in_queue -= (*output_block)->allocated_bytes();
+        blocks_in_queue -= 1;
+        if (blocks.empty()) {
+            sink_dependency->set_ready();
         }
-    }
-    // Notify outside of queue_lock to avoid nested locks.
-    if (need_notify_sink_ready) {
-        sink_dependency->set_ready();
     }
 }
 
 bool SubQueue::try_push(std::unique_ptr<Block> block, std::atomic_uint32_t& total_counter) {
-    bool need_block_sink = false;
-    {
-        LockGuard l(queue_lock);
-        if (is_finished) {
-            return false;
-        }
-        total_counter++;
-        bytes_in_queue += block->allocated_bytes();
-        blocks.emplace_back(std::move(block));
-        blocks_in_queue += 1;
-        need_block_sink = (static_cast<int64_t>(blocks.size()) > max_blocks_in_queue.load());
+    LockGuard l(queue_lock);
+    if (is_finished) {
+        return false;
     }
-    // Notify outside of queue_lock to avoid nested locks.
-    if (need_block_sink) {
+    total_counter++;
+    bytes_in_queue += block->allocated_bytes();
+    blocks.emplace_back(std::move(block));
+    blocks_in_queue += 1;
+    if (static_cast<int64_t>(blocks.size()) > max_blocks_in_queue.load()) {
         sink_dependency->block();
     }
     return true;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
`DataQueueTest.MultiTest` could intermittently hang after DataQueue moved sink dependency notifications outside the per-sub-queue lock. Root cause: `SubQueue` queue state and `sink_dependency` state were no longer serialized by `queue_lock`, so a producer could observe its sink dependency as blocked even after the queue had already become empty, leaving no future push/pop to wake it. This patch updates `sink_dependency->set_ready()` and `sink_dependency->block()` while holding `queue_lock`, keeping queue occupancy and sink readiness transitions atomic with respect to each other.



Related PR: https://github.com/apache/doris/pull/62947

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

