### PR TITLE
[fix](ci) add persist-credentials: false in license-eyes pull_request_target checkout

### DIFF
--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Check License
         uses: apache/skywalking-eyes@v0.2.0


### PR DESCRIPTION
## Problem

The `license-eyes.yml` workflow uses `pull_request_target` and checks out the fork's HEAD without `persist-credentials: false`. This means the `GITHUB_TOKEN` (which has write permissions in `pull_request_target` context) remains configured in `.git/config`, accessible to any code running after the checkout step.

## Fix

Add `persist-credentials: false` to the `pull_request_target` checkout step so the token is not persisted to disk.

Backport of #63486.