### PR TITLE
[fix](be) Guard datelike cast input columns

### DIFF
--- a/be/src/exprs/function/cast/cast_to_date.h
+++ b/be/src/exprs/function/cast/cast_to_date.h
@@ -49,8 +49,16 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = assert_cast<const DataTypeString::ColumnType*>(
-                block.get_by_position(arguments[0]).column.get());
+        const auto& named_from = block.get_by_position(arguments[0]);
+        if (!named_from.column) {
+            return Status::RuntimeError("Illegal null column of first argument of function cast");
+        }
+        const auto* col_from =
+                check_and_get_column<DataTypeString::ColumnType>(named_from.column.get());
+        if (!col_from) {
+            return Status::RuntimeError("Illegal column {} of first argument of function cast",
+                                        named_from.column->get_name());
+        }
 
         auto to_type = block.get_by_position(result).type;
         auto serde = remove_nullable(to_type)->get_serde();
@@ -84,8 +92,16 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = assert_cast<const typename FromDataType::ColumnType*>(
-                block.get_by_position(arguments[0]).column.get());
+        const auto& named_from = block.get_by_position(arguments[0]);
+        if (!named_from.column) {
+            return Status::RuntimeError("Illegal null column of first argument of function cast");
+        }
+        const auto* col_from =
+                check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
+        if (!col_from) {
+            return Status::RuntimeError("Illegal column {} of first argument of function cast",
+                                        named_from.column->get_name());
+        }
         auto to_type = block.get_by_position(result).type;
         auto concrete_serde = std::dynamic_pointer_cast<typename ToDataType::SerDeType>(
                 remove_nullable(to_type)->get_serde());
@@ -141,8 +157,16 @@ public:
         constexpr bool Nullable = std::is_same_v<FromDataType, ToDataType> &&
                                   (IsTimeV2Type<FromDataType> || IsDateTimeV2Type<FromDataType>);
 
-        const auto* col_from = assert_cast<const typename FromDataType::ColumnType*>(
-                block.get_by_position(arguments[0]).column.get());
+        const auto& named_from = block.get_by_position(arguments[0]);
+        if (!named_from.column) {
+            return Status::RuntimeError("Illegal null column of first argument of function cast");
+        }
+        const auto* col_from =
+                check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
+        if (!col_from) {
+            return Status::RuntimeError("Illegal column {} of first argument of function cast",
+                                        named_from.column->get_name());
+        }
         auto col_to = ToDataType::ColumnType::create(input_rows_count);
         ColumnUInt8::MutablePtr col_nullmap;
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63166

Problem Summary: Datelike cast implementations assert the concrete input column type before dereferencing it. If runtime-filter or scan common-expression evaluation passes an unexpected or null input column, the cast path can crash instead of returning an error.

### Release note

Fix BE crash when datelike cast receives an unexpected input column in scan/runtime-filter expression evaluation.

### Check List (For Author)

- Test: Manual test
    - BE format check: build-support/check-format.sh --files be/src/exprs/function/cast/cast_to_date.h
- Behavior changed: Yes, invalid datelike cast input columns now return a runtime error instead of crashing
- Does this need documentation: No