### PR TITLE
[fix](column) validate struct field names in DataTypeStruct constructor

### DIFF
--- a/be/src/core/data_type/data_type_struct.cpp
+++ b/be/src/core/data_type/data_type_struct.cpp
@@ -57,19 +57,19 @@ DataTypeStruct::DataTypeStruct(const DataTypes& elems_)
     }
 }
 
-static Status check_tuple_names(const Strings& names) {
+
+static void check_tuple_names_or_throw(const Strings& names) {
     std::unordered_set<String> names_set;
     for (const auto& name : names) {
         if (name.empty()) {
-            return Status::InvalidArgument("Names of struct elements cannot be empty");
+            throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                   "Names of struct elements cannot be empty");
         }
-
         if (!names_set.insert(name).second) {
-            return Status::InvalidArgument("Names of struct elements must be unique");
+            throw doris::Exception(ErrorCode::INTERNAL_ERROR,
+                                   "Names of struct elements must be unique");
         }
     }
-
-    return {};
 }
 
 DataTypeStruct::DataTypeStruct(const DataTypes& elems_, const Strings& names_)
@@ -80,8 +80,7 @@ DataTypeStruct::DataTypeStruct(const DataTypes& elems_, const Strings& names_)
                                "Wrong number of names passed to constructor of DataTypeStruct");
         __builtin_unreachable();
     }
-
-    Status st = check_tuple_names(names);
+    check_tuple_names_or_throw(names);
 }
 
 std::string DataTypeStruct::do_get_name() const {

--- a/be/src/core/data_type/data_type_struct.cpp
+++ b/be/src/core/data_type/data_type_struct.cpp
@@ -57,7 +57,6 @@ DataTypeStruct::DataTypeStruct(const DataTypes& elems_)
     }
 }
 
-
 static void check_tuple_names_or_throw(const Strings& names) {
     std::unordered_set<String> names_set;
     for (const auto& name : names) {

--- a/be/test/core/data_type/data_type_struct_test.cpp
+++ b/be/test/core/data_type/data_type_struct_test.cpp
@@ -520,4 +520,14 @@ TEST_F(DataTypeStructTest, insertColumnLastValueMultipleTimes) {
     std::cout << "block: " << block.dump_data() << std::endl;
 }
 
+TEST_F(DataTypeStructTest, StructFieldNameValidation) {
+        std::vector<DataTypePtr> elems = {std::make_shared<DataTypeInt32>(),
+                                                                          std::make_shared<DataTypeString>()};
+
+        EXPECT_NO_THROW({ DataTypeStruct data_type(elems, {"a", "b"}); });
+        EXPECT_THROW({ DataTypeStruct data_type(elems, {"", "b"}); }, Exception);
+        EXPECT_THROW({ DataTypeStruct data_type(elems, {"a", ""}); }, Exception);
+        EXPECT_THROW({ DataTypeStruct data_type(elems, {"a", "a"}); }, Exception);
+}
+
 } // namespace doris

--- a/be/test/core/data_type/data_type_struct_test.cpp
+++ b/be/test/core/data_type/data_type_struct_test.cpp
@@ -521,13 +521,13 @@ TEST_F(DataTypeStructTest, insertColumnLastValueMultipleTimes) {
 }
 
 TEST_F(DataTypeStructTest, StructFieldNameValidation) {
-        std::vector<DataTypePtr> elems = {std::make_shared<DataTypeInt32>(),
-                                                                          std::make_shared<DataTypeString>()};
+    std::vector<DataTypePtr> elems = {std::make_shared<DataTypeInt32>(),
+                                      std::make_shared<DataTypeString>()};
 
-        EXPECT_NO_THROW({ DataTypeStruct data_type(elems, {"a", "b"}); });
-        EXPECT_THROW({ DataTypeStruct data_type(elems, {"", "b"}); }, Exception);
-        EXPECT_THROW({ DataTypeStruct data_type(elems, {"a", ""}); }, Exception);
-        EXPECT_THROW({ DataTypeStruct data_type(elems, {"a", "a"}); }, Exception);
+    EXPECT_NO_THROW({ DataTypeStruct data_type(elems, {"a", "b"}); });
+    EXPECT_THROW({ DataTypeStruct data_type(elems, {"", "b"}); }, Exception);
+    EXPECT_THROW({ DataTypeStruct data_type(elems, {"a", ""}); }, Exception);
+    EXPECT_THROW({ DataTypeStruct data_type(elems, {"a", "a"}); }, Exception);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
- Add strict validation for explicit struct field names in `DataTypeStruct`.
- Throw exception when a field name is empty.
- Throw exception when field names are duplicated.
- Add BE unit test to lock in the constructor behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

