### PR TITLE
[chore](build) Ignore local IDE metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ core.*
 # ignore file with specifiy name anywhere
 .DS_Store
 .classpath
+.factorypath
+.worktree_initialized
 nohup.out
 /custom_env.sh
 /custom_env_mac.sh


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: nvim-jdtls generates a local .factorypath file and worktree setup creates .worktree_initialized. These files are local metadata and should not appear as untracked working tree changes.

### Release note

None

### Check List (For Author)

- Test: No need to test (gitignore-only change)
- Behavior changed: No
- Does this need documentation: No