### PR TITLE
 [refine](Field) rename Tuple to Struct in BE core types

### DIFF
--- a/be/src/core/column/column_struct.cpp
+++ b/be/src/core/column/column_struct.cpp
@@ -107,7 +107,7 @@ Field ColumnStruct::operator[](size_t n) const {
 void ColumnStruct::get(size_t n, Field& res) const {
     const size_t tuple_size = columns.size();
 
-    res = Field::create_field<TYPE_STRUCT>(Tuple());
+    res = Field::create_field<TYPE_STRUCT>(Struct());
     auto& res_tuple = res.get<TYPE_STRUCT>();
     res_tuple.reserve(tuple_size);
 
@@ -121,10 +121,11 @@ void ColumnStruct::insert(const Field& x) {
     const auto& tuple = x.get<TYPE_STRUCT>();
     const size_t tuple_size = columns.size();
     if (tuple.size() != tuple_size) {
-        throw doris::Exception(ErrorCode::INTERNAL_ERROR,
-                               "Cannot insert value of different size into tuple. field tuple size "
-                               "{}, columns size {}",
-                               tuple.size(), tuple_size);
+        throw doris::Exception(
+                ErrorCode::INTERNAL_ERROR,
+                "Cannot insert value of different size into struct. field struct size "
+                "{}, columns size {}",
+                tuple.size(), tuple_size);
     }
 
     for (size_t i = 0; i < tuple_size; ++i) {
@@ -138,7 +139,7 @@ void ColumnStruct::insert_from(const IColumn& src_, size_t n) {
     const size_t tuple_size = columns.size();
     if (src.columns.size() != tuple_size) {
         throw doris::Exception(ErrorCode::INTERNAL_ERROR,
-                               "Cannot insert value of different size into tuple.");
+                               "Cannot insert value of different size into struct.");
         __builtin_unreachable();
     }
 

--- a/be/src/core/data_type/convert_field_to_type.cpp
+++ b/be/src/core/data_type/convert_field_to_type.cpp
@@ -215,7 +215,7 @@ public:
     }
     void operator()(const Array& x, JsonbWriter* writer) const;
 
-    void operator()(const Tuple& x, JsonbWriter* writer) const {
+    void operator()(const Struct& x, JsonbWriter* writer) const {
         throw doris::Exception(doris::ErrorCode::NOT_IMPLEMENTED_ERROR, "Not implemeted");
     }
     void operator()(const Decimal32& x, JsonbWriter* writer) const {

--- a/be/src/core/data_type/data_type.h
+++ b/be/src/core/data_type/data_type.h
@@ -131,7 +131,7 @@ public:
 
     virtual bool equals_ignore_precision(const IDataType& rhs) const { return equals(rhs); }
 
-    /** Example: numbers, Date, DateTime, FixedString, Enum... Nullable and Tuple of such types.
+    /** Example: numbers, Date, DateTime, FixedString, Enum... Nullable and Struct of such types.
       * Counterexamples: String, Array.
       * It's Ok to return false for AggregateFunction despite the fact that some of them have fixed size state.
       */

--- a/be/src/core/data_type/data_type_struct.cpp
+++ b/be/src/core/data_type/data_type_struct.cpp
@@ -61,11 +61,11 @@ static Status check_tuple_names(const Strings& names) {
     std::unordered_set<String> names_set;
     for (const auto& name : names) {
         if (name.empty()) {
-            return Status::InvalidArgument("Names of tuple elements cannot be empty");
+            return Status::InvalidArgument("Names of struct elements cannot be empty");
         }
 
         if (!names_set.insert(name).second) {
-            return Status::InvalidArgument("Names of tuple elements must be unique");
+            return Status::InvalidArgument("Names of struct elements must be unique");
         }
     }
 

--- a/be/src/core/data_type/primitive_type.h
+++ b/be/src/core/data_type/primitive_type.h
@@ -47,7 +47,7 @@ class ColumnVarbinary;
 using ColumnString = ColumnStr<UInt32>;
 class JsonbField;
 struct Array;
-struct Tuple;
+struct Struct;
 struct Map;
 struct FieldWithDataType;
 using VariantMap = std::map<PathInData, FieldWithDataType>;
@@ -487,7 +487,7 @@ struct PrimitiveTypeTraits<TYPE_MAP> {
 };
 template <>
 struct PrimitiveTypeTraits<TYPE_STRUCT> {
-    using CppType = Tuple;
+    using CppType = Struct;
     using StorageFieldType = CppType;
     using DataType = DataTypeStruct;
     using ColumnType = ColumnStruct;

--- a/be/src/core/field.h
+++ b/be/src/core/field.h
@@ -58,16 +58,16 @@ class Field;
 
 using FieldVector = std::vector<Field>;
 
-/// Array and Tuple use the same storage type -- FieldVector, but we declare
+/// Array and Struct use the same storage type -- FieldVector, but we declare
 /// distinct types for them, so that the caller can choose whether it wants to
-/// construct a Field of Array or a Tuple type. An alternative approach would be
+/// construct a Field of Array or a Struct type. An alternative approach would be
 /// to construct both of these types from FieldVector, and have the caller
 /// specify the desired Field type explicitly.
 struct Array : public FieldVector {
     using FieldVector::FieldVector;
 };
 
-struct Tuple : public FieldVector {
+struct Struct : public FieldVector {
     using FieldVector::FieldVector;
 };
 
@@ -286,7 +286,7 @@ public:
 
 private:
     std::aligned_union_t<DBMS_MIN_FIELD_SIZE - sizeof(PrimitiveType), Null, UInt64, UInt128, Int64,
-                         Int128, IPv6, Float64, String, JsonbField, StringView, Array, Tuple, Map,
+                         Int128, IPv6, Float64, String, JsonbField, StringView, Array, Struct, Map,
                          VariantMap, Decimal32, Decimal64, DecimalV2Value, Decimal128V3, Decimal256,
                          BitmapValue, HyperLogLog, QuantileState>
             storage;

--- a/be/src/exprs/vstruct_literal.cpp
+++ b/be/src/exprs/vstruct_literal.cpp
@@ -36,7 +36,7 @@ namespace doris {
 Status VStructLiteral::prepare(RuntimeState* state, const RowDescriptor& row_desc,
                                VExprContext* context) {
     RETURN_IF_ERROR_OR_PREPARED(VExpr::prepare(state, row_desc, context));
-    Field struct_field = Field::create_field<TYPE_STRUCT>(Tuple());
+    Field struct_field = Field::create_field<TYPE_STRUCT>(Struct());
     for (const auto& child : _children) {
         Field item;
         auto child_literal = std::dynamic_pointer_cast<const VLiteral>(child);

--- a/be/src/util/json/json_parser.cpp
+++ b/be/src/util/json/json_parser.cpp
@@ -369,9 +369,9 @@ StringRef JSONDataParser<ParserImpl>::getNameOfNested(const PathInData::Parts& p
         return {};
     }
     /// Find first key that is marked as nested,
-    /// because we may have tuple of Nested and there could be
+    /// because we may have struct of Nested and there could be
     /// several arrays with the same prefix, but with independent sizes.
-    /// Consider we have array element with type `k2 Tuple(k3 Nested(...), k5 Nested(...))`
+    /// Consider we have array element with type `k2 Struct(k3 Nested(...), k5 Nested(...))`
     /// Then subcolumns `k2.k3` and `k2.k5` may have indepented sizes and we should extract
     /// `k3` and `k5` keys instead of `k2`.
     for (const auto& part : path) {

--- a/be/test/core/column/column_hash_func_test.cpp
+++ b/be/test/core/column/column_hash_func_test.cpp
@@ -239,7 +239,7 @@ TEST(HashFuncTest, StructTypeTestWithSepcificValueCrcHash) {
     dataTypes.push_back(n1);
     dataTypes.push_back(s1);
 
-    Tuple t;
+    Struct t;
     t.push_back(Field::create_field<TYPE_BIGINT>(Int64(1)));
     t.push_back(Field::create_field<TYPE_STRING>("hello"));
 

--- a/be/test/core/column/column_variant_test.cpp
+++ b/be/test/core/column/column_variant_test.cpp
@@ -2767,9 +2767,9 @@ TEST_F(ColumnVariantTest, get_field_info_all_types) {
         EXPECT_EQ(info.scalar_type_id, PrimitiveType::TYPE_JSONB);
     }
 
-    // Test Tuple
+    // Test Struct
     {
-        Tuple t1;
+        Struct t1;
         t1.push_back(Field::create_field<TYPE_STRING>(String("amory cute")));
         t1.push_back(Field::create_field<TYPE_BIGINT>(Int64(37)));
         t1.push_back(Field::create_field<TYPE_BOOLEAN>(true));

--- a/be/test/core/data_type/data_type_ip_test.cpp
+++ b/be/test/core/data_type/data_type_ip_test.cpp
@@ -290,7 +290,7 @@ TEST_F(DataTypeIPTest, SerdeTOJsonInComplex) {
     column_map_ipv6->insert(Field::create_field<TYPE_MAP>(ipv6_map));
 
     // pack struct
-    Tuple tuple;
+    Struct tuple;
     tuple.push_back(Field::create_field<TYPE_IPV4>(ipv4_values[0]));
     tuple.push_back(Field::create_field<TYPE_IPV6>(ipv6_values[0]));
     tuple.push_back(Field::create_field<TYPE_ARRAY>(ipv4_array));

--- a/be/test/core/data_type/data_type_map_test.cpp
+++ b/be/test/core/data_type/data_type_map_test.cpp
@@ -439,7 +439,7 @@ TEST_F(DataTypeMapTest, SerdeNestedTypeArrowTest) {
                 std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {f4}));
         DataTypePtr ma = std::make_shared<DataTypeMap>(dt1, dt2);
 
-        Tuple t1, t2, t3, t4;
+        Struct t1, t2, t3, t4;
         t1.push_back(Field::create_field<TYPE_STRING>("clever"));
         t1.push_back(Field::create_field<TYPE_LARGEINT>(__int128_t(37)));
         t1.push_back(Field::create_field<TYPE_BOOLEAN>(true));

--- a/be/test/core/data_type/data_type_struct_test.cpp
+++ b/be/test/core/data_type/data_type_struct_test.cpp
@@ -388,7 +388,7 @@ TEST_F(DataTypeStructTest, SerdeNestedTypeArrowTest) {
         m2.push_back(Field::create_field<TYPE_ARRAY>(v2));
 
         // nested Struct
-        Tuple t1, t2;
+        Struct t1, t2;
         t1.push_back(Field::create_field<TYPE_STRING>("clever"));
         t1.push_back(Field::create_field<TYPE_LARGEINT>(__int128_t(37)));
         t1.push_back(Field::create_field<TYPE_BOOLEAN>(true));
@@ -397,7 +397,7 @@ TEST_F(DataTypeStructTest, SerdeNestedTypeArrowTest) {
         t2.push_back(Field::create_field<TYPE_BOOLEAN>(false));
 
         // Struct
-        Tuple tt1, tt2;
+        Struct tt1, tt2;
         tt1.push_back(Field::create_field<TYPE_ARRAY>(a1));
         tt1.push_back(Field::create_field<TYPE_MAP>(m1));
         tt1.push_back(Field::create_field<TYPE_STRUCT>(t1));
@@ -425,7 +425,7 @@ TEST_F(DataTypeStructTest, writeColumnToOrc) {
     DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {dt1, dt2});
     auto serde = st->get_serde(1);
 
-    Tuple test_data;
+    Struct test_data;
     test_data.push_back(Field::create_field<TYPE_BIGINT>(100));
     test_data.push_back(Field::create_field<TYPE_BIGINT>(200));
 
@@ -468,7 +468,7 @@ TEST_F(DataTypeStructTest, formString) {
     DataTypePtr dt1 = std::make_shared<DataTypeInt32>();
     DataTypePtr dt2 = std::make_shared<DataTypeString>();
     DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {dt1, dt2});
-    Tuple tt1;
+    Struct tt1;
     tt1.push_back(Field::create_field<TYPE_INT>(100));
     tt1.push_back(Field::create_field<TYPE_STRING>("asd"));
 
@@ -500,7 +500,7 @@ TEST_F(DataTypeStructTest, insertColumnLastValueMultipleTimes) {
     DataTypePtr dt1 = std::make_shared<DataTypeInt32>();
     DataTypePtr dt2 = std::make_shared<DataTypeString>();
     DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {dt1, dt2});
-    Tuple tt1;
+    Struct tt1;
     tt1.push_back(Field::create_field<TYPE_INT>(100));
     tt1.push_back(Field::create_field<TYPE_STRING>("asd"));
 

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -358,7 +358,7 @@ std::shared_ptr<Block> create_test_block(std::vector<PrimitiveType> cols, int ro
             DataTypePtr m = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
             DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {s, d, m});
             type_desc = st;
-            Tuple t1, t2;
+            Struct t1, t2;
             t1.push_back(Field::create_field<TYPE_STRING>("amory cute"));
             t1.push_back(Field::create_field<TYPE_LARGEINT>(__int128_t(37)));
             t1.push_back(Field::create_field<TYPE_BOOLEAN>(true));

--- a/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
@@ -547,7 +547,7 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTestStruct) {
     DataTypePtr d = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt128>());
     DataTypePtr m = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
     DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {s, d, m});
-    Tuple t1, t2;
+    Struct t1, t2;
     t1.push_back(Field::create_field<TYPE_STRING>(String("amory cute")));
     t1.push_back(Field::create_field<TYPE_LARGEINT>(__int128_t(37)));
     t1.push_back(Field::create_field<TYPE_BOOLEAN>(true));
@@ -578,7 +578,7 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTestStruct2) {
     DataTypePtr d = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt64>());
     DataTypePtr m = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
     DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {s, d, m});
-    Tuple t1, t2;
+    Struct t1, t2;
     t1.push_back(Field::create_field<TYPE_STRING>(String("amory cute")));
     t1.push_back(Field::create_field<TYPE_BIGINT>(37));
     t1.push_back(Field::create_field<TYPE_BOOLEAN>(true));

--- a/be/test/core/data_type_serde/data_type_to_string_test.cpp
+++ b/be/test/core/data_type_serde/data_type_to_string_test.cpp
@@ -54,7 +54,7 @@ TEST(ToStringMethodTest, DataTypeToStringTest) {
     m.push_back(Field::create_field<TYPE_ARRAY>(a1));
     m.push_back(Field::create_field<TYPE_ARRAY>(a2));
 
-    Tuple t;
+    Struct t;
     t.push_back(Field::create_field<TYPE_LARGEINT>(Int128(12345454342)));
     t.push_back(Field::create_field<TYPE_STRING>(String("amory cute")));
     t.push_back(Field::create_field<TYPE_BIGINT>(Int64(0)));

--- a/be/test/core/jsonb/convert_field_to_type_test.cpp
+++ b/be/test/core/jsonb/convert_field_to_type_test.cpp
@@ -502,7 +502,7 @@ TEST_F(ConvertFieldToTypeTest, ConvertFieldToType_ErrorCases) {
 
     // Test with unsupported types (should throw exception)
     {
-        Field tuple_field = Field::create_field<TYPE_STRUCT>(Tuple());
+        Field tuple_field = Field::create_field<TYPE_STRUCT>(Struct());
 
         EXPECT_THROW(
                 {

--- a/be/test/core/jsonb/serialize_test.cpp
+++ b/be/test/core/jsonb/serialize_test.cpp
@@ -288,7 +288,7 @@ TEST(BlockSerializeTest, Struct) {
         DataTypePtr d = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt128>());
         DataTypePtr m = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeUInt8>());
         DataTypePtr st = std::make_shared<DataTypeStruct>(std::vector<DataTypePtr> {s, d, m});
-        Tuple t1, t2;
+        Struct t1, t2;
         t1.push_back(Field::create_field<TYPE_STRING>(String("amory cute")));
         t1.push_back(Field::create_field<TYPE_LARGEINT>(__int128_t(37)));
         t1.push_back(Field::create_field<TYPE_BOOLEAN>(true));


### PR DESCRIPTION

  
  What problem does this PR solve?

  Issue Number: N/A

  Problem Summary:

  The C++ struct Tuple in be/src/core/field.h is a type alias for FieldVector used to represent STRUCT-typed field values. However, the name "Tuple"
   is misleading — this type corresponds to the STRUCT data type, not a tuple. This rename aligns the C++ type name with the actual semantic: Tuple
  → Struct, along with all references in comments, error messages, and variable names.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

