### PR TITLE
[fix](TIMESTAMPTZ) serialize TIMESTAMPTZ schema change defaults with offset

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -145,6 +145,9 @@ public class ColumnDef {
 
         private String formatCurrentTimeStamp(long precision, boolean withTimeZone) {
             ZonedDateTime currentDateTime = ZonedDateTime.now(TimeUtils.getTimeZone().toZoneId());
+            if (!withTimeZone && precision == 0) {
+                return currentDateTime.toLocalDateTime().toString().replace('T', ' ');
+            }
             int scale = Math.toIntExact(precision);
             if (withTimeZone) {
                 return TimestampTzLiteral.formatDateTime(currentDateTime, scale);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -29,13 +29,13 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.SqlUtils;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.nereids.trees.expressions.literal.TimestampTzLiteral;
 import org.apache.doris.nereids.trees.plans.commands.info.ColumnDefinition;
 import org.apache.doris.nereids.types.DataType;
 
 import com.google.common.base.Preconditions;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -130,30 +130,26 @@ public class ColumnDef {
         }
 
         public String getValue() {
+            return getValue(null);
+        }
+
+        public String getValue(Type type) {
             if (isCurrentTimeStamp()) {
-                return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId()).toString().replace('T', ' ');
+                return formatCurrentTimeStamp(0, type != null && type.isTimeStampTz());
             } else if (isCurrentTimeStampWithPrecision()) {
-                long precision = getCurrentTimeStampPrecision();
-                String format = "yyyy-MM-dd HH:mm:ss";
-                if (precision == 0) {
-                    return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId()).toString().replace('T', ' ');
-                } else if (precision == 1) {
-                    format = "yyyy-MM-dd HH:mm:ss.S";
-                } else if (precision == 2) {
-                    format = "yyyy-MM-dd HH:mm:ss.SS";
-                } else if (precision == 3) {
-                    format = "yyyy-MM-dd HH:mm:ss.SSS";
-                } else if (precision == 4) {
-                    format = "yyyy-MM-dd HH:mm:ss.SSSS";
-                } else if (precision == 5) {
-                    format = "yyyy-MM-dd HH:mm:ss.SSSSS";
-                } else if (precision == 6) {
-                    format = "yyyy-MM-dd HH:mm:ss.SSSSSS";
-                }
-                return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId())
-                        .format(DateTimeFormatter.ofPattern(format));
+                return formatCurrentTimeStamp(getCurrentTimeStampPrecision(),
+                        type != null && type.isTimeStampTz());
             }
             return value;
+        }
+
+        private String formatCurrentTimeStamp(long precision, boolean withTimeZone) {
+            ZonedDateTime currentDateTime = ZonedDateTime.now(TimeUtils.getTimeZone().toZoneId());
+            int scale = Math.toIntExact(precision);
+            if (withTimeZone) {
+                return TimestampTzLiteral.formatDateTime(currentDateTime, scale);
+            }
+            return TimestampTzLiteral.formatDateTime(currentDateTime.toLocalDateTime(), scale);
         }
     }
 
