### PR TITLE
[chore](dep) pin esdk-obs-java-bundle to 3.21.11 to fix version range resolution failure

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -246,7 +246,7 @@ under the License.
         <cos-api.version>5.6.211</cos-api.version>
         <tencentcloud-sdk-java-sts.version>3.1.678</tencentcloud-sdk-java-sts.version>
         <huaweicloud-sdk-iam.version>3.1.20</huaweicloud-sdk-iam.version>
-        <esdk-obs.version>[3.21.11,)</esdk-obs.version>
+        <esdk-obs.version>3.21.11</esdk-obs.version>
         <huaweiobs.version>3.1.1-hw-46</huaweiobs.version>
         <!--suppress UnresolvedMavenProperty -->
         <doris.thirdparty>${fe.dir}/../thirdparty</doris.thirdparty>


### PR DESCRIPTION
## Problem

The version `[3.21.11,)` in `fe/pom.xml` is a Maven version range, which requires Maven to download `maven-metadata.xml` from **every configured repository** and merge the results before selecting a version.

The Huawei OBS Maven repository (`https://repo.huaweicloud.com/repository/maven/huaweicloudsdk/`) does not carry this artifact at all (returns 404 for its metadata) or is not stable. This causes `maven-remote-resources-plugin` to fail the entire range resolution and report:

```
No versions are present in the repository for the artifact with a range [3.21.11,)
  com.huaweicloud:esdk-obs-java-bundle:jar:null
```

## Fix

Pin the version to the specific minimum `3.21.11`, which is available on Maven Central (and its mirrors such as aliyunmaven).

With a fixed version, Maven resolves the artifact by trying repositories one by one and succeeds as soon as any working repository (e.g. aliyunmaven) responds — it no longer depends on the unstable Huawei OBS repository for range resolution.

## Verification

`3.21.11` is confirmed present on Maven Central:
```
https://repo1.maven.org/maven2/com/huaweicloud/esdk-obs-java-bundle/3.21.11/
```