### PR TITLE
[fix](be) Rebind storage common expr slots

### DIFF
--- a/be/src/exprs/virtual_slot_ref.h
+++ b/be/src/exprs/virtual_slot_ref.h
@@ -40,6 +40,7 @@ public:
     int slot_id() const { return _slot_id; }
     bool equals(const VExpr& other) override;
     size_t estimate_memory(const size_t rows) override { return 0; }
+    void set_column_id(int column_id) { _column_id = column_id; }
     void collect_slot_column_ids(std::set<int>& column_ids) const override {
         column_ids.insert(_column_id);
     }
@@ -111,7 +112,6 @@ public:
 
 #ifdef BE_TEST
     // Test-only setter methods for unit testing
-    void set_column_id(int column_id) { _column_id = column_id; }
     void set_column_name(const std::string* column_name) { _column_name = column_name; }
     void set_column_data_type(DataTypePtr column_data_type) {
         _column_data_type = std::move(column_data_type);

--- a/be/src/exprs/vslot_ref.h
+++ b/be/src/exprs/vslot_ref.h
@@ -39,9 +39,9 @@ public:
     VSlotRef(const SlotDescriptor* desc);
 #ifdef BE_TEST
     VSlotRef() = default;
-    void set_column_id(int column_id) { _column_id = column_id; }
     void set_slot_id(int slot_id) { _slot_id = slot_id; }
 #endif
+    void set_column_id(int column_id) { _column_id = column_id; }
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -175,6 +175,10 @@ Status rebind_storage_expr_to_reader_schema(
                     virtual_slot_ref->slot_id(), slot->col_name(), cid);
         }
         virtual_slot_ref->set_column_id(cast_set<int>(pos_it->second));
+        // A virtual slot has its own output position in the reader block, and its
+        // materialization expression may also contain real slot refs. Rebind both
+        // sides so evaluating the virtual expression reads from the same block
+        // layout used by SegmentIterator.
         RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(
                 opts, virtual_slot_ref->get_virtual_column_expr(), cid_to_pos));
     }
@@ -193,8 +197,16 @@ Status rebind_storage_exprs_to_reader_schema(const StorageReadOptions& opts, con
     }
     DORIS_CHECK(opts.runtime_state != nullptr);
 
