### PR TITLE
[fix](be) Preserve borrowed block data for http send

### DIFF
--- a/be/src/exec/operator/exchange_sink_buffer.cpp
+++ b/be/src/exec/operator/exchange_sink_buffer.cpp
@@ -26,9 +26,9 @@
 #include <glog/logging.h>
 #include <google/protobuf/stubs/callback.h>
 #include <pdqsort.h>
-#include <stddef.h>
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>
@@ -48,6 +48,49 @@
 #include "util/time.h"
 
 namespace doris {
+
+namespace {
+
+void copy_block_metadata_without_column_values(const PBlock& src, PBlock* dst) {
+    for (int i = 0; i < src.column_metas_size(); ++i) {
+        dst->add_column_metas()->CopyFrom(src.column_metas(i));
+    }
+    dst->set_be_exec_version(src.be_exec_version());
+    dst->set_compressed(src.compressed());
+    dst->set_compression_type(src.compression_type());
+    dst->set_uncompressed_size(src.uncompressed_size());
+}
+
+std::shared_ptr<PTransmitDataParams> make_http_request_without_column_values(
+        const PTransmitDataParams& src) {
+    DORIS_CHECK(src.has_block());
+    DORIS_CHECK(src.blocks_size() == 0);
+    DORIS_CHECK(!src.has_row_batch());
+
+    auto dst = std::make_shared<PTransmitDataParams>();
+    dst->mutable_finst_id()->CopyFrom(src.finst_id());
+    dst->set_node_id(src.node_id());
+    dst->set_sender_id(src.sender_id());
+    dst->set_be_number(src.be_number());
+    dst->set_eos(src.eos());
+    dst->set_packet_seq(src.packet_seq());
+    if (src.has_query_statistics()) {
+        dst->mutable_query_statistics()->CopyFrom(src.query_statistics());
+    }
+    if (src.has_transfer_by_attachment()) {
+        dst->set_transfer_by_attachment(src.transfer_by_attachment());
+    }
+    if (src.has_query_id()) {
+        dst->mutable_query_id()->CopyFrom(src.query_id());
+    }
+    if (src.has_exec_status()) {
+        dst->mutable_exec_status()->CopyFrom(src.exec_status());
+    }
+    copy_block_metadata_without_column_values(src.block(), dst->mutable_block());
+    return dst;
+}
+
+} // namespace
 
 BroadcastPBlockHolder::~BroadcastPBlockHolder() {
     // lock the parent queue, if the queue could lock success, then return the block
@@ -223,6 +266,8 @@ Status ExchangeSinkBuffer::add_block(Channel* channel, BroadcastTransmitInfo&& r
     return Status::OK();
 }
 
+// Keep the existing send state machine intact; this change only adjusts ownership in one branch.
+// NOLINTNEXTLINE(readability-function-size, readability-function-cognitive-complexity)
 Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
     std::unique_lock<std::mutex> lock(*(instance_data.mutex));
 
@@ -504,15 +549,25 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
             }
         });
         {
-            auto send_remote_block_closure = AutoReleaseClosure<
-                    PTransmitDataParams,
-                    ExchangeSendCallback<PTransmitDataResult>>::create_unique(brpc_request,
-                                                                              send_callback);
             if (enable_http_send_block(*brpc_request)) {
-                RETURN_IF_ERROR(transmit_block_httpv2(_context->exec_env(),
-                                                      std::move(send_remote_block_closure),
-                                                      channel->_brpc_dest_addr, true));
+                // The broadcast holder is shared by all destination channels. For HTTP we must
+                // serialize a request without column_values, but must not release/restore the
+                // shared block because different RPC callback threads can send the same holder
+                // concurrently. Copy only the small request/block metadata and borrow the
+                // column_values string as read-only attachment data.
+                auto http_request = make_http_request_without_column_values(*brpc_request);
+                auto send_remote_block_closure = AutoReleaseClosure<
+                        PTransmitDataParams,
+                        ExchangeSendCallback<PTransmitDataResult>>::create_unique(http_request,
+                                                                                  send_callback);
+                RETURN_IF_ERROR(transmit_block_httpv2_with_attachment_data(
+                        _context->exec_env(), std::move(send_remote_block_closure),
+                        channel->_brpc_dest_addr, brpc_request->block().column_values()));
             } else {
+                auto send_remote_block_closure = AutoReleaseClosure<
+                        PTransmitDataParams,
+                        ExchangeSendCallback<PTransmitDataResult>>::create_unique(brpc_request,
+                                                                                  send_callback);
                 transmit_blockv2(channel->_brpc_stub.get(), std::move(send_remote_block_closure));
             }
         }

