### PR TITLE
[fix](regression) Enable Paimon GCS regression

### DIFF
--- a/regression-test/pipeline/external/conf/regression-conf.groovy
+++ b/regression-test/pipeline/external/conf/regression-conf.groovy
@@ -173,6 +173,8 @@ max_failure_num=50
 externalEnvIp="127.0.0.1"
 
 enablePaimonTest=true
+GCSEndpoint="https://storage.googleapis.com"
+GCSRegion="us-east1"
 
 hdfs_port=8020
 

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_gcs.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_gcs.groovy
@@ -26,15 +26,29 @@ suite("test_paimon_gcs", "p0,external,doris,new_catalog_property") {
 
         String table_name = "hive_test_table"
         for (String propertyPrefix : ["gs", "s3"]) {
+            def catalogProperties = { boolean withRegion ->
+                def properties = [
+                        "'type' = 'paimon'",
+                        "'warehouse' = '${gcs_warehouse}'",
+                        "'fs.gcs.support' = 'true'",
+                ]
+                def optionalProperties = [
+                        [gcs_endpoint, "'${propertyPrefix}.endpoint' = '${gcs_endpoint}'"],
+                        [gcs_ak, "'${propertyPrefix}.access_key' = '${gcs_ak}'"],
+                        [gcs_sk, "'${propertyPrefix}.secret_key' = '${gcs_sk}'"],
+                ]
+                if (withRegion) {
+                    optionalProperties.add([gcs_region, "'${propertyPrefix}.region' = '${gcs_region}'"])
+                }
+                properties.addAll(optionalProperties.findAll { it[0] != null && !it[0].trim().isEmpty() }
+                        .collect { it[1] })
+                properties.join(",\n")
+            }
             def catalog_name = "test_paimon_gcs_${propertyPrefix}"
             sql """drop catalog if exists ${catalog_name}"""
             sql """
                     CREATE CATALOG ${catalog_name} PROPERTIES (
-                            'type' = 'paimon',
-                            'warehouse' = '${gcs_warehouse}',
-                            '${propertyPrefix}.endpoint' = '${gcs_endpoint}',
-                            '${propertyPrefix}.access_key' = '${gcs_ak}',
-                            '${propertyPrefix}.secret_key' = '${gcs_sk}'
+                            ${catalogProperties(false)}
                     );
                 """
             sql """switch `${catalog_name}`"""
@@ -55,12 +69,7 @@ suite("test_paimon_gcs", "p0,external,doris,new_catalog_property") {
             sql """drop catalog if exists ${catalog_name}_with_region"""
             sql """
                     CREATE CATALOG ${catalog_name}_with_region PROPERTIES (
-                            'type' = 'paimon',
-                            'warehouse' = '${gcs_warehouse}',
-                            '${propertyPrefix}.endpoint' = '${gcs_endpoint}',
-                            '${propertyPrefix}.access_key' = '${gcs_ak}',
-                            '${propertyPrefix}.secret_key' = '${gcs_sk}',
-                            '${propertyPrefix}.region' = '${gcs_region}'
+                            ${catalogProperties(true)}
                     );
                 """
             sql """switch `${catalog_name}_with_region`"""
@@ -80,5 +89,3 @@ suite("test_paimon_gcs", "p0,external,doris,new_catalog_property") {
         }
     }
 }
-
-


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63521

Problem Summary: Configure the Paimon GCS regression case to explicitly enable GCS filesystem support so Paimon can access the existing GCS warehouse through the S3-compatible path on branch-4.0.

### Release note

None

### Check List (For Author)

- Test: Regression test
    - Regression test: ./run-regression-test.sh --run --conf regression-test/pipeline/external/conf/regression-conf.groovy -d external_table_p0/paimon -s test_paimon_gcs -dryRun
- Behavior changed: No
- Does this need documentation: No
