### PR TITLE
[fix](txn) make TransactionState.publishVersionTasks thread-safe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -236,7 +237,12 @@ public class TransactionState implements Writable {
     private CountDownLatch visibleLatch;
 
     // this state need not be serialized. the map key is backend_id
-    private Map<Long, List<PublishVersionTask>> publishVersionTasks;
+    // NOTE: must be a thread-safe map. When parallel publish version is enabled
+    // (Config.enable_parallel_publish_version), the master PUBLISH_VERSION daemon iterates this map
+    // in tryFinishOneTxn, while the PUBLISH_VERSION_EXEC worker (single-threaded per dbId, routed by
+    // dbId % publish_thread_pool_num) may concurrently iterate it in tryFinishTxnSync and then clear
+    // it via pruneAfterVisible after the txn becomes VISIBLE
+    private Map<Long, List<PublishVersionTask>> publishVersionTasks = new ConcurrentHashMap<>();
     private boolean hasSendTask;
     private TransactionStatus preStatus = null;
 
@@ -352,7 +358,6 @@ public class TransactionState implements Writable {
         this.finishTime = -1;
         this.reason = "";
         this.errorReplicas = Sets.newHashSet();
-        this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.visibleLatch = new CountDownLatch(1);
         this.commitTSO = -1;
@@ -375,7 +380,6 @@ public class TransactionState implements Writable {
         this.finishTime = -1;
         this.reason = "";
         this.errorReplicas = Sets.newHashSet();
-        this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
         this.visibleLatch = new CountDownLatch(1);
         this.callbackId = callbackId;


### PR DESCRIPTION
With parallel publish version (enable_parallel_publish_version=true) the per-transaction publishVersionTasks map is touched by both the master daemon thread (addPublishVersionTask, iterate in tryFinishOneTxn) and the PUBLISH_VERSION_EXEC worker threads (iterate in tryFinishTxnSync, clear in pruneAfterVisible). The plain HashMap raises ConcurrentModificationException; the affected publish silently fails and the txn stays in COMMITTED state. Backlog grows each round and eventually trips max_publishing_txn_num_per_table (default 500), blocking stream load on hot tables.

Switch the map to ConcurrentHashMap. The inner List does not need to be thread-safe: addPublishVersionTask runs at most once per txn during the initial dispatch (guarded by hasSendTask) and worker threads only iterate the list later, so there is no read-during-write on the list.

### What problem does this PR solve?

Issue Number: close #63169

Related PR: N/A

Problem Summary:

When parallel publish version is enabled (`Config.enable_parallel_publish_version`, default `true` since 4.0), the per-transaction `publishVersionTasks` map is touched concurrently by:

- the master `PUBLISH_VERSION` daemon, which iterates the map in `tryFinishOneTxn`; and
- the `PUBLISH_VERSION_EXEC` worker for that txn's db -- routed by `dbId % publish_thread_pool_num` to a single-thread pool, which iterates the map in `tryFinishTxnSync` and clears it via `pruneAfterVisible` after the txn becomes `VISIBLE`.

The plain `HashMap` throws `ConcurrentModificationException`. The CME is caught at the outer layer so FE does not crash, but that publish round aborts and the txn stays in `COMMITTED`. Backlog grows each daemon round and eventually blocks new stream load via `max_running_txn_num_per_db` (default 10000) or `max_publishing_txn_num_per_table` (default 500),
whichever trips first.

Sample stack trace from a production FE:

java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
    at java.util.HashMap$EntryIterator.next(HashMap.java:1630)
    at org.apache.doris.transaction.PublishVersionDaemon.tryFinishOneTxn(PublishVersionDaemon.java:191)

Fix: switch `publishVersionTasks` to `ConcurrentHashMap`. The inner `List<PublishVersionTask>` does not need to be thread-safe -- `addPublishVersionTask` is invoked by the master daemon only during the initial dispatch in `traverseReadyTxnAndDispatchPublishVersionTask` (guarded by `hasSendTask`) and runs strictly before any worker iteration, so there is no
read-during-write on the list.

Release note:

Fix ConcurrentModificationException on `TransactionState.publishVersionTasks` under parallel publish version, which could stall publish and eventually block stream load on hot dbs/tables.

### Check List (For Author)

- Test <!-- At least one of them must be selected -->
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.

  Manual test steps:

  1. Start a cluster with `enable_parallel_publish_version = true` (default in 4.0).
  2. Sustain concurrent stream load across many dbs/tables so that multiple txns enter `tryFinishOneTxn` in the same daemon round while previous-round workers are still running `pruneAfterVisible`.
  3. Before the fix: `fe.warn.log` eventually shows `ConcurrentModificationException` with the stack `java.util.HashMap$HashIterator.nextNode` -> `PublishVersionDaemon.tryFinishOneTxn` (the iteration aborts for that round; the txn is normally re-published in a later round).
  4. After the fix: under the same workload the CME no longer appears in `fe.warn.log`.

- Behavior changed:
    - [x] No.
- Does this need documentation?
    - [x] No.