### PR TITLE
[fix](build) Fix build and test scripts failing due to missing executable permission

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,7 @@ HADOOP_DEPS_NAME="hadoop-deps"
 # ===== Build Profile =====
 if [[ "${DORIS_BUILD_PROFILE}" == "1" ]]; then
     _BP_STATE="${DORIS_HOME}/.build_profile_state.$$"
-    "${DORIS_HOME}/build_profile.sh" collect "${_BP_STATE}" "$*"
+    bash "${DORIS_HOME}/build_profile.sh" collect "${_BP_STATE}" "$*"
     trap '"${DORIS_HOME}/build_profile.sh" record "${_BP_STATE}" 130; exit 130' INT TERM
     trap '"${DORIS_HOME}/build_profile.sh" record "${_BP_STATE}" $?; exit $?' ERR
 fi
@@ -461,9 +461,9 @@ if [[ ! -f "${DORIS_THIRDPARTY}/installed/lib/${LAST_THIRDPARTY_LIB}" ]]; then
     rm -rf "${DORIS_THIRDPARTY}/installed"
 
     if [[ "${CLEAN}" -eq 0 ]]; then
-        "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}"
+        bash "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}"
     else
-        "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}" --clean
+        bash "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}" --clean
     fi
 fi
 
@@ -716,7 +716,7 @@ echo "Feature List: ${DORIS_FEATURE_LIST}"
 if [[ "${CLEAN}" -eq 1 ]]; then
     clean_gensrc
 fi
-"${DORIS_HOME}"/generated-source.sh noclean
+bash "${DORIS_HOME}"/generated-source.sh noclean
 
 # Assesmble FE modules
 FE_MODULES=''
@@ -1042,7 +1042,7 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     #cp -r -p "${DORIS_HOME}/docs/build/help-resource.zip" "${DORIS_OUTPUT}/fe/lib"/
 
     # Third-party filesystem jars (JuiceFS, JindoFS) are packaged by post-build.sh
-    "${DORIS_HOME}/post-build.sh" --fe --output "${DORIS_OUTPUT}"
+    bash "${DORIS_HOME}/post-build.sh" --fe --output "${DORIS_OUTPUT}"
 
     cp -r -p "${DORIS_HOME}/minidump" "${DORIS_OUTPUT}/fe"/
     cp -r -p "${DORIS_HOME}/webroot/static" "${DORIS_OUTPUT}/fe/webroot"/
@@ -1254,7 +1254,7 @@ EOF
     done        
 
     # Third-party filesystem jars (JuiceFS, JindoFS) are packaged by post-build.sh
-    "${DORIS_HOME}/post-build.sh" --be --output "${DORIS_OUTPUT}"
+    bash "${DORIS_HOME}/post-build.sh" --be --output "${DORIS_OUTPUT}"
 
     cp -r -p "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/be/www"/
     copy_common_files "${DORIS_OUTPUT}/be/"
@@ -1273,7 +1273,7 @@ if [[ "${BUILD_BROKER}" -eq 1 ]]; then
     install -d "${DORIS_OUTPUT}/apache_hdfs_broker"
 
     cd "${DORIS_HOME}/fs_brokers/apache_hdfs_broker"
-    ./build.sh
+    bash ./build.sh
     rm -rf "${DORIS_OUTPUT}/apache_hdfs_broker"/*
     cp -r -p "${DORIS_HOME}/fs_brokers/apache_hdfs_broker/output/apache_hdfs_broker"/* "${DORIS_OUTPUT}/apache_hdfs_broker"/
     copy_common_files "${DORIS_OUTPUT}/apache_hdfs_broker/"
@@ -1283,7 +1283,7 @@ fi
 if [[ "${BUILD_BE_CDC_CLIENT}" -eq 1 ]]; then
     install -d "${DORIS_OUTPUT}/be/lib/cdc_client"
     cd "${DORIS_HOME}/fs_brokers/cdc_client"
-    ./build.sh
+    bash ./build.sh
     rm -rf "${DORIS_OUTPUT}/be/lib/cdc_client"/*
     cp -r -p "${DORIS_HOME}/fs_brokers/cdc_client/target/cdc-client.jar" "${DORIS_OUTPUT}/be/lib/cdc_client/"
     cd "${DORIS_HOME}"

--- a/fs_brokers/cdc_client/build.sh
+++ b/fs_brokers/cdc_client/build.sh
@@ -25,7 +25,7 @@ export DORIS_HOME="${ROOT}/../.."
 
 export CDC_CLIENT_HOME="${ROOT}"
 
-"${DORIS_HOME}"/generated-source.sh noclean
+bash "${DORIS_HOME}"/generated-source.sh noclean
 cd "${DORIS_HOME}/fe"
 "${MVN_CMD}" -Pflatten install -pl fe-common -Dskip.doc=true -DskipTests -Dmaven.build.cache.enabled=false
 

--- a/gensrc/script/Makefile
+++ b/gensrc/script/Makefile
@@ -38,5 +38,5 @@ gen_func: ${GEN_FUNC_OUTPUT}
 
 # generate version info
 gen_version:
-	${CURDIR}/gen_build_version.sh
+	bash ${CURDIR}/gen_build_version.sh
 .PHONY: gen_version

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -170,7 +170,7 @@ echo "******************************"
 #cp build/help-resource.zip "${DORIS_HOME}"/fe/fe-core/src/test/resources/real-help-resource.zip
 #cd "${DORIS_HOME}"
 
-"${DORIS_HOME}"/generated-source.sh
+bash "${DORIS_HOME}"/generated-source.sh
 
 cd "${DORIS_HOME}/fe"
 mkdir -p build/compile

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -153,7 +153,7 @@ if [[ "${CLEAN}" -eq 1 ]] && [[ -d "${TP_SOURCE_DIR}" ]]; then
 fi
 
 # Download thirdparties.
-eval "${TP_DIR}/download-thirdparty.sh ${packages[*]}"
+eval "bash ${TP_DIR}/download-thirdparty.sh ${packages[*]}"
 
 export LD_LIBRARY_PATH="${TP_DIR}/installed/lib:${LD_LIBRARY_PATH}"
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63225

Problem Summary: Several shell scripts are invoked directly (e.g., `./build.sh`) without executable permission, causing "Permission denied" errors during build, FE UT, BE UT, and broker build processes. This PR changes all such invocations to use `bash` prefix to ensure they execute correctly regardless of file permission settings.

### Release note

Fix build and test scripts failing due to missing executable permission by using `bash` prefix for shell script invocations.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Successfully built Doris with `bash build.sh --be --fe`
        - Successfully ran FE unit tests with `bash run-fe-ut.sh`
        - Successfully built broker module
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.