### PR TITLE
[fix](fe) Reuse Hive metadata cache for row count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -169,6 +169,10 @@ public interface TableIf {
 
     long fetchRowCount();
 
+    default long fetchRowCount(boolean cacheFileMetadata) {
+        return fetchRowCount();
+    }
+
     long getDataLength();
 
     long getAvgRowLength();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalRowCountCache.java
@@ -56,11 +56,13 @@ public class ExternalRowCountCache {
         private final long catalogId;
         private final long dbId;
         private final long tableId;
+        private final boolean cacheFileMetadata;
 
-        public RowCountKey(long catalogId, long dbId, long tableId) {
+        public RowCountKey(long catalogId, long dbId, long tableId, boolean cacheFileMetadata) {
             this.catalogId = catalogId;
             this.dbId = dbId;
             this.tableId = tableId;
+            this.cacheFileMetadata = cacheFileMetadata;
         }
 
         @Override
@@ -71,12 +73,13 @@ public class ExternalRowCountCache {
             if (!(obj instanceof RowCountKey)) {
                 return false;
             }
-            return ((RowCountKey) obj).tableId == this.tableId;
+            RowCountKey other = (RowCountKey) obj;
+            return other.tableId == this.tableId && other.cacheFileMetadata == this.cacheFileMetadata;
         }
 
         @Override
         public int hashCode() {
-            return (int) tableId;
+            return Long.hashCode(tableId) * 31 + Boolean.hashCode(cacheFileMetadata);
         }
     }
 
@@ -85,7 +88,7 @@ public class ExternalRowCountCache {
         protected Optional<Long> doLoad(RowCountKey rowCountKey) {
             try {
                 TableIf table = StatisticsUtil.findTable(rowCountKey.catalogId, rowCountKey.dbId, rowCountKey.tableId);
-                return Optional.of(table.fetchRowCount());
+                return Optional.of(table.fetchRowCount(rowCountKey.cacheFileMetadata));
             } catch (Exception e) {
                 String message = String.format("Failed to get table row count with catalogId %s, dbId %s, tableId %s. "
                                 + "Reason %s",
@@ -114,7 +117,16 @@ public class ExternalRowCountCache {
      * @return Cached row count or -1 if not exist
      */
     public long getCachedRowCount(long catalogId, long dbId, long tableId) {
-        RowCountKey key = new RowCountKey(catalogId, dbId, tableId);
+        return getCachedRowCount(catalogId, dbId, tableId, false);
+    }
+
+    /**
+     * Get cached row count for the given table. Return -1 if cached not loaded or table not exists.
+     * Cached will be loaded async.
+     * @return Cached row count or -1 if not exist
+     */
+    public long getCachedRowCount(long catalogId, long dbId, long tableId, boolean cacheFileMetadata) {
+        RowCountKey key = new RowCountKey(catalogId, dbId, tableId, cacheFileMetadata);
         try {
             CompletableFuture<Optional<Long>> f = rowCountCache.get(key);
             // Get row count synchronously by default.
@@ -139,7 +151,16 @@ public class ExternalRowCountCache {
      * @return Cached row count or -1 if not exist
      */
     public long getCachedRowCountIfPresent(long catalogId, long dbId, long tableId) {
-        RowCountKey key = new RowCountKey(catalogId, dbId, tableId);
+        return getCachedRowCountIfPresent(catalogId, dbId, tableId, false);
+    }
+
+    /**
+     * Get cached row count for the given table if present. Return -1 if cached not loaded.
+     * This method will not trigger async loading if cache is missing.
+     * @return Cached row count or -1 if not exist
+     */
+    public long getCachedRowCountIfPresent(long catalogId, long dbId, long tableId, boolean cacheFileMetadata) {
+        RowCountKey key = new RowCountKey(catalogId, dbId, tableId, cacheFileMetadata);
         try {
             CompletableFuture<Optional<Long>> f = rowCountCache.getIfPresent(key);
             if (f == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalTable.java
@@ -246,7 +246,8 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
             return TableIf.UNKNOWN_ROW_COUNT;
         }
         // All external table should get external row count from cache.
-        return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache().getCachedRowCount(catalog.getId(), dbId, id);
+        return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache()
+                .getCachedRowCount(catalog.getId(), dbId, id, true);
     }
 
     @Override
@@ -260,7 +261,8 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         }
         // getExtMetaCacheMgr().getRowCountCache().getCachedRowCount() is an asynchronous non-blocking operation.
         // For tables that are not in the cache, it will load asynchronously and return -1.
-        return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache().getCachedRowCount(catalog.getId(), dbId, id);
+        return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache()
+                .getCachedRowCount(catalog.getId(), dbId, id, false);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalView.java
@@ -132,6 +132,11 @@ public class ExternalView implements ViewIf {
     }
 
     @Override
+    public long fetchRowCount(boolean cacheFileMetadata) {
+        return externalTable.fetchRowCount(cacheFileMetadata);
+    }
+
+    @Override
     public long getDataLength() {
         return externalTable.getDataLength();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/PluginDrivenExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/PluginDrivenExternalTable.java
@@ -125,7 +125,7 @@ public class PluginDrivenExternalTable extends ExternalTable {
             return -1;
         }
         return Env.getCurrentEnv().getExtMetaCacheMgr().getRowCountCache()
-                .getCachedRowCount(catalog.getId(), dbId, id);
+                .getCachedRowCount(catalog.getId(), dbId, id, false);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -788,13 +788,18 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
 
     @Override
     public long fetchRowCount() {
+        return fetchRowCount(false);
+    }
+
+    @Override
+    public long fetchRowCount(boolean cacheFileMetadata) {
         makeSureInitialized();
         // Get row count from hive metastore property.
         long rowCount = getRowCountFromExternalSource();
         // Only hive table supports estimate row count by listing file.
         if (rowCount == UNKNOWN_ROW_COUNT && dlaType.equals(DLAType.HIVE)) {
             LOG.info("Will estimate row count for table {} from file list.", name);
-            rowCount = getRowCountFromFileList();
+            rowCount = getRowCountFromFileList(cacheFileMetadata);
         }
         return rowCount;
     }
@@ -1047,7 +1052,7 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
     /**
      * Estimate hive table row count : totalFileSize/estimatedRowSize
      */
-    private long getRowCountFromFileList() {
+    private long getRowCountFromFileList(boolean cacheFileMetadata) {
         if (!GlobalVariable.enable_get_row_count_from_file_list) {
             return UNKNOWN_ROW_COUNT;
         }
@@ -1061,7 +1066,7 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
             // Get files for all partitions.
             int samplePartitionSize = Config.hive_stats_partition_sample_size;
             List<HiveExternalMetaCache.FileCacheValue> filesByPartitions =
-                    getFilesForPartitions(partitionValues, samplePartitionSize);
+                    getFilesForPartitions(partitionValues, samplePartitionSize, cacheFileMetadata);
             LOG.info("Number of files selected for hive table {} is {}", name, filesByPartitions.size());
             long totalSize = 0;
             // Calculate the total file size.
@@ -1128,6 +1133,11 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
     // If sampleSize > 0, randomly choose part of partitions of the whole table.
     private List<HiveExternalMetaCache.FileCacheValue> getFilesForPartitions(
             HiveExternalMetaCache.HivePartitionValues partitionValues, int sampleSize) {
+        return getFilesForPartitions(partitionValues, sampleSize, false);
+    }
+
+    private List<HiveExternalMetaCache.FileCacheValue> getFilesForPartitions(
+            HiveExternalMetaCache.HivePartitionValues partitionValues, int sampleSize, boolean cacheFileMetadata) {
         if (isView()) {
             return Lists.newArrayList();
         }
@@ -1152,9 +1162,13 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
             for (PartitionItem item : partitionItems) {
                 partitionValuesList.add(((ListPartitionItem) item).getItems().get(0).getPartitionValuesAsStringList());
             }
-            // get partitions without cache, so that it will not invalid the cache when executing
-            // non query request such as `show table status`
-            hivePartitions = cache.getAllPartitionsWithoutCache(this, partitionValuesList);
+            if (cacheFileMetadata) {
+                hivePartitions = cache.getAllPartitionsWithCache(this, partitionValuesList);
+            } else {
+                // get partitions without cache, so that it will not invalid the cache when executing
+                // non query request such as `show table status`
+                hivePartitions = cache.getAllPartitionsWithoutCache(this, partitionValuesList);
+            }
             LOG.info("Partition list size for hive partition table {} is {}", name, hivePartitions.size());
         } else {
             hivePartitions.add(new HivePartition(getOrBuildNameMapping(), true,
@@ -1167,7 +1181,8 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
                 LOG.debug("Chosen partition for table {}. [{}]", name, partition.toString());
             }
         }
-        return cache.getFilesByPartitions(hivePartitions, false, true, new FileSystemDirectoryLister(), null);
+        boolean withFileCache = cacheFileMetadata && Config.max_external_file_cache_num > 0;
+        return cache.getFilesByPartitions(hivePartitions, withFileCache, true, new FileSystemDirectoryLister(), null);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalRowCountCacheTest.java
@@ -19,10 +19,12 @@ package org.apache.doris.datasource;
 
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.ThreadPoolManager;
+import org.apache.doris.statistics.util.StatisticsUtil;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.Optional;
@@ -102,6 +104,28 @@ public class ExternalRowCountCacheTest {
                 Thread.sleep(1000);
             }
             Assertions.assertEquals(3, counter.get());
+        }
+    }
+
+    @Test
+    public void testCacheFileMetadataIsPartOfRowCountKey() throws Exception {
+        TableIf table = Mockito.mock(TableIf.class);
+        Mockito.when(table.fetchRowCount(false)).thenReturn(10L);
+        Mockito.when(table.fetchRowCount(true)).thenReturn(20L);
+
+        try (MockedStatic<StatisticsUtil> statisticsUtil = Mockito.mockStatic(StatisticsUtil.class)) {
+            statisticsUtil.when(() -> StatisticsUtil.findTable(1L, 1L, 1L)).thenReturn(table);
+            ExternalRowCountCache.RowCountCacheLoader loader = new ExternalRowCountCache.RowCountCacheLoader();
+            ExternalRowCountCache.RowCountKey withoutFileMetadata =
+                    new ExternalRowCountCache.RowCountKey(1L, 1L, 1L, false);
+            ExternalRowCountCache.RowCountKey withFileMetadata =
+                    new ExternalRowCountCache.RowCountKey(1L, 1L, 1L, true);
+
+            Assertions.assertNotEquals(withoutFileMetadata, withFileMetadata);
+            Assertions.assertEquals(Optional.of(10L), loader.doLoad(withoutFileMetadata));
+            Assertions.assertEquals(Optional.of(20L), loader.doLoad(withFileMetadata));
+            Mockito.verify(table).fetchRowCount(false);
+            Mockito.verify(table).fetchRowCount(true);
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: Hive external table row count estimation falls back to listing partition files when HMS row count and size statistics are missing. The fallback path always bypassed the Hive partition and file metadata caches, so a normal query could read partition and file metadata during CBO and then read the same metadata again during scan planning. This patch distinguishes row count cache load contexts: query planning can let Hive row count estimation populate partition/file caches for scan reuse, while SHOW and information_schema style cached-row-count requests keep the no-heavy-cache behavior to avoid metadata cache pollution.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.datasource.ExternalRowCountCacheTest`
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
