### PR TITLE
[fix](be) Deduplicate cluster key MOW compaction output

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -1279,6 +1279,15 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
     calc_compaction_output_rowset_delete_bitmap(
             input_rowsets, rowid_conversion, 0, version.second + 1, missed_rows.get(),
             location_map.get(), tablet_meta()->delete_bitmap(), output_rowset_delete_bitmap.get());
+
+    // In cluster-key MOW compaction, rows are sorted by cluster key, so duplicate unique keys
+    // may be non-adjacent in merge order. Scan the output primary key index to delete older
+    // duplicate rows inside the output rowset.
+    if (!tablet_schema()->cluster_key_uids().empty()) {
+        RETURN_IF_ERROR(calc_compaction_output_rowset_internal_delete_bitmap(
+                input_rowsets, output_rowset, rowid_conversion, output_rowset_delete_bitmap.get()));
+    }
+
     if (missed_rows) {
         missed_rows_size = missed_rows->size();
         if (!allow_delete_in_cumu_compaction) {

--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -1313,6 +1313,8 @@ Status CompactionMixin::modify_rowsets() {
         _tablet->enable_unique_key_merge_on_write()) {
         Version version = tablet()->max_version();
         DeleteBitmap output_rowset_delete_bitmap(_tablet->tablet_id());
+        DeleteBitmap output_rowset_internal_delete_bitmap(_tablet->tablet_id());
+
         std::unique_ptr<RowLocationSet> missed_rows;
         if ((config::enable_missing_rows_correctness_check ||
              config::enable_mow_compaction_correctness_check_core ||
@@ -1332,12 +1334,19 @@ Status CompactionMixin::modify_rowsets() {
         // New loads are not blocked, so some keys of input rowsets might
         // be deleted during the time. We need to deal with delete bitmap
         // of incremental data later.
-        // TODO(LiaoXin): check if there are duplicate keys
         std::size_t missed_rows_size = 0;
         tablet()->calc_compaction_output_rowset_delete_bitmap(
                 _input_rowsets, *_rowid_conversion, 0, version.second + 1, missed_rows.get(),
                 location_map.get(), _tablet->tablet_meta()->delete_bitmap(),
                 &output_rowset_delete_bitmap);
+        // In cluster-key MOW compaction, rows are sorted by cluster key, so duplicate unique keys
+        // may be non-adjacent in merge order. Scan the output primary key index to delete older
+        // duplicate rows inside the output rowset.
+        if (!tablet()->tablet_schema()->cluster_key_uids().empty()) {
+            RETURN_IF_ERROR(tablet()->calc_compaction_output_rowset_internal_delete_bitmap(
+                    _input_rowsets, _output_rowset, *_rowid_conversion,
+                    &output_rowset_internal_delete_bitmap));
+        }
         if (missed_rows) {
             missed_rows_size = missed_rows->size();
             std::size_t merged_missed_rows_size = _stats.merged_rows;
@@ -1437,6 +1446,7 @@ Status CompactionMixin::modify_rowsets() {
                 tablet()->calc_compaction_output_rowset_delete_bitmap(
                         _input_rowsets, *_rowid_conversion, 0, UINT64_MAX, missed_rows.get(),
                         location_map.get(), *it.delete_bitmap.get(), &txn_output_delete_bitmap);
+                txn_output_delete_bitmap.merge(output_rowset_internal_delete_bitmap);
                 if (config::enable_merge_on_write_correctness_check) {
                     RowsetIdUnorderedSet rowsetids;
                     rowsetids.insert(_output_rowset->rowset_id());

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -347,72 +347,74 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
     // Submit the entire delete bitmap calculation process to thread pool for async execution
     // This avoids blocking memtable flush thread while waiting for file upload to complete
     // The process includes: file_writer->close(), _build_tmp, load_segments, and calc_delete_bitmap
-    return _calc_delete_bitmap_token->submit_func(
-            [this, segment_id, specified_rowsets = std::move(specified_rowsets)]() -> Status {
-                Status st = Status::OK();
-                // Step 1: Close file_writer (must be done before load_segments)
-                auto* file_writer = _seg_files.get(segment_id);
-                if (file_writer && file_writer->state() != io::FileWriter::State::CLOSED) {
-                    MonotonicStopWatch close_timer;
-                    close_timer.start();
-                    st = file_writer->close();
-                    close_timer.stop();
+    return _calc_delete_bitmap_token->submit_func([this, segment_id,
+                                                   specified_rowsets = std::move(
+                                                           specified_rowsets)]() -> Status {
+        Status st = Status::OK();
+        // Step 1: Close file_writer (must be done before load_segments)
+        auto* file_writer = _seg_files.get(segment_id);
+        if (file_writer && file_writer->state() != io::FileWriter::State::CLOSED) {
+            MonotonicStopWatch close_timer;
+            close_timer.start();
+            st = file_writer->close();
+            close_timer.stop();
 
-                    auto close_time_ms = close_timer.elapsed_time_milliseconds();
-                    if (close_time_ms > 1000) {
-                        LOG(INFO) << "file_writer->close() took " << close_time_ms
-                                  << "ms for segment_id=" << segment_id
-                                  << ", tablet_id=" << _context.tablet_id
-                                  << ", rowset_id=" << _context.rowset_id;
-                    }
-                    if (!st.ok()) {
-                        return st;
-                    }
-                }
+            auto close_time_ms = close_timer.elapsed_time_milliseconds();
+            if (close_time_ms > 1000) {
+                LOG(INFO) << "file_writer->close() took " << close_time_ms
+                          << "ms for segment_id=" << segment_id
+                          << ", tablet_id=" << _context.tablet_id
+                          << ", rowset_id=" << _context.rowset_id;
+            }
+            if (!st.ok()) {
+                return st;
+            }
+        }
 
-                OlapStopWatch watch;
-                // Step 2: Build tmp rowset (needs file_writer to be closed)
-                RowsetSharedPtr rowset_ptr;
-                st = _build_tmp(rowset_ptr);
-                if (!st.ok()) {
-                    return st;
-                }
+        OlapStopWatch watch;
+        // Step 2: Build tmp rowset (needs file_writer to be closed)
+        RowsetSharedPtr rowset_ptr;
+        st = _build_tmp(rowset_ptr);
+        if (!st.ok()) {
+            return st;
+        }
 
-                // Step 3: Load segments (needs file_writer to be closed and rowset to be built)
-                auto* beta_rowset = reinterpret_cast<BetaRowset*>(rowset_ptr.get());
-                std::vector<segment_v2::SegmentSharedPtr> segments;
-                st = beta_rowset->load_segments(segment_id, segment_id + 1, &segments);
-                if (!st.ok()) {
-                    return st;
-                }
+        DBUG_EXECUTE_IF("BaseBetaRowsetWriter::_generate_delete_bitmap.block_before_load_segments",
+                        DBUG_RUN_CALLBACK(segment_id));
 
-                // Step 4: Calculate delete bitmap
-                st = BaseTablet::calc_delete_bitmap(
-                        _context.tablet, rowset_ptr, segments, specified_rowsets,
-                        _context.mow_context->delete_bitmap, _context.mow_context->max_version,
-                        nullptr, nullptr, nullptr);
-                if (!st.ok()) {
-                    return st;
-                }
+        // Step 3: Load segments (needs file_writer to be closed and rowset to be built)
+        auto* beta_rowset = reinterpret_cast<BetaRowset*>(rowset_ptr.get());
+        std::vector<segment_v2::SegmentSharedPtr> segments;
+        st = beta_rowset->load_segments(segment_id, segment_id + 1, &segments);
+        if (!st.ok()) {
+            return st;
+        }
 
-                size_t total_rows =
-                        std::accumulate(segments.begin(), segments.end(), 0,
-                                        [](size_t sum, const segment_v2::SegmentSharedPtr& s) {
-                                            return sum += s->num_rows();
-                                        });
-                LOG(INFO) << "[Memtable Flush] construct delete bitmap tablet: "
-                          << _context.tablet->tablet_id()
-                          << ", rowset_ids: " << _context.mow_context->rowset_ids->size()
-                          << ", cur max_version: " << _context.mow_context->max_version
-                          << ", transaction_id: " << _context.mow_context->txn_id
-                          << ", delete_bitmap_count: "
-                          << _context.mow_context->delete_bitmap->get_delete_bitmap_count()
-                          << ", delete_bitmap_cardinality: "
-                          << _context.mow_context->delete_bitmap->cardinality()
-                          << ", cost: " << watch.get_elapse_time_us()
-                          << "(us), total rows: " << total_rows;
-                return Status::OK();
-            });
+        // Step 4: Calculate delete bitmap
+        st = BaseTablet::calc_delete_bitmap(_context.tablet, rowset_ptr, segments,
+                                            specified_rowsets, _context.mow_context->delete_bitmap,
+                                            _context.mow_context->max_version, nullptr, nullptr,
+                                            nullptr);
+        if (!st.ok()) {
+            return st;
+        }
+
+        size_t total_rows = std::accumulate(segments.begin(), segments.end(), 0,
+                                            [](size_t sum, const segment_v2::SegmentSharedPtr& s) {
+                                                return sum += s->num_rows();
+                                            });
+        LOG(INFO) << "[Memtable Flush] construct delete bitmap tablet: "
+                  << _context.tablet->tablet_id()
+                  << ", rowset_ids: " << _context.mow_context->rowset_ids->size()
+                  << ", cur max_version: " << _context.mow_context->max_version
+                  << ", transaction_id: " << _context.mow_context->txn_id
+                  << ", delete_bitmap_count: "
+                  << _context.mow_context->delete_bitmap->get_delete_bitmap_count()
+                  << ", delete_bitmap_cardinality: "
+                  << _context.mow_context->delete_bitmap->cardinality()
+                  << ", cost: " << watch.get_elapse_time_us() << "(us), total rows: " << total_rows;
+        return Status::OK();
+    });
 }
 
 Status BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) {
@@ -705,7 +707,12 @@ Status BetaRowsetWriter::_segcompaction_if_necessary() {
     } else {
         status = _check_segment_number_limit(_num_segcompacted);
     }
+
     if (status.ok() && (_num_segment - _segcompacted_point) >= config::segcompaction_batch_size) {
+        if (_calc_delete_bitmap_token != nullptr) {
+            status = _calc_delete_bitmap_token->wait();
+        }
+
         SegCompactionCandidatesSharedPtr segments;
         status = _find_longest_consecutive_small_segment(segments);
         if (LIKELY(status.ok()) && (!segments->empty())) {

--- a/be/src/storage/tablet/base_tablet.cpp
+++ b/be/src/storage/tablet/base_tablet.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
+#include <queue>
 #include <random>
 #include <shared_mutex>
 
@@ -71,6 +72,103 @@ bvar::PerSecond<bvar::Adder<uint64_t>> g_tablet_pk_not_found_per_second(
 bvar::LatencyRecorder g_tablet_update_delete_bitmap_latency("doris_pk", "update_delete_bitmap");
 
 static bvar::Adder<size_t> g_total_tablet_num("doris_total_tablet_num");
+
+struct CompactionOutputRowSource {
+    Version version;
+    RowLocation src;
+    bool valid = false;
+};
+
+struct CompactionOutputPkEntry {
+    std::string unique_key;
+    std::string encoded_seq_value;
+    RowLocation dst;
+    CompactionOutputRowSource source;
+};
+
+struct CompactionOutputPkScanner {
+    uint32_t segment_id = 0;
+    int64_t remaining = 0;
+    uint32_t next_ordinal = 0;
+    std::unique_ptr<segment_v2::IndexedColumnIterator> iter;
+    DataTypePtr index_type;
+    CompactionOutputPkEntry current;
+};
+
+bool is_newer_compaction_output_row(const CompactionOutputPkEntry& lhs,
+                                    const CompactionOutputPkEntry& rhs) {
+    if (lhs.encoded_seq_value != rhs.encoded_seq_value) {
+        return lhs.encoded_seq_value > rhs.encoded_seq_value;
+    }
+    if (lhs.source.version.second != rhs.source.version.second) {
+        return lhs.source.version.second > rhs.source.version.second;
+    }
+    if (lhs.source.version.first != rhs.source.version.first) {
+        return lhs.source.version.first > rhs.source.version.first;
+    }
+    if (lhs.source.src.segment_id != rhs.source.src.segment_id) {
+        return lhs.source.src.segment_id > rhs.source.src.segment_id;
+    }
+    return lhs.source.src.row_id > rhs.source.src.row_id;
+}
+
+Status parse_compaction_output_pk_entry(
+        const Slice& encoded_key, const RowsetId& output_rowset_id, uint32_t output_segment_id,
+        size_t seq_col_length,
+        const std::vector<std::vector<CompactionOutputRowSource>>& output_row_sources,
+        CompactionOutputPkEntry* entry) {
+    size_t rowid_length = PrimaryKeyIndexReader::ROW_ID_LENGTH;
+    if (UNLIKELY(encoded_key.get_size() < seq_col_length + rowid_length)) {
+        return Status::InternalError("invalid cluster-key MOW primary key size: {}",
+                                     encoded_key.get_size());
+    }
+    auto unique_key_length = encoded_key.get_size() - seq_col_length - rowid_length;
+    entry->unique_key.assign(encoded_key.get_data(), unique_key_length);
+    entry->encoded_seq_value.assign(encoded_key.get_data() + unique_key_length, seq_col_length);
+
+    Slice rowid_slice(encoded_key.get_data() + unique_key_length + seq_col_length + 1,
+                      rowid_length - 1);
+    const auto* type_info = get_scalar_type_info<FieldType::OLAP_FIELD_TYPE_UNSIGNED_INT>();
+    const auto* rowid_coder = get_key_coder(type_info->type());
+    uint32_t row_id = 0;
+    RETURN_IF_ERROR(rowid_coder->decode_ascending(&rowid_slice, rowid_length,
+                                                  reinterpret_cast<uint8_t*>(&row_id)));
+
+    entry->dst = RowLocation(output_rowset_id, output_segment_id, row_id);
+    if (UNLIKELY(output_segment_id >= output_row_sources.size() ||
+                 row_id >= output_row_sources[output_segment_id].size())) {
+        return Status::InternalError(
+                "invalid rowid in cluster-key MOW primary key, segment_id={}, row_id={}",
+                output_segment_id, row_id);
+    }
+    entry->source = output_row_sources[output_segment_id][row_id];
+    if (UNLIKELY(!entry->source.valid)) {
+        return Status::InternalError(
+                "missing rowid conversion source for output rowset={}, segment_id={}, row_id={}",
+                output_rowset_id.to_string(), output_segment_id, row_id);
+    }
+    return Status::OK();
+}
+
+Status load_next_compaction_output_pk_entry(
+        const RowsetId& output_rowset_id, size_t seq_col_length,
+        const std::vector<std::vector<CompactionOutputRowSource>>& output_row_sources,
+        CompactionOutputPkScanner* scanner) {
+    if (scanner->remaining <= 0) {
+        return Status::OK();
+    }
+
+    auto index_column = scanner->index_type->create_column();
+    size_t num_read = 1;
+    RETURN_IF_ERROR(scanner->iter->seek_to_ordinal(scanner->next_ordinal++));
+    RETURN_IF_ERROR(scanner->iter->next_batch(&num_read, index_column));
+    DCHECK_EQ(1, num_read);
+    --scanner->remaining;
+
+    Slice encoded_key(index_column->get_data_at(0).data, index_column->get_data_at(0).size);
+    return parse_compaction_output_pk_entry(encoded_key, output_rowset_id, scanner->segment_id,
+                                            seq_col_length, output_row_sources, &scanner->current);
+}
 
 Status _get_segment_column_iterator(const BetaRowsetSharedPtr& rowset, uint32_t segid,
                                     const TabletColumn& target_column,
@@ -1642,6 +1740,124 @@ void BaseTablet::calc_compaction_output_rowset_delete_bitmap(
             }
         }
     }
+}
+
+Status BaseTablet::calc_compaction_output_rowset_internal_delete_bitmap(
+        const std::vector<RowsetSharedPtr>& input_rowsets, RowsetSharedPtr output_rowset,
+        const RowIdConversion& rowid_conversion, DeleteBitmap* output_rowset_delete_bitmap) {
+    DCHECK(!tablet_schema()->cluster_key_uids().empty());
+    DCHECK(output_rowset != nullptr);
+
+    std::vector<segment_v2::SegmentSharedPtr> output_segments;
+    RETURN_IF_ERROR(
+            std::dynamic_pointer_cast<BetaRowset>(output_rowset)->load_segments(&output_segments));
+
+    std::vector<std::vector<CompactionOutputRowSource>> output_row_sources(output_segments.size());
+    for (size_t segment_id = 0; segment_id < output_segments.size(); ++segment_id) {
+        output_row_sources[segment_id].resize(output_segments[segment_id]->num_rows());
+    }
+
+    std::map<RowsetId, Version> input_rowset_versions;
+    for (const auto& rowset : input_rowsets) {
+        input_rowset_versions.emplace(rowset->rowset_id(), rowset->version());
+    }
+
+    const auto& rowid_conversion_map = rowid_conversion.get_rowid_conversion_map();
+    for (uint32_t source_segment_index = 0; source_segment_index < rowid_conversion_map.size();
+         ++source_segment_index) {
+        auto source_segment = rowid_conversion.get_segment_by_id(source_segment_index);
+        auto version_iter = input_rowset_versions.find(source_segment.first);
+        if (UNLIKELY(version_iter == input_rowset_versions.end())) {
+            return Status::InternalError("missing input rowset version for rowset_id={}",
+                                         source_segment.first.to_string());
+        }
+        const auto& source_rowid_map = rowid_conversion_map[source_segment_index];
+        for (uint32_t source_rowid = 0; source_rowid < source_rowid_map.size(); ++source_rowid) {
+            const auto& [dst_segment_id, dst_rowid] = source_rowid_map[source_rowid];
+            if (dst_segment_id == UINT32_MAX && dst_rowid == UINT32_MAX) {
+                continue;
+            }
+            if (UNLIKELY(dst_segment_id >= output_row_sources.size() ||
+                         dst_rowid >= output_row_sources[dst_segment_id].size())) {
+                return Status::InternalError(
+                        "invalid rowid conversion destination, rowset_id={}, segment_id={}, "
+                        "row_id={}",
+                        output_rowset->rowset_id().to_string(), dst_segment_id, dst_rowid);
+            }
+            output_row_sources[dst_segment_id][dst_rowid] = {
+                    .version = version_iter->second,
+                    .src = RowLocation(source_segment.first, source_segment.second, source_rowid),
+                    .valid = true};
+        }
+    }
+
+    size_t seq_col_length = 0;
+    if (tablet_schema()->has_sequence_col()) {
+        seq_col_length = tablet_schema()->column(tablet_schema()->sequence_col_idx()).length() + 1;
+    }
+
+    struct ScannerComparator {
+        bool operator()(const CompactionOutputPkScanner* lhs,
+                        const CompactionOutputPkScanner* rhs) const {
+            return lhs->current.unique_key > rhs->current.unique_key;
+        }
+    };
+    std::priority_queue<CompactionOutputPkScanner*, std::vector<CompactionOutputPkScanner*>,
+                        ScannerComparator>
+            scanners_heap;
+    std::vector<std::unique_ptr<CompactionOutputPkScanner>> scanners;
+    scanners.reserve(output_segments.size());
+
+    for (uint32_t segment_id = 0; segment_id < output_segments.size(); ++segment_id) {
+        auto& segment = output_segments[segment_id];
+        RETURN_IF_ERROR(segment->load_pk_index_and_bf(nullptr));
+        const auto* pk_index = segment->get_primary_key_index();
+        DCHECK(pk_index != nullptr);
+        if (pk_index->num_rows() == 0) {
+            continue;
+        }
+
+        auto scanner = std::make_unique<CompactionOutputPkScanner>();
+        scanner->segment_id = segment_id;
+        scanner->remaining = pk_index->num_rows();
+        scanner->index_type =
+                DataTypeFactory::instance().create_data_type(pk_index->type_info()->type(), 1, 0);
+        RETURN_IF_ERROR(pk_index->new_iterator(&scanner->iter, nullptr));
+        RETURN_IF_ERROR(load_next_compaction_output_pk_entry(
+                output_rowset->rowset_id(), seq_col_length, output_row_sources, scanner.get()));
+        scanners_heap.push(scanner.get());
+        scanners.push_back(std::move(scanner));
+    }
+
+    bool has_current_key = false;
+    CompactionOutputPkEntry current_visible_entry;
+    const auto delete_version = output_rowset->version().second;
+    while (!scanners_heap.empty()) {
+        auto* scanner = scanners_heap.top();
+        scanners_heap.pop();
+        auto entry = scanner->current;
+
+        if (!has_current_key || current_visible_entry.unique_key != entry.unique_key) {
+            current_visible_entry = std::move(entry);
+            has_current_key = true;
+        } else if (is_newer_compaction_output_row(entry, current_visible_entry)) {
+            output_rowset_delete_bitmap->add({current_visible_entry.dst.rowset_id,
+                                              current_visible_entry.dst.segment_id, delete_version},
+                                             current_visible_entry.dst.row_id);
+            current_visible_entry = std::move(entry);
+        } else {
+            output_rowset_delete_bitmap->add(
+                    {entry.dst.rowset_id, entry.dst.segment_id, delete_version}, entry.dst.row_id);
+        }
+
+        if (scanner->remaining > 0) {
+            RETURN_IF_ERROR(load_next_compaction_output_pk_entry(
+                    output_rowset->rowset_id(), seq_col_length, output_row_sources, scanner));
+            scanners_heap.push(scanner);
+        }
+    }
+
+    return Status::OK();
 }
 
 Status BaseTablet::check_rowid_conversion(

--- a/be/src/storage/tablet/base_tablet.h
+++ b/be/src/storage/tablet/base_tablet.h
@@ -261,6 +261,10 @@ public:
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
             const DeleteBitmap& input_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap);
 
+    Status calc_compaction_output_rowset_internal_delete_bitmap(
+            const std::vector<RowsetSharedPtr>& input_rowsets, RowsetSharedPtr output_rowset,
+            const RowIdConversion& rowid_conversion, DeleteBitmap* output_rowset_delete_bitmap);
+
     Status check_rowid_conversion(
             RowsetSharedPtr dst_rowset,
             const std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>&

--- a/be/test/storage/compaction/segcompaction_mow_test.cpp
+++ b/be/test/storage/compaction/segcompaction_mow_test.cpp
@@ -19,9 +19,14 @@
 #include <gen_cpp/olap_file.pb.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "common/config.h"
@@ -40,6 +45,7 @@
 #include "storage/tablet/tablet_meta.h"
 #include "storage/tablet/tablet_schema.h"
 #include "storage/utils.h"
+#include "util/debug_points.h"
 #include "util/slice.h"
 
 namespace doris {
@@ -94,6 +100,8 @@ public:
     }
 
     void TearDown() {
+        DebugPoints::instance()->clear();
+        config::enable_debug_points = false;
         config::enable_segcompaction = false;
         ExecEnv* exec_env = doris::ExecEnv::GetInstance();
         s_engine = nullptr;
@@ -128,6 +136,35 @@ protected:
             }
         }
         return true;
+    }
+
+    bool wait_until(const std::function<bool()>& pred, int timeout_ms = 10000) {
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (pred()) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return pred();
+    }
+
+    Block create_int_block(TabletSchemaSPtr tablet_schema, uint32_t segment_id,
+                           uint32_t rows_per_segment) {
+        Block block = tablet_schema->create_block();
+        auto columns = block.mutate_columns();
+        for (uint32_t rid = 0; rid < rows_per_segment; ++rid) {
+            uint32_t k1 = rid * 100 + segment_id;
+            uint32_t k2 = segment_id;
+            uint32_t k3 = rid;
+            uint32_t seq = 0;
+            columns[0]->insert_data(reinterpret_cast<const char*>(&k1), sizeof(k1));
+            columns[1]->insert_data(reinterpret_cast<const char*>(&k2), sizeof(k2));
+            columns[2]->insert_data(reinterpret_cast<const char*>(&k3), sizeof(k3));
+            columns[3]->insert_data(reinterpret_cast<const char*>(&seq), sizeof(seq));
+        }
+        block.set_columns(std::move(columns));
+        return block;
     }
 
     // (k1 int, k2 varchar(20), k3 int) keys (k1, k2)
@@ -821,6 +858,85 @@ TEST_F(SegCompactionMoWTest, SegCompactionInterleaveWithBig_OoOoO) {
 
     EXPECT_TRUE(check_data_read_with_delete_bitmap(tablet_schema, delete_bitmap, rowset,
                                                    total_written_rows, rows_mark_deleted));
+}
+
+TEST_F(SegCompactionMoWTest, AsyncDeleteBitmapMustNotReadSegmentsDeletedBySegcompaction) {
+    config::enable_segcompaction = true;
+    config::enable_debug_points = true;
+    config::segcompaction_batch_size = 5;
+    config::segcompaction_candidate_max_rows = 1000;
+    config::segcompaction_candidate_max_bytes = 1 << 20;
+
+    TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+    create_tablet_schema(tablet_schema);
+
+    RowsetWriterContext writer_context;
+    const int raw_rsid = 20052;
+    create_rowset_writer_context(raw_rsid, tablet_schema, &writer_context);
+
+    DeleteBitmapPtr delete_bitmap = std::make_shared<DeleteBitmap>(TABLET_ID);
+    std::shared_ptr<RowsetIdUnorderedSet> rsids {std::make_shared<RowsetIdUnorderedSet>()};
+    std::vector<RowsetSharedPtr> rowset_ptrs;
+    writer_context.mow_context =
+            std::make_shared<MowContext>(1, 1, rsids, rowset_ptrs, delete_bitmap);
+
+    auto res = RowsetFactory::create_rowset_writer(*s_engine, writer_context, false);
+    ASSERT_TRUE(res.has_value()) << res.error();
+    auto rowset_writer = std::move(res).value();
+
+    constexpr int32_t target_segment_id = 3;
+    std::atomic<bool> target_delete_bitmap_task_blocked {false};
+    std::atomic<bool> release_target_delete_bitmap_task {false};
+    DebugPoints::instance()->add_with_callback(
+            "BaseBetaRowsetWriter::_generate_delete_bitmap.block_before_load_segments",
+            std::function<void(int32_t)>([&](int32_t segment_id) {
+                if (segment_id != target_segment_id) {
+                    return;
+                }
+                target_delete_bitmap_task_blocked.store(true);
+                while (!release_target_delete_bitmap_task.load()) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                }
+            }));
+
+    auto target_segment_path = fmt::format("{}/{}_{}.dat", lTestDir, raw_rsid, target_segment_id);
+    bool blocked = false;
+    bool source_segment_deleted_before_release = false;
+    std::thread release_thread([&] {
+        blocked = wait_until([&] { return target_delete_bitmap_task_blocked.load(); });
+        if (blocked) {
+            source_segment_deleted_before_release =
+                    wait_until([&] { return !std::filesystem::exists(target_segment_path); }, 1000);
+        }
+        release_target_delete_bitmap_task.store(true);
+        DebugPoints::instance()->remove(
+                "BaseBetaRowsetWriter::_generate_delete_bitmap.block_before_load_segments");
+    });
+
+    Status write_status = Status::OK();
+    const uint32_t rows_per_segment = 128;
+    for (int32_t segment_id = 0; segment_id < 5; ++segment_id) {
+        auto block = create_int_block(tablet_schema, segment_id, rows_per_segment);
+        write_status = rowset_writer->add_block(&block);
+        if (!write_status.ok()) {
+            break;
+        }
+        write_status = rowset_writer->flush();
+        if (!write_status.ok()) {
+            break;
+        }
+    }
+    release_thread.join();
+
+    RowsetSharedPtr rowset;
+    auto build_status = write_status.ok() ? rowset_writer->build(rowset) : write_status;
+
+    ASSERT_TRUE(blocked) << "delete bitmap task did not reach the injected wait point";
+    EXPECT_FALSE(source_segment_deleted_before_release)
+            << "segcompaction deleted source segment before delete bitmap finished: "
+            << target_segment_path;
+    EXPECT_TRUE(write_status.ok()) << write_status;
+    EXPECT_TRUE(build_status.ok()) << build_status;
 }
 
 TEST_F(SegCompactionMoWTest, SegCompactionNotTrigger) {

--- a/be/test/storage/compaction/vertical_compaction_test.cpp
+++ b/be/test/storage/compaction/vertical_compaction_test.cpp
@@ -30,6 +30,7 @@
 
 #include <iostream>
 #include <memory>
+#include <set>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -155,6 +156,50 @@ protected:
         return tablet_schema;
     }
 
+    TabletSchemaSPtr create_mow_cluster_key_schema() {
+        TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+        TabletSchemaPB tablet_schema_pb;
+        tablet_schema_pb.set_keys_type(UNIQUE_KEYS);
+        tablet_schema_pb.set_num_short_key_columns(1);
+        tablet_schema_pb.set_num_rows_per_row_block(1024);
+        tablet_schema_pb.set_compress_kind(COMPRESS_NONE);
+        tablet_schema_pb.set_next_column_unique_id(4);
+        tablet_schema_pb.add_cluster_key_uids(2);
+
+        ColumnPB* column_1 = tablet_schema_pb.add_column();
+        column_1->set_unique_id(1);
+        column_1->set_name("c1");
+        column_1->set_type("INT");
+        column_1->set_is_key(true);
+        column_1->set_length(4);
+        column_1->set_index_length(4);
+        column_1->set_is_nullable(false);
+        column_1->set_is_bf_column(false);
+
+        ColumnPB* column_2 = tablet_schema_pb.add_column();
+        column_2->set_unique_id(2);
+        column_2->set_name("c2");
+        column_2->set_type("INT");
+        column_2->set_length(4);
+        column_2->set_index_length(4);
+        column_2->set_is_key(false);
+        column_2->set_is_nullable(false);
+        column_2->set_is_bf_column(false);
+
+        ColumnPB* column_3 = tablet_schema_pb.add_column();
+        column_3->set_unique_id(3);
+        column_3->set_name(DELETE_SIGN);
+        column_3->set_type("TINYINT");
+        column_3->set_length(1);
+        column_3->set_index_length(1);
+        column_3->set_is_key(false);
+        column_3->set_is_nullable(false);
+        column_3->set_is_bf_column(false);
+
+        tablet_schema->init_from_pb(tablet_schema_pb);
+        return tablet_schema;
+    }
+
     TabletSchemaSPtr create_agg_schema() {
         TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
         TabletSchemaPB tablet_schema_pb;
@@ -206,6 +251,9 @@ protected:
         rowset_writer_context.version = version;
         rowset_writer_context.segments_overlap = overlap;
         rowset_writer_context.max_rows_per_segment = max_rows_per_segment;
+        rowset_writer_context.enable_unique_key_merge_on_write =
+                tablet_schema->keys_type() == UNIQUE_KEYS &&
+                !tablet_schema->cluster_key_uids().empty();
         inc_id++;
         return rowset_writer_context;
     }
@@ -321,6 +369,9 @@ protected:
             t_tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
         } else if (tablet_schema.keys_type() == AGG_KEYS) {
             t_tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
+        }
+        for (auto uid : tablet_schema.cluster_key_uids()) {
+            t_tablet_schema.cluster_key_uids.push_back(uid);
         }
         t_tablet_schema.__set_storage_type(TStorageType::COLUMN);
         t_tablet_schema.__set_columns(cols);
@@ -742,6 +793,86 @@ TEST_F(VerticalCompactionTest, TestUniqueKeyVerticalMerge) {
             EXPECT_EQ(std::get<1>(input_data[0][s_id][row_id]), std::get<1>(output_data[dst_id]));
             dst_id++;
         }
+    }
+}
+
+TEST_F(VerticalCompactionTest, ClusterKeyMowCompactionNeedsOutputRowsetInternalDedup) {
+    TabletSchemaSPtr tablet_schema = create_mow_cluster_key_schema();
+    TabletSharedPtr tablet = create_tablet(*tablet_schema, true);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    input_rowsets.push_back(create_rowset(tablet_schema, NONOVERLAPPING, {{{1, 30}}}, 2));
+    input_rowsets.push_back(create_rowset(tablet_schema, NONOVERLAPPING, {{{2, 10}, {1, 20}}}, 3));
+
+    std::vector<RowsetReaderSharedPtr> input_rs_readers;
+    for (auto& rowset : input_rowsets) {
+        RowsetReaderSharedPtr rs_reader;
+        ASSERT_TRUE(rowset->create_reader(&rs_reader).ok());
+        input_rs_readers.push_back(std::move(rs_reader));
+    }
+
+    auto writer_context = create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 1024, {2, 3});
+    auto res = RowsetFactory::create_rowset_writer(*engine_ref, writer_context, true);
+    ASSERT_TRUE(res.has_value()) << res.error();
+    auto output_rs_writer = std::move(res).value();
+
+    Merger::Statistics stats;
+    RowIdConversion rowid_conversion;
+    stats.rowid_conversion = &rowid_conversion;
+    auto st = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_CUMULATIVE_COMPACTION,
+                                             *tablet_schema, input_rs_readers,
+                                             output_rs_writer.get(), 1024, 1, &stats);
+    ASSERT_TRUE(st.ok()) << st;
+
+    RowsetSharedPtr output_rowset;
+    ASSERT_EQ(Status::OK(), output_rs_writer->build(output_rowset));
+    ASSERT_NE(output_rowset, nullptr);
+    ASSERT_EQ(1, output_rowset->num_segments());
+    ASSERT_EQ(3, output_rowset->num_rows());
+    ASSERT_EQ(0, stats.merged_rows);
+
+    RowsetReaderContext reader_context;
+    reader_context.tablet_schema = tablet_schema;
+    reader_context.need_ordered_result = false;
+    std::vector<uint32_t> return_columns = {0, 1};
+    reader_context.return_columns = &return_columns;
+    RowsetReaderSharedPtr output_rs_reader;
+    create_and_init_rowset_reader(output_rowset.get(), reader_context, &output_rs_reader);
+
+    std::vector<std::tuple<int64_t, int64_t>> output_data;
+    do {
+        Block output_block = tablet_schema->create_block();
+        st = output_rs_reader->next_batch(&output_block);
+        auto columns = output_block.get_columns_with_type_and_name();
+        ASSERT_GE(columns.size(), 2);
+        for (auto i = 0; i < output_block.rows(); i++) {
+            output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
+        }
+    } while (st.ok());
+    ASSERT_TRUE(st.is<END_OF_FILE>()) << st;
+
+    ASSERT_EQ(3, output_data.size());
+    EXPECT_EQ(output_data[0], std::make_tuple(int64_t {2}, int64_t {10}));
+    EXPECT_EQ(output_data[1], std::make_tuple(int64_t {1}, int64_t {20}));
+    EXPECT_EQ(output_data[2], std::make_tuple(int64_t {1}, int64_t {30}));
+
+    DeleteBitmap input_delete_bitmap(tablet->tablet_id());
+    DeleteBitmap output_delete_bitmap(tablet->tablet_id());
+    tablet->calc_compaction_output_rowset_delete_bitmap(input_rowsets, rowid_conversion, 0,
+                                                        UINT64_MAX, nullptr, nullptr,
+                                                        input_delete_bitmap, &output_delete_bitmap);
+    st = tablet->calc_compaction_output_rowset_internal_delete_bitmap(
+            input_rowsets, output_rowset, rowid_conversion, &output_delete_bitmap);
+    ASSERT_TRUE(st.ok()) << st;
+
+    std::set<int64_t> visible_keys;
+    auto deleted_rows = output_delete_bitmap.get_agg({output_rowset->rowset_id(), 0, UINT64_MAX});
+    for (uint32_t row_id = 0; row_id < output_data.size(); ++row_id) {
+        if (deleted_rows->contains(row_id)) {
+            continue;
+        }
+        ASSERT_TRUE(visible_keys.insert(std::get<0>(output_data[row_id])).second)
+                << "unique key should not be duplicated after cluster-key MOW compaction";
     }
 }
 


### PR DESCRIPTION
Issue Number: None

Related PR: None

Problem Summary: Cluster-key MOW compaction sorts rows by cluster key, so duplicate unique keys may be non-adjacent and can remain visible in the output rowset. Scan the output rowset primary key index after compaction and add output-rowset internal delete bitmap entries for older duplicate unique-key rows.

None

- Test: Unit Test
    - Ran ./run-be-ut.sh --run --filter=VerticalCompactionTest.ClusterKeyMowCompactionNeedsOutputRowsetInternalDedup -j 8
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

