### PR TITLE
[test](regression) Move Iceberg REST HDFS case to P2

### DIFF
--- a/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_on_hdfs.groovy
+++ b/regression-test/suites/external_table_p2/refactor_catalog_param/iceberg_rest_on_hdfs.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("iceberg_rest_on_hdfs", "p0,external") {
+suite("iceberg_rest_on_hdfs", "p2,external") {
 
     def testQueryAndInsert = { String catalogProperties, String prefix ->
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #60915

Problem Summary: Move `iceberg_rest_on_hdfs` out of the P0 external suite because it requires the dedicated `iceberg-rest` Docker environment, which is not started by the default community external pipeline.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Verified the suite is declared only under `external_table_p2` with group `p2,external`
    - Ran `git diff --check`
    - Regression test not run because the case requires the dedicated `iceberg-rest` Docker environment
- Behavior changed: No
- Does this need documentation: No
