### PR TITLE
[Chore](be) Avoid BE crash on exception

### DIFF
--- a/be/src/exec/scan/scanner_scheduler.cpp
+++ b/be/src/exec/scan/scanner_scheduler.cpp
@@ -75,12 +75,10 @@ Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx,
     TabletStorageType type = scanner_delegate->_scanner->get_storage_type();
     auto sumbit_task = [&]() {
         auto work_func = [scanner_ref = scan_task, ctx]() {
-            Status status = Status::OK();
-            try {
-                _scanner_scan(ctx, scanner_ref);
-            } catch (const Exception& e) {
-                status = e.to_status();
-            }
+            auto status = [&] {
+                RETURN_IF_CATCH_EXCEPTION(_scanner_scan(ctx, scanner_ref));
+                return Status::OK();
+            }();
 
             if (!status.ok()) {
                 scanner_ref->set_status(status);

--- a/be/src/exec/scan/scanner_scheduler.cpp
+++ b/be/src/exec/scan/scanner_scheduler.cpp
@@ -75,10 +75,12 @@ Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx,
     TabletStorageType type = scanner_delegate->_scanner->get_storage_type();
     auto sumbit_task = [&]() {
         auto work_func = [scanner_ref = scan_task, ctx]() {
-            auto status = [&] {
-                RETURN_IF_CATCH_EXCEPTION(_scanner_scan(ctx, scanner_ref));
-                return Status::OK();
-            }();
+            Status status = Status::OK();
+            try {
+                _scanner_scan(ctx, scanner_ref);
+            } catch (const Exception& e) {
+                status = e.to_status();
+            }
 
             if (!status.ok()) {
                 scanner_ref->set_status(status);
@@ -371,16 +373,7 @@ void ScannerScheduler::_make_sure_virtual_col_is_materialized(
 
 Result<SharedListenableFuture<Void>> ScannerSplitRunner::process_for(std::chrono::nanoseconds) {
     _started = true;
-    bool is_completed = false;
-    Status status = Status::OK();
-    ASSIGN_STATUS_IF_CATCH_EXCEPTION(is_completed = _scan_func(), status);
-    if (!status.ok()) {
-        if (_exception_handler) {
-            _exception_handler(status);
-        }
-        _completion_future.set_error(status);
-        return unexpected(status);
-    }
+    bool is_completed = _scan_func();
     if (is_completed) {
         _completion_future.set_value(Void {});
     }
@@ -388,7 +381,7 @@ Result<SharedListenableFuture<Void>> ScannerSplitRunner::process_for(std::chrono
 }
 
 bool ScannerSplitRunner::is_finished() {
-    return _completion_future.is_ready();
+    return _completion_future.is_done();
 }
 
 Status ScannerSplitRunner::finished_status() {

--- a/be/src/exec/scan/scanner_scheduler.cpp
+++ b/be/src/exec/scan/scanner_scheduler.cpp
@@ -371,7 +371,16 @@ void ScannerScheduler::_make_sure_virtual_col_is_materialized(
 
 Result<SharedListenableFuture<Void>> ScannerSplitRunner::process_for(std::chrono::nanoseconds) {
     _started = true;
-    bool is_completed = _scan_func();
+    bool is_completed = false;
+    Status status = Status::OK();
+    ASSIGN_STATUS_IF_CATCH_EXCEPTION(is_completed = _scan_func(), status);
+    if (!status.ok()) {
+        if (_exception_handler) {
+            _exception_handler(status);
+        }
+        _completion_future.set_error(status);
+        return unexpected(status);
+    }
     if (is_completed) {
         _completion_future.set_value(Void {});
     }
@@ -379,7 +388,7 @@ Result<SharedListenableFuture<Void>> ScannerSplitRunner::process_for(std::chrono
 }
 
 bool ScannerSplitRunner::is_finished() {
-    return _completion_future.is_done();
+    return _completion_future.is_ready();
 }
 
 Status ScannerSplitRunner::finished_status() {

--- a/be/src/exec/scan/scanner_scheduler.h
+++ b/be/src/exec/scan/scanner_scheduler.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <atomic>
-#include <functional>
 #include <memory>
 
 #include "common/be_mock_util.h"
@@ -62,24 +61,14 @@ struct SimplifiedScanTask {
 
 class ScannerSplitRunner : public SplitRunner {
 public:
-    ScannerSplitRunner(std::string name, std::function<bool()> scan_func,
-                       std::function<void(const Status&)> exception_handler = nullptr)
-            : _name(std::move(name)),
-              _scan_func(std::move(scan_func)),
-              _exception_handler(std::move(exception_handler)),
-              _started(false) {}
+    ScannerSplitRunner(std::string name, std::function<bool()> scan_func)
+            : _name(std::move(name)), _scan_func(std::move(scan_func)), _started(false) {}
 
     Status init() override { return Status::OK(); }
 
     Result<SharedListenableFuture<Void>> process_for(std::chrono::nanoseconds) override;
 
-    void close(const Status& status) override {
-        if (status.ok()) {
-            _completion_future.set_value(Void {});
-        } else {
-            _completion_future.set_error(status);
-        }
-    }
+    void close(const Status& status) override {}
 
     std::string get_info() const override { return ""; }
 
@@ -94,7 +83,6 @@ public:
 private:
     std::string _name;
     std::function<bool()> _scan_func;
-    std::function<void(const Status&)> _exception_handler;
 
     std::atomic<bool> _started;
     SharedListenableFuture<Void> _completion_future;
@@ -306,13 +294,8 @@ public:
         if (!_is_stop) {
             std::shared_ptr<SplitRunner> split_runner;
             if (scan_task.scan_task->is_first_schedule) {
-                auto exception_handler = [ctx = scan_task.scanner_context,
-                                          scanner_ref = scan_task.scan_task](const Status& status) {
-                    scanner_ref->set_status(status);
-                    ctx->push_back_scan_task(scanner_ref);
-                };
-                split_runner = std::make_shared<ScannerSplitRunner>(
-                        "scanner_split_runner", scan_task.scan_func, exception_handler);
+                split_runner = std::make_shared<ScannerSplitRunner>("scanner_split_runner",
+                                                                    scan_task.scan_func);
                 RETURN_IF_ERROR(split_runner->init());
                 auto result = _task_executor->enqueue_splits(
                         scan_task.scanner_context->task_handle(), false, {split_runner});
@@ -358,17 +341,8 @@ public:
                 return result;
             };
 
-            auto exception_handler = [this, task_handle,
-                                      scanner_context = scan_task.scanner_context,
-                                      scanner_task = scan_task.scan_task](const Status& status) {
-                if (scanner_context != nullptr && scanner_task != nullptr) {
-                    scanner_task->set_status(status);
-                    scanner_context->push_back_scan_task(scanner_task);
-                }
-                static_cast<void>(_task_executor->remove_task(task_handle));
-            };
-            auto split_runner = std::make_shared<ScannerSplitRunner>(
-                    "scanner_split_runner", wrapped_scan_func, exception_handler);
+            auto split_runner =
+                    std::make_shared<ScannerSplitRunner>("scanner_split_runner", wrapped_scan_func);
             RETURN_IF_ERROR(split_runner->init());
 
             auto result = _task_executor->enqueue_splits(task_handle, false, {split_runner});

--- a/be/src/exec/scan/scanner_scheduler.h
+++ b/be/src/exec/scan/scanner_scheduler.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
 
 #include "common/be_mock_util.h"
@@ -61,14 +62,24 @@ struct SimplifiedScanTask {
 
 class ScannerSplitRunner : public SplitRunner {
 public:
-    ScannerSplitRunner(std::string name, std::function<bool()> scan_func)
-            : _name(std::move(name)), _scan_func(scan_func), _started(false) {}
+    ScannerSplitRunner(std::string name, std::function<bool()> scan_func,
+                       std::function<void(const Status&)> exception_handler = nullptr)
+            : _name(std::move(name)),
+              _scan_func(std::move(scan_func)),
+              _exception_handler(std::move(exception_handler)),
+              _started(false) {}
 
     Status init() override { return Status::OK(); }
 
     Result<SharedListenableFuture<Void>> process_for(std::chrono::nanoseconds) override;
 
-    void close(const Status& status) override {}
+    void close(const Status& status) override {
+        if (status.ok()) {
+            _completion_future.set_value(Void {});
+        } else {
+            _completion_future.set_error(status);
+        }
+    }
 
     std::string get_info() const override { return ""; }
 
@@ -83,6 +94,7 @@ public:
 private:
     std::string _name;
     std::function<bool()> _scan_func;
+    std::function<void(const Status&)> _exception_handler;
 
     std::atomic<bool> _started;
     SharedListenableFuture<Void> _completion_future;
@@ -294,8 +306,13 @@ public:
         if (!_is_stop) {
             std::shared_ptr<SplitRunner> split_runner;
             if (scan_task.scan_task->is_first_schedule) {
-                split_runner = std::make_shared<ScannerSplitRunner>("scanner_split_runner",
-                                                                    scan_task.scan_func);
+                auto exception_handler = [ctx = scan_task.scanner_context,
+                                          scanner_ref = scan_task.scan_task](const Status& status) {
+                    scanner_ref->set_status(status);
+                    ctx->push_back_scan_task(scanner_ref);
+                };
+                split_runner = std::make_shared<ScannerSplitRunner>(
+                        "scanner_split_runner", scan_task.scan_func, exception_handler);
                 RETURN_IF_ERROR(split_runner->init());
                 auto result = _task_executor->enqueue_splits(
                         scan_task.scanner_context->task_handle(), false, {split_runner});
@@ -341,8 +358,17 @@ public:
                 return result;
             };
 
-            auto split_runner =
-                    std::make_shared<ScannerSplitRunner>("scanner_split_runner", wrapped_scan_func);
+            auto exception_handler = [this, task_handle,
+                                      scanner_context = scan_task.scanner_context,
+                                      scanner_task = scan_task.scan_task](const Status& status) {
+                if (scanner_context != nullptr && scanner_task != nullptr) {
+                    scanner_task->set_status(status);
+                    scanner_context->push_back_scan_task(scanner_task);
+                }
+                static_cast<void>(_task_executor->remove_task(task_handle));
+            };
+            auto split_runner = std::make_shared<ScannerSplitRunner>(
+                    "scanner_split_runner", wrapped_scan_func, exception_handler);
             RETURN_IF_ERROR(split_runner->init());
 
             auto result = _task_executor->enqueue_splits(task_handle, false, {split_runner});

--- a/be/src/exec/scan/task_executor/time_sharing/prioritized_split_runner.cpp
+++ b/be/src/exec/scan/task_executor/time_sharing/prioritized_split_runner.cpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include <thread>
 
+#include "common/exception.h"
 #include "exec/scan/task_executor/time_sharing/time_sharing_task_handle.h"
 
 namespace doris {
@@ -60,6 +61,11 @@ bool PrioritizedSplitRunner::is_closed() const {
 void PrioritizedSplitRunner::close(const Status& status) {
     if (!_closed.exchange(true)) {
         _split_runner->close(status);
+        if (status.ok()) {
+            _finished_future.set_value({});
+        } else {
+            _finished_future.set_error(status);
+        }
     }
 }
 
@@ -70,7 +76,12 @@ int64_t PrioritizedSplitRunner::created_nanos() const {
 bool PrioritizedSplitRunner::is_finished() {
     bool finished = _split_runner->is_finished();
     if (finished) {
-        _finished_future.set_value({});
+        auto status = _split_runner->finished_status();
+        if (status.ok()) {
+            _finished_future.set_value({});
+        } else {
+            _finished_future.set_error(status);
+        }
     }
     return finished || _closed.load() || _task_handle->is_closed();
 }
@@ -99,9 +110,18 @@ Result<SharedListenableFuture<Void>> PrioritizedSplitRunner::process() {
     _wait_nanos.fetch_add(start_nanos - _last_ready.load());
 
     auto process_start_time = _ticker->read();
-    auto blocked = _split_runner->process_for(SPLIT_RUN_QUANTA);
+    Result<SharedListenableFuture<Void>> blocked = SharedListenableFuture<Void>::create_ready();
+    Status status = Status::OK();
+    ASSIGN_STATUS_IF_CATCH_EXCEPTION(blocked = _split_runner->process_for(SPLIT_RUN_QUANTA),
+                                     status);
+    if (!status.ok()) {
+        _finished_future.set_error(status);
+        return unexpected(status);
+    }
     if (!blocked.has_value()) {
-        return unexpected(std::move(blocked).error());
+        auto error_status = blocked.error();
+        _finished_future.set_error(error_status);
+        return unexpected(std::move(error_status));
     }
     auto process_end_time = _ticker->read();
     auto quanta_scheduled_nanos = process_end_time - process_start_time;

--- a/be/src/exec/scan/task_executor/time_sharing/prioritized_split_runner.cpp
+++ b/be/src/exec/scan/task_executor/time_sharing/prioritized_split_runner.cpp
@@ -111,10 +111,10 @@ Result<SharedListenableFuture<Void>> PrioritizedSplitRunner::process() {
 
     auto process_start_time = _ticker->read();
     Result<SharedListenableFuture<Void>> blocked = SharedListenableFuture<Void>::create_ready();
-    Status status = Status::OK();
-    ASSIGN_STATUS_IF_CATCH_EXCEPTION(blocked = _split_runner->process_for(SPLIT_RUN_QUANTA),
-                                     status);
-    if (!status.ok()) {
+    try {
+        blocked = _split_runner->process_for(SPLIT_RUN_QUANTA);
+    } catch (const Exception& e) {
+        Status status = e.to_status();
         _finished_future.set_error(status);
         return unexpected(status);
     }

--- a/be/test/exec/executor/time_sharing/time_sharing_task_executor_test.cpp
+++ b/be/test/exec/executor/time_sharing/time_sharing_task_executor_test.cpp
@@ -29,7 +29,6 @@
 #include <thread>
 
 #include "common/exception.h"
-#include "exec/scan/scanner_scheduler.h"
 #include "exec/scan/task_executor/ticker.h"
 #include "exec/scan/task_executor/time_sharing/multilevel_split_queue.h"
 #include "exec/scan/task_executor/time_sharing/prioritized_split_runner.h"
@@ -348,29 +347,6 @@ private:
         }
     }
 };
-
-TEST(ScannerSplitRunnerTest, test_exception_handler_called) {
-    bool handler_called = false;
-    Status caught_status = Status::OK();
-    ScannerSplitRunner runner(
-            "scanner_split_runner",
-            []() {
-                throw Exception(Status::InternalError("scanner split failed"));
-                return false;
-            },
-            [&](const Status& status) {
-                handler_called = true;
-                caught_status = status;
-            });
-
-    auto result = runner.process_for(std::chrono::nanoseconds(1));
-    ASSERT_FALSE(result.has_value());
-    EXPECT_TRUE(handler_called);
-    EXPECT_FALSE(caught_status.ok());
-    EXPECT_NE(std::string::npos, caught_status.to_string().find("scanner split failed"));
-    EXPECT_TRUE(runner.is_finished());
-    EXPECT_FALSE(runner.finished_status().ok());
-}
 
 TEST_F(TimeSharingTaskExecutorTest, test_tasks_complete) {
     auto ticker = std::make_shared<TestingTicker>();

--- a/be/test/exec/executor/time_sharing/time_sharing_task_executor_test.cpp
+++ b/be/test/exec/executor/time_sharing/time_sharing_task_executor_test.cpp
@@ -28,7 +28,11 @@
 #include <random>
 #include <thread>
 
+#include "common/exception.h"
+#include "exec/scan/scanner_scheduler.h"
 #include "exec/scan/task_executor/ticker.h"
+#include "exec/scan/task_executor/time_sharing/multilevel_split_queue.h"
+#include "exec/scan/task_executor/time_sharing/prioritized_split_runner.h"
 #include "exec/scan/task_executor/time_sharing/time_sharing_task_handle.h"
 
 namespace doris {
@@ -289,6 +293,28 @@ private:
     ListenableFuture<Void> _completion_future {};
 };
 
+class ThrowingSplitRunner : public SplitRunner {
+public:
+    explicit ThrowingSplitRunner(Status status) : _status(std::move(status)) {}
+
+    Status init() override { return Status::OK(); }
+
+    Result<SharedListenableFuture<Void>> process_for(std::chrono::nanoseconds) override {
+        throw Exception(_status);
+    }
+
+    void close(const Status& status) override {}
+
+    bool is_finished() override { return false; }
+
+    Status finished_status() override { return _status; }
+
+    std::string get_info() const override { return ""; }
+
+private:
+    Status _status;
+};
+
 class TimeSharingTaskExecutorTest : public testing::Test {
 protected:
     void SetUp() override {}
@@ -322,6 +348,29 @@ private:
         }
     }
 };
+
+TEST(ScannerSplitRunnerTest, test_exception_handler_called) {
+    bool handler_called = false;
+    Status caught_status = Status::OK();
+    ScannerSplitRunner runner(
+            "scanner_split_runner",
+            []() {
+                throw Exception(Status::InternalError("scanner split failed"));
+                return false;
+            },
+            [&](const Status& status) {
+                handler_called = true;
+                caught_status = status;
+            });
+
+    auto result = runner.process_for(std::chrono::nanoseconds(1));
+    ASSERT_FALSE(result.has_value());
+    EXPECT_TRUE(handler_called);
+    EXPECT_FALSE(caught_status.ok());
+    EXPECT_NE(std::string::npos, caught_status.to_string().find("scanner split failed"));
+    EXPECT_TRUE(runner.is_finished());
+    EXPECT_FALSE(runner.finished_status().ok());
+}
 
 TEST_F(TimeSharingTaskExecutorTest, test_tasks_complete) {
     auto ticker = std::make_shared<TestingTicker>();
@@ -416,6 +465,24 @@ TEST_F(TimeSharingTaskExecutorTest, test_tasks_complete) {
         throw;
     }
     executor.stop();
+}
+
+TEST(PrioritizedSplitRunnerTest, test_process_exception_returns_error) {
+    auto ticker = std::make_shared<TestingTicker>();
+    auto task_handle = TimeSharingTaskHandle::create_shared(
+            TaskId("test_exception_task"), std::make_shared<MultilevelSplitQueue>(2.0),
+            []() { return 0.0; }, 1, std::chrono::milliseconds(1), std::nullopt);
+    ASSERT_TRUE(task_handle->init().ok());
+    auto split =
+            std::make_shared<ThrowingSplitRunner>(Status::InternalError("split process failed"));
+    PrioritizedSplitRunner prioritized_split(task_handle, 0, split, ticker);
+
+    auto result = prioritized_split.process();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(std::string::npos, result.error().to_string().find("split process failed"));
+    EXPECT_TRUE(prioritized_split.finished_future().is_error());
+    EXPECT_NE(std::string::npos, prioritized_split.finished_future().get_status().to_string().find(
+                                         "split process failed"));
 }
 
 TEST_F(TimeSharingTaskExecutorTest, test_quanta_fairness) {


### PR DESCRIPTION
This pull request improves error handling and robustness in the `PrioritizedSplitRunner` and related time-sharing task execution code. It ensures that exceptions thrown during split processing are correctly captured and propagated, and adds testing to verify this behavior.

**Error handling improvements:**

* Updated `PrioritizedSplitRunner::process()` to catch `Exception` thrown by `process_for`, convert it to a `Status`, set the error on `_finished_future`, and return the error result. This ensures exceptions do not go unhandled and are properly surfaced.
* Modified `close` and `is_finished` methods in `PrioritizedSplitRunner` to set `_finished_future` with either a value or error status, depending on the outcome, providing more accurate future state management. [[1]](diffhunk://#diff-eabed95efc8325f788b423182bac8563fa77c0f995683b76fb9628757b210269R64-R68) [[2]](diffhunk://#diff-eabed95efc8325f788b423182bac8563fa77c0f995683b76fb9628757b210269R79-R84)

**Testing enhancements:**

* Added a `ThrowingSplitRunner` test class that throws an exception in `process_for`, and a new test `test_process_exception_returns_error` to verify that exceptions are properly handled and reflected in the runner's future. [[1]](diffhunk://#diff-fa509c2ede062320aa3c657810303ee8d04b70ec095a77d3efca3ffbd4b2eb6aR295-R316) [[2]](diffhunk://#diff-fa509c2ede062320aa3c657810303ee8d04b70ec095a77d3efca3ffbd4b2eb6aR446-R463)

**Code quality improvements:**

* Included missing `common/exception.h` header in both implementation and test files for proper exception handling. [[1]](diffhunk://#diff-eabed95efc8325f788b423182bac8563fa77c0f995683b76fb9628757b210269R26) [[2]](diffhunk://#diff-fa509c2ede062320aa3c657810303ee8d04b70ec095a77d3efca3ffbd4b2eb6aR31-R34)
* Used `std::move` when initializing `_scan_func` in `ScannerSplitRunner` to ensure efficient resource management.