### PR TITLE
[feature](s3) Support S3 Express One Zone (AWS SDK 1.11.400 + CRC32C checksum)

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1497,6 +1497,8 @@ DEFINE_mInt32(s3_read_max_wait_time_ms, "800");
 DEFINE_mBool(enable_s3_object_check_after_upload, "true");
 DEFINE_mInt32(aws_client_request_timeout_ms, "30000");
 
+DEFINE_mBool(s3_disable_content_md5, "false");
+
 DEFINE_mBool(enable_s3_rate_limiter, "false");
 DEFINE_mInt64(s3_get_bucket_tokens, "1000000000000000000");
 DEFINE_Validator(s3_get_bucket_tokens, [](int64_t config) -> bool { return config > 0; });

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1610,6 +1610,12 @@ DECLARE_mInt32(s3_read_max_wait_time_ms);
 DECLARE_mBool(enable_s3_object_check_after_upload);
 DECLARE_mInt32(aws_client_request_timeout_ms);
 
+// When true, omit the Content-MD5 header on S3 PutObject / UploadPart and send a
+// CRC32C checksum instead. Required for S3 Express One Zone, which returns 501
+// NotImplemented for Content-MD5. Endpoints containing "s3express" auto-enable
+// this regardless of the flag.
+DECLARE_mBool(s3_disable_content_md5);
+
 // write as inverted index tmp directory
 DECLARE_String(tmp_file_dir);
 

--- a/be/src/io/fs/s3_obj_storage_client.cpp
+++ b/be/src/io/fs/s3_obj_storage_client.cpp
@@ -34,6 +34,7 @@
 #include <aws/s3/S3Errors.h>
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
 #include <aws/s3/model/AbortMultipartUploadResult.h>
+#include <aws/s3/model/ChecksumAlgorithm.h>
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/CompleteMultipartUploadResult.h>
 #include <aws/s3/model/CompletedMultipartUpload.h>
@@ -61,9 +62,12 @@
 #include <aws/s3/model/UploadPartRequest.h>
 #include <aws/s3/model/UploadPartResult.h>
 
+#include <crc32c/crc32c.h>
+
 #include <algorithm>
 #include <ranges>
 
+#include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "cpp/sync_point.h"
@@ -116,6 +120,31 @@ using namespace Aws::S3::Model;
 
 static constexpr int S3_REQUEST_THRESHOLD_MS = 5000;
 
+namespace {
+// S3 Express One Zone endpoints follow the pattern
+// "*.s3express-<zone>.<region>.amazonaws.com" — substring match is sufficient
+// for both the gateway and the s3express subdomain forms.
+bool is_s3_express_endpoint(const std::string& endpoint) {
+    return endpoint.find("s3express") != std::string::npos;
+}
+
+// AWS expects the CRC32C value as the big-endian 4-byte representation, base64-encoded.
+Aws::String compute_crc32c_b64(std::string_view data) {
+    uint32_t crc = crc32c::Crc32c(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+    uint8_t bytes[4] = {static_cast<uint8_t>((crc >> 24) & 0xff),
+                        static_cast<uint8_t>((crc >> 16) & 0xff),
+                        static_cast<uint8_t>((crc >> 8) & 0xff),
+                        static_cast<uint8_t>(crc & 0xff)};
+    return Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::ByteBuffer(bytes, sizeof(bytes)));
+}
+} // namespace
+
+S3ObjStorageClient::S3ObjStorageClient(std::shared_ptr<Aws::S3::S3Client> client,
+                                       const std::string& endpoint)
+        : _client(std::move(client)),
+          _disable_content_md5(config::s3_disable_content_md5 ||
+                               is_s3_express_endpoint(endpoint)) {}
+
 ObjectStorageUploadResponse S3ObjStorageClient::create_multipart_upload(
         const ObjectStoragePathOptions& opts) {
     CreateMultipartUploadRequest request;
@@ -158,8 +187,15 @@ ObjectStorageResponse S3ObjStorageClient::put_object(const ObjectStoragePathOpti
     Aws::S3::Model::PutObjectRequest request;
     request.WithBucket(opts.bucket).WithKey(opts.key);
     auto string_view_stream = std::make_shared<StringViewStream>(stream.data(), stream.size());
-    Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*string_view_stream));
-    request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
+    if (_disable_content_md5) {
+        // S3 Express One Zone rejects Content-MD5; use CRC32C instead.
+        request.SetChecksumAlgorithm(ChecksumAlgorithm::CRC32C);
+        request.SetChecksumCRC32C(compute_crc32c_b64(stream));
+    } else {
+        Aws::Utils::ByteBuffer part_md5(
+                Aws::Utils::HashingUtils::CalculateMD5(*string_view_stream));
+        request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
+    }
     request.SetBody(string_view_stream);
     request.SetContentLength(stream.size());
     request.SetContentType("application/octet-stream");
