### PR TITLE
[fix](dns-cache) evict hostnames that fail to resolve repeatedly

### DIFF
--- a/be/src/cloud/cloud_warm_up_manager.cpp
+++ b/be/src/cloud/cloud_warm_up_manager.cpp
@@ -986,7 +986,7 @@ void CloudWarmUpManager::_recycle_cache(int64_t tablet_id,
             if (!status.ok()) {
                 LOG(WARNING) << "failed to get ip from host " << replica.replica.host << ": "
                              << status.to_string();
-                return;
+                continue;
             }
         }
         std::string brpc_addr = get_host_port(host, replica.replica.brpc_port);

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -285,6 +285,11 @@ DEFINE_mInt32(download_binlog_meta_timeout_ms, "30000");
 // the interval time(seconds) for agent report index policy to FE
 DEFINE_mInt32(report_index_policy_interval_seconds, "10");
 
+// DNS cache: throttle "use cached ip" warning to once per N failures per host.
+DEFINE_mInt32(dns_cache_log_every_n_failures, "60");
+// DNS cache: evict a hostname after this many consecutive resolution failures.
+DEFINE_mInt32(dns_cache_max_consecutive_failures, "30");
+
 DEFINE_String(sys_log_dir, "");
 DEFINE_String(user_function_dir, "${DORIS_HOME}/lib/udf");
 // INFO, WARNING, ERROR, FATAL

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -286,9 +286,12 @@ DEFINE_mInt32(download_binlog_meta_timeout_ms, "30000");
 DEFINE_mInt32(report_index_policy_interval_seconds, "10");
 
 // DNS cache: throttle "use cached ip" warning to once per N failures per host.
-DEFINE_mInt32(dns_cache_log_every_n_failures, "60");
+DEFINE_mInt32(dns_cache_log_every_n_failures, "10");
 // DNS cache: evict a hostname after this many consecutive resolution failures.
 DEFINE_mInt32(dns_cache_max_consecutive_failures, "30");
+// DNS cache: after eviction, block re-resolve attempts for this many seconds.
+// Set <= 0 to disable the negative cache (legacy behavior).
+DEFINE_mInt32(dns_cache_negative_ttl_seconds, "60");
 
 DEFINE_String(sys_log_dir, "");
 DEFINE_String(user_function_dir, "${DORIS_HOME}/lib/udf");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -342,6 +342,17 @@ DECLARE_mInt32(download_binlog_meta_timeout_ms);
 // the interval time(seconds) for agent report index policy to FE
 DECLARE_mInt32(report_index_policy_interval_seconds);
 
+// DNS cache: log the "Failed to resolve hostname ... use cached ip" warning
+// only once per N consecutive failures for the same hostname, to avoid
+// flooding be.WARNING. Set <= 1 to log every failure (legacy behavior).
+DECLARE_mInt32(dns_cache_log_every_n_failures);
+
+// DNS cache: evict a hostname after this many consecutive resolution failures.
+// At the default refresh interval of 60s, the default value of 30 means an
+// entry is evicted after ~30 minutes of being un-resolvable. Set <= 0 to
+// disable eviction (legacy behavior, kept for backward compatibility).
+DECLARE_mInt32(dns_cache_max_consecutive_failures);
+
 // deprecated, use env var LOG_DIR in be.conf
 DECLARE_String(sys_log_dir);
 // for udf

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -348,9 +348,11 @@ DECLARE_mInt32(report_index_policy_interval_seconds);
 DECLARE_mInt32(dns_cache_log_every_n_failures);
 
 // DNS cache: evict a hostname after this many consecutive resolution failures.
-// At the default refresh interval of 60s, the default value of 30 means an
-// entry is evicted after ~30 minutes of being un-resolvable. Set <= 0 to
-// disable eviction (legacy behavior, kept for backward compatibility).
+// At the default refresh interval of 60s, the default value of 30 means a
+// hostname that was once successfully resolved is evicted after ~30 minutes of
+// being un-resolvable.  Hostnames that have never been successfully resolved are
+// not tracked and are unaffected by this threshold.
+// Set <= 0 to disable eviction (legacy behavior, kept for backward compatibility).
 DECLARE_mInt32(dns_cache_max_consecutive_failures);
 
 // deprecated, use env var LOG_DIR in be.conf

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -345,8 +345,8 @@ DECLARE_mInt32(report_index_policy_interval_seconds);
 // DNS cache: log the "Failed to resolve hostname ... use cached ip" warning
 // only once per N consecutive failures for the same hostname, to avoid
 // flooding be.WARNING. Set <= 1 to log every failure (legacy behavior).
-// Should be set <= dns_cache_max_consecutive_failures so at least one
-// periodic log is emitted before a host is evicted.
+// Should be set <= dns_cache_max_consecutive_failures, otherwise only the
+// first-failure log is ever emitted before a host is evicted.
 DECLARE_mInt32(dns_cache_log_every_n_failures);
 
 // DNS cache: evict a hostname after this many consecutive resolution failures.
@@ -354,13 +354,24 @@ DECLARE_mInt32(dns_cache_log_every_n_failures);
 // hostname that was once successfully resolved is evicted after ~30 minutes of
 // being un-resolvable.  Hostnames that have never been successfully resolved are
 // not tracked and are unaffected by this threshold.
+// Eviction additionally requires the most recent failure to be an authoritative
+// NXDOMAIN (getaddrinfo returning EAI_NONAME), i.e. the resolver positively
+// stating that the name does not exist. Transient failures such as EAI_AGAIN
+// (resolver unreachable or timed out) never evict, so a DNS-server outage
+// degrades to serving the last known IP instead of emptying the cache for every
+// hostname at once and turning a DNS incident into a cluster-wide RPC outage.
 // Set <= 0 to disable eviction (legacy behavior, kept for backward compatibility).
 DECLARE_mInt32(dns_cache_max_consecutive_failures);
 
-// DNS cache: seconds to suppress re-resolve attempts for a hostname that was
-// just evicted due to repeated failures.  During this window get() returns an
-// error immediately (no blocking getaddrinfo) so request threads are not
-// stalled while the evicted backend is being drained.
+// DNS cache: seconds to suppress re-resolve attempts for a hostname that could
+// not be resolved -- either because it was evicted after repeated failures, or
+// because it never resolved in the first place.  During this window get()
+// returns an error immediately (no blocking getaddrinfo) so request threads are
+// not stalled while the backend is being drained or while a bad hostname is
+// being retried.
+// This also bounds recovery latency: the refresh thread does not retry hostnames
+// that are no longer in the cache, so a host comes back only when a caller's
+// get() runs after this TTL expires (one such retry per host per TTL).
 // Set <= 0 to disable the negative cache.
 DECLARE_mInt32(dns_cache_negative_ttl_seconds);
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -345,6 +345,8 @@ DECLARE_mInt32(report_index_policy_interval_seconds);
 // DNS cache: log the "Failed to resolve hostname ... use cached ip" warning
 // only once per N consecutive failures for the same hostname, to avoid
 // flooding be.WARNING. Set <= 1 to log every failure (legacy behavior).
+// Should be set <= dns_cache_max_consecutive_failures so at least one
+// periodic log is emitted before a host is evicted.
 DECLARE_mInt32(dns_cache_log_every_n_failures);
 
 // DNS cache: evict a hostname after this many consecutive resolution failures.
@@ -354,6 +356,13 @@ DECLARE_mInt32(dns_cache_log_every_n_failures);
 // not tracked and are unaffected by this threshold.
 // Set <= 0 to disable eviction (legacy behavior, kept for backward compatibility).
 DECLARE_mInt32(dns_cache_max_consecutive_failures);
+
+// DNS cache: seconds to suppress re-resolve attempts for a hostname that was
+// just evicted due to repeated failures.  During this window get() returns an
+// error immediately (no blocking getaddrinfo) so request threads are not
+// stalled while the evicted backend is being drained.
+// Set <= 0 to disable the negative cache.
+DECLARE_mInt32(dns_cache_negative_ttl_seconds);
 
 // deprecated, use env var LOG_DIR in be.conf
 DECLARE_String(sys_log_dir);

--- a/be/src/util/brpc_client_cache.h
+++ b/be/src/util/brpc_client_cache.h
@@ -174,6 +174,14 @@ public:
             Status status = dns_cache->get(host, &realhost);
             if (!status.ok()) {
                 LOG(WARNING) << "failed to get ip from host:" << status.to_string();
+                // The hostname is no longer resolvable, which normally means the backend
+                // was dropped from the cluster. Returning early is not enough: any stub
+                // cached under this host:port still holds a brpc Channel bound to the last
+                // resolved (now dead) IP, and brpc keeps health-checking that socket
+                // forever, which is the source of the endless
+                // "Fail to wait EPOLLOUT ... Connection timed out" warnings. Drop it here
+                // so the socket is closed along with the last reference to the stub.
+                _stub_map.erase(fmt::format("{}:{}", host, port));
                 return nullptr;
             }
         }

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -35,6 +35,7 @@ DNSCache::DNSCache(Resolver resolver) : _resolver(std::move(resolver)) {}
 
 DNSCache::~DNSCache() {
     stop_refresh = true;
+    _cv.notify_all();
     if (refresh_thread.joinable()) {
         refresh_thread.join();
     }
@@ -49,13 +50,11 @@ Status DNSCache::get(const std::string& hostname, std::string* ip) {
             return Status::OK();
         }
     }
-    // Update if not found
-    RETURN_IF_ERROR(_update(hostname));
-    {
-        std::shared_lock<std::shared_mutex> lock(mutex);
-        *ip = cache[hostname];
-        return Status::OK();
-    }
+    // First access: resolve and populate the cache.  Consume the IP returned by
+    // _update() directly to avoid a second cache lookup — operator[] under a
+    // shared_lock would mutate the map and could reinsert an empty entry if a
+    // concurrent refresh cycle evicted the hostname between _update() and here.
+    return _update(hostname, nullptr, ip);
 }
 
 // Resolve hostname to IP address, similar to Java's DNSCache.resolveHostname.
@@ -137,10 +136,11 @@ void DNSCache::_erase(const std::string& hostname) {
     failure_count.erase(hostname);
 }
 
-Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures) {
+Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, std::string* out_ip) {
     std::string real_ip = _resolve_hostname(hostname);
     if (real_ip.empty()) {
         if (out_failures) *out_failures = 0;
+        if (out_ip) out_ip->clear();
         return Status::InternalError("Failed to resolve hostname {} and no cached ip available",
                                      hostname);
     }
@@ -151,6 +151,7 @@ Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures) {
         cache[hostname] = real_ip;
         LOG(INFO) << "update hostname " << hostname << "'s ip to " << real_ip;
     }
