### PR TITLE
[doc](security) Add SECURITY.md threat model entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This is the codebase for Apache Doris, an MPP OLAP database. It primarily consis
 
 ## Security Threat Model
 
-For security scans, vulnerability triage, security reviews, and changes involving authentication, authorization, network boundaries, external catalogs, cloud tenancy, or other security-sensitive behavior, read `threat-model.md` first. Use it to determine in-scope components, trust boundaries, attacker roles, explicit non-goals, and triage classification. Findings that are out of model or by design under `threat-model.md` should be reported as such, not treated as Doris vulnerabilities.
+For security scans, vulnerability triage, security reviews, and changes involving authentication, authorization, network boundaries, external catalogs, cloud tenancy, or other security-sensitive behavior, read `SECURITY.md` first, then follow it to `threat-model.md`. Use `threat-model.md` to determine in-scope components, trust boundaries, attacker roles, explicit non-goals, and triage classification. Findings that are out of model or by design under `threat-model.md` should be reported as such, not treated as Doris vulnerabilities.
 
 ## When running in a WORKTREE directory
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+Apache Doris security findings should be reported to
+`security@apache.org`. The Apache Security Team will route reports to
+the Doris project maintainers.
+
+For security scope, trust boundaries, attacker roles, explicit
+non-goals, and vulnerability triage classification, use
+`threat-model.md` as the canonical source for this repository. Security
+scanners, review agents, and vulnerability triagers should read
+`threat-model.md` before classifying findings.
+
+Findings that are out of model or by design under `threat-model.md`
+should be reported with that disposition instead of being treated as
+Doris vulnerabilities.

--- a/threat-model.md
+++ b/threat-model.md
@@ -23,13 +23,14 @@ should classify any inbound report.
   matching git tag).
 - **Reporting cross-reference**: per M1, security findings should be
   reported to **`security@apache.org`** (ASF security team will route
-  to Doris). A short `SECURITY.md` at the repo root will link to this
+  to Doris). A short `SECURITY.md` at the repo root links to this
   document as canonical scope (M16 (A)). Findings that fall under
   §4.3 / §4.9 / §4.11a will be closed with a citation to this
   document.
 - **Status**: v1.0 — technical model accepted. The four wave-4 (M15–M18)
-  meta/process answers are recorded below; physical artifacts
-  (`SECURITY.md`, model-version field policy text) are follow-up work.
+  meta/process answers are recorded below; the root `SECURITY.md`
+  coexistence artifact is complete, while model-version field policy
+  text remains follow-up work.
 - **Provenance legend**:
   - *(documented)* — stated in Doris' own README, code comments,
     `conf/*.conf`, or user docs
@@ -741,7 +742,6 @@ the body. Summary table:
 
 **Open follow-up items (not blocking v1.0 acceptance):**
 
-- Add `SECURITY.md` at repo root per M16. (Tracked separately.)
 - Add `model-version` field to top of this doc per M15. Currently
   bound to commit `1d1846591f7` / pre-3.x release. Update when
   cutting next release.
@@ -802,5 +802,5 @@ Not yet produced in v1.0. Optional follow-up.
 - [x] Document length: ~7 pages (within recommended 3–8). v0.1's
       §4.14 wave-3 collapsed into a 14-row summary table.
 
-**v1.0 status**: ACCEPTED for technical content; `SECURITY.md`
-follow-up artifact pending per M16.
+**v1.0 status**: ACCEPTED for technical content; root `SECURITY.md`
+coexistence artifact complete per M16.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Security tooling and reviewers expect a root SECURITY.md entry point. The threat model already defined SECURITY.md coexistence under M16, but the repository did not provide the conventional file.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Ran `git diff --cached --check` and verified the SECURITY.md -> threat-model.md discovery chain.
- Behavior changed: No
- Does this need documentation: No, documentation-only change.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