@@ -202,8 +238,15 @@ ObjectStorageUploadResponse S3ObjStorageClient::upload_part(const ObjectStorageP
 
     request.SetBody(string_view_stream);
 
-    Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*string_view_stream));
-    request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
+    if (_disable_content_md5) {
+        // S3 Express One Zone rejects Content-MD5; use CRC32C instead.
+        request.SetChecksumAlgorithm(ChecksumAlgorithm::CRC32C);
+        request.SetChecksumCRC32C(compute_crc32c_b64(stream));
+    } else {
+        Aws::Utils::ByteBuffer part_md5(
+                Aws::Utils::HashingUtils::CalculateMD5(*string_view_stream));
+        request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
+    }
 
     request.SetContentLength(stream.size());
     request.SetContentType("application/octet-stream");

--- a/be/src/io/fs/s3_obj_storage_client.h
+++ b/be/src/io/fs/s3_obj_storage_client.h
@@ -32,7 +32,8 @@ class ObjClientHolder;
 
 class S3ObjStorageClient final : public ObjStorageClient {
 public:
-    S3ObjStorageClient(std::shared_ptr<Aws::S3::S3Client> client) : _client(std::move(client)) {}
+    explicit S3ObjStorageClient(std::shared_ptr<Aws::S3::S3Client> client,
+                                const std::string& endpoint = {});
     ~S3ObjStorageClient() override = default;
     ObjectStorageUploadResponse create_multipart_upload(
             const ObjectStoragePathOptions& opts) override;
@@ -58,6 +59,10 @@ public:
 
 private:
     std::shared_ptr<Aws::S3::S3Client> _client;
+    // True for S3 Express One Zone endpoints (or when config::s3_disable_content_md5
+    // is on). When set, uploads send a CRC32C checksum instead of Content-MD5,
+    // since S3 Express returns 501 NotImplemented for the latter.
+    bool _disable_content_md5 = false;
 };
 
 } // namespace doris::io

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -533,7 +533,8 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_s3_client(
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
             s3_conf.use_virtual_addressing);
 
