### PR TITLE
[fix](be) Support null-only reads for not-null columns

### DIFF
--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -2120,7 +2120,29 @@ Status FileColumnIterator::next_batch(size_t* n, MutableColumnPtr& dst, bool* ha
     if (read_null_map_only()) {
         DLOG(INFO) << "File column iterator column " << _column_name
                    << " in NULL_MAP_ONLY mode, reading only null map.";
-        DORIS_CHECK(dst->is_nullable());
+        if (!dst->is_nullable()) {
+            DORIS_CHECK(!is_nullable());
+            size_t remaining = *n;
+            *has_null = false;
+            while (remaining > 0) {
+                if (!_page.has_remaining()) {
+                    bool eos = false;
+                    RETURN_IF_ERROR(_load_next_page(&eos));
+                    if (eos) {
+                        break;
+                    }
+                }
+                DORIS_CHECK(!_page.has_null);
+                size_t nrows_to_read = std::min(remaining, _page.remaining());
+                _page.offset_in_page += nrows_to_read;
+                _current_ordinal += nrows_to_read;
+                remaining -= nrows_to_read;
+            }
+            *n -= remaining;
+            dst->insert_many_defaults(*n);
+            return Status::OK();
+        }
+
         auto& nullable_col = assert_cast<ColumnNullable&>(*dst);
         auto& null_map_data = nullable_col.get_null_map_data();
 
@@ -2234,7 +2256,12 @@ Status FileColumnIterator::read_by_rowids(const rowid_t* rowids, const size_t co
         DLOG(INFO) << "File column iterator column " << _column_name
                    << " in NULL_MAP_ONLY mode, reading only null map by rowids.";
 
-        DORIS_CHECK(dst->is_nullable());
+        if (!dst->is_nullable()) {
+            DORIS_CHECK(!is_nullable());
+            dst->insert_many_defaults(count);
+            return Status::OK();
+        }
+
         auto& nullable_col = assert_cast<ColumnNullable&>(*dst);
         auto& null_map_data = nullable_col.get_null_map_data();
         const size_t base_size = null_map_data.size();

--- a/regression-test/suites/nereids_rules_p0/column_pruning/null_column_pruning.groovy
+++ b/regression-test/suites/nereids_rules_p0/column_pruning/null_column_pruning.groovy
@@ -529,4 +529,44 @@ suite("null_column_pruning") {
     }
 
     order_qt_34 "select 1 from ncp_tbl where length(str_col) = 0 or str_col is null";
+
+    sql """ DROP TABLE IF EXISTS ncp_outer_left """
+    sql """ DROP TABLE IF EXISTS ncp_outer_right """
+    sql """
+        CREATE TABLE ncp_outer_left (
+            id      INT NOT NULL,
+            str_col STRING NOT NULL
+        ) ENGINE = OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1")
+    """
+    sql """
+        CREATE TABLE ncp_outer_right (
+            id INT NOT NULL
+        ) ENGINE = OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES ("replication_allocation" = "tag.location.default: 1")
+    """
+    sql """ INSERT INTO ncp_outer_left VALUES (1, 'a'), (2, 'b') """
+    sql """ INSERT INTO ncp_outer_right VALUES (1), (3) """
+
+    explain {
+        sql """
+            SELECT l.id
+            FROM ncp_outer_left l RIGHT JOIN ncp_outer_right r ON l.id = r.id
+            WHERE r.id < 0 OR l.str_col >= l.str_col
+            ORDER BY 1
+        """
+        contains "str_col.NULL"
+        notContains "predicate access paths:"
+    }
+
+    order_qt_35 """
+        SELECT l.id
+        FROM ncp_outer_left l RIGHT JOIN ncp_outer_right r ON l.id = r.id
+        WHERE r.id < 0 OR l.str_col >= l.str_col
+        ORDER BY 1
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Problem Summary: Queries can request a .NULL access path for a NOT NULL base column after outer-join nullability propagation when only the post-join null flag is needed. The scalar FileColumnIterator NULL_MAP_ONLY path assumed that the destination column was always nullable and failed in lazy materialization with Check failed: dst->is_nullable(). For NOT NULL storage columns, the null map is known to be all false, so materialize default non-null placeholders for non-nullable destinations while preserving the existing nullable null-map path.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

