### PR TITLE
[opt](nereids) skip null-check access path for physically non-nullable columns

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathExpressionCollector.java
@@ -114,6 +114,10 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
     @Override
     public Void visitSlotReference(SlotReference slotReference, CollectorContext context) {
         DataType dataType = slotReference.getDataType();
+        if (isFunctionNullCheckPath(context.accessPathBuilder.getPathList())
+                && !isPhysicalNullable(slotReference)) {
+            return null;
+        }
         if (dataType instanceof VariantType
                 && (slotReference.hasSubColPath() || !context.accessPathBuilder.isEmpty())) {
             List<String> path = new ArrayList<>();
@@ -387,6 +391,12 @@ public class AccessPathExpressionCollector extends DefaultExpressionVisitor<Void
 
     private static boolean isFunctionNullCheckPath(List<String> suffixPath) {
         return suffixPath.size() == 1 && AccessPathInfo.ACCESS_NULL.equals(suffixPath.get(0));
+    }
+
+    private static boolean isPhysicalNullable(SlotReference slotReference) {
+        return slotReference.getOriginalColumn()
+                .map(column -> column.isAllowNull())
+                .orElse(slotReference.nullable());
     }
 
     @Override


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

When collecting access path expressions for variant types, null-check paths (`ACCESS_NULL`) were generated even for columns that are physically non-nullable (i.e., `NOT NULL` in schema). This introduced unnecessary access paths that have no effect, since null checks on non-nullable columns are always no-ops.

Root cause: `visitSlotReference` did not check whether the slot's underlying column is physically nullable before processing function null check paths.

Fix: In `visitSlotReference`, skip processing when the access path is a function null check path and the slot reference is physically non-nullable. Physical nullability is determined by the original column's `isAllowNull()` metadata, falling back to the slot's `nullable()` flag.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

