### PR TITLE
[fix](scan) Fix adaptive load batch sizing

### DIFF
--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -610,7 +610,9 @@ Status FileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool* 
                 RETURN_IF_ERROR(_convert_to_output_block(block));
                 // Truncate char columns or varchar columns if size is smaller than file columns
                 // or not found in the file column schema.
+                _update_adaptive_batch_size_before_truncate(*block);
                 RETURN_IF_ERROR(_truncate_char_or_varchar_columns(block));
+                _update_adaptive_batch_size_after_truncate(*block);
             }
         }
         break;


### PR DESCRIPTION
## Summary

Related PR: #63005

- update the file scan load path to feed converted blocks into adaptive batch size prediction before and after varchar truncation

## Root Cause

The load path initialized adaptive batch sizing but did not update the predictor after converting loaded source blocks. As a result, the reader could keep using the initial small probe size.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `./run-regression-test.sh --run -d unique_with_mow_c_p0 -s test_compact_with_seq2`