### PR TITLE
[fix](fe) Deduplicate backends in ADMIN CLEAN TRASH command

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCleanTrashCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCleanTrashCommand.java
@@ -35,12 +35,14 @@ import org.apache.doris.task.CleanTrashTask;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * admin clean trash
@@ -78,6 +80,7 @@ public class AdminCleanTrashCommand extends Command implements NoForward {
             needCleanedBackends.addAll(backendsInfo.values());
         } else {
             Map<String, Long> backendsID = new HashMap<>();
+            Set<Long> addedIds = Sets.newHashSet();
             for (Backend backend : backendsInfo.values()) {
                 backendsID.put(
                         NetUtils.getHostPortInAccessibleFormat(backend.getHost(), backend.getHeartbeatPort()),
@@ -85,7 +88,10 @@ public class AdminCleanTrashCommand extends Command implements NoForward {
             }
             for (String backendQuery : backendsQuery) {
                 if (backendsID.containsKey(backendQuery)) {
-                    needCleanedBackends.add(backendsInfo.get(backendsID.get(backendQuery)));
+                    long backendId = backendsID.get(backendQuery);
+                    if (addedIds.add(backendId)) {
+                        needCleanedBackends.add(backendsInfo.get(backendId));
+                    }
                     backendsID.remove(backendQuery);
                 }
             }
@@ -99,7 +105,12 @@ public class AdminCleanTrashCommand extends Command implements NoForward {
             return;
         }
         AgentBatchTask batchTask = new AgentBatchTask();
+        Set<Long> addedBackendIds = Sets.newHashSet();
         for (Backend backend : backends) {
+            if (!addedBackendIds.add(backend.getId())) {
+                LOG.info("skip duplicate clean trash task for beId {}", backend.getId());
+                continue;
+            }
             CleanTrashTask cleanTrashTask = new CleanTrashTask(backend.getId());
             batchTask.addTask(cleanTrashTask);
             LOG.info("clean trash in be {}, beId {}", backend.getHost(), backend.getId());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCleanTrashCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminCleanTrashCommandTest.java
@@ -1,0 +1,150 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.task.AgentBatchTask;
+import org.apache.doris.task.AgentTaskExecutor;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class AdminCleanTrashCommandTest {
+    private Env env = Mockito.mock(Env.class);
+    private AccessControllerManager accessControllerManager = Mockito.mock(AccessControllerManager.class);
+    private ConnectContext connectContext = Mockito.mock(ConnectContext.class);
+    private SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
+
+    private MockedStatic<Env> mockedEnv;
+    private MockedStatic<ConnectContext> mockedConnectContext;
+
+    @BeforeEach
+    public void setUp() {
+        mockedEnv = Mockito.mockStatic(Env.class);
+        mockedConnectContext = Mockito.mockStatic(ConnectContext.class);
+
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+        mockedConnectContext.when(ConnectContext::get).thenReturn(connectContext);
+
+        Mockito.when(env.getAccessManager()).thenReturn(accessControllerManager);
+        Mockito.when(accessControllerManager.checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class),
+                Mockito.any(PrivPredicate.class))).thenReturn(true);
+        Mockito.when(env.getCurrentSystemInfo()).thenReturn(systemInfoService);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockedConnectContext.close();
+        mockedEnv.close();
+    }
+
+    @Test
+    public void testDedupBackendsWithDuplicateQueries() throws Exception {
+        Backend be1 = new Backend(10001L, "192.168.0.1", 9050);
+        Backend be2 = new Backend(10002L, "192.168.0.2", 9050);
+        ImmutableMap<Long, Backend> backendsMap = ImmutableMap.of(
+                be1.getId(), be1,
+                be2.getId(), be2);
+        Mockito.when(systemInfoService.getAllBackendsByAllCluster()).thenReturn(backendsMap);
+
+        List<AgentBatchTask> capturedTasks = new ArrayList<>();
+        try (MockedStatic<AgentTaskExecutor> mockedExecutor = Mockito.mockStatic(AgentTaskExecutor.class)) {
+            mockedExecutor.when(() -> AgentTaskExecutor.submit(Mockito.any(AgentBatchTask.class)))
+                    .thenAnswer(invocation -> {
+                        capturedTasks.add(invocation.getArgument(0));
+                        return null;
+                    });
+
+            List<String> duplicateQueries = Arrays.asList("192.168.0.1:9050", "192.168.0.1:9050");
+            AdminCleanTrashCommand command = new AdminCleanTrashCommand(duplicateQueries);
+            command.run(connectContext, null);
+
+            Assertions.assertEquals(1, capturedTasks.size());
+            Assertions.assertEquals(1, capturedTasks.get(0).getTaskNum(),
+                    "Should only send one clean trash task for duplicate backend queries");
+        }
+    }
+
+    @Test
+    public void testDedupBackendsWithDistinctQueries() throws Exception {
+        Backend be1 = new Backend(10003L, "192.168.1.1", 9050);
+        Backend be2 = new Backend(10004L, "192.168.1.2", 9050);
+        ImmutableMap<Long, Backend> backendsMap = ImmutableMap.of(
+                be1.getId(), be1,
+                be2.getId(), be2);
+        Mockito.when(systemInfoService.getAllBackendsByAllCluster()).thenReturn(backendsMap);
+
+        List<AgentBatchTask> capturedTasks = new ArrayList<>();
+        try (MockedStatic<AgentTaskExecutor> mockedExecutor = Mockito.mockStatic(AgentTaskExecutor.class)) {
+            mockedExecutor.when(() -> AgentTaskExecutor.submit(Mockito.any(AgentBatchTask.class)))
+                    .thenAnswer(invocation -> {
+                        capturedTasks.add(invocation.getArgument(0));
+                        return null;
+                    });
+
+            List<String> queries = Arrays.asList("192.168.1.1:9050", "192.168.1.2:9050");
+            AdminCleanTrashCommand command = new AdminCleanTrashCommand(queries);
+            command.run(connectContext, null);
+
+            Assertions.assertEquals(1, capturedTasks.size());
+            Assertions.assertEquals(2, capturedTasks.get(0).getTaskNum(),
+                    "Should send one clean trash task per distinct backend");
+        }
+    }
+
+    @Test
+    public void testCleanAllBackendsWithNoDuplicates() throws Exception {
+        Backend be1 = new Backend(10005L, "192.168.2.1", 9050);
+        Backend be2 = new Backend(10006L, "192.168.2.2", 9050);
+        ImmutableMap<Long, Backend> backendsMap = ImmutableMap.of(
+                be1.getId(), be1,
+                be2.getId(), be2);
+        Mockito.when(systemInfoService.getAllBackendsByAllCluster()).thenReturn(backendsMap);
+
+        List<AgentBatchTask> capturedTasks = new ArrayList<>();
+        try (MockedStatic<AgentTaskExecutor> mockedExecutor = Mockito.mockStatic(AgentTaskExecutor.class)) {
+            mockedExecutor.when(() -> AgentTaskExecutor.submit(Mockito.any(AgentBatchTask.class)))
+                    .thenAnswer(invocation -> {
+                        capturedTasks.add(invocation.getArgument(0));
+                        return null;
+                    });
+
+            AdminCleanTrashCommand command = new AdminCleanTrashCommand();
+            command.run(connectContext, null);
+
+            Assertions.assertEquals(1, capturedTasks.size());
+            Assertions.assertEquals(2, capturedTasks.get(0).getTaskNum(),
+                    "Should send one clean trash task per backend when cleaning all");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix deduplication bug in `ADMIN CLEAN TRASH` command where duplicate clean trash tasks could be sent to the same BE
- Add `Set<Long>` dedup by backend ID in both `getNeedCleanedBackends()` and `cleanTrash()` methods
- Add unit test `AdminCleanTrashCommandTest` covering duplicate queries, distinct queries, and clean-all scenarios

## What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: The `ADMIN CLEAN TRASH` command could send duplicate clean trash tasks to the same BE. When `backendsQuery` contains duplicate entries (e.g., same `host:port` specified twice), or when different string representations resolve to the same backend, `getNeedCleanedBackends()` would add the same backend multiple times. Additionally, `cleanTrash()` did not deduplicate by backend ID before creating tasks, so duplicate backends in the list would result in multiple `CleanTrashTask` objects being sent to the same BE.

### Root Cause

1. In `getNeedCleanedBackends()`, the `backendsID.remove(backendQuery)` only deduplicates by the string key format (`host:port`). If the user provides the same backend via different string representations or duplicate entries, the same backend could be added multiple times.

2. In `cleanTrash()`, there was no deduplication by backend ID. The method iterated over the `backends` list and created a `CleanTrashTask` for each entry without checking for duplicates.

3. `CleanTrashTask` has signature `-1` and is NOT added to `AgentTaskQueue` (only `AgentTaskExecutor.submit(batchTask)` is called), so the queue dedup mechanism does not apply.

### Fix

- Add `Set<Long> addedIds` in `getNeedCleanedBackends()` to deduplicate by backend ID when processing `backendsQuery`
- Add `Set<Long> addedBackendIds` in `cleanTrash()` as a safety net to deduplicate by backend ID before creating tasks

## Release note

Fixed a bug where ADMIN CLEAN TRASH could send duplicate clean tasks to the same backend when duplicate backend addresses were specified.

## Check List (For Author)

- Test: Unit Test
    - `AdminCleanTrashCommandTest` verifies dedup with duplicate queries, distinct queries, and clean-all scenarios
- Behavior changed: No
- Does this need documentation: No