### PR TITLE
[improvement](build) Add build and unit test parallel options to run-fe-ut.sh

### DIFF
--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -86,12 +86,17 @@ Usage: $0 <options>
   Optional options:
      --coverage           build and run coverage statistic
      --run                build and run ut
+     -j <num>             build parallel, num is the number of threads, default 1
+     -p <num>             unit test parallel, num is the number of forked JVMs, default 1
 
   Environment variables:
      EXTRA_FE_MODULES     Optional FE feature modules in feature=module_path format, separated by commas.
 
   Eg.
     $0                                                                      build and run ut
+    $0 -j 4                                                                 build with 4 threads and run ut
+    $0 -p 3                                                                 run unit tests with 3 forked JVMs
+    $0 -j 4 -p 3                                                            build with 4 threads and run unit tests with 3 forked JVMs
     $0 --coverage                                                           build and run coverage statistic
     $0 --run org.apache.doris.utframe.Demo                                  build and run the test named Demo
     $0 --run org.apache.doris.utframe.Demo#testCreateDbAndTable+test2       build and run testCreateDbAndTable in Demo test
@@ -102,7 +107,7 @@ Usage: $0 <options>
 
 if ! OPTS="$(getopt \
     -n "$0" \
-    -o '' \
+    -o 'j:p:' \
     -l 'coverage' \
     -l 'run' \
     -- "$@")"; then
@@ -113,8 +118,9 @@ eval set -- "${OPTS}"
 
 RUN=0
 COVERAGE=0
+BUILD_PARALLEL=1
+UT_PARALLEL=1
 if [[ "$#" == 1 ]]; then
-    #default
     RUN=0
     COVERAGE=0
 else
@@ -129,6 +135,14 @@ else
         --run)
             RUN=1
             shift
+            ;;
+        -j)
+            BUILD_PARALLEL="$2"
+            shift 2
+            ;;
+        -p)
+            UT_PARALLEL="$2"
+            shift 2
             ;;
         --)
             shift
@@ -176,9 +190,9 @@ cd "${DORIS_HOME}/fe"
 mkdir -p build/compile
 
 if [[ -z "${FE_UT_PARALLEL}" ]]; then
-    # the default fe unit test parallel is 1
-    export FE_UT_PARALLEL=1
+    export FE_UT_PARALLEL="${UT_PARALLEL}"
 fi
+echo "Build parallel is: ${BUILD_PARALLEL}"
 echo "Unit test parallel is: ${FE_UT_PARALLEL}"
 
 if [[ "${RUN}" -eq 1 ]]; then
@@ -188,18 +202,18 @@ if [[ "${RUN}" -eq 1 ]]; then
     # sh run-fe-ut.sh --run org.apache.doris.utframe.DemoTest#testCreateDbAndTable+test2
 
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" -Pcoverage test jacoco:report -pl "${MVN_MODULES}" -am -DfailIfNoTests=false -Dtest="$1"
+        "${MVN_CMD}" -T "${BUILD_PARALLEL}" -Pcoverage test jacoco:report -pl "${MVN_MODULES}" -am -DfailIfNoTests=false -Dtest="$1"
     else
-        "${MVN_CMD}" test -pl "${MVN_MODULES}" -am -Dcheckstyle.skip=true -DfailIfNoTests=false \
+        "${MVN_CMD}" -T "${BUILD_PARALLEL}" test -pl "${MVN_MODULES}" -am -Dcheckstyle.skip=true -DfailIfNoTests=false \
             -Dmaven.build.cache.enabled=false -Dtest="$1"
     fi
 else
     echo "Run Frontend UT"
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" -Pcoverage test jacoco:report -pl "${MVN_MODULES}" -am -DfailIfNoTests=false \
+        "${MVN_CMD}" -T "${BUILD_PARALLEL}" -Pcoverage test jacoco:report -pl "${MVN_MODULES}" -am -DfailIfNoTests=false \
             -Dmaven.test.failure.ignore=true
     else
-        "${MVN_CMD}" test -pl "${MVN_MODULES}" -am -Dcheckstyle.skip=true -DfailIfNoTests=false \
+        "${MVN_CMD}" -T "${BUILD_PARALLEL}" test -pl "${MVN_MODULES}" -am -Dcheckstyle.skip=true -DfailIfNoTests=false \
             -Dmaven.build.cache.enabled=false
     fi
 fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: `run-fe-ut.sh` does not support build concurrency or unit test execution concurrency. The FE `pom.xml` already supports the `fe_ut_parallel` variable (via `env.FE_UT_PARALLEL`) to control maven-surefire-plugin `forkCount`, but `run-fe-ut.sh` never passes this variable, defaulting to 1 JVM for unit tests. This makes FE unit test execution very slow.

### Release note

Add `-j` and `-p` options to `run-fe-ut.sh` to support build parallelism and unit test parallelism respectively. `-j <num>` controls Maven build thread count (passed as `-T`), and `-p <num>` controls the number of forked JVMs for running unit tests (passed as `FE_UT_PARALLEL` env variable which maps to `forkCount` in maven-surefire-plugin).

### Check List (For Author)

- Test
    - [x] Manual test

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label