### PR TITLE
[improvement](fe) Add configurable interval for catalog recycle bin daemon thread

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2212,6 +2212,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int max_same_name_catalog_trash_num = 3;
 
+    @ConfField(masterOnly = true, description = {
+            "The interval between catalog recycle bin clean tasks. "
+                    + "Default is 30000 milliseconds (30 seconds)."})
+    public static long catalog_recycle_bin_interval_ms = 30 * 1000;
+
     /**
      * NOTE: The storage policy is still under developement.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -61,7 +61,6 @@ import java.util.stream.Stream;
 
 public class CatalogRecycleBin extends MasterDaemon implements Writable {
     private static final Logger LOG = LogManager.getLogger(CatalogRecycleBin.class);
-    private static final int DEFAULT_INTERVAL_SECONDS = 30; // 30 seconds
     // erase meta at least after minEraseLatency milliseconds
     // to avoid erase log ahead of drop log
     private static final long minEraseLatency = 10 * 60 * 1000;  // 10 min
@@ -104,7 +103,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
     String unused;
 
     public CatalogRecycleBin() {
-        super("recycle bin", FeConstants.runningUnitTest ? 10 * 1000L : DEFAULT_INTERVAL_SECONDS * 1000L);
+        super("recycle bin", FeConstants.runningUnitTest ? 10 * 1000L : Config.catalog_recycle_bin_interval_ms);
         idToDatabase = new ConcurrentHashMap<>();
         idToTable = new ConcurrentHashMap<>();
         idToPartition = new ConcurrentHashMap<>();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: The CatalogRecycleBin daemon thread uses a hardcoded 30s interval (`DEFAULT_INTERVAL_SECONDS`), which cannot be adjusted via FE configuration. Other master-only daemon threads like TabletScheduler use configurable intervals via Config parameters (e.g., `tablet_schedule_interval_ms`).

### Release note

Add a new FE config `catalog_recycle_bin_interval_ms` to allow configuring the catalog recycle bin daemon thread interval, default 30s.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
    - [ ] This is a refactor/code format and no logic has been changed.
    - [ ] Previous test can cover this change.
    - [ ] No code files have been changed.
    - [x] Other reason: Simple config parameter replacement following existing pattern (TabletScheduler)

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [ ] No.
    - [x] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label