### PR TITLE
[draft][test](regression) Refine file cache query limit regression case

### DIFF
--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
@@ -15,33 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import org.codehaus.groovy.runtime.dgmimpl.arrays.LongArrayGetAtMetaMethod
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
 
-import java.util.concurrent.TimeUnit;
-import org.awaitility.Awaitility;
-
-// Constants for backend configuration check
+// Keep only reusable prefixes and inline one-off failure messages near assertions.
 final String BACKEND_CONFIG_CHECK_FAILED_PREFIX = "Backend configuration check failed: "
-final String ENABLE_FILE_CACHE_CHECK_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache is empty or not set to true"
-final String FILE_CACHE_BACKGROUND_MONITOR_INTERVAL_CHECK_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "file_cache_background_monitor_interval_ms is empty or not set to true"
-final String FILE_CACHE_PATH_CHECK_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "file_cache_path is empty or not configured"
-final String WEB_SERVER_PORT_CHECK_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "webserver_port is empty or not configured"
-final String BRPC_PORT_CHECK_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "brpc_port is empty or not configured"
-final String ENABLE_FILE_CACHE_QUERY_LIMIT_CHECK_FALSE_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache_query_limit is empty or not set to false"
-final String ENABLE_FILE_CACHE_QUERY_LIMIT_CHECK_TRUE_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache_query_limit is empty or not set to true"
-final String FILE_CACHE_QUERY_LIMIT_BYTES_CHECK_FAILED_MSG = BACKEND_CONFIG_CHECK_FAILED_PREFIX + "file_cache_query_limit_bytes is empty or not configured"
-// Constants for cache query features check
 final String FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX = "File cache features check failed: "
-final String BASE_NORMAL_QUEUE_CURR_SIZE_IS_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "base normal_queue_curr_size is 0"
-final String BASE_NORMAL_QUEUE_CURR_ELEMENTS_IS_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "base normal_queue_curr_elements is 0"
-final String TOTAL_READ_COUNTS_DID_NOT_INCREASE_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "total_read_counts did not increase after cache operation"
-final String INITIAL_NORMAL_QUEUE_CURR_SIZE_NOT_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_size is not 0"
-final String INITIAL_NORMAL_QUEUE_CURR_ELEMENTS_NOT_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_elements is not 0"
-final String INITIAL_NORMAL_QUEUE_MAX_SIZE_IS_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_max_size is 0"
-final String INITIAL_NORMAL_QUEUE_MAX_ELEMENTS_IS_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_max_elements is 0"
-final String NORMAL_QUEUE_CURR_SIZE_NOT_GREATER_THAN_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_size is not greater than 0 after cache operation"
-final String NORMAL_QUEUE_CURR_ELEMENTS_NOT_GREATER_THAN_ZERO_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_elements is not greater than 0 after cache operation"
-final String NORMAL_QUEUE_CURR_SIZE_GREATER_THAN_QUERY_CACHE_CAPACITY_MSG = FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_size is greater than query cache capacity"
 
 suite("test_file_cache_query_limit", "p0,external") {
     String enableHiveTest = context.config.otherConfigs.get("enableHiveTest")
@@ -52,34 +31,121 @@ suite("test_file_cache_query_limit", "p0,external") {
 
     sql """set enable_file_cache=true"""
 
-    // Check backend configuration prerequisites
-    // Note: This test case assumes a single backend scenario. Testing with single backend is logically equivalent
-    // to testing with multiple backends having identical configurations, but simpler in logic.
     def enableFileCacheResult = sql """show backend config like 'enable_file_cache';"""
     logger.info("enable_file_cache configuration: " + enableFileCacheResult)
     assertFalse(enableFileCacheResult.size() == 0 || !enableFileCacheResult[0][3].equalsIgnoreCase("true"),
-            ENABLE_FILE_CACHE_CHECK_FAILED_MSG)
+            BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache is empty or not set to true")
 
     def fileCacheBackgroundMonitorIntervalMsResult = sql """show backend config like 'file_cache_background_monitor_interval_ms';"""
     logger.info("file_cache_background_monitor_interval_ms configuration: " + fileCacheBackgroundMonitorIntervalMsResult)
     assertFalse(fileCacheBackgroundMonitorIntervalMsResult.size() == 0 || fileCacheBackgroundMonitorIntervalMsResult[0][3] == null ||
-            fileCacheBackgroundMonitorIntervalMsResult[0][3].trim().isEmpty(), FILE_CACHE_BACKGROUND_MONITOR_INTERVAL_CHECK_FAILED_MSG)
+            fileCacheBackgroundMonitorIntervalMsResult[0][3].trim().isEmpty(),
+            BACKEND_CONFIG_CHECK_FAILED_PREFIX + "file_cache_background_monitor_interval_ms is empty or not configured")
 
-    String catalog_name = "test_file_cache_query_limit"
-    String ex_db_name = "tpch1_parquet"
+    long backgroundMonitorIntervalMs = fileCacheBackgroundMonitorIntervalMsResult[0][3].toLong()
+    long waitTimeoutSeconds = Math.max(10L, (backgroundMonitorIntervalMs / 1000L) + 5L)
+
+    String catalogName = "test_file_cache_query_limit"
+    String externalDbName = "tpch1_parquet"
     String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
-    String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
-    int queryCacheCapacity
+    String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+    long baseQueryCacheUsageBytes = 0L
 
-    sql """drop catalog if exists ${catalog_name} """
+    // Discover the real Doris backend endpoints
+    def aliveBackends = sql_return_maparray("show backends").findAll { backend ->
+        backend.Alive.toString().equalsIgnoreCase("true")
+    }
+    logger.info("alive backends: " + aliveBackends)
+    assertTrue(aliveBackends.size() == 1,
+            BACKEND_CONFIG_CHECK_FAILED_PREFIX + "query limit test requires exactly one alive backend: " + aliveBackends)
+    def targetBackend = aliveBackends[0]
+    String targetBeIp = targetBackend.Host.toString()
+    String targetHttpPort = targetBackend.HttpPort.toString()
+    String targetBrpcPort = targetBackend.BrpcPort.toString()
 
-    sql """CREATE CATALOG ${catalog_name} PROPERTIES (
+    // Reuse the same command execution path for every backend HTTP request.
+    def runCommandAndCollectOutput = { List<String> command ->
+        def process = new ProcessBuilder(command as String[]).redirectErrorStream(true).start()
+        def output = new StringBuilder()
+        process.inputStream.eachLine { line -> output.append(line).append("\n") }
+        int exitCode = process.waitFor()
+        return [exitCode: exitCode, output: output.toString()]
+    }
+
+    // Aggregate metrics across all cache paths on the target backend to avoid flaky single-row reads.
+    def getMetricSum = { String metricName ->
+        def result = sql """select coalesce(sum(cast(METRIC_VALUE as double)), 0)
+                from information_schema.file_cache_statistics
+                where BE_IP = '${targetBeIp}' and METRIC_NAME = '${metricName}';"""
+        double metricValue = Double.valueOf(result[0][0].toString())
+        logger.info("metric ${metricName} on backend ${targetBeIp}: ${metricValue}")
+        return metricValue
+    }
+
+    // Poll until asynchronous backend state converges to the expected condition.
+    def waitForCondition = { String description, Closure<Boolean> condition ->
+        Awaitility.await()
+                .atMost(waitTimeoutSeconds, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until {
+                    boolean matched = condition()
+                    if (!matched) {
+                        logger.info("Waiting for ${description}")
+                    }
+                    return matched
+                }
+    }
+
+    // Read backend config through SQL and return the raw value for later assertions.
+    def getBackendConfigValue = { String configKey ->
+        def result = sql """SHOW BACKEND CONFIG LIKE '${configKey}';"""
+        logger.info("${configKey} configuration: " + result)
+        assertFalse(result.size() == 0 || result[0][3] == null || result[0][3].toString().trim().isEmpty(),
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "${configKey} is empty or not configured")
+        return result[0][3].toString().trim()
+    }
+
+    // Clear file cache synchronously and wait until the observable queue metrics return to zero.
+    def clearFileCacheAndWait = {
+        def commandResult = runCommandAndCollectOutput([
+                "curl", "-X", "POST", "http://${targetBeIp}:${targetHttpPort}/api/file_cache?op=clear&sync=true"
+        ])
+        logger.info("File cache clear command output: ${commandResult.output}")
+        assertTrue(commandResult.exitCode == 0,
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "HTTP command failed: clear file cache failed with exit code ${commandResult.exitCode}")
+        waitForCondition("file cache clear on ${targetBeIp}") {
+            getMetricSum("normal_queue_curr_size") == 0.0 &&
+                    getMetricSum("normal_queue_curr_elements") == 0.0
+        }
+    }
+
+    // Fetch the total cache capacity from the target backend brpc vars endpoint.
+    def getFileCacheCapacity = {
+        def commandResult = runCommandAndCollectOutput([
+                "curl", "-X", "POST", "http://${targetBeIp}:${targetBrpcPort}/vars"
+        ])
+        logger.info("file cache vars output: ${commandResult.output}")
+        assertTrue(commandResult.exitCode == 0,
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "HTTP command failed: fetch brpc vars failed with exit code ${commandResult.exitCode}")
+        def fileCacheCapacityResult = commandResult.output.split("\n")
+                .find { it.contains("file_cache_capacity") }
+                ?.split(":")
+                ?.last()
+                ?.trim()
+        assertTrue(fileCacheCapacityResult != null,
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "failed to find file_cache_capacity in brpc metrics")
+        return Long.valueOf(fileCacheCapacityResult)
+    }
+
+    sql """drop catalog if exists ${catalogName} """
+
+    sql """CREATE CATALOG ${catalogName} PROPERTIES (
         'type'='hms',
-        'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+        'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hmsPort}',
         'hadoop.username' = 'hive'
     );"""
 
-    String query_sql =
+    String querySql =
             """select sum(l_quantity) as sum_qty,
             sum(l_extendedprice) as sum_base_price,
             sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
