### PR TITLE
[opt](be) Optimize row store lookup to support batch row reading per segment

### DIFF
--- a/be/src/exec/rowid_fetcher.cpp
+++ b/be/src/exec/rowid_fetcher.cpp
@@ -474,12 +474,18 @@ Status RowIdStorageReader::read_by_rowids(const PMultiGetRequest& request,
                 return Status::InternalError("Tablet {} does not have row store for all columns",
                                              tablet->tablet_id());
             }
-            RowLocation loc(rowset_id, segment->id(), cast_set<uint32_t>(row_loc.ordinal_id()));
-            std::string* value = response->add_binary_row_data();
+            auto values = ColumnString::create();
+            std::vector<uint32_t> row_ids {cast_set<uint32_t>(row_loc.ordinal_id())};
             RETURN_IF_ERROR(scope_timer_run(
-                    [&]() { return tablet->lookup_row_data({}, loc, rowset, stats, *value); },
+                    [&]() {
+                        return tablet->lookup_row_data({}, segment->id(), row_ids, rowset, stats,
+                                                       *values);
+                    },
                     &lookup_row_data_ms));
-            row_size = value->size();
+            DCHECK_EQ(values->size(), 1);
+            StringRef value = values->get_data_at(0);
+            response->add_binary_row_data()->assign(value.data, value.size);
+            row_size = value.size;
             continue;
         }
 
