### PR TITLE
[fix](test) stabilize internal copy recycler case

### DIFF
--- a/regression-test/suites/cloud_p0/recycler/test_recycler_with_internal_copy.groovy
+++ b/regression-test/suites/cloud_p0/recycler/test_recycler_with_internal_copy.groovy
@@ -95,11 +95,22 @@ suite("test_recycler_with_internal_copy") {
     logger.info("Request FE Config: code=" + code + ", out=" + out + ", err=" + err)
     assertEquals(code, 0)
 
-    result = sql " copy into ${tableName} from @~('${fileName}') properties ('file.type' = 'csv', 'file.column_separator' = '|', 'copy.async' = 'false'); "
-    logger.info("copy result: " + result)
-    assertTrue(result.size() == 1)
-    assertTrue(result[0].size() == 8)
-    assertTrue(result[0][1].equals("FINISHED"), "Finish copy into, state=" + result[0][1] + ", expected state=FINISHED")
+    retry = 15
+    success = false
+    do {
+        result = sql " copy into ${tableName} from @~('${fileName}') properties ('file.type' = 'csv', 'file.column_separator' = '|', 'copy.async' = 'false'); "
+        logger.info("copy result after recycle: " + result)
+        assertTrue(result.size() == 1)
+        assertTrue(result[0].size() == 8)
+        if (result[0][1].equals("FINISHED")) {
+            success = true
+            break
+        }
+        assertTrue(result[0][1].equals("CANCELLED") && result[0][3].contains("No files can be copied"),
+                "Finish copy into, state=" + result[0][1] + ", expected state=FINISHED")
+        Thread.sleep(20000) // wait copy job metadata recycled
+    } while (retry--)
+    assertTrue(success)
     qt_sql " SELECT COUNT(*) FROM ${tableName}; "
 
     String[][] tabletInfoList = sql """ show tablets from ${tableName}; """


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`cloud_p0/recycler/test_recycler_with_internal_copy.groovy` may fail after recycling internal stage files. The case only waited until the object file disappeared from object storage, but `checkRecycleInternalStage` cannot guarantee that the corresponding `copy_job` / `copy_file` metadata in meta-service has also been removed.

If the same file is uploaded again before the stale copy metadata is cleaned, `copy into` may still be filtered as already loaded and return `CANCELLED` with `No files can be copied`.

This patch retries the post-recycle `copy into` only for that expected stale-metadata cancellation, until it succeeds or times out.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

