### PR TITLE
[fix](regression) Enable Paimon GCS regression

### DIFF
--- a/regression-test/pipeline/external/conf/regression-conf.groovy
+++ b/regression-test/pipeline/external/conf/regression-conf.groovy
@@ -75,7 +75,6 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
     "test_profile," +
     "test_refresh_mtmv," +
     "test_spark_load," +
-    "test_paimon_gcs," +
     "test_broker_load_func," +
     "test_stream_stub_fault_injection," +
     "test_iceberg_overwrite_with_wrong_partition," +
@@ -183,6 +182,8 @@ max_failure_num=50
 externalEnvIp="127.0.0.1"
 
 enablePaimonTest=true
+GCSEndpoint="https://storage.googleapis.com"
+GCSRegion="us-east1"
 
 hdfs_port=8020
 

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_gcs.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_gcs.groovy
@@ -26,15 +26,29 @@ suite("test_paimon_gcs", "p0,external") {
 
         String table_name = "hive_test_table"
         for (String propertyPrefix : ["gs", "s3"]) {
+            def catalogProperties = { boolean withRegion ->
+                def properties = [
+                        "'type' = 'paimon'",
+                        "'warehouse' = '${gcs_warehouse}'",
+                        "'fs.gcs.support' = 'true'",
+                ]
+                def optionalProperties = [
+                        [gcs_endpoint, "'${propertyPrefix}.endpoint' = '${gcs_endpoint}'"],
+                        [gcs_ak, "'${propertyPrefix}.access_key' = '${gcs_ak}'"],
+                        [gcs_sk, "'${propertyPrefix}.secret_key' = '${gcs_sk}'"],
+                ]
+                if (withRegion) {
+                    optionalProperties.add([gcs_region, "'${propertyPrefix}.region' = '${gcs_region}'"])
+                }
+                properties.addAll(optionalProperties.findAll { it[0] != null && !it[0].trim().isEmpty() }
+                        .collect { it[1] })
+                properties.join(",\n")
+            }
             def catalog_name = "test_paimon_gcs_${propertyPrefix}"
             sql """drop catalog if exists ${catalog_name}"""
             sql """
                     CREATE CATALOG ${catalog_name} PROPERTIES (
-                            'type' = 'paimon',
-                            'warehouse' = '${gcs_warehouse}',
-                            '${propertyPrefix}.endpoint' = '${gcs_endpoint}',
-                            '${propertyPrefix}.access_key' = '${gcs_ak}',
-                            '${propertyPrefix}.secret_key' = '${gcs_sk}'
+                            ${catalogProperties(false)}
                     );
                 """
             sql """switch `${catalog_name}`"""
@@ -55,12 +69,7 @@ suite("test_paimon_gcs", "p0,external") {
             sql """drop catalog if exists ${catalog_name}_with_region"""
             sql """
                     CREATE CATALOG ${catalog_name}_with_region PROPERTIES (
-                            'type' = 'paimon',
-                            'warehouse' = '${gcs_warehouse}',
-                            '${propertyPrefix}.endpoint' = '${gcs_endpoint}',
-                            '${propertyPrefix}.access_key' = '${gcs_ak}',
-                            '${propertyPrefix}.secret_key' = '${gcs_sk}',
-                            '${propertyPrefix}.region' = '${gcs_region}'
+                            ${catalogProperties(true)}
                     );
                 """
             sql """switch `${catalog_name}_with_region`"""
@@ -80,5 +89,3 @@ suite("test_paimon_gcs", "p0,external") {
         }
     }
 }
-
-


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Re-enable `test_paimon_gcs` in the external regression pipeline and explicitly mark the Paimon catalog storage as GCS so Doris does not infer it as another S3-compatible provider. The case continues to use the existing S3-compatible warehouse path for GCS because the FE pipeline classpath does not provide native `gs://` Paimon FileIO support.

### Release note

None

### Check List (For Author)

- Test: Regression test / Unit Test
    - Regression test: `./run-regression-test.sh --run --conf regression-test/pipeline/external/conf/regression-conf.groovy -d external_table_p0/paimon -s test_paimon_gcs -dryRun`
    - Unit Test: `./run-fe-ut.sh --run org.apache.doris.datasource.property.storage.GCSPropertiesTest`
- Behavior changed: No
- Does this need documentation: No
