### PR TITLE
[fix](paimon) Pin snapshot ID for Paimon external table queries to avoid compaction issues

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalTable.java
@@ -97,13 +97,7 @@ public class PaimonExternalTable extends ExternalTable implements MTMVRelatedTab
     }
 
     public Table getPaimonTable(Optional<MvccSnapshot> snapshot) {
-        if (snapshot.isPresent()) {
-            // MTMV scenario: get from snapshot cache
-            return getOrFetchSnapshotCacheValue(snapshot).getSnapshot().getTable();
-        } else {
-            // Normal query scenario: get directly from table cache
-            return PaimonUtils.getPaimonTable(this);
-        }
+        return getOrFetchSnapshotCacheValue(snapshot).getSnapshot().getTable();
     }
 
     private PaimonSnapshotCacheValue getPaimonSnapshotCacheValue(Optional<TableSnapshot> tableSnapshot,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: None

Problem Summary:
Doris previously used an unpinned Paimon table handle for normal queries, relying on the Paimon SDK to discover the latest snapshot. This could lead to empty results if a compaction occurred during the query, as the SDK might fail to resolve the new snapshot correctly.

This change modifies PaimonExternalTable to always use the pinned table from the snapshot cache, ensuring consistency across all query types (Normal, MTMV, and MVCC).

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This logic is consistent with the existing MTMV path which is already verified.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.