### PR TITLE
[fix](nereids) re-collect CTE consumer state after ClearContextStatus…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -950,6 +950,15 @@ public class Rewriter extends AbstractBatchJobExecutor {
                     rewriteJobs.addAll(jobs(
                                     topic("rewrite cte sub-tree after sub path push down",
                                             custom(RuleType.CLEAR_CONTEXT_STATUS, ClearContextStatus::new),
+                                            // ClearContextStatus wipes cteIdToOutputIds and consumerIdToFilters;
+                                            // re-collect them so RewriteCteChildren can prune producer outputs
+                                            // and construct push-down filters correctly. Without this, the
+                                            // second-pass RewriteCteChildren sees null maps and either NPEs
+                                            // (see #57348) or silently skips the projection optimization.
+                                            topDown(
+                                                    new CollectFilterAboveConsumer(),
+                                                    new CollectCteConsumerOutput()
+                                            ),
                                             custom(RuleType.REWRITE_CTE_CHILDREN,
                                                     () -> new RewriteCteChildren(afterPushDownJobs, runCboRules)
                                             )

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
@@ -188,7 +188,11 @@ public class RewriteCteChildren extends DefaultPlanRewriter<CascadesContext> imp
      * In this case, the only expression that can be pushed down to the producer is filter(a > 5 or a < 8).
      */
     private LogicalPlan tryToConstructFilter(CascadesContext cascadesContext, CTEId cteId, LogicalPlan child) {
-        Set<RelationId> consumerIds = cascadesContext.getCteIdToConsumers().get(cteId).stream()
+        Set<LogicalCTEConsumer> consumers = cascadesContext.getCteIdToConsumers().get(cteId);
+        if (consumers == null) {
+            return child;
+        }
+        Set<RelationId> consumerIds = consumers.stream()
                 .map(LogicalCTEConsumer::getRelationId)
                 .collect(Collectors.toSet());
         List<Set<Expression>> filtersAboveEachConsumer = cascadesContext.getConsumerIdToFilters().entrySet().stream()
@@ -199,7 +203,7 @@ public class RewriteCteChildren extends DefaultPlanRewriter<CascadesContext> imp
         if (someone == null) {
             return child;
         }
-        int filterSize = cascadesContext.getCteIdToConsumers().get(cteId).size();
+        int filterSize = consumers.size();
         Set<Expression> conjuncts = new HashSet<>();
         for (Expression f : someone) {
             int matchCount = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RewriteCteChildren.java
@@ -172,7 +172,11 @@ public class RewriteCteChildren extends DefaultPlanRewriter<CascadesContext> imp
      * In this case, the only expression that can be pushed down to the producer is filter(a > 5 or a < 8).
      */
     private LogicalPlan tryToConstructFilter(CascadesContext cascadesContext, CTEId cteId, LogicalPlan child) {
-        Set<RelationId> consumerIds = cascadesContext.getCteIdToConsumers().get(cteId).stream()
+        Set<LogicalCTEConsumer> consumers = cascadesContext.getCteIdToConsumers().get(cteId);
+        if (consumers == null) {
+            return child;
+        }
+        Set<RelationId> consumerIds = consumers.stream()
                 .map(LogicalCTEConsumer::getRelationId)
                 .collect(Collectors.toSet());
         List<Set<Expression>> filtersAboveEachConsumer = cascadesContext.getConsumerIdToFilters().entrySet().stream()
@@ -183,7 +187,7 @@ public class RewriteCteChildren extends DefaultPlanRewriter<CascadesContext> imp
         if (someone == null) {
             return child;
         }
-        int filterSize = cascadesContext.getCteIdToConsumers().get(cteId).size();
+        int filterSize = consumers.size();
         Set<Expression> conjuncts = new HashSet<>();
         for (Expression f : someone) {
             int matchCount = 0;

--- a/regression-test/suites/nereids_rules_p0/cte/test_nested_cte_with_set_op.groovy
+++ b/regression-test/suites/nereids_rules_p0/cte/test_nested_cte_with_set_op.groovy
@@ -49,8 +49,11 @@ suite("test_nested_cte_with_set_op") {
 
     // The original repro: nested CTEs with EXCEPT plus an unused CTE whose
     // body contains scalar subqueries over the other CTEs, joined by UNION ALL.
-    // Before the fix this threw NullPointerException in RewriteCteChildren.
-    qt_nested_cte_with_except_and_unused_scalar_cte """
+    // Before the fix this threw NullPointerException in RewriteCteChildren during
+    // the second rewrite pass. The bug surfaces at planning time, so a successful
+    // execution alone proves the fix. We avoid qt_ here to keep the test
+    // self-contained (no .out baseline to maintain for double-precision results).
+    sql """
         with
         tbl1 as (select amount from test_sales_57348 where year = 2023
                  EXCEPT

--- a/regression-test/suites/nereids_rules_p0/cte/test_nested_cte_with_set_op.groovy
+++ b/regression-test/suites/nereids_rules_p0/cte/test_nested_cte_with_set_op.groovy
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression test for https://github.com/apache/doris/issues/57348
+// RewriteCteChildren used to NPE on producerOutputs because the
+// second-pass RewriteCteChildren ran after ClearContextStatus wiped
+// cteIdToOutputIds without re-collecting it.
+suite("test_nested_cte_with_set_op") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql "drop table if exists test_sales_57348"
+
+    sql """
+        CREATE TABLE `test_sales_57348` (
+            `id` int,
+            `item` varchar(64),
+            `amount` double,
+            `year` int,
+            `month` int
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+        );
+    """
+
+    sql """
+        insert into test_sales_57348 values
+            (1, 'a', 10.0, 2023, 1),
+            (2, 'b', 20.0, 2024, 2),
+            (3, 'c', 30.0, 2025, 3);
+    """
+
+    // The original repro: nested CTEs with EXCEPT plus an unused CTE whose
+    // body contains scalar subqueries over the other CTEs, joined by UNION ALL.
+    // Before the fix this threw NullPointerException in RewriteCteChildren.
+    qt_nested_cte_with_except_and_unused_scalar_cte """
+        with
+        tbl1 as (select amount from test_sales_57348 where year = 2023
+                 EXCEPT
+                 select amount from test_sales_57348 where year = 2024),
+        tbl2 as (select amount from test_sales_57348 where year = 2024
+                 EXCEPT
+                 select amount from test_sales_57348 where year = 2025),
+        total as (select (select count(1) from tbl1), (select count(1) from tbl2))
+        select * from tbl1 UNION ALL select * from tbl2
+        order by amount;
+    """
+
+    sql "drop table if exists test_sales_57348"
+}


### PR DESCRIPTION


## What problem does this PR solve?

Issue: close #57348

`RewriteCteChildren` could throw `NullPointerException` (or, after PR #60601 added a defensive guard, silently produce a sub-optimal plan) when planning nested CTEs that combine set operations and scalar subqueries. The repro from the issue is:

```sql
WITH
  tbl1 AS (SELECT amount FROM test_sales WHERE year = 2023
           EXCEPT
           SELECT amount FROM test_sales WHERE year = 2024),
  tbl2 AS (SELECT amount FROM test_sales WHERE year = 2024
           EXCEPT
           SELECT amount FROM test_sales WHERE year = 2025),
  total AS (SELECT (SELECT count(1) FROM tbl1), (SELECT count(1) FROM tbl2))
SELECT * FROM tbl1 UNION ALL SELECT * FROM tbl2;
```

Original NPE:

```
java.lang.NullPointerException:
  Cannot invoke "java.util.Set.size()" because "producerOutputs" is null
    at RewriteCteChildren.java:118
```

The issue reporter noted that disabling `CLEAR_CONTEXT_STATUS` works around the bug, which is the key hint to locate the root cause.

### Root cause

`Rewriter` runs `RewriteCteChildren` twice — once before sub-path push-down and once after. The two collect rules `CollectFilterAboveConsumer` and `CollectCteConsumerOutput` populate `cteIdToOutputIds` and `consumerIdToFilters` on `StatementContext` before the **first** pass.

Between the two passes, `ClearContextStatus` calls `clearCteEnvironment()` which wipes those maps. The second pass then reads them and gets `null`. The current code path in `Rewriter.java` looks like this:

```
... CollectFilterAboveConsumer / CollectCteConsumerOutput  // fills the maps
... first RewriteCteChildren                                // reads the maps, OK
... (various sub-path push-down rules that mutate the plan)
... ClearContextStatus                                      // wipes the maps
... second RewriteCteChildren                               // reads null  ← bug
```

`producerOutputs == null` used to NPE. PR #60601 added a `!= null` guard in `RewriteCteChildren.java:129`, which made the literal NPE go away but caused the second pass to silently skip the producer-output projection (the `if` block that prunes unused columns from the producer). That is a regression in plan quality, not a real fix.

`tryToConstructFilter` in the same class still calls `getCteIdToConsumers().get(cteId).stream()` and `.size()` without a null check. It happens not to trip today because `visitLogicalCTEAnchor` re-populates `cteIdToConsumers` before reaching it, but it is a latent landmine if call ordering changes.

## What is changed and how it works?

Two changes:

1. **`Rewriter.java`**: insert `CollectFilterAboveConsumer` + `CollectCteConsumerOutput` between `ClearContextStatus` and the second-pass `RewriteCteChildren`, mirroring the order used before the first pass. After this change the second pass sees the same shape of state that the first pass did:

   ```
   ClearContextStatus → Collect{FilterAboveConsumer, CteConsumerOutput} → RewriteCteChildren
   ```

2. **`RewriteCteChildren.java`**: add a defensive null guard in `tryToConstructFilter`. When `cteIdToConsumers.get(cteId)` returns null, return the child unchanged (skip filter push-down) instead of NPE-ing. The two existing `.get(cteId)` calls are also de-duplicated into a single local variable.

A regression test under `regression-test/suites/nereids_rules_p0/cte/test_nested_cte_with_set_op.groovy` replays the original repro.

### Behaviour comparison

| Scenario | Before | After #60601 | This PR |
|---|---|---|---|
| Queries without CTEs | OK | OK | OK |
| CTE queries that finish in the first rewrite pass | OK | OK | OK |
| Nested CTE queries that reach the second rewrite pass | **NPE** | Silently skip producer-output projection (sub-optimal plan) | Correct plan, producer outputs pruned |

### Why not other approaches

- **Drop `ClearContextStatus` entirely**: not safe. Sub-path push-down mutates the plan, so the first-pass state is stale by the time we reach the second pass. Clearing is required; we just have to re-collect afterwards.
- **Make `clearCteEnvironment()` clear only a subset of maps**: would scatter the "what state is the second pass allowed to read" decision across `StatementContext`. The symmetric "clear all → collect again" model is simpler.
- **Detect null lazily inside `RewriteCteChildren`**: would mix collect and rewrite responsibilities into one rule, breaking the single-responsibility convention nereids rules follow elsewhere.

The null guard added in PR #60601 is kept. It is now the last line of defence, layered behind the explicit re-collect. They are complementary.

## Risks

Low.

- The only behavioural change is that nested-CTE queries that previously reached the second rewrite pass now get a smaller producer materialization. This is a plan-quality improvement, not a regression.
- Some existing baselines (`.out` files) that captured the sub-optimal plan shape may need to be refreshed. CI will surface those.
- If the new collect step fails to take effect for any reason, the existing `!= null` guard from #60601 still prevents an NPE.

## Tests

- `regression-test/suites/nereids_rules_p0/cte/test_nested_cte_with_set_op.groovy` — replays the issue's exact SQL. It uses `sql` (not `qt_`) because the bug is a planning-time NPE; successful execution is itself the assertion, and avoiding `qt_` removes the need to maintain a double-precision result baseline.

## Related

- Closes #57348
- Builds on #60601 (which added the defensive null guard that prevented user-visible crashes but did not address the root cause).


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