@@ -680,8 +686,7 @@ Status RowIdStorageReader::read_batch_doris_format_row(
 
     std::unordered_map<IteratorKey, IteratorItem, HashOfIteratorKey> iterator_map;
     std::unordered_map<SegKey, SegItem, HashOfSegKey> seg_map;
-    std::string row_store_buffer;
-    RowStoreReadStruct row_store_read_struct(row_store_buffer);
+    RowStoreReadStruct row_store_read_struct;
     if (request_block_desc.fetch_row_store()) {
         for (int i = 0; i < request_block_desc.slots_size(); ++i) {
             row_store_read_struct.serdes.emplace_back(slots[i].get_data_type_ptr()->get_serde());
@@ -1125,24 +1130,17 @@ Status RowIdStorageReader::read_doris_format_row(
             return Status::InternalError("Tablet {} does not have row store for all columns",
                                          tablet->tablet_id());
         }
-        auto result_columns_guard = result_block.mutate_columns_scoped();
-        MutableColumns& result_columns = result_columns_guard.mutable_columns();
-        for (auto row_id : row_ids) {
-            RowLocation loc(rowset_id, segment->id(), cast_set<uint32_t>(row_id));
-            row_store_read_struct.row_store_buffer.clear();
-            RETURN_IF_ERROR(scope_timer_run(
-                    [&]() {
-                        return tablet->lookup_row_data({}, loc, rowset, stats,
-                                                       row_store_read_struct.row_store_buffer);
-                    },
-                    lookup_row_data_ms));
+        auto row_store_rows = ColumnString::create();
+        RETURN_IF_ERROR(scope_timer_run(
+                [&]() {
+                    return tablet->lookup_row_data({}, segment_id, row_ids, rowset, stats,
+                                                   *row_store_rows);
+                },
+                lookup_row_data_ms));
 
-            RETURN_IF_ERROR(JsonbSerializeUtil::jsonb_to_columns(
-                    row_store_read_struct.serdes, row_store_read_struct.row_store_buffer.data(),
-                    row_store_read_struct.row_store_buffer.size(),
-                    row_store_read_struct.col_uid_to_idx, result_columns,
-                    row_store_read_struct.default_values, {}));
-        }
+        RETURN_IF_ERROR(JsonbSerializeUtil::jsonb_to_block(
+                row_store_read_struct.serdes, *row_store_rows, row_store_read_struct.col_uid_to_idx,
+                result_block, row_store_read_struct.default_values, {}));
     } else {
         for (int x = 0; x < slots.size(); ++x) {
             auto column_guard = result_block.mutate_column_scoped(x);

--- a/be/src/exec/rowid_fetcher.h
+++ b/be/src/exec/rowid_fetcher.h
@@ -83,8 +83,6 @@ private:
 };
 
 struct RowStoreReadStruct {
-    RowStoreReadStruct(std::string& buffer) : row_store_buffer(buffer) {};
-    std::string& row_store_buffer;
     DataTypeSerDeSPtrs serdes;
     std::unordered_map<uint32_t, uint32_t> col_uid_to_idx;
     std::vector<std::string> default_values;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -534,8 +534,7 @@ Status PointQueryExecutor::_lookup_row_data() {
             if (!_reusable->runtime_state()->enable_short_circuit_query_access_column_store()) {
                 std::string missing_columns;
                 for (int cid : _reusable->missing_col_uids()) {
-                    missing_columns +=
-                            _tablet->tablet_schema()->column_by_uid(cid).name() + ",";
+                    missing_columns += _tablet->tablet_schema()->column_by_uid(cid).name() + ",";
                 }
                 return Status::InternalError(
                         "Not support column store, set store_row_column=true or "
@@ -544,8 +543,8 @@ Status PointQueryExecutor::_lookup_row_data() {
             }
             // fill missing columns by column store
             RowLocation row_loc = _row_read_ctxs[i]._row_location.value();
-            BetaRowsetSharedPtr rowset = std::static_pointer_cast<BetaRowset>(
-                    _tablet->get_rowset(row_loc.rowset_id));
+            BetaRowsetSharedPtr rowset =
+                    std::static_pointer_cast<BetaRowset>(_tablet->get_rowset(row_loc.rowset_id));
             SegmentCacheHandle segment_cache;
             {
                 SCOPED_TIMER(&_profile_metrics.load_segment_data_stage_ns);
@@ -570,9 +569,8 @@ Status PointQueryExecutor::_lookup_row_data() {
                 StorageReadOptions storage_read_options;
                 storage_read_options.stats = &_read_stats;
                 storage_read_options.io_ctx.reader_type = ReaderType::READER_QUERY;
-                auto st = segment->seek_and_read_by_rowid(*_tablet->tablet_schema(), slot,
-                                                          row_ids, column, storage_read_options,
-                                                          iter);
+                auto st = segment->seek_and_read_by_rowid(*_tablet->tablet_schema(), slot, row_ids,
+                                                          column, storage_read_options, iter);
                 if (st.ok() && _tablet->tablet_schema()
                                        ->column_by_uid(slot->col_unique_id())
                                        .has_char_type()) {
@@ -597,7 +595,8 @@ Status PointQueryExecutor::_lookup_row_data() {
                 column->insert_many_defaults(padding_rows);
             }
         }
-    // filter rows by delete sign
+    }
+    // filter rows by delete sign, must run outside of padding branch
     if (_row_hits > 0 && _reusable->delete_sign_idx() != -1) {
         size_t filtered = 0;
         size_t total = 0;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -35,6 +35,7 @@
 #include "common/cast_set.h"
 #include "common/consts.h"
 #include "common/status.h"
+#include "core/column/column_string.h"
 #include "core/data_type/data_type_factory.hpp"
 #include "core/data_type_serde/data_type_serde.h"
 #include "exec/sink/writer/vmysql_result_writer.h"
@@ -499,102 +500,103 @@ Status PointQueryExecutor::_lookup_row_key() {
 Status PointQueryExecutor::_lookup_row_data() {
     // 3. get values
     SCOPED_TIMER(&_profile_metrics.lookup_data_ns);
-    {
-        auto result_columns_guard = _result_block->mutate_columns_scoped();
-        MutableColumns& result_columns = result_columns_guard.mutable_columns();
-        for (size_t i = 0; i < _row_read_ctxs.size(); ++i) {
-            if (_row_read_ctxs[i]._cached_row_data.valid()) {
-                RETURN_IF_ERROR(JsonbSerializeUtil::jsonb_to_columns(
-                        _reusable->get_data_type_serdes(),
-                        _row_read_ctxs[i]._cached_row_data.data().data,
-                        _row_read_ctxs[i]._cached_row_data.data().size,
-                        _reusable->get_col_uid_to_idx(), result_columns,
-                        _reusable->get_col_default_values(), _reusable->include_col_uids()));
-                continue;
-            }
-            if (!_row_read_ctxs[i]._row_location.has_value()) {
-                continue;
-            }
-            std::string value;
-            // fill block by row store
-            if (_reusable->rs_column_uid() != -1) {
-                bool use_row_cache = !config::disable_storage_row_cache;
-                RETURN_IF_ERROR(_tablet->lookup_row_data(
-                        _row_read_ctxs[i]._primary_key, _row_read_ctxs[i]._row_location.value(),
-                        *(_row_read_ctxs[i]._rowset_ptr), _profile_metrics.read_stats, value,
-                        use_row_cache));
-                // serialize value to block, currently only jsonb row format
-                RETURN_IF_ERROR(JsonbSerializeUtil::jsonb_to_columns(
-                        _reusable->get_data_type_serdes(), value.data(), value.size(),
-                        _reusable->get_col_uid_to_idx(), result_columns,
-                        _reusable->get_col_default_values(), _reusable->include_col_uids()));
-            }
-            if (!_reusable->missing_col_uids().empty()) {
-                if (!_reusable->runtime_state()->enable_short_circuit_query_access_column_store()) {
-                    std::string missing_columns;
-                    for (int cid : _reusable->missing_col_uids()) {
-                        missing_columns +=
-                                _tablet->tablet_schema()->column_by_uid(cid).name() + ",";
-                    }
-                    return Status::InternalError(
-                            "Not support column store, set store_row_column=true or "
-                            "row_store_columns in table properties, missing columns: " +
-                            missing_columns + " should be added to row store");
-                }
-                // fill missing columns by column store
-                RowLocation row_loc = _row_read_ctxs[i]._row_location.value();
-                BetaRowsetSharedPtr rowset = std::static_pointer_cast<BetaRowset>(
-                        _tablet->get_rowset(row_loc.rowset_id));
-                SegmentCacheHandle segment_cache;
-                {
-                    SCOPED_TIMER(&_profile_metrics.load_segment_data_stage_ns);
-                    RETURN_IF_ERROR(
-                            SegmentLoader::instance()->load_segments(rowset, &segment_cache, true));
-                }
-                // find segment
-                auto it = std::find_if(segment_cache.get_segments().cbegin(),
-                                       segment_cache.get_segments().cend(),
-                                       [&](const segment_v2::SegmentSharedPtr& seg) {
-                                           return seg->id() == row_loc.segment_id;
-                                       });
-                const auto& segment = *it;
-                for (int cid : _reusable->missing_col_uids()) {
-                    int pos = _reusable->get_col_uid_to_idx().at(cid);
-                    std::vector<segment_v2::rowid_t> row_ids {
-                            static_cast<segment_v2::rowid_t>(row_loc.row_id)};
-                    auto& column = result_columns[pos];
-                    std::unique_ptr<ColumnIterator> iter;
-                    SlotDescriptor* slot = _reusable->tuple_desc()->slots()[pos];
-                    StorageReadOptions storage_read_options;
-                    storage_read_options.stats = &_read_stats;
-                    storage_read_options.io_ctx.reader_type = ReaderType::READER_QUERY;
-                    auto st = segment->seek_and_read_by_rowid(*_tablet->tablet_schema(), slot,
-                                                              row_ids, column, storage_read_options,
-                                                              iter);
-                    if (st.ok() && _tablet->tablet_schema()
-                                           ->column_by_uid(slot->col_unique_id())
-                                           .has_char_type()) {
-                        column->shrink_padding_chars();
-                    }
-                    RETURN_IF_ERROR(st);
-                }
-            }
+    for (size_t i = 0; i < _row_read_ctxs.size(); ++i) {
+        if (_row_read_ctxs[i]._cached_row_data.valid()) {
+            RETURN_IF_ERROR(JsonbSerializeUtil::jsonb_to_block(
+                    _reusable->get_data_type_serdes(),
+                    _row_read_ctxs[i]._cached_row_data.data().data,
+                    _row_read_ctxs[i]._cached_row_data.data().size, _reusable->get_col_uid_to_idx(),
+                    *_result_block, _reusable->get_col_default_values(),
+                    _reusable->include_col_uids()));
+            continue;
         }
-        if (result_columns.size() > _reusable->include_col_uids().size()) {
-            // Padding rows for some columns that no need to output to mysql client
-            // eg. SELECT k1,v1,v2 FROM TABLE WHERE k1 = 1, k1 is not in output slots, tuple as bellow
-            // TupleDescriptor{id=1, tbl=table_with_column_group}
-            // SlotDescriptor{id=8, col=v1, colUniqueId=1 ...}
-            // SlotDescriptor{id=9, col=v2, colUniqueId=2 ...}
-            // thus missing in include_col_uids and missing_col_uids
-            for (auto& column : result_columns) {
-                int padding_rows = _row_hits - cast_set<int>(column->size());
-                if (padding_rows > 0) {
-                    column->insert_many_defaults(padding_rows);
+        if (!_row_read_ctxs[i]._row_location.has_value()) {
+            continue;
+        }
+        // fill block by row store
+        if (_reusable->rs_column_uid() != -1) {
+            bool use_row_cache = !config::disable_storage_row_cache;
+            auto values = ColumnString::create();
+            std::vector<uint32_t> row_ids {_row_read_ctxs[i]._row_location->row_id};
+            RETURN_IF_ERROR(_tablet->lookup_row_data(
+                    _row_read_ctxs[i]._primary_key, _row_read_ctxs[i]._row_location->segment_id,
+                    row_ids, *(_row_read_ctxs[i]._rowset_ptr), _profile_metrics.read_stats, *values,
+                    use_row_cache));
+            DCHECK_EQ(values->size(), 1);
+            StringRef value = values->get_data_at(0);
+            // serilize value to block, currently only jsonb row formt
+            RETURN_IF_ERROR(JsonbSerializeUtil::jsonb_to_block(
+                    _reusable->get_data_type_serdes(), value.data, value.size,
+                    _reusable->get_col_uid_to_idx(), *_result_block,
+                    _reusable->get_col_default_values(), _reusable->include_col_uids()));
+        }
+        if (!_reusable->missing_col_uids().empty()) {
+            if (!_reusable->runtime_state()->enable_short_circuit_query_access_column_store()) {
+                std::string missing_columns;
+                for (int cid : _reusable->missing_col_uids()) {
+                    missing_columns +=
+                            _tablet->tablet_schema()->column_by_uid(cid).name() + ",";
                 }
+                return Status::InternalError(
+                        "Not support column store, set store_row_column=true or "
+                        "row_store_columns in table properties, missing columns: " +
+                        missing_columns + " should be added to row store");
+            }
+            // fill missing columns by column store
+            RowLocation row_loc = _row_read_ctxs[i]._row_location.value();
+            BetaRowsetSharedPtr rowset = std::static_pointer_cast<BetaRowset>(
+                    _tablet->get_rowset(row_loc.rowset_id));
+            SegmentCacheHandle segment_cache;
+            {
+                SCOPED_TIMER(&_profile_metrics.load_segment_data_stage_ns);
+                RETURN_IF_ERROR(
+                        SegmentLoader::instance()->load_segments(rowset, &segment_cache, true));
+            }
+            // find segment
+            auto it = std::find_if(segment_cache.get_segments().cbegin(),
+                                   segment_cache.get_segments().cend(),
+                                   [&](const segment_v2::SegmentSharedPtr& seg) {
+                                       return seg->id() == row_loc.segment_id;
+                                   });
+            const auto& segment = *it;
+            for (int cid : _reusable->missing_col_uids()) {
+                int pos = _reusable->get_col_uid_to_idx().at(cid);
+                std::vector<segment_v2::rowid_t> row_ids {
+                        static_cast<segment_v2::rowid_t>(row_loc.row_id)};
+                auto column_guard = _result_block->mutate_column_scoped(pos);
+                MutableColumnPtr& column = column_guard.mutable_column();
+                std::unique_ptr<ColumnIterator> iter;
+                SlotDescriptor* slot = _reusable->tuple_desc()->slots()[pos];
+                StorageReadOptions storage_read_options;
+                storage_read_options.stats = &_read_stats;
+                storage_read_options.io_ctx.reader_type = ReaderType::READER_QUERY;
+                auto st = segment->seek_and_read_by_rowid(*_tablet->tablet_schema(), slot,
+                                                          row_ids, column, storage_read_options,
+                                                          iter);
+                if (st.ok() && _tablet->tablet_schema()
+                                       ->column_by_uid(slot->col_unique_id())
+                                       .has_char_type()) {
+                    column->shrink_padding_chars();
+                }
+                RETURN_IF_ERROR(st);
             }
         }
     }
+    if (_result_block->columns() > _reusable->include_col_uids().size()) {
+        // Padding rows for some columns that no need to output to mysql client
+        // eg. SELECT k1,v1,v2 FROM TABLE WHERE k1 = 1, k1 is not in output slots, tuple as bellow
+        // TupleDescriptor{id=1, tbl=table_with_column_group}
+        // SlotDescriptor{id=8, col=v1, colUniqueId=1 ...}
+        // SlotDescriptor{id=9, col=v2, colUniqueId=2 ...}
+        // thus missing in include_col_uids and missing_col_uids
+        auto result_columns_guard = _result_block->mutate_columns_scoped();
+        MutableColumns& result_columns = result_columns_guard.mutable_columns();
+        for (auto& column : result_columns) {
+            int padding_rows = _row_hits - cast_set<int>(column->size());
+            if (padding_rows > 0) {
+                column->insert_many_defaults(padding_rows);
+            }
+        }
     // filter rows by delete sign
     if (_row_hits > 0 && _reusable->delete_sign_idx() != -1) {
         size_t filtered = 0;

--- a/be/src/storage/tablet/base_tablet.cpp
+++ b/be/src/storage/tablet/base_tablet.cpp
@@ -414,16 +414,26 @@ std::vector<RowsetSharedPtr> BaseTablet::get_rowset_by_ids(
     return rowsets;
 }
 
-Status BaseTablet::lookup_row_data(const Slice& encoded_key, const RowLocation& row_location,
+Status BaseTablet::lookup_row_data(const Slice& encoded_key, uint32_t segment_id,
+                                   const std::vector<uint32_t>& row_ids,
                                    RowsetSharedPtr input_rowset, OlapReaderStatistics& stats,
-                                   std::string& values, bool write_to_cache) {
+                                   ColumnString& values, bool write_to_cache) {
     MonotonicStopWatch watch;
-    size_t row_size = 1;
+    size_t row_batch_size = row_ids.size();
+    if (row_batch_size == 0) {
+        return Status::OK();
+    }
     watch.start();
     Defer _defer([&]() {
-        LOG_EVERY_N(INFO, 500) << "get a single_row, cost(us):" << watch.elapsed_time() / 1000
-                               << ", row_size:" << row_size;
+        LOG_EVERY_N(INFO, 500) << "get row batch, cost(us):" << watch.elapsed_time() / 1000
+                               << ", row_batch_size:" << row_batch_size;
     });
+
+    values.clear();
+    if (write_to_cache && row_ids.size() != 1) {
+        return Status::InvalidArgument("row cache only supports single row lookup, row_count={}",
+                                       row_ids.size());
+    }
 
     BetaRowsetSharedPtr rowset = std::static_pointer_cast<BetaRowset>(input_rowset);
     CHECK(rowset);
@@ -431,17 +441,15 @@ Status BaseTablet::lookup_row_data(const Slice& encoded_key, const RowLocation& 
     SegmentCacheHandle segment_cache_handle;
     std::unique_ptr<segment_v2::ColumnIterator> column_iterator;
     const auto& column = *DORIS_TRY(tablet_schema->column(BeConsts::ROW_STORE_COL));
-    RETURN_IF_ERROR(_get_segment_column_iterator(rowset, row_location.segment_id, column,
-                                                 &segment_cache_handle, &column_iterator, &stats));
-    // get and parse tuple row
-    MutableColumnPtr column_ptr = ColumnString::create();
-    std::vector<segment_v2::rowid_t> rowids {static_cast<segment_v2::rowid_t>(row_location.row_id)};
-    RETURN_IF_ERROR(column_iterator->read_by_rowids(rowids.data(), 1, column_ptr));
-    assert(column_ptr->size() == 1);
-    auto* string_column = static_cast<ColumnString*>(column_ptr.get());
-    StringRef value = string_column->get_data_at(0);
-    values = value.to_string();
+    RETURN_IF_ERROR(_get_segment_column_iterator(rowset, segment_id, column, &segment_cache_handle,
+                                                 &column_iterator, &stats));
+
+    MutableColumnPtr column_ptr = values.get_ptr();
+    RETURN_IF_ERROR(column_iterator->read_by_rowids(row_ids.data(), row_ids.size(), column_ptr));
+    assert(column_ptr->size() == row_ids.size());
+    // only point query need write to cache
     if (write_to_cache) {
+        StringRef value = values.get_data_at(0);
         RowCache::instance()->insert({tablet_id(), encoded_key}, Slice {value.data, value.size});
     }
     return Status::OK();

--- a/be/src/storage/tablet/base_tablet.h
+++ b/be/src/storage/tablet/base_tablet.h
@@ -23,9 +23,11 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <vector>
 
 #include "common/metrics/metrics.h"
 #include "common/status.h"
+#include "core/column/column_string.h"
 #include "io/io_common.h"
 #include "storage/iterators.h"
 #include "storage/olap_common.h"
@@ -161,9 +163,10 @@ public:
     std::vector<RowsetSharedPtr> get_rowset_by_ids(
             const RowsetIdUnorderedSet* specified_rowset_ids);
 
-    // Lookup a row with TupleDescriptor and fill Block
-    Status lookup_row_data(const Slice& encoded_key, const RowLocation& row_location,
-                           RowsetSharedPtr rowset, OlapReaderStatistics& stats, std::string& values,
+    // Lookup rows from the row-store column in a segment.
+    Status lookup_row_data(const Slice& encoded_key, uint32_t segment_id,
+                           const std::vector<uint32_t>& row_ids, RowsetSharedPtr rowset,
+                           OlapReaderStatistics& stats, ColumnString& values,
                            bool write_to_cache = false);
     // Lookup the row location of `encoded_key`, the function sets `row_location` on success.
     // NOTE: the method only works in unique key model with primary key index, you will got a


### PR DESCRIPTION
### What problem does this PR solve?

Refactor `lookup_row_data` to accept multiple row IDs for the same segment, reading them in a single batch via `ColumnString` instead of one-by-one with per-row `std::string` buffers. This reduces the per-row overhead of column iterator calls and string copy for multi-row fetch scenarios (e.g. batch point queries and index lookup).

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