-    auto obj_client = std::make_shared<io::S3ObjStorageClient>(std::move(new_client));
+    auto obj_client =
+            std::make_shared<io::S3ObjStorageClient>(std::move(new_client), s3_conf.endpoint);
     LOG_INFO("create one s3 client with {}", s3_conf.to_string());
     return obj_client;
 }

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -492,11 +492,13 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_s3_client(
     TEST_SYNC_POINT_RETURN_WITH_VALUE(
             "s3_client_factory::create",
             std::make_shared<io::S3ObjStorageClient>(std::make_shared<Aws::S3::S3Client>()));
-    Aws::Client::ClientConfiguration aws_config = S3ClientFactory::getClientConfiguration();
-    if (s3_conf.need_override_endpoint) {
-        aws_config.endpointOverride = s3_conf.endpoint;
-    }
+    // Use S3ClientConfiguration (not the legacy ClientConfiguration) so the SDK's
+    // endpoint-rules resolver is active. This is required for S3 Express One Zone:
+    // the resolver detects the --x-s3 bucket suffix, calls CreateSession, and signs
+    // requests with service name "s3express" instead of "s3".
+    Aws::S3::S3ClientConfiguration aws_config;
     aws_config.region = s3_conf.region;
+    aws_config.useVirtualAddressing = s3_conf.use_virtual_addressing;
 
     if (_ca_cert_file_path.empty()) {
         _ca_cert_file_path = get_valid_ca_cert_path(doris::split(config::ca_cert_file_paths, ";"));
@@ -528,10 +530,20 @@ std::shared_ptr<io::ObjStorageClient> S3ClientFactory::_create_s3_client(
     aws_config.retryStrategy = std::make_shared<S3CustomRetryStrategy>(
             config::max_s3_client_retry /*scaleFactor = 25*/);
 
-    std::shared_ptr<Aws::S3::S3Client> new_client = std::make_shared<Aws::S3::S3Client>(
-            get_aws_credentials_provider(s3_conf), std::move(aws_config),
-            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-            s3_conf.use_virtual_addressing);
+    // S3 Express buckets are identified by the --x-s3 suffix or an s3express endpoint.
+    // Skip endpointOverride for these so the SDK resolves the bucket-specific endpoint
+    // and manages CreateSession automatically. For all other buckets, keep the override.
+    const bool is_s3_express = s3_conf.endpoint.find("s3express") != std::string::npos ||
+                               s3_conf.bucket.find("--x-s3") != std::string::npos;
+    if (s3_conf.need_override_endpoint && !is_s3_express) {
+        aws_config.endpointOverride = s3_conf.endpoint;
+    }
+    aws_config.disableS3ExpressAuth = !is_s3_express;
+
+    auto new_client = std::make_shared<Aws::S3::S3Client>(
+            get_aws_credentials_provider(s3_conf),
+            Aws::MakeShared<Aws::S3::S3EndpointProvider>("S3Client"),
+            aws_config);
 
     auto obj_client =
             std::make_shared<io::S3ObjStorageClient>(std::move(new_client), s3_conf.endpoint);

--- a/common/cpp/aws_logger.h
+++ b/common/cpp/aws_logger.h
@@ -20,6 +20,8 @@
 #include <aws/core/utils/logging/LogLevel.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
 #include <glog/logging.h>
+#include <cstdarg>
+#include <cstdio>
 
 class DorisAWSLogger final : public Aws::Utils::Logging::LogSystemInterface {
 public:
@@ -34,6 +36,13 @@ public:
     void LogStream(Aws::Utils::Logging::LogLevel log_level, const char* tag,
                    const Aws::OStringStream& message_stream) final {
         _log_impl(log_level, tag, message_stream.str().c_str());
+    }
+
+    void vaLog(Aws::Utils::Logging::LogLevel log_level, const char* tag, const char* format_str,
+               va_list args) final {
+        char buf[4096];
+        vsnprintf(buf, sizeof(buf), format_str, args);
+        _log_impl(log_level, tag, buf);
     }
 
     void Flush() final {}

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -356,10 +356,10 @@ BOOTSTRAP_TABLE_CSS_FILE="bootstrap-table.min.css"
 BOOTSTRAP_TABLE_CSS_MD5SUM="23389d4456da412e36bae30c469a766a"
 
 # aws sdk
-AWS_SDK_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.219.tar.gz"
-AWS_SDK_NAME="aws-sdk-cpp-1.11.219.tar.gz"
-AWS_SDK_SOURCE="aws-sdk-cpp-1.11.219"
-AWS_SDK_MD5SUM="80aa616efe1a3e7a9bf0dfbc44a97864"
+AWS_SDK_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.400.tar.gz"
+AWS_SDK_NAME="aws-sdk-cpp-1.11.400.tar.gz"
+AWS_SDK_SOURCE="aws-sdk-cpp-1.11.400"
+AWS_SDK_MD5SUM="329c46612df55ba6715d9d2ccd61dc03"
 
 # tsan_header
 TSAN_HEADER_DOWNLOAD="https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=libsanitizer/include/sanitizer/tsan_interface_atomic.h;hb=refs/heads/releases/gcc-7"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

Doris currently cannot read from or write to **Amazon S3 Express One Zone** buckets. Two distinct gaps block this:

1. **AWS SDK is too old / wrong client builder.** The bundled SDK is `aws-sdk-cpp 1.11.219`, which predates S3 Express support. The S3 client is also constructed with the legacy `Aws::Client::ClientConfiguration` path, which bypasses the SDK's endpoint-rules resolver — so even on a newer SDK, the `--x-s3` bucket suffix would not trigger `CreateSession` or the `s3express` SigV4 service name.

2. **`Content-MD5` is unconditionally attached to every PutObject and UploadPart.** S3 Express One Zone rejects `Content-MD5` with `501 NotImplemented` and instead requires a flexible checksum (CRC32 / CRC32C / SHA1 / SHA256).

This PR fixes both:

**Commit 1 — `feat: add support for CRC32C checksum in S3 uploads and disable Content-MD5 for S3 Express`**

- Adds a new BE config `s3_disable_content_md5` (default `false`) and auto-enables it when the endpoint string contains `s3express`.
- When disabled, `PutObject` / `UploadPart` send `x-amz-checksum-crc32c` (computed via the existing `crc32c` thirdparty lib) instead of `Content-MD5`. Behavior for non-S3-Express endpoints is unchanged.
- Threads the endpoint string into `S3ObjStorageClient` so the per-client flag can be set at construction time.

**Commit 2 — `Upgrade AWS SDK and use new create client to support S3 express`**

- Bumps `aws-sdk-cpp` from `1.11.219` to `1.11.400` in `thirdparty/vars.sh` (with refreshed MD5 / URL).
- Switches `S3ClientFactory::_create_s3_client` to `Aws::S3::S3ClientConfiguration` + `S3EndpointProvider`, which activates the endpoint-rules resolver required for S3 Express (`CreateSession`, `s3express` SigV4 service name).
- Detects S3 Express buckets by the `--x-s3` suffix or `s3express` endpoint substring; for those buckets we skip `endpointOverride` (so the SDK resolves the bucket-specific endpoint) and clear `disableS3ExpressAuth`. For all other buckets the behavior is unchanged.
- Adds the `vaLog` override in `DorisAWSLogger` that 1.11.400's `LogSystemInterface` now requires.

### Release note

Support reading from / writing to Amazon S3 Express One Zone buckets. A new BE config `s3_disable_content_md5` is added to send a CRC32C checksum instead of `Content-MD5` on uploads; it is auto-enabled for endpoints whose hostname contains `s3express`.

### Check List (For Author)

- Test
    - [x] Manual test (add detailed scripts or steps below)
        - Verified PutObject / multipart upload against an `--x-s3` (S3 Express One Zone) bucket in `us-east-1`: `CreateSession` is issued, requests are signed as `s3express`, and uploads succeed with CRC32C in place of `Content-MD5`.
        - Verified regression-free behavior against a regular S3 bucket (with and without `endpointOverride`) and against an S3-compatible MinIO endpoint — `Content-MD5` is still sent and uploads succeed.

- Behavior changed:
    - [x] Yes.
        - `s3_disable_content_md5=true` (or any endpoint matching `s3express`) replaces `Content-MD5` with CRC32C on `PutObject` / `UploadPart`. Default is unchanged for non-S3-Express endpoints.
        - AWS SDK upgraded from 1.11.219 → 1.11.400; the BE links a rebuilt thirdparty bundle.

- Does this need documentation?
    - [ ] Yes — a short note for the new `s3_disable_content_md5` BE config and an S3 Express One Zone usage example. Will open the doris-website PR once this is reviewed.