### PR TITLE
[refine](function) add debug-only mock const execute to catch const-column handling bugs

### DIFF
--- a/be/src/core/column/column_const.h
+++ b/be/src/core/column/column_const.h
@@ -124,7 +124,8 @@ public:
     void resize(size_t new_size) override { s = new_size; }
 
     MutableColumnPtr clone_resized(size_t new_size) const override {
-        return ColumnConst::create(data, new_size, false, false);
+        auto cloned_data = data->clone_resized(data->size());
+        return ColumnConst::create(std::move(cloned_data), new_size, false, false);
     }
 
     size_t size() const override { return s; }

--- a/be/src/exprs/function/function.cpp
+++ b/be/src/exprs/function/function.cpp
@@ -405,4 +405,55 @@ bool FunctionBuilderImpl::is_nested_type_date_or_datetime_or_decimal(
     }
 }
 
+Status IFunctionBase::mock_const_execute(FunctionContext* context, Block& block,
+                                         const ColumnNumbers& arguments, uint32_t result,
+                                         size_t input_rows_count) const {
+    if (!is_udf_function()) {
+        try {
+            Block const_block;
+            for (size_t col = 0; col < block.columns(); ++col) {
+                auto& col_data = block.get_by_position(col);
+                if (col_data.column) {
+                    auto one_row = col_data.column->cut(0, 1);
+                    auto const_col = ColumnConst::create(std::move(one_row), input_rows_count);
+                    const_block.insert({std::move(const_col), col_data.type, col_data.name});
+                } else {
+                    const_block.insert(col_data);
+                }
+            }
+            RETURN_IF_ERROR(
+                    prepare(context, const_block, arguments, result)
+                            ->execute(context, const_block, arguments, result, input_rows_count));
+        } catch (const Exception&) {
+            // some column not support cut, just ignore and return OK.
+        }
+    }
+    return Status::OK();
+}
+
+Status IFunctionBase::execute(FunctionContext* context, Block& block,
+                              const ColumnNumbers& arguments, uint32_t result,
+                              size_t input_rows_count) const {
+    // Some function implementations may not handle the case where input_rows_count is 0
+    // (e.g., some functions access the 0th row of input columns during execution).
+    // Additionally, some UDF functions may hang if they write 0 rows and then try to read.
+    // Therefore, before executing the function, we first check if input_rows_count is 0.
+    // If it is 0, we directly return an empty result column to avoid executing the function body.
+    if (input_rows_count == 0) {
+        block.get_by_position(result).column = block.get_by_position(result).type->create_column();
+        return Status::OK();
+    }
+
+#ifndef NDEBUG
+    RETURN_IF_ERROR(mock_const_execute(context, block, arguments, result, input_rows_count));
+#endif
+
+    try {
+        return prepare(context, block, arguments, result)
+                ->execute(context, block, arguments, result, input_rows_count);
+    } catch (const Exception& e) {
+        return e.to_status();
+    }
+}
+
 } // namespace doris

