### PR TITLE
fix: block type reset after dict filter

### DIFF
--- a/be/src/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/format/parquet/vparquet_group_reader.cpp
@@ -751,7 +751,7 @@ Status RowGroupReader::_do_lazy_read(Block* block, size_t batch_size, size_t* re
         DCHECK_EQ(pre_read_rows + _cached_filtered_rows, 0);
         *read_rows = 0;
         *batch_eof = true;
-        _convert_dict_cols_to_string_cols(block);
+        RETURN_IF_ERROR(_convert_dict_cols_to_string_cols(block));
         return Status::OK();
     }
 

--- a/be/src/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/format/parquet/vparquet_group_reader.cpp
@@ -751,6 +751,7 @@ Status RowGroupReader::_do_lazy_read(Block* block, size_t batch_size, size_t* re
         DCHECK_EQ(pre_read_rows + _cached_filtered_rows, 0);
         *read_rows = 0;
         *batch_eof = true;
+        _convert_dict_cols_to_string_cols(block);
         return Status::OK();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

修复读取parquet时，当上一个row group有dict filter时未将block的类型从Int32重置为String，导致报如下错误：
Read parquet file xxxxx.parquet failed, reason = [INTERNAL_ERROR]comparison must input two same type column or column type is decimalv3/numeric, lhs=Int32, rhs=String

在有些情况下会触发如下代码导致be core：
```cpp
LOG(FATAL) << fmt::format("Bad cast from type:{} to {}", demangle(typeid(from).name()),
                                  demangle(typeid(To).name()));
```
