### PR TITLE
[refine](exec/pipeline) replace std::mutex/std::unique_lock with annotated wrappers for thread safety analysis

### DIFF
--- a/be/src/exec/pipeline/dependency.cpp
+++ b/be/src/exec/pipeline/dependency.cpp
@@ -67,7 +67,7 @@ void Dependency::set_ready() {
     }
     std::vector<std::weak_ptr<PipelineTask>> local_block_task {};
     {
-        std::unique_lock<std::mutex> lc(_task_lock);
+        LockGuard lc(_task_lock);
         if (_ready) {
             return;
         }
@@ -77,14 +77,14 @@ void Dependency::set_ready() {
     }
     for (auto task : local_block_task) {
         if (auto t = task.lock()) {
-            std::unique_lock<std::mutex> lc(_task_lock);
+            LockGuard lc(_task_lock);
             t->wake_up(this, lc);
         }
     }
 }
 
 Dependency* Dependency::is_blocked_by(std::shared_ptr<PipelineTask> task) {
-    std::unique_lock<std::mutex> lc(_task_lock);
+    LockGuard lc(_task_lock);
     auto ready = _ready.load();
     if (!ready && task) {
         _add_block_task(task);
@@ -95,19 +95,34 @@ Dependency* Dependency::is_blocked_by(std::shared_ptr<PipelineTask> task) {
 }
 
 std::string Dependency::debug_string(int indentation_level) {
+    size_t blocked_task_size = 0;
+    {
+        LockGuard lc(_task_lock);
+        blocked_task_size = _blocked_task.size();
+    }
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer, "{}{}: id={}, block task = {}, ready={}, _always_ready={}",
-                   std::string(indentation_level * 2, ' '), _name, _node_id, _blocked_task.size(),
+                   std::string(indentation_level * 2, ' '), _name, _node_id, blocked_task_size,
                    _ready, _always_ready);
     return fmt::to_string(debug_string_buffer);
 }
 
 std::string CountedFinishDependency::debug_string(int indentation_level) {
+    size_t blocked_task_size = 0;
+    uint32_t counter = 0;
+    {
+        LockGuard lc(_task_lock);
+        blocked_task_size = _blocked_task.size();
+    }
+    {
+        LockGuard lc(_mtx);
+        counter = _counter;
+    }
     fmt::memory_buffer debug_string_buffer;
     fmt::format_to(debug_string_buffer,
                    "{}{}: id={}, block_task={}, ready={}, _always_ready={}, count={}",
-                   std::string(indentation_level * 2, ' '), _name, _node_id, _blocked_task.size(),
-                   _ready, _always_ready, _counter);
+                   std::string(indentation_level * 2, ' '), _name, _node_id, blocked_task_size,
+                   _ready, _always_ready, counter);
     return fmt::to_string(debug_string_buffer);
 }
 
