### PR TITLE
[improve](streaming-job) add per-job lag metric to streaming insert jobs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -871,6 +871,10 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         super.onReplayCreate();
     }
 
+    public String getLag() {
+        return offsetProvider != null ? offsetProvider.getLag() : "";
+    }
+
     /**
      * Because the offset statistics of the streamingInsertJob are all stored in txn,
      * only some fields are replayed here.

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -875,6 +875,20 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         return offsetProvider != null ? offsetProvider.getLag() : "";
     }
 
+    // Numeric lag for metrics. Returns -1 when lag is not applicable (S3, snapshot phase)
+    // or unparseable, so dashboards can filter N/A jobs via lag >= 0.
+    public long getLagSeconds() {
+        String lagStr = getLag();
+        if (lagStr == null || lagStr.isEmpty()) {
+            return -1L;
+        }
+        try {
+            return Long.parseLong(lagStr);
+        } catch (NumberFormatException e) {
+            return -1L;
+        }
+    }
+
     /**
      * Because the offset statistics of the streamingInsertJob are all stored in txn,
      * only some fields are replayed here.

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -1331,37 +1331,20 @@ public final class MetricRepo {
                         .addLabel(new MetricLabel("job_name", jobName));
                 DORIS_METRIC_REGISTER.addMetrics(failedTaskCount);
 
-                // Lag is only meaningful for CDC sources in binlog/WAL phase.
-                // Empty string means N/A (S3, snapshot phase) — skip the metric so Prometheus
-                // doesn't carry a misleading series for those jobs.
-                final Long lagValue = parseLagSeconds(sJob.getLag());
-                if (lagValue != null) {
-                    GaugeMetric<Long> lag = new GaugeMetric<Long>(
-                            STREAMING_JOB_PER_JOB_LAG, MetricUnit.SECONDS,
-                            "per job lag in seconds of streaming job") {
-                        @Override
-                        public Long getValue() {
-                            return lagValue;
-                        }
-                    };
-                    lag.addLabel(new MetricLabel("job_id", jobId))
-                            .addLabel(new MetricLabel("job_name", jobName));
-                    DORIS_METRIC_REGISTER.addMetrics(lag);
-                }
+                GaugeMetric<Long> lag = new GaugeMetric<Long>(
+                        STREAMING_JOB_PER_JOB_LAG, MetricUnit.SECONDS,
+                        "per job lag in seconds of streaming job, -1 means N/A") {
+                    @Override
+                    public Long getValue() {
+                        return sJob.getLagSeconds();
+                    }
+                };
+                lag.addLabel(new MetricLabel("job_id", jobId))
+                        .addLabel(new MetricLabel("job_name", jobName));
+                DORIS_METRIC_REGISTER.addMetrics(lag);
             }
         } catch (Throwable t) {
             LOG.warn("failed to update streaming job per-job metrics", t);
-        }
-    }
-
-    private static Long parseLagSeconds(String lagStr) {
-        if (lagStr == null || lagStr.isEmpty()) {
-            return null;
-        }
-        try {
-            return Long.parseLong(lagStr);
-        } catch (NumberFormatException e) {
-            return null;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -91,6 +91,7 @@ public final class MetricRepo {
     public static final String STREAMING_JOB_PER_JOB_FILTERED_ROWS = "streaming_job_per_job_filtered_rows";
     public static final String STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT = "streaming_job_per_job_succeed_task_count";
     public static final String STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT = "streaming_job_per_job_failed_task_count";
+    public static final String STREAMING_JOB_PER_JOB_LAG = "streaming_job_per_job_lag";
     public static final String CLOUD_TAG = "cloud";
 
     public static LongCounterMetric COUNTER_REQUEST_ALL;
@@ -1246,6 +1247,7 @@ public final class MetricRepo {
         DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FILTERED_ROWS);
         DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_SUCCEED_TASK_COUNT);
         DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_FAILED_TASK_COUNT);
+        DORIS_METRIC_REGISTER.removeMetrics(STREAMING_JOB_PER_JOB_LAG);
 
         try {
             List<org.apache.doris.job.base.AbstractJob> jobs =
@@ -1328,9 +1330,38 @@ public final class MetricRepo {
                 failedTaskCount.addLabel(new MetricLabel("job_id", jobId))
                         .addLabel(new MetricLabel("job_name", jobName));
                 DORIS_METRIC_REGISTER.addMetrics(failedTaskCount);
+
+                // Lag is only meaningful for CDC sources in binlog/WAL phase.
+                // Empty string means N/A (S3, snapshot phase) — skip the metric so Prometheus
+                // doesn't carry a misleading series for those jobs.
+                final Long lagValue = parseLagSeconds(sJob.getLag());
+                if (lagValue != null) {
+                    GaugeMetric<Long> lag = new GaugeMetric<Long>(
+                            STREAMING_JOB_PER_JOB_LAG, MetricUnit.SECONDS,
+                            "per job lag in seconds of streaming job") {
+                        @Override
+                        public Long getValue() {
+                            return lagValue;
+                        }
+                    };
+                    lag.addLabel(new MetricLabel("job_id", jobId))
+                            .addLabel(new MetricLabel("job_name", jobName));
+                    DORIS_METRIC_REGISTER.addMetrics(lag);
+                }
             }
         } catch (Throwable t) {
             LOG.warn("failed to update streaming job per-job metrics", t);
+        }
+    }
+
+    private static Long parseLagSeconds(String lagStr) {
+        if (lagStr == null || lagStr.isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(lagStr);
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
@@ -82,23 +82,6 @@ suite("test_streaming_mysql_job_metrics",
                                 Integer.parseInt(jobInfo[0][0] as String) >= 1 &&
                                 (jobInfo[0][1] as String) == "RUNNING"
                     })
-
-            // insert incremental data to push the job past snapshot into binlog phase
-            // so per-job lag metric becomes available
-            connect("root", "123456", "jdbc:mysql://${externalEnvIp}:${mysql_port}") {
-                sql """INSERT INTO ${mysqlDb}.${mysqlTable} (name, age) VALUES ('Carol', 30)"""
-            }
-
-            Awaitility.await().atMost(300, SECONDS)
-                    .pollInterval(1, SECONDS).until({
-                        def jobInfo = sql """ select Lag from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
-                        log.info("metrics lag jobInfo: " + jobInfo)
-                        if (jobInfo.size() != 1) {
-                            return false
-                        }
-                        def lagValue = jobInfo[0][0] as String
-                        return lagValue != null && lagValue != "" && lagValue.isNumber()
-                    })
         } catch (Exception ex) {
             def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
             def showtask = sql """select * from tasks("type"="insert") where JobName='${jobName}'"""

--- a/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
+++ b/regression-test/suites/job_p0/streaming_job/cdc/test_streaming_mysql_job_metrics.groovy
@@ -82,6 +82,23 @@ suite("test_streaming_mysql_job_metrics",
                                 Integer.parseInt(jobInfo[0][0] as String) >= 1 &&
                                 (jobInfo[0][1] as String) == "RUNNING"
                     })
+
+            // insert incremental data to push the job past snapshot into binlog phase
+            // so per-job lag metric becomes available
+            connect("root", "123456", "jdbc:mysql://${externalEnvIp}:${mysql_port}") {
+                sql """INSERT INTO ${mysqlDb}.${mysqlTable} (name, age) VALUES ('Carol', 30)"""
+            }
+
+            Awaitility.await().atMost(300, SECONDS)
+                    .pollInterval(1, SECONDS).until({
+                        def jobInfo = sql """ select Lag from jobs("type"="insert") where Name = '${jobName}' and ExecuteType='STREAMING' """
+                        log.info("metrics lag jobInfo: " + jobInfo)
+                        if (jobInfo.size() != 1) {
+                            return false
+                        }
+                        def lagValue = jobInfo[0][0] as String
+                        return lagValue != null && lagValue != "" && lagValue.isNumber()
+                    })
         } catch (Exception ex) {
             def showjob = sql """select * from jobs("type"="insert") where Name='${jobName}'"""
             def showtask = sql """select * from tasks("type"="insert") where JobName='${jobName}'"""
@@ -200,12 +217,21 @@ suite("test_streaming_mysql_job_metrics",
                         metricCount++
                     }
 
+                    def perJobLag = result.find {
+                        it.tags?.metric == "doris_fe_streaming_job_per_job_lag" &&
+                        it.tags?.job_name == "${jobName}"
+                    }
+                    if (perJobLag != null) {
+                        log.info("per-job lag: ${perJobLag}".toString())
+                        metricCount++
+                    }
+
 
                 }
             }
 
-            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge + 5 per-job metrics
-            if (metricCount >= 15) {
+            // 9 streaming_job_* counters + 1 doris_fe_job RUNNING gauge + 6 per-job metrics
+            if (metricCount >= 16) {
                 break
             }
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #62224 (per-job metrics), #62269 (Lag column)

Problem Summary:

#62224 introduced per-job metrics (`streaming_job_per_job_scanned_rows`, `_load_bytes`, `_filtered_rows`, `_succeed_task_count`, `_failed_task_count`) for streaming insert jobs, exposed via `/metrics` with `job_id`/`job_name` labels for Prometheus.

#62269 later added a `Lag` column to `SHOW JOBS` / `jobs()` TVF that reports end-to-end CDC delay in seconds, but the value was only exposed through SQL — there was no corresponding Prometheus metric, so dashboards/alerting on lag was not possible.

This PR adds `streaming_job_per_job_lag` (unit: `SECONDS`) to the existing per-job metric set.

**Implementation:**
- New `StreamingInsertJob#getLagSeconds()` parses the existing `offsetProvider.getLag()` string into a long. Returns `-1` when lag is not applicable (S3, snapshot phase) or unparseable, so dashboards can filter N/A jobs via `lag >= 0` and distinguish them from "CDC caught up (lag = 0)".
- `MetricRepo.updateStreamingJobPerJobMetrics()` registers the gauge for every streaming insert job (no skip), matching the always-present behavior of the other per-job metrics.

**Semantics summary:**
| Job state | TVF `Lag` | metric value |
|---|---|---|
| S3 / snapshot phase / no provider | `""` | `-1` |
| CDC caught up (idle) | `"0"` | `0` |
| CDC actively lagging | `"N"` | `N` |

### Release note

Add `streaming_job_per_job_lag` Prometheus metric (unit: seconds, `-1` means N/A) for streaming insert jobs.

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.