### PR TITLE
[Chore](be) Check column sanity across operator outputs

### DIFF
--- a/be/src/core/block/block.cpp
+++ b/be/src/core/block/block.cpp
@@ -267,7 +267,6 @@ void Block::check_number_of_rows(bool allow_null_columns) const {
 }
 
 Status Block::check_type_and_column() const {
-#ifndef NDEBUG
     for (const auto& elem : data) {
         if (!elem.column) {
             continue;
@@ -282,9 +281,11 @@ Status Block::check_type_and_column() const {
             continue;
         }
 
-        const auto& type = elem.type;
         const auto& column = elem.column;
 
+        RETURN_IF_CATCH_EXCEPTION({ column->sanity_check(); });
+#ifndef NDEBUG
+        const auto& type = elem.type;
         RETURN_IF_ERROR(column->column_self_check());
         auto st = type->check_column(*column);
         if (!st.ok()) {
@@ -293,8 +294,8 @@ Status Block::check_type_and_column() const {
                     "error: {}",
                     elem.name, column->get_name(), type->get_name(), st.msg());
         }
-    }
 #endif
+    }
     return Status::OK();
 }
 

--- a/be/src/core/column/column_string.cpp
+++ b/be/src/core/column/column_string.cpp
@@ -45,8 +45,8 @@ static constexpr auto CONVERT_COLUMN_IF_OVERFLOW_DEBUG_POINT =
 
 template <typename T>
 void ColumnStr<T>::sanity_check() const {
-#ifndef NDEBUG
     sanity_check_simple();
+#ifndef NDEBUG
     auto count = cast_set<int64_t>(offsets.size());
     for (int64_t i = 0; i < count; ++i) {
         if (offsets[i] < offsets[i - 1]) {

--- a/be/src/core/column/column_string.h
+++ b/be/src/core/column/column_string.h
@@ -118,7 +118,6 @@ public:
 
     void sanity_check() const override;
     void sanity_check_simple() const {
-#ifndef NDEBUG
         auto count = cast_set<int64_t>(offsets.size());
         if (chars.size() != offsets[count - 1]) {
             throw Exception(Status::InternalError("row count: {}, chars.size(): {}, offset[{}]: {}",
@@ -128,7 +127,6 @@ public:
         if (offsets[-1] != 0) {
             throw Exception(Status::InternalError("wrong offsets[-1]: {}", offsets[-1]));
         }
-#endif
     }
 
     std::string get_name() const override { return "String"; }

--- a/be/src/exec/operator/nested_loop_join_probe_operator.cpp
+++ b/be/src/exec/operator/nested_loop_join_probe_operator.cpp
@@ -39,6 +39,7 @@ constexpr int8_t MARK_TRUE = 1;
 constexpr int8_t MARK_NULL = -1;
 
 ColumnPtr make_const_column_from_row(const ColumnWithTypeAndName& source, size_t row, size_t rows) {
+    source.column->sanity_check();
     return ColumnConst::create(source.column->cut(row, 1), rows);
 }
 
@@ -51,6 +52,7 @@ ColumnPtr align_eval_column_nullable(const ColumnWithTypeAndName& target, const 
 
 void append_many_from_source(MutableColumnPtr& dst_column, const ColumnWithTypeAndName& src_column,
                              size_t row, size_t rows) {
+    src_column.column->sanity_check();
     if (!src_column.column->is_nullable() && dst_column->is_nullable()) {
         const auto origin_size = dst_column->size();
         auto* nullable_column = assert_cast<ColumnNullable*>(dst_column.get());
@@ -67,7 +69,9 @@ void append_filtered_from_source(MutableColumnPtr& dst_column,
     if (selected_rows == 0) {
         return;
     }
+    src_column.column->sanity_check();
     auto filtered_column = src_column.column->filter(filter, selected_rows);
+    filtered_column->sanity_check();
     if (!src_column.column->is_nullable() && dst_column->is_nullable()) {
         const auto origin_size = dst_column->size();
         auto* nullable_column = assert_cast<ColumnNullable*>(dst_column.get());

--- a/be/src/exec/operator/operator.cpp
+++ b/be/src/exec/operator/operator.cpp
@@ -413,11 +413,14 @@ Status OperatorXBase::get_block_after_projects(RuntimeState* state, Block* block
             return status;
         }
         status = do_projections(state, &local_state->_origin_block, block);
-        return status;
+        RETURN_IF_ERROR(status);
+        RETURN_IF_ERROR(block->check_type_and_column());
+        return Status::OK();
     }
     status = get_block(state, block, eos);
+    RETURN_IF_ERROR(status);
     RETURN_IF_ERROR(block->check_type_and_column());
-    return status;
+    return Status::OK();
 }
 
 void PipelineXLocalStateBase::reached_limit(Block* block, bool* eos) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Invalid column internals, such as a nullable column whose nested column size differs from its null map size, may only fail later when a downstream operator reads nested data. This change runs column sanity checks at pipeline operator output boundaries, including projection outputs, so malformed columns are reported closer to their producer. It also keeps targeted nested loop join lazy materialization sanity checks at the source-copy points that exposed the issue.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - build-support/clang-format.sh
    - build-support/check-format.sh
    - git diff --check
    - ninja -C be/build_Release src/core/CMakeFiles/Core.dir/block/block.cpp.o src/core/CMakeFiles/Core.dir/column/column_string.cpp.o src/exec/CMakeFiles/Exec.dir/operator/operator.cpp.o src/exec/CMakeFiles/Exec.dir/operator/nested_loop_join_probe_operator.cpp.o
- Behavior changed: No
- Does this need documentation: No