### PR TITLE
[fix](fe) Reject sync MV creation when MV qualifier differs from base table qualifier

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
@@ -208,12 +208,7 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
         if (mvDb == null || mvDb.isEmpty()) {
             mvDb = ctx.getDatabase();
         }
-        if (mvDb != null && !mvDb.isEmpty() && !mvDb.equals(dbName)) {
-            throw new AnalysisException(String.format(
-                    "The database '%s' of the sync materialized view must be the same as"
-                            + " the database '%s' of the base table",
-                    mvDb, dbName));
-        }
+        checkDatabaseConsistency(mvDb, dbName);
         if (!Env.getCurrentEnv().getAccessManager()
                 .checkTblPriv(ConnectContext.get(), InternalCatalog.INTERNAL_CATALOG_NAME, dbName, baseIndexName,
                         PrivPredicate.ALTER)) {
@@ -240,6 +235,15 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
             ctx.getStatementContext().invalidCache(SessionVariable.DISABLE_NEREIDS_RULES);
         }
         return Pair.of(plan, planner.getCascadesContext());
+    }
+
+    void checkDatabaseConsistency(String mvDb, String baseTableDb) {
+        if (mvDb != null && !mvDb.isEmpty() && !mvDb.equals(baseTableDb)) {
+            throw new AnalysisException(String.format(
+                    "The database '%s' of the sync materialized view must be the same as"
+                            + " the database '%s' of the base table",
+                    mvDb, baseTableDb));
+        }
     }
 
     private class ValidateContext {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
@@ -202,6 +202,18 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
         mvKeysType = planValidator.context.keysType;
         dbName = planValidator.context.dbName;
         baseIndexName = planValidator.context.baseIndexName;
+        // The MV's effective database (explicitly specified or current session db) must match the base table's db,
+        // because a sync materialized view is stored as an index on the base table.
+        String mvDb = name.getDb();
+        if (mvDb == null || mvDb.isEmpty()) {
+            mvDb = ctx.getDatabase();
+        }
+        if (mvDb != null && !mvDb.isEmpty() && !mvDb.equals(dbName)) {
+            throw new AnalysisException(String.format(
+                    "The database '%s' of the sync materialized view must be the same as"
+                            + " the database '%s' of the base table",
+                    mvDb, dbName));
+        }
         if (!Env.getCurrentEnv().getAccessManager()
                 .checkTblPriv(ConnectContext.get(), InternalCatalog.INTERNAL_CATALOG_NAME, dbName, baseIndexName,
                         PrivPredicate.ALTER)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommand.java
@@ -202,6 +202,13 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
         mvKeysType = planValidator.context.keysType;
         dbName = planValidator.context.dbName;
         baseIndexName = planValidator.context.baseIndexName;
+        // The MV's effective catalog (explicitly specified or current session catalog) must be the internal catalog,
+        // because sync materialized views are stored as indexes on OlapTables.
+        String mvCtl = name.getCtl();
+        if (mvCtl == null || mvCtl.isEmpty()) {
+            mvCtl = ctx.getDefaultCatalog();
+        }
+        checkCatalogConsistency(mvCtl);
         // The MV's effective database (explicitly specified or current session db) must match the base table's db,
         // because a sync materialized view is stored as an index on the base table.
         String mvDb = name.getDb();
@@ -235,6 +242,15 @@ public class CreateMaterializedViewCommand extends Command implements ForwardWit
             ctx.getStatementContext().invalidCache(SessionVariable.DISABLE_NEREIDS_RULES);
         }
         return Pair.of(plan, planner.getCascadesContext());
+    }
+
+    void checkCatalogConsistency(String mvCtl) {
+        if (mvCtl != null && !mvCtl.isEmpty()
+                && !mvCtl.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
+            throw new AnalysisException(String.format(
+                    "The catalog '%s' of the sync materialized view must be the internal catalog '%s'",
+                    mvCtl, InternalCatalog.INTERNAL_CATALOG_NAME));
+        }
     }
 
     void checkDatabaseConsistency(String mvDb, String baseTableDb) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommandTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.info.TableNameInfo;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 
 import com.google.common.collect.ImmutableMap;
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link CreateMaterializedViewCommand}, focusing on the
- * database-consistency validation added for DORIS-19133.
+ * catalog and database consistency validation added for DORIS-19133.
  */
 public class CreateMaterializedViewCommandTest {
 
@@ -36,13 +37,44 @@ public class CreateMaterializedViewCommandTest {
     }
 
     // ---------------------------------------------------------------------------
+    // checkCatalogConsistency tests (DORIS-19133)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void testInternalCatalogDoesNotThrow() {
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        Assertions.assertDoesNotThrow(
+                () -> cmd.checkCatalogConsistency(InternalCatalog.INTERNAL_CATALOG_NAME));
+    }
+
+    @Test
+    public void testExternalCatalogThrows() {
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> cmd.checkCatalogConsistency("hive_catalog"));
+        Assertions.assertTrue(ex.getMessage().contains("internal catalog"),
+                "Exception message should mention the internal catalog requirement");
+    }
+
+    @Test
+    public void testNullCatalogDoesNotThrow() {
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        Assertions.assertDoesNotThrow(() -> cmd.checkCatalogConsistency(null));
+    }
+
+    @Test
+    public void testEmptyCatalogDoesNotThrow() {
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        Assertions.assertDoesNotThrow(() -> cmd.checkCatalogConsistency(""));
+    }
+
+    // ---------------------------------------------------------------------------
     // checkDatabaseConsistency tests (DORIS-19133)
     // ---------------------------------------------------------------------------
 
     @Test
     public void testSameDatabaseDoesNotThrow() {
         CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
-        // No exception when MV db equals base table db.
         Assertions.assertDoesNotThrow(() -> cmd.checkDatabaseConsistency("db1", "db1"));
     }
 
