### PR TITLE
[fix](fe) Skip broken external tables in show tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -438,9 +438,14 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         List<T> tables = Lists.newArrayList();
         Set<String> tblNames = getTableNamesWithLock();
         for (String tblName : tblNames) {
-            T tbl = getTableNullable(tblName);
-            if (tbl != null) {
-                tables.add(tbl);
+            try {
+                T tbl = getTableNullable(tblName);
+                if (tbl != null) {
+                    tables.add(tbl);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to get external table {}.{}.{} in SHOW TABLES path, skip it.",
+                        extCatalog.getName(), name, tblName, e);
             }
         }
         return tables;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: None

Problem Summary:
SHOW TABLES on external catalogs can fail for the whole database when a single table throws during metadata initialization or schema parsing. This change skips the broken table in the SHOW TABLES path so other tables remain visible.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] Previous test can cover this change.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.