### PR TITLE
[fix](pipeline) fix comment-trigger workflow crash due to GitHub API rate limit

### DIFF
--- a/.github/workflows/comment-to-trigger-teamcity.yml
+++ b/.github/workflows/comment-to-trigger-teamcity.yml
@@ -230,6 +230,12 @@ jobs:
         # Matches .sh files under regression-test/pipeline/ but excludes files under conf/ subdirectories.
         source regression-test/pipeline/common/github-utils.sh
 
+        if [[ ! -f all_files ]]; then
+          echo "WARNING: all_files not found (GitHub API call likely failed in previous step)."
+          echo "Skipping sensitive check — previous step already defaulted to trigger-all."
+          exit 0
+        fi
+
         changed_sensitive=false
         while IFS= read -r f; do
           if [[ "${f}" == regression-test/pipeline/*.sh ||

--- a/regression-test/pipeline/common/github-utils.sh
+++ b/regression-test/pipeline/common/github-utils.sh
@@ -131,7 +131,9 @@ _get_pr_changed_files_count() {
     while [[ ${try_times} -gt 0 ]]; do
         set -x
         if ret=$(
-            curl -s -H "Accept: application/vnd.github+json" \
+            curl -s \
+                -H "Accept: application/vnd.github+json" \
+                ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} \
                 https://api.github.com/repos/"${OWNER}"/"${REPO}"/pulls/"${PULL_NUMBER}" | jq -e '.changed_files'
         ); then
             set +x
@@ -169,6 +171,7 @@ _get_pr_changed_files() {
             set -x
             if curl -s \
                 -H "Accept: application/vnd.github+json" \
+                ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} \
                 https://api.github.com/repos/"${OWNER}"/"${REPO}"/pulls/"${PULL_NUMBER}"/files?page="${page}"\&per_page="${per_page}" \
                 >>"${file_name}"; then
                 set +x


### PR DESCRIPTION
## Problem

When a PR author posts a second `run buildall` comment within a short window, the
`comment-to-trigger-teamcity` workflow can silently fail, leaving TeamCity
**not triggered** even though the Actions run appears to have executed.

Root cause is two connected bugs:

### Bug 1 — Unauthenticated GitHub API calls hit rate limits

`_get_pr_changed_files_count` and `_get_pr_changed_files` in
`regression-test/pipeline/common/github-utils.sh` make anonymous `curl` requests
(no `Authorization` header). GitHub's anonymous rate limit is **60 req/h per IP**.
GitHub Actions runner IPs are shared across every workflow in the org, so hitting
the limit is common when many workflows run concurrently.

### Bug 2 — Missing `all_files` crashes step 5

When `_get_pr_changed_files` fails (10 retries exhausted), step 4 ("Check if pr
need run build") has a correct fallback that defaults everything to trigger-all —
but it **does not create the `all_files` file**.

Step 5 ("Check for sensitive pipeline script changes") then executes:
```bash
done < all_files   # bash: all_files: No such file or directory → exit 1
```
This makes step 5 fail, which causes all downstream TeamCity trigger steps to be
skipped. The workflow shows `conclusion: failure` with no useful message to the PR
author.

## Fix

**`regression-test/pipeline/common/github-utils.sh`** — add optional auth header
to both curl calls using the shell idiom `${GITHUB_TOKEN:+-H "Authorization:
Bearer ${GITHUB_TOKEN}"}`. When `GITHUB_TOKEN` is set (always the case in GitHub
Actions), the authenticated rate limit of **5 000 req/h** is used. When unset
(local manual usage), the flag expands to nothing and behaviour is unchanged.

**`.github/workflows/comment-to-trigger-teamcity.yml`** — add an early-exit guard
in step 5 before reading `all_files`. If the file is absent (because the API call
in step 4 failed), the step exits 0 with an explanatory warning instead of
crashing. The previous step already defaulted to trigger-all in this scenario, so
no functionality is lost.

## Reproduction

Observed on run [25771630114](https://github.com/apache/doris/actions/runs/25771630114)
triggered by PR #63110 comment https://github.com/apache/doris/pull/63110#issuecomment-4436143004.