### PR TITLE
 [fix](uniform function) fix constant argument handling and use ColumnView                                                                                                    

### DIFF
--- a/be/src/exprs/function/uniform.cpp
+++ b/be/src/exprs/function/uniform.cpp
@@ -30,6 +30,7 @@
 #include "core/block/block.h"
 #include "core/block/column_numbers.h"
 #include "core/column/column.h"
+#include "core/column/column_execute_util.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h" // IWYU pragma: keep
 #include "core/data_type/primitive_type.h"
@@ -73,12 +74,12 @@ struct UniformIntImpl {
                     "uniform's min should be less than max, but got [{}, {})", min, max);
         }
 
-        // Get gen column (seed values)
-        const auto& gen_column = block.get_by_position(arguments[2]).column;
+        auto gen_column =
+                ColumnView<TYPE_BIGINT>::create(block.get_by_position(arguments[2]).column);
 
         for (int i = 0; i < input_rows_count; i++) {
             // Use gen value as seed for each row
-            auto seed = (*gen_column)[i].get<TYPE_BIGINT>();
+            auto seed = gen_column.value_at(i);
             std::mt19937_64 generator(seed);
             std::uniform_int_distribution<int64_t> distribution(min, max);
             res_data[i] = distribution(generator);
@@ -122,11 +123,12 @@ struct UniformDoubleImpl {
         }
 
         // Get gen column (seed values)
-        const auto& gen_column = block.get_by_position(arguments[2]).column;
+        auto gen_column =
+                ColumnView<TYPE_BIGINT>::create(block.get_by_position(arguments[2]).column);
 
         for (int i = 0; i < input_rows_count; i++) {
             // Use gen value as seed for each row
-            auto seed = (*gen_column)[i].get<TYPE_BIGINT>();
+            auto seed = gen_column.value_at(i);
             std::mt19937_64 generator(seed);
             std::uniform_real_distribution<double> distribution(min, max);
             res_data[i] = distribution(generator);
@@ -156,6 +158,8 @@ public:
     DataTypes get_variadic_argument_types_impl() const override {
         return Impl::get_variadic_argument_types();
     }
+
+    ColumnNumbers get_arguments_that_are_always_constant() const override { return {0, 1}; }
 
     Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
         // init_function_context do set_constant_cols for FRAGMENT_LOCAL scope

--- a/regression-test/suites/nereids_function_p0/scalar_function/U.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/U.groovy
@@ -62,6 +62,8 @@ suite("nereids_scalar_fn_U") {
 
 	def result = sql """select uniform(1, 100, random()*10000) from numbers("number" = "10");"""
 	assertTrue(result.size() == 10)
+	def doubleResult = sql """select uniform(1.23, 100.100, random()*10000) from numbers("number" = "10");"""
+	assertTrue(doubleResult.size() == 10)
 	test {
 		sql """select uniform(100, 1, random()*10000) from numbers("number" = "10");"""
 		exception "uniform's min should be less than max"


### PR DESCRIPTION
                                                                                                                                                              
  What problem does this PR solve?                                                                                                                                   
                                                                                                                                                                     
  Issue Number: N/A                                                                                                                                                  
                                                                                                                                                                     
  Problem Summary:                                                                                                                                                   
                                                                  
  The uniform function takes three arguments: min, max, and seed. Only the first two (min, max) are truly "always constant" — the seed column should be treated as a 
  regular column, not a constant. Without overriding get_arguments_that_are_always_constant(), when a user passes a constant value as the third argument (seed), the
  default framework logic treats it as a constant column, leading to incorrect results.                                                                              
                                                                  
  Root cause: the base class default get_arguments_that_are_always_constant() does not distinguish between the seed argument and the min/max arguments, so a constant
   seed would be folded by the constant-handling path rather than being treated as a per-row value.
                                                                                                                                                                     
  Fix:                                                                                                                                                               
  - Override get_arguments_that_are_always_constant() to return {0, 1}, explicitly marking only min and max as always-constant arguments.
  - Refactor seed column access to use ColumnView<TYPE_BIGINT> for safer and more idiomatic typed column iteration.                                                  


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

