### PR TITLE
[chore](be) Document lightweight JSONB validation

### DIFF
--- a/be/src/util/jsonb_document.cpp
+++ b/be/src/util/jsonb_document.cpp
@@ -52,6 +52,11 @@ Status JsonbDocument::checkAndCreateDocument(const char* pb, size_t size,
     }
 
     const auto* val = (const JsonbValue*)doc_ptr->payload_;
+    // Keep this check lightweight. This API is used by JSONB scalar/table functions on every row,
+    // so recursively validating object/array payloads here would add an O(document size) scan before
+    // the real operation and can regress large JSONB queries. External INSERT/LOAD paths build JSONB
+    // through JsonBinaryValue/JsonbWriter before storage; any untrusted raw binary boundary should
+    // add explicit deep validation there instead of changing this hot-path helper.
     if (val->type < JsonbType::T_Null || val->type >= JsonbType::NUM_TYPES ||
         size != sizeof(JsonbHeader) + val->numPackedBytes()) {
         return Status::InvalidArgument("Invalid JSONB document: invalid type({}) or size({})",

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -1037,6 +1037,9 @@ inline const JsonbValue* JsonbDocument::createValue(const char* pb, size_t size)
     }
 
     const auto* val = (const JsonbValue*)doc->payload_;
+    // Same as checkAndCreateDocument(), this is intentionally a lightweight structural check for
+    // hot paths. Do not recursively validate container bodies here unless the caller is a clearly
+    // untrusted raw binary boundary and accepts the O(document size) cost.
     if (size != sizeof(JsonbHeader) + val->numPackedBytes()) {
         return nullptr;
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-25577

Problem Summary: After evaluating the JSONB INSERT/Stream Load path and JSONB query call sites, recursive full validation in `JsonbDocument::checkAndCreateDocument` is not appropriate for the default helper. INSERT and load inputs are JSON text that BE re-encodes through `JsonBinaryValue`/`JsonbWriter`, while `checkAndCreateDocument` and `createValue` are also used by JSONB scalar/table functions in per-row hot paths.

This PR documents why these helpers intentionally remain lightweight and why any future deep validation should be added only at a clearly untrusted raw JSONB binary boundary.

### Release note

None

### Check List (For Author)

- Test:
    - Manual test: `git diff --check`
- Behavior changed: No
- Does this need documentation: No
