### PR TITLE
[fix](fe) Allow show tablet without selected database

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommand.java
@@ -46,7 +46,6 @@ import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.query.QueryStatsUtil;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 import java.util.List;
@@ -56,7 +55,6 @@ import java.util.List;
  */
 public class ShowTabletIdCommand extends ShowCommand {
     private final long tabletId;
-    private String dbName;
 
     /**
      * constructor
@@ -96,11 +94,6 @@ public class ShowTabletIdCommand extends ShowCommand {
         // check access first
         if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "SHOW TABLET");
-        }
-
-        dbName = ctx.getDatabase();
-        if (Strings.isNullOrEmpty(dbName)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommandTest.java
@@ -85,9 +85,9 @@ public class ShowTabletIdCommandTest {
     }
 
     @Test
-    void dbIsEmpty() {
+    void noDatabaseSelected() {
         runBefore("", true);
         ShowTabletIdCommand command = new ShowTabletIdCommand(CatalogMocker.TEST_TBL_ID);
-        Assertions.assertThrows(AnalysisException.class, () -> command.validate(ctx));
+        Assertions.assertDoesNotThrow(() -> command.validate(ctx));
     }
 }

--- a/regression-test/suites/show_p0/test_show_tablet.groovy
+++ b/regression-test/suites/show_p0/test_show_tablet.groovy
@@ -27,6 +27,12 @@ suite("test_show_tablet") {
             );"""
 
     def res = sql """ SHOW TABLETS FROM show_tablets_test_t """
+    def noDbJdbcUrl = context.config.jdbcUrl.replaceFirst(/(jdbc:mysql:\/\/[^\/]+\/)[^?]*/, '$1')
+    connect(context.config.jdbcUser, context.config.jdbcPassword, noDbJdbcUrl) {
+        def tabletId = res[0][0]
+        def tabletRes = sql """ SHOW TABLET ${tabletId} """
+        assertTrue(tabletRes.size() == 1)
+    }
     if (res.size() == 5) {
         // replication num == 1
         res = sql """SHOW TABLETS FROM show_tablets_test_t limit 5, 1;"""


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary: SHOW TABLET <tablet_id> looked up tablet metadata by id but still required a selected session database during validation. This caused No database selected when the mysql client had not executed USE <db>, even though the command can resolve the owning database from TabletMeta.
Issue Number: close #xxx

Related PR: #48815

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