@@ -57,14 +89,12 @@ public class CreateMaterializedViewCommandTest {
 
     @Test
     public void testNullMvDbDoesNotThrow() {
-        // When no MV db is provided (null), the check is skipped.
         CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
         Assertions.assertDoesNotThrow(() -> cmd.checkDatabaseConsistency(null, "db2"));
     }
 
     @Test
     public void testEmptyMvDbDoesNotThrow() {
-        // When MV db is empty string, the check is skipped.
         CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
         Assertions.assertDoesNotThrow(() -> cmd.checkDatabaseConsistency("", "db2"));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateMaterializedViewCommandTest.java
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.catalog.info.TableNameInfo;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CreateMaterializedViewCommand}, focusing on the
+ * database-consistency validation added for DORIS-19133.
+ */
+public class CreateMaterializedViewCommandTest {
+
+    private CreateMaterializedViewCommand newCmd(String db, String tbl) {
+        TableNameInfo name = new TableNameInfo(db, tbl);
+        return new CreateMaterializedViewCommand(name, null, ImmutableMap.of());
+    }
+
+    // ---------------------------------------------------------------------------
+    // checkDatabaseConsistency tests (DORIS-19133)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void testSameDatabaseDoesNotThrow() {
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        // No exception when MV db equals base table db.
+        Assertions.assertDoesNotThrow(() -> cmd.checkDatabaseConsistency("db1", "db1"));
+    }
+
+    @Test
+    public void testDifferentDatabaseThrows() {
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> cmd.checkDatabaseConsistency("db1", "db2"));
+        Assertions.assertTrue(ex.getMessage().contains("must be the same as"),
+                "Exception message should describe the mismatch");
+    }
+
+    @Test
+    public void testNullMvDbDoesNotThrow() {
+        // When no MV db is provided (null), the check is skipped.
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        Assertions.assertDoesNotThrow(() -> cmd.checkDatabaseConsistency(null, "db2"));
+    }
+
+    @Test
+    public void testEmptyMvDbDoesNotThrow() {
+        // When MV db is empty string, the check is skipped.
+        CreateMaterializedViewCommand cmd = newCmd("db1", "mv1");
+        Assertions.assertDoesNotThrow(() -> cmd.checkDatabaseConsistency("", "db2"));
+    }
+}

