### PR TITLE
[Fix](topn) Reject non-positive topn count argument

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopN.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.VarcharType;
@@ -93,6 +94,16 @@ public class TopN extends NullableAggregateFunction
         if (arity() == 3 && !getArgument(2).isConstant()) {
             throw new AnalysisException(
                     "topn requires third parameter must be a constant: "
+                            + this.toSql());
+        }
+    }
+
+    @Override
+    public void checkLegalityAfterRewrite() {
+        Expression topNCount = getArgument(1);
+        if (!(topNCount instanceof Literal) || ((Literal) topNCount).getDouble() <= 0) {
+            throw new AnalysisException(
+                    "topn requires second parameter must be a constant positive integer: "
                             + this.toSql());
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopN.java
@@ -101,6 +101,9 @@ public class TopN extends NullableAggregateFunction
     @Override
     public void checkLegalityAfterRewrite() {
         Expression topNCount = getArgument(1);
+        if (topNCount.isNullLiteral()) {
+            return;
+        }
         if (!(topNCount instanceof Literal) || ((Literal) topNCount).getDouble() <= 0) {
             throw new AnalysisException(
                     "topn requires second parameter must be a constant positive integer: "

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNArray.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNArray.java
@@ -104,6 +104,9 @@ public class TopNArray extends NullableAggregateFunction
     @Override
     public void checkLegalityAfterRewrite() {
         Expression topNCount = getArgument(1);
+        if (topNCount.isNullLiteral()) {
+            return;
+        }
         if (!(topNCount instanceof Literal) || ((Literal) topNCount).getDouble() <= 0) {
             throw new AnalysisException(
                     "topn_array requires second parameter must be a constant positive integer: "

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNArray.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNArray.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.IntegerType;
@@ -96,6 +97,16 @@ public class TopNArray extends NullableAggregateFunction
         if (arity() == 3 && !getArgument(2).isConstant()) {
             throw new AnalysisException(
                     "topn_array requires third parameter must be a constant: "
+                            + this.toSql());
+        }
+    }
+
+    @Override
+    public void checkLegalityAfterRewrite() {
+        Expression topNCount = getArgument(1);
+        if (!(topNCount instanceof Literal) || ((Literal) topNCount).getDouble() <= 0) {
+            throw new AnalysisException(
+                    "topn_array requires second parameter must be a constant positive integer: "
                             + this.toSql());
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNWeighted.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNWeighted.java
@@ -210,6 +210,9 @@ public class TopNWeighted extends NullableAggregateFunction
     @Override
     public void checkLegalityAfterRewrite() {
         Expression topNCount = getArgument(2);
+        if (topNCount.isNullLiteral()) {
+            return;
+        }
         if (!(topNCount instanceof Literal) || ((Literal) topNCount).getDouble() <= 0) {
             throw new AnalysisException(
                     "topn_weighted requires third parameter must be a constant positive integer: "

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNWeighted.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopNWeighted.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.BigIntType;
@@ -202,6 +203,16 @@ public class TopNWeighted extends NullableAggregateFunction
         if (arity() == 4 && !getArgument(3).isConstant()) {
             throw new AnalysisException(
                     "topn_weighted requires fourth parameter must be a constant: "
+                            + this.toSql());
+        }
+    }
+
+    @Override
+    public void checkLegalityAfterRewrite() {
+        Expression topNCount = getArgument(2);
+        if (!(topNCount instanceof Literal) || ((Literal) topNCount).getDouble() <= 0) {
+            throw new AnalysisException(
+                    "topn_weighted requires third parameter must be a constant positive integer: "
                             + this.toSql());
         }
     }

--- a/regression-test/suites/nereids_function_p0/agg_function/topn/topn.groovy
+++ b/regression-test/suites/nereids_function_p0/agg_function/topn/topn.groovy
@@ -52,20 +52,52 @@ suite("topn") {
     }
 
     test {
+        sql """select topn(id,-1) from test_topn;"""
+        exception "topn requires second parameter must be a constant positive integer"
+    }
+
+    test {
+        sql """select topn(id,0) from test_topn;"""
+        exception "topn requires second parameter must be a constant positive integer"
+    }
+
+    test {
         sql """select topn_array(id,id) from test_topn;"""
     	exception "errCode = 2"
     }
+
     test {
         sql """select topn_array(id,1,id) from test_topn;"""
     	exception "errCode = 2"
     }
 
     test {
+        sql """select topn_array(id,-1) from test_topn;"""
+        exception "topn_array requires second parameter must be a constant positive integer"
+    }
+
+    test {
+        sql """select topn_array(id,0) from test_topn;"""
+        exception "topn_array requires second parameter must be a constant positive integer"
+    }
+
+    test {
         sql """select topn_weighted(id,id,id) from test_topn;"""
     	exception "errCode = 2"
     }
+
     test {
         sql """select topn_weighted(id,id,1,id) from test_topn;"""
     	exception "errCode = 2"
+    }
+
+    test {
+        sql """select topn_weighted(id,id,-1) from test_topn;"""
+        exception "topn_weighted requires third parameter must be a constant positive integer"
+    }
+
+    test {
+        sql """select topn_weighted(id,id,0) from test_topn;"""
+        exception "topn_weighted requires third parameter must be a constant positive integer"
     }
 }


### PR DESCRIPTION
Problem Summary:

According to Doris doc: `topn count must be a positive integer`, but before this, negative numbers and 0 were not handled specially, returning `{}`, leading to unexpected results.

before
```sql
Doris> SELECT TOPN(page_id, 0) as top_zero_pages FROM page_visits;
+----------------+
| top_zero_pages |
+----------------+
| {}             |
+----------------+

Doris> SELECT TOPN(page_id, -1) as top_neg_one_pages FROM page_visits;
+-------------------+
| top_neg_one_pages |
+-------------------+
| {}                |
+-------------------+
```

now: 
```sql
Doris> SELECT TOPN(page_id, 0) as top_pages FROM page_visits;
ERROR 1105 (HY000): errCode = 2, detailMessage = topn requires second parameter must be a constant positive integer: topn(cast(page_id as VARCHAR(65533)), 0)

Doris> SELECT TOPN(page_id, -1) as top_pages FROM page_visits;
ERROR 1105 (HY000): errCode = 2, detailMessage = topn requires second parameter must be a constant positive integer: topn(cast(page_id as VARCHAR(65533)), -1)
```