-    // Storage exprs are prepared with the scan tuple layout, but SegmentIterator executes them on
-    // the reader schema block, whose column order may be expanded for merge/aggregation readers.
+    // Storage exprs are prepared with RowDescriptor, so VSlotRef/VirtualSlotRef column_id points to
+    // the scan tuple column ordinal. SegmentIterator evaluates cloned exprs on a block built from
+    // the reader schema instead. That schema can be expanded or reordered by merge/aggregation
+    // readers, lazy materialization, common expr columns, and virtual columns, so the scan tuple
+    // ordinal is not always the same as the runtime block ordinal.
+    //
+    // Do not skip this only by key model. DUP_KEYS and UNIQUE_KEYS MOW often use direct readers, but
+    // the key model does not guarantee that the reader schema layout matches the scan tuple layout.
+    // The reader schema is the source of truth here; map tablet column id to reader-block position
+    // and rebind every storage expr slot to that position.
     std::unordered_map<ColumnId, size_t> cid_to_pos;
     for (size_t pos = 0; pos < schema.num_column_ids(); ++pos) {
         cid_to_pos.emplace(schema.column_id(cast_set<int>(pos)), pos);

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -196,17 +196,24 @@ Status rebind_storage_exprs_to_reader_schema(const StorageReadOptions& opts, con
         return Status::OK();
     }
     DORIS_CHECK(opts.runtime_state != nullptr);
+    DORIS_CHECK(opts.tablet_schema != nullptr);
+
+    const auto keys_type = opts.tablet_schema->keys_type();
+    if (keys_type == KeysType::DUP_KEYS ||
+        (keys_type == KeysType::UNIQUE_KEYS && opts.enable_unique_key_merge_on_write)) {
+        return Status::OK();
+    }
 
     // Storage exprs are prepared with RowDescriptor, so VSlotRef/VirtualSlotRef column_id points to
     // the scan tuple column ordinal. SegmentIterator evaluates cloned exprs on a block built from
-    // the reader schema instead. That schema can be expanded or reordered by merge/aggregation
-    // readers, lazy materialization, common expr columns, and virtual columns, so the scan tuple
-    // ordinal is not always the same as the runtime block ordinal.
+    // the reader schema instead. AGG_KEYS and non-MOW UNIQUE_KEYS readers may expand the reader
+    // schema, for example by filling all key columns before merging/aggregating rows, so the scan
+    // tuple ordinal is not always the same as the runtime block ordinal.
     //
-    // Do not skip this only by key model. DUP_KEYS and UNIQUE_KEYS MOW often use direct readers, but
-    // the key model does not guarantee that the reader schema layout matches the scan tuple layout.
-    // The reader schema is the source of truth here; map tablet column id to reader-block position
-    // and rebind every storage expr slot to that position.
+    // DUP_KEYS and UNIQUE_KEYS MOW use direct readers for query scans, so their reader block keeps
+    // the scan tuple layout and can skip this per-segment expression-tree traversal. For merge/agg
+    // readers, the reader schema is the source of truth: map tablet column id to reader-block
+    // position and rebind every storage expr slot to that position.
     std::unordered_map<ColumnId, size_t> cid_to_pos;
     for (size_t pos = 0; pos < schema.num_column_ids(); ++pos) {
         cid_to_pos.emplace(schema.column_id(cast_set<int>(pos)), pos);

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -68,6 +68,7 @@
 #include "io/cache/cached_remote_file_reader.h"
 #include "io/fs/file_reader.h"
 #include "io/io_common.h"
+#include "runtime/descriptors.h"
 #include "runtime/query_context.h"
 #include "runtime/runtime_predicate.h"
 #include "runtime/runtime_state.h"
@@ -107,11 +108,113 @@
 #include "storage/utils.h"
 #include "util/concurrency_stats.h"
 #include "util/defer_op.h"
+#include "util/json/path_in_data.h"
 #include "util/simd/bits.h"
 
 namespace doris {
 using namespace ErrorCode;
 namespace segment_v2 {
+namespace {
+
+Status tablet_column_id_by_slot(const TabletSchemaSPtr& tablet_schema, const SlotDescriptor* slot,
+                                ColumnId* cid) {
+    int32_t field_index = -1;
+    if (slot->type()->get_primitive_type() == PrimitiveType::TYPE_VARIANT) {
+        field_index = tablet_schema->field_index(
+                PathInData(tablet_schema->column_by_uid(slot->col_unique_id()).name_lower_case(),
+                           slot->column_paths()));
+    } else {
+        field_index = slot->col_unique_id() >= 0 ? tablet_schema->field_index(slot->col_unique_id())
+                                                 : tablet_schema->field_index(slot->col_name());
+    }
+    if (field_index < 0) {
+        return Status::InternalError(
+                "field name is invalid. field={}, field_name_to_index={}, col_unique_id={}",
+                slot->col_name(), tablet_schema->get_all_field_names(), slot->col_unique_id());
+    }
+    *cid = field_index;
+    return Status::OK();
+}
+
+Status rebind_storage_expr_to_reader_schema(
+        const StorageReadOptions& opts, const VExprSPtr& expr,
+        const std::unordered_map<ColumnId, size_t>& cid_to_pos) {
+    DORIS_CHECK(expr != nullptr);
+
+    if (expr->is_slot_ref()) {
+        auto slot_ref = std::static_pointer_cast<VSlotRef>(expr);
+        auto* slot = opts.runtime_state->desc_tbl().get_slot_descriptor(slot_ref->slot_id());
+        if (slot == nullptr) {
+            return Status::InternalError("slot {} is not found in descriptor table",
+                                         slot_ref->slot_id());
+        }
+
+        ColumnId cid = 0;
+        RETURN_IF_ERROR(tablet_column_id_by_slot(opts.tablet_schema, slot, &cid));
+        auto pos_it = cid_to_pos.find(cid);
+        if (pos_it == cid_to_pos.end()) {
+            return Status::InternalError("slot {} column {} with cid {} is not in reader schema",
+                                         slot_ref->slot_id(), slot->col_name(), cid);
+        }
+        slot_ref->set_column_id(cast_set<int>(pos_it->second));
+    } else if (expr->is_virtual_slot_ref()) {
+        auto virtual_slot_ref = std::static_pointer_cast<VirtualSlotRef>(expr);
+        auto* slot =
+                opts.runtime_state->desc_tbl().get_slot_descriptor(virtual_slot_ref->slot_id());
+        if (slot == nullptr) {
+            return Status::InternalError("slot {} is not found in descriptor table",
+                                         virtual_slot_ref->slot_id());
+        }
+
+        ColumnId cid = 0;
+        RETURN_IF_ERROR(tablet_column_id_by_slot(opts.tablet_schema, slot, &cid));
+        auto pos_it = cid_to_pos.find(cid);
+        if (pos_it == cid_to_pos.end()) {
+            return Status::InternalError(
+                    "virtual slot {} column {} with cid {} is not in reader schema",
+                    virtual_slot_ref->slot_id(), slot->col_name(), cid);
+        }
+        virtual_slot_ref->set_column_id(cast_set<int>(pos_it->second));
+        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(
+                opts, virtual_slot_ref->get_virtual_column_expr(), cid_to_pos));
+    }
+
+    for (const auto& child : expr->children()) {
+        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, child, cid_to_pos));
+    }
+    return Status::OK();
+}
+
+Status rebind_storage_exprs_to_reader_schema(const StorageReadOptions& opts, const Schema& schema,
+                                             const VExprContextSPtrs& common_exprs,
+                                             std::map<ColumnId, VExprContextSPtr>& virtual_exprs,
+                                             std::vector<VExprSPtr>* remaining_conjunct_roots) {
+    if (common_exprs.empty() && virtual_exprs.empty()) {
+        return Status::OK();
+    }
+    DORIS_CHECK(opts.runtime_state != nullptr);
+
+    // Storage exprs are prepared with the scan tuple layout, but SegmentIterator executes them on
+    // the reader schema block, whose column order may be expanded for merge/aggregation readers.
+    std::unordered_map<ColumnId, size_t> cid_to_pos;
+    for (size_t pos = 0; pos < schema.num_column_ids(); ++pos) {
+        cid_to_pos.emplace(schema.column_id(cast_set<int>(pos)), pos);
+    }
+
+    if (!common_exprs.empty()) {
+        remaining_conjunct_roots->clear();
+    }
+    for (const auto& ctx : common_exprs) {
+        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, ctx->root(), cid_to_pos));
+        remaining_conjunct_roots->emplace_back(ctx->root());
+    }
+    for (const auto& [_, ctx] : virtual_exprs) {
+        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, ctx->root(), cid_to_pos));
+    }
+    return Status::OK();
+}
+
+} // namespace
 
 SegmentIterator::~SegmentIterator() = default;
 
