### PR TITLE
[fix](test) replace removed JMockit with Mockito in CloudProcVersionDisplayTest

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/CloudProcVersionDisplayTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/CloudProcVersionDisplayTest.java
@@ -46,12 +46,12 @@ import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class CloudProcVersionDisplayTest {
     private static final long DB_ID = 10001L;
@@ -65,14 +65,11 @@ public class CloudProcVersionDisplayTest {
     private static final long STALE_REPLICA_VERSION = 1L;
     private static final int SCHEMA_HASH = 123456789;
 
-    @Mocked
     private Env env;
-    @Mocked
     private SystemInfoService systemInfoService;
-    @Mocked
     private TabletInvertedIndex invertedIndex;
-    @Mocked
     private InternalCatalog internalCatalog;
+    private MockedStatic<Env> envStatic;
 
     private String originDeployMode;
     private String originCloudUniqueId;
@@ -87,29 +84,24 @@ public class CloudProcVersionDisplayTest {
         Config.cloud_unique_id = "";
         Config.enable_query_hit_stats = false;
 
-        new Expectations(env) {
-            {
-                Env.getServingEnv();
-                minTimes = 0;
-                result = env;
+        env = Mockito.mock(Env.class);
+        systemInfoService = Mockito.mock(SystemInfoService.class);
+        invertedIndex = Mockito.mock(TabletInvertedIndex.class);
+        internalCatalog = Mockito.mock(InternalCatalog.class);
 
-                env.isReady();
-                minTimes = 0;
-                result = true;
+        Mockito.when(env.isReady()).thenReturn(true);
+        Mockito.when(systemInfoService.getAllBackendsByAllCluster()).thenReturn(ImmutableMap.of());
 
-                Env.getCurrentSystemInfo();
-                minTimes = 0;
-                result = systemInfoService;
-
-                systemInfoService.getAllBackendsByAllCluster();
-                minTimes = 0;
-                result = ImmutableMap.of();
-            }
-        };
+        envStatic = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS);
+        envStatic.when(Env::getServingEnv).thenReturn(env);
+        envStatic.when(Env::getCurrentSystemInfo).thenReturn(systemInfoService);
     }
 
     @After
     public void tearDown() {
+        if (envStatic != null) {
+            envStatic.close();
+        }
         Config.deploy_mode = originDeployMode;
         Config.cloud_unique_id = originCloudUniqueId;
         Config.enable_query_hit_stats = originEnableQueryHitStats;
@@ -132,25 +124,10 @@ public class CloudProcVersionDisplayTest {
     public void testReplicasProcNodeShowsPartitionCachedVersionInCloudMode() throws AnalysisException {
         ProcTestContext context = createProcTestContext();
 
-        new Expectations(env) {
-            {
-                Env.getCurrentInvertedIndex();
-                minTimes = 0;
-                result = invertedIndex;
-
-                invertedIndex.getTabletMeta(TABLET_ID);
-                minTimes = 0;
-                result = context.tabletMeta;
-
-                Env.getCurrentInternalCatalog();
-                minTimes = 0;
-                result = internalCatalog;
-
-                internalCatalog.getDbNullable(DB_ID);
-                minTimes = 0;
-                result = context.db;
-            }
-        };
+        envStatic.when(Env::getCurrentInvertedIndex).thenReturn(invertedIndex);
+        envStatic.when(Env::getCurrentInternalCatalog).thenReturn(internalCatalog);
+        Mockito.when(invertedIndex.getTabletMeta(TABLET_ID)).thenReturn(context.tabletMeta);
+        Mockito.when(internalCatalog.getDbNullable(DB_ID)).thenReturn(context.db);
 
         ReplicasProcNode procNode = new ReplicasProcNode(TABLET_ID, context.tablet.getReplicas());
         ProcResult result = procNode.fetchResult();


### PR DESCRIPTION
CloudProcVersionDisplayTest still imported mockit.Expectations / mockit.Mocked, but JMockit was removed from fe-core, so it was the only file under fe/ importing mockit and broke compilation with "package mockit does not exist", failing FE UT on master.

Rewrite the mocking with Mockito (mockito-inline is already a dependency): @Mocked fields become Mockito.mock(...), and the static Env methods are stubbed via Mockito.mockStatic(Env.class, CALLS_REAL_METHODS), following the existing BDBJEJournalTest pattern. Test logic and assertions are unchanged.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

