### PR TITLE
[refine](be) remove unsafe PURE annotations

### DIFF
--- a/be/src/core/binary_cast.hpp
+++ b/be/src/core/binary_cast.hpp
@@ -35,7 +35,7 @@ static_assert(sizeof(DecimalV2Value) == sizeof(__int128_t));
 
 // similar to reinterpret_cast but won't break strict-aliasing rules. you can treat it as std::bit_cast with type checking
 template <typename From, typename To>
-constexpr PURE To binary_cast(const From& from) {
+constexpr To binary_cast(const From& from) {
     constexpr bool from_u64_to_db = match_v<From, uint64_t, To, double>;
     constexpr bool from_i64_to_db = match_v<From, int64_t, To, double>;
     constexpr bool from_db_to_i64 = match_v<From, double, To, int64_t>;

--- a/be/src/core/column/column_nullable.h
+++ b/be/src/core/column/column_nullable.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/column/column.h"
@@ -92,9 +91,7 @@ public:
     std::string get_name() const override { return "Nullable(" + _nested_column->get_name() + ")"; }
     MutableColumnPtr clone_resized(size_t size) const override;
     size_t size() const override { return get_null_map_column().size(); }
-    PURE bool is_null_at(size_t n) const override {
-        return get_null_map_column().get_data()[n] != 0;
-    }
+    bool is_null_at(size_t n) const override { return get_null_map_column().get_data()[n] != 0; }
     Field operator[](size_t n) const override;
     void get(size_t n, Field& res) const override;
     bool get_bool(size_t n) const override {

--- a/be/src/core/data_type_serde/datelike_serde_common.hpp
+++ b/be/src/core/data_type_serde/datelike_serde_common.hpp
@@ -47,19 +47,19 @@ enum class DatelikeFastParseResult : uint8_t {
     DATE_TIME,
 };
 
-inline PURE bool is_fixed_two_digit_ascii(const char* ptr) {
+inline bool is_fixed_two_digit_ascii(const char* ptr) {
     return static_cast<unsigned>(ptr[0] - '0') < 10 && static_cast<unsigned>(ptr[1] - '0') < 10;
 }
 
-inline PURE bool is_fixed_four_digit_ascii(const char* ptr) {
+inline bool is_fixed_four_digit_ascii(const char* ptr) {
     return is_fixed_two_digit_ascii(ptr) && is_fixed_two_digit_ascii(ptr + 2);
 }
 
-inline PURE uint32_t parse_fixed_two_digit_ascii(const char* ptr) {
+inline uint32_t parse_fixed_two_digit_ascii(const char* ptr) {
     return (ptr[0] - '0') * 10 + (ptr[1] - '0');
 }
 
-inline PURE uint32_t parse_fixed_four_digit_ascii(const char* ptr) {
+inline uint32_t parse_fixed_four_digit_ascii(const char* ptr) {
     return parse_fixed_two_digit_ascii(ptr) * 100 + parse_fixed_two_digit_ascii(ptr + 2);
 }
 
@@ -117,7 +117,7 @@ inline DatelikeFastParseResult try_parse_fixed_canonical_datelike_prefix(const c
     return DatelikeFastParseResult::DATE_TIME;
 }
 
-inline PURE uint32_t complete_4digit_year(uint32_t year) {
+inline uint32_t complete_4digit_year(uint32_t year) {
     if (year < 70) {
         return year + 2000; // 00-69 -> 2000-2069
     } else {

--- a/be/src/core/string_ref.h
+++ b/be/src/core/string_ref.h
@@ -146,8 +146,7 @@ inline bool memequalSSE2Wide(const char* p1, const char* p2, size_t size) {
 //   - s1/n1: ptr/len for the first string
 //   - s2/n2: ptr/len for the second string
 //   - len: min(n1, n2) - this can be more cheaply passed in by the caller
-PURE inline int64_t string_compare(const char* s1, int64_t n1, const char* s2, int64_t n2,
-                                   int64_t len) {
+inline int64_t string_compare(const char* s1, int64_t n1, const char* s2, int64_t n2, int64_t len) {
     DCHECK_EQ(len, std::min(n1, n2));
 #if defined(__SSE4_2__) || defined(__aarch64__)
     while (len >= sse_util::CHARS_PER_128_BIT_REGISTER) {

--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -36,7 +36,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/status.h"
 #include "core/data_type/number_traits.h"
 #include "core/data_type/primitive_type.h"
@@ -67,7 +66,9 @@ struct Decimal;
 #define SET_PARAMS_RET_FALSE_FROM_EXCEPTION(stmt) \
     do {                                          \
         try {                                     \
-            { stmt; }                             \
+            {                                     \
+                stmt;                             \
+            }                                     \
         } catch (const doris::Exception& e) {     \
             if constexpr (IsStrict) {             \
                 params.status = e.to_status();    \
@@ -266,7 +267,7 @@ uint32_t count_valid_length(const char* s, const char* end) {
 
 inline auto count_digits = count_valid_length<is_numeric_ascii>;
 
-inline PURE std::string combine_tz_offset(char sign, uint32_t hour_offset, uint32_t minute_offset) {
+inline std::string combine_tz_offset(char sign, uint32_t hour_offset, uint32_t minute_offset) {
     std::string result(6, '0');
     result[0] = sign;
     result[1] = '0' + (hour_offset / 10);

--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -66,9 +66,7 @@ struct Decimal;
 #define SET_PARAMS_RET_FALSE_FROM_EXCEPTION(stmt) \
     do {                                          \
         try {                                     \
-            {                                     \
-                stmt;                             \
-            }                                     \
+            { stmt; }                             \
         } catch (const doris::Exception& e) {     \
             if constexpr (IsStrict) {             \
                 params.status = e.to_status();    \

--- a/be/src/util/thrift_util.h
+++ b/be/src/util/thrift_util.h
@@ -175,9 +175,9 @@ void t_network_address_to_string(const TNetworkAddress& address, std::string* ou
 // string representation
 bool t_network_address_comparator(const TNetworkAddress& a, const TNetworkAddress& b);
 
-PURE std::string to_string(const TUniqueId& id);
+std::string to_string(const TUniqueId& id);
 
-PURE bool _has_inverted_index_v1_or_partial_update(TOlapTableSink sink);
-PURE bool _has_row_binlog(const TOlapTableSink& sink);
+bool _has_inverted_index_v1_or_partial_update(TOlapTableSink sink);
+bool _has_row_binlog(const TOlapTableSink& sink);
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Some BE functions were marked with `PURE` even though their definitions are already visible in headers or they can allocate and throw exceptions. This change removes those annotations, because throwing from a `pure` function can make surrounding `catch` blocks unreliable: https://godbolt.org/z/Y7f73bKoY

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

