### PR TITLE
[fix](thrift) Reserve frontend service field ids

### DIFF
--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -65,6 +65,9 @@ struct TDescribeTablesParams {
   5: optional Types.TUserIdentity current_user_ident // to replace the user and user ip
   6: optional bool show_hidden_columns = false
   7: optional string catalog
+  // Reserved for downstream field `current_roles` to keep thrift field ids
+  // wire-compatible across maintained branches. Do not reuse this id.
+  8: optional set<string> reserved_field_8
 }
 
 // Results of a call to describeTable()
@@ -95,6 +98,9 @@ struct TGetDbsParams {
   4: optional Types.TUserIdentity current_user_ident // to replace the user and user ip
   5: optional string catalog
   6: optional bool get_null_catalog  //if catalog is empty , get dbName ="NULL" and dbId = -1.
+  // Reserved for downstream field `current_roles` to keep thrift field ids
+  // wire-compatible across maintained branches. Do not reuse this id.
+  7: optional set<string> reserved_field_7
 }
 
 // getDbNames returns a list of database names , database ids and catalog names ,catalog ids
@@ -119,6 +125,9 @@ struct TGetTablesParams {
   6: optional string type
   7: optional string catalog
   8: optional string table
+  // Reserved for downstream field `current_roles` to keep thrift field ids
+  // wire-compatible across maintained branches. Do not reuse this id.
+  9: optional set<string> reserved_field_9
 }
 
 struct TTableStatus {
@@ -399,6 +408,11 @@ struct TMasterOpRequest {
     31: optional binary prepareExecuteBuffer
     32: optional bool moreResultExists // Server has more result to send
     33: optional map<string, string> connect_attributes
+
+    // Reserved for downstream fields `current_roles` and `is_su_user` to keep
+    // thrift field ids wire-compatible across maintained branches. Do not reuse these ids.
+    34: optional set<string> reserved_field_34
+    35: optional bool reserved_field_35
 
     // selectdb cloud
     1000: optional string cloud_cluster
@@ -895,6 +909,9 @@ struct TMetadataTableRequestParams {
   12: optional PlanNodes.TMetaCacheStatsParams meta_cache_stats_params
   13: optional PlanNodes.TPartitionValuesMetadataParams partition_values_metadata_params
   14: optional PlanNodes.THudiMetadataParams hudi_metadata_params
+  // Reserved for downstream field `current_roles` to keep thrift field ids
+  // wire-compatible across maintained branches. Do not reuse this id.
+  15: optional set<string> reserved_field_15
 }
 
 struct TSchemaTableRequestParams {
@@ -906,6 +923,9 @@ struct TSchemaTableRequestParams {
     6: optional string time_zone // used for DATETIME field
     7: optional string frontend_conjuncts
     8: optional i64 thread_id // mysql connection id for fetching ConnectContext if needed
+    // Reserved for downstream field `current_roles` to keep thrift field ids
+    // wire-compatible across maintained branches. Do not reuse this id.
+    9: optional set<string> reserved_field_9
 }
 
 struct TFetchSchemaTableDataRequest {
@@ -1536,6 +1556,9 @@ struct TShowProcessListRequest {
     1: optional bool show_full_sql
     2: optional Types.TUserIdentity current_user_ident
     3: optional string time_zone
+    // Reserved for downstream field `current_roles` to keep thrift field ids
+    // wire-compatible across maintained branches. Do not reuse this id.
+    4: optional set<string> reserved_field_4
 }
 
 struct TShowProcessListResult {


### PR DESCRIPTION
### What problem does this PR solve?

  Reserve several unused `FrontendService.thrift` field ids for downstream compatibility.

  These ids are intentionally kept unused in Apache Doris so they are not accidentally reused with different wire semantics in maintained branches or downstream distributions.

  No runtime behavior is changed. All added fields are optional reserved fields and are not read or written by current code.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

