### PR TITLE
[fix](fe) Validate user/role existence in SHOW ROW POLICY command

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowRowPolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowRowPolicyCommand.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -29,6 +30,8 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.qe.ShowResultSetMetaData;
 import org.apache.doris.qe.StmtExecutor;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Represents the command for SHOW STORAGE POLICY.
@@ -52,6 +55,14 @@ public class ShowRowPolicyCommand extends ShowCommand {
     public ShowResultSet doRun(ConnectContext ctx, StmtExecutor executor) throws Exception {
         if (user != null) {
             user.analyze();
+            if (!Env.getCurrentEnv().getAuth().doesUserExist(user)) {
+                throw new AnalysisException("user not exist: " + user);
+            }
+        }
+        if (!StringUtils.isEmpty(role)) {
+            if (!Env.getCurrentEnv().getAuth().doesRoleExist(role)) {
+                throw new AnalysisException("role not exist: " + role);
+            }
         }
         // check auth
         if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {

--- a/regression-test/suites/account_p0/test_show_row_policy_validate.groovy
+++ b/regression-test/suites/account_p0/test_show_row_policy_validate.groovy
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_row_policy_validate") {
+    String nonExistUser = 'show_row_policy_non_exist_user'
+    String nonExistRole = 'show_row_policy_non_exist_role'
+
+    test {
+        sql """SHOW ROW POLICY FOR ${nonExistUser}"""
+        exception "user not exist"
+    }
+
+    test {
+        sql """SHOW ROW POLICY FOR ${nonExistRole}"""
+        exception "role not exist"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: SHOW ROW POLICY FOR <user> and SHOW ROW POLICY FOR ROLE <role> do not validate whether the specified user or role exists. This is inconsistent with CREATE ROW POLICY which does validate, and allows confusing behavior where a non-existent user/role is silently accepted.

### Release note

SHOW ROW POLICY now reports an error when the specified user or role does not exist.

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [ ] No need to test

- Behavior changed:
    - [x] Yes. SHOW ROW POLICY now throws an error for non-existent user/role instead of silently returning empty results.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label