### PR TITLE
[fix](fe) Avoid reusing dropped column unique ids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -3678,6 +3678,16 @@ public class SchemaChangeHandler extends AlterHandler {
         for (int i = 0; i < indexIds.size(); i++) {
             List<Column> indexSchema = indexSchemaMap.get(indexIds.get(i));
             MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(indexIds.get(i));
+
+            // Keep historical column unique ids from the old schema when dropping columns. Some legacy metadata may
+            // have a stale maxColUniqueId, and lowering it can make a later re-added same-name column reuse the
+            // dropped column's unique id and read old segment data.
+            int maxColUniqueId = currentIndexMeta.getMaxColUniqueId();
+            for (Column column : currentIndexMeta.getSchema()) {
+                if (column.getUniqueId() > maxColUniqueId) {
+                    maxColUniqueId = column.getUniqueId();
+                }
+            }
             currentIndexMeta.setSchema(indexSchema);
 
             int currentSchemaVersion = currentIndexMeta.getSchemaVersion();
@@ -3685,7 +3695,6 @@ public class SchemaChangeHandler extends AlterHandler {
             currentIndexMeta.setSchemaVersion(newSchemaVersion);
 
             //update max column unique id
-            int maxColUniqueId = currentIndexMeta.getMaxColUniqueId();
             for (Column column : indexSchema) {
                 if (column.getUniqueId() > maxColUniqueId) {
                     maxColUniqueId = column.getUniqueId();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -279,6 +279,7 @@ public class MaterializedIndexMeta implements GsonPostProcessable {
         if (sessionVariables == null) {
             sessionVariables = Maps.newHashMap();
         }
+        refreshMaxColUniqueId();
         initColumnNameMap();
     }
 
@@ -349,7 +350,7 @@ public class MaterializedIndexMeta implements GsonPostProcessable {
     }
 
     public int getMaxColUniqueId() {
-        return this.maxColUniqueId;
+        return Math.max(maxColUniqueId, getSchemaMaxColUniqueId());
     }
 
     public void setMaxColUniqueId(int maxColUniqueId) {
@@ -365,6 +366,20 @@ public class MaterializedIndexMeta implements GsonPostProcessable {
                         indexId, column, column.getUniqueId());
             }
         });
+    }
+
+    private void refreshMaxColUniqueId() {
+        maxColUniqueId = getMaxColUniqueId();
+    }
+
+    private int getSchemaMaxColUniqueId() {
+        int schemaMaxColUniqueId = Column.COLUMN_UNIQUE_ID_INIT_VALUE;
+        for (Column column : schema) {
+            if (column.getUniqueId() > schemaMaxColUniqueId) {
+                schemaMaxColUniqueId = column.getUniqueId();
+            }
+        }
+        return schemaMaxColUniqueId;
     }
 
     public void initColumnNameMap() {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -849,6 +849,44 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     }
 
     @Test
+    public void testReaddDroppedValueColumnUsesNewUniqueId() throws Exception {
+        String tableName = "sc_dup_readd_value_column";
+        dropTable("test." + tableName, false);
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "event_time DATETIME NOT NULL,\n"
+                + "user_id BIGINT NOT NULL,\n"
+                + "item_id INT NOT NULL,\n"
+                + "amount DECIMAL(10, 2) NOT NULL,\n"
+                + "city VARCHAR(64) NOT NULL\n"
+                + ") DUPLICATE KEY(event_time, user_id)\n"
+                + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true')");
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("test");
+        OlapTable tbl = (OlapTable) db.getTableOrMetaException(tableName, Table.TableType.OLAP);
+        MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+        int oldCityUniqueId = tbl.getColumn("city").getUniqueId();
+
+        tbl.writeLock();
+        try {
+            // Simulate legacy metadata whose maxColUniqueId was not initialized.
+            indexMeta.setMaxColUniqueId(Column.COLUMN_UNIQUE_ID_INIT_VALUE);
+        } finally {
+            tbl.writeUnlock();
+        }
+
+        alterTable("ALTER TABLE test." + tableName + " DROP COLUMN city", connectContext);
+        jobSize++;
+        waitAlterJobDone(Env.getCurrentEnv().getSchemaChangeHandler().getAlterJobsV2());
+        Assertions.assertTrue(indexMeta.getMaxColUniqueId() >= oldCityUniqueId);
+
+        alterTable("ALTER TABLE test." + tableName + " ADD COLUMN city VARCHAR(64)", connectContext);
+        jobSize++;
+        waitAlterJobDone(Env.getCurrentEnv().getSchemaChangeHandler().getAlterJobsV2());
+        Assertions.assertTrue(tbl.getColumn("city").getUniqueId() > oldCityUniqueId);
+    }
+
+    @Test
     public void testAddValueColumnOnAggMV() {
         OlapTable olapTable = Mockito.mock(OlapTable.class);
         Column newColumn = Mockito.mock(Column.class);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Re-adding a dropped value column with the same name can reuse the dropped column's unique id when legacy metadata has a stale `maxColUniqueId`, causing old segment data to be read as the new column.

### Release note

Fix re-added same-name columns reading stale data after light schema change with stale column unique id metadata.

### Check List (For Author)

- Test: Unit Test
    - Added `SchemaChangeHandlerTest` coverage for re-adding a dropped value column with stale `maxColUniqueId`.
    - Ran: `cd fe && mvn checkstyle:check -pl fe-core -am -DfailIfNoTests=false`.
    - Tried: `./run-fe-ut.sh --run org.apache.doris.alter.SchemaChangeHandlerTest#testReaddDroppedValueColumnUsesNewUniqueId`; FE test fork failed before running tests because surefire could not open literal `@{argLine}`.
- Behavior changed: Yes. New columns no longer reuse historical dropped column unique ids when `maxColUniqueId` metadata is stale.
- Does this need documentation: No
