### PR TITLE
[Chore](be) Avoid signaling unbuilt shared hash table

### DIFF
--- a/be/src/exec/operator/hashjoin_build_sink.cpp
+++ b/be/src/exec/operator/hashjoin_build_sink.cpp
@@ -32,6 +32,15 @@
 #include "util/uid_util.h"
 
 namespace doris {
+namespace {
+bool hash_table_built(const HashJoinSharedState* shared_state) {
+    DORIS_CHECK(shared_state != nullptr);
+    DORIS_CHECK(!shared_state->hash_table_variant_vector.empty());
+    return !std::holds_alternative<std::monostate>(
+            shared_state->hash_table_variant_vector.front()->method_variant);
+}
+} // namespace
+
 HashJoinBuildSinkLocalState::HashJoinBuildSinkLocalState(DataSinkOperatorXBase* parent,
                                                          RuntimeState* state)
         : JoinBuildSinkLocalState(parent, state) {
@@ -243,16 +252,9 @@ Status HashJoinBuildSinkLocalState::close(RuntimeState* state, Status exec_statu
 
         if (p._use_shared_hash_table) {
             LockGuard lock(p._mutex);
-            // Only signal non-builder tasks when the builder actually built the hash table.
-            // When the builder is terminated (woken up early because the probe side finished
-            // first), it never called process_build_block() so the hash table variant is still
-            // monostate. Setting _signaled=true in that case would cause non-builder tasks to
-            // enter std::visit on monostate and crash with "Hash table type mismatch".
-            //
-            // _terminated is reliably true here when the task was woken up early, because
-            // operator terminate() is called from the execute() Defer in PipelineTask
-            // before close() is invoked.
-            if (!_terminated) {
+            // Do not wake non-builders into a monostate hash table after early termination/errors.
+            const auto should_signal = !_terminated && hash_table_built(_shared_state);
+            if (should_signal) {
                 p._signaled = true;
             }
             for (auto& dep : _shared_state->sink_deps) {

--- a/be/test/exec/operator/hashjoin_build_sink_test.cpp
+++ b/be/test/exec/operator/hashjoin_build_sink_test.cpp
@@ -540,6 +540,32 @@ TEST_F(SharedHashTableSignalTest, BuilderTerminatedDoesNotSignal) {
     ASSERT_TRUE(st.ok()) << st.to_string();
 }
 
+TEST_F(SharedHashTableSignalTest, UnbuiltHashTableDoesNotSignal) {
+    auto setup = setup_broadcast_join(2);
+    auto* builder_local_state =
+            assert_cast<HashJoinBuildSinkLocalState*>(setup.builder_state->get_sink_local_state());
+
+    ASSERT_FALSE(builder_local_state->_terminated);
+    ASSERT_TRUE(
+            std::holds_alternative<std::monostate>(setup.shared_state->cast<HashJoinSharedState>()
+                                                           ->hash_table_variant_vector.front()
+                                                           ->method_variant));
+
+    auto st = setup.sink_op->close(setup.builder_state, Status::OK());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_FALSE(setup.sink_op->_signaled)
+            << "_signaled should NOT be set when build failed before hash table was built";
+
+    auto* non_builder_state = setup.non_builder_states[0].get();
+    Block empty_block;
+    st = setup.sink_op->sink(non_builder_state, &empty_block, true);
+    ASSERT_TRUE(st.is<ErrorCode::END_OF_FILE>())
+            << "Non-builder should return EOF after builder failure, got: " << st.to_string();
+
+    st = setup.sink_op->close(non_builder_state, Status::OK());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+}
+
 // Test the normal path: when the builder completes normally (not terminated),
 // close() should set _signaled=true, and non-builder tasks should proceed
 // to share the hash table successfully.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

For shared hash table hash joins, the builder task may leave `process_build_block()` before the hash table is actually built, for example when the build side returns an error before the EOS build step completes. In that state the shared hash table variant can still be `monostate`.

`HashJoinBuildSinkLocalState::close()` previously set `_signaled = true` whenever the builder was not terminated. That wakes non-builder tasks even when the shared hash table was never built, so they can reach the shared hash table copy path and report a misleading `Hash table type mismatch when share hash table` instead of preserving the original build-side error.

This PR gates `_signaled` on the actual shared hash table state. Non-builder tasks are signaled only when the builder is not terminated and the shared hash table variant is no longer `monostate`. If the builder closes after an error before the hash table is built, `_signaled` stays false and non-builders take the existing EOF guard instead of visiting an unbuilt hash table.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `./run-be-ut.sh --run --filter=SharedHashTableSignalTest.UnbuiltHashTableDoesNotSignal -j 8`
    - `build-support/check-format.sh`
    - `build-support/run-clang-tidy.sh --build-dir be/ut_build_ASAN` was attempted; it reports pre-existing complexity diagnostics in the touched hash join files and `jni-util.h` static assertions.
- Behavior changed: No
- Does this need documentation: No
