### PR TITLE
[improvement](be) Optimize Variant DESCRIBE metadata reads

### DIFF
--- a/be/src/cloud/cloud_snapshot_mgr.cpp
+++ b/be/src/cloud/cloud_snapshot_mgr.cpp
@@ -283,6 +283,17 @@ Status CloudSnapshotMgr::_create_rowset_meta(
         new_rowset_meta_pb->set_segments_key_bounds_aggregated(
                 source_meta_pb.segments_key_bounds_aggregated());
     }
+    new_rowset_meta_pb->clear_variant_schema_hash_lo();
+    new_rowset_meta_pb->clear_variant_schema_hash_hi();
+    new_rowset_meta_pb->clear_variant_schema_representatives();
+    if (source_meta_pb.has_variant_schema_hash_lo()) {
+        new_rowset_meta_pb->set_variant_schema_hash_lo(source_meta_pb.variant_schema_hash_lo());
+    }
+    if (source_meta_pb.has_variant_schema_hash_hi()) {
+        new_rowset_meta_pb->set_variant_schema_hash_hi(source_meta_pb.variant_schema_hash_hi());
+    }
+    new_rowset_meta_pb->mutable_variant_schema_representatives()->CopyFrom(
+            source_meta_pb.variant_schema_representatives());
     if (source_meta_pb.has_delete_predicate()) {
         DeletePredicatePB* new_delete_condition = new_rowset_meta_pb->mutable_delete_predicate();
         *new_delete_condition = source_meta_pb.delete_predicate();

--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -120,6 +120,13 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in) 
     if (in.has_commit_tso()) {
         out->set_commit_tso(in.commit_tso());
     }
+    if (in.has_variant_schema_hash_lo()) {
+        out->set_variant_schema_hash_lo(in.variant_schema_hash_lo());
+    }
+    if (in.has_variant_schema_hash_hi()) {
+        out->set_variant_schema_hash_hi(in.variant_schema_hash_hi());
+    }
+    out->mutable_variant_schema_representatives()->CopyFrom(in.variant_schema_representatives());
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }
@@ -210,6 +217,14 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in) {
     if (in.has_commit_tso()) {
         out->set_commit_tso(in.commit_tso());
     }
+    if (in.has_variant_schema_hash_lo()) {
+        out->set_variant_schema_hash_lo(in.variant_schema_hash_lo());
+    }
+    if (in.has_variant_schema_hash_hi()) {
+        out->set_variant_schema_hash_hi(in.variant_schema_hash_hi());
+    }
+    out->mutable_variant_schema_representatives()->Swap(
+            in.mutable_variant_schema_representatives());
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }
@@ -310,6 +325,13 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in) 
     if (in.has_commit_tso()) {
         out->set_commit_tso(in.commit_tso());
     }
+    if (in.has_variant_schema_hash_lo()) {
+        out->set_variant_schema_hash_lo(in.variant_schema_hash_lo());
+    }
+    if (in.has_variant_schema_hash_hi()) {
+        out->set_variant_schema_hash_hi(in.variant_schema_hash_hi());
+    }
+    out->mutable_variant_schema_representatives()->CopyFrom(in.variant_schema_representatives());
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }
@@ -399,6 +421,14 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in) {
     if (in.has_commit_tso()) {
         out->set_commit_tso(in.commit_tso());
     }
+    if (in.has_variant_schema_hash_lo()) {
+        out->set_variant_schema_hash_lo(in.variant_schema_hash_lo());
+    }
+    if (in.has_variant_schema_hash_hi()) {
+        out->set_variant_schema_hash_hi(in.variant_schema_hash_hi());
+    }
+    out->mutable_variant_schema_representatives()->Swap(
+            in.mutable_variant_schema_representatives());
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }

--- a/be/src/exec/common/variant_util.cpp
+++ b/be/src/exec/common/variant_util.cpp
@@ -33,10 +33,13 @@
 #include <unicode/uchar.h>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
+#include <limits>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -47,7 +50,9 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -97,12 +102,210 @@
 #include "storage/tablet/tablet_fwd.h"
 #include "storage/tablet/tablet_schema.h"
 #include "util/client_cache.h"
+#include "util/debug_points.h"
 #include "util/defer_op.h"
