### PR TITLE
[refine](column) return ColumnPtrGuard from check_and_get_column

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -359,6 +359,7 @@ if (COMPILER_CLANG)
     endif()
 
     add_compile_options(-fcolor-diagnostics
+                        -Wconsumed
                         -Wpedantic
                         -Wshadow
                         -Wshadow-field

--- a/be/src/core/block/block.cpp
+++ b/be/src/core/block/block.cpp
@@ -956,7 +956,7 @@ Status Block::append_to_block_by_selector(MutableBlock* dst,
 Status Block::filter_block(Block* block, const std::vector<uint32_t>& columns_to_filter,
                            size_t filter_column_id, size_t column_to_keep) {
     const auto& filter_column = block->get_by_position(filter_column_id).column;
-    if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
+    if (const auto nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
         const auto& nested_column = nullable_column->get_nested_column_ptr();
 
         MutableColumnPtr mutable_holder =
@@ -974,7 +974,7 @@ Status Block::filter_block(Block* block, const std::vector<uint32_t>& columns_to
             filter_data[i] &= !null_map[i];
         }
         RETURN_IF_CATCH_EXCEPTION(filter_block_internal(block, columns_to_filter, filter));
-    } else if (const auto* const_column = check_and_get_column<ColumnConst>(*filter_column)) {
+    } else if (const auto const_column = check_and_get_column<ColumnConst>(*filter_column)) {
         bool ret = const_column->get_bool(0);
         if (!ret) {
             for (const auto& col : columns_to_filter) {

--- a/be/src/core/column/column.cpp
+++ b/be/src/core/column/column.cpp
@@ -63,7 +63,7 @@ bool IColumn::const_nested_check() const {
 }
 
 bool IColumn::column_boolean_check() const {
-    if (const auto* col_nullable = check_and_get_column<ColumnNullable>(*this)) {
+    if (const auto col_nullable = check_and_get_column<ColumnNullable>(*this)) {
         // for column nullable, we need to skip null values check
         const auto& nested_col = col_nullable->get_nested_column();
         const auto& null_map = col_nullable->get_null_map_data();
@@ -81,7 +81,7 @@ bool IColumn::column_boolean_check() const {
     }
 
     auto check_boolean_is_zero_or_one = [&](const IColumn& subcolumn) {
-        if (const auto* column_boolean = check_and_get_column<ColumnBool>(subcolumn)) {
+        if (const auto column_boolean = check_and_get_column<ColumnBool>(subcolumn)) {
             for (size_t i = 0; i < column_boolean->size(); ++i) {
                 auto val = column_boolean->get_element(i);
                 if (val != 0 && val != 1) {

--- a/be/src/core/column/column.h
+++ b/be/src/core/column/column.h
@@ -39,6 +39,19 @@
 #include "exec/sort/hybrid_sorter.h"
 #include "storage/olap_common.h"
 
+#if defined(__clang__) && __has_attribute(consumable) && __has_attribute(callable_when) && \
+        __has_attribute(test_typestate) && __has_attribute(return_typestate)
+#define DORIS_CLANG_CONSUMABLE_UNKNOWN __attribute__((consumable(unknown)))
+#define DORIS_CLANG_CALLABLE_WHEN_UNCONSUMED __attribute__((callable_when("unconsumed")))
+#define DORIS_CLANG_TEST_UNCONSUMED __attribute__((test_typestate(unconsumed)))
+#define DORIS_CLANG_RETURN_UNKNOWN __attribute__((return_typestate(unknown)))
+#else
+#define DORIS_CLANG_CONSUMABLE_UNKNOWN
+#define DORIS_CLANG_CALLABLE_WHEN_UNCONSUMED
+#define DORIS_CLANG_TEST_UNCONSUMED
+#define DORIS_CLANG_RETURN_UNKNOWN
+#endif
+
 namespace doris {
 class SipHash;
 }
@@ -798,34 +811,71 @@ struct IsMutableColumns<> {
     static const bool value = true;
 };
 
+template <typename PointerType>
+class DORIS_CLANG_CONSUMABLE_UNKNOWN ColumnPtrGuard {
+public:
+    explicit ColumnPtrGuard(PointerType column) : _column(column) {}
+
+    explicit operator bool() const DORIS_CLANG_TEST_UNCONSUMED { return _column != nullptr; }
+
+    PointerType get() const DORIS_CLANG_CALLABLE_WHEN_UNCONSUMED { return _column; }
+
+    PointerType operator->() const DORIS_CLANG_CALLABLE_WHEN_UNCONSUMED { return _column; }
+
+private:
+    PointerType _column;
+};
+
 // prefer assert_cast than check_and_get
 template <typename Type>
-const Type* check_and_get_column(const IColumn& column) {
-    return typeid_cast<const Type*>(&column);
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<const Type*> check_and_get_column(const IColumn& column) {
+    return ColumnPtrGuard<const Type*>(typeid_cast<const Type*>(&column));
 }
 
 template <typename Type>
-Type* check_and_get_column(IColumn& column) {
-    return typeid_cast<Type*>(&column);
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<Type*> check_and_get_column(IColumn& column) {
+    return ColumnPtrGuard<Type*>(typeid_cast<Type*>(&column));
 }
 
 template <typename Type>
-const Type* check_and_get_column(const IColumn* column) {
-    return typeid_cast<const Type*>(column);
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<const Type*> check_and_get_column(const IColumn* column) {
+    return ColumnPtrGuard<const Type*>(typeid_cast<const Type*>(column));
 }
 
 template <typename Type>
-Type* check_and_get_column(IColumn* column) {
-    return typeid_cast<Type*>(column);
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<Type*> check_and_get_column(IColumn* column) {
+    return ColumnPtrGuard<Type*>(typeid_cast<Type*>(column));
 }
 
 template <typename Type>
 bool is_column(const IColumn& column) {
-    return check_and_get_column<Type>(&column);
+    return static_cast<bool>(check_and_get_column<Type>(&column));
 }
 
 template <typename Type>
 bool is_column(const IColumn* column) {
+    return static_cast<bool>(check_and_get_column<Type>(column));
+}
+
+template <typename Type>
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<const Type*> check_and_get_column_guard(
+        const IColumn& column) {
+    return check_and_get_column<Type>(column);
+}
+
+template <typename Type>
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<Type*> check_and_get_column_guard(IColumn& column) {
+    return check_and_get_column<Type>(column);
+}
+
+template <typename Type>
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<const Type*> check_and_get_column_guard(
+        const IColumn* column) {
+    return check_and_get_column<Type>(column);
+}
+
+template <typename Type>
+DORIS_CLANG_RETURN_UNKNOWN ColumnPtrGuard<Type*> check_and_get_column_guard(IColumn* column) {
     return check_and_get_column<Type>(column);
 }
 
@@ -833,11 +883,11 @@ bool is_column(const IColumn* column) {
 // which will hold ownership. This prevents the occurrence of dangling pointers due to certain situations.
 template <typename ColumnType>
 ColumnType::Ptr check_and_get_column_ptr(const ColumnPtr& column) {
-    const ColumnType* raw_type_ptr = check_and_get_column<ColumnType>(column.get());
-    if (raw_type_ptr == nullptr) {
+    const auto raw_type_ptr = check_and_get_column<ColumnType>(column.get());
+    if (!raw_type_ptr) {
         return nullptr;
     }
-    return ColumnType::cast_to_column_ptr(raw_type_ptr);
+    return ColumnType::cast_to_column_ptr(raw_type_ptr.get());
 }
 
 template <typename ColumnType>

--- a/be/src/core/column/column_array.cpp
+++ b/be/src/core/column/column_array.cpp
@@ -877,7 +877,7 @@ ColumnPtr ColumnArray::filter(const Filter& filt, ssize_t result_size_hint) cons
         return ColumnArray::create(data);
     }
 
-    if (const auto* nullable_data_column = check_and_get_column<ColumnNullable>(*data)) {
+    if (auto nullable_data_column = check_and_get_column_guard<ColumnNullable>(*data)) {
         auto res_null_map = ColumnUInt8::create();
         // filter null map
         filter_arrays_impl_only_data(nullable_data_column->get_null_map_data(), get_offsets(),

--- a/be/src/core/column/column_array.h
+++ b/be/src/core/column/column_array.h
@@ -243,7 +243,7 @@ public:
     }
 
     size_t get_number_of_dimensions() const {
-        const auto* nested_array = check_and_get_column<ColumnArray>(*data);
+        const auto nested_array = check_and_get_column<ColumnArray>(*data);
         if (!nested_array) {
             return 1;
         }

--- a/be/src/core/column/column_array_view.h
+++ b/be/src/core/column/column_array_view.h
@@ -69,7 +69,7 @@ struct ColumnArrayView {
         // Step 2: unpack outer nullable
         const NullMap* outer_null_map = nullptr;
         const IColumn* array_raw = nullptr;
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(unpacked.get())) {
+        if (const auto nullable = check_and_get_column<ColumnNullable>(unpacked.get())) {
             outer_null_map = &nullable->get_null_map_data();
             array_raw = nullable->get_nested_column_ptr().get();
         } else {

--- a/be/src/core/column/column_const.h
+++ b/be/src/core/column/column_const.h
@@ -243,9 +243,8 @@ public:
         const auto& rhs_const_column =
                 assert_cast<const ColumnConst&, TypeCheckOnRelease::DISABLE>(rhs);
 
-        const auto* this_nullable = check_and_get_column<ColumnNullable>(data.get());
-        const auto* rhs_nullable =
-                check_and_get_column<ColumnNullable>(rhs_const_column.data.get());
+        const auto this_nullable = check_and_get_column<ColumnNullable>(data.get());
+        const auto rhs_nullable = check_and_get_column<ColumnNullable>(rhs_const_column.data.get());
         if (this_nullable && rhs_nullable) {
             return data->compare_at(0, 0, *rhs_const_column.data, nan_direction_hint);
         } else if (this_nullable) {
@@ -336,10 +335,18 @@ public:
 // so it is necessary to make a special judgment of ColumnConst.
 template <typename Type>
 const Type* check_and_get_column_with_const(const IColumn& column) {
-    if (const auto* col_const = check_and_get_column<ColumnConst>(&column)) {
-        return check_and_get_column<Type>(col_const->get_data_column());
+    if (const auto col_const = check_and_get_column<ColumnConst>(&column)) {
+        const auto nested_col = check_and_get_column<Type>(col_const->get_data_column());
+        if (nested_col) {
+            return nested_col.get();
+        }
+        return nullptr;
     }
-    return check_and_get_column<Type>(column);
+    const auto col = check_and_get_column<Type>(column);
+    if (col) {
+        return col.get();
+    }
+    return nullptr;
 }
 
 } // namespace doris

--- a/be/src/core/column/column_execute_util.h
+++ b/be/src/core/column/column_execute_util.h
@@ -98,7 +98,7 @@ struct ColumnView {
         const auto& [from_data_column, is_const] = unpack_if_const(column_ptr);
         const NullMap* null_map = nullptr;
         const IColumn* data = nullptr;
-        if (const auto* nullable_column =
+        if (const auto nullable_column =
                     check_and_get_column<ColumnNullable>(from_data_column.get())) {
             null_map = &nullable_column->get_null_map_data();
             data = nullable_column->get_nested_column_ptr().get();

--- a/be/src/core/column/column_map.cpp
+++ b/be/src/core/column/column_map.cpp
@@ -44,12 +44,12 @@ namespace doris {
 namespace {
 
 const ColumnMap::COffsets& check_map_offsets_column(const IColumn& offsets_column) {
-    const auto* offsets_concrete = check_and_get_column<ColumnMap::COffsets>(offsets_column);
+    const auto offsets_concrete = check_and_get_column<ColumnMap::COffsets>(offsets_column);
     if (!offsets_concrete) {
         throw doris::Exception(ErrorCode::INTERNAL_ERROR, "offsets_column must be a ColumnUInt64");
         __builtin_unreachable();
     }
-    return *offsets_concrete;
+    return *offsets_concrete.get();
 }
 
 void validate_map_columns(const IColumn& keys, const IColumn& values, const IColumn& offsets) {
@@ -599,7 +599,7 @@ Status ColumnMap::deduplicate_keys(bool recursive) {
 
     if (recursive) {
         const auto& values_ptr = static_cast<const IColumn::Ptr&>(values_column);
-        if (const auto* nullable_values = check_and_get_column<ColumnNullable>(values_ptr.get())) {
+        if (const auto nullable_values = check_and_get_column<ColumnNullable>(values_ptr.get())) {
             if (check_and_get_column<ColumnMap>(nullable_values->get_nested_column_ptr().get())) {
                 auto values_mut =
                         IColumn::mutate(std::move(static_cast<IColumn::Ptr&>(values_column)));

--- a/be/src/core/column/column_nullable.cpp
+++ b/be/src/core/column/column_nullable.cpp
@@ -31,14 +31,14 @@ namespace doris {
 namespace {
 
 const ColumnUInt8& check_nullable_null_map_column(const IColumn& null_map) {
-    const auto* concrete = check_and_get_column<ColumnUInt8>(null_map);
+    const auto concrete = check_and_get_column<ColumnUInt8>(null_map);
     if (!concrete) {
         throw doris::Exception(ErrorCode::INTERNAL_ERROR,
                                "ColumnNullable null map must be ColumnUInt8, but got {}",
                                null_map.get_name());
         __builtin_unreachable();
     }
-    return *concrete;
+    return *concrete.get();
 }
 
 ColumnUInt8::Ptr check_nullable_null_map_column_ptr(const ColumnPtr& null_map) {
@@ -92,7 +92,7 @@ ColumnNullable::ColumnNullable(MutableColumnPtr&& nested_column_,
 ColumnNullable::ColumnNullable(SharedTag, ColumnPtr nested_column_, ColumnPtr null_map_) {
     check_nullable_sizes(*nested_column_, *null_map_);
 
-    if (const auto* nullable_nested = check_and_get_column<ColumnNullable>(nested_column_.get())) {
+    if (const auto nullable_nested = check_and_get_column<ColumnNullable>(nested_column_.get())) {
         auto merged_null_map = null_map_->clone_empty();
         auto merged_null_map_ptr = assert_mutable_null_map(std::move(merged_null_map));
         merged_null_map_ptr->insert_range_from(*null_map_, 0, null_map_->size());

--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -311,8 +311,8 @@ static DataTypePtr create_array(PrimitiveType type, size_t num_dimensions) {
 static ColumnPtr recreate_column_with_default_values(const ColumnPtr& column,
                                                      PrimitiveType scalar_type,
                                                      size_t num_dimensions) {
-    const auto* column_array = check_and_get_column<ColumnArray>(remove_nullable(column).get());
-    if (column_array != nullptr && num_dimensions != 0) {
+    const auto column_array = check_and_get_column<ColumnArray>(remove_nullable(column).get());
+    if (column_array && num_dimensions != 0) {
         return make_nullable(ColumnArray::create(
                 recreate_column_with_default_values(column_array->get_data_ptr(), scalar_type,
                                                     num_dimensions - 1),
@@ -937,8 +937,11 @@ bool ColumnVariant::Subcolumn::is_null_at(size_t n) const {
     ind -= num_of_defaults_in_prefix;
     for (const auto& part : data) {
         if (ind < part->size()) {
-            const auto* nullable = check_and_get_column<ColumnNullable>(part.get());
-            return nullable ? nullable->is_null_at(ind) : false;
+            const auto nullable = check_and_get_column<ColumnNullable>(part.get());
+            if (nullable) {
+                return nullable->is_null_at(ind);
+            }
+            return false;
         }
         ind -= part->size();
     }
@@ -1413,7 +1416,7 @@ size_t ColumnVariant::Subcolumn::serialize_text_json(size_t n, BufferWritable& o
         if (ind < part.size()) {
             // special case when null flag is true, but the value is empty string in JSON type,
             // other wise will serialize to '\N'
-            const auto* nullable_col = check_and_get_column<ColumnNullable>(*data[i]);
+            const auto nullable_col = check_and_get_column<ColumnNullable>(*data[i]);
             if (nullable_col && nullable_col->is_null_at(ind)) {
                 output.write(EMPTY_JSON.data(), EMPTY_JSON.size());
                 return EMPTY_JSON.size();
@@ -2465,7 +2468,11 @@ DataTypePtr ColumnVariant::get_root_type() const {
 void ColumnVariant::insert_indices_from(const IColumn& src, const uint32_t* indices_begin,
                                         const uint32_t* indices_end) {
     // optimize when src and this column are scalar variant, since try_insert is inefficiency
-    const auto* src_v = check_and_get_column<ColumnVariant>(src);
+    const auto src_v_guard = check_and_get_column<ColumnVariant>(src);
+    const ColumnVariant* src_v = nullptr;
+    if (src_v_guard) {
+        src_v = src_v_guard.get();
+    }
 
     bool src_can_do_quick_insert =
             src_v != nullptr && src_v->is_scalar_variant() && src_v->is_finalized();

--- a/be/src/core/data_type/data_type.h
+++ b/be/src/core/data_type/data_type.h
@@ -97,7 +97,7 @@ protected:
     template <typename Type>
     Status check_column_non_nested_type(const IColumn& column) const {
         if (check_and_get_column_with_const<Type>(column) != nullptr ||
-            check_and_get_column<ColumnNothing>(column) != nullptr) {
+            check_and_get_column<ColumnNothing>(column)) {
             return Status::OK();
         }
         return Status::InternalError("Column type {} is not compatible with data type {}",

--- a/be/src/core/data_type_serde/data_type_map_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_map_serde.cpp
@@ -581,18 +581,20 @@ Status DataTypeMapSerDe::serialize_column_to_jsonb(const IColumn& from_column, i
     DCHECK(keys_column.is_nullable());
     DCHECK(values_column.is_nullable());
 
-    const auto* key_string_column = check_and_get_column<ColumnString>(
+    const auto key_string_column = check_and_get_column<ColumnString>(
             assert_cast<const ColumnNullable&>(keys_column).get_nested_column());
 
-    if (key_string_column == nullptr) {
+    const ColumnString* key_string_column_ptr = nullptr;
+    if (!key_string_column) {
         return Status::InternalError("Cast to Jsonb failed, map key is not string type");
     }
+    key_string_column_ptr = key_string_column.get();
 
     if (!writer.writeStartObject()) {
         return Status::InternalError("writeStartObject failed");
     }
     for (size_t i = offset; i < next_offset; ++i) {
-        auto key_str = key_string_column->get_data_at(i);
+        auto key_str = key_string_column_ptr->get_data_at(i);
         // check key size
         if (key_str.size > std::numeric_limits<uint8_t>::max()) {
             return Status::InternalError("key size exceeds max limit {} ", key_str.to_string());

--- a/be/src/exec/common/hash_table/hash_map_context.h
+++ b/be/src/exec/common/hash_table/hash_map_context.h
@@ -1024,7 +1024,7 @@ struct MethodKeysFixed : public MethodBase<TData> {
         bool has_nullable_key = false;
 
         for (const auto& col : key_columns) {
-            if (const auto* nullable_col = check_and_get_column<ColumnNullable>(col)) {
+            if (const auto nullable_col = check_and_get_column<ColumnNullable>(col)) {
                 actual_columns.push_back(&nullable_col->get_nested_column());
                 null_maps.push_back(&nullable_col->get_null_map_column());
                 has_nullable_key = true;

--- a/be/src/exec/common/join_utils.h
+++ b/be/src/exec/common/join_utils.h
@@ -35,12 +35,12 @@ namespace doris {
 // (or const IColumn* as fallback for unexpected types).
 template <typename Func>
 decltype(auto) asof_column_dispatch(const IColumn* col, Func&& func) {
-    if (const auto* c_dv2 = check_and_get_column<ColumnDateV2>(col)) {
-        return std::forward<Func>(func)(c_dv2);
-    } else if (const auto* c_dtv2 = check_and_get_column<ColumnDateTimeV2>(col)) {
-        return std::forward<Func>(func)(c_dtv2);
-    } else if (const auto* c_tstz = check_and_get_column<ColumnTimeStampTz>(col)) {
-        return std::forward<Func>(func)(c_tstz);
+    if (const auto c_dv2 = check_and_get_column<ColumnDateV2>(col)) {
+        return std::forward<Func>(func)(c_dv2.get());
+    } else if (const auto c_dtv2 = check_and_get_column<ColumnDateTimeV2>(col)) {
+        return std::forward<Func>(func)(c_dtv2.get());
+    } else if (const auto c_tstz = check_and_get_column<ColumnTimeStampTz>(col)) {
+        return std::forward<Func>(func)(c_tstz.get());
     } else {
         return std::forward<Func>(func)(col);
     }

--- a/be/src/exec/common/util.hpp
+++ b/be/src/exec/common/util.hpp
@@ -109,10 +109,11 @@ public:
             return &static_cast<const ColumnNullable&>(*col).get_null_map_data();
         }
         // Handle Const(Nullable) case
-        if (const auto* const_col = check_and_get_column<ColumnConst>(col.get());
-            const_col != nullptr && const_col->is_concrete_nullable()) {
-            return &static_cast<const ColumnNullable&>(const_col->get_data_column())
-                            .get_null_map_data();
+        if (const auto const_col = check_and_get_column<ColumnConst>(col.get()); const_col) {
+            if (const_col->is_concrete_nullable()) {
+                return &static_cast<const ColumnNullable&>(const_col->get_data_column())
+                                .get_null_map_data();
+            }
         }
         return nullptr;
     };

--- a/be/src/exec/common/variant_util.cpp
+++ b/be/src/exec/common/variant_util.cpp
@@ -312,7 +312,7 @@ size_t get_number_of_dimensions(const IDataType& type) {
     return 0;
 }
 size_t get_number_of_dimensions(const IColumn& column) {
-    if (const auto* column_array = check_and_get_column<ColumnArray>(column)) {
+    if (const auto column_array = check_and_get_column<ColumnArray>(column)) {
         return column_array->get_number_of_dimensions();
     }
     return 0;

--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -550,7 +550,7 @@ Status HashJoinBuildSinkLocalState::_extract_join_column(Block& block,
             _key_columns_holder.emplace_back(
                     make_nullable(block.get_by_position(res_col_ids[i]).column));
             raw_ptrs[i] = _key_columns_holder.back().get();
-        } else if (const auto* nullable = check_and_get_column<ColumnNullable>(*column);
+        } else if (const auto nullable = check_and_get_column<ColumnNullable>(*column);
                    !_parent->cast<HashJoinBuildSinkOperatorX>()._serialize_null_into_key[i] &&
                    nullable) {
             // update nulllmap and split nested out of ColumnNullable when serialize_null_into_key is false and column is nullable

--- a/be/src/exec/operator/hashjoin_probe_operator.cpp
+++ b/be/src/exec/operator/hashjoin_probe_operator.cpp
@@ -355,7 +355,7 @@ Status HashJoinProbeLocalState::_extract_join_column(Block& block,
             _key_columns_holder.emplace_back(
                     make_nullable(block.get_by_position(res_col_ids[i]).column));
             _probe_columns[i] = _key_columns_holder.back().get();
-        } else if (const auto* nullable = check_and_get_column<ColumnNullable>(*column);
+        } else if (const auto nullable = check_and_get_column<ColumnNullable>(*column);
                    nullable &&
                    !_parent->cast<HashJoinProbeOperatorX>()._serialize_null_into_key[i]) {
             // update nulllmap and split nested out of ColumnNullable when serialize_null_into_key is false and column is nullable

--- a/be/src/exec/operator/join/process_hash_table_probe_impl.h
+++ b/be/src/exec/operator/join/process_hash_table_probe_impl.h
@@ -442,8 +442,8 @@ uint32_t ProcessHashTableProbe<JoinOpType>::
                       },
                       [&](std::vector<AsofIndexGroup<uint64_t>>& groups) -> uint32_t {
                           // DateTimeV2 or TimestampTZ
-                          if (const auto* c = check_and_get_column<ColumnDateTimeV2>(probe_col)) {
-                              return probe_with_index(groups, c);
+                          if (const auto c = check_and_get_column<ColumnDateTimeV2>(probe_col)) {
+                              return probe_with_index(groups, c.get());
                           }
                           return probe_with_index(groups,
                                                   assert_cast<const ColumnTimeStampTz*>(probe_col));

--- a/be/src/exec/operator/materialization_opertor.cpp
+++ b/be/src/exec/operator/materialization_opertor.cpp
@@ -209,7 +209,7 @@ Status MaterializationSharedState::create_muiltget_result(const Columns& columns
         const ColumnString* column_rowid = nullptr;
         const auto& column = columns[i];
 
-        if (const auto* const column_ptr = check_and_get_column<ColumnNullable>(*column)) {
+        if (const auto column_ptr = check_and_get_column<ColumnNullable>(*column)) {
             null_map = column_ptr->get_null_map_data().data();
             column_rowid =
                     assert_cast<const ColumnString*>(column_ptr->get_nested_column_ptr().get());

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -513,7 +513,7 @@ Status OlapScanLocalState::_should_push_down_function_filter(VectorizedFnCall* f
             DCHECK(is_string_type(children[1 - i]->data_type()->get_primitive_type()));
             std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
             RETURN_IF_ERROR(children[1 - i]->get_const_col(expr_ctx, &const_col_wrapper));
-            if (const auto* const_column =
+            if (const auto const_column =
                         check_and_get_column<ColumnConst>(const_col_wrapper->column_ptr.get())) {
                 *constant_str = const_column->get_data_at(0);
             } else {

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -640,7 +640,7 @@ Status ScanLocalStateBase::_eval_const_conjuncts(VExprContext* expr_ctx, PushDow
     if (vexpr->is_constant()) {
         std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
         RETURN_IF_ERROR(vexpr->get_const_col(expr_ctx, &const_col_wrapper));
-        if (const auto* const_column =
+        if (const auto const_column =
                     check_and_get_column<ColumnConst>(const_col_wrapper->column_ptr.get())) {
             constant_val = const_column->get_data_at(0).data;
             if (constant_val == nullptr || !*reinterpret_cast<const bool*>(constant_val)) {
@@ -648,7 +648,7 @@ Status ScanLocalStateBase::_eval_const_conjuncts(VExprContext* expr_ctx, PushDow
                 _eos = true;
                 _scan_dependency->set_ready();
             }
-        } else if (const auto* bool_column =
+        } else if (const auto bool_column =
                            check_and_get_column<ColumnUInt8>(const_col_wrapper->column_ptr.get())) {
             // TODO: If `vexpr->is_constant()` is true, a const column is expected here.
             //  But now we still don't cover all predicates for const expression.

--- a/be/src/exec/operator/set_probe_sink_operator.cpp
+++ b/be/src/exec/operator/set_probe_sink_operator.cpp
@@ -149,7 +149,7 @@ Status SetProbeSinkOperatorX<is_intersect>::_extract_probe_column(
                 block.get_by_position(result_col_id).column->convert_to_full_column_if_const();
         const auto* column = block.get_by_position(result_col_id).column.get();
 
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(*column)) {
+        if (const auto nullable = check_and_get_column<ColumnNullable>(*column)) {
             if (!build_not_ignore_null[i]) {
                 return Status::InternalError(
                         "SET operator expects a nullable : {} column in column {}, but the "
@@ -158,7 +158,7 @@ Status SetProbeSinkOperatorX<is_intersect>::_extract_probe_column(
                         build_not_ignore_null[i], i,
                         nullable->get_nested_column_ptr()->is_nullable());
             }
-            raw_ptrs[i] = nullable;
+            raw_ptrs[i] = nullable.get();
         } else {
             if (build_not_ignore_null[i]) {
                 auto column_ptr = make_nullable(block.get_by_position(result_col_id).column, false);

--- a/be/src/exec/scan/scanner_scheduler.cpp
+++ b/be/src/exec/scan/scanner_scheduler.cpp
@@ -345,9 +345,8 @@ void ScannerScheduler::_make_sure_virtual_col_is_materialized(
     size_t idx = 0;
     for (const auto& entry : *free_block) {
         // Virtual column must be materialized on the end of SegmentIterator's next batch method.
-        const ColumnNothing* column_nothing =
-                check_and_get_column<ColumnNothing>(entry.column.get());
-        if (column_nothing == nullptr) {
+        const auto column_nothing = check_and_get_column<ColumnNothing>(entry.column.get());
+        if (!column_nothing) {
             idx++;
             continue;
         }

--- a/be/src/exec/sink/viceberg_delete_sink.cpp
+++ b/be/src/exec/sink/viceberg_delete_sink.cpp
@@ -289,15 +289,15 @@ Status VIcebergDeleteSink::_collect_position_deletes(
     const auto& row_id_col = block.get_by_position(row_id_col_idx);
     const IColumn* row_id_data = row_id_col.column.get();
     const IDataType* row_id_type = row_id_col.type.get();
-    const auto* nullable_col = check_and_get_column<ColumnNullable>(row_id_data);
-    if (nullable_col != nullptr) {
+    const auto nullable_col = check_and_get_column<ColumnNullable>(row_id_data);
+    if (nullable_col) {
         row_id_data = nullable_col->get_nested_column_ptr().get();
     }
     const auto* nullable_type = check_and_get_data_type<DataTypeNullable>(row_id_type);
     if (nullable_type != nullptr) {
         row_id_type = nullable_type->get_nested_type().get();
     }
-    const auto* struct_col = check_and_get_column<ColumnStruct>(row_id_data);
+    const auto struct_col = check_and_get_column<ColumnStruct>(row_id_data);
     const auto* struct_type = check_and_get_data_type<DataTypeStruct>(row_id_type);
     if (!struct_col || !struct_type) {
         return Status::InternalError("__DORIS_ICEBERG_ROWID_COL__ column is not a struct column");
@@ -346,9 +346,9 @@ Status VIcebergDeleteSink::_collect_position_deletes(
                 "__DORIS_ICEBERG_ROWID_COL__ must use standard field name partition_data");
     }
 
-    const auto* file_path_col = check_and_get_column<ColumnString>(
+    const auto file_path_col = check_and_get_column<ColumnString>(
             remove_nullable(struct_col->get_column_ptr(file_path_idx)).get());
-    const auto* row_position_col = check_and_get_column<ColumnVector<TYPE_BIGINT>>(
+    const auto row_position_col = check_and_get_column<ColumnVector<TYPE_BIGINT>>(
             remove_nullable(struct_col->get_column_ptr(row_position_idx)).get());
 
     if (!file_path_col || !row_position_col) {
@@ -359,16 +359,22 @@ Status VIcebergDeleteSink::_collect_position_deletes(
     const ColumnVector<TYPE_INT>* spec_id_col = nullptr;
     const ColumnString* partition_data_col = nullptr;
     if (spec_id_idx >= 0 && spec_id_idx < static_cast<int>(field_count)) {
-        spec_id_col = check_and_get_column<ColumnVector<TYPE_INT>>(
+        const auto spec_id_col_guard = check_and_get_column<ColumnVector<TYPE_INT>>(
                 remove_nullable(struct_col->get_column_ptr(spec_id_idx)).get());
+        if (spec_id_col_guard) {
+            spec_id_col = spec_id_col_guard.get();
+        }
         if (!spec_id_col) {
             return Status::InternalError(
                     "__DORIS_ICEBERG_ROWID_COL__ partition_spec_id has incorrect type");
         }
     }
     if (partition_data_idx >= 0 && partition_data_idx < static_cast<int>(field_count)) {
-        partition_data_col = check_and_get_column<ColumnString>(
+        const auto partition_data_col_guard = check_and_get_column<ColumnString>(
                 remove_nullable(struct_col->get_column_ptr(partition_data_idx)).get());
+        if (partition_data_col_guard) {
+            partition_data_col = partition_data_col_guard.get();
+        }
         if (!partition_data_col) {
             return Status::InternalError(
                     "__DORIS_ICEBERG_ROWID_COL__ partition_data has incorrect type");

--- a/be/src/exec/sink/vrow_distribution.cpp
+++ b/be/src/exec/sink/vrow_distribution.cpp
@@ -305,7 +305,7 @@ Status VRowDistribution::_filter_block_by_skip_and_where_clause(
     auto& row_ids = row_part_tablet_id.row_ids;
     auto& partition_ids = row_part_tablet_id.partition_ids;
     auto& tablet_ids = row_part_tablet_id.tablet_ids;
-    if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
+    if (const auto nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
         auto rows = block->rows();
         // row count of a block should not exceed UINT32_MAX
         auto rows_uint32 = cast_set<uint32_t>(rows);
@@ -316,7 +316,7 @@ Status VRowDistribution::_filter_block_by_skip_and_where_clause(
                 tablet_ids.emplace_back(_tablet_ids[i]);
             }
         }
-    } else if (const auto* const_column = check_and_get_column<ColumnConst>(*filter_column)) {
+    } else if (const auto const_column = check_and_get_column<ColumnConst>(*filter_column)) {
         bool ret = const_column->get_bool(0);
         if (!ret) {
             return Status::OK();

--- a/be/src/exec/sink/vtablet_block_convertor.cpp
+++ b/be/src/exec/sink/vtablet_block_convertor.cpp
@@ -211,10 +211,13 @@ Status OlapTableBlockConvertor::_internal_validate_column(RuntimeState* state, B
         return ret;
     };
 
-    const auto* column_ptr = check_and_get_column<ColumnNullable>(*column);
-    const auto& real_column_ptr =
-            column_ptr == nullptr ? column : (column_ptr->get_nested_column_ptr());
-    const auto* null_map = column_ptr == nullptr ? nullptr : column_ptr->get_null_map_data().data();
+    const auto column_ptr = check_and_get_column<ColumnNullable>(*column);
+    ColumnPtr real_column_ptr = column;
+    const auto* null_map = static_cast<const unsigned char*>(nullptr);
+    if (column_ptr) {
+        real_column_ptr = column_ptr->get_nested_column_ptr();
+        null_map = column_ptr->get_null_map_data().data();
+    }
     auto need_to_validate = [](size_t j, size_t row, const std::vector<char>& filter_map,
                                const unsigned char* null_map) {
         return !filter_map[row] && (null_map == nullptr || null_map[j] == 0);
@@ -238,12 +241,16 @@ Status OlapTableBlockConvertor::_internal_validate_column(RuntimeState* state, B
             }
         }
 
-        auto tmp_column_ptr = check_and_get_column<ColumnNullable>(*orig_column);
-        auto tmp_real_column_ptr =
-                tmp_column_ptr == nullptr ? orig_column : (tmp_column_ptr->get_nested_column_ptr());
+        const auto tmp_column_ptr = check_and_get_column<ColumnNullable>(*orig_column);
+        ColumnPtr tmp_real_column_ptr = orig_column;
+        const auto* null_map = static_cast<const unsigned char*>(nullptr);
+        ColumnPtr tmp_null_map_column_ptr = nullptr;
+        if (tmp_column_ptr) {
+            tmp_real_column_ptr = tmp_column_ptr->get_nested_column_ptr();
+            null_map = tmp_column_ptr->get_null_map_data().data();
+            tmp_null_map_column_ptr = tmp_column_ptr->get_null_map_column_ptr();
+        }
         const auto* column_string = assert_cast<const ColumnString*>(tmp_real_column_ptr.get());
-        const auto* null_map =
-                tmp_column_ptr == nullptr ? nullptr : tmp_column_ptr->get_null_map_data().data();
 
         const auto* __restrict offsets = column_string->get_offsets().data();
         int invalid_count = 0;
@@ -284,19 +291,20 @@ Status OlapTableBlockConvertor::_internal_validate_column(RuntimeState* state, B
                 auto result_column =
                         IColumn::mutate(std::move(tmp_block.get_by_position(3).column));
                 if (orig_column->is_nullable()) {
-                    orig_column = ColumnNullable::create(
-                            std::move(result_column),
-                            IColumn::mutate(tmp_column_ptr->get_null_map_column_ptr()));
+                    orig_column = ColumnNullable::create(std::move(result_column),
+                                                         IColumn::mutate(tmp_null_map_column_ptr));
                 } else {
                     orig_column = std::move(result_column);
                 }
-                tmp_column_ptr = check_and_get_column<ColumnNullable>(*orig_column);
-                tmp_real_column_ptr = tmp_column_ptr == nullptr
-                                              ? orig_column
-                                              : tmp_column_ptr->get_nested_column_ptr();
+                const auto refreshed_column_ptr =
+                        check_and_get_column<ColumnNullable>(*orig_column);
+                tmp_real_column_ptr = orig_column;
+                null_map = nullptr;
+                if (refreshed_column_ptr) {
+                    tmp_real_column_ptr = refreshed_column_ptr->get_nested_column_ptr();
+                    null_map = refreshed_column_ptr->get_null_map_data().data();
+                }
                 column_string = assert_cast<const ColumnString*>(tmp_real_column_ptr.get());
-                null_map = tmp_column_ptr == nullptr ? nullptr
-                                                     : tmp_column_ptr->get_null_map_data().data();
             }
             for (size_t j = 0; j < row_count; ++j) {
                 auto row = rows ? (*rows)[j] : j;
@@ -554,7 +562,7 @@ Status OlapTableBlockConvertor::_internal_validate_column(RuntimeState* state, B
         break;
     }
     case TYPE_AGG_STATE: {
-        auto* column_string = check_and_get_column<ColumnString>(*real_column_ptr);
+        auto column_string = check_and_get_column<ColumnString>(*real_column_ptr);
         if (column_string) {
             RETURN_IF_ERROR(string_column_checker(column, type, rows, _filter_map));
         }
@@ -634,7 +642,7 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(Block* block, size_t rows) {
     ColumnInt64::Container& dst_values = dst_column->get_data();
 
     ColumnPtr src_column_ptr = block->get_by_position(idx).column;
-    if (const auto* const_column = check_and_get_column<ColumnConst>(src_column_ptr.get())) {
+    if (const auto const_column = check_and_get_column<ColumnConst>(src_column_ptr.get())) {
         // for insert stmt like "insert into tbl1 select null,col1,col2,... from tbl2" or
         // "insert into tbl1 select 1,col1,col2,... from tbl2", the type of literal's column
         // will be `ColumnConst`
@@ -657,7 +665,7 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(Block* block, size_t rows) {
             int64_t value = const_column->get_int(0);
             dst_values.resize_fill(rows, value);
         }
-    } else if (const auto* src_nullable_column =
+    } else if (const auto src_nullable_column =
                        check_and_get_column<ColumnNullable>(src_column_ptr.get())) {
         auto src_nested_column_ptr = src_nullable_column->get_nested_column_ptr();
         const auto& null_map_data = src_nullable_column->get_null_map_data();

--- a/be/src/exec/sink/writer/iceberg/partition_transformers.h
+++ b/be/src/exec/sink/writer/iceberg/partition_transformers.h
@@ -153,7 +153,7 @@ public:
         ColumnPtr string_column_ptr;
         ColumnPtr null_map_column_ptr;
         bool is_nullable = false;
-        if (const auto* nullable_column =
+        if (const auto nullable_column =
                     check_and_get_column<ColumnNullable>(column_with_type_and_name.column.get())) {
             null_map_column_ptr = nullable_column->get_null_map_column_ptr();
             string_column_ptr = nullable_column->get_nested_column_ptr();
@@ -328,7 +328,7 @@ public:
         ColumnPtr column_ptr;
         ColumnPtr null_map_column_ptr;
         bool is_nullable = false;
-        if (const auto* nullable_column =
+        if (const auto nullable_column =
                     check_and_get_column<ColumnNullable>(column_with_type_and_name.column.get())) {
             null_map_column_ptr = nullable_column->get_null_map_column_ptr();
             column_ptr = nullable_column->get_nested_column_ptr();
@@ -1281,7 +1281,7 @@ public:
 
         ColumnPtr column_ptr;
         ColumnPtr null_map_column_ptr;
-        if (auto* nullable_column =
+        if (auto nullable_column =
                     check_and_get_column<ColumnNullable>(column_with_type_and_name.column.get())) {
             null_map_column_ptr = nullable_column->get_null_map_column_ptr();
             column_ptr = nullable_column->get_nested_column_ptr();

--- a/be/src/exec/sink/writer/vhive_table_writer.cpp
+++ b/be/src/exec/sink/writer/vhive_table_writer.cpp
@@ -435,7 +435,7 @@ std::string VHiveTableWriter::_to_partition_value(const DataTypePtr& type_desc,
                                                   const ColumnWithTypeAndName& partition_column,
                                                   int position) {
     ColumnPtr column;
-    if (auto* nullable_column = check_and_get_column<ColumnNullable>(*partition_column.column)) {
+    if (auto nullable_column = check_and_get_column<ColumnNullable>(*partition_column.column)) {
         auto* __restrict null_map_data = nullable_column->get_null_map_data().data();
         if (null_map_data[position]) {
             return "__HIVE_DEFAULT_PARTITION__";

--- a/be/src/exprs/aggregate/aggregate_function_count_by_enum.h
+++ b/be/src/exprs/aggregate/aggregate_function_count_by_enum.h
@@ -196,17 +196,20 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, ssize_t row_num,
              Arena&) const override {
         for (int i = 0; i < arg_count; i++) {
-            const auto* nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
-            if (nullable_column == nullptr) {
+            const auto nullable_column = check_and_get_column<ColumnNullable>(columns[i]);
+            if (!nullable_column) {
                 this->data(place).add(
                         i, static_cast<const ColumnString&>(*columns[i]).get_data_at(row_num));
-            } else if (nullable_column->is_null_at(row_num)) {
-                // TODO create a null vector
-                this->data(place).add(i);
             } else {
-                this->data(place).add(
-                        i, static_cast<const ColumnString&>(nullable_column->get_nested_column())
-                                   .get_data_at(row_num));
+                const auto* nullable_column_ptr = nullable_column.get();
+                if (nullable_column_ptr->is_null_at(row_num)) {
+                    // TODO create a null vector
+                    this->data(place).add(i);
+                } else {
+                    this->data(place).add(i, static_cast<const ColumnString&>(
+                                                     nullable_column_ptr->get_nested_column())
+                                                     .get_data_at(row_num));
+                }
             }
         }
     }

--- a/be/src/exprs/function/ai/ai_functions.cpp
+++ b/be/src/exprs/function/ai/ai_functions.cpp
@@ -41,15 +41,17 @@ Status FunctionAIClassify::build_prompt(const Block& block, const ColumnNumbers&
     const ColumnWithTypeAndName& labels_column = block.get_by_position(arguments[2]);
     const auto& [array_column, array_row_num] =
             check_column_const_set_readability(*labels_column.column, row_num);
-    const auto* col_array = check_and_get_column<ColumnArray>(*array_column);
-    if (col_array == nullptr) {
+    const ColumnArray* col_array_ptr = nullptr;
+    if (const auto col_array = check_and_get_column<ColumnArray>(*array_column)) {
+        col_array_ptr = col_array.get();
+    } else {
         return Status::InternalError(
                 "labels argument for {} must be Array(String) or Array(Varchar)", name);
     }
 
     std::vector<std::string> label_values;
-    const auto& data = col_array->get_data();
-    const auto& offsets = col_array->get_offsets();
+    const auto& data = col_array_ptr->get_data();
+    const auto& offsets = col_array_ptr->get_offsets();
     size_t start = array_row_num > 0 ? offsets[array_row_num - 1] : 0;
     size_t end = offsets[array_row_num];
     for (size_t i = start; i < end; ++i) {
@@ -83,15 +85,17 @@ Status FunctionAIExtract::build_prompt(const Block& block, const ColumnNumbers& 
     const ColumnWithTypeAndName& labels_column = block.get_by_position(arguments[2]);
     const auto& [array_column, array_row_num] =
             check_column_const_set_readability(*labels_column.column, row_num);
-    const auto* col_array = check_and_get_column<ColumnArray>(*array_column);
-    if (col_array == nullptr) {
+    const ColumnArray* col_array_ptr = nullptr;
+    if (const auto col_array = check_and_get_column<ColumnArray>(*array_column)) {
+        col_array_ptr = col_array.get();
+    } else {
         return Status::InternalError(
                 "labels argument for {} must be Array(String) or Array(Varchar)", name);
     }
 
     std::vector<std::string> label_values;
-    const auto& offsets = col_array->get_offsets();
-    const auto& data = col_array->get_data();
+    const auto& offsets = col_array_ptr->get_offsets();
+    const auto& data = col_array_ptr->get_data();
     size_t start = array_row_num > 0 ? offsets[array_row_num - 1] : 0;
     size_t end = offsets[array_row_num];
     for (size_t i = start; i < end; ++i) {
@@ -134,15 +138,17 @@ Status FunctionAIMask::build_prompt(const Block& block, const ColumnNumbers& arg
     const ColumnWithTypeAndName& labels_column = block.get_by_position(arguments[2]);
     const auto& [array_column, array_row_num] =
             check_column_const_set_readability(*labels_column.column, row_num);
-    const auto* col_array = check_and_get_column<ColumnArray>(*array_column);
-    if (col_array == nullptr) {
+    const ColumnArray* col_array_ptr = nullptr;
+    if (const auto col_array = check_and_get_column<ColumnArray>(*array_column)) {
+        col_array_ptr = col_array.get();
+    } else {
         return Status::InternalError(
                 "labels argument for {} must be Array(String) or Array(Varchar)", name);
     }
 
     std::vector<std::string> label_values;
-    const auto& offsets = col_array->get_offsets();
-    const auto& data = col_array->get_data();
+    const auto& offsets = col_array_ptr->get_offsets();
+    const auto& data = col_array_ptr->get_data();
     size_t start = array_row_num > 0 ? offsets[array_row_num - 1] : 0;
     size_t end = offsets[array_row_num];
     for (size_t i = start; i < end; ++i) {

--- a/be/src/exprs/function/array/function_array_aggregation.cpp
+++ b/be/src/exprs/function/array/function_array_aggregation.cpp
@@ -205,11 +205,19 @@ struct ArrayAggregateImpl {
         using Function =
                 ArrayAggregateFunctionCreator<operation, AggregateFunctionTraits<operation>>;
 
-        const ColumnType* column =
-                data->is_nullable()
-                        ? check_and_get_column<ColumnType>(
-                                  static_cast<const ColumnNullable*>(data)->get_nested_column())
-                        : check_and_get_column<ColumnType>(&*data);
+        const ColumnType* column = nullptr;
+        if (data->is_nullable()) {
+            const auto column_guard = check_and_get_column<ColumnType>(
+                    static_cast<const ColumnNullable*>(data)->get_nested_column());
+            if (column_guard) {
+                column = column_guard.get();
+            }
+        } else {
+            const auto column_guard = check_and_get_column<ColumnType>(&*data);
+            if (column_guard) {
+                column = column_guard.get();
+            }
+        }
         if (!column) {
             return false;
         }
@@ -429,11 +437,19 @@ struct ArrayAggregateImplDecimalV3<operation, ResultType> {
         using Function = ArrayAggregateFunctionCreatorWithResultType<
                 AggregateFunctionTraitsWithResultType<operation>>;
 
-        const ColumnType* column =
-                data->is_nullable()
-                        ? check_and_get_column<ColumnType>(
-                                  static_cast<const ColumnNullable*>(data)->get_nested_column())
-                        : check_and_get_column<ColumnType>(&*data);
+        const ColumnType* column = nullptr;
+        if (data->is_nullable()) {
+            const auto column_guard = check_and_get_column<ColumnType>(
+                    static_cast<const ColumnNullable*>(data)->get_nested_column());
+            if (column_guard) {
+                column = column_guard.get();
+            }
+        } else {
+            const auto column_guard = check_and_get_column<ColumnType>(&*data);
+            if (column_guard) {
+                column = column_guard.get();
+            }
+        }
         if (!column) {
             return false;
         }

--- a/be/src/exprs/function/array/function_array_enumerate.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate.cpp
@@ -81,7 +81,7 @@ public:
                         uint32_t result, size_t input_rows_count) const override {
         auto left_column =
                 block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-        const ColumnArray* array =
+        const auto array =
                 check_and_get_column<ColumnArray>(remove_nullable(left_column->get_ptr()).get());
         if (!array) {
             return Status::RuntimeError(

--- a/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
+++ b/be/src/exprs/function/array/function_array_enumerate_uniq.cpp
@@ -127,7 +127,7 @@ public:
             src_columns.emplace_back(
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const());
             ColumnPtr& cur_column = src_columns[i];
-            const ColumnArray* array =
+            const auto array =
                     check_and_get_column<ColumnArray>(remove_nullable(cur_column->get_ptr()).get());
             if (!array) {
                 return Status::RuntimeError(
@@ -137,7 +137,7 @@ public:
 
             const ColumnArray::Offsets64& cur_offsets = array->get_offsets();
             if (i == 0) {
-                first_column_array = array;
+                first_column_array = array.get();
                 offsets = &cur_offsets;
                 src_offsets = array->get_offsets_ptr();
             } else if (*offsets != cur_offsets) {

--- a/be/src/exprs/function/array/function_array_sort.h
+++ b/be/src/exprs/function/array/function_array_sort.h
@@ -66,14 +66,14 @@ public:
                         uint32_t result, size_t input_rows_count) const override {
         ColumnPtr src_column =
                 block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-        const auto& src_column_array = check_and_get_column<ColumnArray>(*src_column);
+        const auto src_column_array = check_and_get_column<ColumnArray>(*src_column);
         if (!src_column_array) {
             return Status::RuntimeError(
                     fmt::format("unsupported types for function {}({})", get_name(),
                                 block.get_by_position(arguments[0]).type->get_name()));
         }
 
-        auto dest_column_ptr = _execute(*src_column_array);
+        auto dest_column_ptr = _execute(*src_column_array.get());
 
         block.replace_by_position(result, std::move(dest_column_ptr));
         return Status::OK();

--- a/be/src/exprs/function/array/function_array_sortby.cpp
+++ b/be/src/exprs/function/array/function_array_sortby.cpp
@@ -70,7 +70,7 @@ public:
         for (int i = 0; i < 2; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
+            if (auto nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
                 argument_nullmap[i] = nullable->get_null_map_column_ptr();
                 argument_columns[i] = nullable->get_nested_column_ptr();
             }

--- a/be/src/exprs/function/array/function_array_utils.cpp
+++ b/be/src/exprs/function/array/function_array_utils.cpp
@@ -41,10 +41,11 @@ bool extract_column_array_info(const IColumn& src, ColumnArrayExecutionData& dat
     }
 
     // check and get array column
-    data.array_col = check_and_get_column<ColumnArray>(array_col);
-    if (!data.array_col) {
+    const auto array_col_guard = check_and_get_column<ColumnArray>(array_col);
+    if (!array_col_guard) {
         return false;
     }
+    data.array_col = array_col_guard.get();
 
     // extract array offsets and nested column
     data.offsets_ptr = &data.array_col->get_offsets();

--- a/be/src/exprs/function/array/function_array_zip.cpp
+++ b/be/src/exprs/function/array/function_array_zip.cpp
@@ -102,7 +102,7 @@ public:
             auto col = block.get_by_position(arguments[i]).column;
             col = col->convert_to_full_column_if_const();
 
-            const auto* column_array = check_and_get_column<ColumnArray>(col.get());
+            const auto column_array = check_and_get_column<ColumnArray>(col.get());
             if (!column_array) {
                 return Status::RuntimeError(fmt::format(
                         "execute failed, function {}'s {}-th argument should be array bet get {}",

--- a/be/src/exprs/function/cast/cast_base.cpp
+++ b/be/src/exprs/function/cast/cast_base.cpp
@@ -85,7 +85,7 @@ Status cast_from_string_to_generic(FunctionContext* context, Block& block,
     // result column must set type
     DCHECK(block.get_by_position(result).type != nullptr);
     auto data_type_to = block.get_by_position(result).type;
-    if (const auto* col_from_string = check_and_get_column<ColumnString>(&col_from)) {
+    if (const auto col_from_string = check_and_get_column<ColumnString>(&col_from)) {
         auto col_to = data_type_to->create_column();
         auto serde = data_type_to->get_serde();
         size_t size = col_from.size();

--- a/be/src/exprs/function/cast/cast_to_array.h
+++ b/be/src/exprs/function/cast/cast_to_array.h
@@ -63,7 +63,7 @@ WrapperType create_array_wrapper(FunctionContext* context, const DataTypePtr& fr
                    const NullMap::value_type* null_map = nullptr) -> Status {
         ColumnPtr from_column = block.get_by_position(arguments.front()).column;
 
-        const auto* from_col_array = check_and_get_column<ColumnArray>(from_column.get());
+        const auto from_col_array = check_and_get_column<ColumnArray>(from_column.get());
 
         if (from_col_array) {
             /// create columns for converting nested column containing original and result columns

--- a/be/src/exprs/function/cast/cast_to_basic_number_common.h
+++ b/be/src/exprs/function/cast/cast_to_basic_number_common.h
@@ -372,7 +372,7 @@ template <typename FromDataType, typename ToDataType>
 Status static_cast_no_overflow(FunctionContext* context, Block& block,
                                const ColumnNumbers& arguments, uint32_t result,
                                size_t input_rows_count) {
-    const auto* col_from = check_and_get_column<typename FromDataType::ColumnType>(
+    const auto col_from = check_and_get_column<typename FromDataType::ColumnType>(
             block.get_by_position(arguments[0]).column.get());
     if (!col_from) {
         return Status::InternalError(fmt::format(

--- a/be/src/exprs/function/cast/cast_to_decimal.h
+++ b/be/src/exprs/function/cast/cast_to_decimal.h
@@ -724,7 +724,7 @@ public:
         using FromFieldType = typename FromDataType::FieldType;
         using ToFieldType = typename ToDataType::FieldType;
         const ColumnWithTypeAndName& named_from = block.get_by_position(arguments[0]);
-        const auto* col_from =
+        const auto col_from =
                 check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
         if (!col_from) {
             return Status::RuntimeError("Illegal column {} of first argument of function cast",
@@ -820,7 +820,7 @@ public:
         using FromFieldType = typename FromDataType::FieldType;
         using ToFieldType = typename ToDataType::FieldType;
         const ColumnWithTypeAndName& named_from = block.get_by_position(arguments[0]);
-        const auto* col_from =
+        const auto col_from =
                 check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
         if (!col_from) {
             return Status::RuntimeError("Illegal column {} of first argument of function cast",
@@ -908,7 +908,7 @@ public:
         using FromFieldType = typename FromDataType::FieldType;
         using ToFieldType = typename ToDataType::FieldType;
         const ColumnWithTypeAndName& named_from = block.get_by_position(arguments[0]);
-        const auto* col_from =
+        const auto col_from =
                 check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
         if (!col_from) {
             return Status::RuntimeError("Illegal column {} of first argument of function cast",
@@ -1018,7 +1018,7 @@ public:
         using FromFieldType = typename FromDataType::FieldType;
         using ToFieldType = typename ToDataType::FieldType;
         const ColumnWithTypeAndName& named_from = block.get_by_position(arguments[0]);
-        const auto* col_from =
+        const auto col_from =
                 check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
         if (!col_from) {
             return Status::RuntimeError("Illegal column {} of first argument of function cast",

--- a/be/src/exprs/function/cast/cast_to_float.h
+++ b/be/src/exprs/function/cast/cast_to_float.h
@@ -47,7 +47,7 @@ public:
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
         const ColumnWithTypeAndName& named_from = block.get_by_position(arguments[0]);
-        const auto* col_from =
+        const auto col_from =
                 check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
         if (!col_from) {
             return Status::InternalError(fmt::format("Column type mismatch: expected {}, got {}",

--- a/be/src/exprs/function/cast/cast_to_int.h
+++ b/be/src/exprs/function/cast/cast_to_int.h
@@ -55,7 +55,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count,
                         const NullMap::value_type* null_map = nullptr) const override {
-        const auto* col_from = check_and_get_column<typename FromDataType::ColumnType>(
+        const auto col_from = check_and_get_column<typename FromDataType::ColumnType>(
                 block.get_by_position(arguments[0]).column.get());
         if (!col_from) {
             return Status::InternalError(
@@ -143,7 +143,7 @@ public:
         using ToFieldType = typename ToDataType::FieldType;
 
         const ColumnWithTypeAndName& named_from = block.get_by_position(arguments[0]);
-        const auto* col_from =
+        const auto col_from =
                 check_and_get_column<typename FromDataType::ColumnType>(named_from.column.get());
         if (!col_from) {
             return Status::InternalError(fmt::format("Column type mismatch: expected {}, got {}",

--- a/be/src/exprs/function/cast/cast_to_jsonb.h
+++ b/be/src/exprs/function/cast/cast_to_jsonb.h
@@ -43,7 +43,7 @@ struct ConvertImplGenericFromJsonb {
 
         const auto& col_with_type_and_name = block.get_by_position(arguments[0]);
         const IColumn& col_from = *col_with_type_and_name.column;
-        if (const ColumnString* col_from_string = check_and_get_column<ColumnString>(&col_from)) {
+        if (const auto col_from_string = check_and_get_column<ColumnString>(&col_from)) {
             auto col_to = data_type_to->create_column();
 
             size_t size = col_from.size();

--- a/be/src/exprs/function/cast/cast_to_map.h
+++ b/be/src/exprs/function/cast/cast_to_map.h
@@ -26,9 +26,9 @@ inline Status deduplicate_map_keys_in_result(Block& block, uint32_t result) {
     auto result_column_name = block.get_by_position(result).column->get_name();
     auto mutable_result_column = IColumn::mutate(std::move(block.get_by_position(result).column));
 
-    if (auto* nullable_column = check_and_get_column<ColumnNullable>(*mutable_result_column)) {
+    if (const auto nullable_column = check_and_get_column<ColumnNullable>(*mutable_result_column)) {
         auto nested_column = IColumn::mutate(nullable_column->get_nested_column_ptr());
-        auto* map_column = check_and_get_column<ColumnMap>(*nested_column);
+        const auto map_column = check_and_get_column<ColumnMap>(*nested_column);
         if (!map_column) {
             return Status::RuntimeError("Illegal column {} for function CAST AS MAP",
                                         result_column_name);
@@ -38,7 +38,7 @@ inline Status deduplicate_map_keys_in_result(Block& block, uint32_t result) {
         ColumnPtr nested_column_ptr = std::move(nested_column);
         nullable_column->change_nested_column(nested_column_ptr);
     } else {
-        auto* map_column = check_and_get_column<ColumnMap>(*mutable_result_column);
+        const auto map_column = check_and_get_column<ColumnMap>(*mutable_result_column);
         if (!map_column) {
             return Status::RuntimeError("Illegal column {} for function CAST AS MAP",
                                         result_column_name);
@@ -91,7 +91,7 @@ WrapperType create_map_wrapper(FunctionContext* context, const DataTypePtr& from
                    uint32_t result, size_t /*input_rows_count*/,
                    const NullMap::value_type* null_map = nullptr) -> Status {
         auto& from_column = block.get_by_position(arguments.front()).column;
-        const auto* from_col_map = check_and_get_column<ColumnMap>(from_column.get());
+        const auto from_col_map = check_and_get_column<ColumnMap>(from_column.get());
         if (!from_col_map) {
             return Status::RuntimeError("Illegal column {} for function CAST AS MAP",
                                         from_column->get_name());

--- a/be/src/exprs/function/cast/cast_to_struct.h
+++ b/be/src/exprs/function/cast/cast_to_struct.h
@@ -59,7 +59,7 @@ WrapperType create_struct_wrapper(FunctionContext* context, const DataTypePtr& f
                    uint32_t result, size_t /*input_rows_count*/,
                    const NullMap::value_type* null_map = nullptr) -> Status {
         auto& from_column = block.get_by_position(arguments.front()).column;
-        const auto* from_col_struct = check_and_get_column<ColumnStruct>(from_column.get());
+        const auto from_col_struct = check_and_get_column<ColumnStruct>(from_column.get());
         if (!from_col_struct) {
             return Status::RuntimeError("Illegal column {} for function CAST AS Struct",
                                         from_column->get_name());

--- a/be/src/exprs/function/cast/cast_to_variant.h
+++ b/be/src/exprs/function/cast/cast_to_variant.h
@@ -32,19 +32,20 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
     auto& col_with_type_and_name = block.get_by_position(arguments[0]);
     auto& col_from = col_with_type_and_name.column;
     const IColumn* variant_column = col_from.get();
-    if (const auto* nullable = check_and_get_column<ColumnNullable>(*variant_column)) {
+    if (const auto nullable = check_and_get_column<ColumnNullable>(*variant_column)) {
         variant_column = &nullable->get_nested_column();
     }
 
     if (!assert_cast<const ColumnVariant&>(*variant_column).is_finalized()) {
         // ColumnVariant should be finalized before parsing, finalize maybe modify original column structure
         auto mutable_column = IColumn::mutate(std::move(col_with_type_and_name.column));
-        if (auto* nullable = check_and_get_column<ColumnNullable>(*mutable_column)) {
-            const auto& const_nullable = *nullable;
+        if (const auto nullable = check_and_get_column<ColumnNullable>(*mutable_column)) {
+            auto* nullable_column = nullable.get();
+            const auto& const_nullable = *nullable_column;
             auto nested_column = IColumn::mutate(const_nullable.get_nested_column_ptr());
             assert_cast<ColumnVariant&>(*nested_column).finalize();
             ColumnPtr nested_column_ptr = std::move(nested_column);
-            nullable->change_nested_column(nested_column_ptr);
+            nullable_column->change_nested_column(nested_column_ptr);
         } else {
             assert_cast<ColumnVariant&>(*mutable_column).finalize();
         }
@@ -52,7 +53,7 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
     }
 
     variant_column = col_with_type_and_name.column.get();
-    if (const auto* nullable = check_and_get_column<ColumnNullable>(*variant_column)) {
+    if (const auto nullable = check_and_get_column<ColumnNullable>(*variant_column)) {
         variant_column = &nullable->get_nested_column();
     }
     const auto& variant = assert_cast<const ColumnVariant&>(*variant_column);
@@ -127,9 +128,11 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
     }
 
     if (null_map == nullptr) {
-        if (const auto* nullable_result = check_and_get_column<ColumnNullable>(*col_to);
-            nullable_result != nullptr && !nullable_result->has_null()) {
-            col_to = nullable_result->get_nested_column_ptr();
+        if (const auto nullable_result = check_and_get_column<ColumnNullable>(*col_to);
+            nullable_result) {
+            if (!nullable_result->has_null()) {
+                col_to = nullable_result->get_nested_column_ptr();
+            }
         }
     }
 

--- a/be/src/exprs/function/cast/function_cast.cpp
+++ b/be/src/exprs/function/cast/function_cast.cpp
@@ -200,7 +200,7 @@ WrapperType prepare_remove_nullable(FunctionContext* context, const DataTypePtr&
 
             const auto& arg_col = block.get_by_position(arguments[0]);
             const NullMap::value_type* arg_null_map = nullptr;
-            if (const auto* nullable = check_and_get_column<ColumnNullable>(*arg_col.column)) {
+            if (const auto nullable = check_and_get_column<ColumnNullable>(*arg_col.column)) {
                 arg_null_map = nullable->get_null_map_data().data();
             }
             RETURN_IF_ERROR(prepare_impl(context, from_type_not_nullable, to_type_not_nullable)(

--- a/be/src/exprs/function/comparison_equal_for_null.cpp
+++ b/be/src/exprs/function/comparison_equal_for_null.cpp
@@ -134,23 +134,37 @@ public:
         const ColumnNullable* right_column = nullptr;
 
         if (left_const) {
-            left_column = check_and_get_column<const ColumnNullable>(
+            const auto left_column_guard = check_and_get_column<const ColumnNullable>(
                     assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(
                             col_left.column.get())
                             ->get_data_column_ptr()
                             .get());
+            if (left_column_guard) {
+                left_column = left_column_guard.get();
+            }
         } else {
-            left_column = check_and_get_column<const ColumnNullable>(col_left.column.get());
+            const auto left_column_guard =
+                    check_and_get_column<const ColumnNullable>(col_left.column.get());
+            if (left_column_guard) {
+                left_column = left_column_guard.get();
+            }
         }
 
         if (right_const) {
-            right_column = check_and_get_column<const ColumnNullable>(
+            const auto right_column_guard = check_and_get_column<const ColumnNullable>(
                     assert_cast<const ColumnConst*, TypeCheckOnRelease::DISABLE>(
                             col_right.column.get())
                             ->get_data_column_ptr()
                             .get());
+            if (right_column_guard) {
+                right_column = right_column_guard.get();
+            }
         } else {
-            right_column = check_and_get_column<const ColumnNullable>(col_right.column.get());
+            const auto right_column_guard =
+                    check_and_get_column<const ColumnNullable>(col_right.column.get());
+            if (right_column_guard) {
+                right_column = right_column_guard.get();
+            }
         }
 
         bool left_nullable = left_column != nullptr;

--- a/be/src/exprs/function/function_always_not_nullable.h
+++ b/be/src/exprs/function/function_always_not_nullable.h
@@ -49,16 +49,17 @@ public:
         };
         if constexpr (is_nullable) {
             const ColumnNullable* col_nullable = assert_cast<const ColumnNullable*>(column.get());
-            const ColumnType* col =
+            const auto col =
                     check_and_get_column<ColumnType>(col_nullable->get_nested_column_ptr().get());
             const ColumnUInt8* col_nullmap = col_nullable->get_null_map_column_ptr().get();
 
-            if (col != nullptr) {
+            if (col) {
+                const auto* typed_col = col.get();
                 if constexpr (WithReturn) {
-                    RETURN_IF_ERROR(
-                            Function::vector_nullable(col, col_nullmap->get_data(), column_result));
+                    RETURN_IF_ERROR(Function::vector_nullable(typed_col, col_nullmap->get_data(),
+                                                              column_result));
                 } else {
-                    Function::vector_nullable(col, col_nullmap->get_data(), column_result);
+                    Function::vector_nullable(typed_col, col_nullmap->get_data(), column_result);
                 }
             } else {
                 return type_error();

--- a/be/src/exprs/function/function_assert_true.cpp
+++ b/be/src/exprs/function/function_assert_true.cpp
@@ -71,7 +71,7 @@ public:
                         .to_string();
 
         ColumnPtr col_ptr = block.get_by_position(arguments[0]).column;
-        if (const auto* col_nullable = check_and_get_column<ColumnNullable>(col_ptr.get())) {
+        if (const auto col_nullable = check_and_get_column<ColumnNullable>(col_ptr.get())) {
             if (col_nullable->has_null()) {
                 throw doris::Exception(Status::InvalidArgument(errmsg));
             }

--- a/be/src/exprs/function/function_bitmap.cpp
+++ b/be/src/exprs/function/function_bitmap.cpp
@@ -523,7 +523,7 @@ public:
         auto& null_map = data_null_map->get_data();
 
         auto column = block.get_by_position(arguments[0]).column;
-        if (auto* nullable = check_and_get_column<const ColumnNullable>(*column)) {
+        if (auto nullable = check_and_get_column<const ColumnNullable>(*column)) {
             VectorizedUtils::update_null_map(null_map, nullable->get_null_map_data());
             column = nullable->get_nested_column_ptr();
         }

--- a/be/src/exprs/function/function_bitmap_variadic.cpp
+++ b/be/src/exprs/function/function_bitmap_variadic.cpp
@@ -74,7 +74,7 @@ namespace doris {
             if (res_nulls) {                                                                      \
                 res_nulls_data = assert_cast<ColumnUInt8*>(res_nulls)->get_data().data();         \
             }                                                                                     \
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[0])) {    \
+            if (auto nullable = check_and_get_column<ColumnNullable>(*argument_columns[0])) {     \
                 null_map_datas[nullable_cols_count++] = nullable->get_null_map_data().data();     \
                 BITMAP_OR_NULLABLE(nullable, input_rows_count, res, =);                           \
             } else {                                                                              \
@@ -85,7 +85,7 @@ namespace doris {
                 }                                                                                 \
             }                                                                                     \
             for (size_t col = 1; col < col_size; ++col) {                                         \
-                if (auto* nullable =                                                              \
+                if (auto nullable =                                                               \
                             check_and_get_column<ColumnNullable>(*argument_columns[col])) {       \
                     null_map_datas[nullable_cols_count++] = nullable->get_null_map_data().data(); \
                     BITMAP_OR_NULLABLE(nullable, input_rows_count, res, OP);                      \
@@ -123,14 +123,14 @@ namespace doris {
         static Status vector_vector(ColumnPtr argument_columns[], size_t col_size,                \
                                     size_t input_rows_count, ResTData& res, IColumn* res_nulls) { \
             TData vals;                                                                           \
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[0])) {    \
+            if (auto nullable = check_and_get_column<ColumnNullable>(*argument_columns[0])) {     \
                 vals.resize(input_rows_count);                                                    \
                 BITMAP_OR_NULLABLE(nullable, input_rows_count, vals, =);                          \
             } else {                                                                              \
                 vals = assert_cast<const ColumnBitmap*>(argument_columns[0].get())->get_data();   \
             }                                                                                     \
             for (size_t col = 1; col < col_size; ++col) {                                         \
-                if (auto* nullable =                                                              \
+                if (auto nullable =                                                               \
                             check_and_get_column<ColumnNullable>(*argument_columns[col])) {       \
                     BITMAP_OR_NULLABLE(nullable, input_rows_count, vals, OP);                     \
                 } else {                                                                          \

--- a/be/src/exprs/function/function_date_or_datetime_computation.h
+++ b/be/src/exprs/function/function_date_or_datetime_computation.h
@@ -768,12 +768,12 @@ public:
         auto res_col = ColumnVector<Transform::ReturnType>::create(input_rows_count, 0);
 
         // vector-const or vector-vector
-        if (const auto* sources =
+        if (const auto sources =
                     check_and_get_column<ColumnVector<Transform::ArgPType>>(src_nested_col.get())) {
             const ColumnPtr nest_col1 = remove_nullable(col1);
             bool rconst = false;
             // vector-const
-            if (const auto* nest_col1_const = check_and_get_column<ColumnConst>(*nest_col1)) {
+            if (const auto nest_col1_const = check_and_get_column<ColumnConst>(*nest_col1)) {
                 rconst = true;
                 const auto& col1_inside_const =
                         assert_cast<const ColumnVector<Transform::ArgPType>&>(
@@ -894,12 +894,12 @@ public:
                 typename PrimitiveTypeTraits<Transform::ReturnType>::DataType::FieldType());
 
         // vector-const or vector-vector
-        if (const auto* sources =
+        if (const auto sources =
                     check_and_get_column<ColumnVector<Transform::ArgPType>>(src_nested_col.get())) {
             const ColumnPtr nest_col1 = remove_nullable(col1);
             bool rconst = false;
             // vector-const
-            if (const auto* nest_col1_const = check_and_get_column<ColumnConst>(*nest_col1)) {
+            if (const auto nest_col1_const = check_and_get_column<ColumnConst>(*nest_col1)) {
                 rconst = true;
                 const auto& col1_inside_const =
                         assert_cast<const IntervalColumnType&>(nest_col1_const->get_data_column());
@@ -1041,7 +1041,7 @@ struct CurrentDateTimeImpl {
         DateValueType dtv;
         bool use_const;
         if constexpr (WithPrecision) {
-            if (const auto* const_column = check_and_get_column<ColumnConst>(
+            if (const auto const_column = check_and_get_column<ColumnConst>(
                         block.get_by_position(arguments[0]).column.get())) {
                 int64_t scale = const_column->get_int(0);
                 dtv.from_unixtime(context->state()->timestamp_ms() / 1000,
@@ -1053,7 +1053,7 @@ struct CurrentDateTimeImpl {
                 col_to->insert_data(const_cast<const char*>(reinterpret_cast<char*>(&dtv)), 0);
 
                 use_const = true;
-            } else if (const auto* nullable_column = check_and_get_column<ColumnNullable>(
+            } else if (const auto nullable_column = check_and_get_column<ColumnNullable>(
                                block.get_by_position(arguments[0]).column.get())) {
                 const auto& null_map = nullable_column->get_null_map_data();
                 const auto& nested_column = assert_cast<const ColumnInt32*>(
@@ -1206,7 +1206,7 @@ struct SecToTimeImpl {
 
         auto res_col = ColumnTimeV2::create(input_rows_count);
         auto& res_data = res_col->get_data();
-        if (const auto* int_column_ptr = check_and_get_column<ColumnInt32>(arg_col.get())) {
+        if (const auto int_column_ptr = check_and_get_column<ColumnInt32>(arg_col.get())) {
             for (int i = 0; i < input_rows_count; ++i) {
                 res_data[i] = TimeValue::from_seconds_with_limit(int_column_ptr->get_element(i));
             }

--- a/be/src/exprs/function/function_date_or_datetime_to_string.cpp
+++ b/be/src/exprs/function/function_date_or_datetime_to_string.cpp
@@ -152,7 +152,7 @@ public:
             null_map = &nullable_col->get_null_map_data();
         }
 
-        const auto* sources =
+        const auto sources =
                 check_and_get_column<ColumnVector<Transform::OpArgType>>(actual_col.get());
         if (!sources) [[unlikely]] {
             return Status::FatalError("Illegal column {} of first argument of function {}",

--- a/be/src/exprs/function/function_datetime_floor_ceil.cpp
+++ b/be/src/exprs/function/function_datetime_floor_ceil.cpp
@@ -222,7 +222,7 @@ public:
                                               col_to->get_data(), result_null_map, context);
                 }
             } else {
-                if (const auto* delta_vec_column0 =
+                if (const auto delta_vec_column0 =
                             check_and_get_column<ColumnVector<PType>>(delta_column)) {
                     // time_round(datetime, origin)
                     Core::vector_vector_anchor(sources->get_data(), delta_vec_column0->get_data(),

--- a/be/src/exprs/function/function_hamming_distance.cpp
+++ b/be/src/exprs/function/function_hamming_distance.cpp
@@ -59,24 +59,27 @@ public:
         const auto& [right_col, right_const] =
                 unpack_if_const(block.get_by_position(arguments[1]).column);
 
-        const auto* left_nullable = check_and_get_column<ColumnNullable>(left_col.get());
-        const auto* right_nullable = check_and_get_column<ColumnNullable>(right_col.get());
+        const auto left_nullable = check_and_get_column<ColumnNullable>(left_col.get());
+        const auto right_nullable = check_and_get_column<ColumnNullable>(right_col.get());
 
-        const IColumn* left_nested =
-                left_nullable ? &left_nullable->get_nested_column() : left_col.get();
-        const IColumn* right_nested =
-                right_nullable ? &right_nullable->get_nested_column() : right_col.get();
+        const IColumn* left_nested = left_col.get();
+        const IColumn* right_nested = right_col.get();
+        const NullMap* left_null_map = nullptr;
+        const NullMap* right_null_map = nullptr;
+        if (left_nullable) {
+            left_nested = &left_nullable->get_nested_column();
+            left_null_map = &left_nullable->get_null_map_data();
+        }
+        if (right_nullable) {
+            right_nested = &right_nullable->get_nested_column();
+            right_null_map = &right_nullable->get_null_map_data();
+        }
 
         const auto* left_str_col = assert_cast<const ColumnString*>(left_nested);
         const auto* right_str_col = assert_cast<const ColumnString*>(right_nested);
 
         auto res_col = ResultColumnType::create(input_rows_count);
         auto& res_data = res_col->get_data();
-
-        const NullMap* left_null_map =
-                left_nullable ? &left_nullable->get_null_map_data() : nullptr;
-        const NullMap* right_null_map =
-                right_nullable ? &right_nullable->get_null_map_data() : nullptr;
         const bool has_nullable = left_null_map != nullptr || right_null_map != nullptr;
 
         if (!has_nullable) {

--- a/be/src/exprs/function/function_hash.cpp
+++ b/be/src/exprs/function/function_hash.cpp
@@ -86,7 +86,7 @@ struct MurmurHash3Impl {
             }
         }
         auto& col_to_data = to_column.get_data();
-        if (const auto* col_from = check_and_get_column<ColumnString>(column)) {
+        if (const auto col_from = check_and_get_column<ColumnString>(column)) {
             const typename ColumnString::Chars& data = col_from->get_chars();
             const typename ColumnString::Offsets& offsets = col_from->get_offsets();
             size_t size = offsets.size();
@@ -177,7 +177,7 @@ struct XxHashImpl {
             to_column.insert_many_defaults(input_rows_count);
         }
         auto& col_to_data = to_column.get_data();
-        if (const auto* col_from = check_and_get_column<ColumnString>(column)) {
+        if (const auto col_from = check_and_get_column<ColumnString>(column)) {
             const typename ColumnString::Chars& data = col_from->get_chars();
             const typename ColumnString::Offsets& offsets = col_from->get_offsets();
             size_t size = offsets.size();
@@ -206,7 +206,7 @@ struct XxHashImpl {
                             HashUtil::xxHash64WithSeed(value.data(), value.size(), col_to_data[i]);
                 }
             }
-        } else if (const auto* vb_col = check_and_get_column<ColumnVarbinary>(column)) {
+        } else if (const auto vb_col = check_and_get_column<ColumnVarbinary>(column)) {
             for (size_t i = 0; i < input_rows_count; ++i) {
                 auto data_ref = vb_col->get_data_at(i);
                 if constexpr (ReturnType == TYPE_INT) {

--- a/be/src/exprs/function/function_helpers.cpp
+++ b/be/src/exprs/function/function_helpers.cpp
@@ -70,16 +70,22 @@ std::tuple<Block, ColumnNumbers> create_block_with_nested_columns(const Block& b
 
                 if (!col.column) {
                     res.insert({nullptr, nested_type, col.name});
-                } else if (const auto* nullable =
+                } else if (const auto nullable =
                                    check_and_get_column<ColumnNullable>(*col.column)) {
                     const auto& nested_col = nullable->get_nested_column_ptr();
                     res.insert({nested_col, nested_type, col.name});
-                } else if (const auto* const_column =
+                } else if (const auto const_column =
                                    check_and_get_column<ColumnConst>(*col.column)) {
-                    const auto& nested_col =
-                            check_and_get_column<ColumnNullable>(const_column->get_data_column())
-                                    ->get_nested_column_ptr();
-                    res.insert({ColumnConst::create(nested_col, col.column->size()), nested_type,
+                    const ColumnPtr* nested_col = nullptr;
+                    if (const auto nullable_column = check_and_get_column<ColumnNullable>(
+                                const_column->get_data_column())) {
+                        nested_col = &nullable_column.get()->get_nested_column_ptr();
+                    } else {
+                        throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                               "Illegal column= {},  for DataTypeNullable" +
+                                                       col.column->get_name());
+                    }
+                    res.insert({ColumnConst::create(*nested_col, col.column->size()), nested_type,
                                 col.name});
                 } else {
                     throw doris::Exception(

--- a/be/src/exprs/function/function_hll.cpp
+++ b/be/src/exprs/function/function_hll.cpp
@@ -95,18 +95,17 @@ public:
         auto column = block.get_by_position(arguments[0]).column;
 
         auto column_result = ColumnInt64::create(input_rows_count);
-        if (const ColumnNullable* col_nullable =
-                    check_and_get_column<ColumnNullable>(column.get())) {
-            const ColumnHLL* col =
+        if (const auto col_nullable = check_and_get_column<ColumnNullable>(column.get())) {
+            const auto col =
                     check_and_get_column<ColumnHLL>(col_nullable->get_nested_column_ptr().get());
             const ColumnUInt8* col_nullmap = col_nullable->get_null_map_column_ptr().get();
 
-            if (col != nullptr) {
+            if (col) {
                 Function::vector_nullable(col->get_data(), col_nullmap->get_data(), column_result);
                 block.replace_by_position(result, std::move(column_result));
                 return Status::OK();
             }
-        } else if (const ColumnHLL* col = check_and_get_column<ColumnHLL>(column.get())) {
+        } else if (const auto col = check_and_get_column<ColumnHLL>(column.get())) {
             Function::vector(col->get_data(), column_result);
             block.replace_by_position(result, std::move(column_result));
             return Status::OK();

--- a/be/src/exprs/function/function_ifnull.h
+++ b/be/src/exprs/function/function_ifnull.h
@@ -94,7 +94,7 @@ public:
         col_left.column = col_left.column->convert_to_full_column_if_const();
 
         /// implement isnull(col_left) logic
-        if (auto* nullable = check_and_get_column<ColumnNullable>(*col_left.column)) {
+        if (auto nullable = check_and_get_column<ColumnNullable>(*col_left.column)) {
             null_column_arg0.column = nullable->get_null_map_column_ptr();
             nested_column_arg0.column = nullable->get_nested_column_ptr();
             nested_column_arg0.type =

--- a/be/src/exprs/function/function_json.cpp
+++ b/be/src/exprs/function/function_json.cpp
@@ -420,12 +420,18 @@ public:
 
         const ColumnUInt8::Container* input_null_map = nullptr;
         const ColumnString* col_from_string = nullptr;
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(col_from)) {
+        if (const auto nullable = check_and_get_column<ColumnNullable>(col_from)) {
             input_null_map = &nullable->get_null_map_data();
-            col_from_string =
+            const auto col_from_string_guard =
                     check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+            if (col_from_string_guard) {
+                col_from_string = col_from_string_guard.get();
+            }
         } else {
-            col_from_string = check_and_get_column<ColumnString>(col_from);
+            const auto col_from_string_guard = check_and_get_column<ColumnString>(col_from);
+            if (col_from_string_guard) {
+                col_from_string = col_from_string_guard.get();
+            }
         }
 
         if (!col_from_string) {
@@ -515,8 +521,8 @@ public:
 
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
 
-        const ColumnString* col_from_string = check_and_get_column<ColumnString>(col_from);
-        if (auto* nullable = check_and_get_column<ColumnNullable>(col_from)) {
+        auto col_from_string = check_and_get_column<ColumnString>(col_from);
+        if (auto nullable = check_and_get_column<ColumnNullable>(col_from)) {
             col_from_string =
                     check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
         }

--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -523,7 +523,11 @@ public:
                 jsonb_path_column = nullable->get_nested_column_ptr();
                 path_null_map = &nullable->get_null_map_data();
             }
-            jsonb_path_col = check_and_get_column<ColumnString>(jsonb_path_column.get());
+            const auto jsonb_path_col_guard =
+                    check_and_get_column<ColumnString>(jsonb_path_column.get());
+            if (jsonb_path_col_guard) {
+                jsonb_path_col = jsonb_path_col_guard.get();
+            }
         }
 
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
@@ -2582,10 +2586,18 @@ public:
         // prepare jsonb data column
         auto&& [col_json, json_is_const] =
                 unpack_if_const(block.get_by_position(arguments[0]).column);
-        const auto* col_json_string = check_and_get_column<ColumnString>(col_json.get());
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(col_json.get())) {
-            col_json_string =
+        const ColumnString* col_json_string = nullptr;
+        if (const auto nullable = check_and_get_column<ColumnNullable>(col_json.get())) {
+            const auto col_json_string_guard =
                     check_and_get_column<ColumnString>(nullable->get_nested_column_ptr().get());
+            if (col_json_string_guard) {
+                col_json_string = col_json_string_guard.get();
+            }
+        } else {
+            const auto col_json_string_guard = check_and_get_column<ColumnString>(col_json.get());
+            if (col_json_string_guard) {
+                col_json_string = col_json_string_guard.get();
+            }
         }
 
         if (!col_json_string) {
@@ -2624,9 +2636,18 @@ public:
         auto&& [col_one, one_is_const] =
                 unpack_if_const(block.get_by_position(arguments[1]).column);
         one_is_const |= input_rows_count == 1;
-        const auto* col_one_string = check_and_get_column<ColumnString>(col_one.get());
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(col_one.get())) {
-            col_one_string = check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+        const ColumnString* col_one_string = nullptr;
+        if (const auto nullable = check_and_get_column<ColumnNullable>(col_one.get())) {
+            const auto col_one_string_guard =
+                    check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+            if (col_one_string_guard) {
+                col_one_string = col_one_string_guard.get();
+            }
+        } else {
+            const auto col_one_string_guard = check_and_get_column<ColumnString>(col_one.get());
+            if (col_one_string_guard) {
+                col_one_string = col_one_string_guard.get();
+            }
         }
         if (!col_one_string) {
             return Status::RuntimeError("Illegal arg one {} should be ColumnString",
@@ -2670,10 +2691,19 @@ public:
         auto&& [col_search, search_is_const] =
                 unpack_if_const(block.get_by_position(arguments[2]).column);
 
-        const auto* col_search_string = check_and_get_column<ColumnString>(col_search.get());
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(col_search.get())) {
-            col_search_string =
+        const ColumnString* col_search_string = nullptr;
+        if (const auto nullable = check_and_get_column<ColumnNullable>(col_search.get())) {
+            const auto col_search_string_guard =
                     check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+            if (col_search_string_guard) {
+                col_search_string = col_search_string_guard.get();
+            }
+        } else {
+            const auto col_search_string_guard =
+                    check_and_get_column<ColumnString>(col_search.get());
+            if (col_search_string_guard) {
+                col_search_string = col_search_string_guard.get();
+            }
         }
         if (!col_search_string) {
             return Status::RuntimeError("Illegal arg pattern {} should be ColumnString",
@@ -2748,16 +2778,23 @@ public:
         // Get JSON document column
         auto [json_column, json_const] =
                 unpack_if_const(block.get_by_position(arguments[0]).column);
-        const auto* json_nullable = check_and_get_column<ColumnNullable>(json_column.get());
+        const auto json_nullable = check_and_get_column<ColumnNullable>(json_column.get());
         const ColumnString* json_data_column = nullptr;
         const NullMap* json_null_map = nullptr;
 
         if (json_nullable) {
             json_null_map = &json_nullable->get_null_map_data();
-            json_data_column =
+            const auto json_data_column_guard =
                     check_and_get_column<ColumnString>(&json_nullable->get_nested_column());
+            if (json_data_column_guard) {
+                json_data_column = json_data_column_guard.get();
+            }
         } else {
-            json_data_column = check_and_get_column<ColumnString>(json_column.get());
+            const auto json_data_column_guard =
+                    check_and_get_column<ColumnString>(json_column.get());
+            if (json_data_column_guard) {
+                json_data_column = json_data_column_guard.get();
+            }
         }
 
         if (!json_data_column) {
@@ -2772,15 +2809,26 @@ public:
         for (size_t i = 1; i < arguments.size(); ++i) {
             auto [path_column, path_const] =
                     unpack_if_const(block.get_by_position(arguments[i]).column);
-            const auto* path_nullable = check_and_get_column<ColumnNullable>(path_column.get());
+            const auto path_nullable = check_and_get_column<ColumnNullable>(path_column.get());
 
             if (path_nullable) {
                 path_null_maps.push_back(&path_nullable->get_null_map_data());
-                path_columns.push_back(
-                        check_and_get_column<ColumnString>(&path_nullable->get_nested_column()));
+                const auto path_column_guard =
+                        check_and_get_column<ColumnString>(&path_nullable->get_nested_column());
+                if (path_column_guard) {
+                    path_columns.push_back(path_column_guard.get());
+                } else {
+                    path_columns.push_back(nullptr);
+                }
             } else {
                 path_null_maps.push_back(nullptr);
-                path_columns.push_back(check_and_get_column<ColumnString>(path_column.get()));
+                const auto path_column_guard =
+                        check_and_get_column<ColumnString>(path_column.get());
+                if (path_column_guard) {
+                    path_columns.push_back(path_column_guard.get());
+                } else {
+                    path_columns.push_back(nullptr);
+                }
             }
 
             if (!path_columns.back()) {

--- a/be/src/exprs/function/function_map.cpp
+++ b/be/src/exprs/function/function_map.cpp
@@ -182,10 +182,17 @@ public:
         ColumnPtr nullmap_column = nullptr;
         if (left_column->is_nullable()) {
             auto nullable_column = reinterpret_cast<const ColumnNullable*>(left_column.get());
-            map_column = check_and_get_column<ColumnMap>(nullable_column->get_nested_column());
+            const auto map_column_guard =
+                    check_and_get_column<ColumnMap>(nullable_column->get_nested_column());
+            if (map_column_guard) {
+                map_column = map_column_guard.get();
+            }
             nullmap_column = nullable_column->get_null_map_column_ptr();
         } else {
-            map_column = check_and_get_column<ColumnMap>(*left_column.get());
+            const auto map_column_guard = check_and_get_column<ColumnMap>(*left_column.get());
+            if (map_column_guard) {
+                map_column = map_column_guard.get();
+            }
         }
         if (!map_column) {
             return Status::RuntimeError("unsupported types for function {}({})", get_name(),
@@ -271,9 +278,16 @@ public:
         const ColumnMap* map_column = nullptr;
         if (left_column->is_nullable()) {
             auto nullable_column = reinterpret_cast<const ColumnNullable*>(left_column.get());
-            map_column = check_and_get_column<ColumnMap>(nullable_column->get_nested_column());
+            const auto map_column_guard =
+                    check_and_get_column<ColumnMap>(nullable_column->get_nested_column());
+            if (map_column_guard) {
+                map_column = map_column_guard.get();
+            }
         } else {
-            map_column = check_and_get_column<ColumnMap>(*left_column.get());
+            const auto map_column_guard = check_and_get_column<ColumnMap>(*left_column.get());
+            if (map_column_guard) {
+                map_column = map_column_guard.get();
+            }
         }
         if (!map_column) {
             return Status::RuntimeError("unsupported types for function {}({})", get_name(),
@@ -681,10 +695,17 @@ private:
         if (map_column_ptr->is_nullable()) {
             const auto* nullable_column =
                     reinterpret_cast<const ColumnNullable*>(map_column_ptr.get());
-            map_column = check_and_get_column<ColumnMap>(nullable_column->get_nested_column());
+            const auto map_column_guard =
+                    check_and_get_column<ColumnMap>(nullable_column->get_nested_column());
+            if (map_column_guard) {
+                map_column = map_column_guard.get();
+            }
             map_row_nullmap_col = nullable_column->get_null_map_column_ptr();
         } else {
-            map_column = check_and_get_column<ColumnMap>(*map_column_ptr.get());
+            const auto map_column_guard = check_and_get_column<ColumnMap>(*map_column_ptr.get());
+            if (map_column_guard) {
+                map_column = map_column_guard.get();
+            }
         }
         if (!map_column) {
             return Status::RuntimeError("unsupported types for function {}({})", get_name(),

--- a/be/src/exprs/function/function_nullables.cpp
+++ b/be/src/exprs/function/function_nullables.cpp
@@ -53,13 +53,12 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         ColumnPtr& col = block.get_by_position(arguments[0]).column;
-        if (const auto* col_null = check_and_get_column<ColumnNullable>(col.get());
-            col_null == nullptr) {
+        if (const auto col_null = check_and_get_column<ColumnNullable>(col.get()); col_null) {
+            block.replace_by_position(result, col->clone_resized(input_rows_count));
+        } else {
             // not null
             block.replace_by_position(
                     result, ColumnNullable::create(col, ColumnBool::create(input_rows_count, 0)));
-        } else { // column is ColumnNullable
-            block.replace_by_position(result, col->clone_resized(input_rows_count));
         }
         return Status::OK();
     }
@@ -85,8 +84,8 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto& data = block.get_by_position(arguments[0]);
-        if (const auto* col_null = check_and_get_column<ColumnNullable>(data.column.get());
-            col_null != nullptr) {
+        if (const auto col_null = check_and_get_column<ColumnNullable>(data.column.get());
+            col_null) {
             if (col_null->has_null()) [[unlikely]] {
                 return Status::InvalidArgument(
                         "There's NULL value in column {} which is illegal for non_nullable",

--- a/be/src/exprs/function/function_other_types_to_date.cpp
+++ b/be/src/exprs/function/function_other_types_to_date.cpp
@@ -393,7 +393,7 @@ struct MakeTimeImpl {
 
         const auto& hour_data = assert_cast<const ColumnInt64*>(arg_col[0].get())->get_data();
         const auto& min_data = assert_cast<const ColumnInt64*>(arg_col[1].get())->get_data();
-        if (const auto* sec_col = check_and_get_column<ColumnFloat64>(arg_col[2].get())) {
+        if (const auto sec_col = check_and_get_column<ColumnFloat64>(arg_col[2].get())) {
             for (int i = 0; i < input_rows_count; ++i) {
                 int64_t hour = hour_data[index_check_const(i, is_const[0])];
                 int64_t minute = min_data[index_check_const(i, is_const[1])];

--- a/be/src/exprs/function/function_quantile_state.cpp
+++ b/be/src/exprs/function/function_quantile_state.cpp
@@ -169,7 +169,7 @@ public:
         auto& null_map = data_null_map->get_data();
 
         auto column = block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-        if (const auto* nullable = check_and_get_column<const ColumnNullable>(*column)) {
+        if (const auto nullable = check_and_get_column<const ColumnNullable>(*column)) {
             VectorizedUtils::update_null_map(null_map, nullable->get_null_map_data());
             column = nullable->get_nested_column_ptr();
         }

--- a/be/src/exprs/function/function_regexp.cpp
+++ b/be/src/exprs/function/function_regexp.cpp
@@ -190,10 +190,10 @@ struct RegexpExtractEngine {
 struct RegexpCountImpl {
     static void execute_impl(FunctionContext* context, ColumnPtr argument_columns[],
                              size_t input_rows_count, ColumnInt32::Container& result_data) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
         for (int i = 0; i < input_rows_count; ++i) {
-            result_data[i] = _execute_inner_loop(context, str_col, pattern_col, i);
+            result_data[i] = _execute_inner_loop(context, str_col.get(), pattern_col.get(), i);
         }
     }
     static int _execute_inner_loop(FunctionContext* context, const ColumnString* str_col,
@@ -415,34 +415,34 @@ struct RegexpReplaceImpl {
                              const StringRef& options_value, size_t input_rows_count,
                              ColumnString::Chars& result_data, ColumnString::Offsets& result_offset,
                              NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
-        const auto* replace_col = check_and_get_column<ColumnString>(argument_columns[2].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
+        const auto replace_col = check_and_get_column_ptr<ColumnString>(argument_columns[2]);
 
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 StringOP::push_null_string(i, result_data, result_offset, null_map);
                 continue;
             }
-            _execute_inner_loop<false>(context, str_col, pattern_col, replace_col, options_value,
-                                       result_data, result_offset, null_map, i);
+            _execute_inner_loop<false>(context, str_col.get(), pattern_col.get(), replace_col.get(),
+                                       options_value, result_data, result_offset, null_map, i);
         }
     }
     static void execute_impl_const_args(FunctionContext* context, ColumnPtr argument_columns[],
                                         const StringRef& options_value, size_t input_rows_count,
                                         ColumnString::Chars& result_data,
                                         ColumnString::Offsets& result_offset, NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
-        const auto* replace_col = check_and_get_column<ColumnString>(argument_columns[2].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
+        const auto replace_col = check_and_get_column_ptr<ColumnString>(argument_columns[2]);
 
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 StringOP::push_null_string(i, result_data, result_offset, null_map);
                 continue;
             }
-            _execute_inner_loop<true>(context, str_col, pattern_col, replace_col, options_value,
-                                      result_data, result_offset, null_map, i);
+            _execute_inner_loop<true>(context, str_col.get(), pattern_col.get(), replace_col.get(),
+                                      options_value, result_data, result_offset, null_map, i);
         }
     }
     template <bool Const>
@@ -484,17 +484,17 @@ struct RegexpReplaceOneImpl {
                              const StringRef& options_value, size_t input_rows_count,
                              ColumnString::Chars& result_data, ColumnString::Offsets& result_offset,
                              NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
-        const auto* replace_col = check_and_get_column<ColumnString>(argument_columns[2].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
+        const auto replace_col = check_and_get_column_ptr<ColumnString>(argument_columns[2]);
         // 3 args
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 StringOP::push_null_string(i, result_data, result_offset, null_map);
                 continue;
             }
-            _execute_inner_loop<false>(context, str_col, pattern_col, replace_col, options_value,
-                                       result_data, result_offset, null_map, i);
+            _execute_inner_loop<false>(context, str_col.get(), pattern_col.get(), replace_col.get(),
+                                       options_value, result_data, result_offset, null_map, i);
         }
     }
 
@@ -502,17 +502,17 @@ struct RegexpReplaceOneImpl {
                                         const StringRef& options_value, size_t input_rows_count,
                                         ColumnString::Chars& result_data,
                                         ColumnString::Offsets& result_offset, NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
-        const auto* replace_col = check_and_get_column<ColumnString>(argument_columns[2].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
+        const auto replace_col = check_and_get_column_ptr<ColumnString>(argument_columns[2]);
         // 3 args
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 StringOP::push_null_string(i, result_data, result_offset, null_map);
                 continue;
             }
-            _execute_inner_loop<true>(context, str_col, pattern_col, replace_col, options_value,
-                                      result_data, result_offset, null_map, i);
+            _execute_inner_loop<true>(context, str_col.get(), pattern_col.get(), replace_col.get(),
+                                      options_value, result_data, result_offset, null_map, i);
         }
     }
     template <bool Const>
@@ -554,9 +554,9 @@ struct RegexpExtractImpl {
     static void execute_impl(FunctionContext* context, ColumnPtr argument_columns[],
                              size_t input_rows_count, ColumnString::Chars& result_data,
                              ColumnString::Offsets& result_offset, NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
-        const auto* index_col = check_and_get_column<ColumnInt64>(argument_columns[2].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
+        const auto index_col = check_and_get_column_ptr<ColumnInt64>(argument_columns[2]);
         for (size_t i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 StringOP::push_null_string(i, result_data, result_offset, null_map);
@@ -568,17 +568,17 @@ struct RegexpExtractImpl {
                            : StringOP::push_empty_string(i, result_data, result_offset);
                 continue;
             }
-            _execute_inner_loop<false>(context, str_col, pattern_col, index_data, result_data,
-                                       result_offset, null_map, i);
+            _execute_inner_loop<false>(context, str_col.get(), pattern_col.get(), index_data,
+                                       result_data, result_offset, null_map, i);
         }
     }
 
     static void execute_impl_const_args(FunctionContext* context, ColumnPtr argument_columns[],
                                         size_t input_rows_count, ColumnString::Chars& result_data,
                                         ColumnString::Offsets& result_offset, NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
-        const auto* index_col = check_and_get_column<ColumnInt64>(argument_columns[2].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
+        const auto index_col = check_and_get_column_ptr<ColumnInt64>(argument_columns[2]);
 
         const auto& index_data = index_col->get_int(0);
         if (index_data < 0) {
@@ -595,8 +595,8 @@ struct RegexpExtractImpl {
                 continue;
             }
 
-            _execute_inner_loop<true>(context, str_col, pattern_col, index_data, result_data,
-                                      result_offset, null_map, i);
+            _execute_inner_loop<true>(context, str_col.get(), pattern_col.get(), index_data,
+                                      result_data, result_offset, null_map, i);
         }
     }
     template <bool Const>
@@ -655,30 +655,30 @@ struct RegexpExtractAllImpl {
     static void execute_impl(FunctionContext* context, ColumnPtr argument_columns[],
                              size_t input_rows_count, ColumnString::Chars& result_data,
                              ColumnString::Offsets& result_offset, NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
         for (int i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 StringOP::push_null_string(i, result_data, result_offset, null_map);
                 continue;
             }
-            _execute_inner_loop<false>(context, str_col, pattern_col, result_data, result_offset,
-                                       null_map, i);
+            _execute_inner_loop<false>(context, str_col.get(), pattern_col.get(), result_data,
+                                       result_offset, null_map, i);
         }
     }
 
     static void execute_impl_const_args(FunctionContext* context, ColumnPtr argument_columns[],
                                         size_t input_rows_count, ColumnString::Chars& result_data,
                                         ColumnString::Offsets& result_offset, NullMap& null_map) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
+        const auto str_col = check_and_get_column_ptr<ColumnString>(argument_columns[0]);
+        const auto pattern_col = check_and_get_column_ptr<ColumnString>(argument_columns[1]);
         for (int i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 StringOP::push_null_string(i, result_data, result_offset, null_map);
                 continue;
             }
-            _execute_inner_loop<true>(context, str_col, pattern_col, result_data, result_offset,
-                                      null_map, i);
+            _execute_inner_loop<true>(context, str_col.get(), pattern_col.get(), result_data,
+                                      result_offset, null_map, i);
         }
     }
     template <bool Const>

--- a/be/src/exprs/function/function_reverse.h
+++ b/be/src/exprs/function/function_reverse.h
@@ -43,7 +43,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         ColumnPtr& src_column = block.get_by_position(arguments[0]).column;
-        if (const ColumnString* col_string = check_and_get_column<ColumnString>(src_column.get())) {
+        if (const auto col_string = check_and_get_column<ColumnString>(src_column.get())) {
             auto col_res = ColumnString::create();
             RETURN_IF_ERROR(ReverseImpl::vector(col_string->get_chars(), col_string->get_offsets(),
                                                 col_res->get_chars(), col_res->get_offsets()));

--- a/be/src/exprs/function/function_size.cpp
+++ b/be/src/exprs/function/function_size.cpp
@@ -53,9 +53,15 @@ public:
         const ColumnArray* array_column = nullptr;
         const ColumnMap* map_column = nullptr;
         if (type->get_primitive_type() == TYPE_ARRAY) {
-            array_column = check_and_get_column<ColumnArray>(*left_column.get());
+            const auto array_column_guard = check_and_get_column<ColumnArray>(*left_column.get());
+            if (array_column_guard) {
+                array_column = array_column_guard.get();
+            }
         } else if (type->get_primitive_type() == TYPE_MAP) {
-            map_column = check_and_get_column<ColumnMap>(*left_column.get());
+            const auto map_column_guard = check_and_get_column<ColumnMap>(*left_column.get());
+            if (map_column_guard) {
+                map_column = map_column_guard.get();
+            }
         }
 
         auto dst_column = ColumnInt64::create(input_rows_count);

--- a/be/src/exprs/function/function_string_basic.cpp
+++ b/be/src/exprs/function/function_string_basic.cpp
@@ -67,12 +67,14 @@ public:
 
         if (auto arg0 = check_and_get_column<ColumnString>(arg0_column.get())) {
             if (auto arg1 = check_and_get_column<ColumnString>(arg1_column.get())) {
+                const auto* arg0_ptr = arg0.get();
+                const auto* arg1_ptr = arg1.get();
                 if (arg0_const) {
-                    scalar_vector(arg0->get_data_at(0), *arg1, *result_column);
+                    scalar_vector(arg0_ptr->get_data_at(0), *arg1_ptr, *result_column);
                 } else if (arg1_const) {
-                    vector_scalar(*arg0, arg1->get_data_at(0), *result_column);
+                    vector_scalar(*arg0_ptr, arg1_ptr->get_data_at(0), *result_column);
                 } else {
-                    vector_vector(*arg0, *arg1, *result_column);
+                    vector_vector(*arg0_ptr, *arg1_ptr, *result_column);
                 }
             }
         }
@@ -309,7 +311,7 @@ struct NullOrEmptyImpl {
         auto res_map = ColumnUInt8::create(input_rows_count, 0);
 
         auto column = block.get_by_position(arguments[0]).column;
-        if (auto* nullable = check_and_get_column<const ColumnNullable>(*column)) {
+        if (auto nullable = check_and_get_column<const ColumnNullable>(*column)) {
             column = nullable->get_nested_column_ptr();
             VectorizedUtils::update_null_map(res_map->get_data(), nullable->get_null_map_data());
         }

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -387,7 +387,7 @@ public:
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (const auto* nullable =
+            if (const auto nullable =
                         check_and_get_column<const ColumnNullable>(*argument_columns[i])) {
                 // Danger: Here must dispose the null map data first! Because
                 // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem
@@ -579,15 +579,15 @@ public:
                 block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
         argument_ptr[1] = block.get_by_position(arguments[1]).column;
 
-        if (const auto* col1 = check_and_get_column<ColumnString>(*argument_ptr[0])) {
-            if (const auto* col2 = check_and_get_column<ColumnInt32>(*argument_ptr[1])) {
+        if (const auto col1 = check_and_get_column<ColumnString>(*argument_ptr[0])) {
+            if (const auto col2 = check_and_get_column<ColumnInt32>(*argument_ptr[1])) {
                 RETURN_IF_ERROR(vector_vector(col1->get_chars(), col1->get_offsets(),
                                               col2->get_data(), res->get_chars(),
                                               res->get_offsets(), null_map->get_data()));
                 block.replace_by_position(
                         result, ColumnNullable::create(std::move(res), std::move(null_map)));
                 return Status::OK();
-            } else if (const auto* col2_const =
+            } else if (const auto col2_const =
                                check_and_get_column<ColumnConst>(*argument_ptr[1])) {
                 DCHECK(check_and_get_column<ColumnInt32>(col2_const->get_data_column()));
                 int repeat = col2_const->get_int(0);

--- a/be/src/exprs/function/function_string_digest.cpp
+++ b/be/src/exprs/function/function_string_digest.cpp
@@ -184,10 +184,10 @@ public:
         auto& res_data = res_col->get_chars();
         auto& res_offset = res_col->get_offsets();
         res_offset.resize(input_rows_count);
-        if (const auto* str_col = check_and_get_column<ColumnString>(data_col.get())) {
-            vector_execute(str_col, input_rows_count, res_data, res_offset);
-        } else if (const auto* vb_col = check_and_get_column<ColumnVarbinary>(data_col.get())) {
-            vector_execute(vb_col, input_rows_count, res_data, res_offset);
+        if (const auto str_col = check_and_get_column<ColumnString>(data_col.get())) {
+            vector_execute(str_col.get(), input_rows_count, res_data, res_offset);
+        } else if (const auto vb_col = check_and_get_column<ColumnVarbinary>(data_col.get())) {
+            vector_execute(vb_col.get(), input_rows_count, res_data, res_offset);
         } else {
             return Status::RuntimeError("Illegal column {} of argument of function {}",
                                         data_col->get_name(), get_name());
@@ -260,10 +260,10 @@ private:
     template <typename T>
     void execute_base(ColumnPtr data_col, int input_rows_count, ColumnString::Chars& res_data,
                       ColumnString::Offsets& res_offset) const {
-        if (const auto* str_col = check_and_get_column<ColumnString>(data_col.get())) {
-            vector_execute<T>(str_col, input_rows_count, res_data, res_offset);
-        } else if (const auto* vb_col = check_and_get_column<ColumnVarbinary>(data_col.get())) {
-            vector_execute<T>(vb_col, input_rows_count, res_data, res_offset);
+        if (const auto str_col = check_and_get_column<ColumnString>(data_col.get())) {
+            vector_execute<T>(str_col.get(), input_rows_count, res_data, res_offset);
+        } else if (const auto vb_col = check_and_get_column<ColumnVarbinary>(data_col.get())) {
+            vector_execute<T>(vb_col.get(), input_rows_count, res_data, res_offset);
         } else {
             throw Exception(ErrorCode::RUNTIME_ERROR,
                             "Illegal column {} of argument of function {}", data_col->get_name(),

--- a/be/src/exprs/function/function_string_format.h
+++ b/be/src/exprs/function/function_string_format.h
@@ -423,7 +423,7 @@ struct MoneyFormatDecimalImpl {
 
     static void execute(FunctionContext* context, ColumnString* result_column, ColumnPtr col_ptr,
                         size_t input_rows_count) {
-        if (auto* decimalv2_column = check_and_get_column<ColumnDecimal128V2>(*col_ptr)) {
+        if (auto decimalv2_column = check_and_get_column<ColumnDecimal128V2>(*col_ptr)) {
             for (size_t i = 0; i < input_rows_count; i++) {
                 const auto& value = decimalv2_column->get_element(i);
                 // unified_frac_value has 3 digits
@@ -435,7 +435,7 @@ struct MoneyFormatDecimalImpl {
 
                 result_column->insert_data(str.data, str.size);
             }
-        } else if (auto* decimal32_column = check_and_get_column<ColumnDecimal32>(*col_ptr)) {
+        } else if (auto decimal32_column = check_and_get_column<ColumnDecimal32>(*col_ptr)) {
             const UInt32 scale = decimal32_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 const Int32& frac_part = decimal32_column->get_fractional_part(i);
@@ -447,7 +447,7 @@ struct MoneyFormatDecimalImpl {
 
                 result_column->insert_data(str.data, str.size);
             }
-        } else if (auto* decimal64_column = check_and_get_column<ColumnDecimal64>(*col_ptr)) {
+        } else if (auto decimal64_column = check_and_get_column<ColumnDecimal64>(*col_ptr)) {
             const UInt32 scale = decimal64_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 const Int64& frac_part = decimal64_column->get_fractional_part(i);
@@ -459,7 +459,7 @@ struct MoneyFormatDecimalImpl {
 
                 result_column->insert_data(str.data, str.size);
             }
-        } else if (auto* decimal128_column = check_and_get_column<ColumnDecimal128V3>(*col_ptr)) {
+        } else if (auto decimal128_column = check_and_get_column<ColumnDecimal128V3>(*col_ptr)) {
             const UInt32 scale = decimal128_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 const Int128& frac_part = decimal128_column->get_fractional_part(i);
@@ -477,8 +477,7 @@ struct MoneyFormatDecimalImpl {
                                    "Not supported input argument type {}", col_ptr->get_name());
         }
         // TODO: decimal256
-        /* else if (auto* decimal256_column =
-                           check_and_get_column<ColumnDecimal<Decimal256>>(*col_ptr)) {
+        /* else if (auto decimal256_column = check_and_get_column<ColumnDecimal<Decimal256>>(*col_ptr)) {
             const UInt32 scale = decimal256_column->get_scale();
             const auto multiplier =
                     scale > 2 ? common::exp10_i32(scale - 2) : common::exp10_i32(2 - scale);
@@ -690,7 +689,7 @@ struct FormatRoundDecimalImpl {
                           ColumnPtr decimal_places_col_ptr, size_t input_rows_count) {
         const auto& arg_column_data_2 =
                 assert_cast<const ColumnInt32*>(decimal_places_col_ptr.get())->get_data();
-        if (const auto* decimalv2_column = check_and_get_column<ColumnDecimal128V2>(*col_ptr)) {
+        if (const auto decimalv2_column = check_and_get_column<ColumnDecimal128V2>(*col_ptr)) {
             for (size_t i = 0; i < input_rows_count; i++) {
                 int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
                 if (decimal_places < 0 || decimal_places > 1024) {
@@ -708,7 +707,7 @@ struct FormatRoundDecimalImpl {
 
                 result_column->insert_data(str.data, str.size);
             }
-        } else if (const auto* decimal32_column = check_and_get_column<ColumnDecimal32>(*col_ptr)) {
+        } else if (const auto decimal32_column = check_and_get_column<ColumnDecimal32>(*col_ptr)) {
             const UInt32 scale = decimal32_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
@@ -726,7 +725,7 @@ struct FormatRoundDecimalImpl {
 
                 result_column->insert_data(str.data, str.size);
             }
-        } else if (const auto* decimal64_column = check_and_get_column<ColumnDecimal64>(*col_ptr)) {
+        } else if (const auto decimal64_column = check_and_get_column<ColumnDecimal64>(*col_ptr)) {
             const UInt32 scale = decimal64_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {
                 int32_t decimal_places = arg_column_data_2[index_check_const<is_const>(i)];
@@ -744,7 +743,7 @@ struct FormatRoundDecimalImpl {
 
                 result_column->insert_data(str.data, str.size);
             }
-        } else if (const auto* decimal128_column =
+        } else if (const auto decimal128_column =
                            check_and_get_column<ColumnDecimal128V3>(*col_ptr)) {
             const UInt32 scale = decimal128_column->get_scale();
             for (size_t i = 0; i < input_rows_count; i++) {

--- a/be/src/exprs/function/function_string_misc.cpp
+++ b/be/src/exprs/function/function_string_misc.cpp
@@ -118,7 +118,7 @@ public:
         for (int i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (const auto* nullable =
+            if (const auto nullable =
                         check_and_get_column<const ColumnNullable>(*argument_columns[i])) {
                 null_list[i] = &nullable->get_null_map_data();
                 argument_null_columns[i] = nullable->get_null_map_column_ptr();
@@ -629,7 +629,7 @@ public:
                     auto& offsets = str_column->get_offsets();
                     offsets.resize(1);
                     const ColumnInt32* int_column;
-                    if (auto* nullable = check_and_get_column<const ColumnNullable>(
+                    if (auto nullable = check_and_get_column<const ColumnNullable>(
                                 const_column->get_data_column())) {
                         int_column = assert_cast<const ColumnInt32*>(
                                 nullable->get_nested_column_ptr().get());
@@ -1580,15 +1580,17 @@ public:
 
         ColumnPtr col =
                 block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-        const auto* col_str = check_and_get_column<ColumnString>(col.get());
-        if (col_str == nullptr) {
+        const ColumnString* col_str_ptr = nullptr;
+        if (const auto col_str = check_and_get_column<ColumnString>(col.get())) {
+            col_str_ptr = col_str.get();
+        } else {
             return Status::RuntimeError("Illegal column {} of argument of function {}",
                                         block.get_by_position(arguments[0]).column->get_name(),
                                         get_name());
         }
 
-        const auto& data = col_str->get_chars();
-        const auto& offsets = col_str->get_offsets();
+        const auto& data = col_str_ptr->get_chars();
+        const auto& offsets = col_str_ptr->get_offsets();
 
         auto res = ColumnString::create();
         auto& res_data = res->get_chars();

--- a/be/src/exprs/function/function_string_replace.h
+++ b/be/src/exprs/function/function_string_replace.h
@@ -414,7 +414,7 @@ struct SubReplaceThreeImpl {
 
         auto str_col =
                 block.get_by_position(arguments[1]).column->convert_to_full_column_if_const();
-        if (const auto* nullable = check_and_get_column<const ColumnNullable>(*str_col)) {
+        if (const auto nullable = check_and_get_column<const ColumnNullable>(*str_col)) {
             str_col = nullable->get_nested_column_ptr();
         }
         const auto* str_column = assert_cast<const ColumnString*>(str_col.get());

--- a/be/src/exprs/function/function_string_search.cpp
+++ b/be/src/exprs/function/function_string_search.cpp
@@ -235,7 +235,7 @@ public:
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (const auto* nullable =
+            if (const auto nullable =
                         check_and_get_column<const ColumnNullable>(*argument_columns[i])) {
                 // Danger: Here must dispose the null map data first! Because
                 // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem

--- a/be/src/exprs/function/function_string_to_string.h
+++ b/be/src/exprs/function/function_string_to_string.h
@@ -62,7 +62,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         const ColumnPtr column = block.get_by_position(arguments[0]).column;
-        if (const auto* col = check_and_get_column<ColumnString>(column.get())) {
+        if (const auto col = check_and_get_column<ColumnString>(column.get())) {
             auto col_res = ColumnString::create();
             RETURN_IF_ERROR(Impl::vector(col->get_chars(), col->get_offsets(), col_res->get_chars(),
                                          col_res->get_offsets()));

--- a/be/src/exprs/function/function_struct_element.cpp
+++ b/be/src/exprs/function/function_struct_element.cpp
@@ -87,7 +87,7 @@ public:
                         uint32_t result, size_t input_rows_count) const override {
         const auto* struct_type = check_and_get_data_type<DataTypeStruct>(
                 block.get_by_position(arguments[0]).type.get());
-        const auto* struct_col = check_and_get_column<ColumnStruct>(
+        const auto struct_col = check_and_get_column<ColumnStruct>(
                 block.get_by_position(arguments[0]).column.get());
         if (!struct_col || !struct_type) {
             return Status::RuntimeError(

--- a/be/src/exprs/function/function_tokenize.cpp
+++ b/be/src/exprs/function/function_tokenize.cpp
@@ -145,8 +145,9 @@ Status FunctionTokenize::execute_impl(FunctionContext* /*context*/, Block& block
     auto dest_column_type = std::make_shared<DataTypeString>();
     auto dest_column_ptr = dest_column_type->create_column();
 
-    if (const auto* col_left = check_and_get_column<ColumnString>(src_column.get())) {
-        if (const auto* col_right = check_and_get_column<ColumnString>(right_column.get())) {
+    if (const auto col_left = check_and_get_column<ColumnString>(src_column.get())) {
+        const auto* col_left_ptr = col_left.get();
+        if (const auto col_right = check_and_get_column<ColumnString>(right_column.get())) {
             std::map<std::string, std::string> properties;
             auto st = parse(col_right->get_data_at(0).to_string(), properties);
             if (!st.ok()) {
@@ -165,7 +166,7 @@ Status FunctionTokenize::execute_impl(FunctionContext* /*context*/, Block& block
             // Special handling for PARSER_NONE: return original string as single token
             if (config.analyzer_name.empty() &&
                 config.parser_type == InvertedIndexParserType::PARSER_NONE) {
-                _do_tokenize_none(*col_left, dest_column_ptr);
+                _do_tokenize_none(*col_left_ptr, dest_column_ptr);
                 if (left_const) {
                     block.replace_by_position(
                             result,
@@ -201,7 +202,7 @@ Status FunctionTokenize::execute_impl(FunctionContext* /*context*/, Block& block
             analyzer_ctx.parser_type = config.parser_type;
             analyzer_ctx.char_filter_map = config.char_filter_map;
             analyzer_ctx.analyzer = analyzer_holder;
-            _do_tokenize(*col_left, analyzer_ctx, support_phrase, dest_column_ptr);
+            _do_tokenize(*col_left_ptr, analyzer_ctx, support_phrase, dest_column_ptr);
 
             if (left_const) {
                 block.replace_by_position(

--- a/be/src/exprs/function/function_totype.h
+++ b/be/src/exprs/function/function_totype.h
@@ -72,7 +72,7 @@ private:
                         size_t input_rows_count) const {
         const ColumnPtr column = block.get_by_position(arguments[0]).column;
         if constexpr (is_int_or_bool(Impl::PrimitiveTypeImpl)) {
-            if (auto* col =
+            if (auto col =
                         check_and_get_column<ColumnVector<Impl::PrimitiveTypeImpl>>(column.get())) {
                 auto col_res = Impl::ReturnColumnType::create();
                 RETURN_IF_ERROR(Impl::vector(col->get_data(), col_res->get_chars(),
@@ -81,7 +81,7 @@ private:
                 return Status::OK();
             }
         } else if constexpr (is_complex_v<Impl::PrimitiveTypeImpl>) {
-            if (const auto* col = check_and_get_column<ColumnComplexType<Impl::PrimitiveTypeImpl>>(
+            if (const auto col = check_and_get_column<ColumnComplexType<Impl::PrimitiveTypeImpl>>(
                         column.get())) {
                 auto col_res = Impl::ReturnColumnType::create();
                 RETURN_IF_ERROR(Impl::vector(col->get_data(), col_res->get_chars(),
@@ -101,7 +101,7 @@ private:
                         size_t input_rows_count) const {
         const ColumnPtr column = block.get_by_position(arguments[0]).column;
         if constexpr (Impl::PrimitiveTypeImpl == PrimitiveType::TYPE_STRING) {
-            if (const ColumnString* col = check_and_get_column<ColumnString>(column.get())) {
+            if (const auto col = check_and_get_column<ColumnString>(column.get())) {
                 auto col_res = Impl::ReturnColumnType::create();
                 RETURN_IF_ERROR(
                         Impl::vector(col->get_chars(), col->get_offsets(), col_res->get_data()));
@@ -109,7 +109,7 @@ private:
                 return Status::OK();
             }
         } else if constexpr (is_int_or_bool(Impl::PrimitiveTypeImpl)) {
-            if (const auto* col =
+            if (const auto col =
                         check_and_get_column<ColumnVector<Impl::PrimitiveTypeImpl>>(column.get())) {
                 auto col_res = Impl::ReturnColumnType::create();
                 RETURN_IF_ERROR(Impl::vector(col->get_data(), col_res->get_data()));
@@ -117,7 +117,7 @@ private:
                 return Status::OK();
             }
         } else if constexpr (is_complex_v<Impl::PrimitiveTypeImpl>) {
-            if (const auto* col = check_and_get_column<ColumnComplexType<Impl::PrimitiveTypeImpl>>(
+            if (const auto col = check_and_get_column<ColumnComplexType<Impl::PrimitiveTypeImpl>>(
                         column.get())) {
                 auto col_res = Impl::ReturnColumnType::create();
                 RETURN_IF_ERROR(Impl::vector(col->get_data(), col_res->get_data()));
@@ -125,7 +125,7 @@ private:
                 return Status::OK();
             }
         } else if constexpr (Impl::PrimitiveTypeImpl == PrimitiveType::TYPE_VARBINARY) {
-            if (const auto* col = check_and_get_column<ColumnVarbinary>(column.get())) {
+            if (const auto col = check_and_get_column<ColumnVarbinary>(column.get())) {
                 auto col_res = Impl::ReturnColumnType::create();
                 RETURN_IF_ERROR(Impl::vector(col->get_data(), col_res->get_data()));
                 block.replace_by_position(result, std::move(col_res));
@@ -244,8 +244,8 @@ private:
         auto& vec_res = col_res->get_data();
         vec_res.resize(block.rows());
 
-        if (const auto* col_left = check_and_get_column<ColVecLeft>(lcol.get())) {
-            if (const auto* col_right = check_and_get_column<ColVecRight>(rcol.get())) {
+        if (const auto col_left = check_and_get_column<ColVecLeft>(lcol.get())) {
+            if (const auto col_right = check_and_get_column<ColVecRight>(rcol.get())) {
                 if (left_const) {
                     auto st = Impl<LeftDataType, RightDataType>::scalar_vector(
                             col_left->get_data_at(0), col_right->get_chars(),
@@ -473,7 +473,7 @@ public:
 
         auto& col_ptr = block.get_by_position(arguments[0]).column;
 
-        if (const auto* col = check_and_get_column<ColumnString>(col_ptr.get())) {
+        if (const auto col = check_and_get_column<ColumnString>(col_ptr.get())) {
             auto col_res = Impl::ColumnType::create();
             if constexpr (std::is_same_v<typename Impl::ReturnType, DataTypeString>) {
                 RETURN_IF_ERROR(Impl::vector(col->get_chars(), col->get_offsets(),

--- a/be/src/exprs/function/function_utility.cpp
+++ b/be/src/exprs/function/function_utility.cpp
@@ -80,7 +80,7 @@ public:
 
         auto res_column = ColumnUInt8::create(input_rows_count, 0);
 
-        if (auto* nullable_column = check_and_get_column<ColumnNullable>(*argument_column)) {
+        if (auto nullable_column = check_and_get_column<ColumnNullable>(*argument_column)) {
             auto null_map_column = ColumnUInt8::create();
 
             auto nested_column = nullable_column->get_nested_column_ptr();

--- a/be/src/exprs/function/function_varbinary.cpp
+++ b/be/src/exprs/function/function_varbinary.cpp
@@ -58,7 +58,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto& col_ptr = block.get_by_position(arguments[0]).column;
-        if (const auto* col = check_and_get_column<ColumnString>(col_ptr.get())) {
+        if (const auto col = check_and_get_column<ColumnString>(col_ptr.get())) {
             auto null_map = ColumnUInt8::create(input_rows_count, 0);
             auto col_res = ColumnVarbinary::create();
             const auto& data = col->get_chars();
@@ -110,7 +110,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto& col_ptr = block.get_by_position(arguments[0]).column;
-        if (const auto* col = check_and_get_column<ColumnVarbinary>(col_ptr.get())) {
+        if (const auto col = check_and_get_column<ColumnVarbinary>(col_ptr.get())) {
             auto null_map = ColumnUInt8::create(input_rows_count, 0);
             auto col_res = ColumnString::create();
             auto& data = col_res->get_chars();

--- a/be/src/exprs/function/function_variant_element.cpp
+++ b/be/src/exprs/function/function_variant_element.cpp
@@ -100,7 +100,7 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
-        const auto* variant_col = check_and_get_column<ColumnVariant>(
+        const auto variant_col = check_and_get_column<ColumnVariant>(
                 remove_nullable(block.get_by_position(arguments[0]).column).get());
         if (!variant_col) {
             return Status::RuntimeError(
@@ -115,7 +115,7 @@ public:
 
         auto index_column = block.get_by_position(arguments[1]).column;
         ColumnPtr result_column;
-        RETURN_IF_ERROR(get_element_column(*variant_col, index_column, &result_column));
+        RETURN_IF_ERROR(get_element_column(*variant_col.get(), index_column, &result_column));
         if (block.get_by_position(result).type->is_nullable()) {
             result_column = wrap_variant_nullable(result_column);
         }

--- a/be/src/exprs/function/functions_comparison.h
+++ b/be/src/exprs/function/functions_comparison.h
@@ -341,8 +341,8 @@ private:
 
     Status execute_string(Block& block, uint32_t result, const IColumn* c0,
                           const IColumn* c1) const {
-        const ColumnString* c0_string = check_and_get_column<ColumnString>(c0);
-        const ColumnString* c1_string = check_and_get_column<ColumnString>(c1);
+        const auto c0_string = check_and_get_column<ColumnString>(c0);
+        const auto c1_string = check_and_get_column<ColumnString>(c1);
         const ColumnConst* c0_const = check_and_get_column_const_string_or_fixedstring(c0);
         const ColumnConst* c1_const = check_and_get_column_const_string_or_fixedstring(c1);
         if (!((c0_string || c0_const) && (c1_string || c1_const))) {
@@ -356,7 +356,7 @@ private:
         ColumnString::Offset c1_const_size = 0;
 
         if (c0_const) {
-            const ColumnString* c0_const_string =
+            const auto c0_const_string =
                     check_and_get_column<ColumnString>(&c0_const->get_data_column());
 
             if (c0_const_string) {
@@ -369,7 +369,7 @@ private:
         }
 
         if (c1_const) {
-            const ColumnString* c1_const_string =
+            const auto c1_const_string =
                     check_and_get_column<ColumnString>(&c1_const->get_data_column());
 
             if (c1_const_string) {

--- a/be/src/exprs/function/functions_logical.cpp
+++ b/be/src/exprs/function/functions_logical.cpp
@@ -138,9 +138,9 @@ void basic_execute_impl(ColumnRawPtrs arguments, ColumnWithTypeAndName& result_i
                         size_t input_rows_count) {
     auto col_res = ColumnUInt8::create(input_rows_count);
     if (auto l = check_and_get_column<ColumnConst>(arguments[0])) {
-        vector_const<Op>(arguments[1], l, col_res.get(), input_rows_count);
+        vector_const<Op>(arguments[1], l.get(), col_res.get(), input_rows_count);
     } else if (auto r = check_and_get_column<ColumnConst>(arguments[1])) {
-        vector_const<Op>(arguments[0], r, col_res.get(), input_rows_count);
+        vector_const<Op>(arguments[0], r.get(), col_res.get(), input_rows_count);
     } else {
         vector_vector<Op>(arguments[0], arguments[1], col_res.get(), input_rows_count);
     }
@@ -153,9 +153,11 @@ void null_execute_impl(ColumnRawPtrs arguments, ColumnWithTypeAndName& result_in
     auto col_nulls = ColumnUInt8::create(input_rows_count);
     auto col_res = ColumnUInt8::create(input_rows_count);
     if (auto l = check_and_get_column<ColumnConst>(arguments[0])) {
-        vector_const_null<Op>(arguments[1], l, col_res.get(), col_nulls.get(), input_rows_count);
+        vector_const_null<Op>(arguments[1], l.get(), col_res.get(), col_nulls.get(),
+                              input_rows_count);
     } else if (auto r = check_and_get_column<ColumnConst>(arguments[1])) {
-        vector_const_null<Op>(arguments[0], r, col_res.get(), col_nulls.get(), input_rows_count);
+        vector_const_null<Op>(arguments[0], r.get(), col_res.get(), col_nulls.get(),
+                              input_rows_count);
     } else {
         vector_vector_null<Op>(arguments[0], arguments[1], col_res.get(), col_nulls.get(),
                                input_rows_count);

--- a/be/src/exprs/function/functions_multi_string_position.cpp
+++ b/be/src/exprs/function/functions_multi_string_position.cpp
@@ -95,13 +95,19 @@ public:
         auto haystack_ptr = remove_nullable(haystack_column);
         auto needles_ptr = remove_nullable(needles_column);
 
-        const ColumnString* col_haystack_vector =
-                check_and_get_column<ColumnString>(&*haystack_ptr);
+        const auto col_haystack_vector_guard = check_and_get_column<ColumnString>(&*haystack_ptr);
+        const ColumnString* col_haystack_vector = nullptr;
+        if (col_haystack_vector_guard) {
+            col_haystack_vector = col_haystack_vector_guard.get();
+        }
         const ColumnConst* col_haystack_const =
                 check_and_get_column_const<ColumnString>(&*haystack_ptr);
 
-        const ColumnArray* col_needles_vector =
-                check_and_get_column<ColumnArray>(needles_ptr.get());
+        const auto col_needles_vector_guard = check_and_get_column<ColumnArray>(needles_ptr.get());
+        const ColumnArray* col_needles_vector = nullptr;
+        if (col_needles_vector_guard) {
+            col_needles_vector = col_needles_vector_guard.get();
+        }
         const ColumnConst* col_needles_const =
                 check_and_get_column_const<ColumnArray>(needles_ptr.get());
 

--- a/be/src/exprs/function/functions_multi_string_search.cpp
+++ b/be/src/exprs/function/functions_multi_string_search.cpp
@@ -83,11 +83,19 @@ public:
         auto haystack_ptr = remove_nullable(haystack_column);
         auto needles_ptr = remove_nullable(needles_column);
 
-        const auto* col_haystack_vector = check_and_get_column<ColumnString>(&*haystack_ptr);
+        const auto col_haystack_vector_guard = check_and_get_column<ColumnString>(&*haystack_ptr);
+        const ColumnString* col_haystack_vector = nullptr;
+        if (col_haystack_vector_guard) {
+            col_haystack_vector = col_haystack_vector_guard.get();
+        }
         const ColumnConst* col_haystack_const =
                 check_and_get_column_const<ColumnString>(&*haystack_ptr);
 
-        const auto* col_needles_vector = check_and_get_column<ColumnArray>(needles_ptr.get());
+        const auto col_needles_vector_guard = check_and_get_column<ColumnArray>(needles_ptr.get());
+        const ColumnArray* col_needles_vector = nullptr;
+        if (col_needles_vector_guard) {
+            col_needles_vector = col_needles_vector_guard.get();
+        }
         const ColumnConst* col_needles_const =
                 check_and_get_column_const<ColumnArray>(needles_ptr.get());
 
@@ -292,7 +300,7 @@ struct FunctionMultiMatchAnyImpl {
 
         const auto& nested_column =
                 assert_cast<const ColumnNullable&>(needles_data).get_nested_column();
-        const auto* needles_data_string = check_and_get_column<ColumnString>(nested_column);
+        const auto needles_data_string = check_and_get_column<ColumnString>(nested_column);
 
         if (!needles_data_string) {
             return Status::InvalidArgument("needles should be string column");

--- a/be/src/exprs/function/if.cpp
+++ b/be/src/exprs/function/if.cpp
@@ -133,9 +133,9 @@ public:
     }
 
     static ColumnPtr get_nested_column(const ColumnPtr& column) {
-        if (auto* nullable = check_and_get_column<ColumnNullable>(*column))
+        if (auto nullable = check_and_get_column<ColumnNullable>(*column))
             return nullable->get_nested_column_ptr();
-        else if (const auto* column_const = check_and_get_column<ColumnConst>(*column))
+        else if (const auto column_const = check_and_get_column<ColumnConst>(*column))
             return ColumnConst::create(get_nested_column(column_const->get_data_column_ptr()),
                                        column->size());
 
@@ -331,9 +331,14 @@ public:
         if (!then_type_is_nullable && !else_type_is_nullable) {
             return Status::OK();
         }
-
-        auto* then_is_nullable = check_and_get_column<ColumnNullable>(*arg_then.column);
-        auto* else_is_nullable = check_and_get_column<ColumnNullable>(*arg_else.column);
+        const ColumnNullable* then_is_nullable = nullptr;
+        if (auto then_nullable = check_and_get_column<ColumnNullable>(*arg_then.column)) {
+            then_is_nullable = then_nullable.get();
+        }
+        const ColumnNullable* else_is_nullable = nullptr;
+        if (auto else_nullable = check_and_get_column<ColumnNullable>(*arg_else.column)) {
+            else_is_nullable = else_nullable.get();
+        }
         bool then_column_is_const_nullable = false;
         bool else_column_is_const_nullable = false;
         if (then_type_is_nullable && then_is_nullable == nullptr) {
@@ -427,7 +432,7 @@ public:
             return Status::OK();
         }
 
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(*arg_cond.column)) {
+        if (const auto nullable = check_and_get_column<ColumnNullable>(*arg_cond.column)) {
             DCHECK(remove_nullable(arg_cond.type)->get_primitive_type() ==
                    PrimitiveType::TYPE_BOOLEAN);
 

--- a/be/src/exprs/function/if.h
+++ b/be/src/exprs/function/if.h
@@ -61,8 +61,8 @@ public:
 
     static ColumnPtr execute_if(const ArrayCond& cond, const ColumnPtr& then_col,
                                 const ColumnPtr& else_col, int result_scale) {
-        if (const auto* col_then = check_and_get_column<ColVecT>(then_col.get())) {
-            if (const auto* col_else = check_and_get_column<ColVecT>(else_col.get())) {
+        if (const auto col_then = check_and_get_column<ColVecT>(then_col.get())) {
+            if (const auto col_else = check_and_get_column<ColVecT>(else_col.get())) {
                 return execute_impl<false, false>(cond, col_then->get_data(), col_else->get_data(),
                                                   result_scale);
             } else if (const auto* col_const_else =
@@ -73,7 +73,7 @@ public:
             }
         } else if (const auto* col_const_then =
                            check_and_get_column_const<ColVecT>(then_col.get())) {
-            if (const auto* col_else = check_and_get_column<ColVecT>(else_col.get())) {
+            if (const auto col_else = check_and_get_column<ColVecT>(else_col.get())) {
                 return execute_impl<true, false>(cond, get_data_from_column_const(col_const_then),
                                                  col_else->get_data(), result_scale);
             } else if (const auto* col_const_else =

--- a/be/src/exprs/function/is_not_null.h
+++ b/be/src/exprs/function/is_not_null.h
@@ -64,7 +64,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         const ColumnWithTypeAndName& elem = block.get_by_position(arguments[0]);
-        if (auto* nullable = check_and_get_column<ColumnNullable>(*elem.column)) {
+        if (auto nullable = check_and_get_column<ColumnNullable>(*elem.column)) {
             /// Return the negated null map.
             auto res_column = ColumnUInt8::create(input_rows_count);
             const auto* __restrict src_data = nullable->get_null_map_data().data();

--- a/be/src/exprs/function/is_null.h
+++ b/be/src/exprs/function/is_null.h
@@ -62,7 +62,7 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         const ColumnWithTypeAndName& elem = block.get_by_position(arguments[0]);
-        if (auto* nullable = check_and_get_column<ColumnNullable>(*elem.column)) {
+        if (auto nullable = check_and_get_column<ColumnNullable>(*elem.column)) {
             /// Merely return the embedded null map.
             block.get_by_position(result).column = nullable->get_null_map_column_ptr();
         } else {

--- a/be/src/exprs/function/like.cpp
+++ b/be/src/exprs/function/like.cpp
@@ -518,7 +518,11 @@ Status FunctionLikeBase::execute_impl(FunctionContext* context, Block& block,
                                       size_t input_rows_count) const {
     const auto values_col =
             block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-    const auto* values = check_and_get_column<ColumnString>(values_col.get());
+    const auto values_guard = check_and_get_column<ColumnString>(values_col.get());
+    const ColumnString* values = nullptr;
+    if (values_guard) {
+        values = values_guard.get();
+    }
 
     if (!values) {
         return Status::InternalError("Not supported input arguments types");
@@ -539,10 +543,11 @@ Status FunctionLikeBase::execute_impl(FunctionContext* context, Block& block,
                                           &state->search_state));
     } else {
         const auto pattern_col = block.get_by_position(arguments[1]).column;
-        if (const auto* str_patterns = check_and_get_column<ColumnString>(pattern_col.get())) {
+        if (const auto str_patterns = check_and_get_column<ColumnString>(pattern_col.get())) {
+            const auto* str_patterns_ptr = str_patterns.get();
             RETURN_IF_ERROR(
-                    vector_non_const(*values, *str_patterns, vec_res, state, input_rows_count));
-        } else if (const auto* const_patterns =
+                    vector_non_const(*values, *str_patterns_ptr, vec_res, state, input_rows_count));
+        } else if (const auto const_patterns =
                            check_and_get_column<ColumnConst>(pattern_col.get())) {
             const auto& pattern_val = const_patterns->get_data_at(0);
             RETURN_IF_ERROR(vector_const(*values, &pattern_val, vec_res, state->function,

--- a/be/src/exprs/function/match.cpp
+++ b/be/src/exprs/function/match.cpp
@@ -125,10 +125,10 @@ Status FunctionMatchBase::execute_impl(FunctionContext* context, Block& block,
     auto* analyzer_ctx = get_match_analyzer_ctx(context);
     const ColumnPtr source_col =
             block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-    const auto* values = check_and_get_column<ColumnString>(source_col.get());
+    const ColumnString* values = nullptr;
     const ColumnArray* array_col = nullptr;
-    if (is_column<ColumnArray>(source_col.get())) {
-        array_col = check_and_get_column<ColumnArray>(source_col.get());
+    if (const auto array_col_guard = check_and_get_column<ColumnArray>(source_col.get())) {
+        array_col = array_col_guard.get();
         if (array_col && !array_col->get_data().is_column_string()) {
             return Status::NotSupported(fmt::format(
                     "unsupported nested array of type {} for function {}",
@@ -140,14 +140,27 @@ Status FunctionMatchBase::execute_impl(FunctionContext* context, Block& block,
         if (is_column_nullable(array_col->get_data())) {
             const auto& array_nested_null_column =
                     reinterpret_cast<const ColumnNullable&>(array_col->get_data());
-            values = check_and_get_column<ColumnString>(
+            const auto values_guard = check_and_get_column<ColumnString>(
                     *(array_nested_null_column.get_nested_column_ptr()));
+            if (values_guard) {
+                values = values_guard.get();
+            }
         } else {
             // array column element is always set Nullable for now.
-            values = check_and_get_column<ColumnString>(*(array_col->get_data_ptr()));
+            const auto values_guard =
+                    check_and_get_column<ColumnString>(*(array_col->get_data_ptr()));
+            if (values_guard) {
+                values = values_guard.get();
+            }
         }
-    } else if (const auto* nullable = check_and_get_column<ColumnNullable>(source_col.get())) {
-        values = check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+    } else if (const auto nullable = check_and_get_column<ColumnNullable>(source_col.get())) {
+        const auto values_guard =
+                check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+        if (values_guard) {
+            values = values_guard.get();
+        }
+    } else if (const auto values_guard = check_and_get_column<ColumnString>(source_col.get())) {
+        values = values_guard.get();
     }
 
     if (!values) {

--- a/be/src/exprs/function/math.cpp
+++ b/be/src/exprs/function/math.cpp
@@ -445,7 +445,7 @@ private:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
-        const auto* data_col =
+        const auto data_col =
                 check_and_get_column<ColumnInt64>(block.get_by_position(arguments[0]).column.get());
         if (!data_col) {
             return Status::InternalError(
@@ -892,10 +892,10 @@ private:
         auto& dst_data = dst->get_data();
         dst_data.resize(input_rows_count);
         const auto* column = block.get_by_position(arguments[0]).column.get();
-        if (const auto* col_f64 = check_and_get_column<ColumnFloat64>(column)) {
-            execute_impl_with_type(col_f64, dst_data, input_rows_count);
-        } else if (const auto* col_f32 = check_and_get_column<ColumnFloat32>(column)) {
-            execute_impl_with_type(col_f32, dst_data, input_rows_count);
+        if (const auto col_f64 = check_and_get_column<ColumnFloat64>(column)) {
+            execute_impl_with_type(col_f64.get(), dst_data, input_rows_count);
+        } else if (const auto col_f32 = check_and_get_column<ColumnFloat32>(column)) {
+            execute_impl_with_type(col_f32.get(), dst_data, input_rows_count);
         } else {
             return Status::InvalidArgument("Unsupported column type  {} for function {}",
                                            column->get_name(), get_name());

--- a/be/src/exprs/runtime_filter_expr.cpp
+++ b/be/src/exprs/runtime_filter_expr.cpp
@@ -124,7 +124,7 @@ Status RuntimeFilterExpr::execute_filter(VExprContext* context, const Block* blo
         change_null_to_true(filter_column->assert_mutable(), arg_column);
     }
 
-    if (const auto* const_column = check_and_get_column<ColumnConst>(*filter_column)) {
+    if (const auto const_column = check_and_get_column<ColumnConst>(*filter_column)) {
         // const(nullable) or const(bool)
         if (!const_column->get_bool(0)) {
             // filter all
@@ -140,7 +140,7 @@ Status RuntimeFilterExpr::execute_filter(VExprContext* context, const Block* blo
             rf_selectivity.update_judge_selectivity(_filter_id, 0, rows, _ignore_thredhold);
             return Status::OK();
         }
-    } else if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
+    } else if (const auto nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
         // nullable(bool)
         const ColumnPtr& nested_column = nullable_column->get_nested_column_ptr();
         const IColumn::Filter& filter = assert_cast<const ColumnUInt8&>(*nested_column).get_data();

--- a/be/src/exprs/short_circuit_util.h
+++ b/be/src/exprs/short_circuit_util.h
@@ -36,7 +36,7 @@ struct ColumnNullConstView {
     static ColumnNullConstView create(const ColumnPtr& column_ptr) {
         const auto& [from_data_column, is_const] = unpack_if_const(column_ptr);
 
-        if (const auto* nullable_column =
+        if (const auto nullable_column =
                     check_and_get_column<ColumnNullable>(from_data_column.get())) {
             return ColumnNullConstView {.column = nullable_column->get_nested_column(),
                                         .null_map = &nullable_column->get_null_map_data(),
@@ -62,7 +62,7 @@ struct ColumnNullConstViewScalar {
         const auto& [from_data_column, is_const] = unpack_if_const(column_ptr);
         const NullMap* null_map = nullptr;
         const ArrayType* data = nullptr;
-        if (const auto* nullable_column =
+        if (const auto nullable_column =
                     check_and_get_column<ColumnNullable>(from_data_column.get())) {
             null_map = &nullable_column->get_null_map_data();
             const auto& nested_from_column = nullable_column->get_nested_column();
@@ -82,7 +82,7 @@ struct MutableColumnNullView {
     IColumn& column;
     NullMap* null_map;
     static MutableColumnNullView create(const MutableColumnPtr& column_ptr) {
-        if (auto* nullable_column = check_and_get_column<ColumnNullable>(column_ptr.get())) {
+        if (auto nullable_column = check_and_get_column<ColumnNullable>(column_ptr.get())) {
             return MutableColumnNullView {.column = nullable_column->get_nested_column(),
                                           .null_map = &nullable_column->get_null_map_data()};
         } else {
@@ -123,7 +123,7 @@ struct MutableColumnNullViewScalar {
     static MutableColumnNullViewScalar create(const MutableColumnPtr& column_ptr) {
         ColumnType* data_column = nullptr;
         NullMap* null_map = nullptr;
-        if (auto* nullable_column = check_and_get_column<ColumnNullable>(column_ptr.get())) {
+        if (auto nullable_column = check_and_get_column<ColumnNullable>(column_ptr.get())) {
             null_map = &nullable_column->get_null_map_data();
             auto& nested_column = nullable_column->get_nested_column();
             data_column = &(assert_cast<ColumnType&>(nested_column));

--- a/be/src/exprs/table_function/vexplode_map.cpp
+++ b/be/src/exprs/table_function/vexplode_map.cpp
@@ -44,8 +44,10 @@ bool extract_column_map_info(const IColumn& src, ColumnMapExecutionData& data) {
         map_col = null_col.get_nested_column_ptr().get();
     }
 
-    if (data.map_col = check_and_get_column<ColumnMap>(map_col); !data.map_col) {
+    if (const auto map_col_guard = check_and_get_column<ColumnMap>(map_col); !map_col_guard) {
         return false;
+    } else {
+        data.map_col = map_col_guard.get();
     }
 
     data.offsets_ptr = &data.map_col->get_offsets();

--- a/be/src/exprs/table_function/vjson_each.cpp
+++ b/be/src/exprs/table_function/vjson_each.cpp
@@ -98,7 +98,7 @@ void VJsonEachTableFunction<TEXT_MODE>::process_row(size_t row_idx) {
 
     StringRef text;
     const size_t idx = _is_const ? 0 : row_idx;
-    if (const auto* nullable_col = check_and_get_column<ColumnNullable>(*_json_column)) {
+    if (const auto nullable_col = check_and_get_column<ColumnNullable>(*_json_column)) {
         if (nullable_col->is_null_at(idx)) {
             return;
         }

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -63,7 +63,7 @@ size_t VConditionExpr::count_true_with_notnull(const ColumnPtr& col) {
         return 0;
     }
 
-    if (const auto* const_col = check_and_get_column<ColumnConst>(col.get())) {
+    if (const auto const_col = check_and_get_column<ColumnConst>(col.get())) {
         // if is null , get_bool will return false
         // bool get_bool(size_t n) const override {
         //     return is_null_at(n) ? false : _nested_column->get_bool(n);
@@ -109,9 +109,9 @@ ColumnPtr make_nullable_column_if_not(const ColumnPtr& column) {
 }
 
 ColumnPtr get_nested_column(const ColumnPtr& column) {
-    if (auto* nullable = check_and_get_column<ColumnNullable>(*column))
+    if (auto nullable = check_and_get_column<ColumnNullable>(*column))
         return nullable->get_nested_column_ptr();
-    else if (const auto* column_const = check_and_get_column<ColumnConst>(*column))
+    else if (const auto column_const = check_and_get_column<ColumnConst>(*column))
         return ColumnConst::create(get_nested_column(column_const->get_data_column_ptr()),
                                    column->size());
 
@@ -282,8 +282,14 @@ Status VectorizedIfExpr::execute_for_nullable_then_else(Block& block,
         return Status::OK();
     }
 
-    const auto* then_is_nullable = check_and_get_column<ColumnNullable>(*arg_then.column);
-    const auto* else_is_nullable = check_and_get_column<ColumnNullable>(*arg_else.column);
+    const ColumnNullable* then_is_nullable = nullptr;
+    if (const auto then_nullable = check_and_get_column<ColumnNullable>(*arg_then.column)) {
+        then_is_nullable = then_nullable.get();
+    }
+    const ColumnNullable* else_is_nullable = nullptr;
+    if (const auto else_nullable = check_and_get_column<ColumnNullable>(*arg_else.column)) {
+        else_is_nullable = else_nullable.get();
+    }
     bool then_column_is_const_nullable = false;
     bool else_column_is_const_nullable = false;
     if (then_type_is_nullable && then_is_nullable == nullptr) {
@@ -375,7 +381,7 @@ Status VectorizedIfExpr::execute_for_null_condition(Block& block, const ColumnNu
         return Status::OK();
     }
 
-    if (const auto* nullable = check_and_get_column<ColumnNullable>(*arg_cond.column)) {
+    if (const auto nullable = check_and_get_column<ColumnNullable>(*arg_cond.column)) {
         DCHECK(remove_nullable(arg_cond.type)->get_primitive_type() == PrimitiveType::TYPE_BOOLEAN);
 
         // update nested column by null map
@@ -688,7 +694,7 @@ Status VectorizedCoalesceExpr::execute_column_impl(VExprContext* context, const 
     auto* __restrict null_map_data = null_map->get_data().data();
 
     auto is_not_null = [](const ColumnPtr& column, size_t size) -> ColumnUInt8::MutablePtr {
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(*column)) {
+        if (const auto nullable = check_and_get_column<ColumnNullable>(*column)) {
             /// Return the negated null map.
             auto res_column = ColumnUInt8::create(size);
             const auto* __restrict src_data = nullable->get_null_map_data().data();
@@ -713,7 +719,7 @@ Status VectorizedCoalesceExpr::execute_column_impl(VExprContext* context, const 
                 _children[i]->execute_column(context, block, selector, count, original_columns[i]));
         original_columns[i] = original_columns[i]->convert_to_full_column_if_const();
         argument_not_null_columns[i] = original_columns[i];
-        if (const auto* nullable =
+        if (const auto nullable =
                     check_and_get_column<const ColumnNullable>(*argument_not_null_columns[i])) {
             argument_not_null_columns[i] = nullable->get_nested_column_ptr();
         }

--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -1063,7 +1063,7 @@ Status VExpr::execute_filter(VExprContext* context, const Block* block,
                              bool* can_filter_all) const {
     ColumnPtr filter_column;
     RETURN_IF_ERROR(execute_column(context, block, nullptr, rows, filter_column));
-    if (const auto* const_column = check_and_get_column<ColumnConst>(*filter_column)) {
+    if (const auto const_column = check_and_get_column<ColumnConst>(*filter_column)) {
         // const(nullable) or const(bool)
         const bool result = accept_null
                                     ? (const_column->is_null_at(0) || const_column->get_bool(0))
@@ -1074,7 +1074,7 @@ Status VExpr::execute_filter(VExprContext* context, const Block* block,
             memset(result_filter_data, 0, rows);
             return Status::OK();
         }
-    } else if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
+    } else if (const auto nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
         // nullable(bool)
         const ColumnPtr& nested_column = nullable_column->get_nested_column_ptr();
         const IColumn::Filter& filter = assert_cast<const ColumnUInt8&>(*nested_column).get_data();

--- a/be/src/exprs/virtual_slot_ref.cpp
+++ b/be/src/exprs/virtual_slot_ref.cpp
@@ -120,10 +120,10 @@ Status VirtualSlotRef::execute_column_impl(VExprContext* context, const Block* b
                 *_column_name);
     }
 
-    const auto* col_nothing = check_and_get_column<ColumnNothing>(col_type_name.column.get());
+    const auto col_nothing = check_and_get_column<ColumnNothing>(col_type_name.column.get());
     bool column_from_virtual_column_expr = false;
     if (this->_virtual_column_expr != nullptr) {
-        if (col_nothing != nullptr) {
+        if (col_nothing) {
             // Virtual column is not materialized, so we need to materialize it.
             // Note: After executing 'execute', we cannot use the column from line 120 in subsequent code,
             // because the vector might be resized during execution, causing previous references to become invalid.
@@ -154,7 +154,7 @@ Status VirtualSlotRef::execute_column_impl(VExprContext* context, const Block* b
 #endif
     } else {
         // This is a virtual slot ref that not pushed to segment_iterator
-        if (col_nothing == nullptr) {
+        if (!col_nothing) {
             return Status::InternalError("Logical error, virtual column can not be materialized");
         } else {
             return Status::OK();

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -3237,7 +3237,7 @@ Status OrcReader::_convert_dict_cols_to_string_cols(
                 return Status::InternalError("Wrong read column '{}' in orc file",
                                              dict_filter_cols.first);
             }
-            if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*column)) {
+            if (const auto nullable_column = check_and_get_column<ColumnNullable>(*column)) {
                 const ColumnPtr& nested_column = nullable_column->get_nested_column_ptr();
                 const auto* dict_column = assert_cast<const ColumnInt32*>(nested_column.get());
                 DCHECK(dict_column);

--- a/be/src/format/parquet/byte_stream_split_decoder.cpp
+++ b/be/src/format/parquet/byte_stream_split_decoder.cpp
@@ -47,7 +47,7 @@ Status ByteStreamSplitDecoder::_decode_values(MutableColumnPtr& doris_column,
     }
 
     size_t primitive_length = _type_length;
-    if (const auto* fixed_length_column =
+    if (const auto fixed_length_column =
                 check_and_get_column<ColumnFixedLengthObject>(*doris_column)) {
         DCHECK_EQ(fixed_length_column->item_size(), _type_length);
     } else {

--- a/be/src/format/parquet/delta_bit_pack_decoder.h
+++ b/be/src/format/parquet/delta_bit_pack_decoder.h
@@ -89,7 +89,7 @@ public:
         const size_t result_size = select_vector.num_values() - select_vector.num_filtered();
         size_t data_index = 0;
         uint8_t* data = nullptr;
-        if (auto* fixed_length_column =
+        if (auto fixed_length_column =
                     check_and_get_column<ColumnFixedLengthObject>(*doris_column)) {
             DCHECK_EQ(fixed_length_column->item_size(), _type_length);
             data_index = fixed_length_column->size() * _type_length;

--- a/be/src/format/parquet/fix_length_dict_decoder.hpp
+++ b/be/src/format/parquet/fix_length_dict_decoder.hpp
@@ -109,7 +109,7 @@ protected:
     Status _decode_fixed_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                 ColumnSelectVector& select_vector) {
         size_t primitive_length = _type_length;
-        if (const auto* fixed_length_column =
+        if (const auto fixed_length_column =
                     check_and_get_column<ColumnFixedLengthObject>(*doris_column)) {
             DCHECK_EQ(fixed_length_column->item_size(), _type_length);
         } else {

--- a/be/src/format/parquet/fix_length_plain_decoder.h
+++ b/be/src/format/parquet/fix_length_plain_decoder.h
@@ -48,7 +48,7 @@ public:
         }
 
         size_t primitive_length = _type_length;
-        if (const auto* fixed_length_column =
+        if (const auto fixed_length_column =
                     check_and_get_column<ColumnFixedLengthObject>(*doris_column)) {
             DCHECK_EQ(fixed_length_column->item_size(), _type_length);
         } else {

--- a/be/src/format/parquet/parquet_column_convert.h
+++ b/be/src/format/parquet/parquet_column_convert.h
@@ -263,7 +263,7 @@ struct FixedLengthPhysicalData {
 
 inline FixedLengthPhysicalData get_fixed_length_physical_data(const IColumn& column,
                                                               size_t type_length) {
-    if (const auto* fixed_length_column = check_and_get_column<ColumnFixedLengthObject>(column)) {
+    if (const auto fixed_length_column = check_and_get_column<ColumnFixedLengthObject>(column)) {
         DCHECK_EQ(fixed_length_column->item_size(), type_length);
         return {fixed_length_column->get_data().data(), fixed_length_column->byte_size(),
                 fixed_length_column->size()};

--- a/be/src/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/format/parquet/vparquet_group_reader.cpp
@@ -1299,7 +1299,7 @@ Status RowGroupReader::_convert_dict_cols_to_string_cols(Block* block) {
         }
         ColumnWithTypeAndName& column_with_type_and_name = block->get_by_position(block_pos);
         const ColumnPtr& column = column_with_type_and_name.column;
-        if (const auto* nullable_column = check_and_get_column<ColumnNullable>(*column)) {
+        if (const auto nullable_column = check_and_get_column<ColumnNullable>(*column)) {
             const ColumnPtr& nested_column = nullable_column->get_nested_column_ptr();
             const auto* dict_column = assert_cast<const ColumnInt32*>(nested_column.get());
             DCHECK(dict_column);

--- a/be/src/format/table/iceberg_delete_file_reader_helper.cpp
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.cpp
@@ -92,8 +92,7 @@ Status visit_position_delete_block(const Block& block, size_t read_rows,
             assert_cast<const ColumnInt64*>(block.get_by_position(pos_it->second).column.get());
     const auto* path_column = block.get_by_position(path_it->second).column.get();
 
-    if (const auto* string_column = check_and_get_column<ColumnString>(path_column);
-        string_column != nullptr) {
+    if (const auto string_column = check_and_get_column<ColumnString>(path_column); string_column) {
         for (size_t i = 0; i < read_rows; ++i) {
             RETURN_IF_ERROR(visitor->visit(string_column->get_data_at(i).to_string(),
                                            pos_column->get_element(i)));
@@ -101,8 +100,7 @@ Status visit_position_delete_block(const Block& block, size_t read_rows,
         return Status::OK();
     }
 
-    if (const auto* dict_column = check_and_get_column<ColumnDictI32>(path_column);
-        dict_column != nullptr) {
+    if (const auto dict_column = check_and_get_column<ColumnDictI32>(path_column); dict_column) {
         const auto& codes = dict_column->get_data();
         for (size_t i = 0; i < read_rows; ++i) {
             RETURN_IF_ERROR(visitor->visit(dict_column->get_value(codes[i]).to_string(),

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -259,13 +259,19 @@ protected:
             return Status::InvalidArgument("Invalid iceberg rowid column type or output column");
         }
         MutableColumnPtr column = type->create_column();
-        ColumnNullable* nullable_col = check_and_get_column<ColumnNullable>(column.get());
+        auto nullable_col = check_and_get_column<ColumnNullable>(column.get());
         ColumnStruct* struct_col = nullptr;
-        if (nullable_col != nullptr) {
-            struct_col =
+        if (nullable_col) {
+            const auto struct_col_guard =
                     check_and_get_column<ColumnStruct>(nullable_col->get_nested_column_ptr().get());
+            if (struct_col_guard) {
+                struct_col = struct_col_guard.get();
+            }
         } else {
-            struct_col = check_and_get_column<ColumnStruct>(column.get());
+            const auto struct_col_guard = check_and_get_column<ColumnStruct>(column.get());
+            if (struct_col_guard) {
+                struct_col = struct_col_guard.get();
+            }
         }
         if (struct_col == nullptr || struct_col->tuple_size() < 4) {
             return Status::InternalError("Invalid iceberg rowid column structure");
@@ -293,7 +299,7 @@ protected:
         for (size_t i = 0; i < num_rows; ++i) {
             partition_data_col.insert_data(partition_data_json.data(), partition_data_json.size());
         }
-        if (nullable_col != nullptr) {
+        if (nullable_col) {
             nullable_col->get_null_map_data().resize_fill(num_rows, 0);
         }
         *column_out = std::move(column);

--- a/be/src/format/table/paimon_predicate_converter.cpp
+++ b/be/src/format/table/paimon_predicate_converter.cpp
@@ -355,7 +355,7 @@ std::optional<paimon::Literal> PaimonPredicateConverter::_convert_literal(
     PrimitiveType slot_primitive = slot_desc.type()->get_primitive_type();
 
     ColumnPtr col = literal->get_column_ptr()->convert_to_full_column_if_const();
-    if (const auto* nullable = check_and_get_column<ColumnNullable>(*col)) {
+    if (const auto nullable = check_and_get_column<ColumnNullable>(*col)) {
         if (nullable->is_null_at(0)) {
             return std::nullopt;
         }
@@ -533,7 +533,7 @@ std::optional<std::string> PaimonPredicateConverter::_extract_string_literal(
     }
 
     ColumnPtr col = literal->get_column_ptr()->convert_to_full_column_if_const();
-    if (const auto* nullable = check_and_get_column<ColumnNullable>(*col)) {
+    if (const auto nullable = check_and_get_column<ColumnNullable>(*col)) {
         if (nullable->is_null_at(0)) {
             return std::nullopt;
         }

--- a/be/src/format/table/parquet_utils.cpp
+++ b/be/src/format/table/parquet_utils.cpp
@@ -40,7 +40,7 @@ namespace {
 
 template <typename ColumnType, typename T>
 void insert_numeric_impl(MutableColumnPtr& column, T value) {
-    if (auto* nullable_column = check_and_get_column<ColumnNullable>(*column)) {
+    if (auto nullable_column = check_and_get_column<ColumnNullable>(*column)) {
         auto& nested = nullable_column->get_nested_column();
         assert_cast<ColumnType&>(nested).insert_value(value);
         nullable_column->push_false_to_nullmap(1);
@@ -68,7 +68,7 @@ void insert_bool(MutableColumnPtr& column, bool value) {
 }
 
 void insert_string(MutableColumnPtr& column, const std::string& value) {
-    if (auto* nullable = check_and_get_column<ColumnNullable>(*column)) {
+    if (auto nullable = check_and_get_column<ColumnNullable>(*column)) {
         nullable->get_null_map_data().push_back(0);
         auto& nested = nullable->get_nested_column();
         assert_cast<ColumnString&>(nested).insert_data(value.c_str(), value.size());
@@ -78,7 +78,7 @@ void insert_string(MutableColumnPtr& column, const std::string& value) {
 }
 
 void insert_null(MutableColumnPtr& column) {
-    if (auto* nullable = check_and_get_column<ColumnNullable>(*column)) {
+    if (auto nullable = check_and_get_column<ColumnNullable>(*column)) {
         nullable->get_null_map_data().push_back(1);
         nullable->get_nested_column().insert_default();
     } else {

--- a/be/src/format/transformer/iceberg_partition_function.cpp
+++ b/be/src/format/transformer/iceberg_partition_function.cpp
@@ -336,11 +336,11 @@ Status IcebergDeletePartitionFunction::_get_delete_hash_column(const ColumnWithT
                                                                DataTypePtr* out_type) const {
     ColumnPtr hash_col = column.column;
     DataTypePtr hash_type = column.type;
-    if (auto* nullable_col = check_and_get_column<ColumnNullable>(hash_col.get())) {
+    if (auto nullable_col = check_and_get_column<ColumnNullable>(hash_col.get())) {
         hash_col = nullable_col->get_nested_column_ptr();
         hash_type = remove_nullable(hash_type);
     }
-    const auto* struct_col = check_and_get_column<ColumnStruct>(hash_col.get());
+    const auto struct_col = check_and_get_column<ColumnStruct>(hash_col.get());
     const auto* struct_type = check_and_get_data_type<DataTypeStruct>(hash_type.get());
     if (!struct_col || !struct_type) {
         *out_column = column.column;

--- a/be/src/format/transformer/merge_partitioner.cpp
+++ b/be/src/format/transformer/merge_partitioner.cpp
@@ -214,11 +214,17 @@ Status MergePartitioner::do_partitioning(RuntimeState* state, Block* block) cons
         MutableColumns& mutable_columns = mutable_columns_guard.mutable_columns();
         MutableColumnPtr& op_mut = mutable_columns[op_idx];
         ColumnInt8* op_values_col = nullptr;
-        if (auto* nullable_col = check_and_get_column<ColumnNullable>(op_mut.get())) {
-            op_values_col =
+        if (auto nullable_col = check_and_get_column<ColumnNullable>(op_mut.get())) {
+            const auto op_values_col_guard =
                     check_and_get_column<ColumnInt8>(nullable_col->get_nested_column_ptr().get());
+            if (op_values_col_guard) {
+                op_values_col = op_values_col_guard.get();
+            }
         } else {
-            op_values_col = check_and_get_column<ColumnInt8>(op_mut.get());
+            const auto op_values_col_guard = check_and_get_column<ColumnInt8>(op_mut.get());
+            if (op_values_col_guard) {
+                op_values_col = op_values_col_guard.get();
+            }
         }
         if (op_values_col == nullptr) {
             return Status::InternalError("Merge operation column must be tinyint");

--- a/be/src/storage/index/ann/ann_topn_runtime.cpp
+++ b/be/src/storage/index/ann/ann_topn_runtime.cpp
@@ -58,7 +58,7 @@ Result<ColumnFloat32::Ptr> extract_query_vector(std::shared_ptr<VExpr> arg_expr)
 
     // Unwrap ColumnConst without copy to get the underlying single-row column
     IColumn::Ptr col_ptr = column_wrapper->column_ptr;
-    if (const auto* const_col = check_and_get_column<ColumnConst>(*col_ptr)) {
+    if (const auto const_col = check_and_get_column<ColumnConst>(*col_ptr)) {
         col_ptr = const_col->get_data_column_ptr();
     }
 
@@ -67,7 +67,7 @@ Result<ColumnFloat32::Ptr> extract_query_vector(std::shared_ptr<VExpr> arg_expr)
     const IColumn* top_col = col_ptr.get();
     const IColumn* array_holder_col = top_col;
     // Handle outer Nullable and remember result nullability preference
-    if (auto* nullable_col = check_and_get_column<ColumnNullable>(*top_col)) {
+    if (auto nullable_col = check_and_get_column<ColumnNullable>(*top_col)) {
         if (nullable_col->has_null()) {
             return ResultError(Status::InvalidArgument("Ann query vector cannot be NULL"));
         }
@@ -75,8 +75,14 @@ Result<ColumnFloat32::Ptr> extract_query_vector(std::shared_ptr<VExpr> arg_expr)
     }
 
     // Must be an array column with single row
-    const auto* array_col = check_and_get_column<ColumnArray>(*array_holder_col);
-    if (array_col == nullptr || array_col->size() != 1) {
+    const auto array_col_guard = check_and_get_column<ColumnArray>(*array_holder_col);
+    if (!array_col_guard) {
+        return ResultError(Status::InvalidArgument(
+                "Ann topn expr constant should be an Array literal, got column: {}",
+                array_holder_col->get_name()));
+    }
+    const auto* array_col = array_col_guard.get();
+    if (array_col->size() != 1) {
         return ResultError(Status::InvalidArgument(
                 "Ann topn expr constant should be an Array literal, got column: {}",
                 array_holder_col->get_name()));
@@ -91,7 +97,7 @@ Result<ColumnFloat32::Ptr> extract_query_vector(std::shared_ptr<VExpr> arg_expr)
         return ResultError(Status::InvalidArgument("Ann topn query vector cannot be empty"));
     }
 
-    if (auto* value_nullable_col = check_and_get_column<ColumnNullable>(nested_data_any)) {
+    if (auto value_nullable_col = check_and_get_column<ColumnNullable>(nested_data_any)) {
         if (value_nullable_col->has_null(0, value_count)) {
             return ResultError(Status::InvalidArgument(
                     "Ann topn query vector elements cannot contain NULL values"));

--- a/be/src/storage/iterator/olap_data_convertor.cpp
+++ b/be/src/storage/iterator/olap_data_convertor.cpp
@@ -1012,10 +1012,18 @@ void OlapBlockDataConvertor::OlapColumnDataConvertorVariant::set_source_column(
         nullable_column = assert_cast<const ColumnNullable*>(typed_column.column.get());
         _nullmap = nullable_column->get_null_map_data().data();
     }
-    const auto* variant = nullable_column == nullptr
-                                  ? check_and_get_column<const ColumnVariant>(*typed_column.column)
-                                  : check_and_get_column<const ColumnVariant>(
-                                            nullable_column->get_nested_column());
+    const ColumnVariant* variant = nullptr;
+    if (nullable_column == nullptr) {
+        if (const auto variant_guard =
+                    check_and_get_column<const ColumnVariant>(*typed_column.column)) {
+            variant = variant_guard.get();
+        }
+    } else {
+        if (const auto variant_guard = check_and_get_column<const ColumnVariant>(
+                    nullable_column->get_nested_column())) {
+            variant = variant_guard.get();
+        }
+    }
     OlapBlockDataConvertor::OlapColumnDataConvertorBase::set_source_column(typed_column, row_pos,
                                                                            num_rows);
 

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -597,14 +597,18 @@ private:
                 __builtin_unreachable();
             }
         } else {
-            auto* nested_col_ptr =
-                    check_and_get_column<PredicateColumnType<PredicateEvaluateType<Type>>>(column);
-            if (nested_col_ptr == nullptr) {
+            const auto* nested_col =
+                    static_cast<const PredicateColumnType<PredicateEvaluateType<Type>>*>(nullptr);
+            if (auto nested_col_ptr =
+                        check_and_get_column<PredicateColumnType<PredicateEvaluateType<Type>>>(
+                                column)) {
+                nested_col = nested_col_ptr.get();
+            } else {
                 throw Exception(ErrorCode::INTERNAL_ERROR,
                                 "InListPredicateBase: _base_evaluate_bit get invalid column type");
             }
 
-            auto& data_array = nested_col_ptr->get_data();
+            auto& data_array = nested_col->get_data();
 
             for (uint16_t i = 0; i < size; i++) {
                 if (is_and ^ flags[i]) {

--- a/be/src/storage/predicate/null_predicate.cpp
+++ b/be/src/storage/predicate/null_predicate.cpp
@@ -65,7 +65,7 @@ Status NullPredicate::evaluate(const IndexFieldNameAndTypePair& name_with_type,
 
 uint16_t NullPredicate::_evaluate_inner(const IColumn& column, uint16_t* sel, uint16_t size) const {
     uint16_t new_size = 0;
-    if (auto* nullable = check_and_get_column<ColumnNullable>(column)) {
+    if (auto nullable = check_and_get_column<ColumnNullable>(column)) {
         if (!nullable->has_null()) {
             return _is_null ? 0 : size;
         }
@@ -85,7 +85,7 @@ uint16_t NullPredicate::_evaluate_inner(const IColumn& column, uint16_t* sel, ui
 
 void NullPredicate::evaluate_or(const IColumn& column, const uint16_t* sel, uint16_t size,
                                 bool* flags) const {
-    if (auto* nullable = check_and_get_column<ColumnNullable>(column)) {
+    if (auto nullable = check_and_get_column<ColumnNullable>(column)) {
         if (!nullable->has_null()) {
             if (!_is_null) {
                 memset(flags, true, size);
@@ -105,7 +105,7 @@ void NullPredicate::evaluate_or(const IColumn& column, const uint16_t* sel, uint
 
 void NullPredicate::evaluate_and(const IColumn& column, const uint16_t* sel, uint16_t size,
                                  bool* flags) const {
-    if (auto* nullable = check_and_get_column<ColumnNullable>(column)) {
+    if (auto nullable = check_and_get_column<ColumnNullable>(column)) {
         if (!nullable->has_null()) {
             if (_is_null) {
                 memset(flags, false, size);
@@ -124,7 +124,7 @@ void NullPredicate::evaluate_and(const IColumn& column, const uint16_t* sel, uin
 }
 
 void NullPredicate::evaluate_vec(const IColumn& column, uint16_t size, bool* flags) const {
-    if (auto* nullable = check_and_get_column<ColumnNullable>(column)) {
+    if (auto nullable = check_and_get_column<ColumnNullable>(column)) {
         if (!nullable->has_null()) {
             memset(flags, !_is_null, size);
         }

--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -324,7 +324,7 @@ void ColumnReader::check_data_by_zone_map_for_test(const MutableColumnPtr& dst) 
 
     /// `PredicateColumnType<TYPE_INT>` does not support `void get(size_t n, Field& res)`,
     /// So here only check `CoumnVector<TYPE_INT>`
-    if (check_and_get_column<ColumnVector<TYPE_INT>>(non_nullable_column) == nullptr) {
+    if (!check_and_get_column<ColumnVector<TYPE_INT>>(non_nullable_column)) {
         return;
     }
 
@@ -2204,8 +2204,8 @@ Status FileColumnIterator::next_batch(size_t* n, MutableColumnPtr& dst, bool* ha
                     DCHECK_EQ(this_run, num_rows);
                 } else {
                     *has_null = true;
-                    auto* null_col = check_and_get_column<ColumnNullable>(dst.get());
-                    if (null_col != nullptr) {
+                    auto null_col = check_and_get_column<ColumnNullable>(dst.get());
+                    if (null_col) {
                         null_col->insert_many_defaults(this_run);
                     } else {
                         return Status::InternalError("unexpected column type in column reader");
@@ -2337,12 +2337,14 @@ Status FileColumnIterator::read_by_rowids(const rowid_t* rowids, const size_t co
                 auto origin_index = _page.data_decoder->current_index();
                 if (this_read_count > 0) {
                     if (is_null) {
-                        auto* null_col = check_and_get_column<ColumnNullable>(dst.get());
-                        if (UNLIKELY(null_col == nullptr)) {
+                        ColumnNullable* null_col_ptr = nullptr;
+                        if (auto null_col = check_and_get_column<ColumnNullable>(dst.get())) {
+                            null_col_ptr = null_col.get();
+                        } else {
                             return Status::InternalError("unexpected column type in column reader");
                         }
 
-                        null_col->insert_many_defaults(this_read_count);
+                        null_col_ptr->insert_many_defaults(this_read_count);
                     } else {
                         size_t read_count = this_read_count;
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -2360,11 +2360,13 @@ Status SegmentIterator::_output_non_pred_columns(Block* block) {
         //    Here loc=2 for c3, block->columns()=2, so loc < block->columns() is false,
         //    and c3 is skipped — same behavior as the VMergeIterator path.
         if (loc < block->columns()) {
-            bool column_in_block_is_nothing = check_and_get_column<const ColumnNothing>(
+            const auto column_in_block_nothing_guard = check_and_get_column<const ColumnNothing>(
                     block->get_by_position(loc).column.get());
+            bool column_in_block_is_nothing = static_cast<bool>(column_in_block_nothing_guard);
             bool column_is_normal = !_vir_cid_to_idx_in_block.contains(cid);
-            bool return_column_is_nothing =
+            const auto return_column_nothing_guard =
                     check_and_get_column<const ColumnNothing>(_current_return_columns[cid].get());
+            bool return_column_is_nothing = static_cast<bool>(return_column_nothing_guard);
             VLOG_DEBUG << fmt::format(
                     "Cid {} loc {}, column_in_block_is_nothing {}, column_is_normal {}, "
                     "return_column_is_nothing {}",

--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -1625,10 +1625,16 @@ void VariantRootColumnIterator::collect_prefetchers(
 
 static void fill_nested_with_defaults(MutableColumnPtr& dst, MutableColumnPtr& sibling_column,
                                       size_t nrows) {
-    const auto* sibling_array =
-            check_and_get_column<ColumnArray>(remove_nullable(sibling_column->get_ptr()).get());
-    const auto* dst_array =
-            check_and_get_column<ColumnArray>(remove_nullable(dst->get_ptr()).get());
+    const ColumnArray* sibling_array = nullptr;
+    if (const auto sibling_array_guard = check_and_get_column<ColumnArray>(
+                remove_nullable(sibling_column->get_ptr()).get())) {
+        sibling_array = sibling_array_guard.get();
+    }
+    const ColumnArray* dst_array = nullptr;
+    if (const auto dst_array_guard =
+                check_and_get_column<ColumnArray>(remove_nullable(dst->get_ptr()).get())) {
+        dst_array = dst_array_guard.get();
+    }
     if (!dst_array || !sibling_array) {
         throw doris::Exception(ErrorCode::INTERNAL_ERROR,
                                "Expected array column, but met {} and {}", dst->get_name(),

--- a/be/test/core/block/column_array_test.cpp
+++ b/be/test/core/block/column_array_test.cpp
@@ -31,15 +31,15 @@
 namespace doris {
 
 void check_array_offsets(const IColumn& arr, const std::vector<ColumnArray::Offset64>& offs) {
-    auto arr_col = check_and_get_column<ColumnArray>(arr);
-    ASSERT_EQ(arr_col->size(), offs.size());
-    for (size_t i = 0; i < arr_col->size(); ++i) {
-        ASSERT_EQ(arr_col->get_offsets()[i], offs[i]);
+    const auto* arr_col_ptr = assert_cast<const ColumnArray*>(&arr);
+    ASSERT_EQ(arr_col_ptr->size(), offs.size());
+    for (size_t i = 0; i < arr_col_ptr->size(); ++i) {
+        ASSERT_EQ(arr_col_ptr->get_offsets()[i], offs[i]);
     }
 }
 template <typename T>
 void check_array_data(const IColumn& arr, const std::vector<T>& data) {
-    auto arr_col = check_and_get_column<ColumnArray>(arr);
+    const auto* arr_col = assert_cast<const ColumnArray*>(&arr);
     auto data_col = arr_col->get_data_ptr();
     ASSERT_EQ(data_col->size(), data.size());
     for (size_t i = 0; i < data_col->size(); ++i) {
@@ -49,7 +49,7 @@ void check_array_data(const IColumn& arr, const std::vector<T>& data) {
 }
 template <>
 void check_array_data(const IColumn& arr, const std::vector<std::string>& data) {
-    auto arr_col = check_and_get_column<ColumnArray>(arr);
+    const auto* arr_col = assert_cast<const ColumnArray*>(&arr);
     auto data_col = arr_col->get_data_ptr();
     ASSERT_EQ(data_col->size(), data.size());
     for (size_t i = 0; i < data_col->size(); ++i) {

--- a/be/test/core/column/check_and_get_column_ptr_test.cpp
+++ b/be/test/core/column/check_and_get_column_ptr_test.cpp
@@ -87,7 +87,12 @@ TEST(CheckAndGetColumnPtrTest, errorTest) {
         ColumnPtr nested_column = column;
 
         nested_column = nested_column->convert_to_full_column_if_const();
-        const auto* source_column = check_and_get_column<ColumnNullable>(nested_column.get());
+        const ColumnNullable* source_column = nullptr;
+        if (const auto source_column_guard =
+                    check_and_get_column<ColumnNullable>(nested_column.get())) {
+            source_column = source_column_guard.get();
+        }
+        ASSERT_NE(source_column, nullptr);
         nested_column = source_column->get_nested_column_ptr();
         // The source_column is now a dangling pointer.
         // std::cout<<source_column->use_count()<<std::endl;

--- a/be/test/core/column/column_array_test.cpp
+++ b/be/test/core/column/column_array_test.cpp
@@ -642,7 +642,7 @@ TEST_F(ColumnArrayTest, CreateArrayTest) {
     // - ColumnArray requires mutable nested data for operations like insert/filter/clear
     // - Wrapping shared ColumnConst in ColumnArray violates use_count() assumptions in clear_column_data()
     for (auto& array_column : array_columns) {
-        const auto* column = check_and_get_column<ColumnArray>(
+        const auto* column = assert_cast<const ColumnArray*>(
                 remove_nullable(array_column->assert_mutable()).get());
         auto column_size = column->size();
         LOG(INFO) << "column_type: " << column->get_name();
@@ -712,9 +712,10 @@ TEST_F(ColumnArrayTest, ConvertIfOverflowAndInsertTest) {
         // check ptr is itself
         auto ptr = column->convert_column_if_overflow();
         EXPECT_EQ(ptr.get(), column.get());
-        auto arr_col = check_and_get_column<ColumnArray>(remove_nullable(column->get_ptr()).get());
+        const auto* arr_col =
+                assert_cast<const ColumnArray*>(remove_nullable(column->get_ptr()).get());
         auto nested_col = arr_col->get_data_ptr();
-        auto array_col1 = check_and_get_column<ColumnArray>(remove_nullable(ptr).get());
+        const auto* array_col1 = assert_cast<const ColumnArray*>(remove_nullable(ptr).get());
         auto nested_col1 = array_col1->get_data_ptr();
         EXPECT_EQ(nested_col.get(), nested_col1.get());
         // check column data
@@ -739,7 +740,7 @@ TEST_F(ColumnArrayTest, InsertRangeFromIgnoreOverflowTest) {
 TEST_F(ColumnArrayTest, GetNumberOfDimensionsTest) {
     // test dimension of array
     for (int i = 0; i < array_columns.size(); i++) {
-        auto column = check_and_get_column<ColumnArray>(
+        const auto* column = assert_cast<const ColumnArray*>(
                 remove_nullable(array_columns[i]->assert_mutable()).get());
         auto check_type = remove_nullable(array_types[i]);
         auto dimension = 0;
@@ -757,7 +758,7 @@ TEST_F(ColumnArrayTest, GetNumberOfDimensionsTest) {
 TEST_F(ColumnArrayTest, IsExclusiveTest) {
     auto callback = [&](const MutableColumns& columns, const DataTypeSerDeSPtrs& serdes) {
         for (int i = 0; i < columns.size(); i++) {
-            auto column = check_and_get_column<ColumnArray>(
+            const auto* column = assert_cast<const ColumnArray*>(
                     remove_nullable(columns[i]->assert_mutable()).get());
             auto cloned = columns[i]->clone_resized(1);
             // test expect true
@@ -781,7 +782,7 @@ TEST_F(ColumnArrayTest, MaxArraySizeAsFieldTest) {
     // test array max_array_size_as_field which is set to 100w
     //  in operator[] and get()
     for (int i = 0; i < array_columns.size(); i++) {
-        auto column = check_and_get_column<ColumnArray>(
+        const auto* column = assert_cast<const ColumnArray*>(
                 remove_nullable(array_columns[i]->assert_mutable()).get());
         auto check_type = remove_nullable(array_types[i]);
         Field a;
@@ -816,7 +817,7 @@ TEST_F(ColumnArrayTest, IsDefaultAtTest) {
     // default means meet empty array row in column_array, now just only used in ColumnVariant.
     // test is_default_at
     for (int i = 0; i < array_columns.size(); i++) {
-        auto column = check_and_get_column<ColumnArray>(
+        const auto* column = assert_cast<const ColumnArray*>(
                 remove_nullable(array_columns[i]->assert_mutable()).get());
         auto column_size = column->size();
         for (int j = 0; j < column_size; j++) {
@@ -840,11 +841,11 @@ TEST_F(ColumnArrayTest, IsDefaultAtTest) {
 TEST_F(ColumnArrayTest, HasEqualOffsetsTest) {
     // test has_equal_offsets which more likely used in function, eg: function_array_zip
     for (int i = 0; i < array_columns.size(); i++) {
-        auto column = check_and_get_column<ColumnArray>(
+        const auto* column = assert_cast<const ColumnArray*>(
                 remove_nullable(array_columns[i]->assert_mutable()).get());
         auto cloned = array_columns[i]->clone_resized(array_columns[i]->size());
-        auto cloned_arr =
-                check_and_get_column<ColumnArray>(remove_nullable(cloned->assert_mutable()).get());
+        const auto* cloned_arr =
+                assert_cast<const ColumnArray*>(remove_nullable(cloned->assert_mutable()).get());
         // test expect true
         EXPECT_EQ(column->get_offsets().size(), cloned_arr->get_offsets().size());
         EXPECT_TRUE(column->has_equal_offsets(*cloned_arr));
@@ -921,7 +922,7 @@ TEST_F(ColumnArrayTest, IntArrayPermuteTest) {
     auto res1 = array_column->permute(perm, 2);
     // check offsets
     IColumn::Offsets offs1 = {2, 3};
-    auto arr_col = check_and_get_column<ColumnArray>(*res1);
+    const auto* arr_col = assert_cast<const ColumnArray*>(res1.get());
     ASSERT_EQ(arr_col->size(), offs1.size());
     for (size_t i = 0; i < arr_col->size(); ++i) {
         ASSERT_EQ(arr_col->get_offsets()[i], offs1[i]);
@@ -939,7 +940,7 @@ TEST_F(ColumnArrayTest, IntArrayPermuteTest) {
     auto res2 = array_column->permute(perm, 0);
     // check offsets
     IColumn::Offsets offs2 = {2, 3, 3, 6};
-    arr_col = check_and_get_column<ColumnArray>(*res2);
+    arr_col = assert_cast<const ColumnArray*>(res2.get());
     ASSERT_EQ(arr_col->size(), offs2.size());
     for (size_t i = 0; i < arr_col->size(); ++i) {
         ASSERT_EQ(arr_col->get_offsets()[i], offs2[i]);

--- a/be/test/core/value/merge_partitioner_test.cpp
+++ b/be/test/core/value/merge_partitioner_test.cpp
@@ -147,8 +147,9 @@ protected:
 
     const ColumnInt8& _get_op_column(const Block& block) const {
         const auto& column = block.get_by_position(0).column;
-        if (auto* nullable_col = check_and_get_column<ColumnNullable>(column.get())) {
-            return *assert_cast<const ColumnInt8*>(nullable_col->get_nested_column_ptr().get());
+        if (const auto nullable_col = check_and_get_column<ColumnNullable>(column.get())) {
+            return *assert_cast<const ColumnInt8*>(
+                    nullable_col.get()->get_nested_column_ptr().get());
         }
         return *assert_cast<const ColumnInt8*>(column.get());
     }

--- a/be/test/exec/sink/viceberg_delete_sink_test.cpp
+++ b/be/test/exec/sink/viceberg_delete_sink_test.cpp
@@ -441,17 +441,23 @@ TEST_F(VIcebergDeleteSinkTest, TestBuildPositionDeleteBlock) {
     ASSERT_EQ("pos", output_block.get_by_position(1).name);
 
     // Verify file_path column
-    auto file_path_column =
-            check_and_get_column<ColumnString>(output_block.get_by_position(0).column.get());
-    ASSERT_NE(nullptr, file_path_column);
+    const ColumnString* file_path_column = nullptr;
+    if (auto file_path_column_guard =
+                check_and_get_column<ColumnString>(output_block.get_by_position(0).column.get())) {
+        file_path_column = file_path_column_guard.get();
+    }
+    ASSERT_NE(file_path_column, nullptr);
     for (size_t i = 0; i < 4; i++) {
         ASSERT_EQ(file_path, file_path_column->get_data_at(i).to_string());
     }
 
     // Verify pos column
-    auto pos_column =
-            check_and_get_column<ColumnInt64>(output_block.get_by_position(1).column.get());
-    ASSERT_NE(nullptr, pos_column);
+    const ColumnInt64* pos_column = nullptr;
+    if (auto pos_column_guard =
+                check_and_get_column<ColumnInt64>(output_block.get_by_position(1).column.get())) {
+        pos_column = pos_column_guard.get();
+    }
+    ASSERT_NE(pos_column, nullptr);
     ASSERT_EQ(10, pos_column->get_element(0));
     ASSERT_EQ(20, pos_column->get_element(1));
     ASSERT_EQ(30, pos_column->get_element(2));

--- a/be/test/exprs/function/function_test_util.h
+++ b/be/test/exprs/function/function_test_util.h
@@ -449,9 +449,9 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
     // 3.1. check the result of function
     ColumnPtr column = block.get_columns()[result];
     EXPECT_TRUE(column);
-    if (const auto* column_str = check_and_get_column<ColumnString>(column.get());
+    if (const auto column_str = check_and_get_column<ColumnString>(column.get());
         column_str && !expect_result_ne) {
-        column_str->sanity_check();
+        column_str.get()->sanity_check();
     }
 
     for (int i = 0; i < row_size; ++i) {

--- a/be/test/exprs/function/function_time_test.cpp
+++ b/be/test/exprs/function/function_time_test.cpp
@@ -1764,8 +1764,8 @@ TEST(VTimestampFunctionsTest, curtime_test) {
 
         auto result_col = block.get_by_position(0).column;
         EXPECT_TRUE(result_col);
-        if (const auto* const_col = check_and_get_column<ColumnConst>(result_col.get())) {
-            auto time_value = const_col->get_field().get<TYPE_TIMEV2>();
+        if (const auto const_col = check_and_get_column<ColumnConst>(result_col.get())) {
+            auto time_value = const_col.get()->get_field().template get<TYPE_TIMEV2>();
             EXPECT_GE(time_value, 0.0);
             EXPECT_LE(time_value, 24.0 * 3600 * 1000000);
         }
@@ -1807,8 +1807,8 @@ TEST(VTimestampFunctionsTest, curtime_test) {
 
         auto result_col = block.get_by_position(1).column;
         EXPECT_TRUE(result_col);
-        if (const auto* const_col = check_and_get_column<ColumnConst>(result_col.get())) {
-            auto time_value = const_col->get_field().get<TYPE_TIMEV2>();
+        if (const auto const_col = check_and_get_column<ColumnConst>(result_col.get())) {
+            auto time_value = const_col.get()->get_field().template get<TYPE_TIMEV2>();
             EXPECT_GE(time_value, 0.0);
             EXPECT_LE(time_value, 24.0 * 3600 * 1000000);
         }

--- a/be/test/exprs/vcondition_expr_test.cpp
+++ b/be/test/exprs/vcondition_expr_test.cpp
@@ -117,7 +117,7 @@ static ColumnPtr make_float64_column(const std::vector<double>& values) {
 // Helper: extract the Float64 value at `row` from the result column,
 // handling both nullable and non-nullable cases.
 static double get_float64_value(const ColumnPtr& column, size_t row, bool* is_null = nullptr) {
-    if (const auto* nullable = check_and_get_column<ColumnNullable>(column.get())) {
+    if (const auto nullable = check_and_get_column<ColumnNullable>(column.get())) {
         if (is_null) {
             *is_null = nullable->is_null_at(row);
         }
@@ -288,7 +288,7 @@ TEST_F(VConditionExprCoalesceTest, Float32_NaN_NotPolluteResult) {
     ASSERT_EQ(result->size(), 2);
 
     auto get_f32 = [&](size_t row, bool* is_null) -> float {
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(result.get())) {
+        if (const auto nullable = check_and_get_column<ColumnNullable>(result.get())) {
             *is_null = nullable->is_null_at(row);
             return assert_cast<const ColumnFloat32&>(nullable->get_nested_column()).get_data()[row];
         }
@@ -340,7 +340,7 @@ TEST_F(VConditionExprCoalesceTest, Int32_NormalPathStillWorks) {
     ASSERT_EQ(result->size(), 2);
 
     auto get_int = [&](size_t row, bool* is_null) -> int32_t {
-        if (const auto* nullable = check_and_get_column<ColumnNullable>(result.get())) {
+        if (const auto nullable = check_and_get_column<ColumnNullable>(result.get())) {
             *is_null = nullable->is_null_at(row);
             return assert_cast<const ColumnInt32&>(nullable->get_nested_column()).get_data()[row];
         }

--- a/be/test/storage/index/ann/ann_range_search_test.cpp
+++ b/be/test/storage/index/ann/ann_range_search_test.cpp
@@ -197,10 +197,10 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch) {
     doris::segment_v2::VirtualColumnIterator* virtual_column_iter =
             dynamic_cast<doris::segment_v2::VirtualColumnIterator*>(column_iterators[3].get());
     IColumn::Ptr column = virtual_column_iter->get_materialized_column();
-    const ColumnFloat32* float_column = check_and_get_column<const ColumnFloat32>(column.get());
-    const ColumnNothing* nothing_column = check_and_get_column<const ColumnNothing>(column.get());
-    ASSERT_EQ(float_column, nullptr);
-    ASSERT_NE(nothing_column, nullptr);
+    const auto float_column = check_and_get_column<const ColumnFloat32>(column.get());
+    const auto nothing_column = check_and_get_column<const ColumnNothing>(column.get());
+    ASSERT_FALSE(static_cast<bool>(float_column));
+    ASSERT_TRUE(static_cast<bool>(nothing_column));
     EXPECT_EQ(column->size(), 0);
 
     const auto& get_row_id_to_idx = virtual_column_iter->get_row_id_to_idx();
@@ -302,11 +302,14 @@ TEST_F(VectorSearchTest, TestEvaluateAnnRangeSearch2) {
             dynamic_cast<doris::segment_v2::VirtualColumnIterator*>(column_iterators[3].get());
 
     IColumn::Ptr column = virtual_column_iter->get_materialized_column();
-    const ColumnFloat32* nullable_column = check_and_get_column<const ColumnFloat32>(column.get());
-    const ColumnNothing* nothing_column = check_and_get_column<const ColumnNothing>(column.get());
-    ASSERT_NE(nullable_column, nullptr);
-    ASSERT_EQ(nothing_column, nullptr);
-    EXPECT_EQ(nullable_column->size(), 10);
+    const auto nullable_column = check_and_get_column<const ColumnFloat32>(column.get());
+    const auto nothing_column = check_and_get_column<const ColumnNothing>(column.get());
+    ASSERT_FALSE(static_cast<bool>(nothing_column));
+    if (!nullable_column) {
+        FAIL() << "Expected virtual column materialized as ColumnFloat32";
+    } else {
+        EXPECT_EQ(nullable_column.get()->size(), 10);
+    }
     EXPECT_EQ(row_bitmap.cardinality(), 10);
 
     const auto& get_row_id_to_idx = virtual_column_iter->get_row_id_to_idx();

--- a/be/test/storage/index/ann/virtual_column_iterator_test.cpp
+++ b/be/test/storage/index/ann/virtual_column_iterator_test.cpp
@@ -419,14 +419,17 @@ TEST_F(VirtualColumnIteratorTest, TestColumnNothing) {
     Status status = iterator.read_by_rowids(rowids, count, dst);
     ASSERT_TRUE(status.ok());
     auto tmp_nothing = check_and_get_column<ColumnNothing>(*dst);
-    ASSERT_TRUE(tmp_nothing == nullptr);
+    ASSERT_FALSE(static_cast<bool>(tmp_nothing));
     auto tmp_col_i32 =
             check_and_get_column<ColumnVector<TYPE_INT>>(*iterator.get_materialized_column());
-    ASSERT_TRUE(tmp_col_i32 != nullptr);
     ASSERT_EQ(dst->size(), 3);
-    ASSERT_EQ(tmp_col_i32->get_data()[0], 20);
-    ASSERT_EQ(tmp_col_i32->get_data()[1], 40);
-    ASSERT_EQ(tmp_col_i32->get_data()[2], 30);
+    if (!tmp_col_i32) {
+        FAIL() << "Expected materialized int column";
+    } else {
+        ASSERT_EQ(tmp_col_i32->get_data()[0], 20);
+        ASSERT_EQ(tmp_col_i32->get_data()[1], 40);
+        ASSERT_EQ(tmp_col_i32->get_data()[2], 30);
+    }
 }
 
 // Test the combination of seek_to_ordinal + next_batch behavior
@@ -632,7 +635,7 @@ TEST_F(VirtualColumnIteratorTest, DstColumnNothingHandling) {
 
         // dst should be replaced with materialized column data
         auto nothing_check = check_and_get_column<ColumnNothing>(*dst);
-        EXPECT_EQ(nothing_check, nullptr); // Should not be ColumnNothing anymore
+        EXPECT_FALSE(static_cast<bool>(nothing_check)); // Should not be ColumnNothing anymore
         ASSERT_EQ(dst->size(), 2);
         EXPECT_EQ(dst->get_int(0), 100); // ordinal 0 -> value 100
         EXPECT_EQ(dst->get_int(1), 200); // ordinal 1 -> value 200
@@ -647,7 +650,7 @@ TEST_F(VirtualColumnIteratorTest, DstColumnNothingHandling) {
 
         // dst should be replaced with filtered results
         auto nothing_check = check_and_get_column<ColumnNothing>(*dst);
-        EXPECT_EQ(nothing_check, nullptr); // Should not be ColumnNothing anymore
+        EXPECT_FALSE(static_cast<bool>(nothing_check)); // Should not be ColumnNothing anymore
         ASSERT_EQ(dst->size(), 2);
         EXPECT_EQ(dst->get_int(0), 200); // row_id 1 -> value 200
         EXPECT_EQ(dst->get_int(1), 300); // row_id 2 -> value 300
@@ -662,7 +665,7 @@ TEST_F(VirtualColumnIteratorTest, DstColumnNothingHandling) {
 
         // dst should remain ColumnNothing for empty results
         auto nothing_check = check_and_get_column<ColumnNothing>(*dst);
-        EXPECT_NE(nothing_check, nullptr); // Should still be ColumnNothing
+        EXPECT_TRUE(static_cast<bool>(nothing_check)); // Should still be ColumnNothing
         ASSERT_EQ(dst->size(), 0);
     }
 }


### PR DESCRIPTION

### What problem does this PR solve?

The raw pointer return type of check_and_get_column made it easy to use downcast results without an explicit check, which weakens the intended safety around column type probing.

This PR makes the four base check_and_get_column overloads return ColumnPtrGuard, adds get() for explicit raw pointer forwarding, keeps check_and_get_column_ptr unchanged, and updates BE and BE UT call sites to unwrap the guard explicitly.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

