### PR TITLE
[fix](docker) allow overriding fdb image

### DIFF
--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -536,6 +536,11 @@ class UpCommand(Command):
             type=str,
             default="7.3.69",
             help="fdb image version. Only use in cloud cluster.")
+        parser.add_argument(
+            "--fdb-image",
+            type=str,
+            default=os.environ.get("DORIS_FDB_IMAGE", ""),
+            help="Override fdb image. Only use in cloud cluster.")
 
         parser.add_argument(
             "--tde-ak",
@@ -738,9 +743,10 @@ class UpCommand(Command):
             if for_all:
                 cluster.set_image(args.IMAGE)
 
+        fdb_image = args.fdb_image or "foundationdb/foundationdb:{}".format(
+            args.fdb_version)
         for node in cluster.get_all_nodes(CLUSTER.Node.TYPE_FDB):
-            node.set_image("foundationdb/foundationdb:{}".format(
-                args.fdb_version))
+            node.set_image(fdb_image)
 
         cluster.save()
 


### PR DESCRIPTION
Add an --fdb-image option to doris-compose up, with DORIS_FDB_IMAGE as the environment-variable default. This lets docker regression cases use a locally derived FoundationDB image while preserving the existing --fdb-version based default image when no override is provided.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