+#include "util/hash/murmur_hash3.h"
 #include "util/json/json_parser.h"
 #include "util/json/path_in_data.h"
 #include "util/json/simd_json_parser.h"
 
 namespace doris::variant_util {
+
+namespace {
+
+constexpr std::string_view VARIANT_SEGMENT_SCHEMA_KEY_VERSION = "variant_segment_schema_key_v1";
+constexpr std::string_view VARIANT_ROWSET_SCHEMA_KEY_VERSION = "variant_rowset_schema_key_v1";
+constexpr uint32_t VARIANT_SCHEMA_HASH_SEED = 0x9e3779b9;
+
+void append_token(std::string* dst, std::string_view token) {
+    dst->append(std::to_string(token.size()));
+    dst->push_back(':');
+    dst->append(token.data(), token.size());
+    dst->push_back(';');
+}
+
+template <typename T>
+void append_number(std::string* dst, T value) {
+    append_token(dst, std::to_string(value));
+}
+
+void canonicalize_column_path_info(const segment_v2::ColumnPathInfo& path_info,
+                                   segment_v2::ColumnPathInfo* canonical_path_info) {
+    canonical_path_info->set_path(path_info.path());
+    canonical_path_info->set_has_nested(path_info.has_nested());
+    canonical_path_info->set_is_typed(path_info.is_typed());
+    canonical_path_info->set_parrent_column_unique_id(path_info.parrent_column_unique_id());
+    canonical_path_info->set_is_nested_group_offsets(path_info.is_nested_group_offsets());
+    canonical_path_info->set_nested_group_parent_path(path_info.nested_group_parent_path());
+    canonical_path_info->set_nested_group_depth(path_info.nested_group_depth());
+    for (const auto& part : path_info.path_part_infos()) {
+        auto* canonical_part = canonical_path_info->add_path_part_infos();
+        canonical_part->set_key(part.key());
+        canonical_part->set_is_nested(part.is_nested());
+        canonical_part->set_anonymous_array_level(part.anonymous_array_level());
+    }
+}
+
+void canonicalize_column_meta_schema(const segment_v2::ColumnMetaPB& meta,
+                                     segment_v2::ColumnMetaPB* canonical_meta) {
+    canonical_meta->set_type(meta.type());
+    canonical_meta->set_length(meta.length());
+    canonical_meta->set_is_nullable(meta.is_nullable());
+    canonical_meta->set_precision(meta.precision());
+    canonical_meta->set_frac(meta.frac());
+    canonical_meta->set_result_is_nullable(meta.result_is_nullable());
+    canonical_meta->set_variant_max_subcolumns_count(meta.variant_max_subcolumns_count());
+    canonical_meta->set_variant_enable_doc_mode(meta.variant_enable_doc_mode());
+    if (meta.has_column_path_info()) {
+        canonicalize_column_path_info(meta.column_path_info(),
+                                      canonical_meta->mutable_column_path_info());
+    }
+    for (const auto& child_name : meta.children_column_names()) {
+        canonical_meta->add_children_column_names(child_name);
+    }
+    for (const auto& child : meta.children_columns()) {
+        canonicalize_column_meta_schema(child, canonical_meta->add_children_columns());
+    }
+}
+
+std::string serialize_column_meta_schema_key(const segment_v2::ColumnMetaPB& meta) {
+    segment_v2::ColumnMetaPB canonical_meta;
+    canonicalize_column_meta_schema(meta, &canonical_meta);
+    std::string serialized;
+    CHECK(canonical_meta.SerializeToString(&serialized));
+    return serialized;
+}
+
+bool is_describe_variant_subcolumn(const segment_v2::ColumnMetaPB& meta) {
+    if (!meta.has_column_path_info() || !meta.column_path_info().has_parrent_column_unique_id()) {
+        return false;
+    }
+    PathInData full_path;
+    full_path.from_protobuf(meta.column_path_info());
+    auto relative_path = full_path.copy_pop_front();
+    if (relative_path.empty()) {
+        return false;
+    }
+    const auto& path = relative_path.get_path();
+    if (path == SPARSE_COLUMN_PATH || path.starts_with(std::string(SPARSE_COLUMN_PATH) + ".b") ||
+        path.find(DOC_VALUE_COLUMN_PATH) != std::string::npos ||
+        segment_v2::contains_nested_group_marker(path)) {
+        return false;
+    }
+    return true;
+}
+
+bool has_unsupported_describe_fast_path_shape(const segment_v2::ColumnMetaPB& meta) {
+    if (!meta.has_column_path_info() || !meta.column_path_info().has_parrent_column_unique_id()) {
+        return false;
+    }
+    PathInData full_path;
+    full_path.from_protobuf(meta.column_path_info());
+    auto relative_path = full_path.copy_pop_front();
+    if (relative_path.empty()) {
+        return meta.type() != static_cast<int>(FieldType::OLAP_FIELD_TYPE_VARIANT);
+    }
+    const auto& path = relative_path.get_path();
+    if (path == SPARSE_COLUMN_PATH || path.starts_with(std::string(SPARSE_COLUMN_PATH) + ".b")) {
+        return meta.variant_statistics().sparse_column_non_null_size_size() > 0;
+    }
+    return path.find(DOC_VALUE_COLUMN_PATH) != std::string::npos ||
+           segment_v2::contains_nested_group_marker(path);
+}
+
+} // namespace
+
+VariantSchemaHash hash_variant_schema_key(std::string_view key) {
+    DCHECK_LE(key.size(), static_cast<size_t>(std::numeric_limits<int>::max()));
+    std::array<uint64_t, 2> hash {0, 0};
+    murmur_hash3_x64_128(key.data(), static_cast<int>(key.size()), VARIANT_SCHEMA_HASH_SEED,
+                         hash.data());
+    return {.lo = hash[0], .hi = hash[1]};
+}
+
+bool build_segment_variant_schema_key(const segment_v2::SegmentFooterPB& footer,
+                                      VariantSchemaKey* schema_key) {
+    if (schema_key == nullptr) {
+        return false;
+    }
+
+    std::vector<int32_t> root_uids;
+    struct SubcolumnEntry {
+        int32_t parent_uid = -1;
+        std::string path;
+        std::string key;
+    };
+    std::vector<SubcolumnEntry> subcolumns;
+
+    for (const auto& column : footer.columns()) {
+        if (column.type() == static_cast<int>(FieldType::OLAP_FIELD_TYPE_VARIANT)) {
+            // Doc-mode layouts can materialize schema outside ordinary dynamic subcolumns.
+            if (column.variant_enable_doc_mode()) {
+                return false;
+            }
+            root_uids.push_back(static_cast<int32_t>(column.unique_id()));
+        }
+        if (has_unsupported_describe_fast_path_shape(column)) {
+            return false;
+        }
+        if (!is_describe_variant_subcolumn(column)) {
+            continue;
+        }
+        PathInData full_path;
+        full_path.from_protobuf(column.column_path_info());
+        auto relative_path = full_path.copy_pop_front();
+
+        auto entry_key = serialize_column_meta_schema_key(column);
+        subcolumns.push_back(
+                {static_cast<int32_t>(column.column_path_info().parrent_column_unique_id()),
+                 relative_path.get_path(), std::move(entry_key)});
+    }
+
+    if (root_uids.empty() || subcolumns.empty()) {
+        return false;
+    }
+
+    std::sort(root_uids.begin(), root_uids.end());
+    root_uids.erase(std::unique(root_uids.begin(), root_uids.end()), root_uids.end());
+    // Keep the key independent from writer/test construction order even though writers normally
+    // emit a deterministic footer order.
+    std::sort(subcolumns.begin(), subcolumns.end(), [](const auto& lhs, const auto& rhs) {
+        return std::tie(lhs.parent_uid, lhs.path, lhs.key) <
+               std::tie(rhs.parent_uid, rhs.path, rhs.key);
+    });
+
+    std::string key;
+    append_token(&key, VARIANT_SEGMENT_SCHEMA_KEY_VERSION);
+    append_number(&key, root_uids.size());
+    for (const auto root_uid : root_uids) {
+        append_number(&key, root_uid);
+    }
+    append_number(&key, subcolumns.size());
+    for (const auto& subcolumn : subcolumns) {
+        append_token(&key, subcolumn.key);
+    }
+
+    schema_key->key = std::move(key);
+    schema_key->hash = hash_variant_schema_key(schema_key->key);
+    return true;
+}
+
+VariantSchemaHash build_rowset_variant_schema_hash(const std::vector<std::string>& schema_keys) {
+    std::vector<std::string_view> sorted_schema_keys;
+    sorted_schema_keys.reserve(schema_keys.size());
+    for (const auto& schema_key : schema_keys) {
+        sorted_schema_keys.push_back(schema_key);
+    }
+    std::sort(sorted_schema_keys.begin(), sorted_schema_keys.end());
+
+    std::string key;
+    append_token(&key, VARIANT_ROWSET_SCHEMA_KEY_VERSION);
+    append_number(&key, sorted_schema_keys.size());
+    for (const auto& schema_key : sorted_schema_keys) {
+        append_token(&key, schema_key);
+    }
+    return hash_variant_schema_key(key);
+}
 
 inline void append_escaped_regex_char(std::string* regex_output, char ch) {
     switch (ch) {
@@ -1600,17 +1803,118 @@ TabletSchemaSPtr VariantCompactionUtil::calculate_variant_extended_schema(
         return nullptr;
     }
 
-    std::vector<TabletSchemaSPtr> schemas;
+    struct RowsetScanSegments {
+        RowsetSharedPtr rowset;
+        std::vector<int64_t> segment_ids;
+    };
+
+    struct RepresentativeSegments {
+        std::vector<int64_t> segment_ids;
+        bool complete_metadata = false;
+    };
+
+    auto get_all_segment_ids = [](const RowsetSharedPtr& rs) {
+        std::vector<int64_t> segment_ids;
+        segment_ids.reserve(rs->num_segments());
+        for (int64_t segment_id = 0; segment_id < rs->num_segments(); ++segment_id) {
+            segment_ids.push_back(segment_id);
+        }
+        return segment_ids;
+    };
+
+    auto get_representative_segment_ids = [&](const RowsetSharedPtr& rs) {
+        auto rowset_meta = rs->rowset_meta();
+        if (rowset_meta == nullptr || !rowset_meta->has_variant_schema_representatives()) {
+            return RepresentativeSegments {.segment_ids = get_all_segment_ids(rs),
+                                           .complete_metadata = false};
+        }
+        std::unordered_set<int64_t> seen_segment_ids;
+        std::vector<int64_t> segment_ids;
+        segment_ids.reserve(rowset_meta->variant_schema_representatives().size());
+        for (const auto& representative : rowset_meta->variant_schema_representatives()) {
+            if (!representative.has_segment_id()) {
+                LOG(WARNING) << "Incomplete Variant schema representative for rowset "
+                             << rs->rowset_id();
+                return RepresentativeSegments {.segment_ids = get_all_segment_ids(rs),
+                                               .complete_metadata = false};
+            }
+            const int64_t segment_id = representative.segment_id();
+            if (segment_id < 0 || segment_id >= rs->num_segments()) {
+                LOG(WARNING) << "Invalid Variant schema representative segment id " << segment_id
+                             << " for rowset " << rs->rowset_id()
+                             << ", num_segments=" << rs->num_segments();
+                return RepresentativeSegments {.segment_ids = get_all_segment_ids(rs),
+                                               .complete_metadata = false};
+            }
+            if (!seen_segment_ids.insert(segment_id).second) {
+                LOG(WARNING) << "Duplicate Variant schema representative segment id " << segment_id
+                             << " for rowset " << rs->rowset_id();
+                return RepresentativeSegments {.segment_ids = get_all_segment_ids(rs),
+                                               .complete_metadata = false};
+            }
+            segment_ids.push_back(segment_id);
+        }
+        if (segment_ids.empty()) {
+            return RepresentativeSegments {.segment_ids = get_all_segment_ids(rs),
+                                           .complete_metadata = false};
+        }
+        return RepresentativeSegments {.segment_ids = std::move(segment_ids),
+                                       .complete_metadata = true};
+    };
+
+    auto build_rowset_schema_dedup_key = [](const RowsetMetaSharedPtr& rowset_meta) {
+        const auto [hash_lo, hash_hi] = rowset_meta->variant_schema_hash();
+        return fmt::format("{}:{}", hash_lo, hash_hi);
+    };
+
+    std::vector<RowsetScanSegments> rowset_scan_segments;
+    std::unordered_set<std::string> seen_rowset_schema_hashes;
     for (const auto& rs : rowsets) {
         if (rs->num_segments() == 0) {
             continue;
         }
+        auto rowset_meta = rs->rowset_meta();
+        auto representative_segments = get_representative_segment_ids(rs);
+        if (representative_segments.complete_metadata) {
+            const auto dedup_key = build_rowset_schema_dedup_key(rowset_meta);
+            if (!seen_rowset_schema_hashes.insert(dedup_key).second) {
+                continue;
+            }
+        }
+        rowset_scan_segments.push_back({rs, std::move(representative_segments.segment_ids)});
+    }
+
+    DBUG_EXECUTE_IF("VariantCompactionUtil.calculate_variant_extended_schema.check_scan_segments", {
+        int64_t selected_segment_count = 0;
+        for (const auto& scan : rowset_scan_segments) {
+            selected_segment_count += static_cast<int64_t>(scan.segment_ids.size());
+        }
+        const int64_t expected_selected_rowsets = dp->param<int64_t>("selected_rowsets", -1);
+        const int64_t expected_selected_segments = dp->param<int64_t>("selected_segments", -1);
+        if ((expected_selected_rowsets >= 0 &&
+             expected_selected_rowsets != static_cast<int64_t>(rowset_scan_segments.size())) ||
+            (expected_selected_segments >= 0 &&
+             expected_selected_segments != selected_segment_count)) {
+            LOG(WARNING) << "Unexpected Variant DESCRIBE scan segments, selected_rowsets="
+                         << rowset_scan_segments.size()
+                         << ", expected_selected_rowsets=" << expected_selected_rowsets
+                         << ", selected_segments=" << selected_segment_count
+                         << ", expected_selected_segments=" << expected_selected_segments;
+            return base_schema;
+        }
+    });
+
+    std::vector<TabletSchemaSPtr> schemas;
+    for (const auto& scan : rowset_scan_segments) {
+        const auto& rs = scan.rowset;
         const auto& tablet_schema = rs->tablet_schema();
         SegmentCacheHandle segment_cache;
-        auto st = SegmentLoader::instance()->load_segments(std::static_pointer_cast<BetaRowset>(rs),
-                                                           &segment_cache);
-        if (!st.ok()) {
-            return base_schema;
+        for (const auto segment_id : scan.segment_ids) {
+            auto st = SegmentLoader::instance()->load_segment(
+                    std::static_pointer_cast<BetaRowset>(rs), segment_id, &segment_cache, true);
+            if (!st.ok()) {
+                return base_schema;
+            }
         }
         for (const auto& segment : segment_cache.get_segments()) {
             TabletSchemaSPtr schema = tablet_schema->copy_without_variant_extracted_columns();
@@ -1620,7 +1924,7 @@ TabletSchemaSPtr VariantCompactionUtil::calculate_variant_extended_schema(
                 }
                 std::shared_ptr<ColumnReader> column_reader;
                 OlapReaderStatistics stats;
-                st = segment->get_column_reader(column->unique_id(), &column_reader, &stats);
+                auto st = segment->get_column_reader(column->unique_id(), &column_reader, &stats);
                 if (!st.ok()) {
                     LOG(WARNING) << "Failed to get column reader for column: " << column->name()
                                  << " error: " << st.to_string();

--- a/be/src/exec/common/variant_util.h
+++ b/be/src/exec/common/variant_util.h
@@ -44,6 +44,7 @@ namespace doris {
 class TabletSchema;
 enum class FieldType;
 namespace segment_v2 {
+class SegmentFooterPB;
 struct VariantStatisticsPB;
 } // namespace segment_v2
 class Block;
@@ -62,6 +63,23 @@ using JsonParser = JSONDataParser<SimdJSONParser>;
 const std::string SPARSE_COLUMN_PATH = "__DORIS_VARIANT_SPARSE__";
 const std::string DOC_VALUE_COLUMN_PATH = "__DORIS_VARIANT_DOC_VALUE__";
 namespace doris::variant_util {
+
+struct VariantSchemaHash {
+    uint64_t lo = 0;
+    uint64_t hi = 0;
+};
+
+struct VariantSchemaKey {
+    std::string key;
+    VariantSchemaHash hash;
+};
+
+VariantSchemaHash hash_variant_schema_key(std::string_view key);
+
+bool build_segment_variant_schema_key(const segment_v2::SegmentFooterPB& footer,
+                                      VariantSchemaKey* schema_key);
+
+VariantSchemaHash build_rowset_variant_schema_hash(const std::vector<std::string>& schema_keys);
 
 // Convert a restricted glob pattern into a regex (for tests/internal use).
 Status glob_to_regex(const std::string& glob_pattern, std::string* regex_pattern);

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <sstream>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -42,6 +43,7 @@
 #include "core/block/block.h"
 #include "core/column/column.h"
 #include "core/data_type/data_type_factory.hpp"
+#include "exec/common/variant_util.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
@@ -105,9 +107,58 @@ void build_rowset_meta_with_spec_field(RowsetMeta& rowset_meta,
     std::vector<uint32_t> num_segment_rows;
     spec_rowset_meta.get_num_segment_rows(&num_segment_rows);
     rowset_meta.set_num_segment_rows(num_segment_rows);
+    rowset_meta.clear_variant_schema_metadata();
+    if (spec_rowset_meta.has_variant_schema_representatives()) {
+        bool has_complete_representatives = true;
+        for (const auto& representative : spec_rowset_meta.variant_schema_representatives()) {
+            if (!representative.has_segment_id()) {
+                has_complete_representatives = false;
+                break;
+            }
+        }
+        if (has_complete_representatives) {
+            const auto [hash_lo, hash_hi] = spec_rowset_meta.variant_schema_hash();
+            rowset_meta.set_variant_schema_hash(hash_lo, hash_hi);
+            for (const auto& representative : spec_rowset_meta.variant_schema_representatives()) {
+                rowset_meta.add_variant_schema_representative(representative.segment_id());
+            }
+        }
+    }
     if (spec_rowset_meta.is_row_binlog()) {
         rowset_meta.mark_row_binlog();
     }
+}
+
+void set_variant_schema_representatives(
+        RowsetMeta* rowset_meta, const std::map<uint32_t, SegmentStatistics>& segment_statistics,
+        int64_t segment_num, const TabletSchemaSPtr& tablet_schema, int32_t segment_start_id) {
+    rowset_meta->clear_variant_schema_metadata();
+    if (tablet_schema == nullptr || tablet_schema->num_variant_columns() == 0 || segment_num == 0) {
+        return;
+    }
+    // Transient writers append segments to an existing rowset. Since this metadata only stores final
+    // representative segment ids, keep correctness simple and force DESCRIBE to use the full scan.
+    if (segment_start_id != 0 || segment_statistics.size() != static_cast<size_t>(segment_num)) {
+        return;
+    }
+
+    std::unordered_set<std::string> seen_schema_keys;
+    std::vector<std::string> unique_schema_keys;
+    unique_schema_keys.reserve(segment_statistics.size());
+    for (int64_t segment_id = 0; segment_id < segment_num; ++segment_id) {
+        auto it = segment_statistics.find(cast_set<uint32_t>(segment_id));
+        if (it == segment_statistics.end() || !it->second.has_variant_schema_key) {
+            rowset_meta->clear_variant_schema_metadata();
+            return;
+        }
+        if (seen_schema_keys.insert(it->second.variant_schema_key).second) {
+            unique_schema_keys.push_back(it->second.variant_schema_key);
+            rowset_meta->add_variant_schema_representative(cast_set<int32_t>(segment_id));
+        }
+    }
+
+    auto rowset_hash = variant_util::build_rowset_variant_schema_hash(unique_schema_keys);
+    rowset_meta->set_variant_schema_hash(rowset_hash.lo, rowset_hash.hi);
 }
 
 } // namespace
@@ -984,8 +1035,10 @@ Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool ch
     int64_t total_index_size = 0;
     std::vector<KeyBoundsPB> segments_encoded_key_bounds;
     std::vector<uint32_t> segment_rows;
+    std::map<uint32_t, SegmentStatistics> segment_statistics;
     {
         std::lock_guard<std::mutex> lock(_segid_statistics_map_mutex);
+        segment_statistics = _segid_statistics_map;
         for (const auto& itr : _segid_statistics_map) {
             num_rows_written += itr.second.row_num;
             total_data_size += itr.second.data_size;
@@ -1038,6 +1091,8 @@ Status BaseBetaRowsetWriter::_build_rowset_meta(RowsetMeta* rowset_meta, bool ch
     }
 
     rowset_meta->set_num_segments(segment_num);
+    set_variant_schema_representatives(rowset_meta, segment_statistics, segment_num,
+                                       _context.tablet_schema, _segment_start_id);
     rowset_meta->set_num_rows(num_rows_written + _num_rows_written);
     rowset_meta->set_total_disk_size(total_data_size + _total_data_size + total_index_size +
                                      _total_index_size);
@@ -1244,6 +1299,11 @@ Status BetaRowsetWriter::flush_segment_writer_for_segcompaction(
     segstat.data_size = segment_size;
     segstat.index_size = inverted_index_file_size;
     segstat.key_bounds = key_bounds;
+    if ((*writer)->variant_schema_key().has_value()) {
+        const auto& schema_key = (*writer)->variant_schema_key().value();
+        segstat.has_variant_schema_key = true;
+        segstat.variant_schema_key = schema_key.key;
+    }
     {
         std::lock_guard<std::mutex> lock(_segid_statistics_map_mutex);
         CHECK_EQ(_segid_statistics_map.find(segid) == _segid_statistics_map.end(), true);

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -346,6 +346,10 @@ void RowsetMeta::merge_rowset_meta(const RowsetMeta& other) {
     set_total_disk_size(data_disk_size() + index_disk_size());
     set_segments_key_bounds_truncated(is_segments_key_bounds_truncated() ||
                                       other.is_segments_key_bounds_truncated());
+    // The persisted Variant schema metadata contains only hashes and representative segment ids,
+    // not the full canonical keys. After merging rowset metas, keeping a partial summary could make
+    // DESCRIBE skip segments from `other`, so force the safe full-scan fallback.
+    clear_variant_schema_metadata();
     // merge_rowset_meta is used in the MOW partial-update publish path, which relies
     // on per-segment bounds. Aggregation should never be enabled for MOW rowsets,
     // so we do not expect either side to be aggregated here.

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/cast_set.h"
@@ -437,6 +438,40 @@ public:
     int64_t segment_file_size(int seg_id) const;
 
     const auto& segments_file_size() const { return _rowset_meta_pb.segments_file_size(); }
+
+    bool has_variant_schema_hash() const {
+        return _rowset_meta_pb.has_variant_schema_hash_lo() &&
+               _rowset_meta_pb.has_variant_schema_hash_hi();
+    }
+
+    bool has_variant_schema_representatives() const {
+        return has_variant_schema_hash() &&
+               _rowset_meta_pb.variant_schema_representatives_size() > 0;
+    }
+
+    std::pair<uint64_t, uint64_t> variant_schema_hash() const {
+        return {_rowset_meta_pb.variant_schema_hash_lo(), _rowset_meta_pb.variant_schema_hash_hi()};
+    }
+
+    const auto& variant_schema_representatives() const {
+        return _rowset_meta_pb.variant_schema_representatives();
+    }
+
+    void set_variant_schema_hash(uint64_t hash_lo, uint64_t hash_hi) {
+        _rowset_meta_pb.set_variant_schema_hash_lo(hash_lo);
+        _rowset_meta_pb.set_variant_schema_hash_hi(hash_hi);
+    }
+
+    void add_variant_schema_representative(int32_t segment_id) {
+        auto* representative = _rowset_meta_pb.add_variant_schema_representatives();
+        representative->set_segment_id(segment_id);
+    }
+
+    void clear_variant_schema_metadata() {
+        _rowset_meta_pb.clear_variant_schema_hash_lo();
+        _rowset_meta_pb.clear_variant_schema_hash_hi();
+        _rowset_meta_pb.clear_variant_schema_representatives();
+    }
 
     // Used for partial update, when publish, partial update may add a new rowset and we should update rowset meta
     void merge_rowset_meta(const RowsetMeta& other);

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -42,6 +42,8 @@ struct SegmentStatistics {
     int64_t data_size;
     int64_t index_size;
     KeyBoundsPB key_bounds;
+    bool has_variant_schema_key = false;
+    std::string variant_schema_key;
 
     SegmentStatistics() = default;
 
@@ -56,12 +58,16 @@ struct SegmentStatistics {
         segstat_pb->set_data_size(data_size);
         segstat_pb->set_index_size(index_size);
         segstat_pb->mutable_key_bounds()->CopyFrom(key_bounds);
+        // SegmentStatisticsPB is also used by load-stream control messages. Do not serialize the
+        // canonical Variant schema key because it grows with Variant subcolumns; remote receivers
+        // will omit rowset-level Variant schema metadata and fall back to the full DESCRIBE scan.
     }
 
     std::string to_string() {
         std::stringstream ss;
         ss << "row_num: " << row_num << ", data_size: " << data_size
-           << ", index_size: " << index_size << ", key_bounds: " << key_bounds.ShortDebugString();
+           << ", index_size: " << index_size << ", key_bounds: " << key_bounds.ShortDebugString()
+           << ", has_variant_schema_key: " << has_variant_schema_key;
         return ss.str();
     }
 };

--- a/be/src/storage/rowset/segment_creator.cpp
+++ b/be/src/storage/rowset/segment_creator.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <thread>
 #include <utility>
@@ -40,6 +41,7 @@
 #include "core/column/column_variant.h"
 #include "core/data_type/data_type.h"
 #include "core/types.h"
+#include "exec/common/variant_util.h"
 #include "io/fs/file_writer.h"
 #include "storage/olap_define.h"
 #include "storage/rowset/beta_rowset_writer.h" // SegmentStatistics
@@ -54,6 +56,19 @@
 
 namespace doris {
 using namespace ErrorCode;
+
+namespace {
+
+void set_variant_schema_key(const std::optional<variant_util::VariantSchemaKey>& schema_key,
+                            SegmentStatistics* segstat) {
+    if (!schema_key.has_value()) {
+        return;
+    }
+    segstat->has_variant_schema_key = true;
+    segstat->variant_schema_key = schema_key->key;
+}
+
+} // namespace
 
 SegmentFlusher::SegmentFlusher(RowsetWriterContext& context, SegmentFileCollection& seg_files,
                                InvertedIndexFileCollection& idx_files)
@@ -232,6 +247,7 @@ Status SegmentFlusher::_flush_segment_writer(
     segstat.data_size = segment_file_size;
     segstat.index_size = inverted_index_file_size;
     segstat.key_bounds = key_bounds;
+    set_variant_schema_key(writer->variant_schema_key(), &segstat);
 
     writer.reset();
 
@@ -310,6 +326,7 @@ Status SegmentFlusher::_flush_segment_writer(std::unique_ptr<segment_v2::Segment
     segstat.data_size = segment_file_size;
     segstat.index_size = inverted_index_file_size;
     segstat.key_bounds = key_bounds;
+    set_variant_schema_key(writer->variant_schema_key(), &segstat);
 
     writer.reset();
 

--- a/be/src/storage/segment/segment_writer.cpp
+++ b/be/src/storage/segment/segment_writer.cpp
@@ -1120,6 +1120,14 @@ Status SegmentWriter::_write_primary_key_index() {
 
 Status SegmentWriter::_write_footer() {
     _footer.set_num_rows(_row_count);
+    if (_tablet_schema->num_variant_columns() > 0) {
+        variant_util::VariantSchemaKey schema_key;
+        if (variant_util::build_segment_variant_schema_key(_footer, &schema_key)) {
+            _variant_schema_key = std::move(schema_key);
+        } else {
+            _variant_schema_key.reset();
+        }
+    }
     // Decide whether to externalize ColumnMetaPB by tablet default, and stamp footer version
     if (_tablet_schema->is_external_segment_column_meta_used()) {
         _footer.set_version(SEGMENT_FOOTER_VERSION_V3_EXT_COL_META);

--- a/be/src/storage/segment/segment_writer.h
+++ b/be/src/storage/segment/segment_writer.h
@@ -26,10 +26,12 @@
 #include <functional>
 #include <map>
 #include <memory> // unique_ptr
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "common/status.h" // Status
+#include "exec/common/variant_util.h"
 #include "storage/index/index_file_writer.h"
 #include "storage/olap_define.h"
 #include "storage/segment/column_writer.h"
@@ -123,6 +125,9 @@ public:
     Status finalize_columns_data();
     Status finalize_columns_index(uint64_t* index_size);
     Status finalize_footer(uint64_t* segment_file_size);
+    const std::optional<variant_util::VariantSchemaKey>& variant_schema_key() const {
+        return _variant_schema_key;
+    }
 
     void init_column_meta(ColumnMetaPB* meta, uint32_t column_id, const TabletColumn& column,
                           TabletSchemaSPtr tablet_schema);
@@ -205,6 +210,7 @@ private:
     IndexFileWriter* _index_file_writer = nullptr;
 
     SegmentFooterPB _footer;
+    std::optional<variant_util::VariantSchemaKey> _variant_schema_key;
     // for mow tables with cluster key, the sort key is the cluster keys not unique keys
     // for other tables, the sort key is the keys
     size_t _num_sort_key_columns;

--- a/be/src/storage/segment/vertical_segment_writer.cpp
+++ b/be/src/storage/segment/vertical_segment_writer.cpp
@@ -1393,6 +1393,14 @@ Status VerticalSegmentWriter::_write_primary_key_index() {
 
 Status VerticalSegmentWriter::_write_footer() {
     _footer.set_num_rows(_row_count);
+    if (_tablet_schema->num_variant_columns() > 0) {
+        variant_util::VariantSchemaKey schema_key;
+        if (variant_util::build_segment_variant_schema_key(_footer, &schema_key)) {
+            _variant_schema_key = std::move(schema_key);
+        } else {
+            _variant_schema_key.reset();
+        }
+    }
 
     // Decide whether to externalize ColumnMetaPB by tablet default, and stamp footer version
 

--- a/be/src/storage/segment/vertical_segment_writer.h
+++ b/be/src/storage/segment/vertical_segment_writer.h
@@ -25,11 +25,13 @@
 #include <functional>
 #include <map>
 #include <memory> // unique_ptr
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
 #include "common/status.h" // Status
+#include "exec/common/variant_util.h"
 #include "storage/index/index_file_writer.h"
 #include "storage/olap_define.h"
 #include "storage/partial_update_info.h"
@@ -111,6 +113,9 @@ public:
 
     Status finalize_columns_index(uint64_t* index_size);
     Status finalize_footer(uint64_t* segment_file_size);
+    const std::optional<variant_util::VariantSchemaKey>& variant_schema_key() const {
+        return _variant_schema_key;
+    }
 
     Slice min_encoded_key();
     Slice max_encoded_key();
@@ -213,6 +218,7 @@ private:
     IndexFileWriter* _index_file_writer = nullptr;
 
     SegmentFooterPB _footer;
+    std::optional<variant_util::VariantSchemaKey> _variant_schema_key;
     // for mow tables with cluster key, the sort key is the cluster keys not unique keys
     // for other tables, the sort key is the keys
     size_t _num_sort_key_columns;

--- a/be/test/cloud/cloud_snapshot_mgr_test.cpp
+++ b/be/test/cloud/cloud_snapshot_mgr_test.cpp
@@ -109,6 +109,10 @@ TEST_F(CloudSnapshotMgrTest, TestConvertRowsets) {
     rowset_meta->set_index_disk_size(2048);
     rowset_meta->set_rowset_state(RowsetStatePB::VISIBLE);
     rowset_meta->set_newest_write_timestamp(1678901234567890);
+    rowset_meta->set_variant_schema_hash_lo(11);
+    rowset_meta->set_variant_schema_hash_hi(22);
+    auto* representative = rowset_meta->add_variant_schema_representatives();
+    representative->set_segment_id(1);
 
     TabletSchemaPB* rowset_schema = rowset_meta->mutable_tablet_schema();
     rowset_schema->CopyFrom(*input_schema);
@@ -155,6 +159,14 @@ TEST_F(CloudSnapshotMgrTest, TestConvertRowsets) {
     EXPECT_EQ(output_meta_pb.rs_metas(0).data_disk_size(), 2048);
     EXPECT_EQ(output_meta_pb.rs_metas(0).index_disk_size(), 2048);
     EXPECT_EQ(output_meta_pb.rs_metas(0).rowset_state(), RowsetStatePB::VISIBLE);
+    EXPECT_TRUE(output_meta_pb.rs_metas(0).has_variant_schema_hash_lo());
+    EXPECT_TRUE(output_meta_pb.rs_metas(0).has_variant_schema_hash_hi());
+    EXPECT_EQ(output_meta_pb.rs_metas(0).variant_schema_hash_lo(), 11);
+    EXPECT_EQ(output_meta_pb.rs_metas(0).variant_schema_hash_hi(), 22);
+    ASSERT_EQ(output_meta_pb.rs_metas(0).variant_schema_representatives_size(), 1);
+    EXPECT_EQ(output_meta_pb.rs_metas(0).variant_schema_representatives(0).segment_id(), 1);
+    EXPECT_FALSE(output_meta_pb.rs_metas(0).variant_schema_representatives(0).has_schema_hash_lo());
+    EXPECT_FALSE(output_meta_pb.rs_metas(0).variant_schema_representatives(0).has_schema_hash_hi());
     EXPECT_EQ(output_meta_pb.rs_metas(0).resource_id(), storage_resource.fs->id());
     EXPECT_FALSE(file_mapping.empty());
     EXPECT_TRUE(status.ok());

--- a/be/test/exec/common/schema_util_test.cpp
+++ b/be/test/exec/common/schema_util_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gen_cpp/segment_v2.pb.h>
 #include <gmock/gmock-more-matchers.h>
 #include <gtest/gtest.h>
 
@@ -33,6 +34,7 @@
 #include "storage/rowset/rowset_fwd.h"
 #include "storage/segment/variant/variant_column_writer_impl.h"
 #include "testutil/variant_util.h"
+#include "util/json/path_in_data.h"
 
 using namespace doris;
 
@@ -45,6 +47,126 @@ public:
     SchemaUtilTest() = default;
     ~SchemaUtilTest() override = default;
 };
+
+void add_variant_root(SegmentFooterPB* footer, int32_t unique_id) {
+    auto* column = footer->add_columns();
+    column->set_unique_id(unique_id);
+    column->set_type(static_cast<int>(FieldType::OLAP_FIELD_TYPE_VARIANT));
+}
+
+void add_variant_subcolumn(SegmentFooterPB* footer, int32_t parent_unique_id,
+                           const std::string& full_path, FieldType type, bool nullable) {
+    auto* column = footer->add_columns();
+    column->set_type(static_cast<int>(type));
+    column->set_is_nullable(nullable);
+    PathInData path(full_path);
+    path.to_protobuf(column->mutable_column_path_info(), parent_unique_id);
+}
+
+TEST_F(SchemaUtilTest, TestVariantSegmentSchemaKeyIsStableAndTypeAware) {
+    SegmentFooterPB footer_1;
+    add_variant_root(&footer_1, 1);
+    add_variant_subcolumn(&footer_1, 1, "v.a", FieldType::OLAP_FIELD_TYPE_INT, true);
+    add_variant_subcolumn(&footer_1, 1, "v.b", FieldType::OLAP_FIELD_TYPE_STRING, true);
+
+    SegmentFooterPB footer_2;
+    add_variant_subcolumn(&footer_2, 1, "v.b", FieldType::OLAP_FIELD_TYPE_STRING, true);
+    add_variant_root(&footer_2, 1);
+    add_variant_subcolumn(&footer_2, 1, "v.a", FieldType::OLAP_FIELD_TYPE_INT, true);
+    footer_2.mutable_columns(0)->set_column_id(100);
+    footer_2.mutable_columns(0)->set_unique_id(200);
+    footer_2.mutable_columns(0)->set_num_rows(300);
+    footer_2.mutable_columns(0)->set_compressed_data_bytes(400);
+    footer_2.mutable_columns(2)->mutable_column_path_info()->set_has_nested(false);
+    footer_2.mutable_columns(2)->mutable_column_path_info()->set_nested_group_depth(0);
+
+    variant_util::VariantSchemaKey key_1;
+    variant_util::VariantSchemaKey key_2;
+    ASSERT_TRUE(variant_util::build_segment_variant_schema_key(footer_1, &key_1));
+    ASSERT_TRUE(variant_util::build_segment_variant_schema_key(footer_2, &key_2));
+    EXPECT_EQ(key_1.key, key_2.key);
+    EXPECT_EQ(key_1.hash.lo, key_2.hash.lo);
+    EXPECT_EQ(key_1.hash.hi, key_2.hash.hi);
+
+    SegmentFooterPB footer_3;
+    add_variant_root(&footer_3, 1);
+    add_variant_subcolumn(&footer_3, 1, "v.a", FieldType::OLAP_FIELD_TYPE_BIGINT, true);
+    add_variant_subcolumn(&footer_3, 1, "v.b", FieldType::OLAP_FIELD_TYPE_STRING, true);
+
+    variant_util::VariantSchemaKey key_3;
+    ASSERT_TRUE(variant_util::build_segment_variant_schema_key(footer_3, &key_3));
+    EXPECT_NE(key_1.key, key_3.key);
+}
+
+TEST_F(SchemaUtilTest, TestVariantRowsetSchemaHashIsSegmentOrderInsensitive) {
+    const auto hash_ab = variant_util::build_rowset_variant_schema_hash({"schema_a", "schema_b"});
+    const auto hash_ba = variant_util::build_rowset_variant_schema_hash({"schema_b", "schema_a"});
+    EXPECT_EQ(hash_ab.lo, hash_ba.lo);
+    EXPECT_EQ(hash_ab.hi, hash_ba.hi);
+
+    const auto hash_a = variant_util::build_rowset_variant_schema_hash({"schema_a"});
+    EXPECT_TRUE(hash_ab.lo != hash_a.lo || hash_ab.hi != hash_a.hi);
+}
+
+TEST_F(SchemaUtilTest, TestVariantSegmentSchemaKeyRejectsUnsupportedShapes) {
+    {
+        SegmentFooterPB footer;
+        add_variant_root(&footer, 1);
+        variant_util::VariantSchemaKey key;
+        EXPECT_FALSE(variant_util::build_segment_variant_schema_key(footer, &key));
+    }
+
+    {
+        SegmentFooterPB footer;
+        add_variant_root(&footer, 1);
+        footer.mutable_columns(0)->set_variant_enable_doc_mode(true);
+        add_variant_subcolumn(&footer, 1, "v.a", FieldType::OLAP_FIELD_TYPE_INT, true);
+        variant_util::VariantSchemaKey key;
+        EXPECT_FALSE(variant_util::build_segment_variant_schema_key(footer, &key));
+    }
+
+    {
+        SegmentFooterPB footer;
+        add_variant_root(&footer, 1);
+        add_variant_subcolumn(&footer, 1, "v.a", FieldType::OLAP_FIELD_TYPE_INT, true);
+        add_variant_subcolumn(&footer, 1, "v.__DORIS_VARIANT_DOC_VALUE__.b0",
+                              FieldType::OLAP_FIELD_TYPE_STRING, true);
+        variant_util::VariantSchemaKey key;
+        EXPECT_FALSE(variant_util::build_segment_variant_schema_key(footer, &key));
+    }
+
+    {
+        SegmentFooterPB footer;
+        add_variant_root(&footer, 1);
+        add_variant_subcolumn(&footer, 1, "v.a", FieldType::OLAP_FIELD_TYPE_INT, true);
+        add_variant_subcolumn(&footer, 1, "v.a.__D0_ng__.b", FieldType::OLAP_FIELD_TYPE_INT, true);
+        variant_util::VariantSchemaKey key;
+        EXPECT_FALSE(variant_util::build_segment_variant_schema_key(footer, &key));
+    }
+
+    {
+        SegmentFooterPB footer;
+        add_variant_root(&footer, 1);
+        add_variant_subcolumn(&footer, 1, "v.a", FieldType::OLAP_FIELD_TYPE_INT, true);
+        add_variant_subcolumn(&footer, 1, "v.__DORIS_VARIANT_SPARSE__",
+                              FieldType::OLAP_FIELD_TYPE_MAP, true);
+        variant_util::VariantSchemaKey key;
+        EXPECT_TRUE(variant_util::build_segment_variant_schema_key(footer, &key));
+    }
+
+    {
+        SegmentFooterPB footer;
+        add_variant_root(&footer, 1);
+        add_variant_subcolumn(&footer, 1, "v.a", FieldType::OLAP_FIELD_TYPE_INT, true);
+        add_variant_subcolumn(&footer, 1, "v.__DORIS_VARIANT_SPARSE__",
+                              FieldType::OLAP_FIELD_TYPE_MAP, true);
+        (*footer.mutable_columns(2)
+                  ->mutable_variant_statistics()
+                  ->mutable_sparse_column_non_null_size())["a"] = 1;
+        variant_util::VariantSchemaKey key;
+        EXPECT_FALSE(variant_util::build_segment_variant_schema_key(footer, &key));
+    }
+}
 
 void construct_column(ColumnPB* column_pb, TabletIndexPB* tablet_index, int64_t index_id,
                       const std::string& index_name, int32_t col_unique_id,

--- a/be/test/storage/pb_convert_test.cpp
+++ b/be/test/storage/pb_convert_test.cpp
@@ -176,6 +176,31 @@ std::set<std::string> get_set_fields(const google::protobuf::Message& msg) {
     return set_fields;
 }
 
+template <typename RowsetMetaPBType>
+void fill_variant_schema_metadata(RowsetMetaPBType* rowset_meta) {
+    rowset_meta->set_variant_schema_hash_lo(11);
+    rowset_meta->set_variant_schema_hash_hi(22);
+    auto* representative = rowset_meta->add_variant_schema_representatives();
+    representative->set_segment_id(3);
+    representative = rowset_meta->add_variant_schema_representatives();
+    representative->set_segment_id(5);
+}
+
+template <typename RowsetMetaPBType>
+void expect_variant_schema_metadata(const RowsetMetaPBType& rowset_meta) {
+    EXPECT_TRUE(rowset_meta.has_variant_schema_hash_lo());
+    EXPECT_TRUE(rowset_meta.has_variant_schema_hash_hi());
+    EXPECT_EQ(rowset_meta.variant_schema_hash_lo(), 11);
+    EXPECT_EQ(rowset_meta.variant_schema_hash_hi(), 22);
+    ASSERT_EQ(rowset_meta.variant_schema_representatives_size(), 2);
+    EXPECT_EQ(rowset_meta.variant_schema_representatives(0).segment_id(), 3);
+    EXPECT_FALSE(rowset_meta.variant_schema_representatives(0).has_schema_hash_lo());
+    EXPECT_FALSE(rowset_meta.variant_schema_representatives(0).has_schema_hash_hi());
+    EXPECT_EQ(rowset_meta.variant_schema_representatives(1).segment_id(), 5);
+    EXPECT_FALSE(rowset_meta.variant_schema_representatives(1).has_schema_hash_lo());
+    EXPECT_FALSE(rowset_meta.variant_schema_representatives(1).has_schema_hash_hi());
+}
+
 // clang-format off
 
 auto print = [](auto v) { std::stringstream s; for (auto& i : v) s << i << " "; return s.str(); };
@@ -286,6 +311,32 @@ TEST(PbConvert, ensure_all_fields_converted_correctly) {
         << "\n input_fields=" << print(tablet_meta_cloud_set_fields)
         << "\n output_fields=" << print(tablet_meta_out_set_fields)
         << "\n diff=" << print(set_diff(tablet_meta_cloud_set_fields, tablet_meta_out_set_fields));
+}
+
+TEST(PbConvert, test_variant_schema_metadata_round_trip_values) {
+    RowsetMetaPB rs;
+    fill_variant_schema_metadata(&rs);
+
+    RowsetMetaCloudPB cloud_from_const;
+    doris_rowset_meta_to_cloud(&cloud_from_const, rs);
+    expect_variant_schema_metadata(cloud_from_const);
+
+    RowsetMetaPB rs_for_move = rs;
+    RowsetMetaCloudPB cloud_from_move;
+    doris_rowset_meta_to_cloud(&cloud_from_move, std::move(rs_for_move));
+    expect_variant_schema_metadata(cloud_from_move);
+
+    RowsetMetaCloudPB cloud;
+    fill_variant_schema_metadata(&cloud);
+
+    RowsetMetaPB rs_from_const;
+    cloud_rowset_meta_to_doris(&rs_from_const, cloud);
+    expect_variant_schema_metadata(rs_from_const);
+
+    RowsetMetaCloudPB cloud_for_move = cloud;
+    RowsetMetaPB rs_from_move;
+    cloud_rowset_meta_to_doris(&rs_from_move, std::move(cloud_for_move));
+    expect_variant_schema_metadata(rs_from_move);
 }
 
 TEST(PbConvert, test_rvalue_overloads) {

--- a/be/test/storage/rowset/rowset_meta_test.cpp
+++ b/be/test/storage/rowset/rowset_meta_test.cpp
@@ -33,6 +33,7 @@
 #include "gtest/gtest_pred_impl.h"
 #include "storage/olap_common.h"
 #include "storage/olap_meta.h"
+#include "storage/rowset/rowset_writer.h"
 
 using ::testing::_;
 using ::testing::Return;
@@ -165,6 +166,25 @@ TEST_F(RowsetMetaTest, TestNumSegmentRowsSetAndGet) {
     EXPECT_EQ(retrieved_rows_2[2], 300);
 }
 
+TEST(SegmentStatisticsTest, TestVariantSchemaMetadataStaysInMemoryOnly) {
+    SegmentStatistics segstat;
+    segstat.row_num = 10;
+    segstat.data_size = 20;
+    segstat.index_size = 30;
+    segstat.has_variant_schema_key = true;
+    segstat.variant_schema_key = "variant-schema-key";
+
+    SegmentStatisticsPB pb;
+    segstat.to_pb(&pb);
+    EXPECT_EQ(pb.row_num(), 10);
+    EXPECT_EQ(pb.data_size(), 20);
+    EXPECT_EQ(pb.index_size(), 30);
+
+    SegmentStatistics decoded(pb);
+    EXPECT_FALSE(decoded.has_variant_schema_key);
+    EXPECT_TRUE(decoded.variant_schema_key.empty());
+}
+
 TEST_F(RowsetMetaTest, TestNumSegmentRowsEmpty) {
     RowsetMeta rowset_meta;
     EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
@@ -232,6 +252,39 @@ TEST_F(RowsetMetaTest, TestMergeRowsetMetaWithNumSegmentRows) {
 
     // Check merged disk sizes
     EXPECT_EQ(rowset_meta_1.total_disk_size(), 3000);
+}
+
+TEST_F(RowsetMetaTest, TestMergeRowsetMetaClearsVariantSchemaRepresentatives) {
+    RowsetMeta rowset_meta_1;
+    EXPECT_TRUE(rowset_meta_1.init_from_json(_json_rowset_meta));
+    rowset_meta_1.set_num_segments(2);
+    rowset_meta_1.set_variant_schema_hash(11, 22);
+    rowset_meta_1.add_variant_schema_representative(0);
+    ASSERT_TRUE(rowset_meta_1.has_variant_schema_representatives());
+
+    RowsetMeta rowset_meta_2;
+    EXPECT_TRUE(rowset_meta_2.init_from_json(_json_rowset_meta));
+    rowset_meta_2.set_num_segments(3);
+    rowset_meta_2.set_variant_schema_hash(33, 44);
+    rowset_meta_2.add_variant_schema_representative(0);
+
+    auto sp = SyncPoint::get_instance();
+    sp->set_call_back("RowsetMeta::merge_rowset_meta:skip_schema_merge", [&](auto&& args) {
+        auto pred = try_any_cast<bool*>(args.back());
+        *pred = true;
+    });
+    sp->enable_processing();
+
+    rowset_meta_1.merge_rowset_meta(rowset_meta_2);
+
+    sp->clear_all_call_backs();
+    sp->disable_processing();
+    sp->clear_trace();
+
+    EXPECT_EQ(rowset_meta_1.num_segments(), 5);
+    EXPECT_FALSE(rowset_meta_1.has_variant_schema_hash());
+    EXPECT_FALSE(rowset_meta_1.has_variant_schema_representatives());
+    EXPECT_EQ(rowset_meta_1.variant_schema_representatives().size(), 0);
 }
 
 TEST_F(RowsetMetaTest, TestMergeRowsetMetaWithPartialNumSegmentRows) {

--- a/be/test/storage/segment/variant_column_writer_reader_test.cpp
+++ b/be/test/storage/segment/variant_column_writer_reader_test.cpp
@@ -19,12 +19,14 @@
 #include <set>
 #include <thread>
 
+#include "cloud/pb_convert.h"
 #include "common/config.h"
 #include "core/data_type/data_type_map.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type_serde/data_type_serde.h"
 #include "gtest/gtest.h"
 #include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_meta.h"
 #include "storage/segment/column_meta_accessor.h"
 #include "storage/segment/column_reader.h"
 #include "storage/segment/column_reader_cache.h"
@@ -38,6 +40,7 @@
 #include "storage/segment/variant/variant_doc_snpashot_compact_iterator.h"
 #include "storage/storage_engine.h"
 #include "testutil/variant_util.h"
+#include "util/debug_points.h"
 
 using namespace doris;
 
@@ -255,6 +258,29 @@ protected:
         return rowset;
     }
 
+    RowsetSharedPtr manual_build_variant_rowset(const RowsetMetaSharedPtr& spec_rowset_meta,
+                                                int64_t version) {
+        RowsetWriterContext ctx;
+        RowsetId rowset_id;
+        rowset_id.init(version + 1000);
+        ctx.rowset_id = rowset_id;
+        ctx.rowset_type = BETA_ROWSET;
+        ctx.data_dir = _data_dir.get();
+        ctx.rowset_state = VISIBLE;
+        ctx.tablet_schema = _tablet_schema;
+        ctx.tablet_path = _tablet->tablet_path();
+        ctx.tablet_id = _tablet->tablet_id();
+        ctx.tablet = _tablet;
+        ctx.version = Version(version, version);
+        ctx.segments_overlap = NONOVERLAPPING;
+        ctx.write_type = DataWriteType::TYPE_DIRECT;
+
+        auto res = RowsetFactory::create_rowset_writer(*_engine_ref, ctx, false);
+        EXPECT_TRUE(res.has_value()) << res.error();
+        auto rowset_writer = std::move(res).value();
+        return rowset_writer->manual_build(spec_rowset_meta);
+    }
+
     std::vector<RowsetReaderSharedPtr> create_rowset_readers(
             const std::vector<RowsetSharedPtr>& rowsets) const {
         std::vector<RowsetReaderSharedPtr> readers;
@@ -344,6 +370,16 @@ protected:
     std::string _absolute_dir;
     std::string _current_dir;
 };
+
+static std::set<std::string> collect_variant_subcolumn_names(const TabletSchemaSPtr& schema) {
+    std::set<std::string> column_names;
+    for (const auto& column : schema->columns()) {
+        if (column->parent_unique_id() > 0) {
+            column_names.insert(column->name());
+        }
+    }
+    return column_names;
+}
 
 void check_column_meta(const ColumnMetaPB& column_meta, auto& path_with_size) {
     EXPECT_TRUE(column_meta.has_column_path_info());
@@ -4205,6 +4241,314 @@ TEST_F(VariantColumnWriterReaderTest,
     EXPECT_EQ(plan.regular_subcolumns[2].path, "tags");
     ASSERT_NE(plan.regular_subcolumns[2].data_type, nullptr);
     EXPECT_NE(plan.regular_subcolumns[2].data_type->get_name().find("Array"), std::string::npos);
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_variant_describe_metadata_written_for_multi_segment_rowset) {
+    init_variant_tablet(41002, 10);
+
+    auto rowset =
+            create_variant_rowset({{R"({"a": 1})"}, {R"({"b": "x"})"}, {R"({"a": 2})"}}, 3, 10);
+    ASSERT_EQ(rowset->num_segments(), 3);
+    auto rowset_meta = rowset->rowset_meta();
+    ASSERT_TRUE(rowset_meta->has_variant_schema_hash());
+    ASSERT_TRUE(rowset_meta->has_variant_schema_representatives());
+    const auto& representatives = rowset_meta->variant_schema_representatives();
+    ASSERT_EQ(representatives.size(), 2);
+    EXPECT_EQ(representatives[0].segment_id(), 0);
+    EXPECT_EQ(representatives[1].segment_id(), 1);
+    EXPECT_FALSE(representatives[0].has_schema_hash_lo());
+    EXPECT_FALSE(representatives[0].has_schema_hash_hi());
+    EXPECT_FALSE(representatives[1].has_schema_hash_lo());
+    EXPECT_FALSE(representatives[1].has_schema_hash_hi());
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_variant_describe_manual_build_clears_incomplete_representative) {
+    init_variant_tablet(41010, 10);
+
+    auto source_rowset = create_variant_rowset({{R"({"a": 1})"}, {R"({"b": "x"})"}}, 17, 10);
+    auto source_meta = source_rowset->rowset_meta();
+    ASSERT_TRUE(source_meta->has_variant_schema_hash());
+    ASSERT_TRUE(source_meta->has_variant_schema_representatives());
+    const auto rowset_hash = source_meta->variant_schema_hash();
+
+    auto valid_output = manual_build_variant_rowset(source_meta, 18);
+    ASSERT_NE(valid_output, nullptr);
+    auto valid_meta = valid_output->rowset_meta();
+    EXPECT_EQ(valid_meta->variant_schema_hash(), rowset_hash);
+    ASSERT_TRUE(valid_meta->has_variant_schema_representatives());
+    ASSERT_EQ(valid_meta->variant_schema_representatives().size(), 2);
+    EXPECT_EQ(valid_meta->variant_schema_representatives()[0].segment_id(), 0);
+    EXPECT_EQ(valid_meta->variant_schema_representatives()[1].segment_id(), 1);
+
+    RowsetMetaPB incomplete_representative = source_meta->get_rowset_pb();
+    incomplete_representative.set_variant_schema_hash_lo(rowset_hash.first);
+    incomplete_representative.set_variant_schema_hash_hi(rowset_hash.second);
+    incomplete_representative.clear_variant_schema_representatives();
+    incomplete_representative.add_variant_schema_representatives();
+    ASSERT_TRUE(source_meta->init_from_pb(incomplete_representative));
+    ASSERT_TRUE(source_meta->has_variant_schema_representatives());
+    ASSERT_FALSE(source_meta->variant_schema_representatives()[0].has_segment_id());
+
+    auto malformed_output = manual_build_variant_rowset(source_meta, 19);
+    ASSERT_NE(malformed_output, nullptr);
+    auto malformed_meta = malformed_output->rowset_meta();
+    EXPECT_FALSE(malformed_meta->has_variant_schema_hash());
+    EXPECT_FALSE(malformed_meta->has_variant_schema_representatives());
+    EXPECT_EQ(malformed_meta->variant_schema_representatives().size(), 0);
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_variant_describe_metadata_dedups_many_same_schema_segments_for_cloud) {
+    init_variant_tablet(41008, 10);
+
+    std::vector<std::vector<std::string>> batches;
+    batches.reserve(50);
+    for (int i = 0; i < 50; ++i) {
+        batches.push_back({R"({"a": 1, "b": "x"})"});
+    }
+    auto rowset = create_variant_rowset(batches, 12, 1);
+    ASSERT_EQ(rowset->num_segments(), 50);
+
+    auto rowset_meta = rowset->rowset_meta();
+    ASSERT_TRUE(rowset_meta->has_variant_schema_hash());
+    ASSERT_TRUE(rowset_meta->has_variant_schema_representatives());
+    const auto& representatives = rowset_meta->variant_schema_representatives();
+    ASSERT_EQ(representatives.size(), 1);
+    EXPECT_EQ(representatives[0].segment_id(), 0);
+
+    auto cloud_meta = cloud::doris_rowset_meta_to_cloud(rowset_meta->get_rowset_pb());
+    ASSERT_EQ(cloud_meta.variant_schema_representatives_size(), 1);
+    EXPECT_EQ(cloud_meta.variant_schema_representatives(0).segment_id(), 0);
+    EXPECT_FALSE(cloud_meta.variant_schema_representatives(0).has_schema_hash_lo());
+    EXPECT_FALSE(cloud_meta.variant_schema_representatives(0).has_schema_hash_hi());
+}
+
+TEST_F(VariantColumnWriterReaderTest, test_variant_describe_metadata_skipped_for_sparse_fast_path) {
+    init_variant_tablet(41007, 1);
+
+    auto rowset = create_variant_rowset({{R"({"a": 1})"}, {R"({"a": 2, "b": "x"})"}}, 11, 10);
+    ASSERT_EQ(rowset->num_segments(), 2);
+    auto rowset_meta = rowset->rowset_meta();
+    EXPECT_FALSE(rowset_meta->has_variant_schema_hash());
+    EXPECT_FALSE(rowset_meta->has_variant_schema_representatives());
+
+    auto schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+            {rowset}, _tablet_schema);
+    ASSERT_NE(schema, nullptr);
+    const auto fallback_names = collect_variant_subcolumn_names(schema);
+    EXPECT_TRUE(fallback_names.count("v1.a") != 0);
+
+    rowset_meta->clear_variant_schema_metadata();
+    auto full_scan_schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+            {rowset}, _tablet_schema);
+    ASSERT_NE(full_scan_schema, nullptr);
+    EXPECT_EQ(fallback_names, collect_variant_subcolumn_names(full_scan_schema));
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_variant_describe_rowset_schema_hash_is_segment_order_insensitive) {
+    init_variant_tablet(41003, 10);
+
+    auto rowset_ab = create_variant_rowset({{R"({"a": 1})"}, {R"({"b": "x"})"}}, 4, 10);
+    auto rowset_ba = create_variant_rowset({{R"({"b": "x"})"}, {R"({"a": 1})"}}, 5, 10);
+
+    ASSERT_TRUE(rowset_ab->rowset_meta()->has_variant_schema_representatives());
+    ASSERT_TRUE(rowset_ba->rowset_meta()->has_variant_schema_representatives());
+    const auto hash_ab = rowset_ab->rowset_meta()->variant_schema_hash();
+    const auto hash_ba = rowset_ba->rowset_meta()->variant_schema_hash();
+    EXPECT_EQ(hash_ab.first, hash_ba.first);
+    EXPECT_EQ(hash_ab.second, hash_ba.second);
+
+    const auto& representatives_ab = rowset_ab->rowset_meta()->variant_schema_representatives();
+    const auto& representatives_ba = rowset_ba->rowset_meta()->variant_schema_representatives();
+    ASSERT_EQ(representatives_ab.size(), 2);
+    ASSERT_EQ(representatives_ba.size(), 2);
+    EXPECT_EQ(representatives_ab[0].segment_id(), 0);
+    EXPECT_EQ(representatives_ab[1].segment_id(), 1);
+    EXPECT_EQ(representatives_ba[0].segment_id(), 0);
+    EXPECT_EQ(representatives_ba[1].segment_id(), 1);
+
+    auto rowset_field_ab = create_variant_rowset({{R"({"a": 1, "b": "x"})"}}, 13, 10);
+    auto rowset_field_ba = create_variant_rowset({{R"({"b": "x", "a": 1})"}}, 14, 10);
+    ASSERT_TRUE(rowset_field_ab->rowset_meta()->has_variant_schema_representatives());
+    ASSERT_TRUE(rowset_field_ba->rowset_meta()->has_variant_schema_representatives());
+    const auto hash_field_ab = rowset_field_ab->rowset_meta()->variant_schema_hash();
+    const auto hash_field_ba = rowset_field_ba->rowset_meta()->variant_schema_hash();
+    EXPECT_EQ(hash_field_ab.first, hash_field_ba.first);
+    EXPECT_EQ(hash_field_ab.second, hash_field_ba.second);
+    EXPECT_EQ(rowset_field_ab->rowset_meta()->variant_schema_representatives().size(), 1);
+    EXPECT_EQ(rowset_field_ba->rowset_meta()->variant_schema_representatives().size(), 1);
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_variant_describe_dedups_rowsets_with_different_json_key_order) {
+    struct DebugPointGuard {
+        DebugPointGuard() : old_enable_debug_points(config::enable_debug_points) {
+            config::enable_debug_points = true;
+            DebugPoints::instance()->clear();
+        }
+
+        ~DebugPointGuard() {
+            DebugPoints::instance()->clear();
+            config::enable_debug_points = old_enable_debug_points;
+        }
+
+        bool old_enable_debug_points;
+    } guard;
+
+    init_variant_tablet(41009, 10);
+
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.push_back(create_variant_rowset({{R"({"a": 1, "b": "x"})"}}, 15, 10));
+    rowsets.push_back(create_variant_rowset({{R"({"b": "y", "a": 2})"}}, 16, 10));
+
+    const auto hash_ab = rowsets[0]->rowset_meta()->variant_schema_hash();
+    const auto hash_ba = rowsets[1]->rowset_meta()->variant_schema_hash();
+    ASSERT_EQ(hash_ab.first, hash_ba.first);
+    ASSERT_EQ(hash_ab.second, hash_ba.second);
+
+    constexpr std::string_view debug_point =
+            "VariantCompactionUtil.calculate_variant_extended_schema.check_scan_segments";
+    DebugPoints::instance()->add_with_params(
+            std::string(debug_point), {{"selected_rowsets", "1"}, {"selected_segments", "1"}});
+
+    auto schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+            rowsets, _tablet_schema);
+    ASSERT_NE(schema, nullptr);
+    const auto names = collect_variant_subcolumn_names(schema);
+    EXPECT_TRUE(names.count("v1.a") != 0);
+    EXPECT_TRUE(names.count("v1.b") != 0);
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_variant_describe_representative_fast_path_matches_full_scan) {
+    init_variant_tablet(41004, 10);
+
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.push_back(
+            create_variant_rowset({{R"({"a": 1})"}, {R"({"b": "x"})"}, {R"({"a": 2})"}}, 6, 10));
+    rowsets.push_back(create_variant_rowset({{R"({"a": 3})"}, {R"({"b": "y"})"}}, 7, 10));
+
+    auto fast_schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+            rowsets, _tablet_schema);
+    ASSERT_NE(fast_schema, nullptr);
+    auto fast_names = collect_variant_subcolumn_names(fast_schema);
+    EXPECT_TRUE(fast_names.count("v1.a") != 0);
+    EXPECT_TRUE(fast_names.count("v1.b") != 0);
+
+    for (const auto& rowset : rowsets) {
+        rowset->rowset_meta()->clear_variant_schema_metadata();
+    }
+    auto full_scan_schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+            rowsets, _tablet_schema);
+    ASSERT_NE(full_scan_schema, nullptr);
+    EXPECT_EQ(fast_names, collect_variant_subcolumn_names(full_scan_schema));
+}
+
+TEST_F(VariantColumnWriterReaderTest, test_variant_describe_debug_point_checks_selected_segments) {
+    struct DebugPointGuard {
+        DebugPointGuard() : old_enable_debug_points(config::enable_debug_points) {
+            config::enable_debug_points = true;
+            DebugPoints::instance()->clear();
+        }
+
+        ~DebugPointGuard() {
+            DebugPoints::instance()->clear();
+            config::enable_debug_points = old_enable_debug_points;
+        }
+
+        bool old_enable_debug_points;
+    } guard;
+
+    init_variant_tablet(41006, 10);
+
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.push_back(
+            create_variant_rowset({{R"({"a": 1})"}, {R"({"b": "x"})"}, {R"({"a": 2})"}}, 9, 10));
+    rowsets.push_back(create_variant_rowset({{R"({"a": 3})"}, {R"({"b": "y"})"}}, 10, 10));
+
+    constexpr std::string_view debug_point =
+            "VariantCompactionUtil.calculate_variant_extended_schema.check_scan_segments";
+    DebugPoints::instance()->add_with_params(
+            std::string(debug_point), {{"selected_rowsets", "1"}, {"selected_segments", "2"}});
+
+    auto schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+            rowsets, _tablet_schema);
+    ASSERT_NE(schema, nullptr);
+    auto names = collect_variant_subcolumn_names(schema);
+    EXPECT_TRUE(names.count("v1.a") != 0);
+    EXPECT_TRUE(names.count("v1.b") != 0);
+
+    DebugPoints::instance()->add_with_params(
+            std::string(debug_point), {{"selected_rowsets", "2"}, {"selected_segments", "4"}});
+    auto mismatched_schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+            rowsets, _tablet_schema);
+    ASSERT_NE(mismatched_schema, nullptr);
+    EXPECT_TRUE(collect_variant_subcolumn_names(mismatched_schema).empty());
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       test_variant_describe_fallback_for_malformed_representatives) {
+    init_variant_tablet(41005, 10);
+
+    auto rowset = create_variant_rowset({{R"({"a": 1})"}, {R"({"b": "x"})"}}, 8, 10);
+    auto rowset_meta = rowset->rowset_meta();
+    ASSERT_TRUE(rowset_meta->has_variant_schema_representatives());
+    const auto rowset_hash = rowset_meta->variant_schema_hash();
+
+    auto expect_full_scan_result = [&]() {
+        auto schema = variant_util::VariantCompactionUtil::calculate_variant_extended_schema(
+                {rowset}, _tablet_schema);
+        ASSERT_NE(schema, nullptr);
+        const auto names = collect_variant_subcolumn_names(schema);
+        EXPECT_TRUE(names.count("v1.a") != 0);
+        EXPECT_TRUE(names.count("v1.b") != 0);
+    };
+
+    rowset_meta->clear_variant_schema_metadata();
+    rowset_meta->add_variant_schema_representative(0);
+    expect_full_scan_result();
+
+    rowset_meta->clear_variant_schema_metadata();
+    rowset_meta->set_variant_schema_hash(rowset_hash.first, rowset_hash.second);
+    expect_full_scan_result();
+
+    RowsetMetaPB missing_hi = rowset_meta->get_rowset_pb();
+    missing_hi.set_variant_schema_hash_lo(rowset_hash.first);
+    missing_hi.clear_variant_schema_hash_hi();
+    missing_hi.clear_variant_schema_representatives();
+    missing_hi.add_variant_schema_representatives()->set_segment_id(0);
+    ASSERT_TRUE(rowset_meta->init_from_pb(missing_hi));
+    expect_full_scan_result();
+
+    RowsetMetaPB missing_lo = rowset_meta->get_rowset_pb();
+    missing_lo.clear_variant_schema_hash_lo();
+    missing_lo.set_variant_schema_hash_hi(rowset_hash.second);
+    missing_lo.clear_variant_schema_representatives();
+    missing_lo.add_variant_schema_representatives()->set_segment_id(0);
+    ASSERT_TRUE(rowset_meta->init_from_pb(missing_lo));
+    expect_full_scan_result();
+
+    RowsetMetaPB incomplete_representative = rowset_meta->get_rowset_pb();
+    incomplete_representative.set_variant_schema_hash_lo(rowset_hash.first);
+    incomplete_representative.set_variant_schema_hash_hi(rowset_hash.second);
+    incomplete_representative.clear_variant_schema_representatives();
+    incomplete_representative.add_variant_schema_representatives();
+    ASSERT_TRUE(rowset_meta->init_from_pb(incomplete_representative));
+    expect_full_scan_result();
+
+    rowset_meta->clear_variant_schema_metadata();
+    rowset_meta->set_variant_schema_hash(rowset_hash.first, rowset_hash.second);
+    rowset_meta->add_variant_schema_representative(static_cast<int32_t>(rowset->num_segments()));
+    expect_full_scan_result();
+
+    rowset_meta->clear_variant_schema_metadata();
+    rowset_meta->set_variant_schema_hash(rowset_hash.first, rowset_hash.second);
+    rowset_meta->add_variant_schema_representative(0);
+    rowset_meta->add_variant_schema_representative(0);
+    expect_full_scan_result();
 }
 
 TEST_F(VariantColumnWriterReaderTest,

--- a/docs/design/variant-describe-metadata-dedup.md
+++ b/docs/design/variant-describe-metadata-dedup.md
@@ -1,0 +1,151 @@
+# Variant DESCRIBE Metadata Deduplication
+
+## Background
+
+When `describe_extend_variant_column` is enabled, FE requests remote tablet schemas through
+`FetchRemoteTabletSchemaUtil`. BE handles the request in `PInternalService::fetch_remote_tablet_schema`
+and currently calls `VariantCompactionUtil::calculate_variant_extended_schema` on the worker BE.
+
+The current implementation scans all snapshot rowsets and opens every segment to read Variant
+subcolumn metadata. This is expensive when a tablet has many segments whose Variant subcolumn
+schema is identical or highly repeated.
+
+The goal is to reduce repeated metadata reads for DESCRIBE without storing the complete Variant
+subcolumn schema in rowset metadata. This is important for cloud mode because rowset metadata can
+already be large, especially when the table has many columns.
+
+## Design
+
+Each newly written rowset records two compact pieces of Variant schema metadata:
+
+- a rowset-level `variant_schema_hash`, used to skip rowsets with identical Variant DESCRIBE schema;
+- rowset-level `variant_schema_representatives`, the first final segment id for each unique
+  segment-level Variant schema in that rowset.
+
+The rowset metadata does not store complete Variant subcolumn `ColumnPB` data or the full canonical
+schema key. It also does not store a per-representative schema hash; the rowset hash already
+summarizes the full set of unique segment schema keys, and each representative only needs a segment
+id. The persisted data is bounded by the number of unique segment schema layouts, not by the number
+of table columns or Variant subcolumns.
+
+The canonical key used during writing must include every property that affects DESCRIBE output:
+
+- a format version;
+- Variant root column stable identity, preferably parent unique id;
+- canonical Variant subpath;
+- logical type, nested structure, and nullability.
+
+Implementation builds this key from a canonicalized `ColumnMetaPB` serialization for each supported
+Variant subcolumn. Physical segment fields such as page pointers, row counts, byte sizes, and
+segment-local unique ids are deliberately excluded so identical logical schemas still deduplicate.
+
+The canonical key is used only while building the rowset. The persisted hash is a compact
+fingerprint and must not be used to reconstruct schema content.
+
+The fast path intentionally supports only ordinary dynamic Variant subcolumns. Segment footers may
+contain an empty sparse container marker even for ordinary dynamic rows; that marker is ignored.
+Complex layouts such as doc mode, actual sparse column materialization with non-empty sparse
+statistics, typed paths when they produce sparse statistics, nested group markers, and root-only
+scalar Variant segments omit this optimization metadata and use the existing full segment scan. This
+keeps the optimized metadata small and avoids returning an incomplete DESCRIBE schema for partially
+represented layouts.
+
+## Write Path
+
+`SegmentWriter` and `VerticalSegmentWriter` build a segment-level Variant canonical key after the
+segment footer and external column metadata layout are finalized. The key must be generated from a
+stable binary or structured encoding, not from protobuf debug text.
+
+`SegmentStatistics` carries the segment-level canonical key and hash in BE memory. `BaseBetaRowsetWriter`
+uses these fields when building rowset metadata:
+
+- if the tablet has no Variant columns, no new fields are written;
+- if a segment contains doc-mode, actual sparse statistics, typed-path-to-sparse materialized as
+  sparse statistics, nested-group, or root-only scalar Variant layout, no new fields are written;
+- if any non-empty segment lacks a canonical key, no new fields are written and DESCRIBE falls back
+  to the full scan path;
+- otherwise, final segment ids are traversed in order, full canonical keys are deduplicated exactly,
+  and the first segment id for each unique key is persisted as a representative;
+- the rowset-level hash is computed from the sorted set of unique segment canonical keys, so
+  the hash is independent of which segment schema appears first.
+
+Load stream must not send the full canonical key in `SegmentStatisticsPB`, because that would make
+RPC metadata grow with Variant subcolumns. If the receiver cannot rebuild the key from the written
+segment before rowset metadata is built, the rowset must omit the new fields and use the fallback
+scan path.
+
+Segcompaction must use final segment ids. Compacted output segments must produce their own canonical
+keys. Plain segment rename paths must keep any in-memory segment statistics aligned with the final
+segment id. If this cannot be guaranteed, the new fields must be omitted.
+
+## Metadata Merge And Compatibility
+
+Unsafe metadata merges must clear the new fields rather than trying to preserve a partial summary.
+This includes `RowsetMeta::merge_rowset_meta`: because rowset metadata only persists hashes and
+representative segment ids, a merged rowset cannot safely rebuild a precise rowset-level canonical
+key without opening segment metadata or storing full keys. Clearing the new fields preserves
+correctness by forcing DESCRIBE to fall back to the full scan path.
+
+Copy-only metadata paths can copy the fields unchanged when the segment layout is unchanged. Any
+path that combines multiple rowsets must use an all-or-nothing rule: if all inputs have complete
+metadata and the final segment id offsets are known, the representatives may be offset and carried;
+otherwise the new fields must be cleared.
+
+Old rowsets and rowsets written by old BEs do not have the new fields. They remain correct because
+DESCRIBE falls back to scanning all segments.
+
+The new fields are independent of cloud schema dictionary handling. This change does not modify
+`write_schema_kv` behavior and does not solve historical rowset metadata growth caused by existing
+tablet schema or sparse column metadata. It only guarantees that the new optimization metadata does
+not grow with the number of columns or Variant subcolumns.
+
+## DESCRIBE Read Path
+
+`VariantCompactionUtil::calculate_variant_extended_schema` keeps its public behavior but internally
+uses the new metadata when available:
+
+1. Take the tablet snapshot rowsets.
+2. Rowsets with complete Variant schema metadata are deduplicated by the rowset hash.
+3. Rowsets without the new metadata are not deduplicated.
+4. For each selected rowset, scan only representative segment ids when present.
+5. If representative ids are missing, duplicated, or invalid, scan the whole rowset and do not use
+   that rowset for metadata-based deduplication.
+6. Merge the collected schemas with the existing `get_least_common_schema` logic.
+
+Segment loading should use the existing segment cache where possible so repeated DESCRIBE calls do
+not rebuild the same readers unnecessarily.
+
+The rowset-level hash is a fingerprint. This design accepts the practical collision risk of 128-bit
+fingerprints. If the project later requires deterministic zero-collision behavior, the design must
+be extended with a sidecar or dictionary that stores the full canonical schema.
+
+## Proto And Code Touch Points
+
+Expected code areas:
+
+- `gensrc/proto/olap_file.proto`: add compact Variant schema hash and representative segment fields
+  to both `RowsetMetaPB` and `RowsetMetaCloudPB`.
+- `be/src/cloud/pb_convert.cpp`: copy and move the new fields in all four conversion directions.
+- `be/src/storage/rowset/rowset_meta.*`: add helpers and clear new fields on unsafe merge.
+- `be/src/storage/rowset/rowset_writer.h`: carry in-memory segment canonical key data.
+- `be/src/storage/segment/segment_writer.*` and `be/src/storage/segment/vertical_segment_writer.*`:
+  expose segment-level Variant schema key/hash after footer finalization.
+- `be/src/storage/rowset/segment_creator.cpp` and rowset writer paths: pass the in-memory key into
+  rowset metadata construction.
+- `be/src/exec/common/variant_util.*`: use rowset hash and representative segment ids in the
+  DESCRIBE-only schema calculation path.
+
+## Tests
+
+Required focused tests:
+
+- BE unit tests for same-schema and different-schema multi-segment Variant rowsets.
+- BE unit tests for missing canonical key fallback and no-Variant behavior.
+- BE unit tests for sparse/doc/typed/nested/root-only layouts falling back instead of writing
+  optimization metadata.
+- BE unit tests for `RowsetMeta::merge_rowset_meta` clearing the new fields.
+- Segcompaction coverage for final segment id correctness or fallback.
+- Cloud/proto tests for all `RowsetMetaPB <-> RowsetMetaCloudPB` conversion directions.
+- Regression coverage for `describe_extend_variant_column=true` showing DESCRIBE output remains
+  unchanged with multiple rowsets and segments.
+- Performance evidence comparing segment open count or fetch time before and after the optimization.

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -72,6 +72,12 @@ message PackedSliceLocationPB {
     optional int64 packed_file_size = 4;  // Total size of the packed file
 }
 
+message VariantSchemaRepresentativePB {
+    optional int32 segment_id = 1;
+    optional fixed64 schema_hash_lo = 2;
+    optional fixed64 schema_hash_hi = 3;
+}
+
 // ATTN: When adding or deleting fields, please update `message RowsetMetaCloudPB`
 // simultaneously and modify the conversion function in the be/src/cloud/pb_convert.{h,cpp}.
 message RowsetMetaPB {
@@ -174,6 +180,10 @@ message RowsetMetaPB {
     optional string job_id = 1014;
 
     optional int64 commit_tso = 1015 [default = -1];
+
+    optional fixed64 variant_schema_hash_lo = 1016;
+    optional fixed64 variant_schema_hash_hi = 1017;
+    repeated VariantSchemaRepresentativePB variant_schema_representatives = 1018;
 }
 
 message SchemaDictKeyList {
@@ -287,6 +297,10 @@ message RowsetMetaCloudPB {
     optional bool is_recycled = 112;
     optional string job_id = 113;
     optional int64 commit_tso = 114 [default = -1];
+
+    optional fixed64 variant_schema_hash_lo = 115;
+    optional fixed64 variant_schema_hash_hi = 116;
+    repeated VariantSchemaRepresentativePB variant_schema_representatives = 117;
 
 }
 

--- a/regression-test/suites/variant_p0/test_variant_desc_metadata_dedup_debug_point.groovy
+++ b/regression-test/suites/variant_p0/test_variant_desc_metadata_dedup_debug_point.groovy
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_variant_desc_metadata_dedup_debug_point", "p0, nonConcurrent") {
+    String debugPoint = "VariantCompactionUtil.calculate_variant_extended_schema.check_scan_segments"
+
+    sql "DROP TABLE IF EXISTS test_variant_desc_metadata_dedup_debug_point"
+    sql "SET default_variant_enable_doc_mode = false"
+    sql "SET default_variant_max_subcolumns_count = 10"
+    sql "SET default_variant_enable_typed_paths_to_sparse = false"
+    sql "SET default_variant_sparse_hash_shard_count = 0"
+    sql """
+        CREATE TABLE test_variant_desc_metadata_dedup_debug_point (
+            k int,
+            v variant<properties("variant_max_subcolumns_count" = "10")>
+        )
+        DUPLICATE KEY(k)
+        DISTRIBUTED BY HASH(k) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1",
+            "disable_auto_compaction" = "true"
+        )
+    """
+
+    sql """INSERT INTO test_variant_desc_metadata_dedup_debug_point VALUES (1, '{"a": 1, "b": "x"}')"""
+    sql """INSERT INTO test_variant_desc_metadata_dedup_debug_point VALUES (2, '{"a": 2, "b": "y"}')"""
+    sql """INSERT INTO test_variant_desc_metadata_dedup_debug_point VALUES (3, '{"a": 3, "b": "z"}')"""
+    sql "sync"
+    sql "SELECT * FROM test_variant_desc_metadata_dedup_debug_point LIMIT 1"
+    sql "SET describe_extend_variant_column = true"
+
+    def tablets = sql_return_maparray "SHOW TABLETS FROM test_variant_desc_metadata_dedup_debug_point"
+    assertEquals(1, tablets.size())
+    def rowsets = sql_return_maparray """
+        SELECT ROWSET_ID, NUM_SEGMENTS
+        FROM information_schema.rowsets
+        WHERE TABLET_ID = ${tablets[0].TabletId} AND ROWSET_NUM_ROWS > 0
+        ORDER BY START_VERSION
+    """
+    assertEquals(3, rowsets.size())
+    rowsets.each { rowset ->
+        assertEquals(1, rowset.NUM_SEGMENTS as int)
+    }
+
+    def rows = sql "DESC test_variant_desc_metadata_dedup_debug_point"
+    def fieldNames = rows.collect { it[0].toString() }
+    assertTrue(fieldNames.contains("v.a"), "DESC fields: ${fieldNames}")
+    assertTrue(fieldNames.contains("v.b"), "DESC fields: ${fieldNames}")
+
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs(debugPoint)
+        rows = sql "DESC test_variant_desc_metadata_dedup_debug_point"
+        fieldNames = rows.collect { it[0].toString() }
+        assertTrue(fieldNames.contains("v.a"), "DESC fields: ${fieldNames}")
+        assertTrue(fieldNames.contains("v.b"), "DESC fields: ${fieldNames}")
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs(debugPoint)
+    }
+
+    try {
+        GetDebugPoint().enableDebugPointForAllBEs(
+                debugPoint, [selected_rowsets: "0", selected_segments: "0"])
+        rows = sql "DESC test_variant_desc_metadata_dedup_debug_point"
+        fieldNames = rows.collect { it[0].toString() }
+        assertEquals(["k", "v"], fieldNames)
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs(debugPoint)
+    }
+}


### PR DESCRIPTION
## What problem was fixed

`describe_extend_variant_column=true` asks BE to collect Variant subcolumn metadata from snapshot rowsets. Before this change, DESCRIBE may open every segment and recompute identical Variant schema metadata repeatedly. On tablets with many rowsets or segments, that causes many unnecessary segment metadata reads. In cloud mode, storing the full Variant subcolumn schema in rowset metadata is also undesirable because rowset meta can already be large when tables have many columns.

## How it was fixed

- Persist compact rowset-level Variant schema fingerprints and representative segment IDs instead of full Variant subcolumn metadata.
- Build deterministic in-memory canonical schema keys during local segment writing, then persist only 128-bit hashes plus representative segment metadata.
- Make DESCRIBE scan only representative segments for rowsets with complete metadata, and fall back to the full segment scan for old, unsafe, malformed, or load-stream-created rowsets.
- Preserve compact rowset metadata through rowset/cloud protobuf conversion and snapshot conversion.
- Keep load-stream control messages from serializing the full canonical Variant schema key.

## Behavior changes

User-visible DESCRIBE output should not change. The intended behavior change is reduced segment metadata reads when repeated rowset Variant schema metadata is available. Old rowsets and paths without safe metadata remain correct through fallback scanning.

## Features added

- Rowset-level Variant schema hash and representative segment metadata.
- Debug-point coverage for DESCRIBE representative segment selection.
- Design document for the metadata deduplication strategy.

## Refactoring / optimization

The change keeps the public DESCRIBE schema merge behavior intact while avoiding redundant segment opens for identical Variant schema layouts. It does not modify `write_schema_kv` or store full Variant schema data in rowset metadata.

## Testing

- `BUILD_TYPE=ASAN USE_MEM_TRACKER=ON ./build.sh --be -j16`
- `./run-be-ut.sh --run --filter=SegmentStatisticsTest.TestVariantSchemaMetadataStaysInMemoryOnly:VariantColumnWriterReaderTest.test_variant_describe_debug_point_checks_selected_segments:VariantColumnWriterReaderTest.test_variant_describe_representative_fast_path_matches_full_scan`
- `./run-regression-test.sh --conf tmp/regression-conf.auto.groovy --run -d variant_p0 -s test_variant_desc_metadata_dedup_debug_point`
- `python3 build-support/run_clang_format.py --clang-format-executable ./.github/actions/clang-format-lint-action/clang-format/clang-format16 -r --style file --inplace false --extensions c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx --exclude none 'be/src be/test cloud/src cloud/test'`
- `git diff --check`
- `git diff --check upstream/master...HEAD`
- `git rev-list --left-right --count upstream/master...HEAD` => `0 1`

`clang-tidy` was not run in this environment because `clang-tidy` is not installed.