### PR TITLE
[fix](be) Avoid protobuf ownership aliasing in exchange broadcast

### DIFF
--- a/be/src/exec/operator/exchange_sink_buffer.cpp
+++ b/be/src/exec/operator/exchange_sink_buffer.cpp
@@ -294,6 +294,10 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
             }
         } else {
             if (request.block && !request.block->column_metas().empty()) {
+                // Use set_allocated_block as a scoped borrow to avoid copying the serialized
+                // payload. The TransmitInfo unique_ptr remains the real owner, and release_block()
+                // below detaches the borrowed block before this reusable protobuf request is
+                // cleared or destroyed.
                 brpc_request->set_allocated_block(request.block.get());
             }
         }
@@ -420,12 +424,17 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
                     add_block->set_compressed(block->compressed());
                     add_block->set_compression_type(block->compression_type());
                     add_block->set_uncompressed_size(block->uncompressed_size());
+                    // Broadcast blocks are shared by multiple channels. Borrow the large
+                    // column_values string for this RPC request and release it below before
+                    // clear_blocks(), so BroadcastPBlockHolder remains the real owner.
                     add_block->set_allocated_column_values(block->mutable_column_values());
                 }
             }
         } else {
             if (request.block_holder->get_block() &&
                 !request.block_holder->get_block()->column_metas().empty()) {
+                // Same scoped-borrow pattern as above: the broadcast holder owns this PBlock.
+                // release_block() below detaches it before protobuf cleanup can delete it.
                 brpc_request->set_allocated_block(request.block_holder->get_block());
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Avoid using protobuf ownership APIs with shared broadcast PBlock data and document Cloud arena schema alias assumptions.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Ran build-support/check-format.sh
    - Ran git diff --check -- be/src/exec/operator/exchange_sink_buffer.cpp cloud/src/meta-service/meta_service.cpp
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

