### PR TITLE
[fix](fe) Remove oidc plugin assertions from AuthenticationPluginManagerTest

### DIFF
--- a/fe/fe-authentication/fe-authentication-handler/src/test/java/org/apache/doris/authentication/handler/AuthenticationPluginManagerTest.java
+++ b/fe/fe-authentication/fe-authentication-handler/src/test/java/org/apache/doris/authentication/handler/AuthenticationPluginManagerTest.java
@@ -70,7 +70,6 @@ public class AuthenticationPluginManagerTest {
         // Then
         Assertions.assertNotNull(pluginNames);
         Assertions.assertFalse(pluginNames.isEmpty(), "Should load at least built-in plugins");
-        Assertions.assertTrue(pluginNames.contains("oidc"), "Should include oidc plugin");
         Assertions.assertTrue(pluginNames.contains("password"), "Should include password plugin");
     }
 
@@ -147,10 +146,6 @@ public class AuthenticationPluginManagerTest {
         // Then
         Assertions.assertTrue(factory.isPresent());
         Assertions.assertEquals("password", factory.get().name());
-
-        Optional<AuthenticationPluginFactory> oidcFactory = pluginManager.getFactory("oidc");
-        Assertions.assertTrue(oidcFactory.isPresent());
-        Assertions.assertEquals("oidc", oidcFactory.get().name());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: `AuthenticationPluginManagerTest` asserts the existence of an OIDC authentication plugin (`oidc`), but no OIDC plugin implementation exists in the codebase. The `OidcPluginFactory` class referenced in `AuthenticationPluginFactory.java` comments is only a documentation example with no actual implementation, module, or SPI registration. This causes `testPluginsAutoLoaded` and `testGetFactory` to fail.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
- Behavior changed:
    - [x] No.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label