### PR TITLE
[fix](ci) harden license-eyes pull_request_target checkout and Python import

### DIFF
--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Get changed files
         if: github.event_name == 'pull_request_target'
@@ -90,6 +91,9 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.added_modified }}
         run: |
           python3 - <<'EOF'
+          import sys
+          # Prevent fork-supplied files from shadowing stdlib modules
+          sys.path = [p for p in sys.path if p not in ('', '.')]
           import yaml, os
 
           with open('.licenserc.yaml') as f:


### PR DESCRIPTION
## Problem

The \`license-eyes.yml\` workflow uses \`pull_request_target\` and checks out the fork's HEAD without \`persist-credentials: false\`. Additionally, the inline Python script runs \`import yaml\` while the fork's code is in the working directory — a fork-supplied \`yaml.py\` would shadow the stdlib module and execute arbitrary code.

## Fix

- Add \`persist-credentials: false\` to the \`pull_request_target\` checkout step
- Strip \`''\` and \`'.'\` from \`sys.path\` before \`import yaml\` to prevent local module shadowing

Backport of #63486.