@@ -243,7 +239,7 @@ public class ColumnDef {
             if (defaultValue.defaultValueExprDef != null) {
                 value = new org.apache.doris.nereids
                     .trees.plans.commands.info.DefaultValue(
-                    defaultValue.getValue(),
+                    defaultValue.getValue(type),
                     defaultValue.defaultValueExprDef.getExprName(),
                     defaultValue.defaultValueExprDef.getPrecision());
             } else {
@@ -498,7 +494,7 @@ public class ColumnDef {
     public Column toColumn() {
         return new Column(name, this.type, isKey, aggregateType, isAllowNull, autoIncInitValue, defaultValue.value,
             comment, visible, defaultValue.defaultValueExprDef, Column.COLUMN_UNIQUE_ID_INIT_VALUE,
-            defaultValue.getValue(), -1, generatedColumnInfo.orElse(null), generatedColumnsThatReferToThis);
+            defaultValue.getValue(type), -1, generatedColumnInfo.orElse(null), generatedColumnsThatReferToThis);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimestampTzLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimestampTzLiteral.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.types.TimeStampTzType;
 import org.apache.doris.qe.ConnectContext;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /**
@@ -452,6 +453,14 @@ public class TimestampTzLiteral extends DateTimeLiteral {
                         dateTime.getMonthValue(), dateTime.getDayOfMonth(), dateTime.getHour(),
                         dateTime.getMinute(), dateTime.getSecond(),
                         (dateTime.getNano() / 1000) / value * value);
+    }
+
+    public static String formatDateTime(LocalDateTime dateTime, int precision) {
+        return ((TimestampTzLiteral) fromJavaDateType(dateTime, precision)).getStringValue();
+    }
+
+    public static String formatDateTime(ZonedDateTime dateTime, int precision) {
+        return formatDateTime(dateTime.toLocalDateTime(), precision) + dateTime.getOffset();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimestampTzLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimestampTzLiteral.java
@@ -31,6 +31,7 @@ import org.apache.doris.qe.ConnectContext;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 /**
@@ -40,6 +41,7 @@ public class TimestampTzLiteral extends DateTimeLiteral {
 
     public static final TimestampTzLiteral USE_IN_FLOOR_CEIL
             = new TimestampTzLiteral(0001L, 01L, 01L, 0L, 0L, 0L, 0L);
+    private static final DateTimeFormatter ZONE_OFFSET_FORMATTER = DateTimeFormatter.ofPattern("xxx");
 
     public TimestampTzLiteral(String s) {
         this(TimeStampTzType.forTypeFromString(s), s);
@@ -460,7 +462,7 @@ public class TimestampTzLiteral extends DateTimeLiteral {
     }
 
     public static String formatDateTime(ZonedDateTime dateTime, int precision) {
-        return formatDateTime(dateTime.toLocalDateTime(), precision) + dateTime.getOffset();
+        return formatDateTime(dateTime.toLocalDateTime(), precision) + ZONE_OFFSET_FORMATTER.format(dateTime);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ColumnDefinition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/ColumnDefinition.java
@@ -547,7 +547,7 @@ public class ColumnDefinition {
         Column column = new Column(name, type.toCatalogDataType(), isKey, aggType, isNullable,
                 autoIncInitValue, defaultValue.map(DefaultValue::getValue).orElse(null), comment, isVisible,
                 defaultValue.map(DefaultValue::getDefaultValueExprDef).orElse(null), Column.COLUMN_UNIQUE_ID_INIT_VALUE,
-                defaultValue.map(DefaultValue::getRawValue).orElse(null), onUpdateDefaultValue.isPresent(),
+                defaultValue.map(value -> value.getRawValue(type)).orElse(null), onUpdateDefaultValue.isPresent(),
                 onUpdateDefaultValue.map(DefaultValue::getDefaultValueExprDef).orElse(null), clusterKeyId,
                 generatedColumnDesc.map(GeneratedColumnDesc::translateToInfo).orElse(null),
                 generatedColumnsThatReferToThis,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DefaultValue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DefaultValue.java
@@ -21,9 +21,10 @@ import org.apache.doris.analysis.DefaultValueExprDef;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.literal.TimestampTzLiteral;
+import org.apache.doris.nereids.types.DataType;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZonedDateTime;
 
 /**
  * default value of a column.
@@ -114,30 +115,29 @@ public class DefaultValue {
      * get string result of a default value expression.
      */
     public String getRawValue() {
+        return getRawValue(null);
+    }
+
+    /**
+     * get string result of a default value expression.
+     */
+    public String getRawValue(DataType dataType) {
         if (isCurrentTimeStamp()) {
-            return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId()).toString().replace('T', ' ');
+            return formatCurrentTimeStamp(0, dataType != null && dataType.isTimeStampTzType());
         } else if (isCurrentTimeStampWithPrecision()) {
-            long precision = getCurrentTimeStampPrecision();
-            String format = "yyyy-MM-dd HH:mm:ss";
-            if (precision == 0) {
-                return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId()).toString().replace('T', ' ');
-            } else if (precision == 1) {
-                format = "yyyy-MM-dd HH:mm:ss.S";
-            } else if (precision == 2) {
-                format = "yyyy-MM-dd HH:mm:ss.SS";
-            } else if (precision == 3) {
-                format = "yyyy-MM-dd HH:mm:ss.SSS";
-            } else if (precision == 4) {
-                format = "yyyy-MM-dd HH:mm:ss.SSSS";
-            } else if (precision == 5) {
-                format = "yyyy-MM-dd HH:mm:ss.SSSSS";
-            } else if (precision == 6) {
-                format = "yyyy-MM-dd HH:mm:ss.SSSSSS";
-            }
-            return LocalDateTime.now(TimeUtils.getTimeZone().toZoneId())
-                    .format(DateTimeFormatter.ofPattern(format));
+            return formatCurrentTimeStamp(getCurrentTimeStampPrecision(),
+                    dataType != null && dataType.isTimeStampTzType());
         }
         return value;
+    }
+
+    private String formatCurrentTimeStamp(long precision, boolean withTimeZone) {
+        ZonedDateTime currentDateTime = ZonedDateTime.now(TimeUtils.getTimeZone().toZoneId());
+        int scale = Math.toIntExact(precision);
+        if (withTimeZone) {
+            return TimestampTzLiteral.formatDateTime(currentDateTime, scale);
+        }
+        return TimestampTzLiteral.formatDateTime(currentDateTime.toLocalDateTime(), scale);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DefaultValue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/DefaultValue.java
@@ -133,6 +133,9 @@ public class DefaultValue {
 
     private String formatCurrentTimeStamp(long precision, boolean withTimeZone) {
         ZonedDateTime currentDateTime = ZonedDateTime.now(TimeUtils.getTimeZone().toZoneId());
+        if (!withTimeZone && precision == 0) {
+            return currentDateTime.toLocalDateTime().toString().replace('T', ' ');
+        }
         int scale = Math.toIntExact(precision);
         if (withTimeZone) {
             return TimestampTzLiteral.formatDateTime(currentDateTime, scale);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/ColumnDefinitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/ColumnDefinitionTest.java
@@ -18,11 +18,14 @@
 package org.apache.doris.nereids.trees.plans.commands.info;
 
 import org.apache.doris.catalog.Column;
+import org.apache.doris.nereids.trees.expressions.literal.TimestampTzLiteral;
 import org.apache.doris.nereids.types.TimeStampTzType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 public class ColumnDefinitionTest {
@@ -50,5 +53,13 @@ public class ColumnDefinitionTest {
         Assertions.assertNotNull(column.getRealDefaultValue());
         Assertions.assertTrue(column.getRealDefaultValue().matches(
                 "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}[+-]\\d{2}:\\d{2}"));
+    }
+
+    @Test
+    public void testTimestampTzFormatterUsesNumericUtcOffset() {
+        ZonedDateTime utcDateTime = ZonedDateTime.of(2026, 5, 16, 12, 0, 0, 123456000, ZoneOffset.UTC);
+
+        Assertions.assertEquals("2026-05-16 12:00:00.123456+00:00",
+                TimestampTzLiteral.formatDateTime(utcDateTime, 6));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/ColumnDefinitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/ColumnDefinitionTest.java
@@ -17,8 +17,13 @@
 
 package org.apache.doris.nereids.trees.plans.commands.info;
 
+import org.apache.doris.catalog.Column;
+import org.apache.doris.nereids.types.TimeStampTzType;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 public class ColumnDefinitionTest {
 
@@ -32,5 +37,18 @@ public class ColumnDefinitionTest {
         String otherColName2 = "col2";
         boolean expected2 = false;
         Assertions.assertEquals(expected2, columnDefinition.nameEquals(otherColName2, false));
+    }
+
+    @Test
+    public void testTranslateToCatalogStyleForSchemaChangeWithTimeStampTzCurrentTimestamp() {
+        ColumnDefinition columnDefinition = new ColumnDefinition("ts", TimeStampTzType.of(6), false,
+                null, true, Optional.of(DefaultValue.currentTimeStampDefaultValueWithPrecision(6L)), "");
+
+        Column column = columnDefinition.translateToCatalogStyleForSchemaChange();
+
+        Assertions.assertEquals("CURRENT_TIMESTAMP(6)", column.getDefaultValue());
+        Assertions.assertNotNull(column.getRealDefaultValue());
+        Assertions.assertTrue(column.getRealDefaultValue().matches(
+                "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{6}[+-]\\d{2}:\\d{2}"));
     }
 }

--- a/regression-test/suites/schema_change_p0/test_timestamptz_default_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_timestamptz_default_schema_change.groovy
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_timestamptz_default_schema_change", "p0") {
+    def tableName = "test_timestamptz_default_schema_change"
+    def getTableStatusSql = """ SHOW ALTER TABLE COLUMN WHERE IndexName='${tableName}' ORDER BY createtime DESC LIMIT 1 """
+
+    sql "DROP TABLE IF EXISTS ${tableName} FORCE"
+    sql "SET time_zone = '+08:00'"
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+            id INT NOT NULL
+        )
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_num" = "1",
+            "light_schema_change" = "false"
+        )
+    """
+
+    sql """ INSERT INTO ${tableName} VALUES (1), (2), (3) """
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN ts TIMESTAMPTZ(6) DEFAULT CURRENT_TIMESTAMP(6)
+    """
+
+    waitForSchemaChangeDone {
+        sql getTableStatusSql
+        time 120
+    }
+
+    sql """ sync """
+
+    def rows = sql """
+        SELECT id, CAST(ts AS STRING) AS ts_str
+        FROM ${tableName}
+        ORDER BY id
+    """
+
+    assertEquals(3, rows.size())
+    rows.each { row ->
+        assertTrue(row[1] != null)
+        assertTrue(row[1].toString() ==~ /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}[+-]\d{2}:\d{2}/,
+                "Unexpected TIMESTAMPTZ value: ${row[1]}")
+    }
+
+    sql "DROP TABLE IF EXISTS ${tableName} FORCE"
+}

--- a/regression-test/suites/schema_change_p0/test_timestamptz_default_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_timestamptz_default_schema_change.groovy
@@ -16,14 +16,17 @@
 // under the License.
 
 suite("test_timestamptz_default_schema_change", "p0") {
-    def tableName = "test_timestamptz_default_schema_change"
-    def getTableStatusSql = """ SHOW ALTER TABLE COLUMN WHERE IndexName='${tableName}' ORDER BY createtime DESC LIMIT 1 """
+    def getTableStatusSql = """
+        SHOW ALTER TABLE COLUMN
+        WHERE IndexName='test_timestamptz_default_schema_change'
+        ORDER BY createtime DESC LIMIT 1
+    """
 
-    sql "DROP TABLE IF EXISTS ${tableName} FORCE"
+    sql "DROP TABLE IF EXISTS test_timestamptz_default_schema_change FORCE"
     sql "SET time_zone = '+08:00'"
 
     sql """
-        CREATE TABLE IF NOT EXISTS ${tableName} (
+        CREATE TABLE IF NOT EXISTS test_timestamptz_default_schema_change (
             id INT NOT NULL
         )
         DUPLICATE KEY(id)
@@ -34,10 +37,10 @@ suite("test_timestamptz_default_schema_change", "p0") {
         )
     """
 
-    sql """ INSERT INTO ${tableName} VALUES (1), (2), (3) """
+    sql """ INSERT INTO test_timestamptz_default_schema_change VALUES (1), (2), (3) """
 
     sql """
-        ALTER TABLE ${tableName}
+        ALTER TABLE test_timestamptz_default_schema_change
         ADD COLUMN ts TIMESTAMPTZ(6) DEFAULT CURRENT_TIMESTAMP(6)
     """
 
@@ -50,7 +53,7 @@ suite("test_timestamptz_default_schema_change", "p0") {
 
     def rows = sql """
         SELECT id, CAST(ts AS STRING) AS ts_str
-        FROM ${tableName}
+        FROM test_timestamptz_default_schema_change
         ORDER BY id
     """
 
@@ -60,6 +63,4 @@ suite("test_timestamptz_default_schema_change", "p0") {
         assertTrue(row[1].toString() ==~ /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}[+-]\d{2}:\d{2}/,
                 "Unexpected TIMESTAMPTZ value: ${row[1]}")
     }
-
-    sql "DROP TABLE IF EXISTS ${tableName} FORCE"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

Schema change could fail when adding a TIMESTAMPTZ column with DEFAULT CURRENT_TIMESTAMP, such as ALTER TABLE ... ADD COLUMN ts TIMESTAMPTZ(6) DEFAULT CURRENT_TIMESTAMP(6). Existing rows are backfilled from Column.realDefaultValue during schema change, but FE previously materialized CURRENT_TIMESTAMP as a plain datetime string without a timezone offset. Root cause: the schema-change default serialization path was not type-aware for TIMESTAMPTZ, while BE expects a TIMESTAMPTZ literal with an offset when parsing the backfill value. This change makes both the Nereids and legacy ColumnDef paths materialize TIMESTAMPTZ CURRENT_TIMESTAMP defaults with the session offset, reuses TimestampTzLiteral formatting for the datetime body, and adds FE and regression coverage for the schema-change path.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

