### PR TITLE
[opt](compile) Remove Huawei OBS SDK repository from pom.xml

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -787,11 +787,6 @@ under the License.
             <name>central maven repo https</name>
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
-        <!-- for huawei obs sdk -->
-        <repository>
-            <id>huawei-obs-sdk</id>
-            <url>https://repo.huaweicloud.com/repository/maven/huaweicloudsdk/</url>
-        </repository>
     </repositories>
     <build>
         <finalName>doris-fe</finalName>


### PR DESCRIPTION
fe/fe-core/pom.xml 中额外配置了 Huawei OBS SDK 仓库。当前 com.huaweicloud:esdk-obs-java-bundle 已可从 Maven Central 获取，因此该私有仓库配置已非必需。对于版本范围 [3.21.11,) 的解析，保留该额外仓库可能引入不必要的仓库访问或元数据解析问题。删除该仓库配置后，依赖可通过 Maven Central（或其镜像）解析，无需单独的 Huawei 仓库。 依据：Maven Central 已包含 com.huaweicloud:esdk-obs-java-bundle 及相关版本元数据。(repo1.maven.org)