@@ -142,50 +157,47 @@ bool RuntimeFilterTimer::should_be_check_timeout() {
 
 void RuntimeFilterTimerQueue::start() {
     while (!_stop) {
-        std::unique_lock<std::mutex> lk(cv_m);
-
+        UniqueLock queue_lock {_que_lock};
         while (_que.empty() && !_stop) {
-            cv.wait_for(lk, std::chrono::seconds(3), [this] { return !_que.empty() || _stop; });
+            cv.wait_for(queue_lock, std::chrono::seconds(3));
         }
         if (_stop) {
             break;
         }
-        {
-            std::unique_lock<std::mutex> lc(_que_lock);
-            std::list<std::shared_ptr<RuntimeFilterTimer>> new_que;
-            for (auto& it : _que) {
-                if (it.use_count() == 1) {
-                    // `use_count == 1` means this runtime filter has been released
-                } else if (it->should_be_check_timeout()) {
-                    if (it->force_wait_timeout() || it->_parent->is_blocked_by()) {
-                        // This means runtime filter is not ready, so we call timeout or continue to poll this timer.
-                        int64_t ms_since_registration = MonotonicMillis() - it->registration_time();
-                        if (ms_since_registration > it->wait_time_ms()) {
-                            it->call_timeout();
-                        } else {
-                            new_que.push_back(std::move(it));
-                        }
+        std::list<std::shared_ptr<RuntimeFilterTimer>> new_que;
+        for (auto& it : _que) {
+            if (it.use_count() == 1) {
+                // `use_count == 1` means this runtime filter has been released
+            } else if (it->should_be_check_timeout()) {
+                if (it->force_wait_timeout() || it->_parent->is_blocked_by()) {
+                    // This means runtime filter is not ready, so we call timeout or continue to poll this timer.
+                    int64_t ms_since_registration = MonotonicMillis() - it->registration_time();
+                    if (ms_since_registration > it->wait_time_ms()) {
+                        it->call_timeout();
+                    } else {
+                        new_que.push_back(std::move(it));
                     }
-                } else {
-                    new_que.push_back(std::move(it));
                 }
+            } else {
+                new_que.push_back(std::move(it));
             }
-            new_que.swap(_que);
         }
+        new_que.swap(_que);
+        queue_lock.unlock();
         std::this_thread::sleep_for(std::chrono::milliseconds(interval));
     }
     _shutdown = true;
 }
 
 void LocalExchangeSharedState::sub_running_sink_operators() {
-    std::unique_lock<std::mutex> lc(le_lock);
+    LockGuard lc(le_lock);
     if (exchanger->_running_sink_operators.fetch_sub(1) == 1) {
         _set_always_ready();
     }
 }
 
 void LocalExchangeSharedState::sub_running_source_operators() {
-    std::unique_lock<std::mutex> lc(le_lock);
+    LockGuard lc(le_lock);
     if (exchanger->_running_source_operators.fetch_sub(1) == 1) {
         _set_always_ready();
         exchanger->finalize();

--- a/be/src/exec/pipeline/dependency.h
+++ b/be/src/exec/pipeline/dependency.h
@@ -27,6 +27,7 @@
 #include <sqltypes.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -137,7 +138,7 @@ public:
         if (_always_ready) {
             return;
         }
-        std::unique_lock<std::mutex> lc(_always_ready_lock);
+        LockGuard lc(_always_ready_lock);
         if (_always_ready) {
             return;
         }
@@ -148,7 +149,7 @@ public:
         if (_always_ready) {
             return;
         }
-        std::unique_lock<std::mutex> lc(_always_ready_lock);
+        LockGuard lc(_always_ready_lock);
         if (_always_ready) {
             return;
         }
@@ -157,7 +158,7 @@ public:
     }
 
 protected:
-    void _add_block_task(std::shared_ptr<PipelineTask> task);
+    void _add_block_task(std::shared_ptr<PipelineTask> task) REQUIRES(_task_lock);
 
     const int _id;
     const int _node_id;
@@ -167,12 +168,12 @@ protected:
     BasicSharedState* _shared_state = nullptr;
     MonotonicStopWatch _watcher;
 
-    std::mutex _task_lock;
-    std::vector<std::weak_ptr<PipelineTask>> _blocked_task;
+    AnnotatedMutex _task_lock;
+    std::vector<std::weak_ptr<PipelineTask>> _blocked_task GUARDED_BY(_task_lock);
 
     // If `_always_ready` is true, `block()` will never block tasks.
     std::atomic<bool> _always_ready = false;
-    std::mutex _always_ready_lock;
+    AnnotatedMutex _always_ready_lock;
 };
 
 struct FakeSharedState final : public BasicSharedState {
@@ -186,7 +187,7 @@ public:
             : Dependency(id, node_id, std::move(name), true) {}
 
     void add(uint32_t count = 1) {
-        std::unique_lock<std::mutex> l(_mtx);
+        LockGuard l(_mtx);
         if (!_counter) {
             block();
         }
@@ -194,7 +195,7 @@ public:
     }
 
     void sub() {
-        std::unique_lock<std::mutex> l(_mtx);
+        LockGuard l(_mtx);
         // _counter is unsigned: a stray sub() when counter is already 0 would
         // underflow to UINT32_MAX and the dependency would never become ready,
         // hanging the query forever. Fail loudly instead.
@@ -211,8 +212,8 @@ public:
     std::string debug_string(int indentation_level = 0) override;
 
 private:
-    std::mutex _mtx;
-    uint32_t _counter = 0;
+    AnnotatedMutex _mtx;
+    uint32_t _counter GUARDED_BY(_mtx) = 0;
 };
 
 struct RuntimeFilterTimerQueue;
@@ -247,7 +248,7 @@ private:
     friend struct RuntimeFilterTimerQueue;
     std::shared_ptr<Dependency> _parent = nullptr;
     std::vector<std::shared_ptr<Dependency>> _local_runtime_filter_dependencies;
-    std::mutex _lock;
+    AnnotatedMutex _lock;
     int64_t _registration_time;
     const int32_t _wait_time_ms;
     // true only for group_commit_scan_operator
@@ -274,18 +275,17 @@ struct RuntimeFilterTimerQueue {
     ~RuntimeFilterTimerQueue() = default;
     RuntimeFilterTimerQueue() { _thread = std::thread(&RuntimeFilterTimerQueue::start, this); }
     void push_filter_timer(std::vector<std::shared_ptr<RuntimeFilterTimer>>&& filter) {
-        std::unique_lock<std::mutex> lc(_que_lock);
+        LockGuard queue_lock(_que_lock);
         _que.insert(_que.end(), filter.begin(), filter.end());
         cv.notify_all();
     }
 
     std::thread _thread;
-    std::condition_variable cv;
-    std::mutex cv_m;
-    std::mutex _que_lock;
+    std::condition_variable_any cv;
+    AnnotatedMutex _que_lock;
     std::atomic_bool _stop = false;
     std::atomic_bool _shutdown = false;
-    std::list<std::shared_ptr<RuntimeFilterTimer>> _que;
+    std::list<std::shared_ptr<RuntimeFilterTimer>> _que GUARDED_BY(_que_lock);
 };
 
 struct AggSharedState : public BasicSharedState {
@@ -887,7 +887,7 @@ public:
     std::atomic<int64_t> mem_usage = 0;
     std::atomic<size_t> _buffer_mem_limit = config::local_exchange_buffer_mem_limit;
     // We need to make sure to add mem_usage first and then enqueue, otherwise sub mem_usage may cause negative mem_usage during concurrent dequeue.
-    std::mutex le_lock;
+    AnnotatedMutex le_lock;
     void sub_running_sink_operators();
     void sub_running_source_operators();
     void _set_always_ready() {

--- a/be/src/exec/pipeline/pipeline_task.cpp
+++ b/be/src/exec/pipeline/pipeline_task.cpp
@@ -154,7 +154,7 @@ Status PipelineTask::prepare(const std::vector<TScanRangeParams>& scan_range, co
     {
         const auto& deps =
                 _state->get_local_state(_source->operator_id())->execution_dependencies();
-        std::unique_lock<std::mutex> lc(_dependency_lifecycle_lock);
+        LockGuard lc(_dependency_lifecycle_lock);
         std::copy(deps.begin(), deps.end(),
                   std::inserter(_execution_dependencies, _execution_dependencies.end()));
     }
@@ -200,7 +200,7 @@ Status PipelineTask::_extract_dependencies() {
         }
     }
     {
-        std::unique_lock<std::mutex> lc(_dependency_lifecycle_lock);
+        LockGuard lc(_dependency_lifecycle_lock);
         read_dependencies.swap(_read_dependencies);
         write_dependencies.swap(_write_dependencies);
         finish_dependencies.swap(_finish_dependencies);
@@ -347,7 +347,7 @@ bool PipelineTask::_is_blocked() {
 void PipelineTask::unblock_all_dependencies() {
     // Keep dependency pointers and task-owned operator/shared state stable because set_ready() may
     // synchronously call wake_up() and submit this task.
-    std::unique_lock<std::mutex> lock(_dependency_lifecycle_lock);
+    LockGuard lock(_dependency_lifecycle_lock);
     auto fragment = _fragment_context.lock();
     if (!is_finalized() && fragment) {
         try {
@@ -889,7 +889,7 @@ Status PipelineTask::finalize() {
     }
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(fragment->get_query_ctx()->query_mem_tracker());
     // Synchronize with unblock_all_dependencies() before clearing state used by wake_up()->submit().
-    std::unique_lock<std::mutex> lock(_dependency_lifecycle_lock);
+    LockGuard lock(_dependency_lifecycle_lock);
     RETURN_IF_ERROR(_state_transition(State::FINALIZED));
     _sink_shared_state.reset();
     _op_shared_states.clear();
@@ -928,7 +928,7 @@ Status PipelineTask::close(Status exec_status, bool close_sink) {
 
     if (close_sink) {
         // Synchronize FINISHED with forced unblocking so delayed wake_up() sees a stable state.
-        std::unique_lock<std::mutex> lock(_dependency_lifecycle_lock);
+        LockGuard lock(_dependency_lifecycle_lock);
         RETURN_IF_ERROR(_state_transition(State::FINISHED));
     }
     return s;
@@ -936,6 +936,20 @@ Status PipelineTask::close(Status exec_status, bool close_sink) {
 
 std::string PipelineTask::debug_string() {
     fmt::memory_buffer debug_string_buffer;
+    Dependency* cur_blocked_dep = nullptr;
+    std::vector<std::vector<Dependency*>> read_dependencies;
+    std::vector<Dependency*> write_dependencies;
+    std::vector<Dependency*> execution_dependencies;
+    std::vector<Dependency*> finish_dependencies;
+
+    {
+        LockGuard lc(_dependency_lifecycle_lock);
+        cur_blocked_dep = _blocked_dep;
+        read_dependencies = _read_dependencies;
+        write_dependencies = _write_dependencies;
+        execution_dependencies = _execution_dependencies;
+        finish_dependencies = _finish_dependencies;
+    }
 
     fmt::format_to(debug_string_buffer, "QueryId: {}\n", print_id(_query_id));
     fmt::format_to(debug_string_buffer, "InstanceId: {}\n",
@@ -948,8 +962,6 @@ std::string PipelineTask::debug_string() {
                    _index, _opened, _eos, _to_string(_exec_state), _dry_run, _wake_up_early.load(),
                    _wake_by, _state_change_watcher.elapsed_time() / NANOS_PER_SEC, _spilling,
                    is_running());
-    std::unique_lock<std::mutex> lc(_dependency_lifecycle_lock);
-    auto* cur_blocked_dep = _blocked_dep;
     auto fragment = _fragment_context.lock();
     if (is_finalized() || !fragment) {
         fmt::format_to(debug_string_buffer, " pipeline name = {}", _pipeline_name);
@@ -979,10 +991,10 @@ std::string PipelineTask::debug_string() {
     fmt::format_to(debug_string_buffer, "\nRead Dependency Information: \n");
 
     size_t i = 0;
-    for (; i < _read_dependencies.size(); i++) {
-        for (size_t j = 0; j < _read_dependencies[i].size(); j++) {
+    for (; i < read_dependencies.size(); i++) {
+        for (size_t j = 0; j < read_dependencies[i].size(); j++) {
             fmt::format_to(debug_string_buffer, "{}. {}\n", i,
-                           _read_dependencies[i][j]->debug_string(cast_set<int>(i) + 1));
+                           read_dependencies[i][j]->debug_string(cast_set<int>(i) + 1));
         }
     }
 
@@ -990,21 +1002,21 @@ std::string PipelineTask::debug_string() {
                    _memory_sufficient_dependency->debug_string(cast_set<int>(i++)));
 
     fmt::format_to(debug_string_buffer, "\nWrite Dependency Information: \n");
-    for (size_t j = 0; j < _write_dependencies.size(); j++, i++) {
+    for (size_t j = 0; j < write_dependencies.size(); j++, i++) {
         fmt::format_to(debug_string_buffer, "{}. {}\n", i,
-                       _write_dependencies[j]->debug_string(cast_set<int>(j) + 1));
+                       write_dependencies[j]->debug_string(cast_set<int>(j) + 1));
     }
 
     fmt::format_to(debug_string_buffer, "\nExecution Dependency Information: \n");
-    for (size_t j = 0; j < _execution_dependencies.size(); j++, i++) {
+    for (size_t j = 0; j < execution_dependencies.size(); j++, i++) {
         fmt::format_to(debug_string_buffer, "{}. {}\n", i,
-                       _execution_dependencies[j]->debug_string(cast_set<int>(i) + 1));
+                       execution_dependencies[j]->debug_string(cast_set<int>(i) + 1));
     }
 
     fmt::format_to(debug_string_buffer, "Finish Dependency Information: \n");
-    for (size_t j = 0; j < _finish_dependencies.size(); j++, i++) {
+    for (size_t j = 0; j < finish_dependencies.size(); j++, i++) {
         fmt::format_to(debug_string_buffer, "{}. {}\n", i,
-                       _finish_dependencies[j]->debug_string(cast_set<int>(i) + 1));
+                       finish_dependencies[j]->debug_string(cast_set<int>(i) + 1));
     }
     return fmt::to_string(debug_string_buffer);
 }
@@ -1057,7 +1069,7 @@ Status PipelineTask::revoke_memory(const std::shared_ptr<SpillContext>& spill_co
     return Status::OK();
 }
 
-void PipelineTask::wake_up(Dependency* dep, std::unique_lock<std::mutex>& /* dep_lock */) {
+void PipelineTask::wake_up(Dependency* dep, LockGuard<AnnotatedMutex>& /* dep_lock */) {
     auto cancel_if_error = [&](const Status& st) {
         if (!st.ok()) {
             if (auto frag = fragment_context().lock()) {

--- a/be/src/exec/pipeline/pipeline_task.h
+++ b/be/src/exec/pipeline/pipeline_task.h
@@ -118,7 +118,7 @@ public:
         return _op_shared_states[id].get();
     }
 
-    void wake_up(Dependency* dep, std::unique_lock<std::mutex>& /* dep_lock */);
+    void wake_up(Dependency* dep, LockGuard<AnnotatedMutex>& /* dep_lock */);
 
     DataSinkOperatorPtr sink() const { return _sink; }
 
@@ -176,7 +176,7 @@ public:
     [[nodiscard]] size_t get_revocable_size() const;
     [[nodiscard]] Status revoke_memory(const std::shared_ptr<SpillContext>& spill_context);
 
-    Status blocked(Dependency* dependency, std::unique_lock<std::mutex>& /* dep_lock */) {
+    Status blocked(Dependency* dependency, LockGuard<AnnotatedMutex>& /* dep_lock */) {
         DCHECK_EQ(_blocked_dep, nullptr) << "task: " << debug_string();
         _blocked_dep = dependency;
         return _state_transition(PipelineTask::State::BLOCKED);
@@ -188,11 +188,11 @@ protected:
 
 private:
     // Whether this task is blocked before execution (FE 2-phase commit trigger, runtime filters)
-    bool _wait_to_start();
+    bool _wait_to_start() NO_THREAD_SAFETY_ANALYSIS;
     // Whether this task is blocked during execution (read dependency, write dependency)
-    bool _is_blocked();
+    bool _is_blocked() NO_THREAD_SAFETY_ANALYSIS;
     // Whether this task is blocked after execution (pending finish dependency)
-    bool _is_pending_finish();
+    bool _is_pending_finish() NO_THREAD_SAFETY_ANALYSIS;
 
     Status _extract_dependencies();
     void _init_profile();
@@ -251,11 +251,17 @@ private:
     OperatorXBase* _root;
     DataSinkOperatorPtr _sink;
 
+    // Protects dependency containers and the raw Dependency pointers they contain. It also
+    // serializes forced dependency unblocking with close()/finalize(): set_ready() may synchronously
+    // call wake_up() and submit this task, so close()/finalize() must not clear operator/shared
+    // state until forced unblocking finishes. wake_up() must not take this lock.
+    AnnotatedMutex _dependency_lifecycle_lock;
+
     // `_read_dependencies` is stored as same order as `_operators`
-    std::vector<std::vector<Dependency*>> _read_dependencies;
-    std::vector<Dependency*> _write_dependencies;
-    std::vector<Dependency*> _finish_dependencies;
-    std::vector<Dependency*> _execution_dependencies;
+    std::vector<std::vector<Dependency*>> _read_dependencies GUARDED_BY(_dependency_lifecycle_lock);
+    std::vector<Dependency*> _write_dependencies GUARDED_BY(_dependency_lifecycle_lock);
+    std::vector<Dependency*> _finish_dependencies GUARDED_BY(_dependency_lifecycle_lock);
+    std::vector<Dependency*> _execution_dependencies GUARDED_BY(_dependency_lifecycle_lock);
 
     // All shared states of this pipeline task.
     std::map<int, std::shared_ptr<BasicSharedState>> _op_shared_states;
@@ -271,11 +277,6 @@ private:
     Dependency* _blocked_dep = nullptr;
 
     Dependency* _memory_sufficient_dependency;
-    // Protects dependency containers and the raw Dependency pointers they contain. It also
-    // serializes forced dependency unblocking with close()/finalize(): set_ready() may synchronously
-    // call wake_up() and submit this task, so close()/finalize() must not clear operator/shared
-    // state until forced unblocking finishes. wake_up() must not take this lock.
-    std::mutex _dependency_lifecycle_lock;
 
     std::atomic<bool> _running {false};
     std::atomic<bool> _eos {false};

--- a/be/src/exec/pipeline/task_queue.cpp
+++ b/be/src/exec/pipeline/task_queue.cpp
@@ -20,11 +20,9 @@
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
 #include <memory>
-#include <string>
 
 #include "common/logging.h"
 #include "exec/pipeline/pipeline_task.h"
-#include "runtime/workload_group/workload_group.h"
 
 namespace doris {
 
@@ -48,7 +46,7 @@ PriorityTaskQueue::PriorityTaskQueue() : _closed(false) {
 }
 
 void PriorityTaskQueue::close() {
-    std::unique_lock<std::mutex> lock(_work_size_mutex);
+    LockGuard lock(_work_size_mutex);
     _closed = true;
     _wait_task.notify_all();
     DorisMetrics::instance()->pipeline_task_queue_size->increment(-_total_task_size);
@@ -93,12 +91,12 @@ int PriorityTaskQueue::_compute_level(uint64_t runtime) {
 
 PipelineTaskSPtr PriorityTaskQueue::try_take(bool is_steal) {
     // TODO other efficient lock? e.g. if get lock fail, return null_ptr
-    std::unique_lock<std::mutex> lock(_work_size_mutex);
+    LockGuard lock(_work_size_mutex);
     return _try_take_unprotected(is_steal);
 }
 
 PipelineTaskSPtr PriorityTaskQueue::take(uint32_t timeout_ms) {
-    std::unique_lock<std::mutex> lock(_work_size_mutex);
+    UniqueLock lock {_work_size_mutex};
     auto task = _try_take_unprotected(false);
     if (task) {
         return task;
@@ -113,11 +111,11 @@ PipelineTaskSPtr PriorityTaskQueue::take(uint32_t timeout_ms) {
 }
 
 Status PriorityTaskQueue::push(PipelineTaskSPtr task) {
+    auto level = _compute_level(task->get_runtime_ns());
+    LockGuard lock(_work_size_mutex);
     if (_closed) {
         return Status::InternalError("WorkTaskQueue closed");
     }
-    auto level = _compute_level(task->get_runtime_ns());
-    std::unique_lock<std::mutex> lock(_work_size_mutex);
 
     // update empty queue's  runtime, to avoid too high priority
     if (_sub_queues[level].empty() &&

--- a/be/src/exec/pipeline/task_queue.h
+++ b/be/src/exec/pipeline/task_queue.h
@@ -17,18 +17,15 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <stddef.h>
-#include <stdint.h>
 
 #include <atomic>
 #include <condition_variable>
-#include <memory>
-#include <mutex>
-#include <ostream>
+#include <cstddef>
+#include <cstdint>
 #include <queue>
-#include <set>
 
 #include "common/status.h"
+#include "common/thread_safety_annotations.h"
 #include "exec/pipeline/pipeline_task.h"
 
 namespace doris {
@@ -82,21 +79,21 @@ public:
     }
 
 private:
-    PipelineTaskSPtr _try_take_unprotected(bool is_steal);
+    PipelineTaskSPtr _try_take_unprotected(bool is_steal) REQUIRES(_work_size_mutex);
     static constexpr auto LEVEL_QUEUE_TIME_FACTOR = 2;
     static constexpr size_t SUB_QUEUE_LEVEL = 6;
     SubTaskQueue _sub_queues[SUB_QUEUE_LEVEL];
     // 1s, 3s, 10s, 60s, 300s
     uint64_t _queue_level_limit[SUB_QUEUE_LEVEL - 1] = {1000000000, 3000000000, 10000000000,
                                                         60000000000, 300000000000};
-    std::mutex _work_size_mutex;
-    std::condition_variable _wait_task;
+    AnnotatedMutex _work_size_mutex;
+    std::condition_variable_any _wait_task;
     std::atomic<size_t> _total_task_size = 0;
-    bool _closed;
+    bool _closed GUARDED_BY(_work_size_mutex);
 
     // used to adjust vruntime of a queue when it's not empty
     // protected by lock _work_size_mutex
-    uint64_t _queue_level_min_vruntime = 0;
+    uint64_t _queue_level_min_vruntime GUARDED_BY(_work_size_mutex) = 0;
 
     int _compute_level(uint64_t real_runtime);
 };


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

This is a follow-up to #63070, extending the thread safety annotation migration into the pipeline executor (`be/src/exec/pipeline/`). Plain `std::mutex` and `std::unique_lock<std::mutex>` were replaced with `AnnotatedMutex` and `LockGuard`/`UniqueLock` wrappers from `thread_safety_annotations.h`, enabling Clang's `-Wthread-safety` static analysis to catch lock ordering and data race bugs at compile time.

While applying annotations, two latent data races in `debug_string()` methods were fixed:

- `Dependency::debug_string()` and `CountedFinishDependency::debug_string()` read `_blocked_task.size()` without holding `_task_lock`.
- `PipelineTask::debug_string()` read `_blocked_dep` and all dependency vectors without holding `_dependency_lifecycle_lock`.
- `CountedFinishDependency::debug_string()` read `_counter` without holding `_mtx`.

- `RuntimeFilterTimerQueue::start()` held two separate mutexes (`cv_m` + `_que_lock`) simultaneously. Consolidated into a single `AnnotatedMutex _que_lock` with `std::condition_variable_any` and a `UniqueLock`, eliminating the redundant lock.
- `PriorityTaskQueue::push()` checked `_closed` before acquiring the lock — a data race now caught because `_closed` is annotated `GUARDED_BY(_work_size_mutex)`. Moved the `_closed` check inside the lock, and hoisted `_compute_level()` (which doesn't touch shared state) before the lock.
- Replaced C-style `<stddef.h>`/`<stdint.h>` with `<cstddef>`/`<cstdint>`, and removed unused includes.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

