### PR TITLE
[feat](fe) Push limit through full outer join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushDownLimit.java
@@ -138,6 +138,7 @@ public class PushDownLimit implements RewriteRuleFactory {
                         join.left(),
                         limit.withChildren(join.right())
                 );
+            case FULL_OUTER_JOIN:
             case CROSS_JOIN:
                 return join.withChildren(
                         limit.withChildren(join.left()),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownLimitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushDownLimitTest.java
@@ -184,6 +184,28 @@ class PushDownLimitTest extends TestWithFeService implements MemoPatternMatchSup
     }
 
     @Test
+    void testPushLimitThroughFullOuterJoin() {
+        test(JoinType.FULL_OUTER_JOIN, true,
+                logicalLimit(
+                        logicalProject(
+                                logicalJoin(
+                                        logicalLimit(logicalOlapScan().when(s -> s.getTable().getName().equals("score"))),
+                                        logicalLimit(logicalOlapScan().when(s -> s.getTable().getName().equals("student")))
+                                ).when(j -> j.getJoinType() == JoinType.FULL_OUTER_JOIN)
+                        )
+                )
+        );
+        test(JoinType.FULL_OUTER_JOIN, false,
+                logicalLimit(
+                        logicalJoin(
+                                logicalLimit(logicalOlapScan().when(s -> s.getTable().getName().equals("score"))),
+                                logicalLimit(logicalOlapScan().when(s -> s.getTable().getName().equals("student")))
+                        ).when(j -> j.getJoinType() == JoinType.FULL_OUTER_JOIN)
+                )
+        );
+    }
+
+    @Test
     void testPushLimitThroughInnerJoin() {
         test(JoinType.INNER_JOIN, true,
                 logicalLimit(


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: PushDownLimit skipped full outer joins, so LIMIT could not be pushed to either preserved input even though unordered LIMIT can be applied to both sides before the full outer join.


```
before:
mysql>   EXPLAIN SHAPE PLAN
    ->   SELECT [foj_t1.id](http://foj_t1.id/)
    ->   FROM foj_t1
    ->   FULL OUTER JOIN foj_t2
    ->   ON [foj_t1.id](http://foj_t1.id/) = [foj_t2.id](http://foj_t2.id/)
    ->   LIMIT 3;
+-------------------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                           |
+-------------------------------------------------------------------------------------------+
| PhysicalResultSink                                                                        |
| --PhysicalLimit[GLOBAL]                                                                   |
| ----PhysicalLimit[LOCAL]                                                                  |
| ------hashJoin[FULL_OUTER_JOIN] hashCondition=(([foj_t1.id](http://foj_t1.id/) = [foj_t2.id](http://foj_t2.id/))) otherCondition=() |
| --------PhysicalOlapScan[foj_t1]                                                          |
| --------PhysicalOlapScan[foj_t2]                                                          |
+-------------------------------------------------------------------------------------------+
mysql> 
```
```
after:
mysql>   EXPLAIN SHAPE PLAN
    ->   SELECT [foj_t1.id](http://foj_t1.id/)
    ->   FROM foj_t1
    ->   FULL OUTER JOIN foj_t2
    ->   ON [foj_t1.id](http://foj_t1.id/) = [foj_t2.id](http://foj_t2.id/)
    ->   LIMIT 3;
+-------------------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                           |
+-------------------------------------------------------------------------------------------+
| PhysicalResultSink                                                                        |
| --PhysicalLimit[GLOBAL]                                                                   |
| ----PhysicalLimit[LOCAL]                                                                  |
| ------hashJoin[FULL_OUTER_JOIN] hashCondition=(([foj_t1.id](http://foj_t1.id/) = [foj_t2.id](http://foj_t2.id/))) otherCondition=() |
| --------PhysicalLimit[LOCAL]                                                              |
| ----------PhysicalOlapScan[foj_t1]                                                        |
| --------PhysicalLimit[LOCAL]                                                              |
| ----------PhysicalOlapScan[foj_t2]                                                        |
+-------------------------------------------------------------------------------------------+
8 rows in set (0.01 sec)

```

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.nereids.rules.rewrite.PushDownLimitTest#testPushLimitThroughFullOuterJoin
    - ./run-fe-ut.sh --run org.apache.doris.nereids.rules.rewrite.PushDownLimitTest
- Behavior changed: Yes (optimizer now pushes local LIMIT to both sides of full outer joins)
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

