### PR TITLE
[fix](statistics) Skip statistics cache for system dbs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -19,6 +19,8 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.analysis.ColumnDef;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.InternalSchema;
 import org.apache.doris.catalog.MysqlDb;
@@ -29,6 +31,7 @@ import org.apache.doris.datasource.InternalCatalog;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -131,6 +134,17 @@ public class StatisticConstants {
             }
         }
         return false;
+    }
+
+    public static boolean isSystemDb(long catalogId, long dbId) {
+        if (catalogId != InternalCatalog.INTERNAL_CATALOG_ID) {
+            return false;
+        }
+        if (dbId == InfoSchemaDb.DATABASE_ID || dbId == MysqlDb.DATABASE_ID) {
+            return true;
+        }
+        Optional<Database> internalDb = Env.getCurrentEnv().getInternalCatalog().getDb(FeConstants.INTERNAL_DB_NAME);
+        return internalDb.isPresent() && internalDb.get().getId() == dbId;
     }
 
     public static boolean shouldIgnoreCol(TableIf tableIf, Column c) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -93,7 +93,7 @@ public class StatisticsCache {
 
     public ColumnStatistic getColumnStatistics(
             long catalogId, long dbId, long tblId, long idxId, String colName, ConnectContext ctx) {
-        if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
+        if (shouldReturnUnknownStats(catalogId, dbId, ctx)) {
             return ColumnStatistic.UNKNOWN;
         }
         // Need to change base index id to -1 for OlapTable.
@@ -130,7 +130,7 @@ public class StatisticsCache {
 
     public PartitionColumnStatistic getPartitionColumnStatistics(long catalogId, long dbId, long tblId, long idxId,
                                                   String partName, String colName, ConnectContext ctx) {
-        if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
+        if (shouldReturnUnknownStats(catalogId, dbId, ctx)) {
             return PartitionColumnStatistic.UNKNOWN;
         }
         // Need to change base index id to -1 for OlapTable.
@@ -157,6 +157,18 @@ public class StatisticsCache {
         return PartitionColumnStatistic.UNKNOWN;
     }
 
+    private boolean shouldReturnUnknownStats(long catalogId, long dbId, ConnectContext ctx) {
+        return isPlanWithUnknownColumnStats(ctx) || StatisticConstants.isSystemDb(catalogId, dbId);
+    }
+
+    private boolean shouldReturnUnknownStats(long catalogId, long dbId, TableIf table, ConnectContext ctx) {
+        return shouldReturnUnknownStats(catalogId, dbId, ctx) || StatisticConstants.isSystemTable(table);
+    }
+
+    private boolean isPlanWithUnknownColumnStats(ConnectContext ctx) {
+        return ctx != null && ctx.getState().isPlanWithUnKnownColumnStats();
+    }
+
     // Base index id should be set to -1 for OlapTable. Because statistics tables use -1 for base index.
     // TODO: Need to use the real index id in statistics table in later version.
     private long changeBaseIndexId(long catalogId, long dbId, long tblId, long idxId) {
@@ -178,7 +190,7 @@ public class StatisticsCache {
 
     private Optional<Histogram> getHistogram(long ctlId, long dbId, long tblId, long idxId, String colName) {
         ConnectContext ctx = ConnectContext.get();
-        if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
+        if (shouldReturnUnknownStats(ctlId, dbId, ctx)) {
             return Optional.empty();
         }
         StatisticsCacheKey k = new StatisticsCacheKey(ctlId, dbId, tblId, idxId, colName);
@@ -398,10 +410,7 @@ public class StatisticsCache {
 
         // this method can avoid compute table and select index id
         public ColumnStatistic getColumnStatistics(String colName, ConnectContext ctx) {
-            if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
-                return ColumnStatistic.UNKNOWN;
-            }
-            if (StatisticConstants.isSystemTable(olapTable)) {
+            if (shouldReturnUnknownStats(catalogId, schemaId, olapTable, ctx)) {
                 return ColumnStatistic.UNKNOWN;
             }
             return doGetColumnStatistics(
@@ -411,10 +420,7 @@ public class StatisticsCache {
 
         public PartitionColumnStatistic getPartitionColumnStatistics(
                 String partName, String colName, ConnectContext ctx) {
-            if (ctx != null && ctx.getState().isPlanWithUnKnownColumnStats()) {
-                return PartitionColumnStatistic.UNKNOWN;
-            }
-            if (StatisticConstants.isSystemTable(olapTable)) {
+            if (shouldReturnUnknownStats(catalogId, schemaId, olapTable, ctx)) {
                 return PartitionColumnStatistic.UNKNOWN;
             }
             return doGetPartitionColumnStatistics(

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
@@ -172,9 +172,9 @@ public class CacheTest extends TestWithFeService {
                     }).when(mock).doLoad(Mockito.any());
                 })) {
             StatisticsCache statisticsCache = new StatisticsCache();
-            statisticsCache.refreshHistogramSync(0, 0, 0, -1, "col");
+            statisticsCache.refreshHistogramSync(1, 1, 0, -1, "col");
             Thread.sleep(10000);
-            Histogram histogram = statisticsCache.getHistogram(0, 0, 0, "col");
+            Histogram histogram = statisticsCache.getHistogram(1, 1, 0, "col");
             Assertions.assertNotNull(histogram);
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsCacheTest.java
@@ -17,10 +17,14 @@
 
 package org.apache.doris.statistics;
 
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.UtFrameUtils;
@@ -30,6 +34,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 public class StatisticsCacheTest {
@@ -111,6 +116,65 @@ public class StatisticsCacheTest {
                     olapTableStats.getPartitionColumnStatistics("p1", "col", ConnectContext.get()));
 
             Mockito.verifyNoInteractions(columnLoader.constructed().get(0));
+            Mockito.verifyNoInteractions(partitionLoader.constructed().get(0));
+        }
+    }
+
+    @Test
+    public void testGetStatisticsSkipSystemDb() {
+        try (MockedConstruction<ColumnStatisticsCacheLoader> columnLoader = Mockito.mockConstruction(
+                ColumnStatisticsCacheLoader.class);
+                MockedConstruction<HistogramCacheLoader> histogramLoader = Mockito.mockConstruction(
+                        HistogramCacheLoader.class);
+                MockedConstruction<PartitionColumnStatisticCacheLoader> partitionLoader = Mockito.mockConstruction(
+                        PartitionColumnStatisticCacheLoader.class)) {
+            StatisticsCache cache = new StatisticsCache();
+
+            Assertions.assertEquals(ColumnStatistic.UNKNOWN, cache.getColumnStatistics(
+                    InternalCatalog.INTERNAL_CATALOG_ID, InfoSchemaDb.DATABASE_ID, 1L, 2L,
+                    "col", ConnectContext.get()));
+            Assertions.assertEquals(PartitionColumnStatistic.UNKNOWN, cache.getPartitionColumnStatistics(
+                    InternalCatalog.INTERNAL_CATALOG_ID, InfoSchemaDb.DATABASE_ID, 1L, 2L,
+                    "p1", "col", ConnectContext.get()));
+            Assertions.assertNull(cache.getHistogram(
+                    InternalCatalog.INTERNAL_CATALOG_ID, InfoSchemaDb.DATABASE_ID, 1L, "col"));
+
+            Mockito.verifyNoInteractions(columnLoader.constructed().get(0));
+            Mockito.verifyNoInteractions(histogramLoader.constructed().get(0));
+            Mockito.verifyNoInteractions(partitionLoader.constructed().get(0));
+        }
+    }
+
+    @Test
+    public void testGetStatisticsSkipInternalSchemaDb() {
+        long internalSchemaDbId = 12345L;
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog internalCatalog = Mockito.mock(InternalCatalog.class);
+        Mockito.when(env.getInternalCatalog()).thenReturn(internalCatalog);
+        Mockito.when(internalCatalog.getDb(FeConstants.INTERNAL_DB_NAME))
+                .thenReturn(java.util.Optional.of(new Database(internalSchemaDbId, FeConstants.INTERNAL_DB_NAME)));
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class);
+                MockedConstruction<ColumnStatisticsCacheLoader> columnLoader = Mockito.mockConstruction(
+                        ColumnStatisticsCacheLoader.class);
+                MockedConstruction<HistogramCacheLoader> histogramLoader = Mockito.mockConstruction(
+                        HistogramCacheLoader.class);
+                MockedConstruction<PartitionColumnStatisticCacheLoader> partitionLoader = Mockito.mockConstruction(
+                        PartitionColumnStatisticCacheLoader.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            StatisticsCache cache = new StatisticsCache();
+
+            Assertions.assertEquals(ColumnStatistic.UNKNOWN, cache.getColumnStatistics(
+                    InternalCatalog.INTERNAL_CATALOG_ID, internalSchemaDbId, 1L, 2L,
+                    "col", ConnectContext.get()));
+            Assertions.assertEquals(PartitionColumnStatistic.UNKNOWN, cache.getPartitionColumnStatistics(
+                    InternalCatalog.INTERNAL_CATALOG_ID, internalSchemaDbId, 1L, 2L,
+                    "p1", "col", ConnectContext.get()));
+            Assertions.assertNull(cache.getHistogram(
+                    InternalCatalog.INTERNAL_CATALOG_ID, internalSchemaDbId, 1L, "col"));
+
+            Mockito.verifyNoInteractions(columnLoader.constructed().get(0));
+            Mockito.verifyNoInteractions(histogramLoader.constructed().get(0));
             Mockito.verifyNoInteractions(partitionLoader.constructed().get(0));
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

Statistics cache may still try to load column statistics, partition column statistics, or histograms for system databases. This is not expected for information_schema, mysql, or the dynamically assigned __internal_schema database.

### Solution

- Add a system database check in StatisticConstants.
- Reuse the check in StatisticsCache for column statistics, partition statistics, and histograms.
- Resolve __internal_schema by looking up the internal catalog DB object so the dynamic db id is covered.

### Check List

- [x] FE UT

### Test

- StatisticsCacheTest

Result: BUILD SUCCESS. StatisticsCacheTest ran 6 tests with 0 failures and 0 errors.