### PR TITLE
[improvement](cloud) Enable packed file and empty rowset optimization by default

### DIFF
--- a/be/src/cloud/config.cpp
+++ b/be/src/cloud/config.cpp
@@ -115,7 +115,7 @@ DEFINE_mInt32(meta_service_conflict_error_retry_times, "10");
 
 DEFINE_Bool(enable_check_storage_vault, "true");
 
-DEFINE_mBool(skip_writing_empty_rowset_metadata, "false");
+DEFINE_mBool(skip_writing_empty_rowset_metadata, "true");
 
 DEFINE_mInt64(cloud_index_change_task_timeout_second, "3600");
 
@@ -134,7 +134,7 @@ DEFINE_mInt64(warm_up_rowset_sync_wait_max_timeout_ms, "120000");
 DEFINE_mBool(enable_warmup_immediately_on_new_rowset, "false");
 
 // Packed file manager config
-DEFINE_mBool(enable_packed_file, "false");
+DEFINE_mBool(enable_packed_file, "true");
 DEFINE_mInt64(packed_file_size_threshold_bytes, "5242880"); // 5MB
 DEFINE_mInt64(packed_file_time_threshold_ms, "100");        // 100ms
 DEFINE_mInt64(packed_file_try_lock_timeout_ms, "5");        // 5ms


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Cloud mode kept packed file small-file merge and empty rowset metadata skipping disabled by default. This change enables enable_packed_file and skip_writing_empty_rowset_metadata by default so new cloud deployments merge small files and avoid writing metadata for empty rowsets without extra configuration.

### Release note

Enable cloud packed file small-file merge and empty rowset metadata skip optimization by default.

### Check List (For Author)

- Test: Manual test
    - git diff --check -- be/src/cloud/config.cpp
- Behavior changed: Yes. Cloud mode now enables packed file small-file merge and skips writing empty rowset metadata by default.
- Does this need documentation: No