### PR TITLE
[fix](fe) Fix IPv4/IPv6 literal compareLiteral always returning 0

### DIFF
--- a/fe/fe-catalog/pom.xml
+++ b/fe/fe-catalog/pom.xml
@@ -58,6 +58,12 @@ under the License.
             <artifactId>antlr4-runtime</artifactId>
             <version>${antlr4.version}</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.googlecode.java-ipv6/java-ipv6 -->
+        <dependency>
+            <groupId>com.googlecode.java-ipv6</groupId>
+            <artifactId>java-ipv6</artifactId>
+            <version>0.17</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/IPv4Literal.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/IPv4Literal.java
@@ -108,7 +108,20 @@ public class IPv4Literal extends LiteralExpr {
 
     @Override
     public int compareLiteral(LiteralExpr expr) {
-        return 0;
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
+        if (expr instanceof NullLiteral) {
+            return 1;
+        }
+        if (expr == MaxLiteral.MAX_VALUE) {
+            return -1;
+        }
+        if (expr instanceof IPv4Literal) {
+            // value holds the unsigned 32-bit address in a long, always non-negative
+            return Long.compare(this.value, ((IPv4Literal) expr).value);
+        }
+        return getStringValue().compareTo(expr.getStringValue());
     }
 
     @Override

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/IPv6Literal.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/IPv6Literal.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
 import com.google.gson.annotations.SerializedName;
+import com.googlecode.ipv6.IPv6Address;
 
 import java.util.regex.Pattern;
 
@@ -38,6 +39,9 @@ public class IPv6Literal extends LiteralExpr {
 
     @SerializedName("v")
     private String value;
+
+    // lazily parsed numeric form of value, used for value comparison
+    private transient IPv6Address parsedValue;
 
     /**
      * C'tor forcing type, e.g., due to implicit cast
@@ -88,9 +92,28 @@ public class IPv6Literal extends LiteralExpr {
         return IPV6_MIN.equals(this.value);
     }
 
+    private IPv6Address getParsedValue() {
+        if (parsedValue == null) {
+            parsedValue = IPv6Address.fromString(value);
+        }
+        return parsedValue;
+    }
+
     @Override
     public int compareLiteral(LiteralExpr expr) {
-        return 0;
+        if (expr instanceof PlaceHolderExpr) {
+            return this.compareLiteral(((PlaceHolderExpr) expr).getLiteral());
+        }
+        if (expr instanceof NullLiteral) {
+            return 1;
+        }
+        if (expr == MaxLiteral.MAX_VALUE) {
+            return -1;
+        }
+        if (expr instanceof IPv6Literal) {
+            return getParsedValue().compareTo(((IPv6Literal) expr).getParsedValue());
+        }
+        return getStringValue().compareTo(expr.getStringValue());
     }
 
     @Override

--- a/regression-test/suites/datatype_p0/ip/test_ip_neq_predicate.groovy
+++ b/regression-test/suites/datatype_p0/ip/test_ip_neq_predicate.groovy
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression for issue #62672: on IPv4/IPv6 columns, multiple `!=` (or NOT)
+// predicates on the same column were wrongly de-duplicated, so only the first
+// condition took effect. The root cause was that legacy IPv4Literal/IPv6Literal
+// returned 0 from compareLiteral() regardless of value, making any two IP
+// literals compare as equal.
+suite("test_ip_neq_predicate") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    def tbl = "test_ip_neq_predicate"
+    sql "DROP TABLE IF EXISTS ${tbl}"
+    sql """
+        CREATE TABLE ${tbl} (
+          `id` int,
+          `ip_v4` ipv4,
+          `ip_v6` ipv6
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 4
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1");
+    """
+    sql "insert into ${tbl} values(1, '1.1.1.1', '::ffff:1.1.1.1')"
+    sql "insert into ${tbl} values(2, '1.1.1.2', '::ffff:1.1.1.2')"
+    sql "insert into ${tbl} values(3, '1.1.1.3', '::ffff:1.1.1.3')"
+
+    // sanity: a single `!=` works
+    test {
+        sql "select id from ${tbl} where ip_v4 != '1.1.1.1' order by id"
+        result([[2], [3]])
+    }
+
+    // issue #62672: multiple `!=` on the same IPv4 column must all take effect
+    test {
+        sql "select id from ${tbl} where ip_v4 != '1.1.1.1' and ip_v4 != '1.1.1.2' order by id"
+        result([[3]])
+    }
+
+    // issue #62672: multiple `!=` on the same IPv6 column must all take effect
+    test {
+        sql """select id from ${tbl}
+               where ip_v6 != '::ffff:1.1.1.1' and ip_v6 != '::ffff:1.1.1.2' order by id"""
+        result([[3]])
+    }
+
+    // multiple NOT BETWEEN on the same IPv4 column
+    test {
+        sql """select id from ${tbl}
+               where not (ip_v4 between '1.1.1.1' and '1.1.1.1')
+                 and not (ip_v4 between '1.1.1.2' and '1.1.1.2') order by id"""
+        result([[3]])
+    }
+
+    // multiple NOT BETWEEN on the same IPv6 column
+    test {
+        sql """select id from ${tbl}
+               where not (ip_v6 between '::ffff:1.1.1.1' and '::ffff:1.1.1.1')
+                 and not (ip_v6 between '::ffff:1.1.1.2' and '::ffff:1.1.1.2') order by id"""
+        result([[3]])
+    }
+
+    // both `!=` predicates must survive planning, not just the first one
+    explain {
+        sql "select id from ${tbl} where ip_v4 != '1.1.1.1' and ip_v4 != '1.1.1.2'"
+        contains("1.1.1.1")
+        contains("1.1.1.2")
+    }
+
+    sql "DROP TABLE IF EXISTS ${tbl}"
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #62672

### Problem

On `IPv4`/`IPv6` columns, when a query has multiple `!=` (or `NOT`) predicates on the same column, only the first condition takes effect. For example:

```sql
select * from t where a != '::ffff:1.1.1.1' and a != '::ffff:1.1.1.2';
```

`EXPLAIN` shows the second predicate is dropped entirely:

```
PREDICATES: ((b[#3] = 'b2') AND (a[#2] != "::ffff:1.1.1.1"))
```

### Root cause

Legacy `org.apache.doris.analysis.IPv4Literal` and `IPv6Literal` implemented `compareLiteral()` as `return 0;` regardless of value. Since `LiteralExpr.equals()` is defined as `compareLiteral(other) == 0`, **any two IPv4 literals — and any two IPv6 literals — were considered equal**. When the planner de-duplicates conjuncts via `Expr.equals()`, the two distinct `!=` predicates collapse into one.

This also affected ordering / `IN` / min-max / partition pruning on IP columns; the `!=` de-duplication was just the most visible symptom.

### Fix

- `IPv4Literal`: compare numerically via the unsigned 32-bit value (`Long.compare`).
- `IPv6Literal`: compare via the parsed 128-bit address using `java-ipv6` (same library already used by the Nereids-side `IPv6Literal`), with the parsed value lazily cached.
- Add the `java-ipv6` dependency to the `fe-catalog` module.

### Test

Added `regression-test/suites/datatype_p0/ip/test_ip_neq_predicate.groovy` covering multiple `!=` and `NOT BETWEEN` predicates on IPv4/IPv6 columns (including IPv4-mapped IPv6 addresses).