### PR TITLE
[fix](function) prevent count_substrings tail overmatch

### DIFF
--- a/be/src/exprs/function/function_string_search.cpp
+++ b/be/src/exprs/function/function_string_search.cpp
@@ -839,10 +839,17 @@ private:
     size_t find_pos(size_t pos, const StringRef str_ref, const StringRef pattern_ref) const {
         size_t old_size = pos;
         size_t str_size = str_ref.size;
-        while (pos < str_size &&
+        if (pattern_ref.size > str_size || pos > str_size - pattern_ref.size) {
+            return str_size - old_size;
+        }
+        const size_t last_match_pos = str_size - pattern_ref.size;
+        while (pos <= last_match_pos &&
                memcmp_small_allow_overflow15((const uint8_t*)str_ref.data + pos,
                                              (const uint8_t*)pattern_ref.data, pattern_ref.size)) {
             pos++;
+        }
+        if (pos > last_match_pos) {
+            return str_size - old_size;
         }
         return pos - old_size;
     }

--- a/be/test/exprs/function/function_string_test.cpp
+++ b/be/test/exprs/function/function_string_test.cpp
@@ -3648,6 +3648,9 @@ TEST(function_string_test, function_count_substring_test) {
                             {{std::string("hello world"), std::string("")}, std::int32_t(0)},
                             {{std::string(""), std::string("l")}, std::int32_t(0)},
                             {{std::string(""), std::string("")}, std::int32_t(0)},
+                            {{std::string("ccc"), std::string("cc")}, std::int32_t(1)},
+                            {{std::string("aaaa"), std::string("aa")}, std::int32_t(2)},
+                            {{std::string("ab"), std::string("abc")}, std::int32_t(0)},
                             // utf-8 characters
                             {{std::string("你好123世界"), std::string("世")}, std::int32_t(1)},
                             {{std::string("你好123世界"), std::string("你")}, std::int32_t(1)},
@@ -3673,6 +3676,9 @@ TEST(function_string_test, function_count_substring_test) {
                 {{std::string("hello world"), std::string(""), std::int32_t(0)}, std::int32_t(0)},
                 {{std::string(""), std::string("l"), std::int32_t(1)}, std::int32_t(0)},
                 {{std::string(""), std::string(""), std::int32_t(1)}, std::int32_t(0)},
+                {{std::string("ccc"), std::string("cc"), std::int32_t(1)}, std::int32_t(1)},
+                {{std::string("ccc"), std::string("cc"), std::int32_t(3)}, std::int32_t(0)},
+                {{std::string("ab"), std::string("abc"), std::int32_t(1)}, std::int32_t(0)},
                 // utf-8 characters
                 {{std::string("你好123世界"), std::string("世"), std::int32_t(3)}, std::int32_t(1)},
                 {{std::string("你好123世界"), std::string("你"), std::int32_t(1)}, std::int32_t(1)},


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62768

Related PR: None

Problem Summary:

`count_substrings` scanned candidate positions even when the remaining suffix was shorter than the search pattern. Because the implementation uses `memcmp_small_allow_overflow15`, that could count a tail position where the full pattern does not fit, for example `count_substrings("ccc", "cc")`.

This PR limits comparisons to positions where the full pattern fits and keeps the existing not-found distance contract used by the caller.

### Release note

Fix `count_substrings` tail-boundary matching for non-overlapping substring counts.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. `count_substrings` no longer counts a match when the full pattern does not fit in the remaining suffix.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
