### PR TITLE
[fix](memory-tracker) Avoid nested task attach in cloud snapshot manager

### DIFF
--- a/be/src/cloud/cloud_snapshot_mgr.cpp
+++ b/be/src/cloud/cloud_snapshot_mgr.cpp
@@ -61,7 +61,7 @@ CloudSnapshotMgr::CloudSnapshotMgr(CloudStorageEngine& engine) : _engine(engine)
 Status CloudSnapshotMgr::make_snapshot(int64_t target_tablet_id, StorageResource& storage_resource,
                                        std::unordered_map<std::string, std::string>& file_mapping,
                                        bool is_restore, const Slice* slice) {
-    SCOPED_ATTACH_TASK(_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     if (is_restore && slice == nullptr) {
         return Status::Error<INVALID_ARGUMENT>("slice cannot be null in restore.");
     }
@@ -105,7 +105,7 @@ Status CloudSnapshotMgr::make_snapshot(int64_t target_tablet_id, StorageResource
 }
 
 Status CloudSnapshotMgr::commit_snapshot(int64_t tablet_id) {
-    SCOPED_ATTACH_TASK(_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     CloudTabletSPtr tablet = DORIS_TRY(_engine.tablet_mgr().get_tablet(tablet_id));
     if (tablet == nullptr) {
         return Status::Error<TABLE_NOT_FOUND>("failed to get tablet. tablet={}", tablet_id);
@@ -117,7 +117,7 @@ Status CloudSnapshotMgr::commit_snapshot(int64_t tablet_id) {
 }
 
 Status CloudSnapshotMgr::release_snapshot(int64_t tablet_id, bool is_completed) {
-    SCOPED_ATTACH_TASK(_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     RETURN_IF_ERROR(_engine.meta_mgr().finish_restore_job(tablet_id, is_completed));
     LOG(INFO) << "success to release snapshot. [tablet_id=" << tablet_id << "]";
     return Status::OK();

--- a/be/src/storage/snapshot/snapshot_manager.cpp
+++ b/be/src/storage/snapshot/snapshot_manager.cpp
@@ -105,7 +105,7 @@ SnapshotManager::~SnapshotManager() = default;
 
 Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* snapshot_path,
                                       bool* allow_incremental_clone) {
-    SCOPED_ATTACH_TASK(_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     Status res = Status::OK();
     if (snapshot_path == nullptr) {
         return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
@@ -151,7 +151,7 @@ Status SnapshotManager::release_snapshot(const string& snapshot_path) {
 
     // If the requested snapshot_path is located in the root/snapshot folder, it is considered legal and can be deleted.
     // Otherwise, it is considered an illegal request and returns an error result.
-    SCOPED_ATTACH_TASK(_mem_tracker);
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     auto stores = _engine.get_stores();
     for (auto* store : stores) {
         std::string abs_path;


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #62403

Problem Summary:

### Release note

  Cloud download callback already attaches the `SnapshotLoader` resource context.
  During cloud restore,` CloudSnapshotLoader::download()` calls
  `CloudSnapshotMgr::make_snapshot()`, which previously used `SCOPED_ATTACH_TASK`
  again and could hit `ThreadContext::attach_task() `DCHECK because task attach is
  not nestable.

  Use `SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER` in `CloudSnapshotMgr` and`SnapshotMgr` snapshot
  operations avoiding the nested-attach pattern. These methods only need to
  account memory to the manager tracker, and limiter switching works both with
  and without an outer attached task context.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