+    if (out_ip) *out_ip = real_ip;
     // Read failure_count under the same lock we already hold, so _refresh_once
     // does not need a second lock acquisition to decide on eviction.
     if (out_failures) {
@@ -199,9 +200,14 @@ void DNSCache::_refresh_once() {
 
 void DNSCache::_refresh_cache() {
     while (!stop_refresh) {
-        // refresh every 1 min
-        std::this_thread::sleep_for(std::chrono::minutes(1));
-        _refresh_once();
+        {
+            std::unique_lock<std::mutex> lk(_cv_mutex);
+            // Wake up either after 1 minute or when the destructor signals stop.
+            _cv.wait_for(lk, std::chrono::minutes(1), [this] { return stop_refresh.load(); });
+        }
+        if (!stop_refresh) {
+            _refresh_once();
+        }
     }
 }
 

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -18,6 +18,7 @@
 #include "util/dns_cache.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 #include "common/config.h"
 #include "service/backend_options.h"
@@ -28,6 +29,8 @@ namespace doris {
 DNSCache::DNSCache() {
     refresh_thread = std::thread(&DNSCache::_refresh_cache, this);
 }
+
+DNSCache::DNSCache(Resolver resolver) : _resolver(std::move(resolver)) {}
 
 DNSCache::~DNSCache() {
     stop_refresh = true;
@@ -70,16 +73,19 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname) {
 
     // Try to resolve hostname
     std::string resolved_ip;
-    Status status = hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6());
+    Status status = _resolver ? _resolver(hostname, resolved_ip, BackendOptions::is_bind_ipv6())
+                              : hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6());
 
     if (!status.ok() || resolved_ip.empty()) {
-        // Resolution failed - bump the consecutive failure counter.
-        uint32_t failures = 0;
-        {
-            std::unique_lock<std::shared_mutex> lock(mutex);
-            failures = ++failure_count[hostname];
-        }
         if (!cached_ip.empty()) {
+            // Only track failure counts for hosts that are currently in the cache.
+            // Hosts that were never cached or have already been evicted are not
+            // tracked, which prevents unbounded growth of failure_count.
+            uint32_t failures = 0;
+            {
+                std::unique_lock<std::shared_mutex> lock(mutex);
+                failures = ++failure_count[hostname];
+            }
             // Throttle the log: only every N failures or the first failure.
             int32_t every_n = std::max(1, config::dns_cache_log_every_n_failures);
             if (failures == 1 || failures % static_cast<uint32_t>(every_n) == 0) {
@@ -124,44 +130,50 @@ Status DNSCache::_update(const std::string& hostname) {
     return Status::OK();
 }
 
+void DNSCache::_refresh_once() {
+    std::unordered_set<std::string> keys;
+    {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        std::transform(cache.begin(), cache.end(), std::inserter(keys, keys.end()),
+                       [](const auto& pair) { return pair.first; });
+    }
+    for (auto& key : keys) {
+        Status st = _update(key);
+        if (!st.ok()) {
+            LOG(WARNING) << "Failed to update DNS cache for hostname " << key << ": "
+                         << st.to_string();
+        }
+        // Evict hostnames that have failed to resolve for too long.
+        // This avoids two pathological symptoms after a backend is dropped
+        // from the cluster and its DNS record is removed:
+        //   1) be.WARNING gets flooded with `failed to get ip from host`.
+        //   2) brpc keeps re-using the stale IP from cache, producing
+        //      `Fail to wait EPOLLOUT ... Connection timed out`.
+        uint32_t failures = 0;
+        {
+            std::shared_lock<std::shared_mutex> lock(mutex);
+            auto it = failure_count.find(key);
+            if (it != failure_count.end()) {
+                failures = it->second;
+            }
+        }
+        int32_t threshold = config::dns_cache_max_consecutive_failures;
+        if (threshold > 0 && failures >= static_cast<uint32_t>(threshold)) {
+            LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after " << failures
+                         << " consecutive resolution failures";
+            _erase(key);
+        }
+    }
+}
+
 void DNSCache::_refresh_cache() {
     while (!stop_refresh) {
         // refresh every 1 min
         std::this_thread::sleep_for(std::chrono::minutes(1));
-        std::unordered_set<std::string> keys;
-        {
-            std::shared_lock<std::shared_mutex> lock(mutex);
-            std::transform(cache.begin(), cache.end(), std::inserter(keys, keys.end()),
-                           [](const auto& pair) { return pair.first; });
-        }
-        for (auto& key : keys) {
-            Status st = _update(key);
-            if (!st.ok()) {
-                LOG(WARNING) << "Failed to update DNS cache for hostname " << key << ": "
-                             << st.to_string();
-            }
-            // Evict hostnames that have failed to resolve for too long.
-            // This avoids two pathological symptoms after a backend is dropped
-            // from the cluster and its DNS record is removed:
-            //   1) be.WARNING gets flooded with `failed to get ip from host`.
-            //   2) brpc keeps re-using the stale IP from cache, producing
-            //      `Fail to wait EPOLLOUT ... Connection timed out`.
-            uint32_t failures = 0;
-            {
-                std::shared_lock<std::shared_mutex> lock(mutex);
-                auto it = failure_count.find(key);
-                if (it != failure_count.end()) {
-                    failures = it->second;
-                }
-            }
-            int32_t threshold = config::dns_cache_max_consecutive_failures;
-            if (threshold > 0 && failures >= static_cast<uint32_t>(threshold)) {
-                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after " << failures
-                             << " consecutive resolution failures";
-                _erase(key);
-            }
-        }
+        _refresh_once();
     }
 }
+
+} // end of namespace doris
 
 } // end of namespace doris

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -140,6 +140,14 @@ void DNSCache::_refresh_once() {
     for (auto& key : keys) {
         Status st = _update(key);
         if (!st.ok()) {
+            // _update only returns an error when _resolve_hostname returns an
+            // empty string, which happens only if the hostname has never been
+            // successfully resolved (no cached IP to fall back to).  Keys in
+            // the refresh loop come from `cache`, so they all have a prior IP;
+            // during DNS failure _resolve_hostname returns that cached IP and
+            // _update returns OK.  This branch is therefore effectively dead
+            // under normal refresh semantics — the eviction logic below handles
+            // the long-running failure case instead.
             LOG(WARNING) << "Failed to update DNS cache for hostname " << key << ": "
                          << st.to_string();
         }

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -73,8 +73,9 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname) {
 
     // Try to resolve hostname
     std::string resolved_ip;
-    Status status = _resolver ? _resolver(hostname, resolved_ip, BackendOptions::is_bind_ipv6())
-                              : hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6());
+    Status status = _resolver
+                            ? _resolver(hostname, resolved_ip, BackendOptions::is_bind_ipv6())
+                            : hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6());
 
     if (!status.ok() || resolved_ip.empty()) {
         if (!cached_ip.empty()) {

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -114,9 +114,10 @@ void DNSCache::_erase(const std::string& hostname) {
     failure_count.erase(hostname);
 }
 
-Status DNSCache::_update(const std::string& hostname) {
+Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures) {
     std::string real_ip = _resolve_hostname(hostname);
     if (real_ip.empty()) {
+        if (out_failures) *out_failures = 0;
         return Status::InternalError("Failed to resolve hostname {} and no cached ip available",
                                      hostname);
     }
@@ -126,6 +127,12 @@ Status DNSCache::_update(const std::string& hostname) {
     if (it == cache.end() || it->second != real_ip) {
         cache[hostname] = real_ip;
         LOG(INFO) << "update hostname " << hostname << "'s ip to " << real_ip;
+    }
+    // Read failure_count under the same lock we already hold, so _refresh_once
+    // does not need a second lock acquisition to decide on eviction.
+    if (out_failures) {
+        auto fc_it = failure_count.find(hostname);
+        *out_failures = fc_it != failure_count.end() ? fc_it->second : 0;
     }
     return Status::OK();
 }
@@ -138,7 +145,8 @@ void DNSCache::_refresh_once() {
                        [](const auto& pair) { return pair.first; });
     }
     for (auto& key : keys) {
-        Status st = _update(key);
+        uint32_t failures = 0;
+        Status st = _update(key, &failures);
         if (!st.ok()) {
             // _update only returns an error when _resolve_hostname returns an
             // empty string, which happens only if the hostname has never been
@@ -157,14 +165,6 @@ void DNSCache::_refresh_once() {
         //   1) be.WARNING gets flooded with `failed to get ip from host`.
         //   2) brpc keeps re-using the stale IP from cache, producing
         //      `Fail to wait EPOLLOUT ... Connection timed out`.
-        uint32_t failures = 0;
-        {
-            std::shared_lock<std::shared_mutex> lock(mutex);
-            auto it = failure_count.find(key);
-            if (it != failure_count.end()) {
-                failures = it->second;
-            }
-        }
         int32_t threshold = config::dns_cache_max_consecutive_failures;
         if (threshold > 0 && failures >= static_cast<uint32_t>(threshold)) {
             LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after " << failures

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -18,6 +18,7 @@
 #include "util/dns_cache.h"
 
 #include <algorithm>
+#include <atomic>
 #include <unordered_set>
 
 #include "common/config.h"
@@ -85,18 +86,39 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname) {
             uint32_t failures = 0;
             {
                 std::unique_lock<std::shared_mutex> lock(mutex);
-                failures = ++failure_count[hostname];
+                // Re-check that the host is still cached under the unique_lock:
+                // it may have been evicted by the refresh thread between our
+                // earlier shared_lock read of cached_ip and now (hostname_to_ip
+                // can block for seconds on DNS timeout, widening the window).
+                // Skipping the bump here preserves keys(failure_count) ⊆ keys(cache).
+                if (cache.find(hostname) != cache.end()) {
+                    failures = ++failure_count[hostname];
+                }
             }
             // Throttle the log: only every N failures or the first failure.
-            int32_t every_n = std::max(1, config::dns_cache_log_every_n_failures);
-            if (failures == 1 || failures % static_cast<uint32_t>(every_n) == 0) {
-                LOG(WARNING) << "Failed to resolve hostname " << hostname
-                             << " (consecutive failures: " << failures
-                             << "), use cached ip: " << cached_ip;
+            if (failures > 0) {
+                int32_t every_n = std::max(1, config::dns_cache_log_every_n_failures);
+                if (failures == 1 || failures % static_cast<uint32_t>(every_n) == 0) {
+                    LOG(WARNING) << "Failed to resolve hostname " << hostname
+                                 << " (consecutive failures: " << failures
+                                 << "), use cached ip: " << cached_ip;
+                }
             }
             return cached_ip;
         } else {
-            LOG(WARNING) << "Failed to resolve hostname " << hostname << ", no cached ip available";
+            // Throttle to avoid flooding be.WARNING when callers repeatedly
+            // query an evicted or never-resolvable hostname.  This branch
+            // deliberately does not maintain a per-hostname counter (that
+            // would break the keys(failure_count) ⊆ keys(cache) invariant),
+            // so the throttle is a coarse global rate limit shared across
+            // all hostnames hitting this code path.
+            static std::atomic<uint64_t> no_cache_warn_counter {0};
+            uint64_t n = no_cache_warn_counter.fetch_add(1, std::memory_order_relaxed) + 1;
+            int32_t every_n = std::max(1, config::dns_cache_log_every_n_failures);
+            if (n == 1 || n % static_cast<uint64_t>(every_n) == 0) {
+                LOG(WARNING) << "Failed to resolve hostname " << hostname
+                             << ", no cached ip available";
+            }
             return "";
         }
     }

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -184,5 +184,3 @@ void DNSCache::_refresh_cache() {
 }
 
 } // end of namespace doris
-
-} // end of namespace doris

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -156,8 +156,8 @@ void DNSCache::_refresh_cache() {
             }
             int32_t threshold = config::dns_cache_max_consecutive_failures;
             if (threshold > 0 && failures >= static_cast<uint32_t>(threshold)) {
-                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after "
-                             << failures << " consecutive resolution failures";
+                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after " << failures
+                             << " consecutive resolution failures";
                 _erase(key);
             }
         }

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -17,6 +17,9 @@
 
 #include "util/dns_cache.h"
 
+#include <algorithm>
+
+#include "common/config.h"
 #include "service/backend_options.h"
 #include "util/network_util.h"
 
@@ -70,10 +73,20 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname) {
     Status status = hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6());
 
     if (!status.ok() || resolved_ip.empty()) {
-        // Resolution failed
+        // Resolution failed - bump the consecutive failure counter.
+        uint32_t failures = 0;
+        {
+            std::unique_lock<std::shared_mutex> lock(mutex);
+            failures = ++failure_count[hostname];
+        }
         if (!cached_ip.empty()) {
-            LOG(WARNING) << "Failed to resolve hostname " << hostname
-                         << ", use cached ip: " << cached_ip;
+            // Throttle the log: only every N failures or the first failure.
+            int32_t every_n = std::max(1, config::dns_cache_log_every_n_failures);
+            if (failures == 1 || failures % static_cast<uint32_t>(every_n) == 0) {
+                LOG(WARNING) << "Failed to resolve hostname " << hostname
+                             << " (consecutive failures: " << failures
+                             << "), use cached ip: " << cached_ip;
+            }
             return cached_ip;
         } else {
             LOG(WARNING) << "Failed to resolve hostname " << hostname << ", no cached ip available";
@@ -81,7 +94,18 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname) {
         }
     }
 
+    // Resolution succeeded - clear failure counter for this hostname.
+    {
+        std::unique_lock<std::shared_mutex> lock(mutex);
+        failure_count.erase(hostname);
+    }
     return resolved_ip;
+}
+
+void DNSCache::_erase(const std::string& hostname) {
+    std::unique_lock<std::shared_mutex> lock(mutex);
+    cache.erase(hostname);
+    failure_count.erase(hostname);
 }
 
 Status DNSCache::_update(const std::string& hostname) {
@@ -115,6 +139,26 @@ void DNSCache::_refresh_cache() {
             if (!st.ok()) {
                 LOG(WARNING) << "Failed to update DNS cache for hostname " << key << ": "
                              << st.to_string();
+            }
+            // Evict hostnames that have failed to resolve for too long.
+            // This avoids two pathological symptoms after a backend is dropped
+            // from the cluster and its DNS record is removed:
+            //   1) be.WARNING gets flooded with `failed to get ip from host`.
+            //   2) brpc keeps re-using the stale IP from cache, producing
+            //      `Fail to wait EPOLLOUT ... Connection timed out`.
+            uint32_t failures = 0;
+            {
+                std::shared_lock<std::shared_mutex> lock(mutex);
+                auto it = failure_count.find(key);
+                if (it != failure_count.end()) {
+                    failures = it->second;
+                }
+            }
+            int32_t threshold = config::dns_cache_max_consecutive_failures;
+            if (threshold > 0 && failures >= static_cast<uint32_t>(threshold)) {
+                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after "
+                             << failures << " consecutive resolution failures";
+                _erase(key);
             }
         }
     }

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -170,8 +170,7 @@ void DNSCache::_erase(const std::string& hostname) {
     failure_count.erase(hostname);
     int32_t ttl = config::dns_cache_negative_ttl_seconds;
     if (ttl > 0) {
-        _negative_cache[hostname] =
-                std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+        _negative_cache[hostname] = std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
     }
 }
 
@@ -187,8 +186,7 @@ bool DNSCache::_erase_if_still_failing(const std::string& hostname, uint32_t thr
     failure_count.erase(hostname);
     int32_t ttl = config::dns_cache_negative_ttl_seconds;
     if (ttl > 0) {
-        _negative_cache[hostname] =
-                std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+        _negative_cache[hostname] = std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
     }
     return true;
 }
@@ -273,8 +271,8 @@ void DNSCache::_refresh_once() {
             // to fence any concurrent success that cleared the counter between
             // _update() returning and this point.
             if (_erase_if_still_failing(key, static_cast<uint32_t>(threshold))) {
-                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after "
-                             << failures << " consecutive resolution failures";
+                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after " << failures
+                             << " consecutive resolution failures";
             }
         }
     }

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -34,7 +34,10 @@ DNSCache::DNSCache() {
 DNSCache::DNSCache(Resolver resolver) : _resolver(std::move(resolver)) {}
 
 DNSCache::~DNSCache() {
-    stop_refresh = true;
+    {
+        std::lock_guard<std::mutex> lk(_cv_mutex);
+        stop_refresh = true;
+    }
     _cv.notify_all();
     if (refresh_thread.joinable()) {
         refresh_thread.join();
@@ -49,11 +52,23 @@ Status DNSCache::get(const std::string& hostname, std::string* ip) {
             *ip = it->second;
             return Status::OK();
         }
+        // Return a cheap error for recently-evicted hosts to avoid repeated
+        // blocking getaddrinfo calls during the transition after a backend is
+        // dropped.  The entry expires after dns_cache_negative_ttl_seconds;
+        // once expired the next caller falls through and retries the resolve.
+        auto neg_it = _negative_cache.find(hostname);
+        if (neg_it != _negative_cache.end() &&
+            std::chrono::steady_clock::now() < neg_it->second) {
+            return Status::InternalError(
+                    "Hostname {} is in negative DNS cache (recently evicted), skipping resolve",
+                    hostname);
+        }
     }
-    // First access: resolve and populate the cache.  Consume the IP returned by
-    // _update() directly to avoid a second cache lookup — operator[] under a
-    // shared_lock would mutate the map and could reinsert an empty entry if a
-    // concurrent refresh cycle evicted the hostname between _update() and here.
+    // First access (or negative TTL expired): resolve and populate the cache.
+    // Consume the IP returned by _update() directly to avoid a second cache
+    // lookup — operator[] under a shared_lock would mutate the map and could
+    // reinsert an empty entry if a concurrent refresh cycle evicted the hostname
+    // between _update() and here.
     return _update(hostname, nullptr, ip);
 }
 
@@ -134,6 +149,11 @@ void DNSCache::_erase(const std::string& hostname) {
     std::unique_lock<std::shared_mutex> lock(mutex);
     cache.erase(hostname);
     failure_count.erase(hostname);
+    int32_t ttl = config::dns_cache_negative_ttl_seconds;
+    if (ttl > 0) {
+        _negative_cache[hostname] =
+                std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+    }
 }
 
 Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, std::string* out_ip) {
@@ -151,6 +171,9 @@ Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, st
         cache[hostname] = real_ip;
         LOG(INFO) << "update hostname " << hostname << "'s ip to " << real_ip;
     }
+    // DNS resolved successfully — remove any negative cache tombstone so
+    // subsequent get() calls go straight to the main cache.
+    _negative_cache.erase(hostname);
     if (out_ip) *out_ip = real_ip;
     // Read failure_count under the same lock we already hold, so _refresh_once
     // does not need a second lock acquisition to decide on eviction.
@@ -162,6 +185,15 @@ Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, st
 }
 
 void DNSCache::_refresh_once() {
+    // Purge expired negative-cache entries to prevent unbounded map growth.
+    {
+        std::unique_lock<std::shared_mutex> lock(mutex);
+        auto now = std::chrono::steady_clock::now();
+        for (auto it = _negative_cache.begin(); it != _negative_cache.end();) {
+            it = (now >= it->second) ? _negative_cache.erase(it) : std::next(it);
+        }
+    }
+
     std::unordered_set<std::string> keys;
     {
         std::shared_lock<std::shared_mutex> lock(mutex);

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -45,6 +45,7 @@ DNSCache::~DNSCache() {
 }
 
 Status DNSCache::get(const std::string& hostname, std::string* ip) {
+    bool expired_negative = false;
     {
         std::shared_lock<std::shared_mutex> lock(mutex);
         auto it = cache.find(hostname);
@@ -57,11 +58,13 @@ Status DNSCache::get(const std::string& hostname, std::string* ip) {
         // dropped.  The entry expires after dns_cache_negative_ttl_seconds;
         // once expired the next caller falls through and retries the resolve.
         auto neg_it = _negative_cache.find(hostname);
-        if (neg_it != _negative_cache.end() &&
-            std::chrono::steady_clock::now() < neg_it->second) {
-            return Status::InternalError(
-                    "Hostname {} is in negative DNS cache (recently evicted), skipping resolve",
-                    hostname);
+        if (neg_it != _negative_cache.end()) {
+            if (std::chrono::steady_clock::now() < neg_it->second) {
+                return Status::InternalError(
+                        "Hostname {} is in negative DNS cache (recently evicted), skipping resolve",
+                        hostname);
+            }
+            expired_negative = true; // TTL passed; allow one retry
         }
     }
     // First access (or negative TTL expired): resolve and populate the cache.
@@ -69,13 +72,27 @@ Status DNSCache::get(const std::string& hostname, std::string* ip) {
     // lookup — operator[] under a shared_lock would mutate the map and could
     // reinsert an empty entry if a concurrent refresh cycle evicted the hostname
     // between _update() and here.
-    return _update(hostname, nullptr, ip);
+    Status st = _update(hostname, nullptr, ip);
+    if (!st.ok() && expired_negative) {
+        // DNS is still failing after the backoff window.  Re-arm the negative
+        // cache so the retry rate stays bounded at one attempt per TTL period —
+        // otherwise every concurrent caller blocks on a full DNS timeout each time.
+        int32_t ttl = config::dns_cache_negative_ttl_seconds;
+        if (ttl > 0) {
+            std::unique_lock<std::shared_mutex> lock(mutex);
+            _negative_cache[hostname] =
+                    std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+        }
+    }
+    return st;
 }
 
 // Resolve hostname to IP address, similar to Java's DNSCache.resolveHostname.
 // If resolution fails, falls back to cached IP if available.
 // Returns the resolved IP, or cached IP on failure, or empty string if no cache available.
-std::string DNSCache::_resolve_hostname(const std::string& hostname) {
+// *is_fresh (if non-null) is set to true when DNS returned a live result, false
+// when the IP comes from the stale cached fallback path.
+std::string DNSCache::_resolve_hostname(const std::string& hostname, bool* is_fresh) {
     // Get cached IP first (if any)
     std::string cached_ip;
     {
@@ -93,6 +110,7 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname) {
                             : hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6());
 
     if (!status.ok() || resolved_ip.empty()) {
+        if (is_fresh) *is_fresh = false;
         if (!cached_ip.empty()) {
             // Only track failure counts for hosts that are currently in the cache.
             // Hosts that were never cached or have already been evicted are not
@@ -138,6 +156,7 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname) {
     }
 
     // Resolution succeeded - clear failure counter for this hostname.
+    if (is_fresh) *is_fresh = true;
     {
         std::unique_lock<std::shared_mutex> lock(mutex);
         failure_count.erase(hostname);
@@ -156,8 +175,27 @@ void DNSCache::_erase(const std::string& hostname) {
     }
 }
 
+bool DNSCache::_erase_if_still_failing(const std::string& hostname, uint32_t threshold) {
+    std::unique_lock<std::shared_mutex> lock(mutex);
+    auto fc_it = failure_count.find(hostname);
+    if (fc_it == failure_count.end() || fc_it->second < threshold) {
+        // A concurrent successful resolution cleared or reset the counter between
+        // _update() returning and this call — do not erase a now-healthy entry.
+        return false;
+    }
+    cache.erase(hostname);
+    failure_count.erase(hostname);
+    int32_t ttl = config::dns_cache_negative_ttl_seconds;
+    if (ttl > 0) {
+        _negative_cache[hostname] =
+                std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+    }
+    return true;
+}
+
 Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, std::string* out_ip) {
-    std::string real_ip = _resolve_hostname(hostname);
+    bool is_fresh = false;
+    std::string real_ip = _resolve_hostname(hostname, &is_fresh);
     if (real_ip.empty()) {
         if (out_failures) *out_failures = 0;
         if (out_ip) out_ip->clear();
@@ -166,6 +204,18 @@ Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, st
     }
 
     std::unique_lock<std::shared_mutex> lock(mutex);
+    // _resolve_hostname may have captured a stale cached_ip before a concurrent
+    // eviction completed.  If the host is now in the negative cache we must not
+    // reinsert the stale IP: that would silently undo the eviction and clear the
+    // tombstone, defeating the whole purpose of eviction.  Only a fresh DNS
+    // result (is_fresh == true, meaning DNS actually resolved) may override an
+    // eviction — which indicates the backend is genuinely back.
+    if (!is_fresh && _negative_cache.count(hostname)) {
+        if (out_failures) *out_failures = 0;
+        if (out_ip) out_ip->clear();
+        return Status::InternalError(
+                "Hostname {} was concurrently evicted; stale-fallback not reinserted", hostname);
+    }
     auto it = cache.find(hostname);
     if (it == cache.end() || it->second != real_ip) {
         cache[hostname] = real_ip;
@@ -204,14 +254,10 @@ void DNSCache::_refresh_once() {
         uint32_t failures = 0;
         Status st = _update(key, &failures);
         if (!st.ok()) {
-            // _update only returns an error when _resolve_hostname returns an
-            // empty string, which happens only if the hostname has never been
-            // successfully resolved (no cached IP to fall back to).  Keys in
-            // the refresh loop come from `cache`, so they all have a prior IP;
-            // during DNS failure _resolve_hostname returns that cached IP and
-            // _update returns OK.  This branch is therefore effectively dead
-            // under normal refresh semantics — the eviction logic below handles
-            // the long-running failure case instead.
+            // _update returns an error either when _resolve_hostname returns ""
+            // (no fallback IP) or when a stale fallback was suppressed because
+            // the host was concurrently evicted.  Either way, log and move on;
+            // the threshold check below handles the normal eviction path.
             LOG(WARNING) << "Failed to update DNS cache for hostname " << key << ": "
                          << st.to_string();
         }
@@ -223,9 +269,13 @@ void DNSCache::_refresh_once() {
         //      `Fail to wait EPOLLOUT ... Connection timed out`.
         int32_t threshold = config::dns_cache_max_consecutive_failures;
         if (threshold > 0 && failures >= static_cast<uint32_t>(threshold)) {
-            LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after " << failures
-                         << " consecutive resolution failures";
-            _erase(key);
+            // Re-read failure_count under the mutex that also performs the erase
+            // to fence any concurrent success that cleared the counter between
+            // _update() returning and this point.
+            if (_erase_if_still_failing(key, static_cast<uint32_t>(threshold))) {
+                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after "
+                             << failures << " consecutive resolution failures";
+            }
         }
     }
 }

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -45,7 +45,7 @@ DNSCache::~DNSCache() {
 }
 
 Status DNSCache::get(const std::string& hostname, std::string* ip) {
-    bool expired_negative = false;
+    bool has_negative_entry = false;
     {
         std::shared_lock<std::shared_mutex> lock(mutex);
         auto it = cache.find(hostname);
@@ -53,38 +53,53 @@ Status DNSCache::get(const std::string& hostname, std::string* ip) {
             *ip = it->second;
             return Status::OK();
         }
-        // Return a cheap error for recently-evicted hosts to avoid repeated
-        // blocking getaddrinfo calls during the transition after a backend is
-        // dropped.  The entry expires after dns_cache_negative_ttl_seconds;
-        // once expired the next caller falls through and retries the resolve.
         auto neg_it = _negative_cache.find(hostname);
         if (neg_it != _negative_cache.end()) {
-            if (std::chrono::steady_clock::now() < neg_it->second) {
-                return Status::InternalError(
-                        "Hostname {} is in negative DNS cache (recently evicted), skipping resolve",
-                        hostname);
+            int32_t ttl = config::dns_cache_negative_ttl_seconds;
+            if (ttl > 0) {
+                auto deadline = neg_it->second + std::chrono::seconds(ttl);
+                if (std::chrono::steady_clock::now() < deadline) {
+                    return Status::InternalError(
+                            "Hostname {} is in negative DNS cache (recently evicted), "
+                            "skipping resolve",
+                            hostname);
+                }
             }
-            expired_negative = true; // TTL passed; allow one retry
+            has_negative_entry = true;
         }
     }
+
+    // If the host was in the negative cache with an expired (or disabled) TTL,
+    // claim the single-flight retry under unique_lock before the blocking DNS
+    // call.  Re-arming the eviction_time to now() makes concurrent callers see
+    // an unexpired entry, bounding retries to one per host per TTL period.
+    if (has_negative_entry) {
+        std::unique_lock<std::shared_mutex> lock(mutex);
+        auto neg_it = _negative_cache.find(hostname);
+        if (neg_it != _negative_cache.end()) {
+            int32_t ttl = config::dns_cache_negative_ttl_seconds;
+            if (ttl <= 0) {
+                _negative_cache.erase(neg_it);
+            } else {
+                auto deadline = neg_it->second + std::chrono::seconds(ttl);
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    neg_it->second = std::chrono::steady_clock::now();
+                } else {
+                    return Status::InternalError(
+                            "Hostname {} is in negative DNS cache (recently evicted), "
+                            "skipping resolve",
+                            hostname);
+                }
+            }
+        }
+    }
+
     // First access (or negative TTL expired): resolve and populate the cache.
     // Consume the IP returned by _update() directly to avoid a second cache
     // lookup — operator[] under a shared_lock would mutate the map and could
     // reinsert an empty entry if a concurrent refresh cycle evicted the hostname
     // between _update() and here.
-    Status st = _update(hostname, nullptr, ip);
-    if (!st.ok() && expired_negative) {
-        // DNS is still failing after the backoff window.  Re-arm the negative
-        // cache so the retry rate stays bounded at one attempt per TTL period —
-        // otherwise every concurrent caller blocks on a full DNS timeout each time.
-        int32_t ttl = config::dns_cache_negative_ttl_seconds;
-        if (ttl > 0) {
-            std::unique_lock<std::shared_mutex> lock(mutex);
-            _negative_cache[hostname] =
-                    std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
-        }
-    }
-    return st;
+    return _update(hostname, nullptr, ip);
 }
 
 // Resolve hostname to IP address, similar to Java's DNSCache.resolveHostname.
@@ -170,7 +185,7 @@ void DNSCache::_erase(const std::string& hostname) {
     failure_count.erase(hostname);
     int32_t ttl = config::dns_cache_negative_ttl_seconds;
     if (ttl > 0) {
-        _negative_cache[hostname] = std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+        _negative_cache[hostname] = std::chrono::steady_clock::now();
     }
 }
 
@@ -186,7 +201,7 @@ bool DNSCache::_erase_if_still_failing(const std::string& hostname, uint32_t thr
     failure_count.erase(hostname);
     int32_t ttl = config::dns_cache_negative_ttl_seconds;
     if (ttl > 0) {
-        _negative_cache[hostname] = std::chrono::steady_clock::now() + std::chrono::seconds(ttl);
+        _negative_cache[hostname] = std::chrono::steady_clock::now();
     }
     return true;
 }
@@ -233,15 +248,6 @@ Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, st
 }
 
 void DNSCache::_refresh_once() {
-    // Purge expired negative-cache entries to prevent unbounded map growth.
-    {
-        std::unique_lock<std::shared_mutex> lock(mutex);
-        auto now = std::chrono::steady_clock::now();
-        for (auto it = _negative_cache.begin(); it != _negative_cache.end();) {
-            it = (now >= it->second) ? _negative_cache.erase(it) : std::next(it);
-        }
-    }
-
     std::unordered_set<std::string> keys;
     {
         std::shared_lock<std::shared_mutex> lock(mutex);

--- a/be/src/util/dns_cache.cpp
+++ b/be/src/util/dns_cache.cpp
@@ -17,6 +17,8 @@
 
 #include "util/dns_cache.h"
 
+#include <netdb.h>
+
 #include <algorithm>
 #include <atomic>
 #include <unordered_set>
@@ -59,9 +61,14 @@ Status DNSCache::get(const std::string& hostname, std::string* ip) {
             if (ttl > 0) {
                 auto deadline = neg_it->second + std::chrono::seconds(ttl);
                 if (std::chrono::steady_clock::now() < deadline) {
-                    return Status::InternalError(
-                            "Hostname {} is in negative DNS cache (recently evicted), "
-                            "skipping resolve",
+                    // No stack trace: this is an expected steady state, not an anomaly, and
+                    // it is returned once per caller request for as long as the host stays
+                    // unresolvable. Capturing a stack here would make Status::Error() log a
+                    // WARNING per call (and every caller logs status.to_string() again),
+                    // recreating exactly the be.WARNING flood this cache exists to stop.
+                    return Status::InternalError<false>(
+                            "Hostname {} is in negative DNS cache (recently evicted or "
+                            "unresolvable), skipping resolve",
                             hostname);
                 }
             }
@@ -85,9 +92,10 @@ Status DNSCache::get(const std::string& hostname, std::string* ip) {
                 if (std::chrono::steady_clock::now() >= deadline) {
                     neg_it->second = std::chrono::steady_clock::now();
                 } else {
-                    return Status::InternalError(
-                            "Hostname {} is in negative DNS cache (recently evicted), "
-                            "skipping resolve",
+                    // Lost the single-flight race; see above for why this carries no stack.
+                    return Status::InternalError<false>(
+                            "Hostname {} is in negative DNS cache (recently evicted or "
+                            "unresolvable), skipping resolve",
                             hostname);
                 }
             }
@@ -120,12 +128,24 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname, bool* is_fr
 
     // Try to resolve hostname
     std::string resolved_ip;
-    Status status = _resolver
-                            ? _resolver(hostname, resolved_ip, BackendOptions::is_bind_ipv6())
-                            : hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6());
+    int gai_err = 0;
+    Status status =
+            _resolver ? _resolver(hostname, resolved_ip, BackendOptions::is_bind_ipv6(), &gai_err)
+                      : hostname_to_ip(hostname, resolved_ip, BackendOptions::is_bind_ipv6(),
+                                       &gai_err);
 
     if (!status.ok() || resolved_ip.empty()) {
-        if (is_fresh) *is_fresh = false;
+        if (is_fresh) {
+            *is_fresh = false;
+        }
+        // EAI_NONAME is the resolver authoritatively answering "this name does not exist",
+        // which is the only evidence that a backend is really gone. Everything else
+        // (EAI_AGAIN = resolver unreachable or timed out, EAI_SYSTEM, EAI_FAIL, ...) means
+        // DNS itself is unhealthy while the host is most likely still up at its last known
+        // address, so those failures must never lead to eviction — otherwise a resolver
+        // outage would wipe every hostname at once and turn a DNS incident into a
+        // cluster-wide RPC outage.
+        const bool authoritative = (gai_err == EAI_NONAME);
         if (!cached_ip.empty()) {
             // Only track failure counts for hosts that are currently in the cache.
             // Hosts that were never cached or have already been evicted are not
@@ -139,7 +159,12 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname, bool* is_fr
                 // can block for seconds on DNS timeout, widening the window).
                 // Skipping the bump here preserves keys(failure_count) ⊆ keys(cache).
                 if (cache.find(hostname) != cache.end()) {
-                    failures = ++failure_count[hostname];
+                    FailureState& state = failure_count[hostname];
+                    // The counter tracks failures of any kind so the throttled log below
+                    // stays informative during a resolver outage; only `last_authoritative`
+                    // gates eviction.
+                    failures = ++state.count;
+                    state.last_authoritative = authoritative;
                 }
             }
             // Throttle the log: only every N failures or the first failure.
@@ -147,7 +172,9 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname, bool* is_fr
                 int32_t every_n = std::max(1, config::dns_cache_log_every_n_failures);
                 if (failures == 1 || failures % static_cast<uint32_t>(every_n) == 0) {
                     LOG(WARNING) << "Failed to resolve hostname " << hostname
-                                 << " (consecutive failures: " << failures
+                                 << " (consecutive failures: " << failures << ", error: "
+                                 << (authoritative ? "NXDOMAIN, host is gone"
+                                                   : "transient, DNS unhealthy")
                                  << "), use cached ip: " << cached_ip;
                 }
             }
@@ -171,7 +198,9 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname, bool* is_fr
     }
 
     // Resolution succeeded - clear failure counter for this hostname.
-    if (is_fresh) *is_fresh = true;
+    if (is_fresh) {
+        *is_fresh = true;
+    }
     {
         std::unique_lock<std::shared_mutex> lock(mutex);
         failure_count.erase(hostname);
@@ -179,41 +208,67 @@ std::string DNSCache::_resolve_hostname(const std::string& hostname, bool* is_fr
     return resolved_ip;
 }
 
-void DNSCache::_erase(const std::string& hostname) {
-    std::unique_lock<std::shared_mutex> lock(mutex);
+void DNSCache::_evict_locked(const std::string& hostname) {
     cache.erase(hostname);
     failure_count.erase(hostname);
     int32_t ttl = config::dns_cache_negative_ttl_seconds;
     if (ttl > 0) {
         _negative_cache[hostname] = std::chrono::steady_clock::now();
     }
+}
+
+void DNSCache::_remember_unresolvable(const std::string& hostname) {
+    int32_t ttl = config::dns_cache_negative_ttl_seconds;
+    if (ttl <= 0) {
+        return;
+    }
+    std::unique_lock<std::shared_mutex> lock(mutex);
+    // try_emplace, not operator[]: get()'s single-flight path may have just re-armed this
+    // tombstone to now(); overwriting it would be harmless there but would also let two
+    // callers racing on the same host each reset the deadline, loosening the rate limit.
+    _negative_cache.try_emplace(hostname, std::chrono::steady_clock::now());
+}
+
+void DNSCache::_erase(const std::string& hostname) {
+    std::unique_lock<std::shared_mutex> lock(mutex);
+    _evict_locked(hostname);
 }
 
 bool DNSCache::_erase_if_still_failing(const std::string& hostname, uint32_t threshold) {
     std::unique_lock<std::shared_mutex> lock(mutex);
     auto fc_it = failure_count.find(hostname);
-    if (fc_it == failure_count.end() || fc_it->second < threshold) {
-        // A concurrent successful resolution cleared or reset the counter between
-        // _update() returning and this call — do not erase a now-healthy entry.
+    if (fc_it == failure_count.end() || fc_it->second.count < threshold ||
+        !fc_it->second.last_authoritative) {
+        // Either a concurrent successful resolution cleared or reset the counter between
+        // _update() returning and this call — do not erase a now-healthy entry — or the
+        // most recent failure was transient (resolver unreachable) rather than an
+        // authoritative NXDOMAIN, in which case the host is probably still alive.
         return false;
     }
-    cache.erase(hostname);
-    failure_count.erase(hostname);
-    int32_t ttl = config::dns_cache_negative_ttl_seconds;
-    if (ttl > 0) {
-        _negative_cache[hostname] = std::chrono::steady_clock::now();
-    }
+    _evict_locked(hostname);
     return true;
 }
 
-Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, std::string* out_ip) {
+Status DNSCache::_update(const std::string& hostname, FailureState* out_state,
+                         std::string* out_ip) {
     bool is_fresh = false;
     std::string real_ip = _resolve_hostname(hostname, &is_fresh);
     if (real_ip.empty()) {
-        if (out_failures) *out_failures = 0;
-        if (out_ip) out_ip->clear();
-        return Status::InternalError("Failed to resolve hostname {} and no cached ip available",
-                                     hostname);
+        if (out_state) {
+            *out_state = FailureState {};
+        }
+        if (out_ip) {
+            out_ip->clear();
+        }
+        // The host could not be resolved and has no cached IP to fall back on, so it never
+        // entered `cache` and will therefore never reach the eviction path that writes a
+        // tombstone. Record one here as well: otherwise every single get() on a hostname
+        // that has never resolved (a typo in the FE, a backend registered before its DNS
+        // record propagated) pays a full blocking getaddrinfo, and many of those calls run
+        // on bthreads where long blocking is especially costly.
+        _remember_unresolvable(hostname);
+        return Status::InternalError<false>(
+                "Failed to resolve hostname {} and no cached ip available", hostname);
     }
 
     std::unique_lock<std::shared_mutex> lock(mutex);
@@ -224,9 +279,15 @@ Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, st
     // result (is_fresh == true, meaning DNS actually resolved) may override an
     // eviction — which indicates the backend is genuinely back.
     if (!is_fresh && _negative_cache.count(hostname)) {
-        if (out_failures) *out_failures = 0;
-        if (out_ip) out_ip->clear();
-        return Status::InternalError(
+        if (out_state) {
+            *out_state = FailureState {};
+        }
+        if (out_ip) {
+            out_ip->clear();
+        }
+        // No stack trace: like the negative-cache hits in get(), this is an expected
+        // outcome that can repeat on every request while the host stays evicted.
+        return Status::InternalError<false>(
                 "Hostname {} was concurrently evicted; stale-fallback not reinserted", hostname);
     }
     auto it = cache.find(hostname);
@@ -237,12 +298,14 @@ Status DNSCache::_update(const std::string& hostname, uint32_t* out_failures, st
     // DNS resolved successfully — remove any negative cache tombstone so
     // subsequent get() calls go straight to the main cache.
     _negative_cache.erase(hostname);
-    if (out_ip) *out_ip = real_ip;
+    if (out_ip) {
+        *out_ip = real_ip;
+    }
     // Read failure_count under the same lock we already hold, so _refresh_once
     // does not need a second lock acquisition to decide on eviction.
-    if (out_failures) {
+    if (out_state) {
         auto fc_it = failure_count.find(hostname);
-        *out_failures = fc_it != failure_count.end() ? fc_it->second : 0;
+        *out_state = fc_it != failure_count.end() ? fc_it->second : FailureState {};
     }
     return Status::OK();
 }
@@ -255,8 +318,15 @@ void DNSCache::_refresh_once() {
                        [](const auto& pair) { return pair.first; });
     }
     for (auto& key : keys) {
-        uint32_t failures = 0;
-        Status st = _update(key, &failures);
+        // Each _update() below performs a blocking getaddrinfo, so one cycle over a
+        // cluster whose DNS is timing out can take minutes. Without this check the
+        // destructor's join() would be held up for exactly that long, which would
+        // undo the point of making the wait itself interruptible.
+        if (stop_refresh.load(std::memory_order_acquire)) {
+            break;
+        }
+        FailureState state;
+        Status st = _update(key, &state);
         if (!st.ok()) {
             // _update returns an error either when _resolve_hostname returns ""
             // (no fallback IP) or when a stale fallback was suppressed because
@@ -271,14 +341,18 @@ void DNSCache::_refresh_once() {
         //   1) be.WARNING gets flooded with `failed to get ip from host`.
         //   2) brpc keeps re-using the stale IP from cache, producing
         //      `Fail to wait EPOLLOUT ... Connection timed out`.
+        // `last_authoritative` keeps this restricted to hosts the resolver has positively
+        // reported as non-existent; a DNS outage yields transient errors for every host at
+        // once and must leave the cache (and the stale-IP fallback) intact.
         int32_t threshold = config::dns_cache_max_consecutive_failures;
-        if (threshold > 0 && failures >= static_cast<uint32_t>(threshold)) {
+        if (threshold > 0 && state.last_authoritative &&
+            state.count >= static_cast<uint32_t>(threshold)) {
             // Re-read failure_count under the mutex that also performs the erase
             // to fence any concurrent success that cleared the counter between
             // _update() returning and this point.
             if (_erase_if_still_failing(key, static_cast<uint32_t>(threshold))) {
-                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after " << failures
-                             << " consecutive resolution failures";
+                LOG(WARNING) << "Evicting hostname " << key << " from DNS cache after "
+                             << state.count << " consecutive resolution failures";
             }
         }
     }

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <iostream>
 #include <shared_mutex>
 #include <string>
@@ -38,6 +39,12 @@ public:
     // get ip by hostname
     Status get(const std::string& hostname, std::string* ip);
 
+    // visible for testing
+    size_t size_for_test() const {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        return cache.size();
+    }
+
 private:
     // Resolve hostname to IP address.
     // If resolution fails, falls back to cached IP if available.
@@ -47,6 +54,9 @@ private:
     // update the ip of hostname in cache
     Status _update(const std::string& hostname);
 
+    // erase a hostname from cache (with unique_lock)
+    void _erase(const std::string& hostname);
+
     // a function for refresh daemon thread
     // update cache at fix internal
     void _refresh_cache();
@@ -54,6 +64,8 @@ private:
 private:
     // hostname -> ip
     std::unordered_map<std::string, std::string> cache;
+    // hostname -> consecutive resolution failure count
+    std::unordered_map<std::string, uint32_t> failure_count;
     mutable std::shared_mutex mutex;
     std::thread refresh_thread;
     bool stop_refresh = false;

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <iostream>
 #include <shared_mutex>
 #include <string>
@@ -33,7 +34,14 @@ namespace doris {
 // fe/fe-core/src/main/java/org/apache/doris/common/DNSCache.java
 class DNSCache {
 public:
+    using Resolver = std::function<Status(const std::string&, std::string&, bool)>;
+
     DNSCache();
+
+    // Test-only constructor: uses a custom resolver and does NOT start the
+    // background refresh thread.  Call refresh_for_test() to drive one cycle.
+    explicit DNSCache(Resolver resolver);
+
     ~DNSCache();
 
     // get ip by hostname
@@ -44,6 +52,16 @@ public:
         std::shared_lock<std::shared_mutex> lock(mutex);
         return cache.size();
     }
+
+    uint32_t failure_count_for_test(const std::string& hostname) const {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        auto it = failure_count.find(hostname);
+        return it != failure_count.end() ? it->second : 0;
+    }
+
+    // Run one refresh cycle synchronously (no sleep).  Only meaningful when
+    // the object was constructed with the test constructor (no background thread).
+    void refresh_for_test() { _refresh_once(); }
 
 private:
     // Resolve hostname to IP address.
@@ -57,11 +75,15 @@ private:
     // erase a hostname from cache (with unique_lock)
     void _erase(const std::string& hostname);
 
+    // one refresh cycle: update every cached hostname and evict if needed
+    void _refresh_once();
+
     // a function for refresh daemon thread
     // update cache at fix internal
     void _refresh_cache();
 
 private:
+    Resolver _resolver; // null → use global hostname_to_ip
     // hostname -> ip
     std::unordered_map<std::string, std::string> cache;
     // hostname -> consecutive resolution failure count
@@ -70,5 +92,7 @@ private:
     std::thread refresh_thread;
     bool stop_refresh = false;
 };
+
+} // end of namespace doris
 
 } // end of namespace doris

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -47,22 +47,6 @@ public:
     // get ip by hostname
     Status get(const std::string& hostname, std::string* ip);
 
-    // visible for testing
-    size_t size_for_test() const {
-        std::shared_lock<std::shared_mutex> lock(mutex);
-        return cache.size();
-    }
-
-    uint32_t failure_count_for_test(const std::string& hostname) const {
-        std::shared_lock<std::shared_mutex> lock(mutex);
-        auto it = failure_count.find(hostname);
-        return it != failure_count.end() ? it->second : 0;
-    }
-
-    // Run one refresh cycle synchronously (no sleep).  Only meaningful when
-    // the object was constructed with the test constructor (no background thread).
-    void refresh_for_test() { _refresh_once(); }
-
 private:
     // Resolve hostname to IP address.
     // If resolution fails, falls back to cached IP if available.
@@ -82,6 +66,24 @@ private:
     // update cache at fix internal
     void _refresh_cache();
 
+    // ── test helpers (accessible via friend class DNSCacheTest) ──────────────
+    size_t size_for_test() const {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        return cache.size();
+    }
+
+    uint32_t failure_count_for_test(const std::string& hostname) const {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        auto it = failure_count.find(hostname);
+        return it != failure_count.end() ? it->second : 0;
+    }
+
+    // Run one refresh cycle synchronously (no sleep).  Only meaningful when
+    // the object was constructed with the test constructor (no background thread).
+    void refresh_for_test() { _refresh_once(); }
+
+    friend class DNSCacheTest;
+
 private:
     Resolver _resolver; // null → use global hostname_to_ip
     // hostname -> ip
@@ -92,7 +94,5 @@ private:
     std::thread refresh_thread;
     bool stop_refresh = false;
 };
-
-} // end of namespace doris
 
 } // end of namespace doris

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -17,10 +17,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <thread>
@@ -53,10 +56,12 @@ private:
     // Returns the resolved IP, or cached IP on failure, or empty string if no cache available.
     std::string _resolve_hostname(const std::string& hostname);
 
-    // update the ip of hostname in cache; if out_failures is non-null, it is
-    // set to the current consecutive failure count for hostname (read under the
-    // same lock used to update cache, avoiding a second lock acquisition).
-    Status _update(const std::string& hostname, uint32_t* out_failures = nullptr);
+    // update the ip of hostname in cache; out_failures (if non-null) is set to
+    // the current consecutive failure count read under the same lock; out_ip (if
+    // non-null) receives the resolved IP so callers can use it without a second
+    // cache lookup (avoids operator[] mutation under shared_lock).
+    Status _update(const std::string& hostname, uint32_t* out_failures = nullptr,
+                   std::string* out_ip = nullptr);
 
     // erase a hostname from cache (with unique_lock)
     void _erase(const std::string& hostname);
@@ -94,7 +99,10 @@ private:
     std::unordered_map<std::string, uint32_t> failure_count;
     mutable std::shared_mutex mutex;
     std::thread refresh_thread;
-    bool stop_refresh = false;
+    // Protects stop_refresh and signals _refresh_cache to wake early on destroy.
+    std::mutex _cv_mutex;
+    std::condition_variable _cv;
+    std::atomic<bool> stop_refresh {false};
 };
 
 } // end of namespace doris

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -53,8 +53,10 @@ private:
     // Returns the resolved IP, or cached IP on failure, or empty string if no cache available.
     std::string _resolve_hostname(const std::string& hostname);
 
-    // update the ip of hostname in cache
-    Status _update(const std::string& hostname);
+    // update the ip of hostname in cache; if out_failures is non-null, it is
+    // set to the current consecutive failure count for hostname (read under the
+    // same lock used to update cache, avoiding a second lock acquisition).
+    Status _update(const std::string& hostname, uint32_t* out_failures = nullptr);
 
     // erase a hostname from cache (with unique_lock)
     void _erase(const std::string& hostname);

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -54,7 +54,9 @@ private:
     // Resolve hostname to IP address.
     // If resolution fails, falls back to cached IP if available.
     // Returns the resolved IP, or cached IP on failure, or empty string if no cache available.
-    std::string _resolve_hostname(const std::string& hostname);
+    // *is_fresh is set to true when DNS returned a live result, false when the
+    // returned IP is the stale cached fallback from a failed lookup.
+    std::string _resolve_hostname(const std::string& hostname, bool* is_fresh = nullptr);
 
     // update the ip of hostname in cache; out_failures (if non-null) is set to
     // the current consecutive failure count read under the same lock; out_ip (if
@@ -63,8 +65,14 @@ private:
     Status _update(const std::string& hostname, uint32_t* out_failures = nullptr,
                    std::string* out_ip = nullptr);
 
-    // erase a hostname from cache (with unique_lock)
+    // erase a hostname from cache unconditionally (with unique_lock)
     void _erase(const std::string& hostname);
+
+    // Erase a hostname from cache only if failure_count still meets threshold.
+    // Re-reads the live counter under the same lock that performs the erase, so
+    // a concurrent successful resolution that cleared the counter is not lost.
+    // Returns true if the host was erased, false if the counter was already reset.
+    bool _erase_if_still_failing(const std::string& hostname, uint32_t threshold);
 
     // one refresh cycle: update every cached hostname and evict if needed
     void _refresh_once();

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -102,13 +102,16 @@ private:
     // the object was constructed with the test constructor (no background thread).
     void refresh_for_test() { _refresh_once(); }
 
-    // Backdate all negative-cache entries to epoch so they appear expired
-    // without removing them.  Use this to simulate TTL expiry in tests that
-    // need the re-arm path in get() to trigger.
+    // Backdate all negative-cache entries far into the past so they appear
+    // expired without removing them.  Use this to simulate TTL expiry in tests
+    // that need the re-arm path in get() to trigger.
+    // Backdating relative to now() (rather than to steady_clock's epoch, which is
+    // typically boot time) keeps this correct on a freshly booted host.
     void _expire_negative_cache_for_test() {
         std::unique_lock<std::shared_mutex> lock(mutex);
+        auto backdated = std::chrono::steady_clock::now() - std::chrono::hours(24 * 365);
         for (auto& [k, v] : _negative_cache) {
-            v = std::chrono::steady_clock::time_point {};
+            v = backdated;
         }
     }
 

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -79,6 +79,11 @@ private:
         return cache.size();
     }
 
+    size_t negative_cache_size_for_test() const {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        return _negative_cache.size();
+    }
+
     uint32_t failure_count_for_test(const std::string& hostname) const {
         std::shared_lock<std::shared_mutex> lock(mutex);
         auto it = failure_count.find(hostname);
@@ -89,6 +94,11 @@ private:
     // the object was constructed with the test constructor (no background thread).
     void refresh_for_test() { _refresh_once(); }
 
+    void _clear_negative_cache_for_test() {
+        std::unique_lock<std::shared_mutex> lock(mutex);
+        _negative_cache.clear();
+    }
+
     friend class DNSCacheTest;
 
 private:
@@ -97,6 +107,9 @@ private:
     std::unordered_map<std::string, std::string> cache;
     // hostname -> consecutive resolution failure count
     std::unordered_map<std::string, uint32_t> failure_count;
+    // hostname -> earliest time to retry; populated on eviction, prevents
+    // blocking DNS resolves for recently-dropped backends.
+    std::unordered_map<std::string, std::chrono::steady_clock::time_point> _negative_cache;
     mutable std::shared_mutex mutex;
     std::thread refresh_thread;
     // Protects stop_refresh and signals _refresh_cache to wake early on destroy.

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -107,6 +107,16 @@ private:
         _negative_cache.clear();
     }
 
+    // Backdate all negative-cache entries to epoch so they appear expired
+    // without removing them.  Use this to simulate TTL expiry in tests that
+    // need the re-arm path in get() to trigger.
+    void _expire_negative_cache_for_test() {
+        std::unique_lock<std::shared_mutex> lock(mutex);
+        for (auto& [k, v] : _negative_cache) {
+            v = std::chrono::steady_clock::time_point {};
+        }
+    }
+
     friend class DNSCacheTest;
 
 private:

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -102,11 +102,6 @@ private:
     // the object was constructed with the test constructor (no background thread).
     void refresh_for_test() { _refresh_once(); }
 
-    void _clear_negative_cache_for_test() {
-        std::unique_lock<std::shared_mutex> lock(mutex);
-        _negative_cache.clear();
-    }
-
     // Backdate all negative-cache entries to epoch so they appear expired
     // without removing them.  Use this to simulate TTL expiry in tests that
     // need the re-arm path in get() to trigger.
@@ -125,8 +120,8 @@ private:
     std::unordered_map<std::string, std::string> cache;
     // hostname -> consecutive resolution failure count
     std::unordered_map<std::string, uint32_t> failure_count;
-    // hostname -> earliest time to retry; populated on eviction, prevents
-    // blocking DNS resolves for recently-dropped backends.
+    // hostname -> eviction timestamp; effective deadline is computed as
+    // eviction_time + dns_cache_negative_ttl_seconds to honor live config changes.
     std::unordered_map<std::string, std::chrono::steady_clock::time_point> _negative_cache;
     mutable std::shared_mutex mutex;
     std::thread refresh_thread;

--- a/be/src/util/dns_cache.h
+++ b/be/src/util/dns_cache.h
@@ -37,7 +37,21 @@ namespace doris {
 // fe/fe-core/src/main/java/org/apache/doris/common/DNSCache.java
 class DNSCache {
 public:
-    using Resolver = std::function<Status(const std::string&, std::string&, bool)>;
+    // (hostname, out_ip, is_ipv6, out_gai_err) -> Status.
+    // out_gai_err receives the raw getaddrinfo() return code so the cache can tell an
+    // authoritative "no such host" (EAI_NONAME) apart from a transient resolver failure.
+    using Resolver = std::function<Status(const std::string&, std::string&, bool, int*)>;
+
+    // Per-hostname failure bookkeeping. Only tracked for hostnames currently present in
+    // `cache`, which keeps the map bounded (invariant: keys(failure_count) ⊆ keys(cache)).
+    struct FailureState {
+        // Consecutive resolution failures of any kind. Drives the log throttle.
+        uint32_t count = 0;
+        // Whether the most recent failure was an authoritative NXDOMAIN. Eviction requires
+        // this to be true, so that a DNS-server outage (which yields EAI_AGAIN for every
+        // hostname at once) degrades to the stale cached IP instead of wiping the cache.
+        bool last_authoritative = false;
+    };
 
     DNSCache();
 
@@ -58,21 +72,31 @@ private:
     // returned IP is the stale cached fallback from a failed lookup.
     std::string _resolve_hostname(const std::string& hostname, bool* is_fresh = nullptr);
 
-    // update the ip of hostname in cache; out_failures (if non-null) is set to
-    // the current consecutive failure count read under the same lock; out_ip (if
-    // non-null) receives the resolved IP so callers can use it without a second
-    // cache lookup (avoids operator[] mutation under shared_lock).
-    Status _update(const std::string& hostname, uint32_t* out_failures = nullptr,
+    // update the ip of hostname in cache; out_state (if non-null) is set to the
+    // current failure bookkeeping read under the same lock; out_ip (if non-null)
+    // receives the resolved IP so callers can use it without a second cache lookup
+    // (avoids operator[] mutation under shared_lock).
+    Status _update(const std::string& hostname, FailureState* out_state = nullptr,
                    std::string* out_ip = nullptr);
 
     // erase a hostname from cache unconditionally (with unique_lock)
     void _erase(const std::string& hostname);
 
-    // Erase a hostname from cache only if failure_count still meets threshold.
-    // Re-reads the live counter under the same lock that performs the erase, so
-    // a concurrent successful resolution that cleared the counter is not lost.
-    // Returns true if the host was erased, false if the counter was already reset.
+    // Erase a hostname from cache only if it still meets the eviction criteria:
+    // failure_count >= threshold AND the most recent failure was authoritative.
+    // Re-reads the live state under the same lock that performs the erase, so a
+    // concurrent successful resolution that cleared it is not lost.
+    // Returns true if the host was erased, false otherwise.
     bool _erase_if_still_failing(const std::string& hostname, uint32_t threshold);
+
+    // Drop a hostname from the cache and write a negative-cache tombstone (subject to
+    // dns_cache_negative_ttl_seconds). Caller must already hold a unique_lock on `mutex`.
+    void _evict_locked(const std::string& hostname);
+
+    // Record a tombstone for a hostname that could not be resolved and has no cached IP,
+    // so repeated get() calls do not each pay a full blocking getaddrinfo. Uses
+    // try_emplace so an entry just re-armed by get()'s single-flight path is preserved.
+    void _remember_unresolvable(const std::string& hostname);
 
     // one refresh cycle: update every cached hostname and evict if needed
     void _refresh_once();
@@ -95,7 +119,7 @@ private:
     uint32_t failure_count_for_test(const std::string& hostname) const {
         std::shared_lock<std::shared_mutex> lock(mutex);
         auto it = failure_count.find(hostname);
-        return it != failure_count.end() ? it->second : 0;
+        return it != failure_count.end() ? it->second.count : 0;
     }
 
     // Run one refresh cycle synchronously (no sleep).  Only meaningful when
@@ -121,8 +145,8 @@ private:
     Resolver _resolver; // null → use global hostname_to_ip
     // hostname -> ip
     std::unordered_map<std::string, std::string> cache;
-    // hostname -> consecutive resolution failure count
-    std::unordered_map<std::string, uint32_t> failure_count;
+    // hostname -> consecutive resolution failure bookkeeping
+    std::unordered_map<std::string, FailureState> failure_count;
     // hostname -> eviction timestamp; effective deadline is computed as
     // eviction_time + dns_cache_negative_ttl_seconds to honor live config changes.
     std::unordered_map<std::string, std::chrono::steady_clock::time_point> _negative_cache;

--- a/be/src/util/network_util.cpp
+++ b/be/src/util/network_util.cpp
@@ -119,13 +119,13 @@ bool parse_endpoint(const std::string& endpoint, std::string* host, uint16_t* po
     return true;
 }
 
-Status hostname_to_ip(const std::string& host, std::string& ip) {
+Status hostname_to_ip(const std::string& host, std::string& ip, int* gai_err) {
     auto start = std::chrono::high_resolution_clock::now();
-    Status status = hostname_to_ipv4(host, ip);
+    Status status = hostname_to_ipv4(host, ip, gai_err);
     if (status.ok()) {
         return status;
     }
-    status = hostname_to_ipv6(host, ip);
+    status = hostname_to_ipv6(host, ip, gai_err);
 
     auto current = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(current - start);
@@ -136,15 +136,15 @@ Status hostname_to_ip(const std::string& host, std::string& ip) {
     return status;
 }
 
-Status hostname_to_ip(const std::string& host, std::string& ip, bool ipv6) {
+Status hostname_to_ip(const std::string& host, std::string& ip, bool ipv6, int* gai_err) {
     if (ipv6) {
-        return hostname_to_ipv6(host, ip);
+        return hostname_to_ipv6(host, ip, gai_err);
     } else {
-        return hostname_to_ipv4(host, ip);
+        return hostname_to_ipv4(host, ip, gai_err);
     }
 }
 
-Status hostname_to_ipv4(const std::string& host, std::string& ip) {
+Status hostname_to_ipv4(const std::string& host, std::string& ip, int* gai_err) {
     addrinfo hints, *res;
     in_addr addr;
 
@@ -152,10 +152,17 @@ Status hostname_to_ipv4(const std::string& host, std::string& ip) {
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_family = AF_INET;
     int err = getaddrinfo(host.c_str(), NULL, &hints, &res);
+    if (gai_err != nullptr) {
+        *gai_err = err;
+    }
     if (err != 0) {
         LOG(WARNING) << "failed to get ip from host: " << host << "err:" << gai_strerror(err);
-        return Status::InternalError("failed to get ip from host: {}, err: {}", host,
-                                     gai_strerror(err));
+        // No stack trace: the WARNING above already carries the host and the resolver error,
+        // and this failure is expected often enough (a decommissioned backend, a hostname
+        // whose DNS record has not propagated yet) that attaching a stack to every
+        // occurrence floods be.WARNING without adding information.
+        return Status::InternalError<false>("failed to get ip from host: {}, err: {}", host,
+                                            gai_strerror(err));
     }
 
     addr.s_addr = ((sockaddr_in*)(res->ai_addr))->sin_addr.s_addr;
@@ -165,7 +172,7 @@ Status hostname_to_ipv4(const std::string& host, std::string& ip) {
     return Status::OK();
 }
 
-Status hostname_to_ipv6(const std::string& host, std::string& ip) {
+Status hostname_to_ipv6(const std::string& host, std::string& ip, int* gai_err) {
     char ipstr2[128];
     struct sockaddr_in6* sockaddr_ipv6;
 
@@ -175,10 +182,14 @@ Status hostname_to_ipv6(const std::string& host, std::string& ip) {
     hint.ai_socktype = SOCK_STREAM;
 
     int err = getaddrinfo(host.c_str(), NULL, &hint, &answer);
+    if (gai_err != nullptr) {
+        *gai_err = err;
+    }
     if (err != 0) {
         LOG(WARNING) << "failed to get ip from host: " << host << "err:" << gai_strerror(err);
-        return Status::InternalError("failed to get ip from host: {}, err: {}", host,
-                                     gai_strerror(err));
+        // See hostname_to_ipv4() for why this error carries no stack trace.
+        return Status::InternalError<false>("failed to get ip from host: {}, err: {}", host,
+                                            gai_strerror(err));
     }
 
     sockaddr_ipv6 = reinterpret_cast<struct sockaddr_in6*>(answer->ai_addr);

--- a/be/src/util/network_util.h
+++ b/be/src/util/network_util.h
@@ -47,13 +47,21 @@ bool is_valid_ip(const std::string& ip);
 
 bool parse_endpoint(const std::string& endpoint, std::string* host, uint16_t* port);
 
-Status hostname_to_ip(const std::string& host, std::string& ip);
+// The `gai_err` out-parameter, when non-null, receives the raw getaddrinfo() return code
+// (0 on success). Callers need it to tell an authoritative "no such host" (EAI_NONAME)
+// apart from a transient resolver problem (EAI_AGAIN, EAI_SYSTEM, ...): the former means
+// the host is really gone, the latter means DNS itself is unhealthy while the host is
+// most likely still alive. DNSCache relies on that distinction so a resolver outage does
+// not get mistaken for every backend disappearing at once.
+// For the two-argument hostname_to_ip(), which falls back from IPv4 to IPv6, `gai_err`
+// reports the code of the last attempt.
+Status hostname_to_ip(const std::string& host, std::string& ip, int* gai_err = nullptr);
 
-Status hostname_to_ipv4(const std::string& host, std::string& ip);
+Status hostname_to_ipv4(const std::string& host, std::string& ip, int* gai_err = nullptr);
 
-Status hostname_to_ipv6(const std::string& host, std::string& ip);
+Status hostname_to_ipv6(const std::string& host, std::string& ip, int* gai_err = nullptr);
 
-Status hostname_to_ip(const std::string& host, std::string& ip, bool ipv6);
+Status hostname_to_ip(const std::string& host, std::string& ip, bool ipv6, int* gai_err = nullptr);
 
 // Finds the first non-localhost IP address in the given list. Returns
 // true if such an address was found, false otherwise.

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/dns_cache.h"
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
+
+namespace doris {
+
+class DNSCacheTest : public testing::Test {
+public:
+    DNSCacheTest() = default;
+    ~DNSCacheTest() override = default;
+
+protected:
+    void SetUp() override {
+        _saved_threshold = config::dns_cache_max_consecutive_failures;
+        _saved_log_every = config::dns_cache_log_every_n_failures;
+    }
+
+    void TearDown() override {
+        config::dns_cache_max_consecutive_failures = _saved_threshold;
+        config::dns_cache_log_every_n_failures = _saved_log_every;
+    }
+
+private:
+    int32_t _saved_threshold = 0;
+    int32_t _saved_log_every = 0;
+};
+
+// Sanity: localhost resolves successfully and is cached.
+TEST_F(DNSCacheTest, resolve_localhost) {
+    DNSCache cache;
+    std::string ip;
+    EXPECT_TRUE(cache.get("localhost", &ip).ok());
+    EXPECT_FALSE(ip.empty());
+    // Second call hits the cache fast path and returns the same IP.
+    std::string ip2;
+    EXPECT_TRUE(cache.get("localhost", &ip2).ok());
+    EXPECT_EQ(ip, ip2);
+    EXPECT_EQ(1u, cache.size_for_test());
+}
+
+// Unresolvable hostname on first access returns InternalError and is NOT cached.
+TEST_F(DNSCacheTest, first_miss_does_not_cache) {
+    DNSCache cache;
+    std::string ip;
+    Status st = cache.get("this-host-does-not-exist.invalid", &ip);
+    EXPECT_FALSE(st.ok());
+    EXPECT_EQ(0u, cache.size_for_test());
+}
+
+// Repeated successful resolution does not grow the cache and does not accumulate
+// any failure state.
+TEST_F(DNSCacheTest, success_keeps_cache_stable) {
+    DNSCache cache;
+    std::string ip;
+    for (int i = 0; i < 8; ++i) {
+        EXPECT_TRUE(cache.get("localhost", &ip).ok());
+    }
+    EXPECT_EQ(1u, cache.size_for_test());
+}
+
+// The eviction config can be disabled by setting threshold <= 0 (legacy behavior).
+// In legacy mode, an unresolvable hostname on first access is still not cached,
+// matching the pre-fix semantics for callers.
+TEST_F(DNSCacheTest, eviction_disabled_when_threshold_zero) {
+    config::dns_cache_max_consecutive_failures = 0;
+    DNSCache cache;
+    std::string ip;
+    Status st = cache.get("another-non-existent.invalid", &ip);
+    EXPECT_FALSE(st.ok());
+    EXPECT_EQ(0u, cache.size_for_test());
+}
+
+} // end of namespace doris

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -42,8 +42,7 @@ protected:
     }
 
     // Build a resolver whose failure behaviour can be flipped at runtime.
-    static DNSCache::Resolver make_resolver(bool* should_fail,
-                                            const std::string& ip = "1.2.3.4") {
+    static DNSCache::Resolver make_resolver(bool* should_fail, const std::string& ip = "1.2.3.4") {
         return [should_fail, ip](const std::string&, std::string& out, bool) -> Status {
             if (*should_fail) {
                 return Status::InternalError("mock failure");

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -41,10 +41,24 @@ protected:
         config::dns_cache_log_every_n_failures = _saved_log_every;
     }
 
+    // Build a resolver whose failure behaviour can be flipped at runtime.
+    static DNSCache::Resolver make_resolver(bool* should_fail,
+                                            const std::string& ip = "1.2.3.4") {
+        return [should_fail, ip](const std::string&, std::string& out, bool) -> Status {
+            if (*should_fail) {
+                return Status::InternalError("mock failure");
+            }
+            out = ip;
+            return Status::OK();
+        };
+    }
+
 private:
     int32_t _saved_threshold = 0;
     int32_t _saved_log_every = 0;
 };
+
+// ── existing tests ────────────────────────────────────────────────────────────
 
 // Sanity: localhost resolves successfully and is cached.
 TEST_F(DNSCacheTest, resolve_localhost) {
@@ -89,6 +103,111 @@ TEST_F(DNSCacheTest, eviction_disabled_when_threshold_zero) {
     Status st = cache.get("another-non-existent.invalid", &ip);
     EXPECT_FALSE(st.ok());
     EXPECT_EQ(0u, cache.size_for_test());
+}
+
+// ── new tests for eviction logic ─────────────────────────────────────────────
+
+// A hostname that was once successfully resolved is evicted from the cache after
+// dns_cache_max_consecutive_failures refresh cycles of continuous DNS failure.
+TEST_F(DNSCacheTest, evicts_after_threshold) {
+    config::dns_cache_max_consecutive_failures = 3;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail));
+
+    // Populate the cache with one successful resolution.
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+    ASSERT_EQ("1.2.3.4", ip);
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    // Now make DNS fail.
+    should_fail = true;
+
+    // Each refresh_for_test() call is one _refresh_cache iteration.
+    // The entry must survive the first threshold-1 cycles and disappear on the
+    // threshold-th cycle.
+    for (int i = 0; i < 2; ++i) {
+        cache.refresh_for_test();
+        EXPECT_EQ(1u, cache.size_for_test()) << "should not be evicted yet (i=" << i << ")";
+    }
+    cache.refresh_for_test(); // third failure → threshold reached → eviction
+    EXPECT_EQ(0u, cache.size_for_test()) << "host should have been evicted after threshold";
+}
+
+// One successful resolution resets the failure counter, so a full threshold of
+// additional failures is required before the next eviction.
+TEST_F(DNSCacheTest, success_resets_failure_count) {
+    config::dns_cache_max_consecutive_failures = 3;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail));
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Accumulate threshold-1 failures — must NOT evict.
+    should_fail = true;
+    cache.refresh_for_test();
+    cache.refresh_for_test();
+    EXPECT_EQ(1u, cache.size_for_test()) << "should not be evicted yet";
+
+    // One success clears the counter.
+    should_fail = false;
+    cache.refresh_for_test();
+    EXPECT_EQ(1u, cache.size_for_test()) << "success should keep the cache entry";
+
+    // A full new round of threshold failures is needed before eviction.
+    should_fail = true;
+    cache.refresh_for_test();
+    cache.refresh_for_test();
+    EXPECT_EQ(1u, cache.size_for_test()) << "still not enough failures after counter reset";
+    cache.refresh_for_test(); // third failure post-reset → eviction
+    EXPECT_EQ(0u, cache.size_for_test()) << "evicted after second run of threshold failures";
+}
+
+// A hostname that was never successfully cached must not accumulate entries in
+// failure_count, regardless of how many times get() is called (fix for 7.2).
+TEST_F(DNSCacheTest, failure_count_does_not_grow_for_never_cached_host) {
+    auto always_fail = [](const std::string&, std::string&, bool) -> Status {
+        return Status::InternalError("always fails");
+    };
+    DNSCache cache(always_fail);
+
+    std::string ip;
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_FALSE(cache.get("never-cached.test", &ip).ok());
+    }
+
+    EXPECT_EQ(0u, cache.size_for_test());
+    EXPECT_EQ(0u, cache.failure_count_for_test("never-cached.test"))
+            << "failure_count must not grow for a host that was never successfully resolved";
+}
+
+// After a hostname is evicted, subsequent get() calls must not re-accumulate
+// entries in failure_count (fix for 7.2).
+TEST_F(DNSCacheTest, failure_count_does_not_grow_after_eviction) {
+    config::dns_cache_max_consecutive_failures = 2;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail));
+
+    // Populate cache, then evict.
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+    should_fail = true;
+    cache.refresh_for_test();
+    cache.refresh_for_test();
+    ASSERT_EQ(0u, cache.size_for_test()) << "prerequisite: host must be evicted";
+    EXPECT_EQ(0u, cache.failure_count_for_test("fake-host.test"))
+            << "failure_count must be cleared on eviction";
+
+    // Further get() calls on the evicted host must not re-grow failure_count.
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    }
+    EXPECT_EQ(0u, cache.failure_count_for_test("fake-host.test"))
+            << "failure_count must not grow for an evicted host";
 }
 
 } // end of namespace doris

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -218,8 +218,7 @@ TEST_F(DNSCacheTest, failure_count_not_reintroduced_on_eviction_race) {
     config::dns_cache_max_consecutive_failures = 1000; // disable auto-eviction
 
     DNSCache* cache_ptr = nullptr;
-    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&,
-                                        bool) -> Status {
+    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&, bool) -> Status {
         // Simulate the refresh thread's _erase() landing during the
         // small window when _resolve_hostname holds no lock.
         if (cache_ptr != nullptr) {

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -209,4 +209,47 @@ TEST_F(DNSCacheTest, failure_count_does_not_grow_after_eviction) {
             << "failure_count must not grow for an evicted host";
 }
 
+// Race defense: simulate concurrent eviction happening between _resolve_hostname's
+// shared_lock read of cached_ip and the unique_lock used to ++failure_count.
+// The injected resolver erases the host while DNS resolution is "in flight",
+// mimicking what the refresh thread would do.  Under the cache.find() re-check
+// added to the unique_lock section, failure_count must NOT be re-introduced.
+TEST_F(DNSCacheTest, failure_count_not_reintroduced_on_eviction_race) {
+    config::dns_cache_max_consecutive_failures = 1000; // disable auto-eviction
+
+    DNSCache* cache_ptr = nullptr;
+    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&,
+                                        bool) -> Status {
+        // Simulate the refresh thread's _erase() landing during the
+        // small window when _resolve_hostname holds no lock.
+        if (cache_ptr != nullptr) {
+            cache_ptr->_erase(host);
+        }
+        return Status::InternalError("mock DNS failure during eviction race");
+    };
+
+    DNSCache cache(racing_resolver);
+    cache_ptr = &cache;
+
+    // Pre-populate so cached_ip is non-empty at the shared_lock read,
+    // bypassing _update (which would re-insert after the racing erase).
+    {
+        std::unique_lock<std::shared_mutex> lock(cache.mutex);
+        cache.cache["racing.test"] = "1.2.3.4";
+    }
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    // Call _resolve_hostname directly (via friend access) so the caller-side
+    // re-insert in _update does not mask the behavior we want to verify.
+    std::string returned = cache._resolve_hostname("racing.test");
+
+    // _resolve_hostname returns the cached_ip captured before the race.
+    EXPECT_EQ("1.2.3.4", returned);
+    // The racing erase removed the host from cache.
+    EXPECT_EQ(0u, cache.size_for_test());
+    // The re-check under unique_lock prevented re-creating a failure_count entry.
+    EXPECT_EQ(0u, cache.failure_count_for_test("racing.test"))
+            << "failure_count must not be re-introduced for a host evicted mid-resolution";
+}
+
 } // end of namespace doris

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -354,7 +354,7 @@ TEST_F(DNSCacheTest, concurrent_success_prevents_stale_eviction) {
     // was called a concurrent success cleared failure_count.
     {
         std::unique_lock<std::shared_mutex> lock(cache.mutex);
-        cache.failure_count["fake-host.test"] = 1; // set to threshold
+        cache.failure_count["fake-host.test"] = 1;   // set to threshold
         cache.failure_count.erase("fake-host.test"); // concurrent success clears it
     }
 
@@ -432,7 +432,8 @@ TEST_F(DNSCacheTest, negative_cache_rearms_on_continued_failure_after_ttl_expiry
     int calls_before = resolver_calls;
     EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
     EXPECT_GT(resolver_calls, calls_before) << "resolver called after TTL expiry";
-    EXPECT_EQ(1u, cache.negative_cache_size_for_test()) << "negative cache re-armed on continued failure";
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test())
+            << "negative cache re-armed on continued failure";
 
     // Subsequent calls are now blocked without hitting the resolver.
     calls_before = resolver_calls;

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -34,11 +34,13 @@ protected:
     void SetUp() override {
         _saved_threshold = config::dns_cache_max_consecutive_failures;
         _saved_log_every = config::dns_cache_log_every_n_failures;
+        _saved_negative_ttl = config::dns_cache_negative_ttl_seconds;
     }
 
     void TearDown() override {
         config::dns_cache_max_consecutive_failures = _saved_threshold;
         config::dns_cache_log_every_n_failures = _saved_log_every;
+        config::dns_cache_negative_ttl_seconds = _saved_negative_ttl;
     }
 
     // Build a resolver whose failure behaviour can be flipped at runtime.
@@ -55,6 +57,7 @@ protected:
 private:
     int32_t _saved_threshold = 0;
     int32_t _saved_log_every = 0;
+    int32_t _saved_negative_ttl = 0;
 };
 
 // ── existing tests ────────────────────────────────────────────────────────────
@@ -187,6 +190,7 @@ TEST_F(DNSCacheTest, failure_count_does_not_grow_for_never_cached_host) {
 // entries in failure_count (fix for 7.2).
 TEST_F(DNSCacheTest, failure_count_does_not_grow_after_eviction) {
     config::dns_cache_max_consecutive_failures = 2;
+    config::dns_cache_negative_ttl_seconds = 3600; // keep negative cache active
 
     bool should_fail = false;
     DNSCache cache(make_resolver(&should_fail));
@@ -200,8 +204,11 @@ TEST_F(DNSCacheTest, failure_count_does_not_grow_after_eviction) {
     ASSERT_EQ(0u, cache.size_for_test()) << "prerequisite: host must be evicted";
     EXPECT_EQ(0u, cache.failure_count_for_test("fake-host.test"))
             << "failure_count must be cleared on eviction";
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test())
+            << "evicted host must be in the negative cache";
 
-    // Further get() calls on the evicted host must not re-grow failure_count.
+    // Further get() calls on the evicted host are served from the negative cache
+    // and must not reach the resolver, so failure_count stays zero.
     for (int i = 0; i < 5; ++i) {
         EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
     }
@@ -249,6 +256,84 @@ TEST_F(DNSCacheTest, failure_count_not_reintroduced_on_eviction_race) {
     // The re-check under unique_lock prevented re-creating a failure_count entry.
     EXPECT_EQ(0u, cache.failure_count_for_test("racing.test"))
             << "failure_count must not be re-introduced for a host evicted mid-resolution";
+}
+
+// ── negative cache tests ──────────────────────────────────────────────────────
+
+// After a hostname is evicted, get() must return an error immediately without
+// invoking the resolver, as long as the negative-cache TTL has not expired.
+TEST_F(DNSCacheTest, negative_cache_blocks_resolver_after_eviction) {
+    config::dns_cache_max_consecutive_failures = 2;
+    config::dns_cache_negative_ttl_seconds = 3600; // will not expire during test
+
+    int resolver_calls = 0;
+    bool should_fail = false;
+    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
+        ++resolver_calls;
+        if (should_fail) return Status::InternalError("mock failure");
+        out = "1.2.3.4";
+        return Status::OK();
+    });
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+    ASSERT_EQ(1, resolver_calls);
+
+    // Evict via failures.
+    should_fail = true;
+    cache.refresh_for_test();
+    cache.refresh_for_test();
+    ASSERT_EQ(0u, cache.size_for_test()) << "prerequisite: host must be evicted";
+    ASSERT_EQ(1u, cache.negative_cache_size_for_test());
+
+    int calls_at_eviction = resolver_calls;
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    }
+    EXPECT_EQ(calls_at_eviction, resolver_calls)
+            << "resolver must not be called while host is in the negative cache";
+}
+
+// Once the negative-cache TTL expires (simulated by clearing the map), get()
+// must attempt a fresh resolve; on success the host re-enters the main cache
+// and the negative-cache entry is removed.
+TEST_F(DNSCacheTest, negative_cache_retries_after_ttl_expiry) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    int resolver_calls = 0;
+    bool should_fail = false;
+    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
+        ++resolver_calls;
+        if (should_fail) return Status::InternalError("mock failure");
+        out = "1.2.3.4";
+        return Status::OK();
+    });
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Evict.
+    should_fail = true;
+    cache.refresh_for_test();
+    ASSERT_EQ(0u, cache.size_for_test());
+    ASSERT_EQ(1u, cache.negative_cache_size_for_test());
+
+    // Negative cache blocks the resolver.
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    int calls_while_blocked = resolver_calls;
+
+    // Simulate TTL expiry.
+    cache._clear_negative_cache_for_test();
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test());
+
+    // DNS recovers.
+    should_fail = false;
+    EXPECT_TRUE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_GT(resolver_calls, calls_while_blocked) << "resolver must be called after TTL expiry";
+    EXPECT_EQ(1u, cache.size_for_test()) << "host must be re-cached after successful re-resolve";
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test())
+            << "negative cache entry must be removed on successful re-resolve";
 }
 
 } // end of namespace doris

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
+#include <netdb.h>
 
 #include "common/config.h"
 #include "gtest/gtest_pred_impl.h"
@@ -43,11 +44,42 @@ protected:
         config::dns_cache_negative_ttl_seconds = _saved_negative_ttl;
     }
 
-    // Build a resolver whose failure behaviour can be flipped at runtime.
-    static DNSCache::Resolver make_resolver(bool* should_fail, const std::string& ip = "1.2.3.4") {
-        return [should_fail, ip](const std::string&, std::string& out, bool) -> Status {
+    // Build a resolver whose failure behaviour can be flipped at runtime.  Failures are
+    // reported as authoritative NXDOMAIN by default, which is what eviction requires.
+    static DNSCache::Resolver make_resolver(bool* should_fail, const std::string& ip = "1.2.3.4",
+                                            int fail_gai_err = EAI_NONAME) {
+        return [should_fail, ip, fail_gai_err](const std::string&, std::string& out, bool,
+                                               int* gai_err) -> Status {
             if (*should_fail) {
+                if (gai_err != nullptr) {
+                    *gai_err = fail_gai_err;
+                }
                 return Status::InternalError("mock failure");
+            }
+            if (gai_err != nullptr) {
+                *gai_err = 0;
+            }
+            out = ip;
+            return Status::OK();
+        };
+    }
+
+    // Build a resolver that counts its invocations; failures are authoritative NXDOMAIN
+    // unless `fail_gai_err` says otherwise.
+    static DNSCache::Resolver make_counting_resolver(bool* should_fail, int* calls,
+                                                     const std::string& ip = "1.2.3.4",
+                                                     int fail_gai_err = EAI_NONAME) {
+        return [should_fail, calls, ip, fail_gai_err](const std::string&, std::string& out, bool,
+                                                      int* gai_err) -> Status {
+            ++(*calls);
+            if (*should_fail) {
+                if (gai_err != nullptr) {
+                    *gai_err = fail_gai_err;
+                }
+                return Status::InternalError("mock failure");
+            }
+            if (gai_err != nullptr) {
+                *gai_err = 0;
             }
             out = ip;
             return Status::OK();
@@ -77,11 +109,15 @@ TEST_F(DNSCacheTest, resolve_localhost) {
 
 // Unresolvable hostname on first access returns InternalError and is NOT cached.
 TEST_F(DNSCacheTest, first_miss_does_not_cache) {
+    config::dns_cache_negative_ttl_seconds = 3600;
+
     DNSCache cache;
     std::string ip;
     Status st = cache.get("this-host-does-not-exist.invalid", &ip);
     EXPECT_FALSE(st.ok());
     EXPECT_EQ(0u, cache.size_for_test());
+    // It is tombstoned instead, so the next caller does not pay another getaddrinfo.
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test());
 }
 
 // Repeated successful resolution does not grow the cache and does not accumulate
@@ -196,7 +232,15 @@ TEST_F(DNSCacheTest, success_resets_failure_count) {
 // A hostname that was never successfully cached must not accumulate entries in
 // failure_count, regardless of how many times get() is called (fix for 7.2).
 TEST_F(DNSCacheTest, failure_count_does_not_grow_for_never_cached_host) {
-    auto always_fail = [](const std::string&, std::string&, bool) -> Status {
+    config::dns_cache_negative_ttl_seconds = 0; // no tombstone, so every call reaches the resolver
+
+    int resolver_calls = 0;
+    auto always_fail = [&resolver_calls](const std::string&, std::string&, bool,
+                                         int* gai_err) -> Status {
+        ++resolver_calls;
+        if (gai_err != nullptr) {
+            *gai_err = EAI_NONAME;
+        }
         return Status::InternalError("always fails");
     };
     DNSCache cache(always_fail);
@@ -206,6 +250,7 @@ TEST_F(DNSCacheTest, failure_count_does_not_grow_for_never_cached_host) {
         EXPECT_FALSE(cache.get("never-cached.test", &ip).ok());
     }
 
+    EXPECT_EQ(5, resolver_calls) << "with the negative cache disabled every call resolves";
     EXPECT_EQ(0u, cache.size_for_test());
     EXPECT_EQ(0u, cache.failure_count_for_test("never-cached.test"))
             << "failure_count must not grow for a host that was never successfully resolved";
@@ -250,11 +295,15 @@ TEST_F(DNSCacheTest, failure_count_not_reintroduced_on_eviction_race) {
     config::dns_cache_max_consecutive_failures = 1000; // disable auto-eviction
 
     DNSCache* cache_ptr = nullptr;
-    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&, bool) -> Status {
+    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&, bool,
+                                        int* gai_err) -> Status {
         // Simulate the refresh thread's _erase() landing during the
         // small window when _resolve_hostname holds no lock.
         if (cache_ptr != nullptr) {
             cache_ptr->_erase(host);
+        }
+        if (gai_err != nullptr) {
+            *gai_err = EAI_NONAME;
         }
         return Status::InternalError("mock DNS failure during eviction race");
     };
@@ -293,12 +342,7 @@ TEST_F(DNSCacheTest, negative_cache_blocks_resolver_after_eviction) {
 
     int resolver_calls = 0;
     bool should_fail = false;
-    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
-        ++resolver_calls;
-        if (should_fail) return Status::InternalError("mock failure");
-        out = "1.2.3.4";
-        return Status::OK();
-    });
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
 
     std::string ip;
     ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
@@ -328,12 +372,7 @@ TEST_F(DNSCacheTest, negative_cache_retries_after_ttl_expiry) {
 
     int resolver_calls = 0;
     bool should_fail = false;
-    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
-        ++resolver_calls;
-        if (should_fail) return Status::InternalError("mock failure");
-        out = "1.2.3.4";
-        return Status::OK();
-    });
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
 
     std::string ip;
     ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
@@ -379,8 +418,8 @@ TEST_F(DNSCacheTest, concurrent_success_prevents_stale_eviction) {
     // was called a concurrent success cleared failure_count.
     {
         std::unique_lock<std::shared_mutex> lock(cache.mutex);
-        cache.failure_count["fake-host.test"] = 1;   // set to threshold
-        cache.failure_count.erase("fake-host.test"); // concurrent success clears it
+        cache.failure_count["fake-host.test"] = {1, true}; // at threshold, authoritative
+        cache.failure_count.erase("fake-host.test");       // concurrent success clears it
     }
 
     bool erased = cache._erase_if_still_failing("fake-host.test", 1u);
@@ -397,8 +436,14 @@ TEST_F(DNSCacheTest, stale_fallback_not_reinserted_after_concurrent_eviction) {
     config::dns_cache_negative_ttl_seconds = 3600;
 
     DNSCache* cache_ptr = nullptr;
-    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&, bool) -> Status {
-        if (cache_ptr) cache_ptr->_erase(host); // evict mid-DNS-call
+    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&, bool,
+                                        int* gai_err) -> Status {
+        if (cache_ptr) {
+            cache_ptr->_erase(host); // evict mid-DNS-call
+        }
+        if (gai_err != nullptr) {
+            *gai_err = EAI_NONAME;
+        }
         return Status::InternalError("mock DNS failure during concurrent eviction");
     };
 
@@ -431,12 +476,7 @@ TEST_F(DNSCacheTest, negative_cache_rearms_on_continued_failure_after_ttl_expiry
 
     int resolver_calls = 0;
     bool should_fail = false;
-    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
-        ++resolver_calls;
-        if (should_fail) return Status::InternalError("mock failure");
-        out = "1.2.3.4";
-        return Status::OK();
-    });
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
 
     std::string ip;
     ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
@@ -476,12 +516,7 @@ TEST_F(DNSCacheTest, negative_cache_disabled_when_ttl_set_to_zero) {
 
     int resolver_calls = 0;
     bool should_fail = false;
-    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
-        ++resolver_calls;
-        if (should_fail) return Status::InternalError("mock failure");
-        out = "1.2.3.4";
-        return Status::OK();
-    });
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
 
     std::string ip;
     ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
@@ -543,12 +578,7 @@ TEST_F(DNSCacheTest, single_flight_retry_after_negative_ttl_expiry) {
 
     int resolver_calls = 0;
     bool should_fail = false;
-    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
-        ++resolver_calls;
-        if (should_fail) return Status::InternalError("mock failure");
-        out = "1.2.3.4";
-        return Status::OK();
-    });
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
 
     std::string ip;
     ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
@@ -580,12 +610,7 @@ TEST_F(DNSCacheTest, refresh_does_not_erase_negative_cache_tombstone) {
 
     int resolver_calls = 0;
     bool should_fail = false;
-    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
-        ++resolver_calls;
-        if (should_fail) return Status::InternalError("mock failure");
-        out = "1.2.3.4";
-        return Status::OK();
-    });
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
 
     std::string ip;
     ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
@@ -612,6 +637,183 @@ TEST_F(DNSCacheTest, refresh_does_not_erase_negative_cache_tombstone) {
     calls_before = resolver_calls;
     EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
     EXPECT_EQ(calls_before, resolver_calls) << "blocked after re-arm";
+}
+
+// ── only authoritative NXDOMAIN may evict ────────────────────────────────────
+
+// A resolver outage reports transient errors (EAI_AGAIN) for every hostname at once.
+// Those must never evict: the backends are still alive at their last known IP, and
+// dropping the cache would turn a DNS incident into a cluster-wide RPC outage.
+TEST_F(DNSCacheTest, transient_failure_never_evicts) {
+    config::dns_cache_max_consecutive_failures = 3;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail, "1.2.3.4", EAI_AGAIN));
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    // The resolver is now unreachable, but the host itself is fine.
+    should_fail = true;
+
+    // Far more cycles than the threshold would need if the failures counted.
+    for (int i = 0; i < 20; ++i) {
+        cache.refresh_for_test();
+        ASSERT_EQ(1u, cache.size_for_test())
+                << "transient DNS failures must not evict (cycle " << i << ")";
+    }
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test()) << "no tombstone for a transient failure";
+    // The failure counter still advances so the throttled warning stays informative.
+    EXPECT_EQ(20u, cache.failure_count_for_test("fake-host.test"));
+
+    // Callers keep getting the last known good IP - this is the graceful degradation
+    // that lets the cluster ride out a resolver outage.
+    ip.clear();
+    EXPECT_TRUE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_EQ("1.2.3.4", ip);
+}
+
+// Once the resolver comes back and authoritatively answers NXDOMAIN, the host is
+// evicted on that cycle - the failures accumulated during the outage still count
+// toward the threshold, only the eviction action was withheld.
+TEST_F(DNSCacheTest, authoritative_failure_after_transient_evicts) {
+    config::dns_cache_max_consecutive_failures = 3;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    bool should_fail = false;
+    int fail_gai_err = EAI_AGAIN;
+    DNSCache cache([&should_fail, &fail_gai_err](const std::string&, std::string& out, bool,
+                                                 int* gai_err) -> Status {
+        if (should_fail) {
+            *gai_err = fail_gai_err;
+            return Status::InternalError("mock failure");
+        }
+        *gai_err = 0;
+        out = "1.2.3.4";
+        return Status::OK();
+    });
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Resolver outage: well past the threshold, still no eviction.
+    should_fail = true;
+    for (int i = 0; i < 5; ++i) {
+        cache.refresh_for_test();
+    }
+    ASSERT_EQ(1u, cache.size_for_test()) << "prerequisite: transient failures did not evict";
+
+    // The resolver recovers and states the name does not exist.
+    fail_gai_err = EAI_NONAME;
+    cache.refresh_for_test();
+
+    EXPECT_EQ(0u, cache.size_for_test())
+            << "an authoritative NXDOMAIN past the threshold must evict";
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test());
+}
+
+// _erase_if_still_failing() re-reads the state under the erase lock, so a host whose
+// most recent failure turned transient is spared even if the count is past threshold.
+TEST_F(DNSCacheTest, erase_skipped_when_last_failure_is_transient) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail));
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    {
+        std::unique_lock<std::shared_mutex> lock(cache.mutex);
+        // Past the threshold, but the latest failure was a resolver problem.
+        cache.failure_count["fake-host.test"] = {5, false};
+    }
+
+    EXPECT_FALSE(cache._erase_if_still_failing("fake-host.test", 1u))
+            << "must not erase when the most recent failure was not authoritative";
+    EXPECT_EQ(1u, cache.size_for_test());
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test());
+}
+
+// ── negative cache covers hosts that never resolved ──────────────────────────
+
+// A hostname that has never resolved never enters `cache`, so it never reaches the
+// eviction path. It must still be tombstoned, otherwise every get() pays a full
+// blocking getaddrinfo - and many of those calls run on bthreads.
+TEST_F(DNSCacheTest, first_miss_is_negative_cached) {
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    int resolver_calls = 0;
+    bool should_fail = true;
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
+
+    std::string ip;
+    EXPECT_FALSE(cache.get("never-resolved.test", &ip).ok());
+    EXPECT_EQ(1, resolver_calls) << "the first call must actually try to resolve";
+    EXPECT_EQ(0u, cache.size_for_test());
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test())
+            << "a host that never resolved must still be tombstoned";
+
+    // Every later call is served from the negative cache without touching DNS.
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_FALSE(cache.get("never-resolved.test", &ip).ok());
+    }
+    EXPECT_EQ(1, resolver_calls) << "resolver must not be called again within the TTL";
+    EXPECT_EQ(0u, cache.failure_count_for_test("never-resolved.test"))
+            << "failure_count must stay empty for a host that was never cached";
+
+    // Once the TTL lapses and DNS starts working, the host is picked up normally.
+    cache._expire_negative_cache_for_test();
+    should_fail = false;
+    EXPECT_TRUE(cache.get("never-resolved.test", &ip).ok());
+    EXPECT_EQ("1.2.3.4", ip);
+    EXPECT_EQ(1u, cache.size_for_test());
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test());
+}
+
+// Setting the TTL to 0 keeps the legacy behavior: no tombstone for a first miss.
+TEST_F(DNSCacheTest, first_miss_not_negative_cached_when_ttl_disabled) {
+    config::dns_cache_negative_ttl_seconds = 0;
+
+    int resolver_calls = 0;
+    bool should_fail = true;
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
+
+    std::string ip;
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FALSE(cache.get("never-resolved.test", &ip).ok());
+    }
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test());
+    EXPECT_EQ(3, resolver_calls) << "every call resolves when the negative cache is disabled";
+}
+
+// ── shutdown responsiveness ──────────────────────────────────────────────────
+
+// _refresh_once() must bail out as soon as the stop flag is set. Each _update() inside
+// it blocks in getaddrinfo, so a cycle over a cluster with dead DNS can run for minutes
+// and would otherwise hold up ~DNSCache()'s join() for exactly that long.
+TEST_F(DNSCacheTest, refresh_stops_early_when_stopping) {
+    config::dns_cache_max_consecutive_failures = 0; // isolate: no eviction in play
+
+    int resolver_calls = 0;
+    bool should_fail = false;
+    DNSCache cache(make_counting_resolver(&should_fail, &resolver_calls));
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("host-a.test", &ip).ok());
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    int calls_before = resolver_calls;
+    cache.stop_refresh = true;
+    cache.refresh_for_test();
+
+    EXPECT_EQ(calls_before, resolver_calls)
+            << "a refresh cycle must not start resolving once the stop flag is set";
+    EXPECT_EQ(1u, cache.size_for_test()) << "bailing out must leave the cache untouched";
 }
 
 } // end of namespace doris

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -336,4 +336,106 @@ TEST_F(DNSCacheTest, negative_cache_retries_after_ttl_expiry) {
             << "negative cache entry must be removed on successful re-resolve";
 }
 
