### PR TITLE
[fix](fe) Fix int overflow in BeIdComparator causing stream load failure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
@@ -1063,7 +1063,7 @@ public class CloudSystemInfoService extends SystemInfoService {
                         .filter(i -> i.getTagMap().containsKey(Tag.CLOUD_CLUSTER_NAME))
                         .collect(Collectors.toList());
                 // The larger bakendId the later it was added, the order matters
-                toAdd.sort((x, y) -> (int) (x.getId() - y.getId()));
+                toAdd.sort((x, y) -> Long.compare(x.getId(), y.getId()));
                 updateCloudClusterMapNoLock(toAdd, new ArrayList<>());
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -478,7 +478,7 @@ public class SystemInfoService {
 
     class BeIdComparator implements Comparator<Backend> {
         public int compare(Backend a, Backend b) {
-            return (int) (a.getId() - b.getId());
+            return Long.compare(a.getId(), b.getId());
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63562 
Related PR: #xxx

Problem Summary: 

`(int)(a.getId() - b.getId())` overflows when BE ID delta exceeds Integer.MAX_VALUE, breaking the Comparator contract and causing stream load to fail with "Comparison method violates its general contract!". Use `Long.compare` instead. Same fix applied to CloudSystemInfoService.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason: Trivial overflow fix — replacing `(int)(a.getId() - b.getId())` with `Long.compare(a.getId(), b.getId())` preserves the comparator semantics for all non-overflow inputs; the bug only manifests when the BE id delta exceeds Integer.MAX_VALUE, which is difficult to fabricate in a unit test without contrived BE ids.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