--- a/regression-test/suites/mv_p0/test_cross_db_mv_error/test_cross_db_mv_error.groovy
+++ b/regression-test/suites/mv_p0/test_cross_db_mv_error/test_cross_db_mv_error.groovy
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression test for DORIS-19133:
+// Creating a sync materialized view must fail when the MV's database
+// does not match the base table's database.
+
+suite("test_cross_db_mv_error") {
+    String baseDb = context.config.getDbNameByFile(context.file)
+    String otherDb = baseDb + "_other"
+
+    sql "DROP DATABASE IF EXISTS ${otherDb}"
+    sql "DROP DATABASE IF EXISTS ${baseDb}"
+    sql "CREATE DATABASE IF NOT EXISTS ${baseDb}"
+    sql "CREATE DATABASE IF NOT EXISTS ${otherDb}"
+    sql "USE ${baseDb}"
+
+    sql "DROP TABLE IF EXISTS cross_db_test_t"
+    sql """
+        CREATE TABLE cross_db_test_t (
+            id int null,
+            k  largeint null,
+            d  date null,
+            k1 int
+        )
+        PARTITION BY RANGE (id) (
+            PARTITION p1 VALUES [('1'), ('2'))
+        )
+        DISTRIBUTED BY HASH(k, id) BUCKETS 16
+        PROPERTIES ("replication_num" = "1")
+    """
+
+    // Explicitly specifying a different db in the MV name should fail.
+    test {
+        sql """CREATE MATERIALIZED VIEW ${otherDb}.mv_cross_explicit AS SELECT d FROM ${baseDb}.cross_db_test_t"""
+        exception "must be the same as the database"
+    }
+
+    // Using a session db that differs from the base table's db should fail.
+    sql "USE ${otherDb}"
+    test {
+        sql """CREATE MATERIALIZED VIEW mv_cross_implicit AS SELECT d FROM ${baseDb}.cross_db_test_t"""
+        exception "must be the same as the database"
+    }
+
+    // Creating a sync MV in the correct db must succeed.
+    sql "USE ${baseDb}"
+    sql "DROP MATERIALIZED VIEW IF EXISTS mv_cross_ok ON cross_db_test_t"
+    sql """CREATE MATERIALIZED VIEW ${baseDb}.mv_cross_ok AS SELECT d FROM cross_db_test_t"""
+
+    sql "DROP DATABASE IF EXISTS ${otherDb}"
+}

--- a/regression-test/suites/mv_p0/test_cross_db_mv_error/test_cross_db_mv_error.groovy
+++ b/regression-test/suites/mv_p0/test_cross_db_mv_error/test_cross_db_mv_error.groovy
@@ -16,8 +16,8 @@
 // under the License.
 
 // Regression test for DORIS-19133:
-// Creating a sync materialized view must fail when the MV's database
-// does not match the base table's database.
+// Creating a sync materialized view must fail when the MV's database or catalog
+// does not match the base table's database/catalog.
 
 suite("test_cross_db_mv_error") {
     String baseDb = context.config.getDbNameByFile(context.file)
@@ -57,8 +57,14 @@ suite("test_cross_db_mv_error") {
         exception "must be the same as the database"
     }
 
-    // Creating a sync MV in the correct db must succeed.
+    // Specifying an external catalog in the MV name should fail.
     sql "USE ${baseDb}"
+    test {
+        sql """CREATE MATERIALIZED VIEW hive_catalog.${baseDb}.mv_cross_ctl AS SELECT d FROM cross_db_test_t"""
+        exception "internal catalog"
+    }
+
+    // Creating a sync MV in the correct db must succeed.
     sql "DROP MATERIALIZED VIEW IF EXISTS mv_cross_ok ON cross_db_test_t"
     sql """CREATE MATERIALIZED VIEW ${baseDb}.mv_cross_ok AS SELECT d FROM cross_db_test_t"""
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: When creating a sync materialized view, if the MV name specified a different database than the base table (e.g. `CREATE MATERIALIZED VIEW db1.mv_t AS SELECT d FROM db.t`), Doris silently succeeded instead of raising an error. A sync materialized view is stored as an index on its base table and must therefore reside in the same database. The same error now also fires when the current session database differs from the base table's database.

### Root cause

In `CreateMaterializedViewCommand.validate()`, the `dbName` field is extracted from the base table (via the plan validator), but the MV name's database (`name.getDb()`) was never compared against it. As a result, specifying a different database in the MV name was silently ignored and the MV was always created under the base table's database without any error.

### Fix

After extracting `dbName` from the validator, determine the MV's effective database:
- Use `name.getDb()` if explicitly specified.
- Fall back to the session's current database otherwise.

If the effective MV database differs from the base table's database, throw an `AnalysisException`.

### Release note

Sync materialized view creation now fails with an explicit error when the materialized view's effective database (explicitly specified or current session database) does not match the base table's database.

### Check List (For Author)

- Test: Regression test added under `regression-test/suites/mv_p0/test_cross_db_mv_error/`
- Behavior changed: Yes — previously the statement succeeded silently; now it raises an AnalysisException
- Does this need documentation: No