### PR TITLE
[fix](fe) Fix remote Flight SQL result receiver initialization

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiverConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiverConsumer.java
@@ -82,15 +82,18 @@ public class ResultReceiverConsumer {
             ReceiverContext context = new ReceiverContext(resultReceivers.get(i), i);
             contexts.add(context);
         }
-        this.readyOffsets = new ArrayBlockingQueue<>(resultReceivers.size());
+        this.readyOffsets = new ArrayBlockingQueue<>(Math.max(1, resultReceivers.size()));
         timeoutTs = timeoutDeadline;
     }
 
     public boolean isEos() {
-        return finishedReceivers == contexts.size();
+        return !contexts.isEmpty() && finishedReceivers == contexts.size();
     }
 
     public RowBatch getNext(Status status) throws TException, InterruptedException, ExecutionException, UserException {
+        if (contexts.isEmpty()) {
+            throw new UserException("There is no receiver.");
+        }
         if (!futureInitialized) {
             futureInitialized = true;
             for (ReceiverContext context : contexts) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
@@ -86,9 +86,13 @@ public class QueryProcessor extends AbstractJobProcessor {
         }
 
         boolean regenerateInstanceId = coordinatorContext.connectContext.consumeNeedRegenerateQueryId();
+        boolean returnResultFromLocal = coordinatorContext.connectContext.isReturnResultFromLocal();
         for (AssignedJob topInstance : distinctWorkerJobs.values()) {
             if (regenerateInstanceId) {
                 topInstance.resetInstanceId(coordinatorContext.connectContext.nextInstanceId());
+            }
+            if (!returnResultFromLocal) {
+                continue;
             }
             DistributedPlanWorker topWorker = topInstance.getAssignedWorker();
             TNetworkAddress execBeAddr = new TNetworkAddress(topWorker.host(), topWorker.brpcPort());

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ResultReceiverConsumerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ResultReceiverConsumerTest.java
@@ -37,6 +37,16 @@ public class ResultReceiverConsumerTest {
     private ResultReceiver receiver3 = Mockito.mock(ResultReceiver.class);
 
     @Test
+    public void testEmptyReceiversForRemoteResult() throws Exception {
+        ResultReceiverConsumer consumer = new ResultReceiverConsumer(Lists.newArrayList(),
+                System.currentTimeMillis() + 3600);
+        Status status = new Status();
+
+        Assert.assertFalse(consumer.isEos());
+        Assertions.assertThrows(UserException.class, () -> consumer.getNext(status));
+    }
+
+    @Test
     public void testEosHandling() throws Exception {
         ResultReceiverConsumer consumer = new ResultReceiverConsumer(
                 Lists.newArrayList(receiver1, receiver2, receiver3), System.currentTimeMillis() + 3600);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Arrow Flight SQL queries that return results from BE do not create local result receivers. The old coordinator still initialized ResultReceiverConsumer with an empty receiver list, which failed with ArrayBlockingQueue(0), and the new coordinator still created unnecessary local receivers for remote result mode.

### Release note

Fix Arrow Flight SQL query execution when results are returned from BE.

### Check List (For Author)

- Test: Unit Test
    - Ran org.apache.doris.qe.ResultReceiverConsumerTest
    - Ran FE checkstyle for fe-core
- Behavior changed: No
- Does this need documentation: No