### PR TITLE
[fix](compaction) Keep latest 10 versions on new tablet during picking compaction input rowsets when schema change

### DIFF
--- a/be/src/cloud/cloud_cumulative_compaction_policy.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction_policy.cpp
@@ -159,7 +159,7 @@ int64_t CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         if (tablet->tablet_state() == TABLET_NOTREADY) {
             // If tablet under alter, keep latest 10 version so that base tablet max version
             // not merged in new tablet, and then we can copy data from base tablet
-            if (rowset->version().second < max_version - 10) {
+            if (rowset->version().second > max_version - 10) {
                 continue;
             }
         }

--- a/be/src/storage/compaction/cumulative_compaction_policy.cpp
+++ b/be/src/storage/compaction/cumulative_compaction_policy.cpp
@@ -303,7 +303,7 @@ int SizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         if (tablet->tablet_state() == TABLET_NOTREADY) {
             // If tablet under alter, keep latest 10 version so that base tablet max version
             // not merged in new tablet, and then we can copy data from base tablet
-            if (rowset->version().second < max_version - 10) {
+            if (rowset->version().second > max_version - 10) {
                 continue;
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The cumulative compaction policy for NOTREADY tablets is intended to keep the latest 10 versions from being compacted during alter, but the condition skipped older versions instead. This change makes the condition match the documented behavior.

### Release note

None

### Check List (For Author)

- Test: No need to test (condition-only fix; verified with `git diff --check`)
- Behavior changed: Yes. NOTREADY tablet compaction now preserves the latest versions as documented.
- Does this need documentation: No
