### PR TITLE
[refine](core) add compile-time safety checks to assert_cast

### DIFF
--- a/be/src/core/assert_cast.h
+++ b/be/src/core/assert_cast.h
@@ -42,6 +42,9 @@ struct AssertCastNormalizedType {
 template <typename T>
 using AssertCastNormalizedType_t = typename AssertCastNormalizedType<T>::type;
 
+template <typename T>
+using AssertCastClassType_t = std::remove_pointer_t<AssertCastNormalizedType_t<T>>;
+
 /** Perform static_cast in release build when TypeCheckOnRelease is set to DISABLE.
   * Checks type by comparing typeid and throw an exception in all the other situations.
   * The exact match of the type is checked. That is, cast to the ancestor will be unsuccessful.
@@ -50,6 +53,11 @@ template <typename To, TypeCheckOnRelease check = TypeCheckOnRelease::ENABLE, ty
 PURE To assert_cast(From&& from) {
     static_assert(!std::is_same_v<AssertCastNormalizedType_t<To>, AssertCastNormalizedType_t<From>>,
                   "assert_cast is redundant for the same type after removing cv/ref qualifiers");
+    static_assert(std::is_class_v<AssertCastClassType_t<To>> &&
+                          std::is_class_v<AssertCastClassType_t<From>>,
+                  "assert_cast requires casting between class pointer/reference types");
+    static_assert(std::is_base_of_v<AssertCastClassType_t<From>, AssertCastClassType_t<To>>,
+                  "assert_cast only supports downcast from a base type to a derived type");
 
     // https://godbolt.org/z/nrsx7nYhs
     // perform_cast will not be compiled to asm in release build with TypeCheckOnRelease::DISABLE


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`assert_cast` previously only performed runtime type checks (via `typeid` comparison). Misuse — such as casting between unrelated types or upcasting — would only be caught at runtime, making it easy for incorrect usage to slip into release builds where `TypeCheckOnRelease::DISABLE` turns checks into `static_cast` without any verification.


This catches invalid casts at build time instead of producing undefined behavior or hard-to-diagnose runtime errors.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

