### PR TITLE
[fix](fe) Normalize default HDFS paths in LocationPath

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/LocationPath.java
@@ -146,6 +146,9 @@ public class LocationPath {
         String encodedLocation = encodedLocation(normalizedLocation);
         URI uri = URI.create(encodedLocation);
         String fsIdentifier = Strings.nullToEmpty(uri.getScheme()) + "://" + Strings.nullToEmpty(uri.getAuthority());
+        if (StringUtils.isBlank(schema)) {
+            schema = Strings.nullToEmpty(uri.getScheme());
+        }
 
         return new LocationPath(schema, normalizedLocation, fsIdentifier, storageProperties);
     }
@@ -190,6 +193,9 @@ public class LocationPath {
             URI uri = URI.create(encodedLocation);
             String fsIdentifier = Strings.nullToEmpty(uri.getScheme()) + "://"
                     + Strings.nullToEmpty(uri.getAuthority());
+            if (StringUtils.isBlank(schema)) {
+                schema = Strings.nullToEmpty(uri.getScheme());
+            }
             return new LocationPath(schema, normalizedLocation, fsIdentifier, storageProperties);
         } catch (UserException e) {
             throw new StoragePropertiesException("Failed to create LocationPath for location: " + location, e);
@@ -231,6 +237,7 @@ public class LocationPath {
             String normalizedLocation = storageProperties.validateAndNormalizeUri(location);
 
             String fsIdentifier;
+            String schema = cachedSchema;
             if (cachedFsIdPrefix != null && normalizedLocation.startsWith(cachedFsIdPrefix)) {
                 // Fast path: extract authority from normalized location without full URI parsing
                 int authorityStart = cachedFsIdPrefix.length();
@@ -243,6 +250,9 @@ public class LocationPath {
                     throw new StoragePropertiesException("Invalid location, missing authority: " + normalizedLocation);
                 }
                 fsIdentifier = cachedFsIdPrefix + authority;
+                if (StringUtils.isBlank(schema)) {
+                    schema = cachedFsIdPrefix.substring(0, cachedFsIdPrefix.length() - SCHEME_DELIM.length());
+                }
             } else {
                 // Fallback to full URI parsing
                 String encodedLocation = encodedLocation(normalizedLocation);
@@ -253,9 +263,11 @@ public class LocationPath {
                 }
                 fsIdentifier = Strings.nullToEmpty(uri.getScheme()) + "://"
                         + authority;
+                if (StringUtils.isBlank(schema)) {
+                    schema = Strings.nullToEmpty(uri.getScheme());
+                }
             }
 
-            String schema = cachedSchema != null ? cachedSchema : extractScheme(location);
             return new LocationPath(schema, normalizedLocation, fsIdentifier, storageProperties);
         } catch (UserException e) {
             throw new StoragePropertiesException("Failed to create LocationPath for location: " + location, e);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/LocationPathTest.java
@@ -335,6 +335,21 @@ public class LocationPathTest {
     }
 
     @Test
+    public void testLocationPathWithCacheUsesDefaultFsForHdfsPath() {
+        StorageProperties storageProperties = STORAGE_PROPERTIES_MAP.get(StorageProperties.Type.HDFS);
+        String location = "/hadoop_catalog/fdm/f_csm_t_consume_info/data/data_dt=20220407/file.parquet";
+        LocationPath cached = LocationPath.ofWithCache(location, storageProperties, null, null);
+        LocationPath full = LocationPath.of(location, STORAGE_PROPERTIES_MAP);
+        Assertions.assertEquals(full.getNormalizedLocation(), cached.getNormalizedLocation());
+        Assertions.assertEquals("hdfs://namenode:8020/hadoop_catalog/fdm/f_csm_t_consume_info/data/"
+                + "data_dt=20220407/file.parquet", cached.getNormalizedLocation());
+        Assertions.assertEquals("hdfs://namenode:8020", cached.getFsIdentifier());
+        Assertions.assertEquals("hdfs", cached.getSchema());
+        Assertions.assertEquals(TFileType.FILE_HDFS, cached.getTFileTypeForBE());
+        Assertions.assertEquals(FileSystemType.HDFS, cached.getFileSystemType());
+    }
+
+    @Test
     public void testLocationPathWithCacheMissingAuthority() {
         StorageProperties storageProperties = STORAGE_PROPERTIES_MAP.get(StorageProperties.Type.S3);
         Assertions.assertThrows(StoragePropertiesException.class,


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #59217

Problem Summary:

Iceberg tables written through Hadoop catalog can store data file paths without a URI scheme, for example `/hadoop_catalog/db/tbl/data/file.parquet`. Doris should normalize these paths with the catalog `fs.defaultFS` before creating scan ranges.

The Iceberg `LocationPath` cache path kept the original blank schema after normalization and did not derive the schema from the normalized URI in the cached fallback path. As a result, partitioned table planning could fail with `Invalid location, missing authority`, and non-partitioned scans could pass an invalid file type or fs name to BE.

This patch derives the schema from the normalized URI when the original path has no scheme and keeps cached `LocationPath` creation consistent with full parsing.

### Release note

Fix Iceberg Hadoop catalog queries whose data file paths rely on `fs.defaultFS`.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.common.util.LocationPathTest`
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. HDFS paths without URI scheme are normalized with `fs.defaultFS` consistently when using cached `LocationPath` creation.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
