### PR TITLE
[fix](mtmv) support qualified materialized view rename target

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -83,9 +83,9 @@ materializedViewStatement
         propertyClause?
         AS? query                                                                               #createMTMV
     | REFRESH MATERIALIZED VIEW mvName=multipartIdentifier (partitionSpec | COMPLETE | AUTO)    #refreshMTMV
-    | ALTER MATERIALIZED VIEW mvName=multipartIdentifier ((RENAME newName=identifier)
+    | ALTER MATERIALIZED VIEW mvName=multipartIdentifier ((RENAME renameNewName=multipartIdentifier)
         | (REFRESH (refreshMethod | refreshTrigger | refreshMethod refreshTrigger))
-        | REPLACE WITH MATERIALIZED VIEW newName=identifier propertyClause?
+        | REPLACE WITH MATERIALIZED VIEW replaceNewName=identifier propertyClause?
         | (SET  LEFT_PAREN fileProperties=propertyItemList RIGHT_PAREN))                        #alterMTMV
     | DROP MATERIALIZED VIEW (IF EXISTS)? mvName=multipartIdentifier
         (ON tableName=multipartIdentifier)?                                                     #dropMV

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -1918,7 +1918,8 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         TableNameInfo mvName = new TableNameInfo(nameParts);
         AlterMTMVInfo alterMTMVInfo = null;
         if (ctx.RENAME() != null) {
-            alterMTMVInfo = new AlterMTMVRenameInfo(mvName, ctx.newName.getText());
+            alterMTMVInfo = new AlterMTMVRenameInfo(mvName,
+                    new TableNameInfo(visitMultipartIdentifier(ctx.renameNewName)));
         } else if (ctx.REFRESH() != null) {
             MTMVRefreshInfo refreshInfo = new MTMVRefreshInfo();
             if (ctx.refreshMethod() != null) {
@@ -1932,7 +1933,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             alterMTMVInfo = new AlterMTMVPropertyInfo(mvName,
                     Maps.newHashMap(visitPropertyItemList(ctx.fileProperties)));
         } else if (ctx.REPLACE() != null) {
-            String newName = ctx.newName.getText();
+            String newName = ctx.replaceNewName.getText();
             Map<String, String> properties = ctx.propertyClause() != null
                     ? Maps.newHashMap(visitPropertyClause(ctx.propertyClause())) : Maps.newHashMap();
             alterMTMVInfo = new AlterMTMVReplaceInfo(mvName, newName, properties);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AlterMTMVRenameInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AlterMTMVRenameInfo.java
@@ -34,12 +34,12 @@ import java.util.Optional;
  * rename
  */
 public class AlterMTMVRenameInfo extends AlterMTMVInfo {
-    private final String newName;
+    private final TableNameInfo newName;
 
     /**
      * constructor for alter MTMV
      */
-    public AlterMTMVRenameInfo(TableNameInfo mvName, String newName) {
+    public AlterMTMVRenameInfo(TableNameInfo mvName, TableNameInfo newName) {
         super(mvName);
         this.newName = Objects.requireNonNull(newName, "require newName object");
     }
@@ -53,9 +53,16 @@ public class AlterMTMVRenameInfo extends AlterMTMVInfo {
     public void analyze(ConnectContext ctx) throws AnalysisException {
         super.analyze(ctx);
         try {
-            FeNameFormat.checkTableName(newName);
+            FeNameFormat.checkTableName(newName.getTbl());
         } catch (org.apache.doris.common.AnalysisException e) {
             throw new AnalysisException(e.getMessage(), e);
+        }
+        if (newName.getCtl() != null || newName.getDb() != null) {
+            newName.analyze(ctx.getNameSpaceContext());
+            if (!mvName.getCtl().equalsIgnoreCase(newName.getCtl())
+                    || !mvName.getDb().equalsIgnoreCase(newName.getDb())) {
+                throw new AnalysisException("Can not rename materialized view to another database or catalog");
+            }
         }
     }
 
@@ -64,7 +71,7 @@ public class AlterMTMVRenameInfo extends AlterMTMVInfo {
         Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(mvName.getDb());
         Table table = db.getTableOrDdlException(mvName.getTbl());
         BaseTableInfo oldTableInfo = new BaseTableInfo(table);
-        Env.getCurrentEnv().renameTable(db, table, newName);
+        Env.getCurrentEnv().renameTable(db, table, newName.getTbl());
         BaseTableInfo newTableInfo = new BaseTableInfo(table);
         Env.getCurrentEnv().getMtmvService().alterTable(oldTableInfo, Optional.of(newTableInfo), false);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AlterMTMVRenameInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/AlterMTMVRenameInfo.java
@@ -59,8 +59,8 @@ public class AlterMTMVRenameInfo extends AlterMTMVInfo {
         }
         if (newName.getCtl() != null || newName.getDb() != null) {
             newName.analyze(ctx.getNameSpaceContext());
-            if (!mvName.getCtl().equalsIgnoreCase(newName.getCtl())
-                    || !mvName.getDb().equalsIgnoreCase(newName.getDb())) {
+            if (!Objects.equals(mvName.getCtl(), newName.getCtl())
+                    || !Objects.equals(mvName.getDb(), newName.getDb())) {
                 throw new AnalysisException("Can not rename materialized view to another database or catalog");
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.mtmv;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.utframe.TestWithFeService;
 
 import org.junit.jupiter.api.Assertions;
@@ -80,5 +81,21 @@ public class AlterMTMVTest extends TestWithFeService {
                 alterTableSync("ALTER TABLE stu1 REPLACE WITH TABLE mv_c PROPERTIES('swap' = 'true')"));
         Assertions.assertEquals("errCode = 2, detailMessage = replace table[mv_c] cannot be a materialized view",
                 exception.getMessage());
+
+        createDatabaseAndUse("Test");
+        createTable("CREATE TABLE `case_stu` (`sid` int(32) NULL, `sname` varchar(32) NULL)\n"
+                + "ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`sid`)\n"
+                + "DISTRIBUTED BY HASH(`sid`) BUCKETS 1\n"
+                + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1')");
+        createMvByNereids("CREATE MATERIALIZED VIEW mv_case BUILD DEFERRED REFRESH COMPLETE ON COMMIT\n"
+                + "DISTRIBUTED BY HASH(`sid`) BUCKETS 1\n"
+                + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1') "
+                + "AS select * from case_stu limit 1");
+
+        AnalysisException renameException = Assertions.assertThrows(AnalysisException.class, () ->
+                alterMv("ALTER MATERIALIZED VIEW Test.mv_case RENAME test.mv_case_new"));
+        Assertions.assertEquals("Can not rename materialized view to another database or catalog",
+                renameException.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/AlterMTMVTest.java
@@ -46,12 +46,14 @@ public class AlterMTMVTest extends TestWithFeService {
                 + "AS select * from stu limit 1");
 
         alterMv("ALTER MATERIALIZED VIEW mv_a RENAME mv_b");
+        alterMv("ALTER MATERIALIZED VIEW test.mv_b RENAME test.mv_c");
 
         MTMVRelationManager relationManager = Env.getCurrentEnv().getMtmvService().getRelationManager();
         Table table = Env.getCurrentInternalCatalog().getDb("test").get().getTableOrMetaException("stu");
         Set<BaseTableInfo> allMTMVs = relationManager.getMtmvsByBaseTable(new BaseTableInfo(table));
         boolean hasMvA = false;
         boolean hasMvB = false;
+        boolean hasMvC = false;
         for (BaseTableInfo mtmv : allMTMVs) {
             if ("mv_a".equals(mtmv.getTableName())) {
                 hasMvA = true;
@@ -59,9 +61,13 @@ public class AlterMTMVTest extends TestWithFeService {
             if ("mv_b".equals(mtmv.getTableName())) {
                 hasMvB = true;
             }
+            if ("mv_c".equals(mtmv.getTableName())) {
+                hasMvC = true;
+            }
         }
         Assertions.assertFalse(hasMvA);
-        Assertions.assertTrue(hasMvB);
+        Assertions.assertFalse(hasMvB);
+        Assertions.assertTrue(hasMvC);
 
 
         createTable("CREATE TABLE `stu1` (`sid` int(32) NULL, `sname` varchar(32) NULL)\n"
@@ -71,8 +77,8 @@ public class AlterMTMVTest extends TestWithFeService {
                 + "PROPERTIES ('replication_allocation' = 'tag.location.default: 1')");
 
         DdlException exception = Assertions.assertThrows(DdlException.class, () ->
-                alterTableSync("ALTER TABLE stu1 REPLACE WITH TABLE mv_b PROPERTIES('swap' = 'true')"));
-        Assertions.assertEquals("errCode = 2, detailMessage = replace table[mv_b] cannot be a materialized view",
+                alterTableSync("ALTER TABLE stu1 REPLACE WITH TABLE mv_c PROPERTIES('swap' = 'true')"));
+        Assertions.assertEquals("errCode = 2, detailMessage = replace table[mv_c] cannot be a materialized view",
                 exception.getMessage());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62226

Related PR: None

Problem Summary:

`ALTER MATERIALIZED VIEW db.mv RENAME db.new_mv` failed during parsing because the MTMV `RENAME` target accepted only a single identifier. The underlying rename still operates inside the source database, so this PR parses the target as a multipart identifier and validates that any supplied catalog or database qualifier matches the source materialized view.

### Release note

Support qualified target names in `ALTER MATERIALIZED VIEW ... RENAME` when the qualifier matches the source materialized view.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Qualified rename targets for MTMV are now accepted when they resolve to the same catalog and database.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