+// A concurrent successful resolution between _update() returning and the
+// threshold check must prevent eviction: _erase_if_still_failing() re-reads
+// the live failure_count under its own lock so a reset counter is not lost.
+TEST_F(DNSCacheTest, concurrent_success_prevents_stale_eviction) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail));
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    // Simulate: _update() returned failures == threshold, but before _erase()
+    // was called a concurrent success cleared failure_count.
+    {
+        std::unique_lock<std::shared_mutex> lock(cache.mutex);
+        cache.failure_count["fake-host.test"] = 1; // set to threshold
+        cache.failure_count.erase("fake-host.test"); // concurrent success clears it
+    }
+
+    bool erased = cache._erase_if_still_failing("fake-host.test", 1u);
+    EXPECT_FALSE(erased) << "must not erase when failure_count was concurrently reset to zero";
+    EXPECT_EQ(1u, cache.size_for_test()) << "host must survive after concurrent success";
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test());
+}
+
+// When _resolve_hostname returns a stale cached IP after a concurrent eviction,
+// _update must not reinsert it (which would undo the eviction and clear the
+// negative-cache tombstone).
+TEST_F(DNSCacheTest, stale_fallback_not_reinserted_after_concurrent_eviction) {
+    config::dns_cache_max_consecutive_failures = 1000; // disable threshold-based eviction
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    DNSCache* cache_ptr = nullptr;
+    auto racing_resolver = [&cache_ptr](const std::string& host, std::string&, bool) -> Status {
+        if (cache_ptr) cache_ptr->_erase(host); // evict mid-DNS-call
+        return Status::InternalError("mock DNS failure during concurrent eviction");
+    };
+
+    DNSCache cache(racing_resolver);
+    cache_ptr = &cache;
+
+    // Pre-populate so _resolve_hostname reads a non-empty cached_ip before the
+    // DNS call, then the racing erase fires during the call.
+    {
+        std::unique_lock<std::shared_mutex> lock(cache.mutex);
+        cache.cache["racing.test"] = "1.2.3.4";
+    }
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    // Drive one refresh cycle: resolver evicts mid-DNS, returns failure.
+    // _resolve_hostname returns the stale "1.2.3.4".  Without the guard _update
+    // would reinsert it; with the guard it must not.
+    cache.refresh_for_test();
+
+    EXPECT_EQ(0u, cache.size_for_test()) << "stale IP must not be reinserted after eviction";
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test()) << "host must be in negative cache";
+    EXPECT_EQ(0u, cache.failure_count_for_test("racing.test"));
+}
+
+// After negative-cache TTL expiry and DNS still failing, get() must re-arm the
+// negative cache so the retry rate stays bounded at one attempt per TTL period.
+TEST_F(DNSCacheTest, negative_cache_rearms_on_continued_failure_after_ttl_expiry) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    int resolver_calls = 0;
+    bool should_fail = false;
+    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
+        ++resolver_calls;
+        if (should_fail) return Status::InternalError("mock failure");
+        out = "1.2.3.4";
+        return Status::OK();
+    });
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Evict.
+    should_fail = true;
+    cache.refresh_for_test();
+    ASSERT_EQ(0u, cache.size_for_test());
+    ASSERT_EQ(1u, cache.negative_cache_size_for_test());
+
+    // Simulate TTL expiry.
+    cache._clear_negative_cache_for_test();
+    ASSERT_EQ(0u, cache.negative_cache_size_for_test());
+
+    // DNS still failing: one retry is allowed, then negative cache re-arms.
+    int calls_before = resolver_calls;
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_GT(resolver_calls, calls_before) << "resolver called after TTL expiry";
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test()) << "negative cache re-armed on continued failure";
+
+    // Subsequent calls are now blocked without hitting the resolver.
+    calls_before = resolver_calls;
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_EQ(calls_before, resolver_calls) << "resolver NOT called while re-armed";
+}
+
 } // end of namespace doris

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -501,7 +501,7 @@ TEST_F(DNSCacheTest, negative_cache_honors_decreased_ttl) {
 
     // Decrease TTL to 1 second and backdate the entry to make it look older.
     config::dns_cache_negative_ttl_seconds = 1;
-    cache._expire_negative_cache_for_test(); // backdate to epoch → past any 1s deadline
+    cache._expire_negative_cache_for_test(); // backdate far → past any 1s deadline
 
     should_fail = false;
     EXPECT_TRUE(cache.get("fake-host.test", &ip).ok())
@@ -571,7 +571,9 @@ TEST_F(DNSCacheTest, refresh_does_not_erase_negative_cache_tombstone) {
     ASSERT_EQ(1u, cache.negative_cache_size_for_test());
     cache._expire_negative_cache_for_test();
 
-    // Run another refresh cycle — must NOT erase the expired tombstone.
+    // Run another refresh cycle — must NOT erase the expired tombstone.  The
+    // tombstone is what keeps get() from issuing a blocking getaddrinfo on every
+    // call, so it must outlive refresh cycles regardless of age.
     cache.refresh_for_test();
     EXPECT_EQ(1u, cache.negative_cache_size_for_test())
             << "refresh must not erase negative-cache tombstones";

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -323,9 +323,9 @@ TEST_F(DNSCacheTest, negative_cache_retries_after_ttl_expiry) {
     EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
     int calls_while_blocked = resolver_calls;
 
-    // Simulate TTL expiry.
-    cache._clear_negative_cache_for_test();
-    EXPECT_EQ(0u, cache.negative_cache_size_for_test());
+    // Simulate TTL expiry by backdating the entry.
+    cache._expire_negative_cache_for_test();
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test()); // entry exists but expired
 
     // DNS recovers.
     should_fail = false;
@@ -439,6 +439,152 @@ TEST_F(DNSCacheTest, negative_cache_rearms_on_continued_failure_after_ttl_expiry
     calls_before = resolver_calls;
     EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
     EXPECT_EQ(calls_before, resolver_calls) << "resolver NOT called while re-armed";
+}
+
+// ── Finding 1: mutable TTL is honored by existing tombstones ─────────────────
+
+// Setting dns_cache_negative_ttl_seconds to 0 after eviction must immediately
+// disable the negative cache for existing entries.
+TEST_F(DNSCacheTest, negative_cache_disabled_when_ttl_set_to_zero) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    int resolver_calls = 0;
+    bool should_fail = false;
+    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
+        ++resolver_calls;
+        if (should_fail) return Status::InternalError("mock failure");
+        out = "1.2.3.4";
+        return Status::OK();
+    });
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Evict with TTL=3600.
+    should_fail = true;
+    cache.refresh_for_test();
+    ASSERT_EQ(0u, cache.size_for_test());
+    ASSERT_EQ(1u, cache.negative_cache_size_for_test());
+
+    // Negative cache blocks.
+    int calls_at_eviction = resolver_calls;
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_EQ(calls_at_eviction, resolver_calls);
+
+    // Now disable negative cache by setting TTL to 0 — simulates config change.
+    config::dns_cache_negative_ttl_seconds = 0;
+    should_fail = false;
+
+    // get() must now retry immediately (TTL disabled) and succeed.
+    EXPECT_TRUE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_GT(resolver_calls, calls_at_eviction) << "resolver must be called when TTL is disabled";
+    EXPECT_EQ(1u, cache.size_for_test());
+}
+
+// Decreasing dns_cache_negative_ttl_seconds applies to existing tombstones:
+// a tombstone created with TTL=3600 must honor the new smaller TTL.
+TEST_F(DNSCacheTest, negative_cache_honors_decreased_ttl) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail));
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Evict — tombstone stores eviction_time = now.
+    should_fail = true;
+    cache.refresh_for_test();
+    ASSERT_EQ(1u, cache.negative_cache_size_for_test());
+
+    // Decrease TTL to 1 second and backdate the entry to make it look older.
+    config::dns_cache_negative_ttl_seconds = 1;
+    cache._expire_negative_cache_for_test(); // backdate to epoch → past any 1s deadline
+
+    should_fail = false;
+    EXPECT_TRUE(cache.get("fake-host.test", &ip).ok())
+            << "reduced TTL must be honored for existing tombstones";
+}
+
+// ── Finding 2: single-flight retry ──────────────────────────────────────────
+
+// Only one thread claims the expired negative-cache retry; a second concurrent
+// caller sees the re-armed entry and gets the cheap error.
+TEST_F(DNSCacheTest, single_flight_retry_after_negative_ttl_expiry) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    int resolver_calls = 0;
+    bool should_fail = false;
+    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
+        ++resolver_calls;
+        if (should_fail) return Status::InternalError("mock failure");
+        out = "1.2.3.4";
+        return Status::OK();
+    });
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Evict and expire the tombstone.
+    should_fail = true;
+    cache.refresh_for_test();
+    cache._expire_negative_cache_for_test();
+
+    // First get() claims the retry — DNS still fails, re-arm happens.
+    int calls_before = resolver_calls;
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_EQ(calls_before + 1, resolver_calls) << "first caller invokes DNS";
+
+    // Second get() must NOT invoke DNS — the entry was re-armed by the first call.
+    calls_before = resolver_calls;
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_EQ(calls_before, resolver_calls)
+            << "second caller must be blocked by the re-armed entry";
+}
+
+// ── Finding 4: refresh cleanup doesn't break re-arm ─────────────────────────
+
+// After _refresh_once() runs, the negative-cache tombstone must still be present
+// so that get() can recognize the host as evicted and bound retry rate.
+TEST_F(DNSCacheTest, refresh_does_not_erase_negative_cache_tombstone) {
+    config::dns_cache_max_consecutive_failures = 1;
+    config::dns_cache_negative_ttl_seconds = 3600;
+
+    int resolver_calls = 0;
+    bool should_fail = false;
+    DNSCache cache([&](const std::string&, std::string& out, bool) -> Status {
+        ++resolver_calls;
+        if (should_fail) return Status::InternalError("mock failure");
+        out = "1.2.3.4";
+        return Status::OK();
+    });
+
+    std::string ip;
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+
+    // Evict and expire the tombstone to simulate passage of time.
+    should_fail = true;
+    cache.refresh_for_test();
+    ASSERT_EQ(1u, cache.negative_cache_size_for_test());
+    cache._expire_negative_cache_for_test();
+
+    // Run another refresh cycle — must NOT erase the expired tombstone.
+    cache.refresh_for_test();
+    EXPECT_EQ(1u, cache.negative_cache_size_for_test())
+            << "refresh must not erase negative-cache tombstones";
+
+    // get() still recognizes this as an evicted host: one retry then re-arm.
+    int calls_before = resolver_calls;
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_EQ(calls_before + 1, resolver_calls) << "one retry after expiry";
+
+    // Subsequent call is blocked.
+    calls_before = resolver_calls;
+    EXPECT_FALSE(cache.get("fake-host.test", &ip).ok());
+    EXPECT_EQ(calls_before, resolver_calls) << "blocked after re-arm";
 }
 
 } // end of namespace doris

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -422,9 +422,11 @@ TEST_F(DNSCacheTest, negative_cache_rearms_on_continued_failure_after_ttl_expiry
     ASSERT_EQ(0u, cache.size_for_test());
     ASSERT_EQ(1u, cache.negative_cache_size_for_test());
 
-    // Simulate TTL expiry.
-    cache._clear_negative_cache_for_test();
-    ASSERT_EQ(0u, cache.negative_cache_size_for_test());
+    // Simulate TTL expiry by backdating the entry (entry still exists, time is past).
+    // Use _expire (not _clear) so the entry is visible to get()'s TTL check,
+    // which sets expired_negative=true and triggers the re-arm path on failure.
+    cache._expire_negative_cache_for_test();
+    ASSERT_EQ(1u, cache.negative_cache_size_for_test()); // entry exists but expired
 
     // DNS still failing: one retry is allowed, then negative cache re-arms.
     int calls_before = resolver_calls;

--- a/be/test/util/dns_cache_test.cpp
+++ b/be/test/util/dns_cache_test.cpp
@@ -95,16 +95,41 @@ TEST_F(DNSCacheTest, success_keeps_cache_stable) {
     EXPECT_EQ(1u, cache.size_for_test());
 }
 
-// The eviction config can be disabled by setting threshold <= 0 (legacy behavior).
-// In legacy mode, an unresolvable hostname on first access is still not cached,
-// matching the pre-fix semantics for callers.
+// The eviction config can be disabled by setting threshold <= 0 (legacy behavior):
+// a cached host whose DNS record disappears keeps serving its stale IP forever,
+// exactly as it did before this fix.  Drive many refresh cycles (well past any
+// plausible threshold) and assert the entry is never dropped.
 TEST_F(DNSCacheTest, eviction_disabled_when_threshold_zero) {
     config::dns_cache_max_consecutive_failures = 0;
-    DNSCache cache;
+
+    bool should_fail = false;
+    DNSCache cache(make_resolver(&should_fail));
+
+    // Populate the cache with one successful resolution.
     std::string ip;
-    Status st = cache.get("another-non-existent.invalid", &ip);
-    EXPECT_FALSE(st.ok());
-    EXPECT_EQ(0u, cache.size_for_test());
+    ASSERT_TRUE(cache.get("fake-host.test", &ip).ok());
+    ASSERT_EQ("1.2.3.4", ip);
+    ASSERT_EQ(1u, cache.size_for_test());
+
+    // DNS now fails permanently.
+    should_fail = true;
+
+    // Far more cycles than the default threshold (30) would need to evict.
+    for (int i = 0; i < 50; ++i) {
+        cache.refresh_for_test();
+        ASSERT_EQ(1u, cache.size_for_test())
+                << "eviction must be disabled when threshold <= 0 (cycle " << i << ")";
+    }
+
+    // No tombstone was written, and callers still get the stale IP.
+    EXPECT_EQ(0u, cache.negative_cache_size_for_test());
+    ip.clear();
+    EXPECT_TRUE(cache.get("fake-host.test", &ip).ok())
+            << "legacy mode must keep serving the cached ip";
+    EXPECT_EQ("1.2.3.4", ip);
+
+    // The failure counter still accumulates; only the eviction action is disabled.
+    EXPECT_GT(cache.failure_count_for_test("fake-host.test"), 0u);
 }
 
 // ── new tests for eviction logic ─────────────────────────────────────────────


### PR DESCRIPTION
Proposed changes

  Issue Number: close #63358

  DNSCache currently never evicts an entry once it has been inserted. When a backend host is permanently dropped from the cluster and its DNS record is removed, every other BE in the cluster keeps:

  1. logging failed to get ip from host: <removed> every 60 s, indefinitely (from DNSCache::_refresh_cache -> hostname_to_ipv4);
  2. handing the stale cached IP back to brpc through BrpcClientCache / ClientCache, which then keeps emitting Fail to wait EPOLLOUT ... Connection timed out at the brpc socket layer.

  This PR adds a simple consecutive-failure counter to DNSCache. When the counter reaches a configurable threshold, the entry is removed from the cache so that callers no longer get a stale IP and the refresh thread stops logging about
  it. WARNING logs for the same host are also throttled to avoid flooding be.WARNING.

  Configs introduced

  Name: dns_cache_max_consecutive_failures
  Type: mInt32
  Default: 30
  Behavior: Evict a hostname after this many consecutive resolution failures. At the default 60 s refresh interval, that means ~30 minutes of grace. Set <= 0 to disable eviction (legacy behavior).
  ────────────────────────────────────────
  Name: dns_cache_log_every_n_failures
  Type: mInt32
  Default: 60
  Behavior: Throttle the Failed to resolve ... use cached ip warning to once per N failures per hostname. Set <= 1 to log every failure (legacy behavior).

  Both are mutable so operators can tune without restarting BE.

  Backward compatibility

  Setting dns_cache_max_consecutive_failures = 0 and dns_cache_log_every_n_failures = 1 reproduces exactly the pre-PR behavior. Successful resolution clears the failure counter, so transient DNS hiccups don't accumulate across hours. No
  public API or wire format changes.

  Further comments

  - I deliberately did not touch the FE-side DNSCache.java. If the same fix is wanted on FE, happy to send a follow-up PR.
  - The eviction threshold default (30) is conservative; please push back if you'd prefer a smaller / larger default. Operators with very flaky DNS can lower it via the mutable config without redeploying.

  ---
  Checklist

  - I have read the Contributing document.
  - I have created an issue (#63358) on (or commented on) the related issue.
  - I have added unit tests for my change.
  - All new and existing tests passed (verified locally → fails to build on macOS due to unrelated contrib/openblas issue; rely on CI).
  - My change requires a change to the documentation. — No (config doc auto-generated)