### PR TITLE
[fix](be) Remove pure attribute from assert_cast

### DIFF
--- a/be/src/core/assert_cast.h
+++ b/be/src/core/assert_cast.h
@@ -50,7 +50,7 @@ using AssertCastClassType_t = std::remove_pointer_t<AssertCastNormalizedType_t<T
   * The exact match of the type is checked. That is, cast to the ancestor will be unsuccessful.
   */
 template <typename To, TypeCheckOnRelease check = TypeCheckOnRelease::ENABLE, typename From>
-PURE To assert_cast(From&& from) {
+To assert_cast(From&& from) {
     static_assert(!std::is_same_v<AssertCastNormalizedType_t<To>, AssertCastNormalizedType_t<From>>,
                   "assert_cast is redundant for the same type after removing cv/ref qualifiers");
     static_assert(std::is_class_v<AssertCastClassType_t<To>> &&


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: `assert_cast` can throw `doris::Exception` when release type checking detects an invalid cast. The function was annotated with `PURE`, but throwing an exception is an observable side effect and changes control flow, so the annotation gives the compiler an invalid optimization contract for the failure path. This removes the incorrect annotation and leaves the existing cast logic unchanged.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - `git diff --cached --check`
- Behavior changed: No
- Does this need documentation: No
