### PR TITLE
[fix](config) Remove fuzzy of string_overflow_size

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -2259,8 +2259,6 @@ Status set_fuzzy_configs() {
             ((distribution(*generator) % 2) == 0) ? "true" : "false";
     fuzzy_field_and_value["enable_shrink_memory"] =
             ((distribution(*generator) % 2) == 0) ? "true" : "false";
-    fuzzy_field_and_value["string_overflow_size"] =
-            ((distribution(*generator) % 2) == 0) ? "10" : "4294967295";
     fuzzy_field_and_value["skip_writing_empty_rowset_metadata"] =
             ((distribution(*generator) % 2) == 0) ? "true" : "false";
     fuzzy_field_and_value["enable_packed_file"] =


### PR DESCRIPTION
Related PR: https://github.com/apache/doris/pull/63183

Problem Summary:

don't fuzzy it since the overflow may occurs in loading path which has no proper exception deal.