### PR TITLE
[fix](streaming-job) keep isCanceled set when cancel runs on terminal task

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/AbstractStreamingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/AbstractStreamingTask.java
@@ -140,15 +140,15 @@ public abstract class AbstractStreamingTask {
     }
 
     public void cancel(boolean needWaitCancelComplete) {
+        // Flip isCanceled even on terminal states so late BE callbacks short-circuit.
+        if (getIsCanceled().getAndSet(true)) {
+            return;
+        }
         if (TaskStatus.SUCCESS.equals(status) || TaskStatus.FAILED.equals(status)
                 || TaskStatus.CANCELED.equals(status)) {
             return;
         }
         status = TaskStatus.CANCELED;
-        if (getIsCanceled().get()) {
-            return;
-        }
-        getIsCanceled().getAndSet(true);
         this.errMsg = "task cancelled";
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -1437,6 +1437,11 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         try {
             if (this.runningStreamTask != null
                     && this.runningStreamTask instanceof StreamingMultiTblTask) {
+                if (this.runningStreamTask.getIsCanceled().get()) {
+                    log.info("Streaming multi table job {} skip late commit offset on canceled task {}",
+                            getJobId(), offsetRequest.getTaskId());
+                    return;
+                }
                 if (this.runningStreamTask.getTaskId() != offsetRequest.getTaskId()) {
                     throw new JobException("Task id mismatch when commit offset. expected: "
                             + this.runningStreamTask.getTaskId() + ", actual: " + offsetRequest.getTaskId());

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -1438,8 +1438,9 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
             if (this.runningStreamTask != null
                     && this.runningStreamTask instanceof StreamingMultiTblTask) {
                 if (this.runningStreamTask.getIsCanceled().get()) {
-                    log.info("Streaming multi table job {} skip late commit offset on canceled task {}",
-                            getJobId(), offsetRequest.getTaskId());
+                    log.info("Streaming multi table job {} skip late commit offset on canceled task "
+                                    + "(expected: {}, actual: {})",
+                            getJobId(), this.runningStreamTask.getTaskId(), offsetRequest.getTaskId());
                     return;
                 }
                 if (this.runningStreamTask.getTaskId() != offsetRequest.getTaskId()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobLateCallbackTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobLateCallbackTest.java
@@ -26,15 +26,15 @@ import org.apache.doris.job.offset.jdbc.JdbcSourceOffsetProvider;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.HashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class StreamingInsertJobLateCallbackTest {
 
     private static StreamingMultiTblTask newTask(long taskId, TaskStatus initialStatus) {
-        StreamingMultiTblTask task = Deencapsulation.newInstance(StreamingMultiTblTask.class);
-        Deencapsulation.setField(task, "taskId", taskId);
-        Deencapsulation.setField(task, "isCanceled", new AtomicBoolean(false));
+        StreamingJobProperties jobProps = new StreamingJobProperties(new HashMap<>());
+        StreamingMultiTblTask task = new StreamingMultiTblTask(
+                0L, taskId, null, null, null, null, null, jobProps, null, null);
         Deencapsulation.setField(task, "status", initialStatus);
         return task;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobLateCallbackTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobLateCallbackTest.java
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.job.extensions.insert.streaming;
+
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.job.cdc.request.CommitOffsetRequest;
+import org.apache.doris.job.common.JobStatus;
+import org.apache.doris.job.common.TaskStatus;
+import org.apache.doris.job.offset.jdbc.JdbcSourceOffsetProvider;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class StreamingInsertJobLateCallbackTest {
+
+    private static StreamingMultiTblTask newTask(long taskId, TaskStatus initialStatus) {
+        StreamingMultiTblTask task = Deencapsulation.newInstance(StreamingMultiTblTask.class);
+        Deencapsulation.setField(task, "taskId", taskId);
+        Deencapsulation.setField(task, "isCanceled", new AtomicBoolean(false));
+        Deencapsulation.setField(task, "status", initialStatus);
+        return task;
+    }
+
+    @Test
+    public void testCancelMarksIsCanceledOnFailedTask() {
+        StreamingMultiTblTask task = newTask(1001L, TaskStatus.FAILED);
+
+        task.cancel(true);
+
+        Assert.assertTrue("isCanceled must flip even when task already FAILED",
+                task.getIsCanceled().get());
+        Assert.assertEquals("status preserved when already terminal",
+                TaskStatus.FAILED, task.getStatus());
+    }
+
+    @Test
+    public void testCancelMarksIsCanceledOnSuccessTask() {
+        StreamingMultiTblTask task = newTask(1002L, TaskStatus.SUCCESS);
+
+        task.cancel(true);
+
+        Assert.assertTrue(task.getIsCanceled().get());
+        Assert.assertEquals(TaskStatus.SUCCESS, task.getStatus());
+    }
+
+    @Test
+    public void testCancelTransitionsRunningToCanceled() {
+        StreamingMultiTblTask task = newTask(1003L, TaskStatus.RUNNING);
+
+        task.cancel(true);
+
+        Assert.assertTrue(task.getIsCanceled().get());
+        Assert.assertEquals(TaskStatus.CANCELED, task.getStatus());
+    }
+
+    @Test
+    public void testCancelIdempotent() {
+        StreamingMultiTblTask task = newTask(1004L, TaskStatus.RUNNING);
+
+        task.cancel(true);
+        Assert.assertEquals(TaskStatus.CANCELED, task.getStatus());
+        Assert.assertTrue(task.getIsCanceled().get());
+
+        Deencapsulation.setField(task, "errMsg", "first cancel");
+        task.cancel(true);
+        Assert.assertEquals("second cancel must early-return and leave state untouched",
+                "first cancel", Deencapsulation.getField(task, "errMsg"));
+    }
+
+    @Test
+    public void testCommitOffsetSkipsCanceledTask() throws Exception {
+        StreamingInsertJob job = Deencapsulation.newInstance(StreamingInsertJob.class);
+        Deencapsulation.setField(job, "lock", new ReentrantReadWriteLock(true));
+        Deencapsulation.setField(job, "jobId", 9001L);
+        Deencapsulation.setField(job, "jobName", "test_job");
+        Deencapsulation.setField(job, "jobStatus", JobStatus.PAUSED);
+
+        JdbcSourceOffsetProvider provider = Deencapsulation.newInstance(JdbcSourceOffsetProvider.class);
+        Deencapsulation.setField(job, "offsetProvider", provider);
+
+        StreamingMultiTblTask task = newTask(7777L, TaskStatus.FAILED);
+        // simulate the bug timeline: task already FAILED via onFail, then cancel marks isCanceled.
+        task.cancel(true);
+        Assert.assertTrue(task.getIsCanceled().get());
+
+        Deencapsulation.setField(job, "runningStreamTask", task);
+
+        CommitOffsetRequest req = new CommitOffsetRequest();
+        req.setJobId(9001L);
+        req.setTaskId(7777L);
+        req.setOffset("[{\"splitId\":\"binlog-split\"}]");
+        req.setScannedRows(123L);
+        req.setLoadBytes(456L);
+
+        // Should silently skip — no JobException, no Task.status flip back to SUCCESS,
+        // no successCallback side-effects.
+        job.commitOffset(req);
+
+        Assert.assertEquals("task status must stay terminal — late callback ignored",
+                TaskStatus.FAILED, task.getStatus());
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

Streaming insert job (CDC source / JdbcSourceOffsetProvider) can become permanently stuck in PAUSED when a BE-side commit arrives after FE-side task timeout. Symptoms observed in production:

- Job status PAUSED with empty ErrorMsg / JobRuntimeMsg.
- Latest task PENDING and never scheduled (scheduler logs "do not need to schedule invalid task ... job status: PAUSED").
- Previous task status SUCCESS but its ErrorMsg = "task failed cause timeout".
- `auto resume` never recovers the job; only manual `RESUME JOB` works.

**Root cause**

1. FE `processTimeoutTasks` detects task timeout and calls `runningMultiTask.onFail("task failed cause timeout")`. `AbstractStreamingTask.onFail` sets task status to FAILED.
2. `StreamingInsertJob.onStreamTaskFail` sets `failureReason` and calls `updateJobStatus(PAUSED)`, which in turn invokes `clearRunningStreamTask` → `task.cancel(true)`.
3. `AbstractStreamingTask.cancel()` short-circuits on terminal status: it returns immediately when status is already FAILED/SUCCESS/CANCELED, so `isCanceled` is never flipped to `true`.
4. A late BE callback arrives at `StreamingInsertJob.commitOffset`. The current `runningStreamTask != null && instanceof StreamingMultiTblTask + taskId match` checks all pass, and downstream defenses in `successCallback`/`beforeCommitted` also gate on `getIsCanceled().get()`, which is still `false`. `successCallback` therefore overrides task status back to SUCCESS, calls `onStreamTaskSuccess` → `resetFailureInfo(null)`, clearing `failureReason`.
5. `StreamingJobSchedulerTask.autoResumeHandler` returns early whenever `failureReason == null`, so the PAUSED job is never resumed.

The bug is essentially: `cancel()` is supposed to be the single source of truth that says "this task instance is dead, do not accept further callbacks", but its terminal short-circuit prevents the signal from being broadcast through `isCanceled`, leaving every other defense in the streaming task path silently bypassed.

**Fix**

- `AbstractStreamingTask.cancel()`: always flip `isCanceled` on entry, even when the task is already in a terminal state. This restores the contract that 10+ existing `getIsCanceled().get()` checks across the streaming task path rely on (e.g. `successCallback`, `beforeCommitted`, internal abort points in `StreamingInsertTask` / `StreamingMultiTblTask`).
- `StreamingInsertJob.commitOffset()`: add an `isCanceled` guard right after the `instanceof StreamingMultiTblTask` check so the late callback is dropped (logged at INFO) before any side effects (`updateNoTxnJobStatisticAndOffset`, `onTaskCommitted`, `persistOffsetProviderIfNeed`) run.

### Release note

Fix streaming insert job stuck in PAUSED when a late BE commit callback arrives after FE-side task timeout.

### Check List (For Author)

- Test
    - [x] Unit Test
    - [ ] Regression test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

New unit tests in `StreamingInsertJobLateCallbackTest`:
- `cancel()` flips `isCanceled` on a terminal-state task (FAILED / SUCCESS) without overriding the existing status.
- `cancel()` transitions a RUNNING task to CANCELED correctly.
- `cancel()` is idempotent — the second invocation early-returns and leaves task state untouched.
- `commitOffset()` silently skips when the running task is already canceled (status preserved, no successCallback side effects).

Regression coverage relies on existing CDC pause/resume suites under `regression-test/suites/job_p0/streaming_job/cdc/` to guard the normal happy path. The exact "BE late callback after FE timeout" timing cannot be reliably reproduced in the existing non-`nonConcurrent` CDC tests without adding debug points to `commitOffset`.

- Behavior changed:
    - [x] Yes. A late BE `commitOffset` arriving after a streaming task has been canceled is now dropped (logged at INFO) instead of being allowed to mutate task / job state and clear `failureReason`. Side effect: on non-unique-key target tables, auto-resume may now produce a small number of duplicate rows from re-running the same input range, in exchange for the job no longer being permanently stuck in PAUSED.

- Does this need documentation?
    - [x] No.