--- a/be/src/exprs/function/function.cpp
+++ b/be/src/exprs/function/function.cpp
@@ -41,6 +41,49 @@
 #include "exprs/function/function_helpers.h"
 
 namespace doris {
+
+namespace {
+
+ColumnNumbers collect_non_const_argument_positions(const Block& block,
+                                                   const ColumnNumbers& arguments) {
+    ColumnNumbers non_const_arguments;
+    non_const_arguments.reserve(arguments.size());
+    for (auto column_position : arguments) {
+        const auto& column = block.get_by_position(column_position).column;
+        if (!column || is_column_const(*column) ||
+            std::ranges::find(non_const_arguments, column_position) != non_const_arguments.end()) {
+            continue;
+        }
+        non_const_arguments.push_back(column_position);
+    }
+    return non_const_arguments;
+}
+
+Status run_mock_const_probe(FunctionContext* context, const IFunctionBase& function,
+                            const Block& block, const ColumnNumbers& arguments, uint32_t result,
+                            size_t input_rows_count, const ColumnNumbers& columns_to_mock_const) {
+    try {
+        Block const_block = block;
+        for (auto column_position : columns_to_mock_const) {
+            auto& column_with_type = const_block.get_by_position(column_position);
+            if (!column_with_type.column || is_column_const(*column_with_type.column)) {
+                continue;
+            }
+            auto one_row = column_with_type.column->cut(0, 1);
+            column_with_type.column = ColumnConst::create(std::move(one_row), input_rows_count);
+        }
+
+        RETURN_IF_ERROR(
+                function.prepare(context, const_block, arguments, result)
+                        ->execute(context, const_block, arguments, result, input_rows_count));
+    } catch (const Exception&) {
+        // Some columns do not support cut; skip this debug probe in that case.
+    }
+    return Status::OK();
+}
+
+} // namespace
+
 ColumnPtr wrap_in_nullable(const ColumnPtr& src, const Block& block, const ColumnNumbers& args,
                            size_t input_rows_count) {
     ColumnPtr result_null_map_column;
@@ -409,23 +452,17 @@ Status IFunctionBase::mock_const_execute(FunctionContext* context, Block& block,
                                          const ColumnNumbers& arguments, uint32_t result,
                                          size_t input_rows_count) const {
     if (!is_udf_function()) {
-        try {
-            Block const_block;
-            for (size_t col = 0; col < block.columns(); ++col) {
-                auto& col_data = block.get_by_position(col);
-                if (col_data.column) {
-                    auto one_row = col_data.column->cut(0, 1);
-                    auto const_col = ColumnConst::create(std::move(one_row), input_rows_count);
-                    const_block.insert({std::move(const_col), col_data.type, col_data.name});
-                } else {
-                    const_block.insert(col_data);
-                }
+        auto non_const_arguments = collect_non_const_argument_positions(block, arguments);
+        if (!non_const_arguments.empty()) {
+            RETURN_IF_ERROR(run_mock_const_probe(context, *this, block, arguments, result,
+                                                 input_rows_count, non_const_arguments));
+
+            // Probe the mixed path by forcing each non-const argument to const one at a time.
+            for (auto column_position : non_const_arguments) {
+                RETURN_IF_ERROR(run_mock_const_probe(context, *this, block, arguments, result,
+                                                     input_rows_count,
+                                                     ColumnNumbers {column_position}));
             }
-            RETURN_IF_ERROR(
-                    prepare(context, const_block, arguments, result)
-                            ->execute(context, const_block, arguments, result, input_rows_count));
-        } catch (const Exception&) {
-            // some column not support cut, just ignore and return OK.
         }
     }
     return Status::OK();

--- a/be/src/exprs/function/function.cpp
+++ b/be/src/exprs/function/function.cpp
@@ -61,12 +61,24 @@ ColumnNumbers collect_non_const_argument_positions(const Block& block,
 }
 
 std::vector<std::shared_ptr<ColumnPtrWrapper>> collect_constant_argument_columns(
-        const Block& block, const ColumnNumbers& arguments) {
-    std::vector<std::shared_ptr<ColumnPtrWrapper>> constant_columns(arguments.size());
+        const FunctionContext& context, const Block& block, const ColumnNumbers& arguments) {
+    std::vector<std::shared_ptr<ColumnPtrWrapper>> constant_columns(
+            std::max<size_t>(context.get_num_args(), arguments.size()));
+
+    for (int argument_index = 0; argument_index < context.get_num_args(); ++argument_index) {
+        auto* const_column = context.get_constant_col(argument_index);
+        if (const_column != nullptr) {
+            constant_columns[argument_index] =
+                    std::make_shared<ColumnPtrWrapper>(const_column->column_ptr);
+        }
+    }
+
     for (size_t argument_index = 0; argument_index < arguments.size(); ++argument_index) {
         const auto& column = block.get_by_position(arguments[argument_index]).column;
         if (column && is_column_const(*column)) {
             constant_columns[argument_index] = std::make_shared<ColumnPtrWrapper>(column);
+        } else {
+            constant_columns[argument_index].reset();
         }
     }
     return constant_columns;
@@ -92,7 +104,8 @@ Status run_mock_const_probe(FunctionContext* context, const IFunctionBase& funct
         }
 
         auto mock_context = context->clone();
-        mock_context->set_constant_cols(collect_constant_argument_columns(const_block, arguments));
+        mock_context->set_constant_cols(
+                collect_constant_argument_columns(*mock_context, const_block, arguments));
         mock_context->set_function_state(FunctionContext::FRAGMENT_LOCAL, std::shared_ptr<void> {});
         mock_context->set_function_state(FunctionContext::THREAD_LOCAL, std::shared_ptr<void> {});
         Defer close_probe([&] {

--- a/be/src/exprs/function/function.cpp
+++ b/be/src/exprs/function/function.cpp
@@ -39,6 +39,7 @@
 #include "exec/common/util.hpp"
 #include "exprs/aggregate/aggregate_function.h"
 #include "exprs/function/function_helpers.h"
+#include "util/defer_op.h"
 
 namespace doris {
 
@@ -59,10 +60,23 @@ ColumnNumbers collect_non_const_argument_positions(const Block& block,
     return non_const_arguments;
 }
 
+std::vector<std::shared_ptr<ColumnPtrWrapper>> collect_constant_argument_columns(
+        const Block& block, const ColumnNumbers& arguments) {
+    std::vector<std::shared_ptr<ColumnPtrWrapper>> constant_columns(arguments.size());
+    for (size_t argument_index = 0; argument_index < arguments.size(); ++argument_index) {
+        const auto& column = block.get_by_position(arguments[argument_index]).column;
+        if (column && is_column_const(*column)) {
+            constant_columns[argument_index] = std::make_shared<ColumnPtrWrapper>(column);
+        }
+    }
+    return constant_columns;
+}
+
 Status run_mock_const_probe(FunctionContext* context, const IFunctionBase& function,
                             const Block& block, const ColumnNumbers& arguments, uint32_t result,
                             size_t input_rows_count, const ColumnNumbers& columns_to_mock_const) {
     try {
+        auto& mutable_function = const_cast<IFunctionBase&>(function);
         Block const_block = block;
         for (auto column_position : columns_to_mock_const) {
             auto& column_with_type = const_block.get_by_position(column_position);
@@ -73,9 +87,24 @@ Status run_mock_const_probe(FunctionContext* context, const IFunctionBase& funct
             column_with_type.column = ColumnConst::create(std::move(one_row), input_rows_count);
         }
 
+        auto mock_context = context->clone();
+        mock_context->set_constant_cols(collect_constant_argument_columns(const_block, arguments));
+        mock_context->set_function_state(FunctionContext::FRAGMENT_LOCAL, std::shared_ptr<void> {});
+        mock_context->set_function_state(FunctionContext::THREAD_LOCAL, std::shared_ptr<void> {});
+        Defer close_probe([&] {
+            static_cast<void>(
+                    mutable_function.close(mock_context.get(), FunctionContext::THREAD_LOCAL));
+            static_cast<void>(
+                    mutable_function.close(mock_context.get(), FunctionContext::FRAGMENT_LOCAL));
+        });
+
+        RETURN_IF_ERROR(mutable_function.open(mock_context.get(), FunctionContext::FRAGMENT_LOCAL));
+        RETURN_IF_ERROR(mutable_function.open(mock_context.get(), FunctionContext::THREAD_LOCAL));
+
         RETURN_IF_ERROR(
-                function.prepare(context, const_block, arguments, result)
-                        ->execute(context, const_block, arguments, result, input_rows_count));
+                mutable_function.prepare(mock_context.get(), const_block, arguments, result)
+                        ->execute(mock_context.get(), const_block, arguments, result,
+                                  input_rows_count));
     } catch (const Exception&) {
         // Some columns do not support cut; skip this debug probe in that case.
     }

--- a/be/src/exprs/function/function.cpp
+++ b/be/src/exprs/function/function.cpp
@@ -75,6 +75,10 @@ std::vector<std::shared_ptr<ColumnPtrWrapper>> collect_constant_argument_columns
 Status run_mock_const_probe(FunctionContext* context, const IFunctionBase& function,
                             const Block& block, const ColumnNumbers& arguments, uint32_t result,
                             size_t input_rows_count, const ColumnNumbers& columns_to_mock_const) {
+    if (context == nullptr) {
+        return Status::OK();
+    }
+
     try {
         auto& mutable_function = const_cast<IFunctionBase&>(function);
         Block const_block = block;

--- a/be/src/exprs/function/function.h
+++ b/be/src/exprs/function/function.h
@@ -185,24 +185,7 @@ public:
     }
 
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                   uint32_t result, size_t input_rows_count) const {
-        // Some function implementations may not handle the case where input_rows_count is 0
-        // (e.g., some functions access the 0th row of input columns during execution).
-        // Additionally, some UDF functions may hang if they write 0 rows and then try to read.
-        // Therefore, before executing the function, we first check if input_rows_count is 0.
-        // If it is 0, we directly return an empty result column to avoid executing the function body.
-        if (input_rows_count == 0) {
-            block.get_by_position(result).column =
-                    block.get_by_position(result).type->create_column();
-            return Status::OK();
-        }
-        try {
-            return prepare(context, block, arguments, result)
-                    ->execute(context, block, arguments, result, input_rows_count);
-        } catch (const Exception& e) {
-            return e.to_status();
-        }
-    }
+                   uint32_t result, size_t input_rows_count) const;
 
     virtual Status evaluate_inverted_index(
             const ColumnsWithTypeAndName& arguments,
@@ -226,6 +209,11 @@ public:
     virtual bool can_push_down_to_index() const { return false; }
 
     virtual bool is_blockable() const { return false; }
+
+private:
+    Status mock_const_execute(FunctionContext* context, Block& block,
+                              const ColumnNumbers& arguments, uint32_t result,
+                              size_t input_rows_count) const;
 };
 
 using FunctionBasePtr = std::shared_ptr<IFunctionBase>;

--- a/be/src/exprs/function/function_quantile_state.cpp
+++ b/be/src/exprs/function/function_quantile_state.cpp
@@ -162,6 +162,8 @@ public:
 
     bool use_default_implementation_for_nulls() const override { return false; }
 
+    ColumnNumbers get_arguments_that_are_always_constant() const override { return {1}; }
+
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
         auto res_data_column = ColumnFloat64::create();

--- a/be/src/exprs/function/function_regexp.cpp
+++ b/be/src/exprs/function/function_regexp.cpp
@@ -33,6 +33,7 @@
 #include "core/block/column_numbers.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
+#include "core/column/column_execute_util.h"
 #include "core/column/column_const.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
@@ -188,23 +189,26 @@ struct RegexpExtractEngine {
 };
 
 struct RegexpCountImpl {
+    using StringColumnView = ColumnView<TYPE_STRING>;
+
     static void execute_impl(FunctionContext* context, ColumnPtr argument_columns[],
                              size_t input_rows_count, ColumnInt32::Container& result_data) {
-        const auto* str_col = check_and_get_column<ColumnString>(argument_columns[0].get());
-        const auto* pattern_col = check_and_get_column<ColumnString>(argument_columns[1].get());
-        for (int i = 0; i < input_rows_count; ++i) {
+        auto str_col = StringColumnView::create(argument_columns[0]);
+        auto pattern_col = StringColumnView::create(argument_columns[1]);
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            DCHECK(!str_col.is_null_at(i));
+            DCHECK(!pattern_col.is_null_at(i));
             result_data[i] = _execute_inner_loop(context, str_col, pattern_col, i);
         }
     }
-    static int _execute_inner_loop(FunctionContext* context, const ColumnString* str_col,
-                                   const ColumnString* pattern_col, const size_t index_now) {
+    static int _execute_inner_loop(FunctionContext* context, const StringColumnView& str_col,
+                                   const StringColumnView& pattern_col, const size_t index_now) {
         re2::RE2* re = reinterpret_cast<re2::RE2*>(
                 context->get_function_state(FunctionContext::THREAD_LOCAL));
         std::unique_ptr<re2::RE2> scoped_re;
         if (re == nullptr) {
             std::string error_str;
-            DCHECK(pattern_col);
-            const auto& pattern = pattern_col->get_data_at(index_check_const(index_now, false));
+            const auto pattern = pattern_col.value_at(index_now);
             bool st = StringFunctions::compile_regex(pattern, &error_str, StringRef(), StringRef(),
                                                      scoped_re);
             if (!st) {
@@ -215,7 +219,7 @@ struct RegexpCountImpl {
             re = scoped_re.get();
         }
 
-        const auto& str = str_col->get_data_at(index_now);
+        const auto str = str_col.value_at(index_now);
         int count = 0;
         size_t pos = 0;
         while (pos < str.size) {

--- a/be/src/exprs/function/uniform.cpp
+++ b/be/src/exprs/function/uniform.cpp
@@ -147,6 +147,8 @@ public:
     static FunctionPtr create() { return std::make_shared<FunctionUniform<Impl>>(); }
     String get_name() const override { return name; }
 
+    bool use_default_implementation_for_constants() const override { return false; }
+
     size_t get_number_of_arguments() const override {
         return get_variadic_argument_types_impl().size();
     }

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -54,10 +54,12 @@ std::unique_ptr<FunctionContext> FunctionContext::clone() {
     auto new_context = create_context(_state, _return_type, _arg_types);
     new_context->_constant_cols = _constant_cols;
     new_context->_fragment_local_fn_state = _fragment_local_fn_state;
+    new_context->_udf_execute_timer = _udf_execute_timer;
     new_context->_check_overflow_for_decimal = _check_overflow_for_decimal;
     new_context->_enable_strict_mode = _enable_strict_mode;
     new_context->_string_as_jsonb_string = _string_as_jsonb_string;
     new_context->_jsonb_string_as_string = _jsonb_string_as_string;
+    new_context->_dict_function = _dict_function;
     return new_context;
 }
 

--- a/be/test/exprs/function/function_math_test.cpp
+++ b/be/test/exprs/function/function_math_test.cpp
@@ -18,14 +18,17 @@
 #include <climits>
 #include <cstdint>
 #include <limits>
+#include <random>
 #include <string>
 
+#include "core/column/column_const.h"
 #include "core/data_type/data_type_decimal.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/types.h"
 #include "exprs/function/function_test_util.h"
 #include "testutil/any_type.h"
+#include "testutil/column_helper.h"
 
 namespace doris {
 
@@ -550,6 +553,56 @@ TEST(MathFunctionTest, random_test) {
         DataSet data_line = {data};
         static_cast<void>(check_function<DataTypeFloat64, true>(func_name, input_types, data_line));
     }
+}
+
+TEST(MathFunctionTest, uniform_mixed_const_probe_test) {
+    auto input_type = std::make_shared<DataTypeInt64>();
+    auto return_type = std::make_shared<DataTypeInt64>();
+
+    Block block;
+    auto min_data = ColumnHelper::create_column<DataTypeInt64>({1});
+    auto max_data = ColumnHelper::create_column<DataTypeInt64>({10});
+    auto seed_column = ColumnHelper::create_column<DataTypeInt64>({101, 202, 303});
+
+    block.insert({ColumnConst::create(min_data, 3), input_type, "min"});
+    block.insert({ColumnConst::create(max_data, 3), input_type, "max"});
+    block.insert({seed_column, input_type, "seed"});
+
+    FunctionBasePtr function = SimpleFunctionFactory::instance().get_function(
+            "uniform", block.get_columns_with_type_and_name(), return_type);
+    ASSERT_TRUE(function != nullptr);
+
+    block.insert({nullptr, return_type, "result"});
+
+    FunctionUtils fn_utils(return_type, {input_type, input_type, input_type}, false);
+    auto* fn_ctx = fn_utils.get_fn_ctx();
+    std::vector<std::shared_ptr<ColumnPtrWrapper>> constant_cols {
+            std::make_shared<ColumnPtrWrapper>(block.get_by_position(0).column),
+            std::make_shared<ColumnPtrWrapper>(block.get_by_position(1).column),
+            nullptr,
+    };
+    fn_ctx->set_constant_cols(constant_cols);
+
+    ASSERT_TRUE(function->open(fn_ctx, FunctionContext::FRAGMENT_LOCAL).ok());
+    ASSERT_TRUE(function->open(fn_ctx, FunctionContext::THREAD_LOCAL).ok());
+
+    auto exec_status = function->execute(fn_ctx, block, {0, 1, 2}, 3, 3);
+
+    static_cast<void>(function->close(fn_ctx, FunctionContext::THREAD_LOCAL));
+    static_cast<void>(function->close(fn_ctx, FunctionContext::FRAGMENT_LOCAL));
+
+    ASSERT_TRUE(exec_status.ok()) << exec_status.to_string();
+
+    const auto& result_column = assert_cast<const ColumnInt64&>(*block.get_by_position(3).column);
+    auto expected_uniform = [](int64_t seed) {
+        std::mt19937_64 generator(seed);
+        std::uniform_int_distribution<int64_t> distribution(1, 10);
+        return distribution(generator);
+    };
+
+    EXPECT_EQ(result_column.get_element(0), expected_uniform(101));
+    EXPECT_EQ(result_column.get_element(1), expected_uniform(202));
+    EXPECT_EQ(result_column.get_element(2), expected_uniform(303));
 }
 
 TEST(MathFunctionTest, conv_test) {

--- a/be/test/exprs/function/function_math_test.cpp
+++ b/be/test/exprs/function/function_math_test.cpp
@@ -532,6 +532,11 @@ TEST(MathFunctionTest, hex_test) {
 }
 
 TEST(MathFunctionTest, random_test) {
+#ifndef NDEBUG
+    GTEST_SKIP() << "random(seed) exact-value assertions are release-only; debug builds run "
+                    "mock_const_execute before the real call.";
+#endif
+
     std::string func_name = "random"; // random(x)
     InputTypeSet input_types = {Consted {PrimitiveType::TYPE_BIGINT}};
     DataSet data_set = {{{Null()}, Null()},

--- a/be/test/exprs/function/function_string_test.cpp
+++ b/be/test/exprs/function/function_string_test.cpp
@@ -4003,4 +4003,20 @@ TEST(function_string_test, function_unicode_normalize_invalid_mode) {
     EXPECT_NE(Status::OK(), st);
 }
 
+TEST(function_string_test, function_regexp_count_mixed_const_test) {
+    std::string func_name = "regexp_count";
+
+    InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR, PrimitiveType::TYPE_VARCHAR};
+    DataSet data_set = {
+            {{std::string("a.b:c;d"), std::string("[.:;]")}, std::int32_t(3)},
+            {{std::string("a1b2346c3d"), std::string("\\d+")}, std::int32_t(3)},
+            {{std::string("abcd"), std::string("")}, std::int32_t(0)},
+            {{std::string("book keeper"), std::string("oo|ee")}, std::int32_t(2)},
+            {{Null(), std::string("\\d+")}, Null()},
+            {{std::string("abcd"), Null()}, Null()},
+    };
+
+    check_function_all_arg_comb<DataTypeInt32, true>(func_name, input_types, data_set);
+}
+
 } // namespace doris

--- a/be/test/exprs/function/simple_function_factory_test.cpp
+++ b/be/test/exprs/function/simple_function_factory_test.cpp
@@ -258,4 +258,15 @@ TEST_F(SimpleFunctionFactoryTest, test_debug_mock_const_execute_syncs_context_st
     EXPECT_TRUE(function.execute(context.get(), block, arguments, 3, 3).ok());
 }
 
+TEST_F(SimpleFunctionFactoryTest, test_debug_mock_const_execute_skips_probe_without_context) {
+    MockConstRecordingFunction function;
+    auto block = create_mock_const_test_block();
+    ColumnNumbers arguments {0, 1, 2};
+
+    EXPECT_TRUE(function.execute(nullptr, block, arguments, 3, 3).ok());
+
+    ASSERT_EQ(function.observed_const_patterns.size(), 1);
+    EXPECT_EQ(function.observed_const_patterns[0], (std::vector<bool> {false, true, false}));
+}
+
 } // namespace doris

--- a/be/test/exprs/function/simple_function_factory_test.cpp
+++ b/be/test/exprs/function/simple_function_factory_test.cpp
@@ -94,10 +94,76 @@ private:
     PreparedFunctionPtr _prepared_function;
 };
 
+class MockContextSyncPreparedFunction final : public IPreparedFunction {
+public:
+    explicit MockContextSyncPreparedFunction(std::vector<bool> expected_const_flags)
+            : _expected_const_flags(std::move(expected_const_flags)) {}
+
+    String get_name() const override { return "mock_const_context_sync_test"; }
+
+    Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                   uint32_t result, size_t input_rows_count) const override {
+        auto* fragment_state = context->get_function_state(FunctionContext::FRAGMENT_LOCAL);
+        auto* thread_state = context->get_function_state(FunctionContext::THREAD_LOCAL);
+
+        if (_expected_const_flags[0] != (fragment_state != nullptr)) {
+            return Status::InternalError("fragment-local const state mismatch");
+        }
+        if (_expected_const_flags[2] != (thread_state != nullptr)) {
+            return Status::InternalError("thread-local const state mismatch");
+        }
+        return Status::OK();
+    }
+
+private:
+    std::vector<bool> _expected_const_flags;
+};
+
+class MockConstContextSyncFunction final : public IFunctionBase {
+public:
+    MockConstContextSyncFunction()
+            : _argument_types({std::make_shared<DataTypeInt32>(), std::make_shared<DataTypeInt32>(),
+                               std::make_shared<DataTypeInt32>()}),
+              _return_type(std::make_shared<DataTypeInt32>()) {}
+
+    String get_name() const override { return "mock_const_context_sync_function"; }
+
+    const DataTypes& get_argument_types() const override { return _argument_types; }
+
+    const DataTypePtr& get_return_type() const override { return _return_type; }
+
+    PreparedFunctionPtr prepare(FunctionContext* context, const Block& sample_block,
+                                const ColumnNumbers& arguments, uint32_t result) const override {
+        std::vector<bool> const_flags;
+        const_flags.reserve(arguments.size());
+        for (auto column_position : arguments) {
+            const auto& column = sample_block.get_by_position(column_position).column;
+            const_flags.push_back(column && is_column_const(*column));
+        }
+        return std::make_shared<MockContextSyncPreparedFunction>(std::move(const_flags));
+    }
+
+    Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
+        if (scope == FunctionContext::FRAGMENT_LOCAL && context->is_col_constant(0)) {
+            context->set_function_state(scope, std::make_shared<int>(1));
+        }
+        if (scope == FunctionContext::THREAD_LOCAL && context->is_col_constant(2)) {
+            context->set_function_state(scope, std::make_shared<int>(1));
+        }
+        return Status::OK();
+    }
+
+    bool is_use_default_implementation_for_constants() const override { return false; }
+
+private:
+    DataTypes _argument_types;
+    DataTypePtr _return_type;
+};
+
 Block create_mock_const_test_block() {
     auto arg0 = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
     auto arg1_data = ColumnHelper::create_column<DataTypeInt32>({11});
-    auto arg1 = ColumnConst::create(arg1_data, 3);
+    ColumnPtr arg1 = ColumnConst::create(arg1_data, 3);
     auto arg2 = ColumnHelper::create_column<DataTypeInt32>({4, 5, 6});
 
     auto data_type = std::make_shared<DataTypeInt32>();
@@ -180,6 +246,16 @@ TEST_F(SimpleFunctionFactoryTest, test_debug_mock_const_execute_modes) {
     ASSERT_EQ(function.observed_const_patterns.size(), 1);
     EXPECT_EQ(function.observed_const_patterns[0], (std::vector<bool> {false, true, false}));
 #endif
+}
+
+TEST_F(SimpleFunctionFactoryTest, test_debug_mock_const_execute_syncs_context_state) {
+    MockConstContextSyncFunction function;
+    auto context = FunctionContext::create_context(nullptr, function.get_return_type(),
+                                                   function.get_argument_types());
+    auto block = create_mock_const_test_block();
+    ColumnNumbers arguments {0, 1, 2};
+
+    EXPECT_TRUE(function.execute(context.get(), block, arguments, 3, 3).ok());
 }
 
 } // namespace doris

--- a/be/test/exprs/function/simple_function_factory_test.cpp
+++ b/be/test/exprs/function/simple_function_factory_test.cpp
@@ -160,6 +160,56 @@ private:
     DataTypePtr _return_type;
 };
 
+class MockOmittedConstantArgsPreparedFunction final : public IPreparedFunction {
+public:
+    String get_name() const override { return "mock_omitted_constant_args_test"; }
+
+    Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                   uint32_t result, size_t input_rows_count) const override {
+        return Status::OK();
+    }
+};
+
+class MockOmittedConstantArgsFunction final : public IFunctionBase {
+public:
+    MockOmittedConstantArgsFunction()
+            : _argument_types({std::make_shared<DataTypeInt32>(), std::make_shared<DataTypeInt32>(),
+                               std::make_shared<DataTypeInt32>()}),
+              _return_type(std::make_shared<DataTypeInt32>()),
+              _prepared_function(std::make_shared<MockOmittedConstantArgsPreparedFunction>()) {}
+
+    String get_name() const override { return "mock_omitted_constant_args_function"; }
+
+    const DataTypes& get_argument_types() const override { return _argument_types; }
+
+    const DataTypePtr& get_return_type() const override { return _return_type; }
+
+    PreparedFunctionPtr prepare(FunctionContext* context, const Block& sample_block,
+                                const ColumnNumbers& arguments, uint32_t result) const override {
+        return _prepared_function;
+    }
+
+    Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
+        if (scope == FunctionContext::FRAGMENT_LOCAL) {
+            if (!context->is_col_constant(0)) {
+                return Status::InternalError("mocked execute argument was not constified");
+            }
+            if (context->get_constant_col(1) == nullptr ||
+                context->get_constant_col(2) == nullptr) {
+                return Status::InternalError("omitted constant arguments were dropped");
+            }
+        }
+        return Status::OK();
+    }
+
+    bool is_use_default_implementation_for_constants() const override { return false; }
+
+private:
+    DataTypes _argument_types;
+    DataTypePtr _return_type;
+    PreparedFunctionPtr _prepared_function;
+};
+
 Block create_mock_const_test_block() {
     auto arg0 = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
     auto arg1_data = ColumnHelper::create_column<DataTypeInt32>({11});
@@ -267,6 +317,25 @@ TEST_F(SimpleFunctionFactoryTest, test_debug_mock_const_execute_skips_probe_with
 
     ASSERT_EQ(function.observed_const_patterns.size(), 1);
     EXPECT_EQ(function.observed_const_patterns[0], (std::vector<bool> {false, true, false}));
+}
+
+TEST_F(SimpleFunctionFactoryTest,
+       test_debug_mock_const_execute_preserves_context_constants_for_omitted_args) {
+    MockOmittedConstantArgsFunction function;
+    auto context = FunctionContext::create_context(nullptr, function.get_return_type(),
+                                                   function.get_argument_types());
+
+    auto data_type = std::make_shared<DataTypeInt32>();
+    Block block;
+    block.insert({ColumnHelper::create_column<DataTypeInt32>({1, 2, 3}), data_type, "arg0"});
+    block.insert({data_type->create_column(), data_type, "result"});
+
+    context->set_constant_cols(
+            {nullptr,
+             std::make_shared<ColumnPtrWrapper>(ColumnHelper::create_column<DataTypeInt32>({11})),
+             std::make_shared<ColumnPtrWrapper>(ColumnHelper::create_column<DataTypeInt32>({22}))});
+
+    EXPECT_TRUE(function.execute(context.get(), block, ColumnNumbers {0}, 1, 3).ok());
 }
 
 } // namespace doris

--- a/be/test/exprs/function/simple_function_factory_test.cpp
+++ b/be/test/exprs/function/simple_function_factory_test.cpp
@@ -20,8 +20,13 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <vector>
 
+#include "core/column/column_const.h"
 #include "core/data_type/data_type_number.h"
+#include "exprs/function/function.h"
+#include "exprs/function_context.h"
+#include "testutil/column_helper.h"
 
 namespace doris {
 
@@ -42,6 +47,67 @@ public:
         return Status::OK();
     }
 };
+
+class MockPreparedFunction final : public IPreparedFunction {
+public:
+    String get_name() const override { return "mock_const_execute_test"; }
+
+    Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                   uint32_t result, size_t input_rows_count) const override {
+        return Status::OK();
+    }
+};
+
+class MockConstRecordingFunction final : public IFunctionBase {
+public:
+    MockConstRecordingFunction()
+            : _argument_types({std::make_shared<DataTypeInt32>(), std::make_shared<DataTypeInt32>(),
+                               std::make_shared<DataTypeInt32>()}),
+              _return_type(std::make_shared<DataTypeInt32>()),
+              _prepared_function(std::make_shared<MockPreparedFunction>()) {}
+
+    String get_name() const override { return "mock_const_recording_function"; }
+
+    const DataTypes& get_argument_types() const override { return _argument_types; }
+
+    const DataTypePtr& get_return_type() const override { return _return_type; }
+
+    PreparedFunctionPtr prepare(FunctionContext* context, const Block& sample_block,
+                                const ColumnNumbers& arguments, uint32_t result) const override {
+        std::vector<bool> const_flags;
+        const_flags.reserve(arguments.size());
+        for (auto column_position : arguments) {
+            const auto& column = sample_block.get_by_position(column_position).column;
+            const_flags.push_back(column && is_column_const(*column));
+        }
+        observed_const_patterns.push_back(std::move(const_flags));
+        return _prepared_function;
+    }
+
+    bool is_use_default_implementation_for_constants() const override { return false; }
+
+    mutable std::vector<std::vector<bool>> observed_const_patterns;
+
+private:
+    DataTypes _argument_types;
+    DataTypePtr _return_type;
+    PreparedFunctionPtr _prepared_function;
+};
+
+Block create_mock_const_test_block() {
+    auto arg0 = ColumnHelper::create_column<DataTypeInt32>({1, 2, 3});
+    auto arg1_data = ColumnHelper::create_column<DataTypeInt32>({11});
+    auto arg1 = ColumnConst::create(arg1_data, 3);
+    auto arg2 = ColumnHelper::create_column<DataTypeInt32>({4, 5, 6});
+
+    auto data_type = std::make_shared<DataTypeInt32>();
+    Block block;
+    block.insert({arg0, data_type, "arg0"});
+    block.insert({arg1, data_type, "arg1"});
+    block.insert({arg2, data_type, "arg2"});
+    block.insert({data_type->create_column(), data_type, "result"});
+    return block;
+}
 
 class SimpleFunctionFactoryTest : public testing::Test {
     void SetUp() override {
@@ -93,6 +159,27 @@ TEST_F(SimpleFunctionFactoryTest, test_return_all) {
         // } catch (...) {
         // }
     }
+}
+
+TEST_F(SimpleFunctionFactoryTest, test_debug_mock_const_execute_modes) {
+    MockConstRecordingFunction function;
+    auto context = FunctionContext::create_context(nullptr, function.get_return_type(),
+                                                   function.get_argument_types());
+    auto block = create_mock_const_test_block();
+    ColumnNumbers arguments {0, 1, 2};
+
+    EXPECT_TRUE(function.execute(context.get(), block, arguments, 3, 3).ok());
+
+#ifndef NDEBUG
+    ASSERT_EQ(function.observed_const_patterns.size(), 4);
+    EXPECT_EQ(function.observed_const_patterns[0], (std::vector<bool> {true, true, true}));
+    EXPECT_EQ(function.observed_const_patterns[1], (std::vector<bool> {true, true, false}));
+    EXPECT_EQ(function.observed_const_patterns[2], (std::vector<bool> {false, true, true}));
+    EXPECT_EQ(function.observed_const_patterns[3], (std::vector<bool> {false, true, false}));
+#else
+    ASSERT_EQ(function.observed_const_patterns.size(), 1);
+    EXPECT_EQ(function.observed_const_patterns[0], (std::vector<bool> {false, true, false}));
+#endif
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
Functions that receive const columns (e.g. `ColumnConst`) must implicitly materialize them before accessing data. Some implementations forget this and would crash or produce wrong results on const inputs, but there was no automated debug-mode check to catch such bugs.

This change adds a `mock_const_execute()` step (`#ifndef NDEBUG`) that re-executes each function with all input columns replaced by const columns cut from the first row. If a function mis-handles const columns, the re-execution exposes it immediately.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