@@ -3189,6 +3292,9 @@ Status SegmentIterator::_construct_compound_expr_context() {
         context->set_index_context(inverted_index_context);
         expr_ctx = context;
     }
+    RETURN_IF_ERROR(rebind_storage_exprs_to_reader_schema(
+            _opts, *_schema, _common_expr_ctxs_push_down, _virtual_column_exprs,
+            &_remaining_conjunct_roots));
     return Status::OK();
 }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -187,8 +187,7 @@ Status rebind_storage_expr_to_reader_schema(
 
 Status rebind_storage_exprs_to_reader_schema(const StorageReadOptions& opts, const Schema& schema,
                                              const VExprContextSPtrs& common_exprs,
-                                             std::map<ColumnId, VExprContextSPtr>& virtual_exprs,
-                                             std::vector<VExprSPtr>* remaining_conjunct_roots) {
+                                             std::map<ColumnId, VExprContextSPtr>& virtual_exprs) {
     if (common_exprs.empty() && virtual_exprs.empty()) {
         return Status::OK();
     }
@@ -201,12 +200,8 @@ Status rebind_storage_exprs_to_reader_schema(const StorageReadOptions& opts, con
         cid_to_pos.emplace(schema.column_id(cast_set<int>(pos)), pos);
     }
 
-    if (!common_exprs.empty()) {
-        remaining_conjunct_roots->clear();
-    }
     for (const auto& ctx : common_exprs) {
         RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, ctx->root(), cid_to_pos));
-        remaining_conjunct_roots->emplace_back(ctx->root());
     }
     for (const auto& [_, ctx] : virtual_exprs) {
         RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, ctx->root(), cid_to_pos));
