### PR TITLE
[fix](streaming-job) start counting task max interval after the first record is received

### DIFF
--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
@@ -454,15 +454,17 @@ public class PipelineCoordinator {
 
             isSnapshotSplit = sourceReader.isSnapshotSplit(readResult.getSplit());
             long startTime = System.currentTimeMillis();
+            long streamingStartTime = -1;
             long maxIntervalMillis = writeRecordRequest.getMaxInterval() * 1000;
             boolean shouldStop = false;
             boolean lastMessageIsHeartbeat = false;
 
             LOG.info(
-                    "Start polling records for jobId={} taskId={}, isSnapshotSplit={}",
+                    "Start polling records for jobId={} taskId={}, isSnapshotSplit={}, maxIntervalMillis={}",
                     writeRecordRequest.getJobId(),
                     writeRecordRequest.getTaskId(),
-                    isSnapshotSplit);
+                    isSnapshotSplit,
+                    maxIntervalMillis);
 
             // 2. poll record
             while (!shouldStop) {
@@ -471,10 +473,12 @@ public class PipelineCoordinator {
                 if (!recordIterator.hasNext()) {
                     Thread.sleep(100);
 
-                    // Check if should stop
-                    long elapsedTime = System.currentTimeMillis() - startTime;
+                    long now = System.currentTimeMillis();
+                    long elapsedTime = now - startTime;
                     boolean timeoutReached =
-                            maxIntervalMillis > 0 && elapsedTime >= maxIntervalMillis;
+                            streamingStartTime > 0
+                                    && maxIntervalMillis > 0
+                                    && (now - streamingStartTime) >= maxIntervalMillis;
 
                     if (shouldStop(
                             isSnapshotSplit,
@@ -488,22 +492,29 @@ public class PipelineCoordinator {
                     continue;
                 }
 
+                if (streamingStartTime < 0) {
+                    streamingStartTime = System.currentTimeMillis();
+                    LOG.info(
+                            "Streaming phase started after {} ms setup for jobId={} taskId={}",
+                            streamingStartTime - startTime,
+                            writeRecordRequest.getJobId(),
+                            writeRecordRequest.getTaskId());
+                }
+
                 while (recordIterator.hasNext()) {
                     SourceRecord element = recordIterator.next();
 
-                    // Check if this is a heartbeat message
                     if (isHeartbeatEvent(element)) {
                         heartbeatCount++;
 
-                        // Mark last message as heartbeat (only for binlog split)
                         if (!isSnapshotSplit) {
                             lastMessageIsHeartbeat = true;
                         }
 
-                        // If already timeout, stop immediately when heartbeat received
-                        long elapsedTime = System.currentTimeMillis() - startTime;
+                        long now = System.currentTimeMillis();
                         boolean timeoutReached =
-                                maxIntervalMillis > 0 && elapsedTime >= maxIntervalMillis;
+                                maxIntervalMillis > 0
+                                        && (now - streamingStartTime) >= maxIntervalMillis;
 
                         if (!isSnapshotSplit && timeoutReached) {
                             LOG.info(
@@ -511,7 +522,6 @@ public class PipelineCoordinator {
                             shouldStop = true;
                             break;
                         }
-                        // Skip heartbeat messages during normal processing
                         continue;
                     }
 

--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
@@ -473,12 +473,15 @@ public class PipelineCoordinator {
                 if (!recordIterator.hasNext()) {
                     Thread.sleep(100);
 
-                    long now = System.currentTimeMillis();
-                    long elapsedTime = now - startTime;
+                    // Check if should stop
+                    long elapsedTime =
+                            streamingStartTime > 0
+                                    ? System.currentTimeMillis() - streamingStartTime
+                                    : 0;
                     boolean timeoutReached =
                             streamingStartTime > 0
                                     && maxIntervalMillis > 0
-                                    && (now - streamingStartTime) >= maxIntervalMillis;
+                                    && elapsedTime >= maxIntervalMillis;
 
                     if (shouldStop(
                             isSnapshotSplit,
@@ -504,17 +507,21 @@ public class PipelineCoordinator {
                 while (recordIterator.hasNext()) {
                     SourceRecord element = recordIterator.next();
 
+                    // Check if this is a heartbeat message
                     if (isHeartbeatEvent(element)) {
                         heartbeatCount++;
 
+                        // Mark last message as heartbeat (only for binlog split)
                         if (!isSnapshotSplit) {
                             lastMessageIsHeartbeat = true;
                         }
 
-                        long now = System.currentTimeMillis();
+                        // If already timeout, stop immediately when heartbeat received
+                        long elapsedTime = System.currentTimeMillis() - streamingStartTime;
                         boolean timeoutReached =
-                                maxIntervalMillis > 0
-                                        && (now - streamingStartTime) >= maxIntervalMillis;
+                                streamingStartTime > 0
+                                        && maxIntervalMillis > 0
+                                        && elapsedTime >= maxIntervalMillis;
 
                         if (!isSnapshotSplit && timeoutReached) {
                             LOG.info(
@@ -522,6 +529,7 @@ public class PipelineCoordinator {
                             shouldStop = true;
                             break;
                         }
+                        // Skip heartbeat messages during normal processing
                         continue;
                     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

For PG CDC streaming jobs, when a task creates a fresh logical replication
connection, the walsender must re-decode the WAL region from `slot.restart_lsn`
up to the client-supplied `startLsn` before any event can be emitted. On high
RTT networks (e.g. cross-region Aurora) this catch-up alone can take several
seconds.

Under the previous behavior the task's `maxInterval` window started the moment
the task entered `writeRecords`, so the time spent on WAL position lookup +
walsender catch-up was charged against the interval. With `max_interval=10s`
this consistently caused tasks to finish with `0 records, 0 heartbeats`, the
slot's `confirmed_flush_lsn` never advanced, and every following task repeated
the same catch-up — the slot was effectively stuck and replication lag grew
indefinitely.

This PR delays the start of the `maxInterval` countdown until the first record
(or heartbeat) is actually received from the source reader, so the per-task
interval governs the real streaming window rather than being consumed by setup.
The FE-side `streaming_task_timeout_multiplier * maxIntervalSec` still acts as
the hard ceiling.

### Release note

None

### Check List (For Author)

- Test
    - [x] Manual test (add detailed scripts or steps below)

    Steps:
    1. Create a PG CDC streaming job with `max_interval=10` against a source
       whose replication slot has accumulated > 100MB of unconsumed WAL
       (e.g. by pausing the consumer for a while).
    2. Replace the BE-side `cdc-client.jar` with the build from this PR and
       restart cdc-client.
    3. Observe the new log line on each task start:
       \`Streaming phase started after <X> ms setup for jobId=... taskId=...\`.
       \`X\` is the time the walsender spent re-decoding the already-acked WAL
       region; it can be larger than \`maxInterval\` without causing the task
       to abort with \`0 records\`.
    4. On the PG side, \`pg_replication_slots.confirmed_flush_lsn\` for the slot
       advances over successive tasks, and \`MAX(inserted_at)\` on the Doris
       table catches up to the source.

- Behavior changed:
    - [x] Yes.

    The per-task \`maxInterval\` window now begins when the first record (or
    heartbeat) is delivered, instead of when the task starts. Tasks where the
    source already has data ready see no end-to-end change; tasks that hit
    catch-up / setup delays now have the full \`maxInterval\` to actually
    consume data, at the cost of a longer overall task lifetime in those
    cases.

- Does this need documentation?
    - [x] No.