### PR TITLE
fix: Compatibility ClickHouse cluster with Nullable(Nothing) type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClickHouseClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClickHouseClient.java
@@ -50,6 +50,9 @@ public class JdbcClickHouseClient extends JdbcClient {
         }
     }
 
+    protected JdbcClickHouseClient() {
+    }
+
     @Override
     public List<String> getDatabaseNameList() {
         Connection conn = null;
@@ -123,7 +126,7 @@ public class JdbcClickHouseClient extends JdbcClient {
 
     @Override
     protected String[] getTableTypes() {
-        return new String[] {"TABLE", "VIEW", "SYSTEM TABLE"};
+        return new String[] { "TABLE", "VIEW", "SYSTEM TABLE" };
     }
 
     @Override
@@ -184,6 +187,8 @@ public class JdbcClickHouseClient extends JdbcClient {
             case "Bool":
                 return Type.BOOLEAN;
             case "Int8":
+                return Type.TINYINT;
+            case "Nothing":
                 return Type.TINYINT;
             case "Int16":
             case "UInt8":

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClickHouseClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClickHouseClient.java
@@ -189,7 +189,7 @@ public class JdbcClickHouseClient extends JdbcClient {
             case "Int8":
                 return Type.TINYINT;
             case "Nothing":
-                return Type.TINYINT;
+                return Type.STRING;
             case "Int16":
             case "UInt8":
                 return Type.SMALLINT;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -121,6 +121,9 @@ public abstract class JdbcClient {
         System.setProperty("com.zaxxer.hikari.useWeakReferences", "true");
     }
 
+    protected JdbcClient() {
+    }
+
     // Initialize DataSource
     private void initializeDataSource(JdbcClientConfig config) {
         ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/client/JdbcClickHouseClientTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/jdbc/client/JdbcClickHouseClientTest.java
@@ -64,4 +64,433 @@ public class JdbcClickHouseClientTest {
             Assert.fail("Exception occurred while testing isNewClickHouseDriver: " + e.getMessage());
         }
     }
+
+    @Test
+    public void testDecimalType(@Injectable JdbcFieldSchema fieldSchema) {
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Decimal(10, 2)";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        String ckType = fieldSchema.getDataTypeName().orElse("unknown");
+        String[] accuracy = ckType.substring(8, ckType.length() - 1).split(", ");
+        int precision = Integer.parseInt(accuracy[0]);
+        int scale = Integer.parseInt(accuracy[1]);
+        Type type = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(ScalarType.createDecimalV3Type(precision, scale), type);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Decimal(40, 39)";
+            }
+        };
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type1);
+    }
+
+    @Test
+    public void testStringType(@Injectable JdbcFieldSchema fieldSchema) {
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "String";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Enum8";
+            }
+        };
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type1);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Enum16";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type2);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "IPv4";
+            }
+        };
+        Type type3 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type3);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "IPv6";
+            }
+        };
+        Type type4 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type4);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "UUID";
+            }
+        };
+        Type type5 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type5);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "FixedString";
+            }
+        };
+        Type type6 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type6);
+    }
+
+    @Test
+    public void testDateTime64Type(@Injectable JdbcFieldSchema fieldSchema) {
+        // test DateTime
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "DateTime";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DEFAULT_DATETIMEV2, type1);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "DateTime()";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DEFAULT_DATETIMEV2, type2);
+        final int expectedPrecision6 = 6;
+        // test DateTime64
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "DateTime64(" + expectedPrecision6 + ")";
+            }
+        };
+        Type type3 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DATETIMEV2_WITH_MAX_SCALAR, type3);
+        final int expectedPrecisio7 = 7;
+        // test DateTime64
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "DateTime64(" + expectedPrecisio7 + ")";
+            }
+        };
+        Type type4 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DATETIMEV2_WITH_MAX_SCALAR, type4);
+        // test DateTime64
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "DateTime64(6, 'Asia/Shanghai')";
+            }
+        };
+        Type type5 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DATETIMEV2_WITH_MAX_SCALAR, type5);
+    }
+
+    @Test
+    public void testArrayType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Array
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Int32";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.INT, type);
+    }
+
+    @Test
+    public void testBooleanType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Bool
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Bool";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.BOOLEAN, type);
+    }
+
+    @Test
+    public void testTinyIntType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Nullable(Nothing)
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Nullable(Nothing)";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.TINYINT, type1);
+        // test Int8
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Int8";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.TINYINT, type2);
+    }
+
+    @Test
+    public void testSmallIntType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Int16
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Int16";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.SMALLINT, type1);
+        // test UInt8
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "UInt8";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.SMALLINT, type2);
+    }
+
+    @Test
+    public void testIntType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Int32
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Int32";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.INT, type1);
+        // test UInt16
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "UInt16";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.INT, type2);
+    }
+
+    @Test
+    public void testBigIntType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Int64
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Int64";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.BIGINT, type1);
+        // test UInt32
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "UInt32";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.BIGINT, type2);
+    }
+
+    @Test
+    public void testLargeIntType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Int128
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Int128";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.LARGEINT, type1);
+        // test UInt64
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "UInt64";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.LARGEINT, type2);
+    }
+
+    @Test
+    public void testScalarStringType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Int256
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Int256";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type1);
+        // test UInt128
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "UInt128";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type2);
+        // test UInt256
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "UInt256";
+            }
+        };
+        Type type3 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.STRING, type3);
+    }
+
+    @Test
+    public void testFloatType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Float32
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Float32";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.FLOAT, type);
+    }
+
+    @Test
+    public void testDoubleType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Float64
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Float64";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DOUBLE, type);
+    }
+
+    @Test
+    public void testScalarDateType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test Date
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Date";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DATEV2, type1);
+        // test Date32
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Date32";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.DATEV2, type2);
+    }
+
+    @Test
+    public void testUnsupportedType(@Injectable JdbcFieldSchema fieldSchema) {
+        // test others
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Tuple(Int8, Int8)";
+            }
+        };
+        JdbcClickHouseClient client = new JdbcClickHouseClient();
+        Type type = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.UNSUPPORTED, type);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Nested(Int8)";
+            }
+        };
+        Type type1 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.UNSUPPORTED, type1);
+        new Expectations() {
+            {
+                fieldSchema.getDataTypeName();
+                minTimes = 1;
+                result = "Null";
+            }
+        };
+        Type type2 = client.jdbcTypeToDoris(fieldSchema);
+        Assertions.assertEquals(Type.UNSUPPORTED, type2);
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

CK
`CREATE TABLE t_example ON CLUSTER LFRH_CK_TS_981
(
    `id` UInt32,
    `v` Nullable(Nothing)
)
ENGINE = MergeTree
ORDER BY id`

DORIS
`
SELECT * FROM QUERY(   'catalog' = 'ck981db5',   'query'   = 'SELECT * from db5.t_example
' );`

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