@@ -3293,8 +3288,7 @@ Status SegmentIterator::_construct_compound_expr_context() {
         expr_ctx = context;
     }
     RETURN_IF_ERROR(rebind_storage_exprs_to_reader_schema(
-            _opts, *_schema, _common_expr_ctxs_push_down, _virtual_column_exprs,
-            &_remaining_conjunct_roots));
+            _opts, *_schema, _common_expr_ctxs_push_down, _virtual_column_exprs));
     return Status::OK();
 }
 

--- a/regression-test/suites/nereids_rules_p0/predicate_infer/infer_predicate.groovy
+++ b/regression-test/suites/nereids_rules_p0/predicate_infer/infer_predicate.groovy
@@ -307,4 +307,40 @@ suite("infer_predicate") {
     qt_infer11 """
         explain shape plan select * from (select * from t1 where t1.id = 12345) t1 join t2 on cast(t1.id as largeint) = cast(t2.id as largeint);
     """
+
+    sql "DROP TABLE IF EXISTS infer_predicate_cast_common_expr_agg"
+    sql """
+        CREATE TABLE infer_predicate_cast_common_expr_agg (
+            pk int,
+            col_int int,
+            col_bigint bigint,
+            col_bitmap bitmap bitmap_union
+        )
+        AGGREGATE KEY(pk, col_int, col_bigint)
+        DISTRIBUTED BY HASH(pk) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1"
+        )
+    """
+    sql """
+        INSERT INTO infer_predicate_cast_common_expr_agg VALUES
+            (1, 10, 1, to_bitmap(1)),
+            (2, 20, 3, to_bitmap(2)),
+            (3, 30, 3, to_bitmap(3))
+    """
+    test {
+        sql """
+            SELECT pk, col_bigint, bitmap_union_count(col_bitmap)
+            FROM infer_predicate_cast_common_expr_agg
+            WHERE col_bigint = CAST(pk AS BIGINT)
+            GROUP BY pk, col_bigint
+            ORDER BY pk, col_bigint
+        """
+        check { result, exception, startTime, endTime ->
+            if (exception != null) {
+                throw exception
+            }
+            assertEquals("[[1, 1, 1], [3, 3, 1]]", result.toString())
+        }
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: Introduced by #62222

Problem Summary: #62222 allowed key-only common expressions to be pushed down for aggregation/merge readers. Those expressions are prepared with scan tuple column positions, but SegmentIterator evaluates them on storage reader blocks whose schema can be expanded for aggregation/merge readers. This can make slot refs read the wrong column and trigger type mismatches such as BIGINT vs INT in eq predicates.

### Release note

None

### Check List (For Author)

- Test: Regression test / Manual test
    - Added regression case for AGG key common expr with cast predicate.
    - Ran build-support/clang-format.sh and build-support/check-format.sh.
    - Ran syntax-only compile for be/src/storage/segment/segment_iterator.cpp and be/src/exec/scan/olap_scanner.cpp.
    - Ran build-support/run-clang-tidy.sh --build-dir be/ut_build_ASAN; it reports no warnings in the new segment_iterator.cpp helper, but still fails on existing diagnostics and jni-util.h static_assert in this environment.
- Behavior changed: Yes. Fix storage common expr evaluation to use SegmentIterator reader schema column positions.
- Does this need documentation: No