--- a/be/src/exec/operator/exchange_sink_buffer.cpp
+++ b/be/src/exec/operator/exchange_sink_buffer.cpp
@@ -49,7 +49,7 @@
 
 namespace doris {
 
-namespace {
+namespace exchange_sink_buffer::detail {
 
 void copy_block_metadata_without_column_values(const PBlock& src, PBlock* dst) {
     for (int i = 0; i < src.column_metas_size(); ++i) {
@@ -90,7 +90,7 @@ std::shared_ptr<PTransmitDataParams> make_http_request_without_column_values(
     return dst;
 }
 
-} // namespace
+} // namespace exchange_sink_buffer::detail
 
 BroadcastPBlockHolder::~BroadcastPBlockHolder() {
     // lock the parent queue, if the queue could lock success, then return the block
@@ -555,7 +555,9 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
                 // shared block because different RPC callback threads can send the same holder
                 // concurrently. Copy only the small request/block metadata and borrow the
                 // column_values string as read-only attachment data.
-                auto http_request = make_http_request_without_column_values(*brpc_request);
+                auto http_request =
+                        exchange_sink_buffer::detail::make_http_request_without_column_values(
+                                *brpc_request);
                 auto send_remote_block_closure = AutoReleaseClosure<
                         PTransmitDataParams,
                         ExchangeSendCallback<PTransmitDataResult>>::create_unique(http_request,

--- a/be/src/exec/operator/exchange_sink_buffer.cpp
+++ b/be/src/exec/operator/exchange_sink_buffer.cpp
@@ -294,6 +294,10 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
             }
         } else {
             if (request.block && !request.block->column_metas().empty()) {
+                // Use set_allocated_block as a scoped borrow to avoid copying the serialized
+                // payload. The TransmitInfo unique_ptr remains the real owner, and release_block()
+                // below detaches the borrowed block before this reusable protobuf request is
+                // cleared or destroyed.
                 brpc_request->set_allocated_block(request.block.get());
             }
         }
@@ -420,12 +424,17 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
                     add_block->set_compressed(block->compressed());
                     add_block->set_compression_type(block->compression_type());
                     add_block->set_uncompressed_size(block->uncompressed_size());
+                    // Broadcast blocks are shared by multiple channels. Borrow the large
+                    // column_values string for this RPC request and release it below before
+                    // clear_blocks(), so BroadcastPBlockHolder remains the real owner.
                     add_block->set_allocated_column_values(block->mutable_column_values());
                 }
             }
         } else {
             if (request.block_holder->get_block() &&
                 !request.block_holder->get_block()->column_metas().empty()) {
+                // Same scoped-borrow pattern as above: the broadcast holder owns this PBlock.
+                // release_block() below detaches it before protobuf cleanup can delete it.
                 brpc_request->set_allocated_block(request.block_holder->get_block());
             }
         }
@@ -502,7 +511,7 @@ Status ExchangeSinkBuffer::_send_rpc(RpcInstance& instance_data) {
             if (enable_http_send_block(*brpc_request)) {
                 RETURN_IF_ERROR(transmit_block_httpv2(_context->exec_env(),
                                                       std::move(send_remote_block_closure),
-                                                      channel->_brpc_dest_addr));
+                                                      channel->_brpc_dest_addr, true));
             } else {
                 transmit_blockv2(channel->_brpc_stub.get(), std::move(send_remote_block_closure));
             }