@@ -88,308 +154,140 @@ suite("test_file_cache_query_limit", "p0,external") {
             avg(l_extendedprice) as avg_price,
             avg(l_discount) as avg_disc,
             count(*) as count_order
-            from ${catalog_name}.${ex_db_name}.lineitem
+            from ${catalogName}.${externalDbName}.lineitem
             where l_shipdate <= date '1998-12-01' - interval '90' day
             group by l_returnflag, l_linestatus
             order by l_returnflag, l_linestatus;"""
 
-    def webserverPortResult = sql """SHOW BACKEND CONFIG LIKE 'webserver_port';"""
-    logger.info("webserver_port configuration: " + webserverPortResult)
-    assertFalse(webserverPortResult.size() == 0 || webserverPortResult[0][3] == null || webserverPortResult[0][3].trim().isEmpty(),
-            WEB_SERVER_PORT_CHECK_FAILED_MSG)
+    long fileCacheCapacity = getFileCacheCapacity()
+    logger.info("File cache capacity: ${fileCacheCapacity}")
 
-    String webserver_port = webserverPortResult[0][3]
+    // Build a baseline without query limit so the next stage can derive a meaningful limit percent.
+    logger.info("Start file cache base test")
 
-    def brpcPortResult = sql """SHOW BACKEND CONFIG LIKE 'brpc_port';"""
-    logger.info("brpcPortResult configuration: " + brpcPortResult)
-    assertFalse(brpcPortResult.size() == 0 || brpcPortResult[0][3] == null || brpcPortResult[0][3].trim().isEmpty(),
-            BRPC_PORT_CHECK_FAILED_MSG)
+    clearFileCacheAndWait()
 
-    String brpc_port = brpcPortResult[0][3]
+    double initialNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+    assertTrue(initialNormalQueueCurrSize == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_size is not 0")
 
-    // Search file cache capacity
-    def command = ["curl", "-X", "POST", "${externalEnvIp}:${brpc_port}/vars"]
-    def stringCommand = command.collect{it.toString()}
-    def process = new ProcessBuilder(stringCommand as String[]).redirectErrorStream(true).start()
+    double initialNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
+    assertTrue(initialNormalQueueCurrElements == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_elements is not 0")
 
-    def output = new StringBuilder()
-    def errorOutput = new StringBuilder()
-    process.inputStream.eachLine{line -> output.append(line).append("\n")}
-    process.errorStream.eachLine{line -> errorOutput.append(line).append("\n")}
-
-    // Wait for process completion and check exit status
-    def exitCode = process.waitFor()
-    def fileCacheCapacityResult = output.toString().split("\n").find { it.contains("file_cache_capacity") }?.split(":")?.last()?.trim()
-
-    logger.info("File cache capacity: ${fileCacheCapacityResult}")
-    assertTrue(fileCacheCapacityResult != null, "Failed to find file_cache_capacity in brpc metrics")
-    def fileCacheCapacity = Long.valueOf(fileCacheCapacityResult)
-
-    // Run file cache base test for setting the parameter file_cache_query_limit_bytes
-    logger.info("========================= Start running file cache base test ========================")
-
-    // Clear file cache
-    command = ["curl", "-X", "POST", "${externalEnvIp}:${webserver_port}/api/file_cache?op=clear&sync=true"]
-    stringCommand = command.collect{it.toString()}
-    process = new ProcessBuilder(stringCommand as String[]).redirectErrorStream(true).start()
-
-    output = new StringBuilder()
-    errorOutput = new StringBuilder()
-    process.inputStream.eachLine{line -> output.append(line).append("\n")}
-    process.errorStream.eachLine{line -> errorOutput.append(line).append("\n")}
-
-    // Wait for process completion and check exit status
-    exitCode = process.waitFor()
-    logger.info("File cache clear command output: ${output.toString()}")
-    assertTrue(exitCode == 0, "File cache clear failed with exit code ${exitCode}. Error: ${errorOutput.toString()}")
-
-    // brpc metrics will be updated at most 5 seconds
-    def totalWaitTime = (fileCacheBackgroundMonitorIntervalMsResult[0][3].toLong() / 1000) as int
-    def interval = 1
-    def iterations = totalWaitTime / interval
-
-    // Waiting for file cache clearing
-    (1..iterations).each { count ->
-        Thread.sleep(interval * 1000)
-        def elapsedSeconds = count * interval
-        def remainingSeconds = totalWaitTime - elapsedSeconds
-        logger.info("Waited for file cache clearing ${elapsedSeconds} seconds, ${remainingSeconds} seconds remaining")
-    }
-
-    def initialNormalQueueCurrSizeResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_curr_size' limit 1;"""
-    logger.info("normal_queue_curr_size result: " + initialNormalQueueCurrSizeResult)
-    assertFalse(initialNormalQueueCurrSizeResult.size() == 0 || Double.valueOf(initialNormalQueueCurrSizeResult[0][0]) != 0.0,
-            INITIAL_NORMAL_QUEUE_CURR_SIZE_NOT_ZERO_MSG)
-
-    // Check normal queue current elements
-    def initialNormalQueueCurrElementsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_curr_elements' limit 1;"""
-    logger.info("normal_queue_curr_elements result: " + initialNormalQueueCurrElementsResult)
-    assertFalse(initialNormalQueueCurrElementsResult.size() == 0 || Double.valueOf(initialNormalQueueCurrElementsResult[0][0]) != 0.0,
-            INITIAL_NORMAL_QUEUE_CURR_ELEMENTS_NOT_ZERO_MSG)
-
-    double initialNormalQueueCurrSize = Double.valueOf(initialNormalQueueCurrSizeResult[0][0])
-    double initialNormalQueueCurrElements = Double.valueOf(initialNormalQueueCurrElementsResult[0][0])
-
-    logger.info("Initial normal queue curr size and elements - size: ${initialNormalQueueCurrSize} , " +
-            "elements: ${initialNormalQueueCurrElements}")
+    logger.info("Initial normal queue curr size and elements - size: ${initialNormalQueueCurrSize} , elements: ${initialNormalQueueCurrElements}")
 
     setBeConfigTemporary([
             "enable_file_cache_query_limit": "false"
     ]) {
-        // Execute test logic with modified configuration for file_cache_query_limit
         logger.info("Backend configuration set - enable_file_cache_query_limit: false")
 
-        // Waiting for backend configuration update
-        (1..iterations).each { count ->
-            Thread.sleep(interval * 1000)
-            def elapsedSeconds = count * interval
-            def remainingSeconds = totalWaitTime - elapsedSeconds
-            logger.info("Waited for backend configuration update ${elapsedSeconds} seconds, ${remainingSeconds} seconds remaining")
+        waitForCondition("backend config enable_file_cache_query_limit=false") {
+            getBackendConfigValue("enable_file_cache_query_limit") == "false"
         }
 
-        // Check if the configuration is modified
-        def enableFileCacheQueryLimitResult = sql """SHOW BACKEND CONFIG LIKE 'enable_file_cache_query_limit';"""
-        logger.info("enable_file_cache_query_limit configuration: " + enableFileCacheQueryLimitResult)
-        assertFalse(enableFileCacheQueryLimitResult.size() == 0 || enableFileCacheQueryLimitResult[0][3] == null || enableFileCacheQueryLimitResult[0][3] != "false",
-                ENABLE_FILE_CACHE_QUERY_LIMIT_CHECK_FALSE_FAILED_MSG)
+        assertEquals("false", getBackendConfigValue("enable_file_cache_query_limit"),
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache_query_limit is empty or not set to false")
 
-        sql """switch ${catalog_name}"""
-        // load the table into file cache
-        sql query_sql
+        sql """switch ${catalogName}"""
+        sql querySql
 
-        // Waiting for file cache statistics update
-        (1..iterations).each { count ->
-            Thread.sleep(interval * 1000)
-            def elapsedSeconds = count * interval
-            def remainingSeconds = totalWaitTime - elapsedSeconds
-            logger.info("Waited for file cache statistics update ${elapsedSeconds} seconds, ${remainingSeconds} seconds remaining")
+        waitForCondition("base file cache statistics update") {
+            getMetricSum("normal_queue_curr_size") > 0.0 &&
+                    getMetricSum("normal_queue_curr_elements") > 0.0
         }
 
-        def baseNormalQueueCurrElementsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_curr_elements' limit 1;"""
-        logger.info("normal_queue_curr_elements result: " + baseNormalQueueCurrElementsResult)
-        assertFalse(baseNormalQueueCurrElementsResult.size() == 0 || Double.valueOf(baseNormalQueueCurrElementsResult[0][0]) == 0.0,
-                BASE_NORMAL_QUEUE_CURR_ELEMENTS_IS_ZERO_MSG)
+        double baseNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
+        assertTrue(baseNormalQueueCurrElements > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "base normal_queue_curr_elements is 0")
 
-        def baseNormalQueueCurrSizeResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_curr_size' limit 1;"""
-        logger.info("normal_queue_curr_size result: " + baseNormalQueueCurrSizeResult)
-        assertFalse(baseNormalQueueCurrSizeResult.size() == 0 || Double.valueOf(baseNormalQueueCurrSizeResult[0][0]) == 0.0,
-                BASE_NORMAL_QUEUE_CURR_SIZE_IS_ZERO_MSG)
+        double baseNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+        assertTrue(baseNormalQueueCurrSize > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "base normal_queue_curr_size is 0")
 
-        int baseNormalQueueCurrElements = Double.valueOf(baseNormalQueueCurrElementsResult[0][0]) as Long
-        queryCacheCapacity = Double.valueOf(baseNormalQueueCurrSizeResult[0][0]) as Long
+        baseQueryCacheUsageBytes = baseNormalQueueCurrSize as Long
     }
 
-    // The parameter file_cache_query_limit_percent must be set smaller than the cache capacity required by the query
-    def fileCacheQueryLimitPercent = (queryCacheCapacity / fileCacheCapacity) * 100
+    double fileCacheQueryLimitPercent = baseQueryCacheUsageBytes * 100.0d / fileCacheCapacity
     logger.info("file_cache_query_limit_percent: " + fileCacheQueryLimitPercent)
 
-    logger.info("========================== End running file cache base test =========================")
+    // Re-run the same query with a lower per-query cache limit and verify the observed cache usage stays bounded.
+    logger.info("Start file cache query limit test")
 
-    logger.info("==================== Start running file cache query limit test 1 ====================")
-
-    def fileCacheQueryLimitPercentTest1 = (fileCacheQueryLimitPercent / 2) as Long
+    long fileCacheQueryLimitPercentTest1 = Math.max(1L, Math.floor(fileCacheQueryLimitPercent / 2.0d) as Long)
     logger.info("file_cache_query_limit_percent_test1: " + fileCacheQueryLimitPercentTest1)
 
-    // Clear file cache
-    process = new ProcessBuilder(stringCommand as String[]).redirectErrorStream(true).start()
+    clearFileCacheAndWait()
 
-    output = new StringBuilder()
-    errorOutput = new StringBuilder()
-    process.inputStream.eachLine{line -> output.append(line).append("\n")}
-    process.errorStream.eachLine{line -> errorOutput.append(line).append("\n")}
+    initialNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+    assertTrue(initialNormalQueueCurrSize == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_size is not 0")
 
-    // Wait for process completion and check exit status
-    exitCode = process.waitFor()
-    logger.info("File cache clear command output: ${output.toString()}")
-    assertTrue(exitCode == 0, "File cache clear failed with exit code ${exitCode}. Error: ${errorOutput.toString()}")
+    initialNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
+    assertTrue(initialNormalQueueCurrElements == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_elements is not 0")
 
-    // Waiting for file cache clearing
-    (1..iterations).each { count ->
-        Thread.sleep(interval * 1000)
-        def elapsedSeconds = count * interval
-        def remainingSeconds = totalWaitTime - elapsedSeconds
-        logger.info("Waited for file cache clearing ${elapsedSeconds} seconds, ${remainingSeconds} seconds remaining")
-    }
+    double initialNormalQueueMaxSize = getMetricSum("normal_queue_max_size")
+    assertTrue(initialNormalQueueMaxSize > 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_max_size is 0")
 
-    // ===== Normal Queue Metrics Check =====
-    // Check normal queue current size
-    initialNormalQueueCurrSizeResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_curr_size' limit 1;"""
-    logger.info("normal_queue_curr_size result: " + initialNormalQueueCurrSizeResult)
-    assertFalse(initialNormalQueueCurrSizeResult.size() == 0 || Double.valueOf(initialNormalQueueCurrSizeResult[0][0]) != 0.0,
-            INITIAL_NORMAL_QUEUE_CURR_SIZE_NOT_ZERO_MSG)
+    double initialNormalQueueMaxElements = getMetricSum("normal_queue_max_elements")
+    assertTrue(initialNormalQueueMaxElements > 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_max_elements is 0")
 
-    // Check normal queue current elements
-    initialNormalQueueCurrElementsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_curr_elements' limit 1;"""
-    logger.info("normal_queue_curr_elements result: " + initialNormalQueueCurrElementsResult)
-    assertFalse(initialNormalQueueCurrElementsResult.size() == 0 || Double.valueOf(initialNormalQueueCurrElementsResult[0][0]) != 0.0,
-            INITIAL_NORMAL_QUEUE_CURR_ELEMENTS_NOT_ZERO_MSG)
+    logger.info("Initial normal queue curr size and elements - size: ${initialNormalQueueCurrSize} , elements: ${initialNormalQueueCurrElements}")
+    logger.info("Initial normal queue max size and elements - size: ${initialNormalQueueMaxSize} , elements: ${initialNormalQueueMaxElements}")
 
-    // Check normal queue max size
-    def initialNormalQueueMaxSizeResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_max_size' limit 1;"""
-    logger.info("normal_queue_max_size result: " + initialNormalQueueMaxSizeResult)
-    assertFalse(initialNormalQueueMaxSizeResult.size() == 0 || Double.valueOf(initialNormalQueueMaxSizeResult[0][0]) == 0.0,
-            INITIAL_NORMAL_QUEUE_MAX_SIZE_IS_ZERO_MSG)
+    double initialTotalHitCounts = getMetricSum("total_hit_counts")
+    double initialTotalReadCounts = getMetricSum("total_read_counts")
 
-    // Check normal queue max elements
-    def initialNormalQueueMaxElementsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'normal_queue_max_elements' limit 1;"""
-    logger.info("normal_queue_max_elements result: " + initialNormalQueueMaxElementsResult)
-    assertFalse(initialNormalQueueMaxElementsResult.size() == 0 || Double.valueOf(initialNormalQueueMaxElementsResult[0][0]) == 0.0,
-            INITIAL_NORMAL_QUEUE_MAX_ELEMENTS_IS_ZERO_MSG)
-
-    initialNormalQueueCurrSize = Double.valueOf(initialNormalQueueCurrSizeResult[0][0])
-    initialNormalQueueCurrElements = Double.valueOf(initialNormalQueueCurrElementsResult[0][0])
-    double initialNormalQueueMaxSize = Double.valueOf(initialNormalQueueMaxSizeResult[0][0])
-    double initialNormalQueueMaxElements = Double.valueOf(initialNormalQueueMaxElementsResult[0][0])
-
-    logger.info("Initial normal queue curr size and elements - size: ${initialNormalQueueCurrSize} , " +
-                "elements: ${initialNormalQueueCurrElements}")
-
-    logger.info("Initial normal queue max size and elements - size: ${initialNormalQueueMaxSize} , " +
-                "elements: ${initialNormalQueueMaxElements}")
-
-    // ===== Hit And Read Counts Metrics Check =====
-    // Get initial values for hit and read counts
-    def initialTotalHitCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'total_hit_counts' limit 1;"""
-    logger.info("Initial total_hit_counts result: " + initialTotalHitCountsResult)
-
-    def initialTotalReadCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-            where METRIC_NAME = 'total_read_counts' limit 1;"""
-    logger.info("Initial total_read_counts result: " + initialTotalReadCountsResult)
-
-    // Store initial values
-    double initialTotalHitCounts = Double.valueOf(initialTotalHitCountsResult[0][0])
-    double initialTotalReadCounts = Double.valueOf(initialTotalReadCountsResult[0][0])
-
-    // Set backend configuration parameters for file_cache_query_limit test 1
     setBeConfigTemporary([
             "enable_file_cache_query_limit": "true"
     ]) {
-        // Execute test logic with modified configuration for file_cache_query_limit
         logger.info("Backend configuration set - enable_file_cache_query_limit: true")
 
-        sql """set file_cache_query_limit_percent =  ${fileCacheQueryLimitPercentTest1}"""
+        sql """set file_cache_query_limit_percent = ${fileCacheQueryLimitPercentTest1}"""
 
-        // Waiting for backend configuration update
-        (1..iterations).each { count ->
-            Thread.sleep(interval * 1000)
-            def elapsedSeconds = count * interval
-            def remainingSeconds = totalWaitTime - elapsedSeconds
-            logger.info("Waited for backend configuration update ${elapsedSeconds} seconds, ${remainingSeconds} seconds remaining")
+        waitForCondition("backend config enable_file_cache_query_limit=true") {
+            getBackendConfigValue("enable_file_cache_query_limit") == "true"
         }
 
-        // Check if the configuration is modified
-        def enableFileCacheQueryLimitResult = sql """SHOW BACKEND CONFIG LIKE 'enable_file_cache_query_limit';"""
-        logger.info("enable_file_cache_query_limit configuration: " + enableFileCacheQueryLimitResult)
-        assertFalse(enableFileCacheQueryLimitResult.size() == 0 || enableFileCacheQueryLimitResult[0][3] == null || enableFileCacheQueryLimitResult[0][3] != "true",
-                ENABLE_FILE_CACHE_QUERY_LIMIT_CHECK_TRUE_FAILED_MSG)
+        assertEquals("true", getBackendConfigValue("enable_file_cache_query_limit"),
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache_query_limit is empty or not set to true")
 
-        sql """switch ${catalog_name}"""
+        sql """switch ${catalogName}"""
+        sql querySql
 
-        // load the table into file cache
-        sql query_sql
-
-        // Waiting for file cache statistics update
-        (1..iterations).each { count ->
-            Thread.sleep(interval * 1000)
-            def elapsedSeconds = count * interval
-            def remainingSeconds = totalWaitTime - elapsedSeconds
-            logger.info("Waited for file cache statistics update ${elapsedSeconds} seconds, ${remainingSeconds} seconds remaining")
+        waitForCondition("query limit file cache statistics update") {
+            getMetricSum("normal_queue_curr_size") > 0.0 &&
+                    getMetricSum("normal_queue_curr_elements") > 0.0 &&
+                    getMetricSum("total_read_counts") > initialTotalReadCounts
         }
 
-        // Get updated value of normal queue current elements and max elements after cache operations
-        def updatedNormalQueueCurrSizeResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-                where METRIC_NAME = 'normal_queue_curr_size' limit 1;"""
-        logger.info("normal_queue_curr_size result: " + updatedNormalQueueCurrSizeResult)
+        double updatedNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+        double updatedNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
 
-        def updatedNormalQueueCurrElementsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-                where METRIC_NAME = 'normal_queue_curr_elements' limit 1;"""
-        logger.info("normal_queue_curr_elements result: " + updatedNormalQueueCurrElementsResult)
+        logger.info("Updated normal queue curr size and elements - size: ${updatedNormalQueueCurrSize} , elements: ${updatedNormalQueueCurrElements}")
 
-        // Check if updated values are greater than initial values
-        double updatedNormalQueueCurrSize = Double.valueOf(updatedNormalQueueCurrSizeResult[0][0])
-        double updatedNormalQueueCurrElements = Double.valueOf(updatedNormalQueueCurrElementsResult[0][0])
+        assertTrue(updatedNormalQueueCurrSize > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_size is not greater than 0 after cache operation")
+        assertTrue(updatedNormalQueueCurrElements > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_elements is not greater than 0 after cache operation")
 
-        logger.info("Updated normal queue curr size and elements - size: ${updatedNormalQueueCurrSize} , " +
-                "elements: ${updatedNormalQueueCurrElements}")
+        long expectedQueryLimitBytes = fileCacheCapacity * fileCacheQueryLimitPercentTest1 / 100
+        logger.info("Normal queue curr size and expected query limit comparison - normal queue curr size: ${updatedNormalQueueCurrSize as Long} , expected query limit: ${expectedQueryLimitBytes}")
 
-        assertTrue(updatedNormalQueueCurrSize > 0.0, NORMAL_QUEUE_CURR_SIZE_NOT_GREATER_THAN_ZERO_MSG)
-        assertTrue(updatedNormalQueueCurrElements > 0.0, NORMAL_QUEUE_CURR_ELEMENTS_NOT_GREATER_THAN_ZERO_MSG)
+        assertTrue((updatedNormalQueueCurrSize as Long) <= expectedQueryLimitBytes,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_size is greater than expected query limit")
 
-        logger.info("Normal queue curr size and query cache capacity comparison - normal queue curr size: ${updatedNormalQueueCurrSize as Long} , " +
-                "query cache capacity: ${fileCacheCapacity}")
+        double updatedTotalHitCounts = getMetricSum("total_hit_counts")
+        double updatedTotalReadCounts = getMetricSum("total_read_counts")
 
-        assertTrue((updatedNormalQueueCurrSize as Long) <= queryCacheCapacity,
-                NORMAL_QUEUE_CURR_SIZE_GREATER_THAN_QUERY_CACHE_CAPACITY_MSG)
+        logger.info("Total hit and read counts comparison - hit counts: ${initialTotalHitCounts} -> ${updatedTotalHitCounts} , read counts: ${initialTotalReadCounts} -> ${updatedTotalReadCounts}")
 
-        // Get updated values for hit and read counts after cache operations
-        def updatedTotalHitCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-                where METRIC_NAME = 'total_hit_counts' limit 1;"""
-        logger.info("Updated total_hit_counts result: " + updatedTotalHitCountsResult)
-
-        def updatedTotalReadCountsResult = sql """select METRIC_VALUE from information_schema.file_cache_statistics
-                where METRIC_NAME = 'total_read_counts' limit 1;"""
-        logger.info("Updated total_read_counts result: " + updatedTotalReadCountsResult)
-
-        // Check if updated values are greater than initial values
-        double updatedTotalHitCounts = Double.valueOf(updatedTotalHitCountsResult[0][0])
-        double updatedTotalReadCounts = Double.valueOf(updatedTotalReadCountsResult[0][0])
-
-        logger.info("Total hit and read counts comparison - hit counts: ${initialTotalHitCounts} -> " +
-                "${updatedTotalHitCounts} , read counts: ${initialTotalReadCounts} -> ${updatedTotalReadCounts}")
-
-        assertTrue(updatedTotalReadCounts > initialTotalReadCounts, TOTAL_READ_COUNTS_DID_NOT_INCREASE_MSG)
+        assertTrue(updatedTotalReadCounts > initialTotalReadCounts,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "total_read_counts did not increase after cache operation")
     }
 
-    logger.info("===================== End running file cache query limit test 1 =====================")
-
-    return true;
+    return true
 }

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
@@ -43,7 +43,7 @@ suite("test_file_cache_query_limit", "p0,external") {
             BACKEND_CONFIG_CHECK_FAILED_PREFIX + "file_cache_background_monitor_interval_ms is empty or not configured")
 
     long backgroundMonitorIntervalMs = fileCacheBackgroundMonitorIntervalMsResult[0][3].toLong()
-    long waitTimeoutSeconds = Math.max(10L, (backgroundMonitorIntervalMs / 1000L) + 5L)
+    long waitTimeoutSeconds = Math.max(10L, backgroundMonitorIntervalMs.intdiv(1000L) + 5L)
 
     String catalogName = "test_file_cache_query_limit"
     String externalDbName = "tpch1_parquet"
@@ -214,7 +214,8 @@ suite("test_file_cache_query_limit", "p0,external") {
     // Re-run the same query with a lower per-query cache limit and verify the observed cache usage stays bounded.
     logger.info("Start file cache query limit test")
 
-    long fileCacheQueryLimitPercentTest1 = Math.max(1L, Math.floor(fileCacheQueryLimitPercent / 2.0d) as Long)
+    long fileCacheQueryLimitPercentCandidate = Math.floor(fileCacheQueryLimitPercent / 2.0d).longValue()
+    long fileCacheQueryLimitPercentTest1 = Math.max(1L, fileCacheQueryLimitPercentCandidate)
     logger.info("file_cache_query_limit_percent_test1: " + fileCacheQueryLimitPercentTest1)
 
     clearFileCacheAndWait()

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
@@ -22,7 +22,7 @@ import org.awaitility.Awaitility
 final String BACKEND_CONFIG_CHECK_FAILED_PREFIX = "Backend configuration check failed: "
 final String FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX = "File cache features check failed: "
 
-suite("test_file_cache_query_limit", "p0,external,nonConcurrent") {
+suite("test_file_cache_query_limit", "p0,external") {
     String enableHiveTest = context.config.otherConfigs.get("enableHiveTest")
     if (enableHiveTest == null || !enableHiveTest.equalsIgnoreCase("true")) {
         logger.info("disable hive test.")

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit.groovy
@@ -22,7 +22,7 @@ import org.awaitility.Awaitility
 final String BACKEND_CONFIG_CHECK_FAILED_PREFIX = "Backend configuration check failed: "
 final String FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX = "File cache features check failed: "
 
-suite("test_file_cache_query_limit", "p0,external") {
+suite("test_file_cache_query_limit", "p0,external,nonConcurrent") {
     String enableHiveTest = context.config.otherConfigs.get("enableHiveTest")
     if (enableHiveTest == null || !enableHiveTest.equalsIgnoreCase("true")) {
         logger.info("disable hive test.")

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit_stable.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit_stable.groovy
@@ -1,0 +1,295 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import java.util.concurrent.TimeUnit
+import org.awaitility.Awaitility
+
+// Keep only reusable prefixes and inline one-off failure messages near assertions.
+final String BACKEND_CONFIG_CHECK_FAILED_PREFIX = "Backend configuration check failed: "
+final String FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX = "File cache features check failed: "
+
+// Stable replacement for the muted query limit regression case in GitHub CI.
+suite("test_file_cache_query_limit_stable", "p0,external") {
+    String enableHiveTest = context.config.otherConfigs.get("enableHiveTest")
+    if (enableHiveTest == null || !enableHiveTest.equalsIgnoreCase("true")) {
+        logger.info("disable hive test.")
+        return
+    }
+
+    sql """set enable_file_cache=true"""
+
+    def enableFileCacheResult = sql """show backend config like 'enable_file_cache';"""
+    logger.info("enable_file_cache configuration: " + enableFileCacheResult)
+    assertFalse(enableFileCacheResult.size() == 0 || !enableFileCacheResult[0][3].equalsIgnoreCase("true"),
+            BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache is empty or not set to true")
+
+    def fileCacheBackgroundMonitorIntervalMsResult = sql """show backend config like 'file_cache_background_monitor_interval_ms';"""
+    logger.info("file_cache_background_monitor_interval_ms configuration: " + fileCacheBackgroundMonitorIntervalMsResult)
+    assertFalse(fileCacheBackgroundMonitorIntervalMsResult.size() == 0 || fileCacheBackgroundMonitorIntervalMsResult[0][3] == null ||
+            fileCacheBackgroundMonitorIntervalMsResult[0][3].trim().isEmpty(),
+            BACKEND_CONFIG_CHECK_FAILED_PREFIX + "file_cache_background_monitor_interval_ms is empty or not configured")
+
+    long backgroundMonitorIntervalMs = fileCacheBackgroundMonitorIntervalMsResult[0][3].toLong()
+    long waitTimeoutSeconds = Math.max(10L, backgroundMonitorIntervalMs.intdiv(1000L) + 5L)
+
+    String catalogName = "test_file_cache_query_limit_stable"
+    String externalDbName = "tpch1_parquet"
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+    String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+    long baseQueryCacheUsageBytes = 0L
+
+    // Discover the real Doris backend endpoints
+    def aliveBackends = sql_return_maparray("show backends").findAll { backend ->
+        backend.Alive.toString().equalsIgnoreCase("true")
+    }
+    logger.info("alive backends: " + aliveBackends)
+    assertTrue(aliveBackends.size() == 1,
+            BACKEND_CONFIG_CHECK_FAILED_PREFIX + "query limit test requires exactly one alive backend: " + aliveBackends)
+    def targetBackend = aliveBackends[0]
+    String targetBeIp = targetBackend.Host.toString()
+    String targetHttpPort = targetBackend.HttpPort.toString()
+    String targetBrpcPort = targetBackend.BrpcPort.toString()
+
+    // Reuse the same command execution path for every backend HTTP request.
+    def runCommandAndCollectOutput = { List<String> command ->
+        def process = new ProcessBuilder(command as String[]).redirectErrorStream(true).start()
+        def output = new StringBuilder()
+        process.inputStream.eachLine { line -> output.append(line).append("\n") }
+        int exitCode = process.waitFor()
+        return [exitCode: exitCode, output: output.toString()]
+    }
+
+    // Aggregate metrics across all cache paths on the target backend to avoid flaky single-row reads.
+    def getMetricSum = { String metricName ->
+        def result = sql """select coalesce(sum(cast(METRIC_VALUE as double)), 0)
+                from information_schema.file_cache_statistics
+                where BE_IP = '${targetBeIp}' and METRIC_NAME = '${metricName}';"""
+        double metricValue = Double.valueOf(result[0][0].toString())
+        logger.info("metric ${metricName} on backend ${targetBeIp}: ${metricValue}")
+        return metricValue
+    }
+
+    // Poll until asynchronous backend state converges to the expected condition.
+    def waitForCondition = { String description, Closure<Boolean> condition ->
+        Awaitility.await()
+                .atMost(waitTimeoutSeconds, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until {
+                    boolean matched = condition()
+                    if (!matched) {
+                        logger.info("Waiting for ${description}")
+                    }
+                    return matched
+                }
+    }
+
+    // Read backend config through SQL and return the raw value for later assertions.
+    def getBackendConfigValue = { String configKey ->
+        def result = sql """SHOW BACKEND CONFIG LIKE '${configKey}';"""
+        logger.info("${configKey} configuration: " + result)
+        assertFalse(result.size() == 0 || result[0][3] == null || result[0][3].toString().trim().isEmpty(),
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "${configKey} is empty or not configured")
+        return result[0][3].toString().trim()
+    }
+
+    // Clear file cache synchronously and wait until the observable queue metrics return to zero.
+    def clearFileCacheAndWait = {
+        def commandResult = runCommandAndCollectOutput([
+                "curl", "-X", "POST", "http://${targetBeIp}:${targetHttpPort}/api/file_cache?op=clear&sync=true"
+        ])
+        logger.info("File cache clear command output: ${commandResult.output}")
+        assertTrue(commandResult.exitCode == 0,
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "HTTP command failed: clear file cache failed with exit code ${commandResult.exitCode}")
+        waitForCondition("file cache clear on ${targetBeIp}") {
+            getMetricSum("normal_queue_curr_size") == 0.0 &&
+                    getMetricSum("normal_queue_curr_elements") == 0.0
+        }
+    }
+
+    // Fetch the total cache capacity from the target backend brpc vars endpoint.
+    def getFileCacheCapacity = {
+        def commandResult = runCommandAndCollectOutput([
+                "curl", "-X", "POST", "http://${targetBeIp}:${targetBrpcPort}/vars"
+        ])
+        logger.info("file cache vars output: ${commandResult.output}")
+        assertTrue(commandResult.exitCode == 0,
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "HTTP command failed: fetch brpc vars failed with exit code ${commandResult.exitCode}")
+        def fileCacheCapacityResult = commandResult.output.split("\n")
+                .find { it.contains("file_cache_capacity") }
+                ?.split(":")
+                ?.last()
+                ?.trim()
+        assertTrue(fileCacheCapacityResult != null,
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "failed to find file_cache_capacity in brpc metrics")
+        return Long.valueOf(fileCacheCapacityResult)
+    }
+
+    sql """drop catalog if exists ${catalogName} """
+
+    sql """CREATE CATALOG ${catalogName} PROPERTIES (
+        'type'='hms',
+        'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hmsPort}',
+        'hadoop.username' = 'hive'
+    );"""
+
+    String querySql =
+            """select sum(l_quantity) as sum_qty,
+            sum(l_extendedprice) as sum_base_price,
+            sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+            sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+            avg(l_quantity) as avg_qty,
+            avg(l_extendedprice) as avg_price,
+            avg(l_discount) as avg_disc,
+            count(*) as count_order
+            from ${catalogName}.${externalDbName}.lineitem
+            where l_shipdate <= date '1998-12-01' - interval '90' day
+            group by l_returnflag, l_linestatus
+            order by l_returnflag, l_linestatus;"""
+
+    long fileCacheCapacity = getFileCacheCapacity()
+    logger.info("File cache capacity: ${fileCacheCapacity}")
+
+    // Build a baseline without query limit so the next stage can derive a meaningful limit percent.
+    logger.info("Start file cache base test")
+
+    clearFileCacheAndWait()
+
+    double initialNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+    assertTrue(initialNormalQueueCurrSize == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_size is not 0")
+
+    double initialNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
+    assertTrue(initialNormalQueueCurrElements == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_elements is not 0")
+
+    logger.info("Initial normal queue curr size and elements - size: ${initialNormalQueueCurrSize} , elements: ${initialNormalQueueCurrElements}")
+
+    setBeConfigTemporary([
+            "enable_file_cache_query_limit": "false"
+    ]) {
+        logger.info("Backend configuration set - enable_file_cache_query_limit: false")
+
+        waitForCondition("backend config enable_file_cache_query_limit=false") {
+            getBackendConfigValue("enable_file_cache_query_limit") == "false"
+        }
+
+        assertEquals("false", getBackendConfigValue("enable_file_cache_query_limit"),
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache_query_limit is empty or not set to false")
+
+        sql """switch ${catalogName}"""
+        sql querySql
+
+        waitForCondition("base file cache statistics update") {
+            getMetricSum("normal_queue_curr_size") > 0.0 &&
+                    getMetricSum("normal_queue_curr_elements") > 0.0
+        }
+
+        double baseNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
+        assertTrue(baseNormalQueueCurrElements > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "base normal_queue_curr_elements is 0")
+
+        double baseNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+        assertTrue(baseNormalQueueCurrSize > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "base normal_queue_curr_size is 0")
+
+        baseQueryCacheUsageBytes = baseNormalQueueCurrSize as Long
+    }
+
+    double fileCacheQueryLimitPercent = baseQueryCacheUsageBytes * 100.0d / fileCacheCapacity
+    logger.info("file_cache_query_limit_percent: " + fileCacheQueryLimitPercent)
+
+    // Re-run the same query with a lower per-query cache limit and verify the observed cache usage stays bounded.
+    logger.info("Start file cache query limit test")
+
+    long fileCacheQueryLimitPercentCandidate = Math.floor(fileCacheQueryLimitPercent / 2.0d).longValue()
+    long fileCacheQueryLimitPercentTest1 = Math.max(1L, fileCacheQueryLimitPercentCandidate)
+    logger.info("file_cache_query_limit_percent_test1: " + fileCacheQueryLimitPercentTest1)
+
+    clearFileCacheAndWait()
+
+    initialNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+    assertTrue(initialNormalQueueCurrSize == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_size is not 0")
+
+    initialNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
+    assertTrue(initialNormalQueueCurrElements == 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_curr_elements is not 0")
+
+    double initialNormalQueueMaxSize = getMetricSum("normal_queue_max_size")
+    assertTrue(initialNormalQueueMaxSize > 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_max_size is 0")
+
+    double initialNormalQueueMaxElements = getMetricSum("normal_queue_max_elements")
+    assertTrue(initialNormalQueueMaxElements > 0.0,
+            FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "initial normal_queue_max_elements is 0")
+
+    logger.info("Initial normal queue curr size and elements - size: ${initialNormalQueueCurrSize} , elements: ${initialNormalQueueCurrElements}")
+    logger.info("Initial normal queue max size and elements - size: ${initialNormalQueueMaxSize} , elements: ${initialNormalQueueMaxElements}")
+
+    double initialTotalHitCounts = getMetricSum("total_hit_counts")
+    double initialTotalReadCounts = getMetricSum("total_read_counts")
+
+    setBeConfigTemporary([
+            "enable_file_cache_query_limit": "true"
+    ]) {
+        logger.info("Backend configuration set - enable_file_cache_query_limit: true")
+
+        sql """set file_cache_query_limit_percent = ${fileCacheQueryLimitPercentTest1}"""
+
+        waitForCondition("backend config enable_file_cache_query_limit=true") {
+            getBackendConfigValue("enable_file_cache_query_limit") == "true"
+        }
+
+        assertEquals("true", getBackendConfigValue("enable_file_cache_query_limit"),
+                BACKEND_CONFIG_CHECK_FAILED_PREFIX + "enable_file_cache_query_limit is empty or not set to true")
+
+        sql """switch ${catalogName}"""
+        sql querySql
+
+        waitForCondition("query limit file cache statistics update") {
+            getMetricSum("normal_queue_curr_size") > 0.0 &&
+                    getMetricSum("normal_queue_curr_elements") > 0.0 &&
+                    getMetricSum("total_read_counts") > initialTotalReadCounts
+        }
+
+        double updatedNormalQueueCurrSize = getMetricSum("normal_queue_curr_size")
+        double updatedNormalQueueCurrElements = getMetricSum("normal_queue_curr_elements")
+
+        logger.info("Updated normal queue curr size and elements - size: ${updatedNormalQueueCurrSize} , elements: ${updatedNormalQueueCurrElements}")
+
+        assertTrue(updatedNormalQueueCurrSize > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_size is not greater than 0 after cache operation")
+        assertTrue(updatedNormalQueueCurrElements > 0.0,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_elements is not greater than 0 after cache operation")
+
+        long expectedQueryLimitBytes = fileCacheCapacity * fileCacheQueryLimitPercentTest1 / 100
+        logger.info("Normal queue curr size and expected query limit comparison - normal queue curr size: ${updatedNormalQueueCurrSize as Long} , expected query limit: ${expectedQueryLimitBytes}")
+
+        assertTrue((updatedNormalQueueCurrSize as Long) <= expectedQueryLimitBytes,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "normal_queue_curr_size is greater than expected query limit")
+
+        double updatedTotalHitCounts = getMetricSum("total_hit_counts")
+        double updatedTotalReadCounts = getMetricSum("total_read_counts")
+
+        logger.info("Total hit and read counts comparison - hit counts: ${initialTotalHitCounts} -> ${updatedTotalHitCounts} , read counts: ${initialTotalReadCounts} -> ${updatedTotalReadCounts}")
+
+        assertTrue(updatedTotalReadCounts > initialTotalReadCounts,
+                FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX + "total_read_counts did not increase after cache operation")
+    }
+
+    return true
+}

--- a/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit_stable.groovy
+++ b/regression-test/suites/external_table_p0/cache/test_file_cache_query_limit_stable.groovy
@@ -23,7 +23,7 @@ final String BACKEND_CONFIG_CHECK_FAILED_PREFIX = "Backend configuration check f
 final String FILE_CACHE_FEATURES_CHECK_FAILED_PREFIX = "File cache features check failed: "
 
 // Stable replacement for the muted query limit regression case in GitHub CI.
-suite("test_file_cache_query_limit_stable", "p0,external") {
+suite("test_file_cache_query_limit_stable", "p0,external,nonConcurrent") {
     String enableHiveTest = context.config.otherConfigs.get("enableHiveTest")
     if (enableHiveTest == null || !enableHiveTest.equalsIgnoreCase("true")) {
         logger.info("disable hive test.")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

This PR refactors the file cache query limit regression case to make it more stable and easier to maintain. It replaces the incorrect use of the Hive metastore IP with real backend endpoints discovered from `show backends`, aggregates file cache statistics by backend instead of reading a random single row, replaces fixed sleeps with polling, and tightens the query limit assertion to compare against the expected per-query limit. It also simplifies messages, logs, naming, and comments in the regression case.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

CI will be triggered by a `run buildall` comment right after PR creation.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
