### PR TITLE
[fix](be) Fix macOS BE build

### DIFF
--- a/be/src/common/multi_version.h
+++ b/be/src/common/multi_version.h
@@ -23,6 +23,10 @@
 #include <atomic>
 #include <memory>
 
+#ifdef USE_LIBCPP
+#include "common/atomic_shared_ptr.h"
+#endif
+
 /** Allow to store and read-only usage of an object in several threads,
   *  and to atomically replace an object in another thread.
   * The replacement is atomic and reading threads can work with different versions of an object.
@@ -59,5 +63,9 @@ public:
     }
 
 private:
+#ifdef USE_LIBCPP
+    doris::atomic_shared_ptr<const T> current_version;
+#else
     std::atomic<Version> current_version;
+#endif
 };

--- a/be/src/exec/common/memory.cpp
+++ b/be/src/exec/common/memory.cpp
@@ -51,7 +51,8 @@ int MemLimiter::available_scanner_count(int ins_idx) const {
     int64_t estimated_block_mem_bytes_value = get_estimated_block_mem_bytes();
     DCHECK_GT(estimated_block_mem_bytes_value, 0);
 
-    int64_t max_count = std::max(1L, mem_limit_value / estimated_block_mem_bytes_value);
+    int64_t max_count =
+            std::max<int64_t>(1, mem_limit_value / estimated_block_mem_bytes_value);
     int64_t avail_count = max_count;
     int64_t per_count = avail_count / parallelism;
     if (serial_operator) {

--- a/be/src/exec/common/memory.cpp
+++ b/be/src/exec/common/memory.cpp
@@ -51,8 +51,7 @@ int MemLimiter::available_scanner_count(int ins_idx) const {
     int64_t estimated_block_mem_bytes_value = get_estimated_block_mem_bytes();
     DCHECK_GT(estimated_block_mem_bytes_value, 0);
 
-    int64_t max_count =
-            std::max<int64_t>(1, mem_limit_value / estimated_block_mem_bytes_value);
+    int64_t max_count = std::max<int64_t>(1, mem_limit_value / estimated_block_mem_bytes_value);
     int64_t avail_count = max_count;
     int64_t per_count = avail_count / parallelism;
     if (serial_operator) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Fix BE compilation failures on macOS libc++ while keeping the Linux path on the original `std::atomic<std::shared_ptr<...>>` implementation. `MultiVersion` now uses the existing Doris `atomic_shared_ptr` fallback only when `USE_LIBCPP` is enabled, and `MemLimiter` avoids mixed `long`/`int64_t` template deduction in `std::max`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `./build.sh --be -j 30`
        - `clang-tidy` changed-line checks for modified files using clang-tidy 20 with a temporary no-PCH compilation database because `build-support/run-clang-tidy.sh` requires Bash associative arrays unavailable in macOS bash 3.2
        - `build-support/clang-format.sh be/src/common/multi_version.h` was attempted but could not run because llvm@16 clang-format is not installed
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
