### PR TITLE
[fix](thirdparty) fix aws_sdk compilation failure with Clang due to unsupported warning option

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1429,7 +1429,7 @@ build_aws_sdk() {
         -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTING=OFF \
         -DCURL_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libcurl.a" -DZLIB_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libz.a" \
         -DBUILD_ONLY="core;s3;s3-crt;transfer;identity-management;sts;kinesis" \
-        -DCMAKE_CXX_FLAGS="-Wno-nonnull -Wno-deprecated-literal-operator ${warning_deprecated_literal_operator} -Wno-deprecated-declarations ${warning_dangling_reference}" -DCPP_STANDARD=17
+        -DCMAKE_CXX_FLAGS="-Wno-nonnull ${warning_deprecated_literal_operator} -Wno-deprecated-declarations ${warning_dangling_reference}" -DCPP_STANDARD=17
 
     cd "${BUILD_DIR}"
 


### PR DESCRIPTION
### PR Description

#### Problem

The aws_sdk build command in build-thirdparty.sh hardcodes `-Wno-deprecated-literal-operator` flag while also using the `${warning_deprecated_literal_operator}` variable. This variable is only set for GCC 15+ in the toolchain flags section. When compiling with Clang, the hardcoded flag causes "unknown warning option" error since Clang does not recognize this flag.

```bash
gcc_major_version=$("${CC}" -dumpversion | cut -d. -f1)
if [[ "${gcc_major_version}" -ge 15 ]]; then
    warning_deprecated_literal_operator='-Wno-deprecated-literal-operator'
fi

...

-DCMAKE_CXX_FLAGS="-Wno-nonnull -Wno-deprecated-literal-operator ${warning_deprecated_literal_operator} -Wno-deprecated-declarations ${warning_dangling_reference}" -DCPP_STANDARD=17
```

#### Behavior Change

  - Before: aws_sdk build fails with Clang due to unsupported `-Wno-deprecated-literal-operator` warning option
  - After: aws_sdk builds successfully with both GCC and Clang

#### Fix

Remove the hardcoded `-Wno-deprecated-literal-operator` flag, keeping only the variable reference.

#### Author Checklist

- [x] aws_sdk build succeeds with GCC and Clang
- [x] No user-visible behavior change
- [x] No new tests required (build-only fix)