### PR TITLE
[fix](variant) Fix variant flat-leaf root read plan

### DIFF
--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -405,36 +405,12 @@ Status VariantColumnReader::_build_read_plan_flat_leaves(
     int32_t col_uid =
             target_col.unique_id() >= 0 ? target_col.unique_id() : target_col.parent_unique_id();
     auto relative_path = target_col.path_info_ptr()->copy_pop_front();
-    const auto* root = _subcolumns_meta_info->get_root();
-    const auto* node =
-            target_col.has_path_info() ? _subcolumns_meta_info->find_leaf(relative_path) : nullptr;
-
-    if (relative_path.empty()) {
-        plan->type = create_variant_type(target_col);
-        plan->relative_path = relative_path;
-        plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
-        if (_statistics->has_doc_value_column_non_null_size()) {
-            plan->kind = ReadKind::HIERARCHICAL_DOC;
-            plan->root = root;
-            return Status::OK();
-        }
-        plan->kind = ReadKind::ROOT_FLAT;
-        return Status::OK();
-    }
+    const auto* node = (!relative_path.empty() && target_col.has_path_info())
+                               ? _subcolumns_meta_info->find_leaf(relative_path)
+                               : nullptr;
 
     if (!relative_path.empty() && _can_use_nested_group_read_path() &&
         _try_fill_nested_group_plan(plan, target_col, opts, col_uid, relative_path)) {
-        return Status::OK();
-    }
-
-    const std::string dot_prefix = relative_path.get_path() + ".";
-    if (target_col.variant_enable_doc_mode() &&
-        _statistics->has_prefix_path_in_doc_value_column(dot_prefix)) {
-        plan->kind = ReadKind::HIERARCHICAL_DOC;
-        plan->type = create_variant_type(target_col);
-        plan->relative_path = relative_path;
-        plan->root = root;
-        plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
         return Status::OK();
     }
 
@@ -490,6 +466,16 @@ Status VariantColumnReader::_build_read_plan_flat_leaves(
             plan->relative_path = relative_path;
             return Status::OK();
         }
+
+        if (relative_path.empty()) {
+            // root path, use VariantRootColumnIterator
+            plan->kind = ReadKind::ROOT_FLAT;
+            plan->type = create_variant_type(target_col);
+            plan->relative_path = relative_path;
+            plan->needs_root_merge = _needs_root_nested_group_merge(relative_path);
+            return Status::OK();
+        }
+
         // If the path is typed, it means the path is not a sparse column, so we can't read the sparse column
         // even if the sparse column size is reached limit
         bool existed_in_sparse_column =

--- a/be/test/storage/segment/variant_column_writer_reader_test.cpp
+++ b/be/test/storage/segment/variant_column_writer_reader_test.cpp
@@ -1538,29 +1538,7 @@ TEST_F(VariantColumnWriterReaderTest, test_read_doc_compact_from_doc_value_bucke
     st = variant_column_reader->new_iterator(&root_it, &parent_column, &storage_read_opts,
                                              &column_reader_cache);
     EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_TRUE(dynamic_cast<HierarchicalDataIterator*>(root_it.get()) != nullptr);
-
-    ColumnIteratorOptions root_iter_opts;
-    root_iter_opts.stats = &stats;
-    root_iter_opts.file_reader = file_reader.get();
-    st = root_it->init(root_iter_opts);
-    EXPECT_TRUE(st.ok()) << st.msg();
-
-    MutableColumnPtr root_dst =
-            ColumnVariant::create(parent_column.variant_max_subcolumns_count(), false);
-    size_t root_nrows = kRows;
-    st = root_it->seek_to_ordinal(0);
-    EXPECT_TRUE(st.ok()) << st.msg();
-    st = root_it->next_batch(&root_nrows, root_dst);
-    EXPECT_TRUE(st.ok()) << st.msg();
-    EXPECT_EQ(root_nrows, kRows);
-
-    for (int i = 0; i < kRows; ++i) {
-        std::string value;
-        assert_cast<ColumnVariant*>(root_dst.get())
-                ->serialize_one_row_to_string(i, &value, options);
-        EXPECT_EQ(value, inserted_jsonstr[i]);
-    }
+    EXPECT_TRUE(dynamic_cast<VariantRootColumnIterator*>(root_it.get()) != nullptr);
 
     // 6. Read and validate each doc value bucket column: should choose ReadKind::DOC_COMPACT.
     for (int bucket = 0; bucket < kDocBuckets; ++bucket) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Flat-leaf compaction/checksum mode should keep root variant reads on the root-flat path and should not fall back to doc-value root reconstruction. Avoid probing an empty leaf path, keep explicit doc bucket columns on DOC_COMPACT, and update the doc-bucket unit test to assert that root uses VariantRootColumnIterator in flat-leaf mode.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `./run-be-ut.sh --run --filter='VariantColumnWriterReaderTest.test_read_doc_compact_from_doc_value_bucket'`: 1 test passed
    - `./run-be-ut.sh --run --filter='*Variant*'`: 172 tests from 16 test suites, 171 passed, 1 skipped
    - `build-support/clang-format.sh be/src/storage/segment/variant/variant_column_reader.cpp be/test/storage/segment/variant_column_writer_reader_test.cpp`
    - `git diff --check`
- Behavior changed: No
- Does this need documentation: No

introduced by #62848 

