### PR TITLE
[fix](fe) Clean up row policies when dropping a role or user

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -586,12 +586,14 @@ public class Auth implements Writable {
         writeLock();
         String mysqlUserName = userIdent.getUser();
         String toDropMysqlUserId;
+        boolean userExisted = true;
         try {
             // check if user exists
             if (!doesUserExist(userIdent)) {
                 if (ignoreIfNonExists) {
                     LOG.info("user non exists, ignored to drop user: {}, is replay: {}",
                             userIdent.getQualifiedUser(), isReplay);
+                    userExisted = false;
                     return;
                 }
                 throw new DdlException(String.format("User `%s`@`%s` does not exist.",
@@ -616,6 +618,10 @@ public class Auth implements Writable {
             LOG.info("finished to drop user: {}, is replay: {}", userIdent.getQualifiedUser(), isReplay);
         } finally {
             writeUnlock();
+        }
+
+        if (userExisted) {
+            Env.getCurrentEnv().getPolicyMgr().dropPoliciesByUser(userIdent, isReplay);
         }
 
         if (Config.isNotCloudMode()) {
@@ -1120,10 +1126,12 @@ public class Auth implements Writable {
     }
 
     private void dropRoleInternal(String role, boolean ignoreIfNonExists, boolean isReplay) throws DdlException {
+        boolean roleExisted = true;
         writeLock();
         try {
             if (ignoreIfNonExists && roleManager.getRole(role) == null) {
                 LOG.info("role non exists, ignored to drop role: {}, is replay: {}", role, isReplay);
+                roleExisted = false;
                 return;
             }
 
@@ -1135,6 +1143,9 @@ public class Auth implements Writable {
             }
         } finally {
             writeUnlock();
+        }
+        if (roleExisted) {
+            Env.getCurrentEnv().getPolicyMgr().dropPoliciesByRole(role, isReplay);
         }
         LOG.info("finished to drop role: {}, is replay: {}", role, isReplay);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -540,6 +540,69 @@ public class PolicyMgr implements Writable {
         }
     }
 
+    public void dropPoliciesByRole(String roleName, boolean isReplay) {
+        writeLock();
+        try {
+            List<Policy> policies = getPoliciesByType(PolicyTypeEnum.ROW);
+            List<DropPolicyLog> dropLogs = Lists.newArrayList();
+            policies.removeIf(policy -> {
+                if (policy instanceof RowPolicy) {
+                    RowPolicy rowPolicy = (RowPolicy) policy;
+                    if (roleName.equals(rowPolicy.getRoleName())) {
+                        dropTablePolicies(rowPolicy);
+                        if (!isReplay) {
+                            dropLogs.add(new DropPolicyLog(rowPolicy.getCtlName(), rowPolicy.getDbName(),
+                                    rowPolicy.getTableName(), PolicyTypeEnum.ROW, rowPolicy.getPolicyName(),
+                                    rowPolicy.getUser(), rowPolicy.getRoleName()));
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            });
+            typeToPolicyMap.put(PolicyTypeEnum.ROW, policies);
+            if (!isReplay) {
+                for (DropPolicyLog log : dropLogs) {
+                    Env.getCurrentEnv().getEditLog().logDropPolicy(log);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void dropPoliciesByUser(UserIdentity user, boolean isReplay) {
+        writeLock();
+        try {
+            List<Policy> policies = getPoliciesByType(PolicyTypeEnum.ROW);
+            List<DropPolicyLog> dropLogs = Lists.newArrayList();
+            policies.removeIf(policy -> {
+                if (policy instanceof RowPolicy) {
+                    RowPolicy rowPolicy = (RowPolicy) policy;
+                    if (rowPolicy.getUser() != null
+                            && user.getQualifiedUser().equals(rowPolicy.getUser().getQualifiedUser())) {
+                        dropTablePolicies(rowPolicy);
+                        if (!isReplay) {
+                            dropLogs.add(new DropPolicyLog(rowPolicy.getCtlName(), rowPolicy.getDbName(),
+                                    rowPolicy.getTableName(), PolicyTypeEnum.ROW, rowPolicy.getPolicyName(),
+                                    rowPolicy.getUser(), rowPolicy.getRoleName()));
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            });
+            typeToPolicyMap.put(PolicyTypeEnum.ROW, policies);
+            if (!isReplay) {
+                for (DropPolicyLog log : dropLogs) {
+                    Env.getCurrentEnv().getEditLog().logDropPolicy(log);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
     private void addTablePolicies(RowPolicy policy) {
         if (policy.getUser() != null) {
             policy.getUser().setIsAnalyzed();

--- a/regression-test/suites/account_p0/test_drop_role_clean_row_policy.groovy
+++ b/regression-test/suites/account_p0/test_drop_role_clean_row_policy.groovy
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_drop_role_clean_row_policy") {
+    def dbName = context.config.getDbNameByFile(context.file)
+    def tableName = "drop_role_row_policy_tbl"
+    def user1 = "drop_role_policy_user1"
+    def user2 = "drop_role_policy_user2"
+    def role = "drop_role_policy_role"
+    def tokens = context.config.jdbcUrl.split('/')
+    def url = tokens[0] + "//" + tokens[2] + "/" + dbName + "?"
+
+    sql """DROP TABLE IF EXISTS ${tableName}"""
+    sql """CREATE TABLE ${tableName} (k INT, v INT) DISTRIBUTED BY HASH(k) PROPERTIES('replication_num'='1')"""
+    sql """INSERT INTO ${tableName} VALUES (1,1), (2,2), (3,3)"""
+
+    // ========== Test 1: drop role should clean row policies bound to that role ==========
+    sql """DROP USER IF EXISTS ${user1}"""
+    sql """CREATE USER ${user1} IDENTIFIED BY '123456'"""
+    sql """GRANT SELECT_PRIV ON ${dbName} TO ${user1}"""
+
+    sql """DROP ROLE IF EXISTS ${role}"""
+    sql """CREATE ROLE ${role}"""
+    sql """GRANT ${role} TO ${user1}"""
+    sql """GRANT SELECT_PRIV ON ${dbName} TO '${role}'"""
+
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${user1}""";
+    }
+
+    sql """DROP ROW POLICY IF EXISTS policy_drop_role_test ON ${tableName} FOR ROLE ${role}"""
+    sql """CREATE ROW POLICY policy_drop_role_test ON ${tableName} AS RESTRICTIVE TO ROLE ${role} USING(k=1)"""
+
+    order_qt_select_before_drop_role "SELECT * FROM ${tableName} ORDER BY k"
+
+    connect(user1, '123456', url) {
+        def result = sql "SELECT * FROM ${tableName} ORDER BY k"
+        assertEquals(1, result.size())
+        assertEquals(1, result[0][0])
+    }
+
+    sql """DROP ROLE ${role}"""
+
+    connect(user1, '123456', url) {
+        def result = sql "SELECT * FROM ${tableName} ORDER BY k"
+        assertEquals(3, result.size())
+    }
+
+    sql """DROP ROW POLICY IF EXISTS policy_drop_role_test ON ${tableName} FOR ROLE ${role}"""
+    sql """DROP USER IF EXISTS ${user1}"""
+
+    // ========== Test 2: drop user should clean row policies bound to that user ==========
+    sql """DROP USER IF EXISTS ${user2}"""
+    sql """CREATE USER ${user2} IDENTIFIED BY '123456'"""
+    sql """GRANT SELECT_PRIV ON ${dbName} TO ${user2}"""
+
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${user2}""";
+    }
+
+    sql """DROP ROW POLICY IF EXISTS policy_drop_user_test ON ${tableName} FOR ${user2}"""
+    sql """CREATE ROW POLICY policy_drop_user_test ON ${tableName} AS RESTRICTIVE TO ${user2} USING(k=2)"""
+
+    connect(user2, '123456', url) {
+        def result = sql "SELECT * FROM ${tableName} ORDER BY k"
+        assertEquals(1, result.size())
+        assertEquals(2, result[0][0])
+    }
+
+    sql """DROP USER ${user2}"""
+
+    // After dropping the user, the row policy bound to that user should be cleaned up.
+    // Verify by creating a new user with the same name - it should see all rows.
+    sql """CREATE USER ${user2} IDENTIFIED BY '123456'"""
+    sql """GRANT SELECT_PRIV ON ${dbName} TO ${user2}"""
+
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        sql """GRANT USAGE_PRIV ON CLUSTER `${validCluster}` TO ${user2}""";
+    }
+
+    connect(user2, '123456', url) {
+        def result = sql "SELECT * FROM ${tableName} ORDER BY k"
+        assertEquals(3, result.size())
+    }
+
+    sql """DROP ROW POLICY IF EXISTS policy_drop_user_test ON ${tableName} FOR ${user2}"""
+    sql """DROP USER IF EXISTS ${user2}"""
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: When a role is dropped, row policies bound to that role are not cleaned up. Similarly, when a user is dropped, row policies bound to that user are not cleaned up. This causes orphaned row policies that can never be removed through normal `DROP ROW POLICY` commands since the referenced role/user no longer exists.

### Release note

Row policies bound to a role are now automatically cleaned up when the role is dropped. Row policies bound to a user are now automatically cleaned up when the user is dropped.

### Check List (For Author)

- Test: Regression test
- Behavior changed: Yes, row policies are now automatically cleaned up when dropping role/user
- Does this need documentation: No

### Changes

1. Added `PolicyMgr.dropPoliciesByRole(String roleName, boolean isReplay)` - removes all row policies bound to a given role, with proper edit log handling for non-replay mode
2. Added `PolicyMgr.dropPoliciesByUser(UserIdentity user, boolean isReplay)` - removes all row policies bound to a given user, with proper edit log handling for non-replay mode
3. Modified `Auth.dropRoleInternal()` to call `dropPoliciesByRole` after the role is dropped
4. Modified `Auth.dropUserInternal()` to call `dropPoliciesByUser` after the user is dropped
5. Added regression test covering both drop role and drop user scenarios