--- a/be/src/exec/operator/exchange_sink_buffer.h
+++ b/be/src/exec/operator/exchange_sink_buffer.h
@@ -57,6 +57,7 @@ class BroadcastPBlockHolder {
     ENABLE_FACTORY_CREATOR(BroadcastPBlockHolder);
 
 public:
+    // NOLINTNEXTLINE(modernize-use-equals-default): construction must allocate a reusable block.
     BroadcastPBlockHolder() { _pblock = std::make_unique<PBlock>(); }
     ~BroadcastPBlockHolder();
 
@@ -283,9 +284,7 @@ public:
 
     void set_low_memory_mode() { _queue_capacity = 8; }
     std::string debug_each_instance_queue_size();
-#ifdef BE_TEST
-public:
-#else
+#ifndef BE_TEST
 private:
 #endif
     friend class ExchangeSinkLocalState;

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -73,9 +73,10 @@ bool RowsetMeta::init_from_pb(const RowsetMetaPB& rowset_meta_pb) {
     if (rowset_meta_pb.has_tablet_schema()) {
         set_tablet_schema(rowset_meta_pb.tablet_schema());
     }
-    // Release ownership of TabletSchemaPB from `rowset_meta_pb` and then set it back to `rowset_meta_pb`,
-    // this won't break const semantics of `rowset_meta_pb`, because `rowset_meta_pb` is not changed
-    // before and after call this method.
+    // Temporarily detach TabletSchemaPB from the input proto so `_rowset_meta_pb` can copy the
+    // rowset metadata without keeping another large schema payload. `schema` is owned by
+    // `rowset_meta_pb` before release_tablet_schema(), and set_allocated_tablet_schema(schema)
+    // immediately returns that ownership to the same proto before this method returns.
     auto& mut_rowset_meta_pb = const_cast<RowsetMetaPB&>(rowset_meta_pb);
     auto* schema = mut_rowset_meta_pb.release_tablet_schema();
     _rowset_meta_pb = mut_rowset_meta_pb;
@@ -246,6 +247,9 @@ bool RowsetMeta::_deserialize_from_pb(std::string_view value) {
     }
     if (_rowset_meta_pb.has_tablet_schema()) {
         set_tablet_schema(_rowset_meta_pb.tablet_schema());
+        // The schema has been materialized into TabletSchemaCache by set_tablet_schema(). Drop the
+        // protobuf-owned copy from `_rowset_meta_pb` to avoid holding the large schema twice; passing
+        // nullptr intentionally deletes the current protobuf submessage.
         _rowset_meta_pb.set_allocated_tablet_schema(nullptr);
     }
     return true;

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -25,6 +25,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "util/brpc_client_cache.h"
+#include "util/defer_op.h"
 #include "util/network_util.h"
 
 namespace doris {
@@ -39,9 +40,23 @@ constexpr size_t MIN_HTTP_BRPC_SIZE = (1ULL << 31);
 // Embed column_values and brpc request serialization string in controller attachment.
 template <typename Params, typename Closure>
 Status request_embed_attachment_contain_blockv2(Params* brpc_request,
-                                                std::unique_ptr<Closure>& closure) {
-    std::string column_values = std::move(*brpc_request->mutable_block()->mutable_column_values());
-    brpc_request->mutable_block()->mutable_column_values()->clear();
+                                                std::unique_ptr<Closure>& closure,
+                                                bool restore_column_values = false) {
+    auto* block = brpc_request->mutable_block();
+    if (restore_column_values) {
+        // Some callers borrow block storage from a shared owner. Temporarily detach the large
+        // column_values field so the serialized request stays small, then restore it before
+        // returning so the real owner can still be reused by later sends.
+        auto* column_values = block->release_column_values();
+        DORIS_CHECK(column_values != nullptr);
+
+        Defer restore([block, column_values] { block->set_allocated_column_values(column_values); });
+
+        return request_embed_attachmentv2(brpc_request, *column_values, closure);
+    }
+
+    std::string column_values = std::move(*block->mutable_column_values());
+    block->mutable_column_values()->clear();
     return request_embed_attachmentv2(brpc_request, column_values, closure);
 }
 
@@ -68,8 +83,9 @@ void transmit_blockv2(PBackendService_Stub* stub, std::unique_ptr<Closure> closu
 
 template <typename Closure>
 Status transmit_block_httpv2(ExecEnv* exec_env, std::unique_ptr<Closure> closure,
-                             TNetworkAddress brpc_dest_addr) {
-    RETURN_IF_ERROR(request_embed_attachment_contain_blockv2(closure->request_.get(), closure));
+                             TNetworkAddress brpc_dest_addr, bool restore_column_values = false) {
+    RETURN_IF_ERROR(request_embed_attachment_contain_blockv2(closure->request_.get(), closure,
+                                                             restore_column_values));
 
     std::string host = brpc_dest_addr.hostname;
     auto dns_cache = ExecEnv::GetInstance()->dns_cache();

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -50,7 +50,8 @@ Status request_embed_attachment_contain_blockv2(Params* brpc_request,
         auto* column_values = block->release_column_values();
         DORIS_CHECK(column_values != nullptr);
 
-        Defer restore([block, column_values] { block->set_allocated_column_values(column_values); });
+        Defer restore(
+                [block, column_values] { block->set_allocated_column_values(column_values); });
 
         return request_embed_attachmentv2(brpc_request, *column_values, closure);
     }

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -25,7 +25,6 @@
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "util/brpc_client_cache.h"
-#include "util/defer_op.h"
 #include "util/network_util.h"
 
 namespace doris {
@@ -37,25 +36,15 @@ namespace doris {
 // 2G: In the default "baidu_std" brpcd, upper limit of the request and attachment length is 2G.
 constexpr size_t MIN_HTTP_BRPC_SIZE = (1ULL << 31);
 
+template <typename Params, typename Closure>
+Status request_embed_attachmentv2(Params* brpc_request, const std::string& data,
+                                  std::unique_ptr<Closure>& closure);
+
 // Embed column_values and brpc request serialization string in controller attachment.
 template <typename Params, typename Closure>
 Status request_embed_attachment_contain_blockv2(Params* brpc_request,
-                                                std::unique_ptr<Closure>& closure,
-                                                bool restore_column_values = false) {
+                                                std::unique_ptr<Closure>& closure) {
     auto* block = brpc_request->mutable_block();
-    if (restore_column_values) {
-        // Some callers borrow block storage from a shared owner. Temporarily detach the large
-        // column_values field so the serialized request stays small, then restore it before
-        // returning so the real owner can still be reused by later sends.
-        auto* column_values = block->release_column_values();
-        DORIS_CHECK(column_values != nullptr);
-
-        Defer restore(
-                [block, column_values] { block->set_allocated_column_values(column_values); });
-
-        return request_embed_attachmentv2(brpc_request, *column_values, closure);
-    }
-
     std::string column_values = std::move(*block->mutable_column_values());
     block->mutable_column_values()->clear();
     return request_embed_attachmentv2(brpc_request, column_values, closure);
@@ -83,13 +72,10 @@ void transmit_blockv2(PBackendService_Stub* stub, std::unique_ptr<Closure> closu
 }
 
 template <typename Closure>
-Status transmit_block_httpv2(ExecEnv* exec_env, std::unique_ptr<Closure> closure,
-                             TNetworkAddress brpc_dest_addr, bool restore_column_values = false) {
-    RETURN_IF_ERROR(request_embed_attachment_contain_blockv2(closure->request_.get(), closure,
-                                                             restore_column_values));
-
+Status transmit_block_httpv2_impl(ExecEnv* exec_env, std::unique_ptr<Closure> closure,
+                                  TNetworkAddress brpc_dest_addr) {
     std::string host = brpc_dest_addr.hostname;
-    auto dns_cache = ExecEnv::GetInstance()->dns_cache();
+    auto* dns_cache = ExecEnv::GetInstance()->dns_cache();
     if (dns_cache == nullptr) {
         LOG(WARNING) << "DNS cache is not initialized, skipping hostname resolve";
     } else if (!is_valid_ip(brpc_dest_addr.hostname)) {
@@ -117,6 +103,22 @@ Status transmit_block_httpv2(ExecEnv* exec_env, std::unique_ptr<Closure> closure
     closure.release();
 
     return Status::OK();
+}
+
+template <typename Closure>
+Status transmit_block_httpv2(ExecEnv* exec_env, std::unique_ptr<Closure> closure,
+                             TNetworkAddress brpc_dest_addr) {
+    RETURN_IF_ERROR(request_embed_attachment_contain_blockv2(closure->request_.get(), closure));
+    return transmit_block_httpv2_impl(exec_env, std::move(closure), brpc_dest_addr);
+}
+
+template <typename Closure>
+Status transmit_block_httpv2_with_attachment_data(ExecEnv* exec_env,
+                                                  std::unique_ptr<Closure> closure,
+                                                  TNetworkAddress brpc_dest_addr,
+                                                  const std::string& data) {
+    RETURN_IF_ERROR(request_embed_attachmentv2(closure->request_.get(), data, closure));
+    return transmit_block_httpv2_impl(exec_env, std::move(closure), brpc_dest_addr);
 }
 
 template <typename Params, typename Closure>

--- a/be/test/exec/operator/exchange_sink_buffer_test.cpp
+++ b/be/test/exec/operator/exchange_sink_buffer_test.cpp
@@ -1,0 +1,168 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exec/operator/exchange_sink_buffer.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace doris {
+
+namespace exchange_sink_buffer::detail {
+
+void copy_block_metadata_without_column_values(const PBlock& src, PBlock* dst);
+std::shared_ptr<PTransmitDataParams> make_http_request_without_column_values(
+        const PTransmitDataParams& src);
+
+} // namespace exchange_sink_buffer::detail
+
+namespace {
+
+PBlock make_block_with_column_values(const std::string& column_values) {
+    PBlock block;
+
+    auto* int_meta = block.add_column_metas();
+    int_meta->set_name("int_col");
+    int_meta->set_type(PGenericType::INT32);
+    int_meta->set_is_nullable(false);
+    int_meta->set_be_exec_version(12);
+
+    auto* struct_meta = block.add_column_metas();
+    struct_meta->set_name("struct_col");
+    struct_meta->set_type(PGenericType::STRUCT);
+    struct_meta->set_is_nullable(true);
+    struct_meta->set_result_is_nullable(true);
+    struct_meta->set_function_name("named_struct");
+    auto* child_meta = struct_meta->add_children();
+    child_meta->set_name("child_string");
+    child_meta->set_type(PGenericType::STRING);
+    child_meta->set_is_nullable(true);
+
+    block.set_column_values(column_values);
+    block.set_be_exec_version(37);
+    block.set_compressed(true);
+    block.set_compression_type(segment_v2::CompressionTypePB::LZ4);
+    block.set_uncompressed_size(4096);
+    return block;
+}
+
+PTransmitDataParams make_transmit_data_params(const std::string& column_values) {
+    PTransmitDataParams request;
+    request.mutable_finst_id()->set_hi(1);
+    request.mutable_finst_id()->set_lo(2);
+    request.set_node_id(3);
+    request.set_sender_id(4);
+    request.set_be_number(5);
+    request.set_eos(true);
+    request.set_packet_seq(6);
+
+    auto* query_statistics = request.mutable_query_statistics();
+    query_statistics->set_scan_rows(7);
+    query_statistics->set_scan_bytes(8);
+    auto* node_statistics = query_statistics->add_nodes_statistics();
+    node_statistics->set_node_id(9);
+    node_statistics->set_peak_memory_bytes(10);
+
+    request.set_transfer_by_attachment(false);
+    request.mutable_query_id()->set_hi(11);
+    request.mutable_query_id()->set_lo(12);
+    request.mutable_exec_status()->set_status_code(13);
+    request.mutable_exec_status()->add_error_msgs("exec status");
+    request.mutable_block()->CopyFrom(make_block_with_column_values(column_values));
+    return request;
+}
+
+} // namespace
+
+TEST(ExchangeSinkBufferTest, CopyBlockMetadataWithoutColumnValues) {
+    const std::string column_values = "large-column-values";
+    auto src = make_block_with_column_values(column_values);
+    PBlock dst;
+
+    exchange_sink_buffer::detail::copy_block_metadata_without_column_values(src, &dst);
+
+    EXPECT_EQ(dst.column_metas_size(), 2);
+    EXPECT_EQ(dst.column_metas(0).name(), "int_col");
+    EXPECT_EQ(dst.column_metas(0).type(), PGenericType::INT32);
+    EXPECT_FALSE(dst.column_metas(0).is_nullable());
+    EXPECT_EQ(dst.column_metas(0).be_exec_version(), 12);
+
+    EXPECT_EQ(dst.column_metas(1).name(), "struct_col");
+    EXPECT_EQ(dst.column_metas(1).type(), PGenericType::STRUCT);
+    EXPECT_TRUE(dst.column_metas(1).is_nullable());
+    EXPECT_TRUE(dst.column_metas(1).result_is_nullable());
+    EXPECT_EQ(dst.column_metas(1).function_name(), "named_struct");
+    ASSERT_EQ(dst.column_metas(1).children_size(), 1);
+    EXPECT_EQ(dst.column_metas(1).children(0).name(), "child_string");
+    EXPECT_EQ(dst.column_metas(1).children(0).type(), PGenericType::STRING);
+
+    EXPECT_FALSE(dst.has_column_values());
+    EXPECT_TRUE(src.has_column_values());
+    EXPECT_EQ(src.column_values(), column_values);
+    EXPECT_EQ(dst.be_exec_version(), 37);
+    EXPECT_TRUE(dst.compressed());
+    EXPECT_EQ(dst.compression_type(), segment_v2::CompressionTypePB::LZ4);
+    EXPECT_EQ(dst.uncompressed_size(), 4096);
+}
+
+TEST(ExchangeSinkBufferTest, MakeHttpRequestWithoutColumnValues) {
+    const std::string column_values = "borrowed-column-values";
+    auto src = make_transmit_data_params(column_values);
+
+    auto dst = exchange_sink_buffer::detail::make_http_request_without_column_values(src);
+
+    ASSERT_NE(dst, nullptr);
+    EXPECT_EQ(dst->finst_id().hi(), 1);
+    EXPECT_EQ(dst->finst_id().lo(), 2);
+    EXPECT_EQ(dst->node_id(), 3);
+    EXPECT_EQ(dst->sender_id(), 4);
+    EXPECT_EQ(dst->be_number(), 5);
+    EXPECT_TRUE(dst->eos());
+    EXPECT_EQ(dst->packet_seq(), 6);
+
+    ASSERT_TRUE(dst->has_query_statistics());
+    EXPECT_EQ(dst->query_statistics().scan_rows(), 7);
+    EXPECT_EQ(dst->query_statistics().scan_bytes(), 8);
+    ASSERT_EQ(dst->query_statistics().nodes_statistics_size(), 1);
+    EXPECT_EQ(dst->query_statistics().nodes_statistics(0).node_id(), 9);
+    EXPECT_EQ(dst->query_statistics().nodes_statistics(0).peak_memory_bytes(), 10);
+
+    EXPECT_TRUE(dst->has_transfer_by_attachment());
+    EXPECT_FALSE(dst->transfer_by_attachment());
+    ASSERT_TRUE(dst->has_query_id());
+    EXPECT_EQ(dst->query_id().hi(), 11);
+    EXPECT_EQ(dst->query_id().lo(), 12);
+    ASSERT_TRUE(dst->has_exec_status());
+    EXPECT_EQ(dst->exec_status().status_code(), 13);
+    ASSERT_EQ(dst->exec_status().error_msgs_size(), 1);
+    EXPECT_EQ(dst->exec_status().error_msgs(0), "exec status");
+
+    ASSERT_TRUE(dst->has_block());
+    EXPECT_EQ(dst->block().column_metas_size(), 2);
+    EXPECT_FALSE(dst->block().has_column_values());
+    EXPECT_EQ(dst->block().be_exec_version(), 37);
+    EXPECT_TRUE(dst->block().compressed());
+    EXPECT_EQ(dst->block().compression_type(), segment_v2::CompressionTypePB::LZ4);
+    EXPECT_EQ(dst->block().uncompressed_size(), 4096);
+
+    EXPECT_EQ(src.block().column_values(), column_values);
+    EXPECT_EQ(dst->blocks_size(), 0);
+    EXPECT_FALSE(dst->has_row_batch());
+}
+
+} // namespace doris

--- a/be/test/util/proto_util_test.cpp
+++ b/be/test/util/proto_util_test.cpp
@@ -66,15 +66,19 @@ TEST(ProtoUtilTest, EmbedAttachmentMovesOwnedColumnValuesByDefault) {
     EXPECT_EQ(extracted.block().column_values(), column_values);
 }
 
-TEST(ProtoUtilTest, EmbedAttachmentRestoresBorrowedColumnValues) {
+TEST(ProtoUtilTest, EmbedAttachmentUsesBorrowedColumnValuesWithoutMutation) {
     const std::string column_values = "borrowed-column-values";
+    auto borrowed_owner = make_transmit_request(column_values);
     auto request = make_transmit_request(column_values);
+    request.mutable_block()->clear_column_values();
     auto closure = std::make_unique<ProtoUtilTestClosure>();
 
-    auto status = request_embed_attachment_contain_blockv2(&request, closure, true);
+    auto status =
+            request_embed_attachmentv2(&request, borrowed_owner.block().column_values(), closure);
     ASSERT_TRUE(status.ok()) << status.to_string();
 
-    EXPECT_EQ(request.block().column_values(), column_values);
+    EXPECT_EQ(borrowed_owner.block().column_values(), column_values);
+    EXPECT_FALSE(request.block().has_column_values());
 
     auto extracted = extract_request_from_attachment(closure->cntl_.get());
     EXPECT_EQ(extracted.block().column_values(), column_values);

--- a/be/test/util/proto_util_test.cpp
+++ b/be/test/util/proto_util_test.cpp
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/proto_util.h"
+
+#include <brpc/controller.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace doris {
+namespace {
+
+struct ProtoUtilTestClosure {
+    std::shared_ptr<brpc::Controller> cntl_ = std::make_shared<brpc::Controller>();
+};
+
+PTransmitDataParams make_transmit_request(const std::string& column_values) {
+    PTransmitDataParams request;
+    request.mutable_finst_id()->set_hi(1);
+    request.mutable_finst_id()->set_lo(2);
+    request.set_node_id(3);
+    request.set_sender_id(4);
+    request.set_be_number(5);
+    request.set_eos(false);
+    request.set_packet_seq(6);
+    request.mutable_block()->set_column_values(column_values);
+    return request;
+}
+
+PTransmitDataParams extract_request_from_attachment(brpc::Controller* cntl) {
+    PTransmitDataParams extracted;
+    auto status = attachment_extract_request_contain_block(&extracted, cntl);
+    EXPECT_TRUE(status.ok()) << status.to_string();
+    return extracted;
+}
+
+} // namespace
+
+TEST(ProtoUtilTest, EmbedAttachmentMovesOwnedColumnValuesByDefault) {
+    const std::string column_values = "owned-column-values";
+    auto request = make_transmit_request(column_values);
+    auto closure = std::make_unique<ProtoUtilTestClosure>();
+
+    auto status = request_embed_attachment_contain_blockv2(&request, closure);
+    ASSERT_TRUE(status.ok()) << status.to_string();
+
+    EXPECT_TRUE(request.block().column_values().empty());
+
+    auto extracted = extract_request_from_attachment(closure->cntl_.get());
+    EXPECT_EQ(extracted.block().column_values(), column_values);
+}
+
+TEST(ProtoUtilTest, EmbedAttachmentRestoresBorrowedColumnValues) {
+    const std::string column_values = "borrowed-column-values";
+    auto request = make_transmit_request(column_values);
+    auto closure = std::make_unique<ProtoUtilTestClosure>();
+
+    auto status = request_embed_attachment_contain_blockv2(&request, closure, true);
+    ASSERT_TRUE(status.ok()) << status.to_string();
+
+    EXPECT_EQ(request.block().column_values(), column_values);
+
+    auto extracted = extract_request_from_attachment(closure->cntl_.get());
+    EXPECT_EQ(extracted.block().column_values(), column_values);
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Broadcast exchange sends can borrow a shared `PBlock` through `set_allocated_block`. When such a request takes the HTTP attachment path, the helper must remove `column_values` from the protobuf request before serialization, but it must not permanently consume data owned by the shared broadcast block. This PR adds an explicit restore mode for borrowed block storage while keeping the default owned-request path unchanged.

It also documents intentional protobuf `set_allocated_*` ownership patterns in exchange sink buffer and rowset meta code, and adds focused unit coverage for the attachment helper's owned vs borrowed behavior.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `./run-be-ut.sh --run --filter=ProtoUtilTest.*`
- Behavior changed: Yes (broadcast exchange HTTP sends preserve borrowed `column_values` for later channel sends)
- Does this need documentation: No
