### PR TITLE
[fix](catalog) Mask sensitive properties in show create catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DatasourcePrintableMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DatasourcePrintableMap.java
@@ -20,6 +20,7 @@ package org.apache.doris.common.util;
 import org.apache.doris.common.maxcompute.MCProperties;
 import org.apache.doris.datasource.property.metastore.AWSGlueMetaStoreBaseProperties;
 import org.apache.doris.datasource.property.metastore.AliyunDLFBaseProperties;
+import org.apache.doris.datasource.property.metastore.IcebergRestProperties;
 import org.apache.doris.datasource.property.storage.AzureProperties;
 import org.apache.doris.datasource.property.storage.COSProperties;
 import org.apache.doris.datasource.property.storage.GCSProperties;
@@ -58,6 +59,7 @@ public class DatasourcePrintableMap<K, V> extends BasicPrintableMap<K, V> {
         SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(S3Properties.class));
         SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(AliyunDLFBaseProperties.class));
         SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(AWSGlueMetaStoreBaseProperties.class));
+        SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(IcebergRestProperties.class));
         SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(GCSProperties.class));
         SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(AzureProperties.class));
         SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(OSSProperties.class));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/IcebergRestProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/IcebergRestProperties.java
@@ -81,6 +81,7 @@ public class IcebergRestProperties extends AbstractIcebergProperties {
 
     @ConnectorProperty(names = {"iceberg.rest.oauth2.token"},
             required = false,
+            sensitive = true,
             description = "The oauth2 token for the iceberg rest catalog service.")
     private String icebergRestOauth2Token;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DatasourcePrintableMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DatasourcePrintableMapTest.java
@@ -44,6 +44,7 @@ public class DatasourcePrintableMapTest {
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("jdbc.password"));
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("elasticsearch.password"));
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("iceberg.rest.oauth2.credential"));
+        Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("iceberg.rest.oauth2.token"));
 
         // Verify cloud storage related sensitive keys (these are constants added in static initialization block)
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("s3.secret_key"));
@@ -158,6 +159,7 @@ public class DatasourcePrintableMapTest {
         testMap.put("s3.secret_key", "s3_secret_value");
         testMap.put("kerberos_keytab_content", "kerberos_content");
         testMap.put("iceberg.rest.oauth2.credential", "iceberg_rest_credential");
+        testMap.put("iceberg.rest.oauth2.token", "iceberg_rest_token");
 
         DatasourcePrintableMap<String, String> printableMap = new DatasourcePrintableMap<>(testMap, "=", false, false, true);
         String result = printableMap.toString();
@@ -168,6 +170,8 @@ public class DatasourcePrintableMapTest {
         Assertions.assertTrue(result.contains("s3.secret_key = " + DatasourcePrintableMap.PASSWORD_MASK));
         Assertions.assertTrue(result.contains("kerberos_keytab_content = " + DatasourcePrintableMap.PASSWORD_MASK));
         Assertions.assertTrue(result.contains("iceberg.rest.oauth2.credential = "
+                + DatasourcePrintableMap.PASSWORD_MASK));
+        Assertions.assertTrue(result.contains("iceberg.rest.oauth2.token = "
                 + DatasourcePrintableMap.PASSWORD_MASK));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DatasourcePrintableMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DatasourcePrintableMapTest.java
@@ -43,6 +43,7 @@ public class DatasourcePrintableMapTest {
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("bos_secret_accesskey"));
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("jdbc.password"));
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("elasticsearch.password"));
+        Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("iceberg.rest.oauth2.credential"));
 
         // Verify cloud storage related sensitive keys (these are constants added in static initialization block)
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("s3.secret_key"));
@@ -156,6 +157,7 @@ public class DatasourcePrintableMapTest {
         testMap.put("dlf.secret_key", "dlf_secret_value");
         testMap.put("s3.secret_key", "s3_secret_value");
         testMap.put("kerberos_keytab_content", "kerberos_content");
+        testMap.put("iceberg.rest.oauth2.credential", "iceberg_rest_credential");
 
         DatasourcePrintableMap<String, String> printableMap = new DatasourcePrintableMap<>(testMap, "=", false, false, true);
         String result = printableMap.toString();
@@ -165,6 +167,8 @@ public class DatasourcePrintableMapTest {
         Assertions.assertTrue(result.contains("dlf.secret_key = " + DatasourcePrintableMap.PASSWORD_MASK));
         Assertions.assertTrue(result.contains("s3.secret_key = " + DatasourcePrintableMap.PASSWORD_MASK));
         Assertions.assertTrue(result.contains("kerberos_keytab_content = " + DatasourcePrintableMap.PASSWORD_MASK));
+        Assertions.assertTrue(result.contains("iceberg.rest.oauth2.credential = "
+                + DatasourcePrintableMap.PASSWORD_MASK));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.DatasourcePrintableMap;
 import org.apache.doris.datasource.hive.HMSExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.nereids.parser.NereidsParser;
@@ -142,6 +143,33 @@ public class ExternalCatalogTest extends TestWithFeService {
         prop.put(ExternalCatalog.ENABLE_AUTO_ANALYZE, "TRUE");
         catalog.modifyCatalogProps(prop);
         Assertions.assertTrue(catalog.enableAutoAnalyze());
+    }
+
+    @Test
+    public void testShowCreateCatalogMasksSensitiveProperties() throws Exception {
+        String createStmt = "create catalog mask_iceberg_rest properties(\n"
+                + "    \"type\" = \"iceberg\",\n"
+                + "    \"iceberg.catalog.type\" = \"rest\",\n"
+                + "    \"iceberg.rest.uri\" = \"http://localhost:8181\",\n"
+                + "    \"warehouse\" = \"test_db\",\n"
+                + "    \"iceberg.rest.security.type\" = \"oauth2\",\n"
+                + "    \"iceberg.rest.oauth2.credential\" = \"super-secret-pat\",\n"
+                + "    \"iceberg.rest.oauth2.server-uri\" = \"http://localhost:8181/v1/oauth/tokens\",\n"
+                + "    \"iceberg.rest.oauth2.scope\" = \"session:role:TEST_ROLE\"\n"
+                + ");";
+
+        NereidsParser nereidsParser = new NereidsParser();
+        LogicalPlan logicalPlan = nereidsParser.parseSingle(createStmt);
+        if (logicalPlan instanceof CreateCatalogCommand) {
+            ((CreateCatalogCommand) logicalPlan).run(rootCtx, null);
+        }
+
+        List<List<String>> rows = mgr.showCreateCatalog("mask_iceberg_rest");
+        Assertions.assertEquals(1, rows.size());
+        String ddl = rows.get(0).get(1);
+        Assertions.assertTrue(ddl.contains("\"iceberg.rest.oauth2.credential\" = \""
+                + DatasourcePrintableMap.PASSWORD_MASK + "\""));
+        Assertions.assertFalse(ddl.contains("super-secret-pat"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
@@ -160,9 +160,8 @@ public class ExternalCatalogTest extends TestWithFeService {
 
         NereidsParser nereidsParser = new NereidsParser();
         LogicalPlan logicalPlan = nereidsParser.parseSingle(createStmt);
-        if (logicalPlan instanceof CreateCatalogCommand) {
-            ((CreateCatalogCommand) logicalPlan).run(rootCtx, null);
-        }
+        Assertions.assertTrue(logicalPlan instanceof CreateCatalogCommand);
+        ((CreateCatalogCommand) logicalPlan).run(rootCtx, null);
 
         List<List<String>> rows = mgr.showCreateCatalog("mask_iceberg_rest");
         Assertions.assertEquals(1, rows.size());
@@ -170,6 +169,26 @@ public class ExternalCatalogTest extends TestWithFeService {
         Assertions.assertTrue(ddl.contains("\"iceberg.rest.oauth2.credential\" = \""
                 + DatasourcePrintableMap.PASSWORD_MASK + "\""));
         Assertions.assertFalse(ddl.contains("super-secret-pat"));
+
+        String createTokenStmt = "create catalog mask_iceberg_rest_token properties(\n"
+                + "    \"type\" = \"iceberg\",\n"
+                + "    \"iceberg.catalog.type\" = \"rest\",\n"
+                + "    \"iceberg.rest.uri\" = \"http://localhost:8181\",\n"
+                + "    \"warehouse\" = \"test_db\",\n"
+                + "    \"iceberg.rest.security.type\" = \"oauth2\",\n"
+                + "    \"iceberg.rest.oauth2.token\" = \"super-secret-token\"\n"
+                + ");";
+
+        logicalPlan = nereidsParser.parseSingle(createTokenStmt);
+        Assertions.assertTrue(logicalPlan instanceof CreateCatalogCommand);
+        ((CreateCatalogCommand) logicalPlan).run(rootCtx, null);
+
+        rows = mgr.showCreateCatalog("mask_iceberg_rest_token");
+        Assertions.assertEquals(1, rows.size());
+        ddl = rows.get(0).get(1);
+        Assertions.assertTrue(ddl.contains("\"iceberg.rest.oauth2.token\" = \""
+                + DatasourcePrintableMap.PASSWORD_MASK + "\""));
+        Assertions.assertFalse(ddl.contains("super-secret-token"));
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

`SHOW CREATE CATALOG` currently prints sensitive catalog properties in plain text. For Iceberg REST catalogs this exposes `iceberg.rest.oauth2.credential`, which is commonly a PAT or similar secret.

This change ensures sensitive connector properties are masked in catalog DDL output.

### Changes

- Register `IcebergRestProperties` sensitive keys in `DatasourcePrintableMap.SENSITIVE_KEY`
- Add masking coverage for `iceberg.rest.oauth2.credential`
- Add a regression test for `SHOW CREATE CATALOG` to ensure the credential is printed as `*XXX` instead of the raw value

### Verification

- Current workspace targeted tests passed for the same content:
  `mvn -pl fe-core -am -Dtest=DatasourcePrintableMapTest,ExternalCatalogTest -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false test`
- Clean `origin/master` worktree code/test compilation succeeded through `testCompile`, but `fe-core` test execution hit an unrelated surefire fork configuration issue on master (`Error: could not open {argLine}`), so the runtime test evidence is from the equivalent patch in the main workspace.