### PR TITLE
[refine](column) replace misused check_and_get_column with assert_cast

### DIFF
--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -839,7 +839,7 @@ void ColumnVariant::for_each_subcolumn(ColumnCallback callback) {
 }
 
 void ColumnVariant::insert_from(const IColumn& src, size_t n) {
-    const auto* src_v = check_and_get_column<ColumnVariant>(src);
+    const auto* src_v = assert_cast<const ColumnVariant*>(&src);
     ENABLE_CHECK_CONSISTENCY(src_v);
     ENABLE_CHECK_CONSISTENCY(this);
     // Preserve the original root-only copy path for ordinary variant columns.

--- a/be/src/core/data_type_serde/data_type_decimal_serde.h
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.h
@@ -152,7 +152,7 @@ template <PrimitiveType T>
 Status DataTypeDecimalSerDe<T>::write_column_to_pb(const IColumn& column, PValues& result,
                                                    int64_t start, int64_t end) const {
     auto row_count = cast_set<int>(end - start);
-    const auto* col = check_and_get_column<ColumnDecimal<T>>(column);
+    const auto* col = assert_cast<const ColumnDecimal<T>*>(&column);
     auto* ptype = result.mutable_type();
     if constexpr (T == TYPE_DECIMALV2) {
         ptype->set_id(PGenericType::DECIMAL128);

--- a/be/src/core/data_type_serde/data_type_map_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_map_serde.cpp
@@ -341,7 +341,7 @@ Status DataTypeMapSerDe::write_column_to_arrow(const IColumn& column, const Null
     DCHECK(nested_keys_column.is_nullable());
     DCHECK(nested_values_column.is_nullable());
     const auto* keys_nullmap_data =
-            check_and_get_column<ColumnNullable>(nested_keys_column)->get_null_map_data().data();
+            assert_cast<const ColumnNullable&>(nested_keys_column).get_null_map_data().data();
     const auto& offsets = map_column.get_offsets();
     auto* key_builder = builder.key_builder();
     auto* value_builder = builder.item_builder();

--- a/be/src/core/data_type_serde/data_type_nullable_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_nullable_serde.cpp
@@ -268,8 +268,7 @@ Status DataTypeNullableSerDe::write_column_to_pb(const IColumn& column, PValues&
         result.set_has_null(true);
         auto* null_map = result.mutable_null_map();
         null_map->Reserve(row_count);
-        const auto* col = check_and_get_column<ColumnUInt8>(null_col);
-        const auto& data = col->get_data();
+        const auto& data = null_col.get_data();
         null_map->Add(data.begin() + start, data.begin() + end);
     }
     return nested_serde->write_column_to_pb(nullable_col.get_nested_column(), result, start, end);

--- a/be/src/core/data_type_serde/data_type_number_serde.h
+++ b/be/src/core/data_type_serde/data_type_number_serde.h
@@ -239,7 +239,7 @@ Status DataTypeNumberSerDe<T>::write_column_to_pb(const IColumn& column, PValues
                                                   int64_t start, int64_t end) const {
     auto row_count = cast_set<int>(end - start);
     auto* ptype = result.mutable_type();
-    const auto* col = check_and_get_column<ColumnType>(column);
+    const auto* col = assert_cast<const ColumnType*>(&column);
     if constexpr (T == TYPE_LARGEINT) {
         ptype->set_id(PGenericType::INT128);
         result.mutable_bytes_value()->Reserve(row_count);

--- a/be/src/core/data_type_serde/data_type_variant_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_variant_serde.cpp
@@ -101,7 +101,7 @@ void DataTypeVariantSerDe::read_one_cell_from_jsonb(IColumn& column, const Jsonb
 Status DataTypeVariantSerDe::serialize_one_cell_to_json(const IColumn& column, int64_t row_num,
                                                         BufferWritable& bw,
                                                         FormatOptions& options) const {
-    const auto* var = check_and_get_column<ColumnVariant>(column);
+    const auto* var = assert_cast<const ColumnVariant*>(&column);
     var->serialize_one_row_to_string(row_num, bw, options);
     return Status::OK();
 }
@@ -127,7 +127,7 @@ Status DataTypeVariantSerDe::write_column_to_arrow(const IColumn& column, const 
                                                    arrow::ArrayBuilder* array_builder,
                                                    int64_t start, int64_t end,
                                                    const cctz::time_zone& ctz) const {
-    const auto* var = check_and_get_column<ColumnVariant>(column);
+    const auto* var = assert_cast<const ColumnVariant*>(&column);
     auto& builder = assert_cast<arrow::StringBuilder&>(*array_builder);
     FormatOptions options;
     options.timezone = &ctz;
@@ -158,7 +158,7 @@ Status DataTypeVariantSerDe::write_column_to_orc(const std::string& timezone, co
                                                  orc::ColumnVectorBatch* orc_col_batch,
                                                  int64_t start, int64_t end, Arena& arena,
                                                  const FormatOptions& options) const {
-    const auto* var = check_and_get_column<ColumnVariant>(column);
+    const auto* var = assert_cast<const ColumnVariant*>(&column);
     orc::StringVectorBatch* cur_batch = dynamic_cast<orc::StringVectorBatch*>(orc_col_batch);
     // First pass: calculate total memory needed and collect serialized values
     std::vector<std::string> serialized_values;

--- a/be/src/core/decimal_comparison.h
+++ b/be/src/core/decimal_comparison.h
@@ -217,30 +217,18 @@ private:
             if (c0_is_const) {
                 const ColumnConst* c0_const = check_and_get_column_const<ColVecA>(c0.get());
                 const auto& a = c0_const->template get_value<A>();
-                if (const ColVecB* c1_vec = check_and_get_column<ColVecB>(c1.get()))
-                    constant_vector<scale_left, scale_right>(a, c1_vec->get_data(), vec_res, scale);
-                else {
-                    throw Exception(Status::FatalError("Wrong column in Decimal comparison"));
-                }
+                const auto* c1_vec = assert_cast<const ColVecB*>(c1.get());
+                constant_vector<scale_left, scale_right>(a, c1_vec->get_data(), vec_res, scale);
             } else if (c1_is_const) {
                 const ColumnConst* c1_const = check_and_get_column_const<ColVecB>(c1.get());
                 const auto& b = c1_const->template get_value<B>();
-                if (const ColVecA* c0_vec = check_and_get_column<ColVecA>(c0.get()))
-                    vector_constant<scale_left, scale_right>(c0_vec->get_data(), b, vec_res, scale);
-                else {
-                    throw Exception(Status::FatalError("Wrong column in Decimal comparison"));
-                }
+                const auto* c0_vec = assert_cast<const ColVecA*>(c0.get());
+                vector_constant<scale_left, scale_right>(c0_vec->get_data(), b, vec_res, scale);
             } else {
-                if (const ColVecA* c0_vec = check_and_get_column<ColVecA>(c0.get())) {
-                    if (const ColVecB* c1_vec = check_and_get_column<ColVecB>(c1.get()))
-                        vector_vector<scale_left, scale_right>(c0_vec->get_data(),
-                                                               c1_vec->get_data(), vec_res, scale);
-                    else {
-                        throw Exception(Status::FatalError("Wrong column in Decimal comparison"));
-                    }
-                } else {
-                    throw Exception(Status::FatalError("Wrong column in Decimal comparison"));
-                }
+                const auto* c0_vec = assert_cast<const ColVecA*>(c0.get());
+                const auto* c1_vec = assert_cast<const ColVecB*>(c1.get());
+                vector_vector<scale_left, scale_right>(c0_vec->get_data(), c1_vec->get_data(),
+                                                       vec_res, scale);
             }
             return c_res;
         } else {

--- a/be/src/exec/common/columns_hashing.h
+++ b/be/src/exec/common/columns_hashing.h
@@ -114,8 +114,7 @@ struct HashMethodSingleLowNullableColumn : public SingleColumnMethod {
     const ColumnNullable* key_column;
 
     static ColumnRawPtrs get_nested_column(const IColumn* col) {
-        const auto* nullable = check_and_get_column<ColumnNullable>(*col);
-        DCHECK(nullable != nullptr);
+        const auto* nullable = assert_cast<const ColumnNullable*>(col);
         const auto* const nested_col = nullable->get_nested_column_ptr().get();
         return {nested_col};
     }

--- a/be/src/exec/common/variant_util.cpp
+++ b/be/src/exec/common/variant_util.cpp
@@ -358,7 +358,7 @@ Status cast_column(const ColumnWithTypeAndName& arg, const DataTypePtr& type, Co
         variant->create_root(arg.type, arg.column->assume_mutable());
         ColumnPtr nullable = ColumnNullable::create(
                 variant->get_ptr(),
-                check_and_get_column<ColumnNullable>(arg.column.get())->get_null_map_column_ptr());
+                assert_cast<const ColumnNullable*>(arg.column.get())->get_null_map_column_ptr());
         *result = type->is_nullable() ? nullable : variant->get_ptr();
         return Status::OK();
     }

--- a/be/src/exec/operator/join_probe_operator.cpp
+++ b/be/src/exec/operator/join_probe_operator.cpp
@@ -66,7 +66,8 @@ void JoinProbeLocalState<SharedStateArg, Derived>::_construct_mutable_join_block
         const auto& mark_column = assert_cast<const ColumnNullable&>(
                 *_join_block.get_by_position(_mark_column_id).column);
         auto& nested_column = mark_column.get_nested_column();
-        DCHECK(check_and_get_column<ColumnUInt8>(nested_column) != nullptr);
+        [[maybe_unused]] const auto& nested_uint8_column =
+                assert_cast<const ColumnUInt8&>(nested_column);
 #endif
     }
 }

--- a/be/src/exec/sink/writer/iceberg/partition_transformers.h
+++ b/be/src/exec/sink/writer/iceberg/partition_transformers.h
@@ -338,7 +338,7 @@ public:
             is_nullable = false;
         }
 
-        const auto* const decimal_col = check_and_get_column<ColumnDecimal<PT>>(column_ptr.get());
+        const auto* const decimal_col = assert_cast<const ColumnDecimal<PT>*>(column_ptr.get());
         const auto& vec_src = decimal_col->get_data();
 
         auto col_res = ColumnDecimal<PT>::create(vec_src.size(), decimal_col->get_scale());

--- a/be/src/exec/sink/writer/iceberg/viceberg_table_writer.cpp
+++ b/be/src/exec/sink/writer/iceberg/viceberg_table_writer.cpp
@@ -664,7 +664,7 @@ std::any VIcebergTableWriter::_get_iceberg_partition_value(
     auto [item, size] = col_ptr->get_data_at(position);
     switch (type_desc) {
     case TYPE_BOOLEAN: {
-        Field field = check_and_get_column<const ColumnUInt8>(*col_ptr)->operator[](position);
+        Field field = assert_cast<const ColumnUInt8*>(col_ptr.get())->operator[](position);
         return field.get<TYPE_BOOLEAN>();
     }
     case TYPE_TINYINT: {

--- a/be/src/exec/sink/writer/vhive_table_writer.cpp
+++ b/be/src/exec/sink/writer/vhive_table_writer.cpp
@@ -447,7 +447,7 @@ std::string VHiveTableWriter::_to_partition_value(const DataTypePtr& type_desc,
     auto [item, size] = column->get_data_at(position);
     switch (type_desc->get_primitive_type()) {
     case TYPE_BOOLEAN: {
-        Field field = check_and_get_column<const ColumnUInt8>(*column)->operator[](position);
+        Field field = assert_cast<const ColumnUInt8*>(column.get())->operator[](position);
         return std::to_string(field.get<TYPE_BOOLEAN>());
     }
     case TYPE_TINYINT: {

--- a/be/src/exprs/function/array/function_array_aggregation.cpp
+++ b/be/src/exprs/function/array/function_array_aggregation.cpp
@@ -495,10 +495,10 @@ public:
         auto ptr = typed_column.column->convert_to_full_column_if_const();
         const typename Impl::column_type* column_array;
         if (ptr->is_nullable()) {
-            column_array = check_and_get_column<const typename Impl::column_type>(
+            column_array = assert_cast<const typename Impl::column_type*>(
                     assert_cast<const ColumnNullable*>(ptr.get())->get_nested_column_ptr().get());
         } else {
-            column_array = check_and_get_column<const typename Impl::column_type>(ptr.get());
+            column_array = assert_cast<const typename Impl::column_type*>(ptr.get());
         }
         const auto* data_type_array =
                 assert_cast<const DataTypeArray*>(remove_nullable(typed_column.type).get());

--- a/be/src/exprs/function/array/function_array_apply.cpp
+++ b/be/src/exprs/function/array/function_array_apply.cpp
@@ -146,7 +146,7 @@ private:
         if (!src_column.is_nullable()) {
             src_column_data_ptr = src_column.get_raw_data().data;
         } else {
-            const auto* nullable_col = check_and_get_column<ColumnNullable>(src_column);
+            const auto* nullable_col = assert_cast<const ColumnNullable*>(&src_column);
             src_column_data_ptr = nullable_col->get_nested_column().get_raw_data().data;
             null_map_data = nullable_col->get_null_map_data().data();
         }

--- a/be/src/exprs/function/array/function_array_concat.cpp
+++ b/be/src/exprs/function/array/function_array_concat.cpp
@@ -82,7 +82,7 @@ public:
         for (size_t col : arguments) {
             ColumnPtr src_column =
                     block.get_by_position(col).column->convert_to_full_column_if_const();
-            const auto& src_column_array = check_and_get_column<ColumnArray>(*src_column);
+            const auto* src_column_array = assert_cast<const ColumnArray*>(src_column.get());
             total_size += src_column_array->get_data().size();
         }
         result_nested_col.reserve(total_size);
@@ -92,7 +92,7 @@ public:
             for (size_t col : arguments) {
                 ColumnPtr src_column =
                         block.get_by_position(col).column->convert_to_full_column_if_const();
-                const auto& src_column_array = check_and_get_column<ColumnArray>(*src_column);
+                const auto* src_column_array = assert_cast<const ColumnArray*>(src_column.get());
                 const auto& src_column_offsets = src_column_array->get_offsets();
                 const size_t length = src_column_offsets[row] - src_column_offsets[row - 1];
                 result_nested_col.insert_range_from(src_column_array->get_data(),

--- a/be/src/exprs/function/array/function_array_cum_sum.cpp
+++ b/be/src/exprs/function/array/function_array_cum_sum.cpp
@@ -133,8 +133,7 @@ public:
         auto src_nested_type = assert_cast<const DataTypeArray&>(*src_arg.type).get_nested_type();
 
         // get null map
-        const ColumnNullable* src_nested_nullable_col =
-                check_and_get_column<ColumnNullable>(*src_nested_column);
+        const auto* src_nested_nullable_col = assert_cast<const ColumnNullable*>(src_nested_column);
         src_nested_column = src_nested_nullable_col->get_nested_column_ptr().get();
         const NullMapType& src_null_map = src_nested_nullable_col->get_null_map_column().get_data();
 

--- a/be/src/exprs/function/array/function_array_distinct.h
+++ b/be/src/exprs/function/array/function_array_distinct.h
@@ -104,7 +104,7 @@ public:
         const NullMapType* src_null_map = nullptr;
         if (src_nested_column->is_nullable()) {
             const auto* src_nested_nullable_col =
-                    check_and_get_column<ColumnNullable>(*src_nested_column);
+                    assert_cast<const ColumnNullable*>(src_nested_column);
             src_nested_column = src_nested_nullable_col->get_nested_column_ptr().get();
             src_null_map = &src_nested_nullable_col->get_null_map_column().get_data();
         }

--- a/be/src/exprs/function/array/function_array_element.h
+++ b/be/src/exprs/function/array/function_array_element.h
@@ -110,7 +110,7 @@ public:
                 block.get_by_position(arguments[0]).column->convert_to_full_column_if_const());
         auto col_left = block.get_by_position(arguments[0]);
         if (col_left.column->is_nullable()) {
-            auto null_col = check_and_get_column<ColumnNullable>(*col_left.column);
+            const auto* null_col = assert_cast<const ColumnNullable*>(col_left.column.get());
             src_null_map = null_col->get_null_map_column().get_data().data();
             args = {{null_col->get_nested_column_ptr(), remove_nullable(col_left.type),
                      col_left.name},

--- a/be/src/exprs/function/array/function_array_enumerate.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate.cpp
@@ -106,8 +106,7 @@ public:
         ColumnPtr res_column =
                 ColumnArray::create(std::move(nested_column), array->get_offsets_ptr());
         if (block.get_by_position(arguments[0]).column->is_nullable()) {
-            const ColumnNullable* nullable =
-                    check_and_get_column<ColumnNullable>(left_column.get());
+            const auto* nullable = assert_cast<const ColumnNullable*>(left_column.get());
             res_column = ColumnNullable::create(
                     res_column, nullable->get_null_map_column().clone_resized(nullable->size()));
         }

--- a/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
@@ -150,7 +150,7 @@ public:
 
         const NullMapType* null_map = nullptr;
         if (arguments.size() == 1 && data_columns[0]->is_nullable()) {
-            const ColumnNullable* nullable = check_and_get_column<ColumnNullable>(*data_columns[0]);
+            const auto* nullable = assert_cast<const ColumnNullable*>(data_columns[0]);
             data_columns[0] = nullable->get_nested_column_ptr().get();
             null_map = &nullable->get_null_map_column().get_data();
         }
@@ -196,8 +196,7 @@ public:
         if (arguments.size() == 1 && block.get_by_position(arguments[0]).column->is_nullable()) {
             auto left_column =
                     block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-            const ColumnNullable* nullable =
-                    check_and_get_column<ColumnNullable>(left_column.get());
+            const auto* nullable = assert_cast<const ColumnNullable*>(left_column.get());
             res_column = ColumnNullable::create(
                     res_column, nullable->get_null_map_column().clone_resized(nullable->size()));
         }

--- a/be/src/exprs/function/array/function_array_mapped.h
+++ b/be/src/exprs/function/array/function_array_mapped.h
@@ -51,10 +51,10 @@ public:
         auto ptr = typed_column.column->convert_to_full_column_if_const();
         const typename Impl::column_type* column_array;
         if (ptr->is_nullable()) {
-            column_array = check_and_get_column<const typename Impl::column_type>(
+            column_array = assert_cast<const typename Impl::column_type*>(
                     assert_cast<const ColumnNullable*>(ptr.get())->get_nested_column_ptr().get());
         } else {
-            column_array = check_and_get_column<const typename Impl::column_type>(ptr.get());
+            column_array = assert_cast<const typename Impl::column_type*>(ptr.get());
         }
         const auto* data_type_array =
                 assert_cast<const DataTypeArray*>(remove_nullable(typed_column.type).get());

--- a/be/src/exprs/function/cast/cast_base.cpp
+++ b/be/src/exprs/function/cast/cast_base.cpp
@@ -171,7 +171,7 @@ Status cast_from_string_to_complex_type(FunctionContext* context, Block& block,
                                         const ColumnNumbers& arguments, uint32_t result,
                                         size_t input_rows_count,
                                         const NullMap::value_type* null_map) {
-    const auto* col_from = check_and_get_column<DataTypeString::ColumnType>(
+    const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
             block.get_by_position(arguments[0]).column.get());
 
     auto to_type = block.get_by_position(result).type;
@@ -209,7 +209,7 @@ Status cast_from_string_to_complex_type_strict_mode(FunctionContext* context, Bl
                                                     const ColumnNumbers& arguments, uint32_t result,
                                                     size_t input_rows_count,
                                                     const NullMap::value_type* null_map) {
-    const auto* col_from = check_and_get_column<DataTypeString::ColumnType>(
+    const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
             block.get_by_position(arguments[0]).column.get());
 
     auto to_type = block.get_by_position(result).type;

--- a/be/src/exprs/function/cast/cast_base.h
+++ b/be/src/exprs/function/cast/cast_base.h
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "core/assert_cast.h"
 #include "core/block/block.h"
 #include "core/call_on_type_index.h"
 #include "core/data_type/data_type.h"

--- a/be/src/exprs/function/cast/cast_to_basic_number_common.h
+++ b/be/src/exprs/function/cast/cast_to_basic_number_common.h
@@ -457,7 +457,7 @@ class CastToImpl<Mode, DataTypeString, ToDataType> : public CastToBase {
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<DataTypeString::ColumnType>(
+        const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
         auto to_type = block.get_by_position(result).type;
         auto serde = remove_nullable(to_type)->get_serde();

--- a/be/src/exprs/function/cast/cast_to_boolean.h
+++ b/be/src/exprs/function/cast/cast_to_boolean.h
@@ -124,7 +124,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<DataTypeString::ColumnType>(
+        const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
         auto to_type = block.get_by_position(result).type;
         auto serde = remove_nullable(to_type)->get_serde();
@@ -156,7 +156,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<typename NumberType::ColumnType>(
+        const auto* col_from = assert_cast<const typename NumberType::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
         DataTypeBool::ColumnType::MutablePtr col_to =
                 DataTypeBool::ColumnType::create(input_rows_count);
@@ -179,7 +179,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<typename DecimalType::ColumnType>(
+        const auto* col_from = assert_cast<const typename DecimalType::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
         const auto type_from = block.get_by_position(arguments[0]).type;
         DataTypeBool::ColumnType::MutablePtr col_to =

--- a/be/src/exprs/function/cast/cast_to_date.h
+++ b/be/src/exprs/function/cast/cast_to_date.h
@@ -49,7 +49,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<DataTypeString::ColumnType>(
+        const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
 
         auto to_type = block.get_by_position(result).type;
@@ -84,7 +84,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<typename FromDataType::ColumnType>(
+        const auto* col_from = assert_cast<const typename FromDataType::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
         auto to_type = block.get_by_position(result).type;
         auto concrete_serde = std::dynamic_pointer_cast<typename ToDataType::SerDeType>(
@@ -141,7 +141,7 @@ public:
         constexpr bool Nullable = std::is_same_v<FromDataType, ToDataType> &&
                                   (IsTimeV2Type<FromDataType> || IsDateTimeV2Type<FromDataType>);
 
-        const auto* col_from = check_and_get_column<typename FromDataType::ColumnType>(
+        const auto* col_from = assert_cast<const typename FromDataType::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
         auto col_to = ToDataType::ColumnType::create(input_rows_count);
         ColumnUInt8::MutablePtr col_nullmap;

--- a/be/src/exprs/function/cast/cast_to_decimal.h
+++ b/be/src/exprs/function/cast/cast_to_decimal.h
@@ -686,7 +686,7 @@ class CastToImpl<Mode, DataTypeString, ToDataType> : public CastToBase {
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<DataTypeString::ColumnType>(
+        const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
 
         auto to_type = block.get_by_position(result).type;

--- a/be/src/exprs/function/cast/cast_to_ip.h
+++ b/be/src/exprs/function/cast/cast_to_ip.h
@@ -53,7 +53,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<DataTypeString::ColumnType>(
+        const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
 
         auto to_type = block.get_by_position(result).type;
@@ -86,7 +86,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<DataTypeIPv4::ColumnType>(
+        const auto* col_from = assert_cast<const DataTypeIPv4::ColumnType*>(
                 block.get_by_position(arguments[0]).column.get());
         const auto size = col_from->size();
         auto col_to = DataTypeIPv6::ColumnType::create(size);

--- a/be/src/exprs/function/function_always_not_nullable.h
+++ b/be/src/exprs/function/function_always_not_nullable.h
@@ -48,13 +48,13 @@ public:
                                         column->get_name(), get_name());
         };
         if constexpr (is_nullable) {
-            const ColumnNullable* col_nullable = check_and_get_column<ColumnNullable>(column.get());
+            const ColumnNullable* col_nullable = assert_cast<const ColumnNullable*>(column.get());
             const ColumnType* col =
                     check_and_get_column<ColumnType>(col_nullable->get_nested_column_ptr().get());
-            const ColumnUInt8* col_nullmap = check_and_get_column<ColumnUInt8>(
-                    col_nullable->get_null_map_column_ptr().get());
+            const ColumnUInt8* col_nullmap =
+                    assert_cast<const ColumnUInt8*>(col_nullable->get_null_map_column_ptr().get());
 
-            if (col != nullptr && col_nullmap != nullptr) {
+            if (col != nullptr) {
                 if constexpr (WithReturn) {
                     RETURN_IF_ERROR(
                             Function::vector_nullable(col, col_nullmap->get_data(), column_result));
@@ -65,7 +65,7 @@ public:
                 return type_error();
             }
         } else {
-            const ColumnType* col = check_and_get_column<ColumnType>(column.get());
+            const ColumnType* col = assert_cast<const ColumnType*>(column.get());
             if constexpr (WithReturn) {
                 RETURN_IF_ERROR(Function::vector(col, column_result));
             } else {

--- a/be/src/exprs/function/function_collection_in.h
+++ b/be/src/exprs/function/function_collection_in.h
@@ -114,7 +114,7 @@ public:
             DCHECK(const_column_ptr != nullptr);
             const auto& [col, _] = unpack_if_const(const_column_ptr->column_ptr);
             if (col->is_nullable()) {
-                const auto* null_col = check_and_get_column<ColumnNullable>(col.get());
+                const auto* null_col = assert_cast<const ColumnNullable*>(col.get());
                 if (null_col->has_null()) {
                     state->null_in_set = true;
                 } else {
@@ -157,7 +157,7 @@ public:
         auto materialized_column_not_null = materialized_column;
         if (materialized_column_not_null->is_nullable()) {
             materialized_column_not_null =
-                    check_and_get_column<ColumnNullable>(materialized_column_not_null.get())
+                    assert_cast<const ColumnNullable*>(materialized_column_not_null.get())
                             ->get_nested_column_ptr();
         }
 

--- a/be/src/exprs/function/function_date_or_datetime_to_string.cpp
+++ b/be/src/exprs/function/function_date_or_datetime_to_string.cpp
@@ -147,7 +147,7 @@ public:
         ColumnPtr actual_col = source_col;
 
         if (is_column_nullable(*source_col)) {
-            const auto* nullable_col = check_and_get_column<ColumnNullable>(source_col.get());
+            const auto* nullable_col = assert_cast<const ColumnNullable*>(source_col.get());
             actual_col = nullable_col->get_nested_column_ptr();
             null_map = &nullable_col->get_null_map_data();
         }
@@ -164,7 +164,7 @@ public:
                null_map);
 
         if (null_map) {
-            const auto* nullable_col = check_and_get_column<ColumnNullable>(source_col.get());
+            const auto* nullable_col = assert_cast<const ColumnNullable*>(source_col.get());
             block.replace_by_position(
                     result,
                     ColumnNullable::create(std::move(col_res),

--- a/be/src/exprs/function/function_datetime_floor_ceil.cpp
+++ b/be/src/exprs/function/function_datetime_floor_ceil.cpp
@@ -228,8 +228,7 @@ public:
                     Core::vector_vector_anchor(sources->get_data(), delta_vec_column0->get_data(),
                                                col_to->get_data(), result_null_map, context);
                 } else {
-                    const auto* delta_vec_column1 = check_and_get_column<ColumnInt32>(delta_column);
-                    DCHECK(delta_vec_column1 != nullptr);
+                    const auto* delta_vec_column1 = assert_cast<const ColumnInt32*>(&delta_column);
                     // time_round(datetime, period)
                     Core::vector_vector_period(sources->get_data(), delta_vec_column1->get_data(),
                                                col_to->get_data(), result_null_map, context);
@@ -248,8 +247,8 @@ public:
                 Core::vector_const_const(sources->get_data(), period, origin, col_to->get_data(),
                                          result_null_map, context);
             } else if (col_const[1] && !col_const[2]) {
-                const auto arg2_column =
-                        check_and_get_column<ColumnVector<PType>>(*argument_columns[2]);
+                const auto* arg2_column =
+                        assert_cast<const ColumnVector<PType>*>(argument_columns[2].get());
                 // time_round(datetime, const(period), origin)
                 Int32 period = (*argument_columns[1])[0].get<TYPE_INT>();
                 bool period_is_null = block.get_by_position(arguments[1]).type->is_nullable() &&
@@ -260,17 +259,17 @@ public:
                 Core::vector_const_vector(sources->get_data(), period, arg2_column->get_data(),
                                           col_to->get_data(), result_null_map, context);
             } else if (!col_const[1] && col_const[2]) {
-                const auto* arg1_column = check_and_get_column<ColumnInt32>(*argument_columns[1]);
+                const auto* arg1_column =
+                        assert_cast<const ColumnInt32*>(argument_columns[1].get());
                 // time_round(datetime, period, const(origin))
                 Core::vector_vector_const(sources->get_data(), arg1_column->get_data(),
                                           (*argument_columns[2])[0].get<PType>(),
                                           col_to->get_data(), result_null_map, context);
             } else {
-                const auto* arg1_column = check_and_get_column<ColumnInt32>(*argument_columns[1]);
-                const auto arg2_column =
-                        check_and_get_column<ColumnVector<PType>>(*argument_columns[2]);
-                DCHECK(arg1_column != nullptr);
-                DCHECK(arg2_column != nullptr);
+                const auto* arg1_column =
+                        assert_cast<const ColumnInt32*>(argument_columns[1].get());
+                const auto* arg2_column =
+                        assert_cast<const ColumnVector<PType>*>(argument_columns[2].get());
                 // time_round(datetime, period, origin)
                 Core::vector_vector_vector(sources->get_data(), arg1_column->get_data(),
                                            arg2_column->get_data(), col_to->get_data(),

--- a/be/src/exprs/function/function_hex.cpp
+++ b/be/src/exprs/function/function_hex.cpp
@@ -89,7 +89,7 @@ struct HexStringImpl {
 
     static Status vector(ColumnPtr argument_column, size_t input_rows_count,
                          ColumnString::Chars& dst_data, ColumnString::Offsets& dst_offsets) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_column.get());
+        const auto* str_col = assert_cast<const ColumnString*>(argument_column.get());
         const auto& data = str_col->get_chars();
         const auto& offsets = str_col->get_offsets();
         dst_offsets.resize(input_rows_count);
@@ -136,7 +136,7 @@ struct HexIntImpl {
 
     static Status vector(ColumnPtr argument_column, size_t input_rows_count,
                          ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets) {
-        const auto* str_col = check_and_get_column<ColumnInt64>(argument_column.get());
+        const auto* str_col = assert_cast<const ColumnInt64*>(argument_column.get());
         const auto& data = str_col->get_data();
 
         res_offsets.resize(input_rows_count);
@@ -153,7 +153,7 @@ struct HexHLLImpl {
 
     static Status vector(ColumnPtr argument_column, size_t input_rows_count,
                          ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets) {
-        const auto* str_col = check_and_get_column<ColumnHLL>(argument_column.get());
+        const auto* str_col = assert_cast<const ColumnHLL*>(argument_column.get());
         const auto& hll_data = str_col->get_data();
         res_offsets.resize(input_rows_count);
         size_t total_length = 0, offset = 0;

--- a/be/src/exprs/function/function_hll.cpp
+++ b/be/src/exprs/function/function_hll.cpp
@@ -99,10 +99,10 @@ public:
                     check_and_get_column<ColumnNullable>(column.get())) {
             const ColumnHLL* col =
                     check_and_get_column<ColumnHLL>(col_nullable->get_nested_column_ptr().get());
-            const ColumnUInt8* col_nullmap = check_and_get_column<ColumnUInt8>(
-                    col_nullable->get_null_map_column_ptr().get());
+            const ColumnUInt8* col_nullmap =
+                    assert_cast<const ColumnUInt8*>(col_nullable->get_null_map_column_ptr().get());
 
-            if (col != nullptr && col_nullmap != nullptr) {
+            if (col != nullptr) {
                 Function::vector_nullable(col->get_data(), col_nullmap->get_data(), column_result);
                 block.replace_by_position(result, std::move(column_result));
                 return Status::OK();

--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -501,7 +501,7 @@ public:
         auto&& [jsonb_data_column, json_data_const] =
                 unpack_if_const(block.get_by_position(arguments[0]).column);
         if (jsonb_data_column->is_nullable()) {
-            const auto* nullable = check_and_get_column<ColumnNullable>(jsonb_data_column.get());
+            const auto* nullable = assert_cast<const ColumnNullable*>(jsonb_data_column.get());
             col_from_string =
                     assert_cast<const ColumnString*>(nullable->get_nested_column_ptr().get());
             data_null_map = &nullable->get_null_map_data();
@@ -519,8 +519,7 @@ public:
             std::tie(jsonb_path_column, path_const) =
                     unpack_if_const(block.get_by_position(arguments[1]).column);
             if (jsonb_path_column->is_nullable()) {
-                const auto* nullable =
-                        check_and_get_column<ColumnNullable>(jsonb_path_column.get());
+                const auto* nullable = assert_cast<const ColumnNullable*>(jsonb_path_column.get());
                 jsonb_path_column = nullable->get_nested_column_ptr();
                 path_null_map = &nullable->get_null_map_data();
             }

--- a/be/src/exprs/function/function_needs_to_handle_null.h
+++ b/be/src/exprs/function/function_needs_to_handle_null.h
@@ -136,7 +136,7 @@ private:
 
             if (is_column_nullable(*col_ptr)) {
                 has_nullable = true;
-                const auto* nullable = check_and_get_column<ColumnNullable>(col_ptr.get());
+                const auto* nullable = assert_cast<const ColumnNullable*>(col_ptr.get());
                 columns_info[i].nested_col = &nullable->get_nested_column();
                 columns_info[i].null_map = &nullable->get_null_map_data();
             } else {

--- a/be/src/exprs/function/function_quantile_state.cpp
+++ b/be/src/exprs/function/function_quantile_state.cpp
@@ -85,26 +85,19 @@ public:
     template <bool is_nullable>
     Status execute_internal(const ColumnPtr& column, const DataTypePtr& data_type,
                             MutableColumnPtr& column_result, float compression) const {
-        auto type_error = [&]() {
-            return Status::RuntimeError("Illegal column {} of argument of function {}",
-                                        column->get_name(), get_name());
-        };
         const ColumnNullable* col_nullable = nullptr;
         const ColumnUInt8* col_nullmap = nullptr;
         const ColumnFloat64* col = nullptr;
         const NullMap* nullmap = nullptr;
         if constexpr (is_nullable) {
-            col_nullable = check_and_get_column<ColumnNullable>(column.get());
-            col_nullmap = check_and_get_column<ColumnUInt8>(
-                    col_nullable->get_null_map_column_ptr().get());
-            col = check_and_get_column<ColumnFloat64>(col_nullable->get_nested_column_ptr().get());
-            if (col == nullptr || col_nullmap == nullptr) {
-                return type_error();
-            }
+            col_nullable = assert_cast<const ColumnNullable*>(column.get());
+            col_nullmap =
+                    assert_cast<const ColumnUInt8*>(col_nullable->get_null_map_column_ptr().get());
+            col = assert_cast<const ColumnFloat64*>(col_nullable->get_nested_column_ptr().get());
 
             nullmap = &col_nullmap->get_data();
         } else {
-            col = check_and_get_column<ColumnFloat64>(column.get());
+            col = assert_cast<const ColumnFloat64*>(column.get());
         }
         auto* res_column = reinterpret_cast<ColumnQuantileState*>(column_result.get());
         auto& res_data = res_column->get_data();

--- a/be/src/exprs/function/function_variant_element.cpp
+++ b/be/src/exprs/function/function_variant_element.cpp
@@ -274,7 +274,7 @@ private:
             auto type = std::make_shared<DataTypeString>();
             MutableColumnPtr result_column = type->create_column();
             const ColumnString& docs =
-                    *check_and_get_column<ColumnString>(remove_nullable(src.get_root()).get());
+                    *assert_cast<const ColumnString*>(remove_nullable(src.get_root()).get());
             simdjson::ondemand::parser parser;
             std::vector<JsonPath> parsed_paths;
             if (field_name.empty() || field_name[0] != '$') {

--- a/be/src/exprs/function/functions_multi_string_position.cpp
+++ b/be/src/exprs/function/functions_multi_string_position.cpp
@@ -141,7 +141,7 @@ public:
         }
 
         if (haystack_nullable) {
-            auto column_nullable = check_and_get_column<ColumnNullable>(haystack_column.get());
+            const auto* column_nullable = assert_cast<const ColumnNullable*>(haystack_column.get());
             auto& null_map = column_nullable->get_null_map_data();
             for (size_t i = 0; i != input_rows_count; ++i) {
                 if (null_map[i] == 1) {
@@ -153,7 +153,7 @@ public:
         }
 
         if (needles_nullable) {
-            auto column_nullable = check_and_get_column<ColumnNullable>(needles_column.get());
+            const auto* column_nullable = assert_cast<const ColumnNullable*>(needles_column.get());
             auto& null_map = column_nullable->get_null_map_data();
             for (size_t i = 0; i != input_rows_count; ++i) {
                 if (null_map[i] == 1) {
@@ -247,9 +247,8 @@ public:
         offsets_res.reserve(haystack_data.size());
         uint64_t offset_now = 0;
 
-        auto& nested_column =
-                check_and_get_column<ColumnNullable>(needles_data)->get_nested_column();
-        const ColumnString* needles_data_string = check_and_get_column<ColumnString>(nested_column);
+        auto& nested_column = assert_cast<const ColumnNullable&>(needles_data).get_nested_column();
+        const ColumnString* needles_data_string = assert_cast<const ColumnString*>(&nested_column);
 
         std::vector<StringRef> needles_for_row;
         // haystack first, row by row.

--- a/be/src/exprs/function/functions_multi_string_search.cpp
+++ b/be/src/exprs/function/functions_multi_string_search.cpp
@@ -291,7 +291,7 @@ struct FunctionMultiMatchAnyImpl {
         size_t prev_needles_offset = 0;
 
         const auto& nested_column =
-                check_and_get_column<ColumnNullable>(needles_data)->get_nested_column();
+                assert_cast<const ColumnNullable&>(needles_data).get_nested_column();
         const auto* needles_data_string = check_and_get_column<ColumnString>(nested_column);
 
         if (!needles_data_string) {

--- a/be/src/exprs/function/in.h
+++ b/be/src/exprs/function/in.h
@@ -215,7 +215,7 @@ public:
         if (in_state->use_set) {
             if (materialized_column->is_nullable()) {
                 const auto* null_col_ptr =
-                        check_and_get_column<ColumnNullable>(materialized_column.get());
+                        assert_cast<const ColumnNullable*>(materialized_column.get());
                 const auto& null_map = null_col_ptr->get_null_map_column().get_data();
                 const auto* nested_col_ptr = null_col_ptr->get_nested_column_ptr().get();
 

--- a/be/src/exprs/function/round.h
+++ b/be/src/exprs/function/round.h
@@ -460,7 +460,7 @@ struct Dispatcher {
                                      [[maybe_unused]] Int16 result_scale) {
         if constexpr (is_int_or_bool(T) || is_ip(T) || is_date_type(T) || is_float_or_double(T) ||
                       T == TYPE_TIMEV2 || T == TYPE_UINT32 || T == TYPE_UINT64) {
-            const auto* const col = check_and_get_column<ColumnVector<T>>(col_general);
+            const auto* const col = assert_cast<const ColumnVector<T>*>(col_general);
             auto col_res = ColumnVector<T>::create();
 
             typename ColumnVector<T>::Container& vec_res = col_res->get_data();
@@ -484,7 +484,7 @@ struct Dispatcher {
             return col_res;
         } else if constexpr (T == TYPE_DECIMALV2) {
             const auto* const decimal_col =
-                    check_and_get_column<typename PrimitiveTypeTraits<T>::ColumnType>(col_general);
+                    assert_cast<const typename PrimitiveTypeTraits<T>::ColumnType*>(col_general);
             const auto& vec_src = decimal_col->get_data();
             const size_t input_rows_count = vec_src.size();
             auto col_res = PrimitiveTypeTraits<T>::ColumnType::create(vec_src.size(), result_scale);
@@ -520,7 +520,7 @@ struct Dispatcher {
             return col_res;
         } else if constexpr (is_decimal(T)) {
             const auto* const decimal_col =
-                    check_and_get_column<typename PrimitiveTypeTraits<T>::ColumnType>(col_general);
+                    assert_cast<const typename PrimitiveTypeTraits<T>::ColumnType*>(col_general);
             const auto& vec_src = decimal_col->get_data();
             const size_t input_rows_count = vec_src.size();
             auto col_res = PrimitiveTypeTraits<T>::ColumnType::create(vec_src.size(), result_scale);

--- a/be/src/storage/predicate/comparison_predicate.h
+++ b/be/src/storage/predicate/comparison_predicate.h
@@ -393,14 +393,13 @@ public:
         });
 
         if (column.is_nullable()) {
-            const auto* nullable_column_ptr = check_and_get_column<ColumnNullable>(column);
+            const auto* nullable_column_ptr = assert_cast<const ColumnNullable*>(&column);
             const auto& nested_column = nullable_column_ptr->get_nested_column();
             const auto& null_map = nullable_column_ptr->get_null_map_column().get_data();
 
             if (nested_column.is_column_dictionary()) {
                 if constexpr (is_string_type(Type)) {
-                    const auto* dict_column_ptr =
-                            check_and_get_column<ColumnDictI32>(nested_column);
+                    const auto* dict_column_ptr = assert_cast<const ColumnDictI32*>(&nested_column);
 
                     auto dict_code = _find_code_from_dictionary_column(*dict_column_ptr);
                     do {
@@ -420,18 +419,18 @@ public:
                     __builtin_unreachable();
                 }
             } else {
-                auto* data_array = check_and_get_column<
-                                           const PredicateColumnType<PredicateEvaluateType<Type>>>(
-                                           nested_column)
-                                           ->get_data()
-                                           .data();
+                auto* data_array =
+                        assert_cast<const PredicateColumnType<PredicateEvaluateType<Type>>*>(
+                                &nested_column)
+                                ->get_data()
+                                .data();
 
                 _base_loop_vec<true, is_and>(size, flags, null_map.data(), data_array, _value);
             }
         } else {
             if (column.is_column_dictionary()) {
                 if constexpr (is_string_type(Type)) {
-                    const auto* dict_column_ptr = check_and_get_column<ColumnDictI32>(column);
+                    const auto* dict_column_ptr = assert_cast<const ColumnDictI32*>(&column);
                     auto dict_code = _find_code_from_dictionary_column(*dict_column_ptr);
                     do {
                         if constexpr (PT == PredicateType::EQ) {
@@ -450,8 +449,8 @@ public:
                 }
             } else {
                 auto* data_array =
-                        check_and_get_column<PredicateColumnType<PredicateEvaluateType<Type>>>(
-                                column)
+                        assert_cast<const PredicateColumnType<PredicateEvaluateType<Type>>*>(
+                                &column)
                                 ->get_data()
                                 .data();
 
@@ -487,7 +486,7 @@ public:
 private:
     uint16_t _evaluate_inner(const IColumn& column, uint16_t* sel, uint16_t size) const override {
         if (column.is_nullable()) {
-            const auto* nullable_column_ptr = check_and_get_column<ColumnNullable>(column);
+            const auto* nullable_column_ptr = assert_cast<const ColumnNullable*>(&column);
             const auto& nested_column = nullable_column_ptr->get_nested_column();
             const auto& null_map = nullable_column_ptr->get_null_map_column().get_data();
 
@@ -540,7 +539,7 @@ private:
     void _evaluate_bit(const IColumn& column, const uint16_t* sel, uint16_t size,
                        bool* flags) const {
         if (column.is_nullable()) {
-            const auto* nullable_column_ptr = check_and_get_column<ColumnNullable>(column);
+            const auto* nullable_column_ptr = assert_cast<const ColumnNullable*>(&column);
             const auto& nested_column = nullable_column_ptr->get_nested_column();
             const auto& null_map = nullable_column_ptr->get_null_map_column().get_data();
 
@@ -601,7 +600,7 @@ private:
                             uint16_t size, bool* flags) const {
         if (column->is_column_dictionary()) {
             if constexpr (is_string_type(Type)) {
-                const auto* dict_column_ptr = check_and_get_column<ColumnDictI32>(column);
+                const auto* dict_column_ptr = assert_cast<const ColumnDictI32*>(column);
                 const auto* data_array = dict_column_ptr->get_data().data();
                 auto dict_code = _find_code_from_dictionary_column(*dict_column_ptr);
                 _base_loop_bit<is_nullable, is_and>(sel, size, flags, null_map, data_array,
@@ -612,7 +611,7 @@ private:
             }
         } else {
             auto* data_array =
-                    check_and_get_column<PredicateColumnType<PredicateEvaluateType<Type>>>(column)
+                    assert_cast<const PredicateColumnType<PredicateEvaluateType<Type>>*>(column)
                             ->get_data()
                             .data();
 
@@ -625,7 +624,7 @@ private:
                             uint16_t size) const {
         if (column->is_column_dictionary()) {
             if constexpr (is_string_type(Type)) {
-                const auto* dict_column_ptr = check_and_get_column<ColumnDictI32>(column);
+                const auto* dict_column_ptr = assert_cast<const ColumnDictI32*>(column);
                 const auto& pred_col = dict_column_ptr->get_data();
                 const auto* pred_col_data = pred_col.data();
                 auto dict_code = _find_code_from_dictionary_column(*dict_column_ptr);
@@ -650,7 +649,7 @@ private:
             }
         } else {
             auto& pred_col =
-                    check_and_get_column<PredicateColumnType<PredicateEvaluateType<Type>>>(column)
+                    assert_cast<const PredicateColumnType<PredicateEvaluateType<Type>>*>(column)
                             ->get_data();
             auto pred_col_data = pred_col.data();
             uint16_t new_size = 0;

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -208,7 +208,7 @@ public:
     void _evaluate_bit(const IColumn& column, const uint16_t* sel, uint16_t size,
                        bool* flags) const {
         if (column.is_nullable()) {
-            const auto* nullable_col = check_and_get_column<ColumnNullable>(column);
+            const auto* nullable_col = assert_cast<const ColumnNullable*>(&column);
             const auto& null_bitmap = nullable_col->get_null_map_column().get_data();
             const auto& nested_col = nullable_col->get_nested_column();
 
@@ -461,7 +461,7 @@ private:
         int16_t new_size = 0;
 
         if (column.is_nullable()) {
-            const auto* nullable_col = check_and_get_column<ColumnNullable>(column);
+            const auto* nullable_col = assert_cast<const ColumnNullable*>(&column);
             const auto& null_map = nullable_col->get_null_map_column().get_data();
             const auto& nested_col = nullable_col->get_nested_column();
 
@@ -495,7 +495,7 @@ private:
 
         if (column->is_column_dictionary()) {
             if constexpr (is_string_type(Type)) {
-                const auto* nested_col_ptr = check_and_get_column<ColumnDictI32>(column);
+                const auto* nested_col_ptr = assert_cast<const ColumnDictI32*>(column);
                 const auto& data_array = nested_col_ptr->get_data();
                 auto segid = column->get_rowset_segment_id();
                 DCHECK((segid.first.hi | segid.first.mi | segid.first.lo) != 0);
@@ -537,7 +537,7 @@ private:
             }
         } else {
             auto& pred_col =
-                    check_and_get_column<PredicateColumnType<PredicateEvaluateType<Type>>>(column)
+                    assert_cast<const PredicateColumnType<PredicateEvaluateType<Type>>*>(column)
                             ->get_data();
             auto pred_col_data = pred_col.data();
 
@@ -559,7 +559,7 @@ private:
                             const uint16_t* sel, uint16_t size, bool* flags) const {
         if (column->is_column_dictionary()) {
             if constexpr (is_string_type(Type)) {
-                const auto* nested_col_ptr = check_and_get_column<ColumnDictI32>(column);
+                const auto* nested_col_ptr = assert_cast<const ColumnDictI32*>(column);
                 const auto& data_array = nested_col_ptr->get_data();
                 auto& value_in_dict_flags =
                         _segment_id_to_value_in_dict_flags[column->get_rowset_segment_id()];

--- a/be/src/storage/predicate/like_column_predicate.cpp
+++ b/be/src/storage/predicate/like_column_predicate.cpp
@@ -53,11 +53,11 @@ uint16_t LikeColumnPredicate<T>::_evaluate_inner(const IColumn& column, uint16_t
                                                  uint16_t size) const {
     uint16_t new_size = 0;
     if (column.is_nullable()) {
-        auto* nullable_col = check_and_get_column<ColumnNullable>(column);
+        auto* nullable_col = assert_cast<const ColumnNullable*>(&column);
         auto& null_map_data = nullable_col->get_null_map_column().get_data();
         auto& nested_col = nullable_col->get_nested_column();
         if (nested_col.is_column_dictionary()) {
-            auto* nested_col_ptr = check_and_get_column<ColumnDictI32>(nested_col);
+            auto* nested_col_ptr = assert_cast<const ColumnDictI32*>(&nested_col);
             auto& data_array = nested_col_ptr->get_data();
             const auto& dict_res = _find_code_from_dictionary_column(*nested_col_ptr);
             if (!nullable_col->has_null()) {
@@ -80,7 +80,7 @@ uint16_t LikeColumnPredicate<T>::_evaluate_inner(const IColumn& column, uint16_t
                 }
             }
         } else {
-            auto* str_col = check_and_get_column<PredicateColumnType<T>>(nested_col);
+            auto* str_col = assert_cast<const PredicateColumnType<T>*>(&nested_col);
             if (!nullable_col->has_null()) {
                 ColumnUInt8::Container res(size, 0);
                 for (uint16_t i = 0; i != size; i++) {
@@ -111,7 +111,7 @@ uint16_t LikeColumnPredicate<T>::_evaluate_inner(const IColumn& column, uint16_t
         }
     } else {
         if (column.is_column_dictionary()) {
-            auto* nested_col_ptr = check_and_get_column<ColumnDictI32>(column);
+            auto* nested_col_ptr = assert_cast<const ColumnDictI32*>(&column);
             const auto& dict_res = _find_code_from_dictionary_column(*nested_col_ptr);
             auto& data_array = nested_col_ptr->get_data();
             for (uint16_t i = 0; i != size; i++) {
@@ -121,8 +121,7 @@ uint16_t LikeColumnPredicate<T>::_evaluate_inner(const IColumn& column, uint16_t
                 new_size += _opposite ^ flag;
             }
         } else {
-            const PredicateColumnType<T>* str_col =
-                    check_and_get_column<PredicateColumnType<T>>(column);
+            const auto* str_col = assert_cast<const PredicateColumnType<T>*>(&column);
 
             ColumnUInt8::Container res(size, 0);
             for (uint16_t i = 0; i != size; i++) {

--- a/be/src/storage/predicate/like_column_predicate.h
+++ b/be/src/storage/predicate/like_column_predicate.h
@@ -97,11 +97,11 @@ private:
     template <bool is_and>
     void _evaluate_vec(const IColumn& column, uint16_t size, bool* flags) const {
         if (column.is_nullable()) {
-            auto* nullable_col = check_and_get_column<ColumnNullable>(column);
+            auto* nullable_col = assert_cast<const ColumnNullable*>(&column);
             auto& null_map_data = nullable_col->get_null_map_column().get_data();
             auto& nested_col = nullable_col->get_nested_column();
             if (nested_col.is_column_dictionary()) {
-                auto* nested_col_ptr = check_and_get_column<ColumnDictI32>(nested_col);
+                auto* nested_col_ptr = assert_cast<const ColumnDictI32*>(&nested_col);
                 const auto& dict_res = _find_code_from_dictionary_column(*nested_col_ptr);
                 auto& data_array = nested_col_ptr->get_data();
                 for (uint16_t i = 0; i < size; i++) {
@@ -127,7 +127,7 @@ private:
             }
         } else {
             if (column.is_column_dictionary()) {
-                auto* nested_col_ptr = check_and_get_column<ColumnDictI32>(column);
+                auto* nested_col_ptr = assert_cast<const ColumnDictI32*>(&column);
                 auto& data_array = nested_col_ptr->get_data();
                 const auto& dict_res = _find_code_from_dictionary_column(*nested_col_ptr);
                 for (uint16_t i = 0; i < size; i++) {

--- a/be/src/storage/schema_change/schema_change.cpp
+++ b/be/src/storage/schema_change/schema_change.cpp
@@ -435,8 +435,8 @@ Status BlockChanger::_check_cast_valid(ColumnPtr input_column, ColumnPtr output_
 
     if (input_column->is_nullable() != output_column->is_nullable()) {
         if (input_column->is_nullable()) {
-            const auto* ref_null_map = check_and_get_column<ColumnNullable>(input_column.get())
-                                               ->get_null_map_column()
+            const auto* ref_null_map = assert_cast<const ColumnNullable&>(*input_column)
+                                               .get_null_map_column()
                                                .get_data()
                                                .data();
 
@@ -450,10 +450,9 @@ Status BlockChanger::_check_cast_valid(ColumnPtr input_column, ColumnPtr output_
                         input_column->get_name());
             }
         } else {
-            const auto& null_map_column = check_and_get_column<ColumnNullable>(output_column.get())
-                                                  ->get_null_map_column();
-            const auto& nested_column =
-                    check_and_get_column<ColumnNullable>(output_column.get())->get_nested_column();
+            const auto& output_nullable = assert_cast<const ColumnNullable&>(*output_column);
+            const auto& null_map_column = output_nullable.get_null_map_column();
+            const auto& nested_column = output_nullable.get_nested_column();
             const auto* new_null_map = null_map_column.get_data().data();
 
             if (null_map_column.size() != output_column->size()) {
@@ -483,12 +482,12 @@ Status BlockChanger::_check_cast_valid(ColumnPtr input_column, ColumnPtr output_
     }
 
     if (input_column->is_nullable() && output_column->is_nullable()) {
-        const auto* ref_null_map = check_and_get_column<ColumnNullable>(input_column.get())
-                                           ->get_null_map_column()
+        const auto* ref_null_map = assert_cast<const ColumnNullable&>(*input_column)
+                                           .get_null_map_column()
                                            .get_data()
                                            .data();
-        const auto* new_null_map = check_and_get_column<ColumnNullable>(output_column.get())
-                                           ->get_null_map_column()
+        const auto* new_null_map = assert_cast<const ColumnNullable&>(*output_column)
+                                           .get_null_map_column()
                                            .get_data()
                                            .data();
 

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -1078,9 +1078,9 @@ Status MapFileColumnIterator::read_by_rowids(const rowid_t* rowids, const size_t
         return Status::OK();
     }
     // resolve ColumnMap and nullable wrapper
-    const auto* column_map = check_and_get_column<ColumnMap>(
+    const auto& column_map = assert_cast<const ColumnMap&>(
             dst->is_nullable() ? static_cast<ColumnNullable&>(*dst).get_nested_column() : *dst);
-    auto offsets_ptr = column_map->get_offsets_column().assume_mutable();
+    auto offsets_ptr = column_map.get_offsets_column().assume_mutable();
     auto& offsets = static_cast<ColumnArray::ColumnOffsets&>(*offsets_ptr);
     size_t base = offsets.get_data().empty() ? 0 : offsets.get_data().back();
 
@@ -1164,8 +1164,8 @@ Status MapFileColumnIterator::read_by_rowids(const rowid_t* rowids, const size_t
     }
 
     // 6. read key/value elements for non-empty sizes
-    auto keys_ptr = column_map->get_keys().assume_mutable();
-    auto vals_ptr = column_map->get_values().assume_mutable();
+    auto keys_ptr = column_map.get_keys().assume_mutable();
+    auto vals_ptr = column_map.get_values().assume_mutable();
 
     size_t this_run = sizes[0];
     auto start_idx = starts_data[0];
@@ -1770,11 +1770,11 @@ Status ArrayFileColumnIterator::next_batch(size_t* n, MutableColumnPtr& dst, boo
         return Status::OK();
     }
 
-    const auto* column_array = check_and_get_column<ColumnArray>(
+    const auto& column_array = assert_cast<const ColumnArray&>(
             dst->is_nullable() ? static_cast<ColumnNullable&>(*dst).get_nested_column() : *dst);
 
     bool offsets_has_null = false;
-    auto column_offsets_ptr = column_array->get_offsets_column().assume_mutable();
+    auto column_offsets_ptr = column_array.get_offsets_column().assume_mutable();
     ssize_t start = column_offsets_ptr->size();
     RETURN_IF_ERROR(_offset_iterator->next_batch(n, column_offsets_ptr, &offsets_has_null));
     if (*n == 0) {
@@ -1784,7 +1784,7 @@ Status ArrayFileColumnIterator::next_batch(size_t* n, MutableColumnPtr& dst, boo
     RETURN_IF_ERROR(_offset_iterator->_calculate_offsets(start, column_offsets));
     size_t num_items =
             column_offsets.get_data().back() - column_offsets.get_data()[start - 1]; // -1 is valid
-    auto column_items_ptr = column_array->get_data().assume_mutable();
+    auto column_items_ptr = column_array.get_data().assume_mutable();
     if (num_items > 0) {
         if (read_offset_only()) {
             // OFFSET_ONLY mode: skip reading actual item data, fill with defaults

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -2884,11 +2884,8 @@ void SegmentIterator::_fill_column_nothing() {
     for (const auto pair : _vir_cid_to_idx_in_block) {
         auto cid = pair.first;
         auto pos = pair.second;
-        const auto* nothing_col =
-                check_and_get_column<ColumnNothing>(_current_return_columns[cid].get());
-        DCHECK(nothing_col != nullptr)
-                << fmt::format("ColumnNothing expected, but got {}, cid: {}, pos: {}",
-                               _current_return_columns[cid]->get_name(), cid, pos);
+        [[maybe_unused]] const auto* nothing_col =
+                assert_cast<const ColumnNothing*>(_current_return_columns[cid].get());
         _current_return_columns[cid] = _opts.vir_col_idx_to_type[pos]->create_column();
     }
 }

--- a/be/src/storage/segment/variant/hierarchical_data_iterator.cpp
+++ b/be/src/storage/segment/variant/hierarchical_data_iterator.cpp
@@ -222,7 +222,7 @@ Status HierarchicalDataIterator::_process_nested_columns(
     // will type the type of ColumnVariant::NESTED_TYPE, whih is Nullable<ColumnArray<NULLABLE(ColumnVariant)>>.
     for (const auto& entry : nested_subcolumns) {
         const auto* base_array =
-                check_and_get_column<ColumnArray>(*remove_nullable(entry.second[0].column));
+                assert_cast<const ColumnArray*>(remove_nullable(entry.second[0].column).get());
         MutableColumnPtr nested_object =
                 ColumnVariant::create(0, false, base_array->get_data().size());
         MutableColumnPtr offset = base_array->get_offsets_ptr()->assume_mutable();
@@ -237,7 +237,7 @@ Status HierarchicalDataIterator::_process_nested_columns(
                         subcolumn.path.get_path(), subcolumn.type->get_name());
             }
             const auto* target_array =
-                    check_and_get_column<ColumnArray>(remove_nullable(subcolumn.column).get());
+                    assert_cast<const ColumnArray*>(remove_nullable(subcolumn.column).get());
 #ifndef NDEBUG
             if (!base_array->has_equal_offsets(*target_array)) {
                 return Status::InvalidArgument(

--- a/be/test/core/column/column_array_test.cpp
+++ b/be/test/core/column/column_array_test.cpp
@@ -776,7 +776,7 @@ TEST_F(ColumnArrayTest, MaxArraySizeAsFieldTest) {
             cloned->insert(Field::create_field<TYPE_ARRAY>(af));
             // get cloned offset size
             auto cloned_offset_size =
-                    check_and_get_column<ColumnArray>(cloned.get())->get_offsets().back();
+                    assert_cast<const ColumnArray*>(cloned.get())->get_offsets().back();
             EXPECT_EQ(cloned_offset_size, start_size + max_array_size_as_field)
                     << "cloned offset size is not equal to start size + max_array_size_as_field";
 

--- a/be/test/core/value/merge_partitioner_test.cpp
+++ b/be/test/core/value/merge_partitioner_test.cpp
@@ -148,9 +148,9 @@ protected:
     const ColumnInt8& _get_op_column(const Block& block) const {
         const auto& column = block.get_by_position(0).column;
         if (auto* nullable_col = check_and_get_column<ColumnNullable>(column.get())) {
-            return *check_and_get_column<ColumnInt8>(nullable_col->get_nested_column_ptr().get());
+            return *assert_cast<const ColumnInt8*>(nullable_col->get_nested_column_ptr().get());
         }
-        return *check_and_get_column<ColumnInt8>(column.get());
+        return *assert_cast<const ColumnInt8*>(column.get());
     }
 
     void _build_descriptors() {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`check_and_get_column` returns nullptr when the column type doesn't match, but many call sites either:
- used the result without null-checking, risking silent null dereference, or
- wrapped it in an `if (ptr)` / `else { throw FatalError }` pattern, which is exactly what `assert_cast` does — but with a clearer error message.

Root cause: these call sites always expect a specific column type. The type invariant is guaranteed by upstream logic, so a null-return path is dead code that obscures the real contract.

Fix: replace `check_and_get_column<T>(column)` with `assert_cast<const T*>(&column)`, which asserts the type match immediately. Also removed the dead else-throw branches that became unreachable.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

