### PR TITLE
[fix](fe) Define default argLine for FE unit tests

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -397,6 +397,7 @@ under the License.
         <arrow.vector.classifier>shade-format-flatbuffers</arrow.vector.classifier>
         <flatbuffers.version>1.12.0</flatbuffers.version>
         <jacoco.version>0.8.10</jacoco.version>
+        <argLine></argLine>
         <trino.version>435</trino.version>
         <nimbusds.version>10.0.1</nimbusds.version>
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: 

FE core surefire config uses `@{argLine}` to preserve Jacoco late property replacement. In normal non-coverage FE unit test runs, the coverage profile is not active, so Jacoco does not define the Maven `argLine` property. Without a default value, surefire may pass `@{argLine}` unchanged to the forked JVM, and JDK 17 treats it as an argfile reference, failing with `Error: could not open {argLine}` before tests start. Define an empty default `argLine` in the FE parent POM so normal FE UT resolves it to empty while coverage runs can still inject Jacoco agent options.