### PR TITLE
[refine](exec) reject redundant same-type assert_cast

### DIFF
--- a/be/src/core/assert_cast.h
+++ b/be/src/core/assert_cast.h
@@ -29,12 +29,28 @@
 
 enum class TypeCheckOnRelease : bool { ENABLE = true, DISABLE = false };
 
+template <typename T>
+struct AssertCastNormalizedType {
+    using no_ref_t = std::remove_reference_t<T>;
+    using no_cv_t = std::remove_cv_t<no_ref_t>;
+    using type =
+            std::conditional_t<std::is_pointer_v<no_cv_t>,
+                               std::add_pointer_t<std::remove_cv_t<std::remove_pointer_t<no_cv_t>>>,
+                               no_cv_t>;
+};
+
+template <typename T>
+using AssertCastNormalizedType_t = typename AssertCastNormalizedType<T>::type;
+
 /** Perform static_cast in release build when TypeCheckOnRelease is set to DISABLE.
   * Checks type by comparing typeid and throw an exception in all the other situations.
   * The exact match of the type is checked. That is, cast to the ancestor will be unsuccessful.
   */
 template <typename To, TypeCheckOnRelease check = TypeCheckOnRelease::ENABLE, typename From>
 PURE To assert_cast(From&& from) {
+    static_assert(!std::is_same_v<AssertCastNormalizedType_t<To>, AssertCastNormalizedType_t<From>>,
+                  "assert_cast is redundant for the same type after removing cv/ref qualifiers");
+
     // https://godbolt.org/z/nrsx7nYhs
     // perform_cast will not be compiled to asm in release build with TypeCheckOnRelease::DISABLE
     auto perform_cast = [](auto&& from) -> To {

--- a/be/src/core/column/column_complex.h
+++ b/be/src/core/column/column_complex.h
@@ -260,7 +260,7 @@ MutableColumnPtr ColumnComplexType<T>::clone_resized(size_t size) const {
     auto res = this->create();
 
     if (size > 0) {
-        auto& new_col = assert_cast<Self&>(*res);
+        auto& new_col = *res;
         size_t count = std::min(size, data.size());
         new_col.insert_range_from(*this, 0, count);
         if (size > count) {

--- a/be/src/core/column/column_decimal.cpp
+++ b/be/src/core/column/column_decimal.cpp
@@ -330,7 +330,7 @@ MutableColumnPtr ColumnDecimal<T>::clone_resized(size_t size) const {
     auto res = this->create(0, scale);
 
     if (size > 0) {
-        auto& new_col = assert_cast<Self&>(*res);
+        auto& new_col = *res;
         new_col.data.resize(size);
 
         size_t count = std::min(this->size(), size);

--- a/be/src/core/column/column_fixed_length_object.h
+++ b/be/src/core/column/column_fixed_length_object.h
@@ -68,7 +68,7 @@ public:
         auto res = create(_item_size);
 
         if (size > 0) {
-            auto& new_col = assert_cast<Self&>(*res);
+            auto& new_col = *res;
             new_col.resize(size);
             auto* new_data = new_col._data.data();
 

--- a/be/src/core/column/column_nullable.cpp
+++ b/be/src/core/column/column_nullable.cpp
@@ -56,8 +56,7 @@ void ColumnNullable::update_xxHash_with_value(size_t start, size_t end, uint64_t
     if (!has_null(start, end)) {
         _nested_column->update_xxHash_with_value(start, end, hash, nullptr);
     } else {
-        const auto* __restrict real_null_data =
-                assert_cast<const ColumnUInt8&>(get_null_map_column()).get_data().data();
+        const auto* __restrict real_null_data = get_null_map_column().get_data().data();
         for (size_t i = start; i < end; ++i) {
             if (real_null_data[i] != 0) {
                 hash = HashUtil::xxHash64NullWithSeed(hash);
@@ -72,8 +71,7 @@ void ColumnNullable::update_crc_with_value(size_t start, size_t end, uint32_t& h
     if (!has_null(start, end)) {
         _nested_column->update_crc_with_value(start, end, hash, nullptr);
     } else {
-        const auto* __restrict real_null_data =
-                assert_cast<const ColumnUInt8&>(get_null_map_column()).get_data().data();
+        const auto* __restrict real_null_data = get_null_map_column().get_data().data();
         for (size_t i = start; i < end; ++i) {
             if (real_null_data[i] != 0) {
                 hash = HashUtil::zlib_crc_hash_null(hash);
@@ -97,8 +95,7 @@ void ColumnNullable::update_crcs_with_value(uint32_t* __restrict hashes, doris::
     DCHECK(null_data == nullptr);
     auto s = rows;
     DCHECK(s == size());
-    const auto* __restrict real_null_data =
-            assert_cast<const ColumnUInt8&>(get_null_map_column()).get_data().data();
+    const auto* __restrict real_null_data = get_null_map_column().get_data().data();
     if (!has_null()) {
         _nested_column->update_crcs_with_value(hashes, type, rows, offset, nullptr);
     } else {
@@ -113,8 +110,7 @@ void ColumnNullable::update_crcs_with_value(uint32_t* __restrict hashes, doris::
 
 void ColumnNullable::update_crc32c_batch(uint32_t* __restrict hashes,
                                          const uint8_t* __restrict /* null_map */) const {
-    const auto* __restrict real_null_data =
-            assert_cast<const ColumnUInt8&>(get_null_map_column()).get_data().data();
+    const auto* __restrict real_null_data = get_null_map_column().get_data().data();
     if (_nested_column->support_replace_column_null_data()) {
         // nullmap process is slow, replace null data to default value to avoid nullmap process
         _nested_column->assume_mutable()->replace_column_null_data(real_null_data);
@@ -132,8 +128,7 @@ void ColumnNullable::update_crc32c_batch(uint32_t* __restrict hashes,
 
 void ColumnNullable::update_crc32c_single(size_t start, size_t end, uint32_t& hash,
                                           const uint8_t* __restrict /* null_map */) const {
-    const auto* __restrict real_null_data =
-            assert_cast<const ColumnUInt8&>(get_null_map_column()).get_data().data();
+    const auto* __restrict real_null_data = get_null_map_column().get_data().data();
     constexpr int NULL_VALUE = 0;
     for (size_t i = start; i < end; ++i) {
         if (real_null_data[i] != 0) {
@@ -147,8 +142,7 @@ void ColumnNullable::update_hashes_with_value(uint64_t* __restrict hashes,
                                               const uint8_t* __restrict null_data) const {
     DCHECK(null_data == nullptr);
     auto s = size();
-    const auto* __restrict real_null_data =
-            assert_cast<const ColumnUInt8&>(get_null_map_column()).get_data().data();
+    const auto* __restrict real_null_data = get_null_map_column().get_data().data();
     if (!has_null()) {
         _nested_column->update_hashes_with_value(hashes, nullptr);
     } else {
@@ -275,8 +269,7 @@ size_t ColumnNullable::serialize_impl(char* pos, const size_t row) const {
 
 void ColumnNullable::serialize(StringRef* keys, size_t num_rows) const {
     const bool has_null = simd::contain_one(get_null_map_data().data(), num_rows);
-    const auto* __restrict null_map =
-            assert_cast<const ColumnUInt8&>(get_null_map_column()).get_data().data();
+    const auto* __restrict null_map = get_null_map_column().get_data().data();
     _nested_column->serialize_with_nullable(keys, num_rows, has_null, null_map);
 }
 

--- a/be/src/core/column/column_nullable.h
+++ b/be/src/core/column/column_nullable.h
@@ -91,13 +91,9 @@ public:
 
     std::string get_name() const override { return "Nullable(" + _nested_column->get_name() + ")"; }
     MutableColumnPtr clone_resized(size_t size) const override;
-    size_t size() const override {
-        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(get_null_map_column())
-                .size();
-    }
+    size_t size() const override { return get_null_map_column().size(); }
     PURE bool is_null_at(size_t n) const override {
-        return assert_cast<const ColumnUInt8&, TypeCheckOnRelease::DISABLE>(get_null_map_column())
-                       .get_data()[n] != 0;
+        return get_null_map_column().get_data()[n] != 0;
     }
     Field operator[](size_t n) const override;
     void get(size_t n, Field& res) const override;

--- a/be/src/core/column/column_varbinary.cpp
+++ b/be/src/core/column/column_varbinary.cpp
@@ -34,7 +34,7 @@ namespace doris {
 MutableColumnPtr ColumnVarbinary::clone_resized(size_t size) const {
     auto res = create();
     if (size > 0) {
-        auto& new_col = assert_cast<Self&>(*res);
+        auto& new_col = *res;
         size_t count = std::min(this->size(), size);
         for (size_t i = 0; i < count; ++i) {
             auto value = this->get_data_at(i);
@@ -108,7 +108,7 @@ ColumnPtr ColumnVarbinary::filter(const IColumn::Filter& filt, ssize_t result_si
 
 size_t ColumnVarbinary::filter(const IColumn::Filter& filter) {
     size_t pos = 0;
-    const Self& src_vec = assert_cast<const Self&>(*this);
+    const Self& src_vec = *this;
     for (size_t i = 0; i < filter.size(); i++) {
         if (filter[i]) {
             if (src_vec.get_data()[i].isInline()) {
@@ -225,8 +225,7 @@ void ColumnVarbinary::insert_many_strings_overflow(const StringRef* strings, siz
 void ColumnVarbinary::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
                                   IColumn::Permutation& perms, EqualRange& range,
                                   bool last_column) const {
-    sorter->sort_column(assert_cast<const ColumnVarbinary&>(*this), flags, perms, range,
-                        last_column);
+    sorter->sort_column(*this, flags, perms, range, last_column);
 }
 
 } // namespace doris

--- a/be/src/core/column/column_vector.cpp
+++ b/be/src/core/column/column_vector.cpp
@@ -327,7 +327,7 @@ template <PrimitiveType T>
 MutableColumnPtr ColumnVector<T>::clone_resized(size_t size) const {
     auto res = this->create();
     if (size > 0) {
-        auto& new_col = assert_cast<Self&>(*res);
+        auto& new_col = *res;
         size_t count = std::min(this->size(), size);
         new_col.data.resize(count);
         memcpy(new_col.data.data(), data.data(), count * sizeof(data[0]));

--- a/be/src/core/data_type/data_type_decimal.cpp
+++ b/be/src/core/data_type/data_type_decimal.cpp
@@ -197,7 +197,7 @@ template <PrimitiveType T>
 void DataTypeDecimal<T>::to_pb_column_meta(PColumnMeta* col_meta) const {
     IDataType::to_pb_column_meta(col_meta);
     if constexpr (T == TYPE_DECIMALV2) {
-        const auto* real_type_t = assert_cast<const DataTypeDecimalV2*>(this);
+        const auto* real_type_t = this;
         col_meta->mutable_decimal_param()->set_precision(real_type_t->get_original_precision());
         col_meta->mutable_decimal_param()->set_scale(real_type_t->get_original_scale());
     } else {

--- a/be/src/core/data_type_serde/data_type_date_or_datetime_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_date_or_datetime_serde.cpp
@@ -327,7 +327,7 @@ Status DataTypeDateSerDe<T>::from_string_batch(
         const ColumnString& col_str, ColumnNullable& col_res,
         const typename DataTypeNumberSerDe<T>::FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnType&>(col_res.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(col_res.get_null_map_column());
+    auto& col_nullmap = col_res.get_null_map_column();
     size_t row = col_str.size();
     col_res.resize(row);
 
@@ -467,7 +467,7 @@ template <typename IntDataType>
 Status DataTypeDateSerDe<T>::from_int_batch(const typename IntDataType::ColumnType& int_col,
                                             ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(int_col.size());
     col_nullmap.resize(int_col.size());
 
@@ -519,7 +519,7 @@ template <typename FloatDataType>
 Status DataTypeDateSerDe<T>::from_float_batch(const typename FloatDataType::ColumnType& float_col,
                                               ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(float_col.size());
     col_nullmap.resize(float_col.size());
 
@@ -570,7 +570,7 @@ template <typename DecimalDataType>
 Status DataTypeDateSerDe<T>::from_decimal_batch(
         const typename DecimalDataType::ColumnType& decimal_col, ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnType&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(decimal_col.size());
     col_nullmap.resize(decimal_col.size());
 

--- a/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datetimev2_serde.cpp
@@ -49,7 +49,7 @@ Status DataTypeDateTimeV2SerDe::from_string_batch(const ColumnString& col_str,
                                                   ColumnNullable& col_res,
                                                   const FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnDateTimeV2&>(col_res.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(col_res.get_null_map_column());
+    auto& col_nullmap = col_res.get_null_map_column();
     size_t row = col_str.size();
     col_res.resize(row);
 
@@ -170,7 +170,7 @@ template <typename IntDataType>
 Status DataTypeDateTimeV2SerDe::from_int_batch(const typename IntDataType::ColumnType& int_col,
                                                ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnDateTimeV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(int_col.size());
     col_nullmap.resize(int_col.size());
 
@@ -215,7 +215,7 @@ template <typename FloatDataType>
 Status DataTypeDateTimeV2SerDe::from_float_batch(
         const typename FloatDataType::ColumnType& float_col, ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnDateTimeV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(float_col.size());
     col_nullmap.resize(float_col.size());
 
@@ -260,7 +260,7 @@ template <typename DecimalDataType>
 Status DataTypeDateTimeV2SerDe::from_decimal_batch(
         const typename DecimalDataType::ColumnType& decimal_col, ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnDateTimeV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(decimal_col.size());
     col_nullmap.resize(decimal_col.size());
 

--- a/be/src/core/data_type_serde/data_type_datev2_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_datev2_serde.cpp
@@ -203,7 +203,7 @@ void DataTypeDateV2SerDe::write_one_cell_to_binary(const IColumn& src_column,
 Status DataTypeDateV2SerDe::from_string_batch(const ColumnString& col_str, ColumnNullable& col_res,
                                               const FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnDateV2&>(col_res.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(col_res.get_null_map_column());
+    auto& col_nullmap = col_res.get_null_map_column();
     size_t row = col_str.size();
     col_res.resize(row);
 
@@ -323,7 +323,7 @@ template <typename IntDataType>
 Status DataTypeDateV2SerDe::from_int_batch(const typename IntDataType::ColumnType& int_col,
                                            ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnDateV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(int_col.size());
     col_nullmap.resize(int_col.size());
 
@@ -366,7 +366,7 @@ template <typename FloatDataType>
 Status DataTypeDateV2SerDe::from_float_batch(const typename FloatDataType::ColumnType& float_col,
                                              ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnDateV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(float_col.size());
     col_nullmap.resize(float_col.size());
 
@@ -410,7 +410,7 @@ template <typename DecimalDataType>
 Status DataTypeDateV2SerDe::from_decimal_batch(
         const typename DecimalDataType::ColumnType& decimal_col, ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnDateV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(decimal_col.size());
     col_nullmap.resize(decimal_col.size());
 

--- a/be/src/core/data_type_serde/data_type_time_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_time_serde.cpp
@@ -43,7 +43,7 @@ Status DataTypeTimeV2SerDe::write_column_to_mysql_binary(const IColumn& column,
 Status DataTypeTimeV2SerDe::from_string_batch(const ColumnString& col_str, ColumnNullable& col_res,
                                               const FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnTimeV2&>(col_res.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(col_res.get_null_map_column());
+    auto& col_nullmap = col_res.get_null_map_column();
     size_t row = col_str.size();
     col_res.resize(row);
 
@@ -149,7 +149,7 @@ template <typename IntDataType>
 Status DataTypeTimeV2SerDe::from_int_batch(const typename IntDataType::ColumnType& int_col,
                                            ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnTimeV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(int_col.size());
     col_nullmap.resize(int_col.size());
 
@@ -192,7 +192,7 @@ template <typename FloatDataType>
 Status DataTypeTimeV2SerDe::from_float_batch(const typename FloatDataType::ColumnType& float_col,
                                              ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnTimeV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(float_col.size());
     col_nullmap.resize(float_col.size());
 
@@ -237,7 +237,7 @@ template <typename DecimalDataType>
 Status DataTypeTimeV2SerDe::from_decimal_batch(
         const typename DecimalDataType::ColumnType& decimal_col, ColumnNullable& target_col) const {
     auto& col_data = assert_cast<ColumnTimeV2&>(target_col.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(target_col.get_null_map_column());
+    auto& col_nullmap = target_col.get_null_map_column();
     col_data.resize(decimal_col.size());
     col_nullmap.resize(decimal_col.size());
 

--- a/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_timestamptz_serde.cpp
@@ -61,7 +61,7 @@ Status DataTypeTimeStampTzSerDe::from_string_batch(const ColumnString& col_str,
                                                    ColumnNullable& col_res,
                                                    const FormatOptions& options) const {
     auto& col_data = assert_cast<ColumnTimeStampTz&>(col_res.get_nested_column());
-    auto& col_nullmap = assert_cast<ColumnBool&>(col_res.get_null_map_column());
+    auto& col_nullmap = col_res.get_null_map_column();
     size_t row = col_str.size();
     col_res.resize(row);
 

--- a/be/src/exec/common/hash_table/hash_map_context.h
+++ b/be/src/exec/common/hash_table/hash_map_context.h
@@ -1071,9 +1071,7 @@ struct MethodKeysFixed : public MethodBase<TData> {
                 // nullable_col is obtained via key_columns and is itself a mutable element. However, when accessed
                 // through get_raw_data().data, it yields a const char*, necessitating the use of const_cast.
                 data = const_cast<char*>(nullable_col.get_nested_column().get_raw_data().data);
-                UInt8* nullmap = assert_cast<ColumnUInt8*>(&nullable_col.get_null_map_column())
-                                         ->get_data()
-                                         .data();
+                UInt8* nullmap = nullable_col.get_null_map_column().get_data().data();
 
                 // The current column is nullable. Check if the value of the
                 // corresponding key is nullable. Update the null map accordingly.

--- a/be/src/exec/common/variant_util.cpp
+++ b/be/src/exec/common/variant_util.cpp
@@ -1321,8 +1321,7 @@ void VariantCompactionUtil::calculate_variant_stats(const IColumn& encoded_spars
     // Get the keys column which contains the paths as strings
     const auto& sparse_data_paths =
             assert_cast<const ColumnString*>(map_column.get_keys_ptr().get());
-    const auto& serialized_sparse_column_offsets =
-            assert_cast<const ColumnArray::Offsets64&>(map_column.get_offsets());
+    const auto& serialized_sparse_column_offsets = map_column.get_offsets();
     auto& count_map = *stats->mutable_sparse_column_non_null_size();
     // Iterate through all paths in the sparse column
     for (size_t i = row_pos; i != row_pos + num_rows; ++i) {

--- a/be/src/exec/runtime_filter/runtime_filter_wrapper.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_wrapper.cpp
@@ -122,8 +122,7 @@ Status RuntimeFilterWrapper::insert(const ColumnPtr& column, size_t start) {
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
             const auto& col = assert_cast<const ColumnBitmap&>(nullable->get_nested_column());
-            const auto& nullmap =
-                    assert_cast<const ColumnUInt8&>(nullable->get_null_map_column()).get_data();
+            const auto& nullmap = nullable->get_null_map_column().get_data();
             for (size_t i = start; i < column->size(); i++) {
                 if (!nullmap[i]) {
                     bitmaps.push_back(&(col.get_data()[i]));

--- a/be/src/exprs/aggregate/aggregate_function_collect.h
+++ b/be/src/exprs/aggregate/aggregate_function_collect.h
@@ -266,9 +266,7 @@ struct AggregateFunctionCollectListData<T, HasLimit> {
             max_size = rhs.max_size;
 
             data->insert_range_from(*rhs.data, 0,
-                                    std::min(assert_cast<size_t, TypeCheckOnRelease::DISABLE>(
-                                                     static_cast<size_t>(max_size - size())),
-                                             rhs.size()));
+                                    std::min(static_cast<size_t>(max_size - size()), rhs.size()));
         } else {
             data->insert_range_from(*rhs.data, 0, rhs.size());
         }
@@ -338,9 +336,7 @@ struct AggregateFunctionCollectListData<T, HasLimit> {
 
             column_data->insert_range_from(
                     *rhs.column_data, 0,
-                    std::min(assert_cast<size_t, TypeCheckOnRelease::DISABLE>(
-                                     static_cast<size_t>(max_size - size())),
-                             rhs.size()));
+                    std::min(static_cast<size_t>(max_size - size()), rhs.size()));
         } else {
             column_data->insert_range_from(*rhs.column_data, 0, rhs.size());
         }

--- a/be/src/exprs/bloom_filter_func_adaptor.h
+++ b/be/src/exprs/bloom_filter_func_adaptor.h
@@ -108,8 +108,7 @@ struct CommonFindOp {
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
             const auto& col = nullable->get_nested_column();
-            const auto& nullmap =
-                    assert_cast<const ColumnUInt8&>(nullable->get_null_map_column()).get_data();
+            const auto& nullmap = nullable->get_null_map_column().get_data();
 
             const T* data = (T*)col.get_raw_data().data;
             for (size_t i = start; i < size; i++) {
@@ -142,9 +141,7 @@ struct CommonFindOp {
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
             if (nullable->has_null()) {
-                nullmap = assert_cast<const ColumnUInt8&>(nullable->get_null_map_column())
-                                  .get_data()
-                                  .data();
+                nullmap = nullable->get_null_map_column().get_data().data();
             }
             data = (T*)nullable->get_nested_column().get_raw_data().data;
         } else {
@@ -189,8 +186,7 @@ struct StringFindOp : CommonFindOp<fixed_len_to_uint32_method, StringRef> {
 
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
-            const auto& nullmap =
-                    assert_cast<const ColumnUInt8&>(nullable->get_null_map_column()).get_data();
+            const auto& nullmap = nullable->get_null_map_column().get_data();
             if (nullable->get_nested_column().is_column_string64()) {
                 _insert_batch_col_str(
                         assert_cast<const ColumnString64&>(nullable->get_nested_column()),
@@ -216,8 +212,7 @@ struct StringFindOp : CommonFindOp<fixed_len_to_uint32_method, StringRef> {
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
             const auto& col = assert_cast<const ColumnString&>(nullable->get_nested_column());
-            const auto& nullmap =
-                    assert_cast<const ColumnUInt8&>(nullable->get_null_map_column()).get_data();
+            const auto& nullmap = nullable->get_null_map_column().get_data();
             if (nullable->has_null()) {
                 auto update = [&](size_t i) {
                     if (!nullmap[i]) {

--- a/be/src/exprs/function/array/function_array_contains_all.cpp
+++ b/be/src/exprs/function/array/function_array_contains_all.cpp
@@ -83,8 +83,8 @@ public:
 
         // execute check of contains all
         auto array_type = remove_nullable(block.get_by_position(arguments[0]).type);
-        auto left_element_type =
-                remove_nullable(assert_cast<const DataTypeArray&>(*array_type).get_nested_type());
+        auto left_element_type = remove_nullable(
+                assert_cast<const DataTypeArray*>(array_type.get())->get_nested_type());
 
         Status status = Status::OK();
         auto call = [&](const auto& type) -> bool {

--- a/be/src/exprs/function/array/function_array_enumerate.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate.cpp
@@ -66,7 +66,7 @@ public:
                     get_name(), arguments[0]->get_name());
         }
 
-        auto nested_type = assert_cast<const DataTypeArray&>(*array_type).get_nested_type();
+        auto nested_type = array_type->get_nested_type();
         bool is_nested_nullable = nested_type->is_nullable();
         bool is_nullable = arguments[0]->is_nullable();
         auto return_nested_type = std::make_shared<DataTypeInt64>();

--- a/be/src/exprs/function/array/function_array_index.h
+++ b/be/src/exprs/function/array/function_array_index.h
@@ -408,8 +408,8 @@ private:
         }
         // execute
         auto array_type = remove_nullable(block.get_by_position(arguments[0]).type);
-        auto left_element_type =
-                remove_nullable(assert_cast<const DataTypeArray&>(*array_type).get_nested_type());
+        auto left_element_type = remove_nullable(
+                assert_cast<const DataTypeArray*>(array_type.get())->get_nested_type());
         auto right_type = remove_nullable(block.get_by_position(arguments[1]).type);
 
         ColumnPtr return_column = nullptr;

--- a/be/src/exprs/function/array/function_array_remove.h
+++ b/be/src/exprs/function/array/function_array_remove.h
@@ -364,8 +364,8 @@ private:
         }
         // execute
         auto array_type = remove_nullable(arguments[0].type);
-        auto left_element_type =
-                remove_nullable(assert_cast<const DataTypeArray&>(*array_type).get_nested_type());
+        auto left_element_type = remove_nullable(
+                assert_cast<const DataTypeArray*>(array_type.get())->get_nested_type());
         auto right_type = remove_nullable(arguments[1].type);
 
         ColumnPtr res = nullptr;

--- a/be/src/exprs/function/array/function_arrays_overlap.h
+++ b/be/src/exprs/function/array/function_arrays_overlap.h
@@ -313,8 +313,8 @@ public:
 
         // execute overlap check
         auto array_type = remove_nullable(block.get_by_position(arguments[0]).type);
-        auto left_element_type =
-                remove_nullable(assert_cast<const DataTypeArray&>(*array_type).get_nested_type());
+        auto left_element_type = remove_nullable(
+                assert_cast<const DataTypeArray*>(array_type.get())->get_nested_type());
 
         auto call = [&](const auto& type) -> bool {
             using DispatchType = std::decay_t<decltype(type)>;

--- a/be/src/exprs/function/cast/cast_to_map.h
+++ b/be/src/exprs/function/cast/cast_to_map.h
@@ -76,7 +76,7 @@ WrapperType create_map_wrapper(FunctionContext* context, const DataTypePtr& from
 
         auto map_column = ColumnMap::create(converted_columns[0], converted_columns[1],
                                             from_col_map->get_offsets_ptr());
-        static_cast<void>(assert_cast<ColumnMap&>(*map_column).deduplicate_keys());
+        static_cast<void>(map_column->deduplicate_keys());
         block.get_by_position(result).column = std::move(map_column);
         return Status::OK();
     };

--- a/be/src/exprs/function/function_bitmap_min_or_max.h
+++ b/be/src/exprs/function/function_bitmap_min_or_max.h
@@ -57,8 +57,7 @@ public:
         ColumnPtr argument_column = block.get_by_position(arguments[0]).column;
 
         execute_straight(assert_cast<const ColumnBitmap*>(argument_column.get()),
-                         assert_cast<ColumnInt64*>(result_column.get()),
-                         assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                         result_column.get(), result_null_map_column.get()->get_data(),
                          input_rows_count);
 
         block.get_by_position(result).column =

--- a/be/src/exprs/function/function_collection_in.h
+++ b/be/src/exprs/function/function_collection_in.h
@@ -156,9 +156,9 @@ public:
         const auto& [materialized_column, col_const] = unpack_if_const(left_arg.column);
         auto materialized_column_not_null = materialized_column;
         if (materialized_column_not_null->is_nullable()) {
-            materialized_column_not_null = assert_cast<ColumnPtr>(
+            materialized_column_not_null =
                     check_and_get_column<ColumnNullable>(materialized_column_not_null.get())
-                            ->get_nested_column_ptr());
+                            ->get_nested_column_ptr();
         }
 
         for (size_t i = 0; i < input_rows_count; ++i) {

--- a/be/src/exprs/function/function_conv.cpp
+++ b/be/src/exprs/function/function_conv.cpp
@@ -95,17 +95,14 @@ public:
                             argument_columns[0].get()),
                     assert_cast<const ColumnInt8*>(argument_columns[1].get())->get_element(0),
                     assert_cast<const ColumnInt8*>(argument_columns[2].get())->get_element(0),
-                    assert_cast<ColumnString*>(result_column.get()),
-                    assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
-                    input_rows_count);
+                    result_column.get(), result_null_map_column->get_data(), input_rows_count);
         } else {
             execute_straight(context,
                              assert_cast<const typename Impl::DataType::ColumnType*>(
                                      argument_columns[0].get()),
                              assert_cast<const ColumnInt8*>(argument_columns[1].get()),
                              assert_cast<const ColumnInt8*>(argument_columns[2].get()),
-                             assert_cast<ColumnString*>(result_column.get()),
-                             assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                             result_column.get(), result_null_map_column->get_data(),
                              input_rows_count);
         }
 

--- a/be/src/exprs/function/function_convert_tz.cpp
+++ b/be/src/exprs/function/function_convert_tz.cpp
@@ -143,7 +143,7 @@ public:
         }
 
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr argument_columns[3];
         bool col_const[3];
@@ -173,21 +173,18 @@ public:
             // ignore argument columns, use cached timezone input in state
             execute_tz_const_with_state(convert_tz_state,
                                         assert_cast<const ColumnType*>(argument_columns[0].get()),
-                                        assert_cast<ColumnType*>(result_column.get()),
-                                        result_null_map, input_rows_count);
+                                        result_column.get(), result_null_map, input_rows_count);
         } else if (col_const[1] && col_const[2]) {
             // arguments are const
             execute_tz_const(context, assert_cast<const ColumnType*>(argument_columns[0].get()),
                              assert_cast<const ColumnString*>(argument_columns[1].get()),
                              assert_cast<const ColumnString*>(argument_columns[2].get()),
-                             assert_cast<ColumnType*>(result_column.get()), result_null_map,
-                             input_rows_count);
+                             result_column.get(), result_null_map, input_rows_count);
         } else {
             _execute(context, assert_cast<const ColumnType*>(argument_columns[0].get()),
                      assert_cast<const ColumnString*>(argument_columns[1].get()),
                      assert_cast<const ColumnString*>(argument_columns[2].get()),
-                     assert_cast<ColumnType*>(result_column.get()), result_null_map,
-                     input_rows_count);
+                     result_column.get(), result_null_map, input_rows_count);
         } //if const
 
         if (block.get_data_type(result)->is_nullable()) {

--- a/be/src/exprs/function/function_date_or_datetime_computation.h
+++ b/be/src/exprs/function/function_date_or_datetime_computation.h
@@ -778,7 +778,7 @@ public:
             // update result nullmap with inputs
             if (result_nullable) {
                 auto null_map = ColumnBool::create(input_rows_count, 0);
-                NullMap& result_null_map = assert_cast<ColumnBool&>(*null_map).get_data();
+                NullMap& result_null_map = null_map->get_data();
                 if (nullmap0) {
                     VectorizedUtils::update_null_map(result_null_map, *nullmap0);
                 }
@@ -805,7 +805,7 @@ public:
             // update result nullmap with inputs
             if (result_nullable) {
                 auto null_map = ColumnBool::create(input_rows_count, 0);
-                NullMap& result_null_map = assert_cast<ColumnBool&>(*null_map).get_data();
+                NullMap& result_null_map = null_map->get_data();
                 if (nullmap0) {
                     VectorizedUtils::update_null_map(result_null_map, *nullmap0, true);
                 }
@@ -902,7 +902,7 @@ public:
             // update result nullmap with inputs
             if (result_nullable) {
                 auto null_map = ColumnBool::create(input_rows_count, 0);
-                NullMap& result_null_map = assert_cast<ColumnBool&>(*null_map).get_data();
+                NullMap& result_null_map = null_map->get_data();
                 if (nullmap0) {
                     VectorizedUtils::update_null_map(result_null_map, *nullmap0);
                 }
@@ -928,7 +928,7 @@ public:
             // update result nullmap with inputs
             if (result_nullable) {
                 auto null_map = ColumnBool::create(input_rows_count, 0);
-                NullMap& result_null_map = assert_cast<ColumnBool&>(*null_map).get_data();
+                NullMap& result_null_map = null_map->get_data();
                 if (nullmap0) {
                     VectorizedUtils::update_null_map(result_null_map, *nullmap0, true);
                 }
@@ -1243,7 +1243,7 @@ struct TimestampToDateTime : IFunction {
                         uint32_t result, size_t input_rows_count) const override {
         // Handle null map manually
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr argument_column = block.get_by_position(arguments[0]).column;
         const NullMap* null_map = VectorizedUtils::get_null_map(argument_column);

--- a/be/src/exprs/function/function_datetime_floor_ceil.cpp
+++ b/be/src/exprs/function/function_datetime_floor_ceil.cpp
@@ -160,7 +160,7 @@ public:
                         uint32_t result, size_t input_rows_count) const override {
         // Handle null map manually - update result null map from input null maps upfront
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr argument_columns[3];
         bool col_const[3];

--- a/be/src/exprs/function/function_format.cpp
+++ b/be/src/exprs/function/function_format.cpp
@@ -160,15 +160,13 @@ public:
             std::tie(argument_columns[1], is_consts[1]) =
                     unpack_if_const(block.get_by_position(arguments[1]).column);
             execute_for_two_argument<ColVecData, T>(argument_columns, is_consts,
-                                                    assert_cast<ColumnString*>(result_column.get()),
-                                                    input_rows_count);
+                                                    result_column.get(), input_rows_count);
         } else {
             for (size_t i = 0; i < argument_size; ++i) {
                 argument_columns[i] = block.get_by_position(arguments[i])
                                               .column->convert_to_full_column_if_const();
             }
-            execute_for_others_arg<ColVecData, T>(argument_columns,
-                                                  assert_cast<ColumnString*>(result_column.get()),
+            execute_for_others_arg<ColVecData, T>(argument_columns, result_column.get(),
                                                   argument_size, input_rows_count);
         }
 

--- a/be/src/exprs/function/function_hll.cpp
+++ b/be/src/exprs/function/function_hll.cpp
@@ -51,12 +51,8 @@ namespace doris {
 struct HLLCardinality {
     static constexpr auto name = "hll_cardinality";
 
-    using ReturnType = DataTypeInt64;
-
-    static void vector(const std::vector<HyperLogLog>& data, MutableColumnPtr& col_res) {
-        typename ColumnInt64::Container& res =
-                reinterpret_cast<ColumnInt64*>(col_res.get())->get_data();
-
+    static void vector(const std::vector<HyperLogLog>& data, ColumnInt64::MutablePtr& col_res) {
+        auto& res = col_res->get_data();
         auto size = res.size();
         for (int i = 0; i < size; ++i) {
             res[i] = data[i].estimate_cardinality();
@@ -64,10 +60,8 @@ struct HLLCardinality {
     }
 
     static void vector_nullable(const std::vector<HyperLogLog>& data, const NullMap& nullmap,
-                                MutableColumnPtr& col_res) {
-        typename ColumnInt64::Container& res =
-                reinterpret_cast<ColumnInt64*>(col_res.get())->get_data();
-
+                                ColumnInt64::MutablePtr& col_res) {
+        auto& res = col_res->get_data();
         auto size = res.size();
         for (int i = 0; i < size; ++i) {
             if (nullmap[i]) {
@@ -91,7 +85,7 @@ public:
     size_t get_number_of_arguments() const override { return 1; }
 
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
-        return std::make_shared<typename Function::ReturnType>();
+        return std::make_shared<DataTypeInt64>();
     }
 
     bool use_default_implementation_for_nulls() const override { return false; }
@@ -100,8 +94,7 @@ public:
                         uint32_t result, size_t input_rows_count) const override {
         auto column = block.get_by_position(arguments[0]).column;
 
-        MutableColumnPtr column_result = get_return_type_impl({})->create_column();
-        column_result->resize(input_rows_count);
+        auto column_result = ColumnInt64::create(input_rows_count);
         if (const ColumnNullable* col_nullable =
                     check_and_get_column<ColumnNullable>(column.get())) {
             const ColumnHLL* col =

--- a/be/src/exprs/function/function_ip.h
+++ b/be/src/exprs/function/function_ip.h
@@ -395,7 +395,7 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
     ColumnString* column_string = nullptr;
     if constexpr (std::is_same_v<ToColumn, ColumnString>) {
         offset_inc = IPV6_BINARY_LENGTH;
-        column_string = assert_cast<ColumnString*>(col_res.get());
+        column_string = col_res.get();
     }
 
     for (size_t out_offset = 0, i = 0; i < column_size; out_offset += offset_inc, ++i) {
@@ -457,7 +457,7 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
                 std::reverse(res_value, res_value + IPV6_BINARY_LENGTH);
             }
             if constexpr (std::is_same_v<ToColumn, ColumnString>) {
-                auto* column_string_res = assert_cast<ColumnString*>(col_res.get());
+                auto* column_string_res = static_cast<ColumnString*>(col_res.get());
                 std::copy(res_value, res_value + IPV6_BINARY_LENGTH,
                           column_string_res->get_chars().begin() + i * IPV6_BINARY_LENGTH);
                 column_string_res->get_offsets().push_back((i + 1) * IPV6_BINARY_LENGTH);
@@ -470,7 +470,7 @@ ColumnPtr convert_to_ipv6(const StringColumnType& string_column,
             }
             std::fill_n(&vec_res[out_offset], offset_inc, 0);
             if constexpr (std::is_same_v<ToColumn, ColumnString>) {
-                auto* column_string_res = assert_cast<ColumnString*>(col_res.get());
+                auto* column_string_res = static_cast<ColumnString*>(col_res.get());
                 column_string_res->get_offsets().push_back((i + 1) * IPV6_BINARY_LENGTH);
             }
             if constexpr (exception_mode == IPConvertExceptionMode::Null) {

--- a/be/src/exprs/function/function_json.cpp
+++ b/be/src/exprs/function/function_json.cpp
@@ -391,8 +391,7 @@ public:
             data_columns.push_back(assert_cast<const ColumnString*>(column_ptrs.back().get()));
         }
 
-        Impl::execute(data_columns, *assert_cast<ColumnString*>(result_column.get()),
-                      input_rows_count);
+        Impl::execute(data_columns, *result_column.get(), input_rows_count);
         block.get_by_position(result).column = std::move(result_column);
         return Status::OK();
     }

--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -714,7 +714,7 @@ public:
         NullMap* result_null_map = nullptr;
         if (data_null_map || path_null_map) {
             result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-            result_null_map = &assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+            result_null_map = &static_cast<ColumnUInt8&>(*result_null_map_column).get_data();
 
             if (data_null_map) {
                 VectorizedUtils::update_null_map(*result_null_map, *data_null_map,

--- a/be/src/exprs/function/function_other_types_to_date.cpp
+++ b/be/src/exprs/function/function_other_types_to_date.cpp
@@ -108,7 +108,7 @@ struct StrToDate {
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           uint32_t result, size_t input_rows_count) {
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr argument_columns[2];
         bool col_const[2];
@@ -263,7 +263,7 @@ struct MakeDateImpl {
 
         // Handle null map manually - update result null map from input null maps upfront
         auto result_null_map_column = ColumnBool::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnBool&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr argument_columns[2];
         bool col_const[2];
@@ -584,7 +584,7 @@ public:
 
         // Handle null map manually - update result null map from input null map upfront
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         // Update result null map from input null map using standard approach
         bool col_const = is_column_const(*argument_column);
@@ -794,7 +794,7 @@ struct UnixTimeStampStrImpl {
                                size_t input_rows_count) {
         // Handle null map manually
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr col_left = nullptr, col_right = nullptr;
         bool source_const = false, format_const = false;
@@ -1011,7 +1011,7 @@ public:
                         uint32_t result, size_t input_rows_count) const override {
         // Handle null map manually - update result null map from input null maps upfront
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr argument_column = block.get_by_position(arguments[0]).column;
         const NullMap* null_map = VectorizedUtils::get_null_map(argument_column);
@@ -1260,7 +1260,7 @@ struct FromIso8601DateV2 {
                           uint32_t result, size_t input_rows_count) {
         const auto* src_column_ptr = block.get_by_position(arguments[0]).column.get();
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
-        NullMap& result_null_map = assert_cast<ColumnUInt8&>(*result_null_map_column).get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnDateV2::MutablePtr res = ColumnDateV2::create(input_rows_count);
         auto& result_data = res->get_data();

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -278,8 +278,7 @@ public:
                 } else if (auto target_nullable_column =
                                    check_and_get_column<ColumnNullable>(*target_column)) {
                     auto& target_null_map = target_nullable_column->get_null_map_data();
-                    VectorizedUtils::update_null_map(
-                            assert_cast<ColumnUInt8&>(*null_map).get_data(), target_null_map);
+                    VectorizedUtils::update_null_map(null_map->get_data(), target_null_map);
 
                     auto& target_str_column = assert_cast<const ColumnString&>(
                             target_nullable_column->get_nested_column());
@@ -303,7 +302,7 @@ public:
                     assert_cast<const ColumnInt32&>(pos_null_column->get_nested_column());
             auto& pos_null_map = pos_null_column->get_null_map_data();
             auto null_map = ColumnUInt8::create(input_rows_count, false);
-            auto& res_null_map = assert_cast<ColumnUInt8&>(*null_map).get_data();
+            auto& res_null_map = null_map->get_data();
 
             for (size_t i = 0; i < input_rows_count; ++i) {
                 auto pos = pos_column.get_element(i);
@@ -324,7 +323,7 @@ public:
             auto& pos_column =
                     assert_cast<const ColumnInt32&>(*block.get_by_position(arguments[0]).column);
             auto null_map = ColumnUInt8::create(input_rows_count, false);
-            auto& res_null_map = assert_cast<ColumnUInt8&>(*null_map).get_data();
+            auto& res_null_map = null_map->get_data();
 
             for (size_t i = 0; i < input_rows_count; ++i) {
                 auto pos = pos_column.get_element(i);

--- a/be/src/exprs/function/function_string_format.h
+++ b/be/src/exprs/function/function_string_format.h
@@ -354,7 +354,7 @@ public:
         auto res_column = ColumnString::create();
         ColumnPtr argument_column = block.get_by_position(arguments[0]).column;
 
-        auto result_column = assert_cast<ColumnString*>(res_column.get());
+        auto result_column = res_column.get();
 
         Impl::execute(context, result_column, argument_column, input_rows_count);
 
@@ -528,7 +528,7 @@ public:
         bool is_const;
         std::tie(argument_column_2, is_const) =
                 unpack_if_const(block.get_by_position(arguments[1]).column);
-        auto* result_column = assert_cast<ColumnString*>(res_column.get());
+        auto* result_column = res_column.get();
 
         if (is_const) {
             RETURN_IF_ERROR(Impl::template execute<true>(context, result_column, argument_column,

--- a/be/src/exprs/function/function_string_replace.h
+++ b/be/src/exprs/function/function_string_replace.h
@@ -293,7 +293,7 @@ struct SubReplaceImpl {
     static Status replace_execute(Block& block, const ColumnNumbers& arguments, uint32_t result,
                                   size_t input_rows_count) {
         auto res_column = ColumnString::create();
-        auto* result_column = assert_cast<ColumnString*>(res_column.get());
+        auto* result_column = res_column.get();
         auto args_null_map = ColumnUInt8::create(input_rows_count, 0);
         ColumnPtr argument_columns[4];
         bool col_const[4];

--- a/be/src/exprs/function/function_variant_element.cpp
+++ b/be/src/exprs/function/function_variant_element.cpp
@@ -273,7 +273,7 @@ private:
                 field_name = "$." + field_name;
             }
             JsonFunctions::parse_json_paths(field_name, &parsed_paths);
-            ColumnString* col_str = assert_cast<ColumnString*>(result_column.get());
+            ColumnString* col_str = static_cast<ColumnString*>(result_column.get());
             for (size_t i = 0; i < docs.size(); ++i) {
                 if (!extract_from_document(parser, docs.get_data_at(i), parsed_paths, col_str)) {
                     VLOG_DEBUG << "failed to parse " << docs.get_data_at(i) << ", field "

--- a/be/src/exprs/function/function_width_bucket.cpp
+++ b/be/src/exprs/function/function_width_bucket.cpp
@@ -81,7 +81,7 @@ public:
         DataTypePtr expr_type = block.get_by_position(arguments[0]).type;
 
         if (!_execute_by_type(*expr_ptr, *min_value_ptr, *max_value_ptr, num_buckets,
-                              *nested_column_ptr, expr_type)) {
+                              nested_column_ptr, expr_type)) {
             return Status::InvalidArgument("Unsupported type for width_bucket: {}",
                                            expr_type->get_name());
         }
@@ -94,11 +94,11 @@ private:
     template <typename ColumnType>
     void _execute(const IColumn& expr_column, const IColumn& min_value_column,
                   const IColumn& max_value_column, const int64_t num_buckets,
-                  IColumn& nested_column) const {
+                  ColumnInt64::MutablePtr& nested_column) const {
         const auto& expr_column_concrete = assert_cast<const ColumnType&>(expr_column);
         const auto& min_value_column_concrete = assert_cast<const ColumnType&>(min_value_column);
         const auto& max_value_column_concrete = assert_cast<const ColumnType&>(max_value_column);
-        auto& nested_column_concrete = assert_cast<ColumnInt64&>(nested_column);
+        auto& nested_column_concrete = *nested_column;
 
         size_t input_rows_count = expr_column.size();
 
@@ -123,7 +123,8 @@ private:
 
     bool _execute_by_type(const IColumn& expr_column, const IColumn& min_value_column,
                           const IColumn& max_value_column, const int64_t num_buckets,
-                          IColumn& nested_column_column, DataTypePtr& expr_type) const {
+                          ColumnInt64::MutablePtr& nested_column_column,
+                          DataTypePtr& expr_type) const {
         switch (expr_type->get_primitive_type()) {
         case PrimitiveType::TYPE_TINYINT:
             _execute<ColumnInt8>(expr_column, min_value_column, max_value_column, num_buckets,

--- a/be/src/exprs/function/in.h
+++ b/be/src/exprs/function/in.h
@@ -219,9 +219,7 @@ public:
             if (materialized_column->is_nullable()) {
                 const auto* null_col_ptr =
                         check_and_get_column<ColumnNullable>(materialized_column.get());
-                const auto& null_map =
-                        assert_cast<const ColumnUInt8&>(null_col_ptr->get_null_map_column())
-                                .get_data();
+                const auto& null_map = null_col_ptr->get_null_map_column().get_data();
                 const auto* nested_col_ptr = null_col_ptr->get_nested_column_ptr().get();
 
                 if (nested_col_ptr->is_column_string()) {

--- a/be/src/exprs/function/is_not_null.h
+++ b/be/src/exprs/function/is_not_null.h
@@ -68,7 +68,7 @@ public:
             /// Return the negated null map.
             auto res_column = ColumnUInt8::create(input_rows_count);
             const auto* __restrict src_data = nullable->get_null_map_data().data();
-            auto* __restrict res_data = assert_cast<ColumnUInt8&>(*res_column).get_data().data();
+            auto* __restrict res_data = res_column->get_data().data();
 
             for (size_t i = 0; i < input_rows_count; ++i) {
                 res_data[i] = !src_data[i];

--- a/be/src/exprs/function/least_greast.cpp
+++ b/be/src/exprs/function/least_greast.cpp
@@ -174,7 +174,7 @@ struct FunctionFieldImpl {
                              size_t input_rows_count) {
         const auto& data_type = block.get_by_position(arguments[0]).type;
         auto result_column = ColumnInt32::create(input_rows_count, 0);
-        auto& res_data = static_cast<ColumnInt32*>(result_column.get())->get_data();
+        auto& res_data = result_column->get_data();
 
         const auto& column_size = arguments.size();
         std::vector<ColumnPtr> argument_columns(column_size);

--- a/be/src/exprs/function/math.cpp
+++ b/be/src/exprs/function/math.cpp
@@ -732,8 +732,7 @@ public:
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
 
         auto& result_data = result_column->get_data();
-        NullMap& result_null_map =
-                assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data();
+        NullMap& result_null_map = result_null_map_column->get_data();
 
         ColumnPtr argument_columns[3];
         bool col_const[3];

--- a/be/src/exprs/function/random.cpp
+++ b/be/src/exprs/function/random.cpp
@@ -103,7 +103,7 @@ private:
                                      const ColumnNumbers& arguments, uint32_t result,
                                      size_t input_rows_count) {
         auto res_column = ColumnInt64::create(input_rows_count);
-        auto& res_data = static_cast<ColumnInt64&>(*res_column).get_data();
+        auto& res_data = res_column->get_data();
 
         auto* generator = reinterpret_cast<std::mt19937_64*>(
                 context->get_function_state(FunctionContext::THREAD_LOCAL));

--- a/be/src/exprs/function/uniform.cpp
+++ b/be/src/exprs/function/uniform.cpp
@@ -56,7 +56,7 @@ struct UniformIntImpl {
                                const ColumnNumbers& arguments, uint32_t result,
                                size_t input_rows_count) {
         auto res_column = ColumnInt64::create(input_rows_count);
-        auto& res_data = static_cast<ColumnInt64&>(*res_column).get_data();
+        auto& res_data = res_column->get_data();
 
         // Get min and max values (constants)
         const auto& left =

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -271,8 +271,7 @@ public:
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
             const auto& col = nullable->get_nested_column();
-            const auto& nullmap =
-                    assert_cast<const ColumnUInt8&>(nullable->get_null_map_column()).get_data();
+            const auto& nullmap = nullable->get_null_map_column().get_data();
 
             const ElementType* data = (ElementType*)col.get_raw_data().data;
             for (size_t i = start; i < end; i++) {
@@ -463,8 +462,7 @@ public:
         }
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
-            const auto& nullmap =
-                    assert_cast<const ColumnUInt8&>(nullable->get_null_map_column()).get_data();
+            const auto& nullmap = nullable->get_null_map_column().get_data();
             if (nullable->get_nested_column().is_column_string64()) {
                 _insert_fixed_len_string(
                         assert_cast<const ColumnString64&>(nullable->get_nested_column()),
@@ -667,8 +665,7 @@ public:
         }
         if (column->is_nullable()) {
             const auto* nullable = assert_cast<const ColumnNullable*>(column.get());
-            const auto& nullmap =
-                    assert_cast<const ColumnUInt8&>(nullable->get_null_map_column()).get_data();
+            const auto& nullmap = nullable->get_null_map_column().get_data();
             if (nullable->get_nested_column().is_column_string64()) {
                 _insert_fixed_len_string(
                         assert_cast<const ColumnString64&>(nullable->get_nested_column()),

--- a/be/src/exprs/lambda_function/varray_sort_function.cpp
+++ b/be/src/exprs/lambda_function/varray_sort_function.cpp
@@ -144,7 +144,7 @@ public:
             auto* temp_column = assert_cast<ColumnNullable*>(
                     lambda_block.get_by_position(i).column->assume_mutable().get());
             temp_data[i] = temp_column->get_nested_column_ptr();
-            auto& null_map_col = assert_cast<ColumnUInt8&>(temp_column->get_null_map_column());
+            auto& null_map_col = temp_column->get_null_map_column();
             temp_nullmap_data[i] = &null_map_col.get_data();
             temp_data[i]->resize(1);
             temp_nullmap_data[i]->resize(1);

--- a/be/src/exprs/vcompound_pred.h
+++ b/be/src/exprs/vcompound_pred.h
@@ -246,10 +246,8 @@ public:
             auto col_res = ColumnUInt8::create(size);
             auto col_nulls = ColumnUInt8::create(size);
 
-            auto* __restrict res_datas =
-                    assert_cast<ColumnUInt8*>(col_res.get())->get_data().data();
-            auto* __restrict res_nulls =
-                    assert_cast<ColumnUInt8*>(col_nulls.get())->get_data().data();
+            auto* __restrict res_datas = col_res->get_data().data();
+            auto* __restrict res_nulls = col_nulls->get_data().data();
             ColumnPtr temp_null_map = nullptr;
             // maybe both children are nullable / or one of children is nullable
             auto* __restrict lhs_null_map_tmp = create_null_map_column(temp_null_map, lhs_null_map);

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -680,7 +680,7 @@ Status VectorizedCoalesceExpr::execute_column_impl(VExprContext* context, const 
             /// Return the negated null map.
             auto res_column = ColumnUInt8::create(size);
             const auto* __restrict src_data = nullable->get_null_map_data().data();
-            auto* __restrict res_data = assert_cast<ColumnUInt8&>(*res_column).get_data().data();
+            auto* __restrict res_data = res_column->get_data().data();
 
             for (size_t i = 0; i < size; ++i) {
                 res_data[i] = !src_data[i];

--- a/be/src/format/jni/jni_data_bridge.cpp
+++ b/be/src/format/jni/jni_data_bridge.cpp
@@ -528,9 +528,9 @@ Status JniDataBridge::_fill_column_meta(const ColumnPtr& doris_column, const Dat
         const auto& element_column = assert_cast<const ColumnArray&>(*data_column).get_data_ptr();
         meta_data.emplace_back(
                 (long)assert_cast<const ColumnArray&>(*data_column).get_offsets().data());
-        const auto& element_type = assert_cast<const DataTypePtr&>(
+        const auto& element_type =
                 (assert_cast<const DataTypeArray*>(remove_nullable(data_type).get()))
-                        ->get_nested_type());
+                        ->get_nested_type();
         RETURN_IF_ERROR(_fill_column_meta(element_column, element_type, meta_data));
         break;
     }
@@ -540,19 +540,17 @@ Status JniDataBridge::_fill_column_meta(const ColumnPtr& doris_column, const Dat
                 assert_cast<const DataTypeStruct*>(remove_nullable(data_type).get());
         for (int i = 0; i < doris_struct.tuple_size(); ++i) {
             const auto& struct_field = doris_struct.get_column_ptr(i);
-            const auto& field_type =
-                    assert_cast<const DataTypePtr&>(doris_struct_type->get_element(i));
+            const auto& field_type = doris_struct_type->get_element(i);
             RETURN_IF_ERROR(_fill_column_meta(struct_field, field_type, meta_data));
         }
         break;
     }
     case PrimitiveType::TYPE_MAP: {
         const auto& map = assert_cast<const ColumnMap&>(*data_column);
-        const auto& key_type = assert_cast<const DataTypePtr&>(
-                assert_cast<const DataTypeMap*>(remove_nullable(data_type).get())->get_key_type());
-        const auto& value_type = assert_cast<const DataTypePtr&>(
-                assert_cast<const DataTypeMap*>(remove_nullable(data_type).get())
-                        ->get_value_type());
+        const auto& key_type =
+                assert_cast<const DataTypeMap*>(remove_nullable(data_type).get())->get_key_type();
+        const auto& value_type =
+                assert_cast<const DataTypeMap*>(remove_nullable(data_type).get())->get_value_type();
         const auto& key_column = map.get_keys_ptr();
         const auto& value_column = map.get_values_ptr();
         meta_data.emplace_back((long)map.get_offsets().data());
@@ -562,8 +560,7 @@ Status JniDataBridge::_fill_column_meta(const ColumnPtr& doris_column, const Dat
     }
     case PrimitiveType::TYPE_VARBINARY: {
         const auto& varbinary_col = assert_cast<const ColumnVarbinary&>(*data_column);
-        meta_data.emplace_back(
-                (long)assert_cast<const ColumnVarbinary&>(varbinary_col).get_data().data());
+        meta_data.emplace_back((long)varbinary_col.get_data().data());
         break;
     }
     default:

--- a/be/src/format/table/table_schema_change_helper.cpp
+++ b/be/src/format/table/table_schema_change_helper.cpp
@@ -80,18 +80,18 @@ Status TableSchemaChangeHelper::BuildTableInfoUtil::by_parquet_name(
         std::shared_ptr<TableSchemaChangeHelper::Node> key_node = nullptr;
 
         {
-            const auto& key_type = assert_cast<const DataTypePtr&>(
+            const auto& key_type =
                     assert_cast<const DataTypeMap*>(remove_nullable(table_data_type).get())
-                            ->get_key_type());
+                            ->get_key_type();
 
             RETURN_IF_ERROR(by_parquet_name(key_type, file_field.children[0], key_node));
         }
 
         std::shared_ptr<TableSchemaChangeHelper::Node> value_node = nullptr;
         {
-            const auto& value_type = assert_cast<const DataTypePtr&>(
+            const auto& value_type =
                     assert_cast<const DataTypeMap*>(remove_nullable(table_data_type).get())
-                            ->get_value_type());
+                            ->get_value_type();
 
             RETURN_IF_ERROR(by_parquet_name(value_type, file_field.children[1], value_node));
         }
@@ -105,9 +105,9 @@ Status TableSchemaChangeHelper::BuildTableInfoUtil::by_parquet_name(
         MOCK_REMOVE(DCHECK(file_field.children.size() == 1));
 
         std::shared_ptr<TableSchemaChangeHelper::Node> element_node = nullptr;
-        const auto& element_type = assert_cast<const DataTypePtr&>(
+        const auto& element_type =
                 assert_cast<const DataTypeArray*>(remove_nullable(table_data_type).get())
-                        ->get_nested_type());
+                        ->get_nested_type();
 
         RETURN_IF_ERROR(by_parquet_name(element_type, file_field.children[0], element_node));
 
@@ -197,15 +197,15 @@ Status TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_name(
         MOCK_REMOVE(DCHECK(orc_root->getSubtypeCount() == 2));
 
         std::shared_ptr<TableSchemaChangeHelper::Node> key_node = nullptr;
-        const auto& key_type = assert_cast<const DataTypePtr&>(
+        const auto& key_type =
                 assert_cast<const DataTypeMap*>(remove_nullable(table_data_type).get())
-                        ->get_key_type());
+                        ->get_key_type();
         RETURN_IF_ERROR(by_orc_name(key_type, orc_root->getSubtype(0), key_node));
 
         std::shared_ptr<TableSchemaChangeHelper::Node> value_node = nullptr;
-        const auto& value_type = assert_cast<const DataTypePtr&>(
+        const auto& value_type =
                 assert_cast<const DataTypeMap*>(remove_nullable(table_data_type).get())
-                        ->get_value_type());
+                        ->get_value_type();
         RETURN_IF_ERROR(by_orc_name(value_type, orc_root->getSubtype(1), value_node));
         node = std::make_shared<TableSchemaChangeHelper::MapNode>(key_node, value_node);
 
@@ -218,9 +218,9 @@ Status TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_name(
         MOCK_REMOVE(DCHECK(orc_root->getSubtypeCount() == 1));
 
         std::shared_ptr<TableSchemaChangeHelper::Node> element_node = nullptr;
-        const auto& element_type = assert_cast<const DataTypePtr&>(
+        const auto& element_type =
                 assert_cast<const DataTypeArray*>(remove_nullable(table_data_type).get())
-                        ->get_nested_type());
+                        ->get_nested_type();
 
         RETURN_IF_ERROR(by_orc_name(element_type, orc_root->getSubtype(0), element_node));
         node = std::make_shared<TableSchemaChangeHelper::ArrayNode>(element_node);

--- a/be/src/storage/predicate/accept_null_predicate.h
+++ b/be/src/storage/predicate/accept_null_predicate.h
@@ -46,10 +46,7 @@ public:
               _nested {nested} {}
     AcceptNullPredicate(const AcceptNullPredicate& other, uint32_t col_id)
             : ColumnPredicate(other, col_id),
-              _nested(assert_cast<const AcceptNullPredicate&>(other)._nested
-                              ? assert_cast<const AcceptNullPredicate&>(other)._nested->clone(
-                                        col_id)
-                              : nullptr) {}
+              _nested(other._nested ? other._nested->clone(col_id) : nullptr) {}
     AcceptNullPredicate(const AcceptNullPredicate& other) = delete;
     ~AcceptNullPredicate() override = default;
     std::shared_ptr<ColumnPredicate> clone(uint32_t col_id) const override {

--- a/be/src/storage/predicate/comparison_predicate.h
+++ b/be/src/storage/predicate/comparison_predicate.h
@@ -398,9 +398,7 @@ public:
         if (column.is_nullable()) {
             const auto* nullable_column_ptr = check_and_get_column<ColumnNullable>(column);
             const auto& nested_column = nullable_column_ptr->get_nested_column();
-            const auto& null_map =
-                    assert_cast<const ColumnUInt8&>(nullable_column_ptr->get_null_map_column())
-                            .get_data();
+            const auto& null_map = nullable_column_ptr->get_null_map_column().get_data();
 
             if (nested_column.is_column_dictionary()) {
                 if constexpr (is_string_type(Type)) {
@@ -494,9 +492,7 @@ private:
         if (column.is_nullable()) {
             const auto* nullable_column_ptr = check_and_get_column<ColumnNullable>(column);
             const auto& nested_column = nullable_column_ptr->get_nested_column();
-            const auto& null_map =
-                    assert_cast<const ColumnUInt8&>(nullable_column_ptr->get_null_map_column())
-                            .get_data();
+            const auto& null_map = nullable_column_ptr->get_null_map_column().get_data();
 
             return _base_evaluate<true>(&nested_column, null_map.data(), sel, size);
         } else {
@@ -549,9 +545,7 @@ private:
         if (column.is_nullable()) {
             const auto* nullable_column_ptr = check_and_get_column<ColumnNullable>(column);
             const auto& nested_column = nullable_column_ptr->get_nested_column();
-            const auto& null_map =
-                    assert_cast<const ColumnUInt8&>(nullable_column_ptr->get_null_map_column())
-                            .get_data();
+            const auto& null_map = nullable_column_ptr->get_null_map_column().get_data();
 
             _base_evaluate_bit<true, is_and>(&nested_column, null_map.data(), sel, size, flags);
         } else {

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -211,8 +211,7 @@ public:
                        bool* flags) const {
         if (column.is_nullable()) {
             const auto* nullable_col = check_and_get_column<ColumnNullable>(column);
-            const auto& null_bitmap =
-                    assert_cast<const ColumnUInt8&>(nullable_col->get_null_map_column()).get_data();
+            const auto& null_bitmap = nullable_col->get_null_map_column().get_data();
             const auto& nested_col = nullable_col->get_nested_column();
 
             if (_opposite) {
@@ -465,8 +464,7 @@ private:
 
         if (column.is_nullable()) {
             const auto* nullable_col = check_and_get_column<ColumnNullable>(column);
-            const auto& null_map =
-                    assert_cast<const ColumnUInt8&>(nullable_col->get_null_map_column()).get_data();
+            const auto& null_map = nullable_col->get_null_map_column().get_data();
             const auto& nested_col = nullable_col->get_nested_column();
 
             if (_opposite) {

--- a/be/src/storage/predicate/shared_predicate.h
+++ b/be/src/storage/predicate/shared_predicate.h
@@ -42,9 +42,7 @@ public:
     SharedPredicate(const SharedPredicate& other, uint32_t column_id)
             : ColumnPredicate(other, column_id),
               _mtx(std::make_shared<std::shared_mutex>()),
-              _nested(assert_cast<const SharedPredicate&>(other)._nested
-                              ? other._nested->clone(column_id)
-                              : nullptr) {}
+              _nested(other._nested ? other._nested->clone(column_id) : nullptr) {}
     ~SharedPredicate() override = default;
     std::string debug_string() const override {
         std::shared_lock<std::shared_mutex> lock(*_mtx);

--- a/be/src/storage/segment/variant/binary_column_reader.cpp
+++ b/be/src/storage/segment/variant/binary_column_reader.cpp
@@ -236,7 +236,7 @@ void CombineMultipleBinaryColumnIterator::_collect_sparse_data_from_buckets(
     auto& column_map = assert_cast<ColumnMap&>(binary_data_column);
     auto& dst_paths = assert_cast<ColumnString&>(column_map.get_keys());
     auto& dst_values = assert_cast<ColumnString&>(column_map.get_values());
-    auto& dst_offsets = assert_cast<ColumnArray::Offsets64&>(column_map.get_offsets());
+    auto& dst_offsets = column_map.get_offsets();
 
     std::vector<const ColumnString*> src_paths(_binary_column_data.size());
     std::vector<const ColumnString*> src_values(_binary_column_data.size());
@@ -245,7 +245,7 @@ void CombineMultipleBinaryColumnIterator::_collect_sparse_data_from_buckets(
         const auto& src_map = assert_cast<const ColumnMap&>(*_binary_column_data[i]);
         src_paths[i] = assert_cast<const ColumnString*>(&src_map.get_keys());
         src_values[i] = assert_cast<const ColumnString*>(&src_map.get_values());
-        src_offsets[i] = assert_cast<const ColumnArray::Offsets64*>(&src_map.get_offsets());
+        src_offsets[i] = &src_map.get_offsets();
     }
 
     size_t num_rows = _binary_column_data[0]->size();

--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -1431,7 +1431,7 @@ Status VariantRootColumnIterator::_process_root_column(MutableColumnPtr& dst,
 
     // add root column to a tmp object column
     auto tmp = ColumnVariant::create(0, obj.enable_doc_mode(), root_column->size());
-    auto& tmp_obj = assert_cast<ColumnVariant&>(*tmp);
+    auto& tmp_obj = *tmp;
     tmp_obj.add_sub_column({}, std::move(root_column), most_common_type);
     // tmp_obj.get_sparse_column()->assume_mutable()->insert_many_defaults(root_column->size());
 

--- a/be/test/core/column/column_const_test.cpp
+++ b/be/test/core/column/column_const_test.cpp
@@ -48,9 +48,10 @@ TEST(ColumnConstTest, TestFilter) {
         IColumn::Filter filter = {1, 0, 1};
 
         auto res = column_const->filter(filter, 2);
+        const auto& res_column = assert_cast<const ColumnConst&>(*res);
         EXPECT_EQ(res->size(), 2);
-        EXPECT_EQ(assert_cast<const ColumnConst&>(*res).get_data_column_ptr()->size(), 1);
-        EXPECT_EQ(assert_cast<const ColumnConst&>(*res).get_data_column_ptr()->get_int(0), 7);
+        EXPECT_EQ(res_column.get_data_column_ptr()->size(), 1);
+        EXPECT_EQ(res_column.get_data_column_ptr()->get_int(0), 7);
     }
 
     {
@@ -60,9 +61,8 @@ TEST(ColumnConstTest, TestFilter) {
 
         auto size = column_const->filter(filter);
         EXPECT_EQ(size, 2);
-        EXPECT_EQ(assert_cast<const ColumnConst&>(*column_const).get_data_column_ptr()->size(), 1);
-        EXPECT_EQ(assert_cast<const ColumnConst&>(*column_const).get_data_column_ptr()->get_int(0),
-                  7);
+        EXPECT_EQ(column_const->get_data_column_ptr()->size(), 1);
+        EXPECT_EQ(column_const->get_data_column_ptr()->get_int(0), 7);
     }
 }
 

--- a/be/test/core/column/column_dictionary_test.cpp
+++ b/be/test/core/column/column_dictionary_test.cpp
@@ -217,8 +217,7 @@ TEST_F(ColumnDictionaryTest, insert) {
 }
 TEST_F(ColumnDictionaryTest, field) {
     auto count = column_dict_char->size();
-    auto* col_vec = assert_cast<ColumnDictI32*>(column_dict_char.get());
-    const auto& codes_data = col_vec->get_data();
+    const auto& codes_data = column_dict_char->get_data();
     for (size_t i = 0; i != count; ++i) {
         Field f;
         column_dict_char->get(i, f);

--- a/be/test/core/column/column_string_test.cpp
+++ b/be/test/core/column/column_string_test.cpp
@@ -476,7 +476,7 @@ TEST_F(ColumnStringTest, insert_many_continuous_binary_data) {
     auto test_func = [&](size_t clone_count, auto x, const auto& source_column) {
         using ColumnType = decltype(x);
         auto src_size = source_column->size();
-        auto* col_vec_src = assert_cast<ColumnType*>(source_column.get());
+        auto* col_vec_src = source_column.get();
         size_t actual_clone_count = std::min(clone_count, src_size);
 
         auto target_column = source_column->clone_resized(actual_clone_count);

--- a/be/test/core/column/column_varbinary_test.cpp
+++ b/be/test/core/column/column_varbinary_test.cpp
@@ -175,8 +175,7 @@ TEST_F(ColumnVarbinaryTest, FilterBothModes) {
     IColumn::Filter f = {1, 0, 1, 1, 0, 1};
     size_t expected = 4; // number of ones
 
-    const auto& ccol = assert_cast<const ColumnVarbinary&>(*col);
-    ColumnPtr filtered = ccol.filter(f, -1);
+    ColumnPtr filtered = col->filter(f, -1);
     const auto& fcol = assert_cast<const ColumnVarbinary&>(*filtered);
     ASSERT_EQ(fcol.size(), expected);
     std::vector<size_t> kept_idx = {0, 2, 3, 5}; // includes both inline and non-inline
@@ -250,7 +249,7 @@ TEST_F(ColumnVarbinaryTest, CloneResized) {
 
     // enlarge
     auto c2 = col->clone_resized(5);
-    const auto& cc2 = assert_cast<const ColumnVarbinary&>(*c2);
+    const auto& cc2 = *c2;
     ASSERT_EQ(cc2.size(), 5U);
     for (size_t i = 0; i < vals.size(); ++i) {
         auto r = cc2.get_data_at(i);
@@ -264,7 +263,7 @@ TEST_F(ColumnVarbinaryTest, CloneResized) {
 
     // shrink
     auto c3 = col->clone_resized(2);
-    const auto& cc3 = assert_cast<const ColumnVarbinary&>(*c3);
+    const auto& cc3 = *c3;
     ASSERT_EQ(cc3.size(), 2U);
     for (size_t i = 0; i < 2; ++i) {
         auto r = cc3.get_data_at(i);
@@ -589,7 +588,7 @@ TEST_F(ColumnVarbinaryTest, CloneResizedZero) {
     col->insert_data("a", 1);
     col->insert_data("", 0);
     auto c0 = col->clone_resized(0);
-    const auto& cc0 = assert_cast<const ColumnVarbinary&>(*c0);
+    const auto& cc0 = *c0;
     EXPECT_EQ(cc0.size(), 0U);
 }
 

--- a/be/test/core/column/column_variant_test.cpp
+++ b/be/test/core/column/column_variant_test.cpp
@@ -1196,7 +1196,7 @@ TEST_F(ColumnVariantTest, serialize_one_row_to_string) {
     auto tz = cctz::utc_time_zone();
     options.timezone = &tz;
     {
-        const auto* variant = assert_cast<const ColumnVariant*>(column_variant.get());
+        const auto* variant = column_variant.get();
         // Serialize hierarchy types to json format
         std::string buffer;
         for (size_t row_idx = 2000; row_idx < variant->size(); ++row_idx) {
@@ -2099,7 +2099,7 @@ TEST_F(ColumnVariantTest, find_path_lower_bound_in_sparse_data) {
     auto test_func = [](const auto& source_column) {
         auto src_size = source_column->size();
         EXPECT_TRUE(src_size > 0);
-        auto* mutable_ptr = assert_cast<ColumnVariant*>(source_column.get());
+        auto* mutable_ptr = source_column.get();
         //        auto [sparse_data_paths, sparse_data_values] = mutable_ptr->get_sparse_data_paths_and_values();
         // forloop
         PathInData pat("object.array");

--- a/be/test/core/data_type/data_type_datetime_v1_test.cpp
+++ b/be/test/core/data_type/data_type_datetime_v1_test.cpp
@@ -443,7 +443,7 @@ TEST_F(DataTypeDateTimeV1Test, to_string) {
         std::cout << "test datatype to string: " << dt.get_family_name() << std::endl;
         using DataType = decltype(dt);
         using ColumnType = typename std::remove_reference<DataType>::type::ColumnType;
-        const auto* col_with_type = assert_cast<const ColumnType*>(&source_column);
+        const auto* col_with_type = &source_column;
 
         size_t row_count = source_column.size();
         {

--- a/be/test/core/data_type/data_type_datetime_v2_test.cpp
+++ b/be/test/core/data_type/data_type_datetime_v2_test.cpp
@@ -768,7 +768,7 @@ TEST_F(DataTypeDateTimeV2Test, to_string) {
         std::cout << "test datatype to string: " << dt.get_family_name() << std::endl;
         using DataType = decltype(dt);
         using ColumnType = typename std::remove_reference<DataType>::type::ColumnType;
-        const auto* col_with_type = assert_cast<const ColumnType*>(&source_column);
+        const auto* col_with_type = &source_column;
 
         size_t row_count = source_column.size();
         {

--- a/be/test/core/data_type/data_type_decimal_test.cpp
+++ b/be/test/core/data_type/data_type_decimal_test.cpp
@@ -534,7 +534,7 @@ TEST_F(DataTypeDecimalTest, to_string) {
         std::cout << "test datatype to string: " << dt.get_family_name() << std::endl;
         using DataType = decltype(dt);
         using ColumnType = typename std::remove_reference<DataType>::type::ColumnType;
-        const auto* col_with_type = assert_cast<const ColumnType*>(&source_column);
+        const auto* col_with_type = &source_column;
 
         size_t row_count = source_column.size();
         {

--- a/be/test/core/data_type/data_type_number_test.cpp
+++ b/be/test/core/data_type/data_type_number_test.cpp
@@ -347,7 +347,7 @@ TEST_F(DataTypeNumberTest, to_string) {
         std::cout << "test datatype to string: " << dt.get_family_name() << std::endl;
         using DataType = decltype(dt);
         using ColumnType = typename std::remove_reference<DataType>::type::ColumnType;
-        const auto* col_with_type = assert_cast<const ColumnType*>(&source_column);
+        const auto* col_with_type = &source_column;
 
         size_t row_count = source_column.size();
         {

--- a/be/test/core/data_type_serde/data_type_serde_varbinary_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_varbinary_test.cpp
@@ -65,7 +65,7 @@ TEST_F(DataTypeVarbinarySerDeTest, Name) {
 TEST_F(DataTypeVarbinarySerDeTest, JsonTextBehavior) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::vector<std::string> vals = {make_bytes(0), make_bytes(5), std::string("ABC", 3)};
     for (auto& v : vals) {
         vb->insert_data(v.data(), v.size());
@@ -80,8 +80,8 @@ TEST_F(DataTypeVarbinarySerDeTest, JsonTextBehavior) {
         auto st = serde.serialize_one_cell_to_json(*col, 1, bw, opt);
         EXPECT_TRUE(st.ok()) << st.to_string();
         bw.commit();
-        auto written = assert_cast<ColumnString&>(*out).get_data_at(0);
-        auto original = assert_cast<ColumnVarbinary&>(*col).get_data_at(1);
+        auto written = out->get_data_at(0);
+        auto original = col->get_data_at(1);
         EXPECT_EQ(written.size, original.size);
         EXPECT_EQ(memcmp(written.data, original.data, original.size), 0);
     }
@@ -118,7 +118,7 @@ TEST_F(DataTypeVarbinarySerDeTest, JsonTextBehavior) {
 TEST_F(DataTypeVarbinarySerDeTest, ProtobufNotSupported) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::string v = make_bytes(4);
     vb->insert_data(v.data(), v.size());
 
@@ -133,7 +133,7 @@ TEST_F(DataTypeVarbinarySerDeTest, ProtobufNotSupported) {
 TEST_F(DataTypeVarbinarySerDeTest, JsonbThrows) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::string v = make_bytes(6);
     vb->insert_data(v.data(), v.size());
 
@@ -151,7 +151,7 @@ TEST_F(DataTypeVarbinarySerDeTest, JsonbThrows) {
 TEST_F(DataTypeVarbinarySerDeTest, MysqlTextAndBinaryAndConst) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::vector<std::string> vals = {make_bytes(1, 0x11), make_bytes(3, 0x22), make_bytes(5, 0x33)};
     for (auto& v : vals) {
         vb->insert_data(v.data(), v.size());
@@ -173,7 +173,7 @@ TEST_F(DataTypeVarbinarySerDeTest, MysqlTextAndBinaryAndConst) {
 TEST_F(DataTypeVarbinarySerDeTest, ArrowWriteSupportedReadNotImplemented) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::string v = make_bytes(2);
     vb->insert_data(v.data(), v.size());
 
@@ -201,7 +201,7 @@ TEST_F(DataTypeVarbinarySerDeTest, ArrowWriteSupportedReadNotImplemented) {
 TEST_F(DataTypeVarbinarySerDeTest, OrcWriteSupported) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::string v = make_bytes(3);
     vb->insert_data(v.data(), v.size());
 
@@ -227,7 +227,7 @@ TEST_F(DataTypeVarbinarySerDeTest, OrcWriteSupported) {
 TEST_F(DataTypeVarbinarySerDeTest, ArrowBinaryAndStringWithNullsAndInvalidType) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::vector<std::string> vals = {std::string("A", 1), std::string("BC", 2),
                                      std::string("XYZ", 3)};
     for (auto& v : vals) {
@@ -292,7 +292,7 @@ TEST_F(DataTypeVarbinarySerDeTest, ArrowBinaryAndStringWithNullsAndInvalidType) 
 TEST_F(DataTypeVarbinarySerDeTest, OrcWriteStartEndNullMapIgnoredAndEmptyRange) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
     std::vector<std::string> vals = {std::string("aa", 2), std::string("bbb", 3),
                                      std::string("cccc", 4)};
     for (auto& v : vals) {
@@ -329,7 +329,7 @@ TEST_F(DataTypeVarbinarySerDeTest, OrcWriteStartEndNullMapIgnoredAndEmptyRange) 
 TEST_F(DataTypeVarbinarySerDeTest, SerializeOneCellToJsonWithRawBytes) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
 
     // Test binary data with embedded NUL character
     std::string v = std::string("A\0B", 3);
@@ -342,7 +342,7 @@ TEST_F(DataTypeVarbinarySerDeTest, SerializeOneCellToJsonWithRawBytes) {
     EXPECT_TRUE(st.ok()) << st.to_string();
     bw.commit();
 
-    auto written = assert_cast<ColumnString&>(*out).get_data_at(0);
+    auto written = out->get_data_at(0);
     EXPECT_EQ(written.size, v.size());
     EXPECT_EQ(memcmp(written.data, v.data(), v.size()), 0);
 }
@@ -350,7 +350,7 @@ TEST_F(DataTypeVarbinarySerDeTest, SerializeOneCellToJsonWithRawBytes) {
 TEST_F(DataTypeVarbinarySerDeTest, DeserializeOneCellFromJsonWithRawBytes) {
     DataTypeVarbinarySerDe serde;
     auto col = ColumnVarbinary::create();
-    auto* vb = assert_cast<ColumnVarbinary*>(col.get());
+    auto* vb = col.get();
 
     // Test 1: String with quotes and backslash, inserted as-is
     {

--- a/be/test/exec/operator/nested_loop_join_probe_operator_test.cpp
+++ b/be/test/exec/operator/nested_loop_join_probe_operator_test.cpp
@@ -59,18 +59,15 @@ TEST_F(NLJAppendProbeDataWithNullTest, NullMapSizeMustMatchNestedColumnAfterInse
     const size_t probe_side_process_count = num_rows;
     const size_t probe_block_start_pos = 0;
 
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_nested_column_ptr()
-            ->insert_range_from(*src_column, probe_block_start_pos, probe_side_process_count);
+    dst_column->get_nested_column_ptr()->insert_range_from(*src_column, probe_block_start_pos,
+                                                           probe_side_process_count);
 
     // The fix: resize_fill must use probe_side_process_count, not 1.
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_null_map_column()
-            .get_data()
-            .resize_fill(origin_sz + probe_side_process_count, 0);
+    dst_column->get_null_map_column().get_data().resize_fill(origin_sz + probe_side_process_count,
+                                                             0);
 
     // Verify: nested column and null map must have the same size.
-    auto* nullable = assert_cast<ColumnNullable*>(dst_column.get());
+    auto* nullable = dst_column.get();
     ASSERT_EQ(nullable->get_nested_column().size(), num_rows);
     ASSERT_EQ(nullable->get_null_map_column().size(), num_rows);
     ASSERT_EQ(nullable->size(), num_rows);
@@ -104,17 +101,12 @@ TEST_F(NLJAppendProbeDataWithNullTest, BugReproNullMapSizeMismatchWhenExtendedBy
     auto origin_sz = dst_column->size();
 
     // Insert N rows into nested column.
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_nested_column_ptr()
-            ->insert_range_from(*src_column, 0, num_rows);
+    dst_column->get_nested_column_ptr()->insert_range_from(*src_column, 0, num_rows);
 
     // Simulate the OLD buggy code: resize_fill(origin_sz + 1, 0)
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_null_map_column()
-            .get_data()
-            .resize_fill(origin_sz + 1, 0);
+    dst_column->get_null_map_column().get_data().resize_fill(origin_sz + 1, 0);
 
-    auto* nullable = assert_cast<ColumnNullable*>(dst_column.get());
+    auto* nullable = dst_column.get();
     // The nested column has 5 rows but null map only has 1 — invariant broken.
     EXPECT_EQ(nullable->get_nested_column().size(), num_rows);
     EXPECT_EQ(nullable->get_null_map_column().size(), 1);
@@ -133,15 +125,10 @@ TEST_F(NLJAppendProbeDataWithNullTest, SingleRowInsertIsCorrect) {
     auto origin_sz = dst_column->size();
     constexpr size_t count = 1;
 
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_nested_column_ptr()
-            ->insert_range_from(*src_column, 0, count);
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_null_map_column()
-            .get_data()
-            .resize_fill(origin_sz + count, 0);
+    dst_column->get_nested_column_ptr()->insert_range_from(*src_column, 0, count);
+    dst_column->get_null_map_column().get_data().resize_fill(origin_sz + count, 0);
 
-    auto* nullable = assert_cast<ColumnNullable*>(dst_column.get());
+    auto* nullable = dst_column.get();
     ASSERT_EQ(nullable->get_nested_column().size(), 1);
     ASSERT_EQ(nullable->get_null_map_column().size(), 1);
     ASSERT_EQ(nullable->size(), 1);
@@ -168,15 +155,10 @@ TEST_F(NLJAppendProbeDataWithNullTest, AppendToNonEmptyColumn) {
     ASSERT_EQ(origin_sz, 2);
 
     constexpr size_t count = 3;
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_nested_column_ptr()
-            ->insert_range_from(*src_column, 0, count);
-    assert_cast<ColumnNullable*>(dst_column.get())
-            ->get_null_map_column()
-            .get_data()
-            .resize_fill(origin_sz + count, 0);
+    dst_column->get_nested_column_ptr()->insert_range_from(*src_column, 0, count);
+    dst_column->get_null_map_column().get_data().resize_fill(origin_sz + count, 0);
 
-    auto* nullable = assert_cast<ColumnNullable*>(dst_column.get());
+    auto* nullable = dst_column.get();
     ASSERT_EQ(nullable->get_nested_column().size(), 5);
     ASSERT_EQ(nullable->get_null_map_column().size(), 5);
     ASSERT_EQ(nullable->size(), 5);

--- a/be/test/exprs/aggregate/vec_retention_test.cpp
+++ b/be/test/exprs/aggregate/vec_retention_test.cpp
@@ -86,8 +86,7 @@ TEST_F(VRetentionTest, testEmpty) {
     auto column_result =
             ColumnArray::create(((DataTypePtr)std::make_shared<DataTypeUInt8>())->create_column());
     agg_function->insert_result_into(place, *column_result);
-    auto& result = assert_cast<ColumnUInt8&>(assert_cast<ColumnArray&>(*column_result).get_data())
-                           .get_data();
+    auto& result = assert_cast<ColumnUInt8&>(column_result->get_data()).get_data();
     for (int i = 0; i < result.size(); i++) {
         EXPECT_EQ(result[i], 0);
     }
@@ -95,8 +94,7 @@ TEST_F(VRetentionTest, testEmpty) {
     auto column_result2 =
             ColumnArray::create(((DataTypePtr)std::make_shared<DataTypeUInt8>())->create_column());
     agg_function->insert_result_into(place2, *column_result2);
-    auto& result2 = assert_cast<ColumnUInt8&>(assert_cast<ColumnArray&>(*column_result2).get_data())
-                            .get_data();
+    auto& result2 = assert_cast<ColumnUInt8&>(column_result2->get_data()).get_data();
     for (int i = 0; i < result2.size(); i++) {
         EXPECT_EQ(result2[i], 0);
     }
@@ -146,8 +144,7 @@ TEST_F(VRetentionTest, testSample) {
     auto column_result2 =
             ColumnArray::create(((DataTypePtr)std::make_shared<DataTypeUInt8>())->create_column());
     agg_function->insert_result_into(place2, *column_result2);
-    auto& result2 = assert_cast<ColumnUInt8&>(assert_cast<ColumnArray&>(*column_result2).get_data())
-                            .get_data();
+    auto& result2 = assert_cast<ColumnUInt8&>(column_result2->get_data()).get_data();
     for (int i = 0; i < result2.size(); i++) {
         EXPECT_EQ(result2[i], 1);
     }
@@ -190,8 +187,7 @@ TEST_F(VRetentionTest, testNoMerge) {
     auto column_result =
             ColumnArray::create(((DataTypePtr)std::make_shared<DataTypeUInt8>())->create_column());
     agg_function->insert_result_into(place, *column_result);
-    auto& result = assert_cast<ColumnUInt8&>(assert_cast<ColumnArray&>(*column_result).get_data())
-                           .get_data();
+    auto& result = assert_cast<ColumnUInt8&>(column_result->get_data()).get_data();
     for (int i = 0; i < result.size(); i++) {
         EXPECT_EQ(result[i], 1);
     }
@@ -240,8 +236,7 @@ TEST_F(VRetentionTest, testSerialize) {
     auto column_result =
             ColumnArray::create(((DataTypePtr)std::make_shared<DataTypeUInt8>())->create_column());
     agg_function->insert_result_into(place2, *column_result);
-    auto& result = assert_cast<ColumnUInt8&>(assert_cast<ColumnArray&>(*column_result).get_data())
-                           .get_data();
+    auto& result = assert_cast<ColumnUInt8&>(column_result->get_data()).get_data();
     for (int i = 0; i < result.size(); i++) {
         if (i == 0) {
             EXPECT_EQ(result[i], 1);
@@ -275,8 +270,7 @@ TEST_F(VRetentionTest, testSerialize) {
     auto column_result2 =
             ColumnArray::create(((DataTypePtr)std::make_shared<DataTypeUInt8>())->create_column());
     agg_function->insert_result_into(place2, *column_result2);
-    auto& result2 = assert_cast<ColumnUInt8&>(assert_cast<ColumnArray&>(*column_result2).get_data())
-                            .get_data();
+    auto& result2 = assert_cast<ColumnUInt8&>(column_result2->get_data()).get_data();
     for (int i = 0; i < result2.size(); i++) {
         if (i == result2.size() - 1) {
             EXPECT_EQ(result2[i], 0);

--- a/be/test/exprs/function/function_variant_element_test.cpp
+++ b/be/test/exprs/function/function_variant_element_test.cpp
@@ -23,7 +23,7 @@ namespace doris {
 
 TEST(function_variant_element_test, extract_from_sparse_column) {
     auto variant_column = ColumnVariant::create(1 /*max_subcolumns_count*/, false);
-    auto* variant_ptr = assert_cast<ColumnVariant*>(variant_column.get());
+    auto* variant_ptr = variant_column.get();
 
     ColumnVariant::Subcolumn subcolumn(0, true, false);
     Field field = Field::create_field<TYPE_STRING>("John");

--- a/be/test/storage/iterator/vertical_merge_iterator_test.cpp
+++ b/be/test/storage/iterator/vertical_merge_iterator_test.cpp
@@ -149,7 +149,7 @@ TEST_F(SparseColumnOptimizationTest, AllNullColumn) {
     std::vector<bool> null_flags = {true, true, true, true, true, true, true, true, true, true};
 
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     // Create destination columns
     auto dst_optimized = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
@@ -161,11 +161,10 @@ TEST_F(SparseColumnOptimizationTest, AllNullColumn) {
     copy_rows_original(src.get(), 0, 10, dst_original.get());
 
     // Verify results are equal
-    EXPECT_TRUE(columns_equal(assert_cast<const ColumnNullable*>(dst_optimized.get()),
-                              assert_cast<const ColumnNullable*>(dst_original.get())));
+    EXPECT_TRUE(columns_equal(dst_optimized.get(), dst_original.get()));
 
     // Verify all are NULL
-    const auto* result = assert_cast<const ColumnNullable*>(dst_optimized.get());
+    const auto* result = dst_optimized.get();
     EXPECT_EQ(result->size(), 10);
     EXPECT_TRUE(is_all_null(result, 0, 10));
 }
@@ -177,7 +176,7 @@ TEST_F(SparseColumnOptimizationTest, AllNonNullColumn) {
                                     false, false, false, false, false};
 
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     auto dst_optimized = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
     auto dst_original = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
@@ -185,11 +184,10 @@ TEST_F(SparseColumnOptimizationTest, AllNonNullColumn) {
     copy_rows_with_optimization(nullable_src, 0, 10, dst_optimized.get());
     copy_rows_original(src.get(), 0, 10, dst_original.get());
 
-    EXPECT_TRUE(columns_equal(assert_cast<const ColumnNullable*>(dst_optimized.get()),
-                              assert_cast<const ColumnNullable*>(dst_original.get())));
+    EXPECT_TRUE(columns_equal(dst_optimized.get(), dst_original.get()));
 
     // Verify all are non-NULL
-    const auto* result = assert_cast<const ColumnNullable*>(dst_optimized.get());
+    const auto* result = dst_optimized.get();
     EXPECT_EQ(result->size(), 10);
     EXPECT_TRUE(is_all_non_null(result, 0, 10));
 
@@ -207,7 +205,7 @@ TEST_F(SparseColumnOptimizationTest, SparseMixedColumn) {
     std::vector<bool> null_flags = {false, true, true, true, true, false, true, true, true, true};
 
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     auto dst_optimized = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
     auto dst_original = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
@@ -215,11 +213,10 @@ TEST_F(SparseColumnOptimizationTest, SparseMixedColumn) {
     copy_rows_with_optimization(nullable_src, 0, 10, dst_optimized.get());
     copy_rows_original(src.get(), 0, 10, dst_original.get());
 
-    EXPECT_TRUE(columns_equal(assert_cast<const ColumnNullable*>(dst_optimized.get()),
-                              assert_cast<const ColumnNullable*>(dst_original.get())));
+    EXPECT_TRUE(columns_equal(dst_optimized.get(), dst_original.get()));
 
     // Verify count
-    const auto* result = assert_cast<const ColumnNullable*>(dst_optimized.get());
+    const auto* result = dst_optimized.get();
     EXPECT_EQ(result->size(), 10);
     EXPECT_EQ(count_non_null(result, 0, 10), 2);
 
@@ -241,7 +238,7 @@ TEST_F(SparseColumnOptimizationTest, DenseMixedColumn) {
                                     false, false, false, false, true};
 
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     auto dst_optimized = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
     auto dst_original = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
@@ -249,10 +246,9 @@ TEST_F(SparseColumnOptimizationTest, DenseMixedColumn) {
     copy_rows_with_optimization(nullable_src, 0, 10, dst_optimized.get());
     copy_rows_original(src.get(), 0, 10, dst_original.get());
 
-    EXPECT_TRUE(columns_equal(assert_cast<const ColumnNullable*>(dst_optimized.get()),
-                              assert_cast<const ColumnNullable*>(dst_original.get())));
+    EXPECT_TRUE(columns_equal(dst_optimized.get(), dst_original.get()));
 
-    const auto* result = assert_cast<const ColumnNullable*>(dst_optimized.get());
+    const auto* result = dst_optimized.get();
     EXPECT_EQ(count_non_null(result, 0, 10), 8);
 }
 
@@ -262,7 +258,7 @@ TEST_F(SparseColumnOptimizationTest, PartialRangeCopy) {
     std::vector<bool> null_flags = {false, true, true, true, true, true, true, true, true, false};
 
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     // Copy middle range (indices 2-7, all NULL)
     auto dst_optimized = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
@@ -271,10 +267,9 @@ TEST_F(SparseColumnOptimizationTest, PartialRangeCopy) {
     copy_rows_with_optimization(nullable_src, 2, 6, dst_optimized.get());
     copy_rows_original(src.get(), 2, 6, dst_original.get());
 
-    EXPECT_TRUE(columns_equal(assert_cast<const ColumnNullable*>(dst_optimized.get()),
-                              assert_cast<const ColumnNullable*>(dst_original.get())));
+    EXPECT_TRUE(columns_equal(dst_optimized.get(), dst_original.get()));
 
-    const auto* result = assert_cast<const ColumnNullable*>(dst_optimized.get());
+    const auto* result = dst_optimized.get();
     EXPECT_EQ(result->size(), 6);
     EXPECT_TRUE(is_all_null(result, 0, 6));
 }
@@ -292,7 +287,7 @@ TEST_F(SparseColumnOptimizationTest, LargeSparseCopy) {
     }
 
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     auto dst_optimized = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
     auto dst_original = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
@@ -300,10 +295,9 @@ TEST_F(SparseColumnOptimizationTest, LargeSparseCopy) {
     copy_rows_with_optimization(nullable_src, 0, num_rows, dst_optimized.get());
     copy_rows_original(src.get(), 0, num_rows, dst_original.get());
 
-    EXPECT_TRUE(columns_equal(assert_cast<const ColumnNullable*>(dst_optimized.get()),
-                              assert_cast<const ColumnNullable*>(dst_original.get())));
+    EXPECT_TRUE(columns_equal(dst_optimized.get(), dst_original.get()));
 
-    const auto* result = assert_cast<const ColumnNullable*>(dst_optimized.get());
+    const auto* result = dst_optimized.get();
     EXPECT_EQ(result->size(), num_rows);
     // 1024 / 20 = 51.2 -> 52 non-NULL rows (0, 20, 40, ..., 1000, 1020)
     EXPECT_EQ(count_non_null(result, 0, num_rows), 52);
@@ -315,7 +309,7 @@ TEST_F(SparseColumnOptimizationTest, MultipleCopies) {
     std::vector<bool> null_flags = {false, true, true, true, false};
 
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     auto dst_optimized = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
     auto dst_original = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
@@ -326,10 +320,9 @@ TEST_F(SparseColumnOptimizationTest, MultipleCopies) {
         copy_rows_original(src.get(), 0, 5, dst_original.get());
     }
 
-    EXPECT_TRUE(columns_equal(assert_cast<const ColumnNullable*>(dst_optimized.get()),
-                              assert_cast<const ColumnNullable*>(dst_original.get())));
+    EXPECT_TRUE(columns_equal(dst_optimized.get(), dst_original.get()));
 
-    const auto* result = assert_cast<const ColumnNullable*>(dst_optimized.get());
+    const auto* result = dst_optimized.get();
     EXPECT_EQ(result->size(), 15);
     EXPECT_EQ(count_non_null(result, 0, 15), 6); // 2 non-NULL per copy * 3 copies
 }
@@ -348,7 +341,7 @@ TEST_F(SparseColumnOptimizationTest, DisabledOptimization) {
     // When disabled, should still work correctly via direct copy path
     copy_rows_original(src.get(), 0, 5, dst.get());
 
-    const auto* result = assert_cast<const ColumnNullable*>(dst.get());
+    const auto* result = dst.get();
     EXPECT_EQ(result->size(), 5);
     EXPECT_TRUE(is_all_null(result, 0, 5));
 }
@@ -359,11 +352,11 @@ TEST_F(SparseColumnOptimizationTest, ReplaceColumnDataRange) {
     std::vector<bool> src_null_flags = {false, true, false, true, false};
 
     auto src = create_nullable_column(src_values, src_null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     // Create destination with pre-filled NULLs
     auto dst = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
-    auto* nullable_dst = assert_cast<ColumnNullable*>(dst.get());
+    auto* nullable_dst = dst.get();
 
     // Pre-fill with NULLs
     nullable_dst->get_null_map_column().get_data().resize_fill(5, 1);
@@ -589,11 +582,11 @@ TEST_F(SparseColumnOptimizationTest, AllNonNullBatchOptimization) {
     std::vector<Int64> values = {10, 20, 30, 40, 50};
     std::vector<bool> null_flags = {false, false, false, false, false};
     auto src = create_nullable_column(values, null_flags);
-    const auto* nullable_src = assert_cast<const ColumnNullable*>(src.get());
+    const auto* nullable_src = src.get();
 
     // Create destination with pre-filled NULLs (simulating sparse optimization)
     auto dst = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
-    auto* nullable_dst = assert_cast<ColumnNullable*>(dst.get());
+    auto* nullable_dst = dst.get();
 
     // Pre-fill with NULLs
     nullable_dst->get_null_map_column().get_data().resize_fill(5, 1); // all NULL
@@ -635,7 +628,7 @@ TEST_F(SparseColumnOptimizationTest, BatchReplaceWithOffset) {
 
     // Create destination pre-filled with NULLs
     auto dst = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
-    auto* nullable_dst = assert_cast<ColumnNullable*>(dst.get());
+    auto* nullable_dst = dst.get();
 
     nullable_dst->get_null_map_column().get_data().resize_fill(5, 1);
     nullable_dst->get_nested_column().resize(5);
@@ -663,7 +656,7 @@ TEST_F(SparseColumnOptimizationTest, BatchReplaceWithOffset) {
 TEST_F(SparseColumnOptimizationTest, MixedBatchProcessing) {
     // Test mixed scenario: some batches all-NULL, some all-non-NULL, some mixed
     auto dst = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
-    auto* nullable_dst = assert_cast<ColumnNullable*>(dst.get());
+    auto* nullable_dst = dst.get();
 
     // Pre-fill with 15 NULLs
     nullable_dst->get_null_map_column().get_data().resize_fill(15, 1);
@@ -682,7 +675,7 @@ TEST_F(SparseColumnOptimizationTest, MixedBatchProcessing) {
     std::vector<Int64> values3 = {100, 101, 102, 103, 104};
     std::vector<bool> null_flags3 = {false, true, false, true, false};
     auto src3 = create_nullable_column(values3, null_flags3);
-    const auto* nullable_src3 = assert_cast<const ColumnNullable*>(src3.get());
+    const auto* nullable_src3 = src3.get();
     const auto& null_map3 = nullable_src3->get_null_map_data();
 
     for (size_t i = 0; i < 5; ++i) {
@@ -730,7 +723,7 @@ TEST_F(SparseColumnOptimizationTest, LargeBatchMemcpyPerformance) {
 
     // Create destination pre-filled with NULLs
     auto dst = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
-    auto* nullable_dst = assert_cast<ColumnNullable*>(dst.get());
+    auto* nullable_dst = dst.get();
     nullable_dst->get_null_map_column().get_data().resize_fill(num_rows, 1);
     nullable_dst->get_nested_column().resize(num_rows);
 
@@ -1110,7 +1103,7 @@ TEST_F(SparseColumnOptimizationTest, NullableColumnAllNullReplace) {
     auto src = create_nullable_column(src_values, src_null_flags);
 
     auto dst = ColumnNullable::create(ColumnInt64::create(), ColumnUInt8::create());
-    auto* nullable_dst = assert_cast<ColumnNullable*>(dst.get());
+    auto* nullable_dst = dst.get();
 
     // Pre-fill with non-NULL values
     for (int i = 0; i < 5; ++i) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

BE code currently allows assert_cast usages where From and To are effectively the same type after removing cv/ref qualifiers, so a large number of no-op casts have accumulated across column, expression, storage, and format code. This weakens the signal of assert_cast, obscures the real static type of nullable maps and result columns, and leaves obviously redundant casts unnoticed during development. 

Root cause: assert_cast only checked the requested cast form and did not reject semantically identical types such as cv/ref-qualified aliases or pointer variants with cv-qualified pointees. This change normalizes assert_cast template arguments, adds a compile-time static_assert to ban same-type casts, and updates the existing C++ call sites to use direct access or explicit static_cast only where the holder is still base-typed.
Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

