### PR TITLE
[Fix](p0) rename duplicate pyudf across p0 suites

### DIFF
--- a/regression-test/suites/pythonudf_complex_p0/test_python_udf_business_logic.groovy
+++ b/regression-test/suites/pythonudf_complex_p0/test_python_udf_business_logic.groovy
@@ -144,9 +144,9 @@ suite("test_python_udf_business_logic") {
         // ========================================
         // Test 6: Comprehensive Statistics
         // ========================================
-        sql """ DROP FUNCTION IF EXISTS py_statistics(STRING); """
+        sql """ DROP FUNCTION IF EXISTS py_statistics_complex(STRING); """
         sql """
-        CREATE FUNCTION py_statistics(STRING)
+        CREATE FUNCTION py_statistics_complex(STRING)
         RETURNS STRING
         PROPERTIES (
             "file" = "file://${pyPath}",
@@ -157,7 +157,7 @@ suite("test_python_udf_business_logic") {
         """
 
         qt_statistics """
-            SELECT py_statistics('[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]') AS stats;
+            SELECT py_statistics_complex('[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]') AS stats;
         """
 
         // ========================================
@@ -402,7 +402,7 @@ suite("test_python_udf_business_logic") {
         try_sql("DROP FUNCTION IF EXISTS py_detect_anomalies(STRING, DOUBLE);")
         try_sql("DROP FUNCTION IF EXISTS py_calculate_trend(STRING);")
         try_sql("DROP FUNCTION IF EXISTS py_percentiles(STRING, STRING);")
-        try_sql("DROP FUNCTION IF EXISTS py_statistics(STRING);")
+        try_sql("DROP FUNCTION IF EXISTS py_statistics_complex(STRING);")
         try_sql("DROP FUNCTION IF EXISTS py_correlation(STRING, STRING);")
         try_sql("DROP FUNCTION IF EXISTS py_rfm_score(INT, INT, DOUBLE);")
         try_sql("DROP FUNCTION IF EXISTS py_calculate_ltv(DOUBLE, DOUBLE, DOUBLE, DOUBLE);")

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_inline_complex.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_inline_complex.groovy
@@ -104,9 +104,9 @@ def evaluate(first_name, last_name):
         qt_select_format_name """ SELECT py_format_name('john', 'doe') AS result; """
         
         // Test 5: Numeric range validation
-        sql """ DROP FUNCTION IF EXISTS py_in_range(INT, INT, INT); """
+        sql """ DROP FUNCTION IF EXISTS py_in_range_inline(INT, INT, INT); """
         sql """
-        CREATE FUNCTION py_in_range(INT, INT, INT) 
+        CREATE FUNCTION py_in_range_inline(INT, INT, INT) 
         RETURNS BOOLEAN 
         PROPERTIES (
             "type" = "PYTHON_UDF",
@@ -121,14 +121,14 @@ def evaluate(value, min_val, max_val):
 \$\$;
         """
         
-        qt_select_in_range_true """ SELECT py_in_range(50, 0, 100) AS result; """
-        qt_select_in_range_false """ SELECT py_in_range(150, 0, 100) AS result; """
+        qt_select_in_range_true """ SELECT py_in_range_inline(50, 0, 100) AS result; """
+        qt_select_in_range_false """ SELECT py_in_range_inline(150, 0, 100) AS result; """
         
     } finally {
         try_sql("DROP FUNCTION IF EXISTS py_array_sum(ARRAY<INT>);")
         try_sql("DROP FUNCTION IF EXISTS py_reverse_string(STRING);")
         try_sql("DROP FUNCTION IF EXISTS py_weighted_avg(DOUBLE, DOUBLE, DOUBLE, DOUBLE);")
         try_sql("DROP FUNCTION IF EXISTS py_format_name(STRING, STRING);")
-        try_sql("DROP FUNCTION IF EXISTS py_in_range(INT, INT, INT);")
+        try_sql("DROP FUNCTION IF EXISTS py_in_range_inline(INT, INT, INT);")
     }
 }

--- a/regression-test/suites/pythonudf_p0/test_pythonudf_mixed_params.groovy
+++ b/regression-test/suites/pythonudf_p0/test_pythonudf_mixed_params.groovy
@@ -238,20 +238,20 @@ def py_vec_add_prefix(categories: pd.Series, prefix: str) -> pd.Series:
         // ==================== Test 6: pd.Series + scalar int ====================
         log.info("=== Test 6: pd.Series + scalar int ===")
         
-        sql """ DROP FUNCTION IF EXISTS py_vec_add_int(INT, INT); """
+        sql """ DROP FUNCTION IF EXISTS py_vec_add_int_inline(INT, INT); """
         sql """
-        CREATE FUNCTION py_vec_add_int(INT, INT) 
+        CREATE FUNCTION py_vec_add_int_inline(INT, INT) 
         RETURNS INT 
         PROPERTIES (
             "type" = "PYTHON_UDF",
-            "symbol" = "py_vec_add_int",
+            "symbol" = "py_vec_add_int_inline",
             "runtime_version" = "${runtime_version}",
             "always_nullable" = "true"
         )
         AS \$\$
 import pandas as pd
 
-def py_vec_add_int(quantities: pd.Series, bonus: int) -> pd.Series:
+def py_vec_add_int_inline(quantities: pd.Series, bonus: int) -> pd.Series:
     # quantities: pd.Series (vectorized int column)
     # bonus: int (scalar constant)
     return quantities + bonus
@@ -262,7 +262,7 @@ def py_vec_add_int(quantities: pd.Series, bonus: int) -> pd.Series:
         SELECT 
             id,
             quantity,
-            py_vec_add_int(quantity, 10) AS quantity_with_bonus
+            py_vec_add_int_inline(quantity, 10) AS quantity_with_bonus
         FROM test_mixed_params_table
         ORDER BY id
         LIMIT 5;
@@ -433,7 +433,7 @@ def py_vec_multi_scalar(prices: pd.Series, tax: float, discount: float, fee: flo
         sql """ DROP FUNCTION IF EXISTS py_vec_apply_discount(DOUBLE, DOUBLE); """
         sql """ DROP FUNCTION IF EXISTS py_vec_complex_calc(DOUBLE, INT, DOUBLE, DOUBLE); """
         sql """ DROP FUNCTION IF EXISTS py_vec_add_prefix(STRING, STRING); """
-        sql """ DROP FUNCTION IF EXISTS py_vec_add_int(INT, INT); """
+        sql """ DROP FUNCTION IF EXISTS py_vec_add_int_inline(INT, INT); """
         sql """ DROP FUNCTION IF EXISTS py_vec_conditional_discount(DOUBLE, DOUBLE, DOUBLE); """
         sql """ DROP FUNCTION IF EXISTS py_vec_scale_and_add(DOUBLE, DOUBLE, INT); """
         sql """ DROP FUNCTION IF EXISTS py_vec_alternating(DOUBLE, DOUBLE, INT, INT); """


### PR DESCRIPTION
Problem Summary:

prevent failures caused by conflicting function names across test suites.
```text
Exception in pythonudf_p0/test_pythonudf_mixed_params.groovy(line 242):
    sql """ DROP FUNCTION IF EXISTS py_vec_add_int(INT, INT); """

    // If another suite creates a function with the same name at this time, it will cause the test to fail.
    sql """
    CREATE FUNCTION py_vec_add_int(INT, INT)

Exception:
java.sql.SQLException: errCode = 2, detailMessage = function already exists
```