### PR TITLE
fix(cast): correct scientific notation string to decimal parsing (#63085)

### DIFF
--- a/be/src/util/string_parser.cpp
+++ b/be/src/util/string_parser.cpp
@@ -188,7 +188,7 @@ typename PrimitiveTypeTraits<P>::CppType::NativeType StringParser::string_to_dec
             }
             int_part_number = int_part_number * 10 + (s[digit_index] - '0');
         }
-        auto total_significant_digit_count = i - ((found_dot && int_part_count > 0) ? 1 : 0);
+        auto total_significant_digit_count = end_digit_index - ((found_dot && int_part_count > 0) ? 1 : 0);
         if (result_int_part_digit_count > total_significant_digit_count) {
             int_part_number *= get_scale_multiplier<T>(result_int_part_digit_count -
                                                        total_significant_digit_count);


### PR DESCRIPTION
## Problem
`CAST('1.4E+4' AS DECIMAL(38, 15))` returns 14.000... instead of 14000.000... in Doris 4.0.5 (regression from 2.1).

## Root Cause
`be/src/util/string_parser.cpp` — `string_to_decimal` function at line 191 uses a loop variable `i` that was contaminated by the exponent parsing loop, instead of the preserved `end_digit_index`.

Introduced by commit c10826315c0.

## Fix
Replace `i` with `end_digit_index` on line 191.

Fixes #63085