### PR TITLE
[feat](connector) P0 SPI baseline + DDL/Partition + import gate (T03-T27)

### DIFF
--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorMetadata.java
@@ -17,10 +17,14 @@
 
 package org.apache.doris.connector.api;
 
+import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.api.mvcc.ConnectorMvccSnapshot;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Central metadata interface that a connector must implement.
@@ -42,6 +46,34 @@ public interface ConnectorMetadata extends
     /** Returns connector-level properties. */
     default Map<String, String> getProperties() {
         return Collections.emptyMap();
+    }
+
+    // ──────────────────── MVCC Snapshots ────────────────────
+
+    /**
+     * Returns the current snapshot at query begin time, used as the MVCC pin
+     * for all subsequent reads of {@code handle}.
+     *
+     * <p>Returning {@link Optional#empty()} means the connector does not
+     * support MVCC and reads see whatever is current.</p>
+     */
+    default Optional<ConnectorMvccSnapshot> beginQuerySnapshot(
+            ConnectorSession session, ConnectorTableHandle handle) {
+        return Optional.empty();
+    }
+
+    /** Returns the snapshot at the given wall-clock time, or empty if none. */
+    default Optional<ConnectorMvccSnapshot> getSnapshotAt(
+            ConnectorSession session, ConnectorTableHandle handle,
+            long timestampMillis) {
+        return Optional.empty();
+    }
+
+    /** Returns the snapshot with the given id, or empty if none. */
+    default Optional<ConnectorMvccSnapshot> getSnapshotById(
+            ConnectorSession session, ConnectorTableHandle handle,
+            long snapshotId) {
+        return Optional.empty();
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorPartitionInfo.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorPartitionInfo.java
@@ -26,13 +26,31 @@ import java.util.Objects;
  */
 public final class ConnectorPartitionInfo {
 
+    /** Sentinel for "unknown" on the numeric stats fields. */
+    public static final long UNKNOWN = -1L;
+
     private final String partitionName;
     private final Map<String, String> partitionValues;
     private final Map<String, String> properties;
+    private final long rowCount;
+    private final long sizeBytes;
+    private final long lastModifiedMillis;
 
+    /**
+     * Backward-compatible constructor. Numeric stats fields are set to
+     * {@link #UNKNOWN}.
+     */
     public ConnectorPartitionInfo(String partitionName,
             Map<String, String> partitionValues,
             Map<String, String> properties) {
+        this(partitionName, partitionValues, properties,
+                UNKNOWN, UNKNOWN, UNKNOWN);
+    }
+
+    public ConnectorPartitionInfo(String partitionName,
+            Map<String, String> partitionValues,
+            Map<String, String> properties,
+            long rowCount, long sizeBytes, long lastModifiedMillis) {
         this.partitionName = Objects.requireNonNull(
                 partitionName, "partitionName");
         this.partitionValues = partitionValues == null
@@ -41,6 +59,9 @@ public final class ConnectorPartitionInfo {
         this.properties = properties == null
                 ? Collections.emptyMap()
                 : Collections.unmodifiableMap(properties);
+        this.rowCount = rowCount;
+        this.sizeBytes = sizeBytes;
+        this.lastModifiedMillis = lastModifiedMillis;
     }
 
     public String getPartitionName() {
@@ -55,6 +76,21 @@ public final class ConnectorPartitionInfo {
         return properties;
     }
 
+    /** @return row count, or {@link #UNKNOWN} when not collected. */
+    public long getRowCount() {
+        return rowCount;
+    }
+
+    /** @return on-disk size in bytes, or {@link #UNKNOWN}. */
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    /** @return last-modified epoch millis, or {@link #UNKNOWN}. */
+    public long getLastModifiedMillis() {
+        return lastModifiedMillis;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -64,19 +100,25 @@ public final class ConnectorPartitionInfo {
             return false;
         }
         ConnectorPartitionInfo that = (ConnectorPartitionInfo) o;
-        return partitionName.equals(that.partitionName)
+        return rowCount == that.rowCount
+                && sizeBytes == that.sizeBytes
+                && lastModifiedMillis == that.lastModifiedMillis
+                && partitionName.equals(that.partitionName)
                 && partitionValues.equals(that.partitionValues)
                 && properties.equals(that.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(partitionName, partitionValues, properties);
+        return Objects.hash(partitionName, partitionValues, properties,
+                rowCount, sizeBytes, lastModifiedMillis);
     }
 
     @Override
     public String toString() {
         return "ConnectorPartitionInfo{name='" + partitionName
-                + "', values=" + partitionValues + "}";
+                + "', values=" + partitionValues
+                + ", rowCount=" + rowCount
+                + ", sizeBytes=" + sizeBytes + "}";
     }
 }

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorSession.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorSession.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.connector.api;
 
+import org.apache.doris.connector.api.handle.ConnectorTransaction;
+
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Session context passed to every connector operation.
@@ -59,5 +62,18 @@ public interface ConnectorSession {
      */
     default Map<String, String> getSessionProperties() {
         return java.util.Collections.emptyMap();
+    }
+
+    /**
+     * Returns the transaction this session is currently bound to, if any.
+     *
+     * <p>Used by connectors whose {@code begin*} write operations need to
+     * attach work to an outer transaction opened by
+     * {@link ConnectorWriteOps#beginTransaction(ConnectorSession)}.
+     * Connectors with statement-scoped writes (e.g. JDBC auto-commit) can
+     * ignore this and the default empty value.</p>
+     */
+    default Optional<ConnectorTransaction> getCurrentTransaction() {
+        return Optional.empty();
     }
 }

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorTableOps.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorTableOps.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.connector.api;
 
+import org.apache.doris.connector.api.ddl.ConnectorCreateTableRequest;
 import org.apache.doris.connector.api.handle.ConnectorColumnHandle;
 import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.api.pushdown.ConnectorExpression;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,6 +65,27 @@ public interface ConnectorTableOps {
             Map<String, String> properties) {
         throw new DorisConnectorException(
                 "CREATE TABLE not supported");
+    }
+
+    /**
+     * Creates a table with full DDL semantics (partition, bucket, external,
+     * {@code IF NOT EXISTS}).
+     *
+     * <p>Connectors should override this when they support advanced
+     * {@code CREATE TABLE} options. The default degrades to the legacy
+     * {@link #createTable(ConnectorSession, ConnectorTableSchema, Map)},
+     * dropping partition / bucket / external / {@code ifNotExists} info.</p>
+     *
+     * @throws DorisConnectorException if the connector cannot honor the request
+     */
+    default void createTable(ConnectorSession session,
+            ConnectorCreateTableRequest request) {
+        ConnectorTableSchema schema = new ConnectorTableSchema(
+                request.getTableName(),
+                request.getColumns(),
+                null,
+                request.getProperties());
+        createTable(session, schema, request.getProperties());
     }
 
     /** Drops the specified table. */
@@ -125,5 +148,39 @@ public interface ConnectorTableOps {
             long tableId, String tableName, String dbName,
             String remoteName, int numCols, long catalogId) {
         return null;
+    }
+
+    /**
+     * Lists all partition display names (e.g., {@code "year=2024/month=01"}).
+     *
+     * <p>Should be cheap and avoid loading per-partition metadata.</p>
+     */
+    default List<String> listPartitionNames(ConnectorSession session,
+            ConnectorTableHandle handle) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Lists partitions matching the optional filter, with full metadata.
+     *
+     * <p>Connectors should push the filter into the metastore / catalog when
+     * possible. {@code filter} is empty when the caller wants the full list.</p>
+     */
+    default List<ConnectorPartitionInfo> listPartitions(ConnectorSession session,
+            ConnectorTableHandle handle,
+            Optional<ConnectorExpression> filter) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Lists distinct partition column value combinations for the given columns.
+     *
+     * <p>Used by the {@code partition_values()} TVF and by column-distinct-value
+     * optimizations. Inner list order matches {@code partitionColumns}.</p>
+     */
+    default List<List<String>> listPartitionValues(ConnectorSession session,
+            ConnectorTableHandle handle,
+            List<String> partitionColumns) {
+        return Collections.emptyList();
     }
 }

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorWriteOps.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorWriteOps.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.api.handle.ConnectorDeleteHandle;
 import org.apache.doris.connector.api.handle.ConnectorInsertHandle;
 import org.apache.doris.connector.api.handle.ConnectorMergeHandle;
 import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.api.handle.ConnectorTransaction;
 import org.apache.doris.connector.api.write.ConnectorWriteConfig;
 
 import java.util.Collection;
@@ -196,5 +197,21 @@ public interface ConnectorWriteOps {
     default void abortMerge(ConnectorSession session,
             ConnectorMergeHandle handle) {
         // default: no-op
+    }
+
+    // ──────────────────── TRANSACTION ────────────────────
+
+    /**
+     * Begins a new transaction scoped to a single SQL statement (auto-commit)
+     * or to an explicit BEGIN..COMMIT block. The returned transaction is passed
+     * to subsequent {@code begin*} / {@code finish*} / {@code abort*} calls via
+     * the same {@link ConnectorSession}.
+     *
+     * <p>Connectors that do not support multi-statement transactions can either
+     * return a no-op transaction whose commit/rollback do nothing, or throw, in
+     * which case the engine treats every statement as auto-commit.</p>
+     */
+    default ConnectorTransaction beginTransaction(ConnectorSession session) {
+        throw new DorisConnectorException("Transactions not supported");
     }
 }

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorBucketSpec.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorBucketSpec.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.api.ddl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Bucket / distribution specification carried by
+ * {@link ConnectorCreateTableRequest}.
+ *
+ * <p>{@code algorithm} is a connector-known string. Common values:</p>
+ * <ul>
+ *   <li>{@code "hive_hash"} — Hive-compatible 32-bit hash.</li>
+ *   <li>{@code "iceberg_bucket"} — Iceberg bucket transform.</li>
+ *   <li>{@code "doris_default"} — Doris CRC32 distribution.</li>
+ * </ul>
+ */
+public final class ConnectorBucketSpec {
+
+    private final List<String> columns;
+    private final int numBuckets;
+    private final String algorithm;
+
+    public ConnectorBucketSpec(List<String> columns, int numBuckets,
+            String algorithm) {
+        this.columns = columns == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(columns);
+        this.numBuckets = numBuckets;
+        this.algorithm = Objects.requireNonNull(algorithm, "algorithm");
+    }
+
+    public List<String> getColumns() {
+        return columns;
+    }
+
+    public int getNumBuckets() {
+        return numBuckets;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConnectorBucketSpec)) {
+            return false;
+        }
+        ConnectorBucketSpec that = (ConnectorBucketSpec) o;
+        return numBuckets == that.numBuckets
+                && columns.equals(that.columns)
+                && algorithm.equals(that.algorithm);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(columns, numBuckets, algorithm);
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectorBucketSpec{algorithm=" + algorithm
+                + ", columns=" + columns
+                + ", numBuckets=" + numBuckets + "}";
+    }
+}

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorCreateTableRequest.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorCreateTableRequest.java
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.api.ddl;
+
+import org.apache.doris.connector.api.ConnectorColumn;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Full {@code CREATE TABLE} payload passed to
+ * {@code ConnectorTableOps.createTable(session, request)}.
+ *
+ * <p>Carries partition / bucket / external / {@code IF NOT EXISTS} information
+ * absent from the legacy
+ * {@code createTable(session, ConnectorTableSchema, Map<String,String>)}
+ * signature.</p>
+ *
+ * <p>{@code partitionSpec} and {@code bucketSpec} are nullable when the
+ * underlying DDL omits them.</p>
+ */
+public final class ConnectorCreateTableRequest {
+
+    private final String dbName;
+    private final String tableName;
+    private final List<ConnectorColumn> columns;
+    private final ConnectorPartitionSpec partitionSpec;
+    private final ConnectorBucketSpec bucketSpec;
+    private final String comment;
+    private final Map<String, String> properties;
+    private final boolean ifNotExists;
+    private final boolean external;
+
+    private ConnectorCreateTableRequest(Builder b) {
+        this.dbName = Objects.requireNonNull(b.dbName, "dbName");
+        this.tableName = Objects.requireNonNull(b.tableName, "tableName");
+        this.columns = b.columns == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(b.columns);
+        this.partitionSpec = b.partitionSpec;
+        this.bucketSpec = b.bucketSpec;
+        this.comment = b.comment;
+        this.properties = b.properties == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(b.properties);
+        this.ifNotExists = b.ifNotExists;
+        this.external = b.external;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public List<ConnectorColumn> getColumns() {
+        return columns;
+    }
+
+    /** @return partition spec, or {@code null} for non-partitioned tables. */
+    public ConnectorPartitionSpec getPartitionSpec() {
+        return partitionSpec;
+    }
+
+    /** @return bucket spec, or {@code null} when no bucketing is declared. */
+    public ConnectorBucketSpec getBucketSpec() {
+        return bucketSpec;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public boolean isIfNotExists() {
+        return ifNotExists;
+    }
+
+    public boolean isExternal() {
+        return external;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectorCreateTableRequest{" + dbName + "." + tableName
+                + ", cols=" + columns.size()
+                + ", partition=" + partitionSpec
+                + ", bucket=" + bucketSpec
+                + ", external=" + external
+                + ", ifNotExists=" + ifNotExists + "}";
+    }
+
+    public static final class Builder {
+        private String dbName;
+        private String tableName;
+        private List<ConnectorColumn> columns;
+        private ConnectorPartitionSpec partitionSpec;
+        private ConnectorBucketSpec bucketSpec;
+        private String comment;
+        private Map<String, String> properties;
+        private boolean ifNotExists;
+        private boolean external;
+
+        public Builder dbName(String dbName) {
+            this.dbName = dbName;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder columns(List<ConnectorColumn> columns) {
+            this.columns = columns;
+            return this;
+        }
+
+        public Builder partitionSpec(ConnectorPartitionSpec partitionSpec) {
+            this.partitionSpec = partitionSpec;
+            return this;
+        }
+
+        public Builder bucketSpec(ConnectorBucketSpec bucketSpec) {
+            this.bucketSpec = bucketSpec;
+            return this;
+        }
+
+        public Builder comment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            // copy to preserve caller's map identity and keep insertion order
+            this.properties = properties == null
+                    ? null
+                    : new LinkedHashMap<>(properties);
+            return this;
+        }
+
+        public Builder ifNotExists(boolean ifNotExists) {
+            this.ifNotExists = ifNotExists;
+            return this;
+        }
+
+        public Builder external(boolean external) {
+            this.external = external;
+            return this;
+        }
+
+        public ConnectorCreateTableRequest build() {
+            return new ConnectorCreateTableRequest(this);
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionField.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionField.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.api.ddl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A single field in a {@link ConnectorPartitionSpec}.
+ *
+ * <p>The {@code transform} string follows Appendix B of the connector SPI RFC:
+ * {@code identity / year / month / day / hour / bucket / truncate / list / range}.
+ * Unlisted values are treated as {@code CUSTOM} and interpreted by the connector.</p>
+ *
+ * <p>{@code transformArgs} carries numeric parameters (e.g., {@code [16]} for
+ * {@code bucket(16, col)} or {@code [10]} for {@code truncate(10, col)}).</p>
+ */
+public final class ConnectorPartitionField {
+
+    private final String columnName;
+    private final String transform;
+    private final List<Integer> transformArgs;
+
+    public ConnectorPartitionField(String columnName, String transform,
+            List<Integer> transformArgs) {
+        this.columnName = Objects.requireNonNull(columnName, "columnName");
+        this.transform = Objects.requireNonNull(transform, "transform");
+        this.transformArgs = transformArgs == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(transformArgs);
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public String getTransform() {
+        return transform;
+    }
+
+    public List<Integer> getTransformArgs() {
+        return transformArgs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConnectorPartitionField)) {
+            return false;
+        }
+        ConnectorPartitionField that = (ConnectorPartitionField) o;
+        return columnName.equals(that.columnName)
+                && transform.equals(that.transform)
+                && transformArgs.equals(that.transformArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(columnName, transform, transformArgs);
+    }
+
+    @Override
+    public String toString() {
+        if (transformArgs.isEmpty()) {
+            return transform + "(" + columnName + ")";
+        }
+        return transform + transformArgs + "(" + columnName + ")";
+    }
+}

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionSpec.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionSpec.java
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.api.ddl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Partition specification carried by {@link ConnectorCreateTableRequest}.
+ *
+ * <p>{@link Style} distinguishes the four supported partition flavors:</p>
+ * <ul>
+ *   <li>{@code IDENTITY} — Hive style: {@code PARTITIONED BY (col1, col2)}.</li>
+ *   <li>{@code TRANSFORM} — Iceberg style: {@code PARTITIONED BY (bucket(16, c), year(d))}.</li>
+ *   <li>{@code LIST} — Doris {@code PARTITION BY LIST} with explicit value definitions.</li>
+ *   <li>{@code RANGE} — Doris {@code PARTITION BY RANGE} with [lower, upper) tuples.</li>
+ * </ul>
+ *
+ * <p>{@code initialValues} is only meaningful for {@code LIST} / {@code RANGE} styles.</p>
+ */
+public final class ConnectorPartitionSpec {
+
+    public enum Style {
+        IDENTITY,
+        TRANSFORM,
+        LIST,
+        RANGE,
+    }
+
+    private final Style style;
+    private final List<ConnectorPartitionField> fields;
+    private final List<ConnectorPartitionValueDef> initialValues;
+
+    public ConnectorPartitionSpec(Style style,
+            List<ConnectorPartitionField> fields,
+            List<ConnectorPartitionValueDef> initialValues) {
+        this.style = Objects.requireNonNull(style, "style");
+        this.fields = fields == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(fields);
+        this.initialValues = initialValues == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(initialValues);
+    }
+
+    public Style getStyle() {
+        return style;
+    }
+
+    public List<ConnectorPartitionField> getFields() {
+        return fields;
+    }
+
+    public List<ConnectorPartitionValueDef> getInitialValues() {
+        return initialValues;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConnectorPartitionSpec)) {
+            return false;
+        }
+        ConnectorPartitionSpec that = (ConnectorPartitionSpec) o;
+        return style == that.style
+                && fields.equals(that.fields)
+                && initialValues.equals(that.initialValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(style, fields, initialValues);
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectorPartitionSpec{style=" + style
+                + ", fields=" + fields
+                + ", initialValues=" + initialValues.size() + "}";
+    }
+}

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionValueDef.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionValueDef.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.api.ddl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Initial value definition for a Doris-style {@code LIST} or {@code RANGE}
+ * partition declared in a {@code CREATE TABLE} statement.
+ *
+ * <p>For {@code LIST} partitions, {@code values} contains the literal list of
+ * permitted values (each inner list is one tuple matching the partition columns).
+ * For {@code RANGE} partitions, {@code values} contains exactly two tuples
+ * representing the [lower, upper) bound.</p>
+ */
+public final class ConnectorPartitionValueDef {
+
+    private final String partitionName;
+    private final List<List<String>> values;
+
+    public ConnectorPartitionValueDef(String partitionName,
+            List<List<String>> values) {
+        this.partitionName = Objects.requireNonNull(partitionName, "partitionName");
+        this.values = values == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(values);
+    }
+
+    public String getPartitionName() {
+        return partitionName;
+    }
+
+    public List<List<String>> getValues() {
+        return values;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConnectorPartitionValueDef)) {
+            return false;
+        }
+        ConnectorPartitionValueDef that = (ConnectorPartitionValueDef) o;
+        return partitionName.equals(that.partitionName)
+                && values.equals(that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionName, values);
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectorPartitionValueDef{name='" + partitionName
+                + "', values=" + values + "}";
+    }
+}

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/handle/ConnectorTransaction.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/handle/ConnectorTransaction.java
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.api.handle;
+
+import java.io.Closeable;
+
+/**
+ * A connector-managed transaction that scopes one or more write operations.
+ *
+ * <p>Lifecycle: the engine calls {@link #commit()} on success or
+ * {@link #rollback()} on failure, then always calls {@link #close()} to
+ * release resources. {@code rollback()} and {@code close()} are safe to
+ * call multiple times.</p>
+ *
+ * <p>Extends the marker {@link ConnectorTransactionHandle} so that existing
+ * APIs that traffic in opaque handles continue to work without change.</p>
+ */
+public interface ConnectorTransaction extends ConnectorTransactionHandle, Closeable {
+
+    /** Stable transaction ID assigned by the connector. */
+    long getTransactionId();
+
+    /**
+     * Commits all pending operations bound to this transaction.
+     *
+     * @throws org.apache.doris.connector.api.DorisConnectorException
+     *         on conflict, IO failure, or external system error
+     */
+    void commit();
+
+    /**
+     * Aborts all pending operations and releases resources.
+     * Safe to call multiple times; subsequent calls are no-ops.
+     */
+    void rollback();
+
+    /** Called by the engine after commit OR rollback to release connections etc. */
+    @Override
+    void close();
+}

--- a/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/mvcc/ConnectorMvccSnapshot.java
+++ b/fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/mvcc/ConnectorMvccSnapshot.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.api.mvcc;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable description of a point-in-time snapshot taken from an MVCC-capable
+ * external table (Iceberg, Paimon, Hudi, ...).
+ *
+ * <p>Returned by {@code ConnectorMetadata.beginQuerySnapshot} and friends.
+ * Used by the engine as the MVCC pin for all subsequent reads of the same
+ * table handle within a query, and serialized into BE scan ranges so the
+ * read path sees a consistent version.</p>
+ */
+public final class ConnectorMvccSnapshot {
+
+    private final long snapshotId;
+    private final long timestampMillis;
+    private final String description;
+    private final Map<String, String> properties;
+
+    private ConnectorMvccSnapshot(Builder b) {
+        this.snapshotId = b.snapshotId;
+        this.timestampMillis = b.timestampMillis;
+        this.description = b.description;
+        this.properties = b.properties.isEmpty()
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new HashMap<>(b.properties));
+    }
+
+    /** Connector-assigned snapshot identifier (e.g. Iceberg snapshot id). */
+    public long getSnapshotId() {
+        return snapshotId;
+    }
+
+    /** Wall-clock time at which the snapshot was committed, in ms since epoch. */
+    public long getTimestampMillis() {
+        return timestampMillis;
+    }
+
+    /** Optional human-readable description; may be empty, never null. */
+    public String getDescription() {
+        return description;
+    }
+
+    /** Connector-specific metadata propagated to BE. Unmodifiable, never null. */
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private long snapshotId;
+        private long timestampMillis;
+        private String description = "";
+        private final Map<String, String> properties = new HashMap<>();
+
+        public Builder snapshotId(long snapshotId) {
+            this.snapshotId = snapshotId;
+            return this;
+        }
+
+        public Builder timestampMillis(long timestampMillis) {
+            this.timestampMillis = timestampMillis;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = Objects.requireNonNull(description, "description");
+            return this;
+        }
+
+        public Builder property(String key, String value) {
+            this.properties.put(
+                    Objects.requireNonNull(key, "key"),
+                    Objects.requireNonNull(value, "value"));
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties.putAll(Objects.requireNonNull(properties, "properties"));
+            return this;
+        }
+
+        public ConnectorMvccSnapshot build() {
+            return new ConnectorMvccSnapshot(this);
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java
+++ b/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java
@@ -92,4 +92,15 @@ public interface ConnectorContext {
     default <T> T executeAuthenticated(Callable<T> task) throws Exception {
         return task.call();
     }
+
+    /**
+     * Returns the meta invalidator the connector can call to notify the engine
+     * of external metadata changes (e.g. from HMS notification events).
+     *
+     * <p>Connectors that have no external change notifications can ignore this;
+     * the default returns {@link ConnectorMetaInvalidator#NOOP}.</p>
+     */
+    default ConnectorMetaInvalidator getMetaInvalidator() {
+        return ConnectorMetaInvalidator.NOOP;
+    }
 }

--- a/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorMetaInvalidator.java
+++ b/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorMetaInvalidator.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.spi;
+
+import java.util.List;
+
+/**
+ * Callback the connector uses to notify the engine that external metadata
+ * has changed and cached entries should be dropped (e.g. when an HMS
+ * notification event reports a CREATE / ALTER / DROP).
+ *
+ * <p>Obtained from {@link ConnectorContext#getMetaInvalidator()}.</p>
+ *
+ * <p>Connectors that have no external change notifications can ignore this
+ * interface entirely; the engine provides a {@link #NOOP} default.</p>
+ */
+public interface ConnectorMetaInvalidator {
+
+    ConnectorMetaInvalidator NOOP = new ConnectorMetaInvalidator() { };
+
+    /** Invalidates the entire catalog's metadata caches. */
+    default void invalidateAll() { }
+
+    /** Invalidates cached metadata for one database. */
+    default void invalidateDatabase(String dbName) { }
+
+    /** Invalidates cached metadata for one table. */
+    default void invalidateTable(String dbName, String tableName) { }
+
+    /**
+     * Invalidates cached partition info for one partition.
+     *
+     * @param partitionValues partition column values in declared order
+     *                        (e.g. {@code ["2024", "01"]} for a table
+     *                        partitioned by {@code (year, month)})
+     */
+    default void invalidatePartition(String dbName, String tableName,
+            List<String> partitionValues) { }
+
+    /** Invalidates cached statistics for one table (without dropping schema cache). */
+    default void invalidateStatistics(String dbName, String tableName) { }
+}

--- a/fe/fe-connector/pom.xml
+++ b/fe/fe-connector/pom.xml
@@ -51,4 +51,43 @@ under the License.
         <module>fe-connector-iceberg</module>
     </modules>
 
+    <build>
+        <plugins>
+            <!--
+              Forbidden-import gate: fe-connector modules MUST NOT import
+              fe-core internals. See plan-doc/01-spi-extensions-rfc.md §15.4
+              and tools/check-connector-imports.sh.
+
+              Runs once in this aggregator's validate phase (inherited=false
+              keeps the 11 child modules from re-running the same scan).
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>check-connector-imports</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <!--
+                              Use ${project.basedir}-relative path so we don't
+                              depend on directory-maven-plugin's `fe.dir`
+                              property (which is only set at `initialize`).
+                            -->
+                            <executable>${project.basedir}/../../tools/check-connector-imports.sh</executable>
+                            <arguments>
+                                <argument>${project.basedir}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorMvccSnapshotAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorMvccSnapshotAdapter.java
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector;
+
+import org.apache.doris.connector.api.mvcc.ConnectorMvccSnapshot;
+import org.apache.doris.datasource.mvcc.MvccSnapshot;
+
+import java.util.Objects;
+
+/**
+ * Adapter that lets a connector-provided {@link ConnectorMvccSnapshot} flow through the
+ * engine's existing {@link MvccSnapshot} contract (consumed by the nereids analyzer and
+ * the scan plan). Constructed when {@code ConnectorMetadata.beginQuerySnapshot} returns
+ * a value; passed unchanged through fe-core MVCC pinning, then unwrapped on the BE
+ * serialization boundary via {@link #getSnapshot()}.
+ */
+public final class ConnectorMvccSnapshotAdapter implements MvccSnapshot {
+
+    private final ConnectorMvccSnapshot snapshot;
+
+    public ConnectorMvccSnapshotAdapter(ConnectorMvccSnapshot snapshot) {
+        this.snapshot = Objects.requireNonNull(snapshot, "snapshot");
+    }
+
+    public ConnectorMvccSnapshot getSnapshot() {
+        return snapshot;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.EnvUtils;
 import org.apache.doris.common.security.authentication.ExecutionAuthenticator;
 import org.apache.doris.connector.api.ConnectorHttpSecurityHook;
 import org.apache.doris.connector.spi.ConnectorContext;
+import org.apache.doris.connector.spi.ConnectorMetaInvalidator;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,6 +89,11 @@ public class DefaultConnectorContext implements ConnectorContext {
     @Override
     public ConnectorHttpSecurityHook getHttpSecurityHook() {
         return httpSecurityHook;
+    }
+
+    @Override
+    public ConnectorMetaInvalidator getMetaInvalidator() {
+        return new ExternalMetaCacheInvalidator(catalogId);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/connector/ExternalMetaCacheInvalidator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/connector/ExternalMetaCacheInvalidator.java
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.connector.spi.ConnectorMetaInvalidator;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * fe-core side bridge from the connector SPI {@link ConnectorMetaInvalidator} to the
+ * engine's {@link ExternalMetaCacheMgr}. Returned by
+ * {@link DefaultConnectorContext#getMetaInvalidator()} so connectors that receive
+ * external change notifications (e.g. HMS notification events) can drop the right
+ * cache entries without depending on fe-core internals directly.
+ */
+public final class ExternalMetaCacheInvalidator implements ConnectorMetaInvalidator {
+
+    private final long catalogId;
+
+    public ExternalMetaCacheInvalidator(long catalogId) {
+        this.catalogId = catalogId;
+    }
+
+    @Override
+    public void invalidateAll() {
+        mgr().invalidateCatalog(catalogId);
+    }
+
+    @Override
+    public void invalidateDatabase(String dbName) {
+        mgr().invalidateDb(catalogId, Objects.requireNonNull(dbName, "dbName"));
+    }
+
+    @Override
+    public void invalidateTable(String dbName, String tableName) {
+        mgr().invalidateTable(catalogId,
+                Objects.requireNonNull(dbName, "dbName"),
+                Objects.requireNonNull(tableName, "tableName"));
+    }
+
+    @Override
+    public void invalidatePartition(String dbName, String tableName, List<String> partitionValues) {
+        // The SPI carries partition column VALUES (e.g. ["2024", "01"]) but the engine's
+        // partition cache is keyed by partition NAMES (e.g. "year=2024/month=01").
+        // Reconstructing the name requires partition column names which are not carried by
+        // the SPI today. Until the SPI grows that metadata, fall back to table-level
+        // invalidation — correct but over-broad.
+        mgr().invalidateTable(catalogId,
+                Objects.requireNonNull(dbName, "dbName"),
+                Objects.requireNonNull(tableName, "tableName"));
+    }
+
+    @Override
+    public void invalidateStatistics(String dbName, String tableName) {
+        // ExternalMetaCacheMgr exposes no per-table statistics-only invalidation today
+        // (the row count cache is keyed by id, not name). Calling invalidateTable here
+        // would violate the SPI contract ("without dropping schema cache"), so leave as
+        // a no-op until a stats-only entry point exists.
+    }
+
+    private static ExternalMetaCacheMgr mgr() {
+        return Env.getCurrentEnv().getExtMetaCacheMgr();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/connector/ddl/CreateTableInfoToConnectorRequestConverter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/connector/ddl/CreateTableInfoToConnectorRequestConverter.java
@@ -1,0 +1,209 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.ddl;
+
+import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.connector.api.ConnectorColumn;
+import org.apache.doris.connector.api.ConnectorType;
+import org.apache.doris.connector.api.ddl.ConnectorBucketSpec;
+import org.apache.doris.connector.api.ddl.ConnectorCreateTableRequest;
+import org.apache.doris.connector.api.ddl.ConnectorPartitionField;
+import org.apache.doris.connector.api.ddl.ConnectorPartitionSpec;
+import org.apache.doris.datasource.ConnectorColumnConverter;
+import org.apache.doris.nereids.analyzer.UnboundFunction;
+import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.commands.info.ColumnDefinition;
+import org.apache.doris.nereids.trees.plans.commands.info.CreateTableInfo;
+import org.apache.doris.nereids.trees.plans.commands.info.DistributionDescriptor;
+import org.apache.doris.nereids.trees.plans.commands.info.PartitionTableInfo;
+import org.apache.doris.nereids.types.DataType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Converts a nereids {@link CreateTableInfo} into a connector-SPI
+ * {@link ConnectorCreateTableRequest}.
+ *
+ * <p>Covers Hive-style {@code IDENTITY}, Iceberg-style {@code TRANSFORM}, and
+ * Doris {@code LIST} / {@code RANGE} partitioning, plus hash / random
+ * distribution.</p>
+ */
+public final class CreateTableInfoToConnectorRequestConverter {
+
+    private CreateTableInfoToConnectorRequestConverter() {
+    }
+
+    /**
+     * @param info   the nereids CREATE TABLE info (must be analyzed)
+     * @param dbName target database name (caller may normalize case)
+     */
+    public static ConnectorCreateTableRequest convert(CreateTableInfo info,
+            String dbName) {
+        return ConnectorCreateTableRequest.builder()
+                .dbName(dbName)
+                .tableName(info.getTableName())
+                .columns(convertColumns(info.getColumnDefinitions()))
+                .partitionSpec(convertPartition(info.getPartitionTableInfo()))
+                .bucketSpec(convertBucket(info.getDistribution()))
+                .comment(info.getComment())
+                .properties(info.getProperties())
+                .ifNotExists(info.isIfNotExists())
+                .external(info.isExternal())
+                .build();
+    }
+
+    // -------- columns --------
+
+    private static List<ConnectorColumn> convertColumns(
+            List<ColumnDefinition> defs) {
+        if (defs == null || defs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<ConnectorColumn> out = new ArrayList<>(defs.size());
+        for (ColumnDefinition d : defs) {
+            DataType nereidsType = d.getType();
+            ConnectorType type = ConnectorColumnConverter.toConnectorType(
+                    nereidsType.toCatalogDataType());
+            // Default value is not exposed via a public getter on ColumnDefinition
+            // (private Optional<DefaultValue>); pass null until the SPI gains a
+            // typed default-value carrier. See HANDOFF open issues.
+            out.add(new ConnectorColumn(
+                    d.getName(), type, d.getComment(),
+                    d.isNullable(), null, d.isKey()));
+        }
+        return out;
+    }
+
+    // -------- partition --------
+
+    private static ConnectorPartitionSpec convertPartition(
+            PartitionTableInfo info) {
+        if (info == null) {
+            return null;
+        }
+        String pType = info.getPartitionType();
+        List<Expression> exprs = info.getPartitionList();
+        boolean isList = PartitionType.LIST.name().equalsIgnoreCase(pType);
+        boolean isRange = PartitionType.RANGE.name().equalsIgnoreCase(pType);
+        boolean hasExprs = exprs != null && !exprs.isEmpty();
+        if (!isList && !isRange && !hasExprs) {
+            return null;
+        }
+
+        ConnectorPartitionSpec.Style style;
+        if (isList) {
+            style = ConnectorPartitionSpec.Style.LIST;
+        } else if (isRange) {
+            style = ConnectorPartitionSpec.Style.RANGE;
+        } else if (hasAnyTransform(exprs)) {
+            style = ConnectorPartitionSpec.Style.TRANSFORM;
+        } else {
+            style = ConnectorPartitionSpec.Style.IDENTITY;
+        }
+
+        List<ConnectorPartitionField> fields = hasExprs
+                ? convertFields(exprs)
+                : Collections.emptyList();
+        // LIST/RANGE PartitionDefinition values are not lowered here: each
+        // PartitionDefinition is a sealed family (InPartition/LessThanPartition/
+        // FixedRangePartition/StepPartition) carrying nereids Expressions that
+        // require full analysis to flatten into List<List<String>>. Connectors
+        // that need the initial values today read the Doris PartitionDesc
+        // directly; this converter passes an empty list and leaves richer
+        // lowering for a follow-up.
+        return new ConnectorPartitionSpec(style, fields, Collections.emptyList());
+    }
+
+    private static boolean hasAnyTransform(List<Expression> exprs) {
+        for (Expression e : exprs) {
+            if (e instanceof UnboundFunction) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<ConnectorPartitionField> convertFields(
+            List<Expression> exprs) {
+        List<ConnectorPartitionField> out = new ArrayList<>(exprs.size());
+        for (Expression e : exprs) {
+            if (e instanceof UnboundSlot) {
+                out.add(new ConnectorPartitionField(
+                        ((UnboundSlot) e).getName(), "identity",
+                        Collections.emptyList()));
+            } else if (e instanceof UnboundFunction) {
+                out.add(convertTransformField((UnboundFunction) e));
+            }
+            // Unknown expression shapes are dropped; the connector can still
+            // honor the spec via its own analysis if richer info is required.
+        }
+        return out;
+    }
+
+    private static ConnectorPartitionField convertTransformField(
+            UnboundFunction fn) {
+        String transform = fn.getName().toLowerCase();
+        String columnName = null;
+        List<Integer> args = new ArrayList<>();
+        for (Expression child : fn.children()) {
+            if (child instanceof UnboundSlot && columnName == null) {
+                columnName = ((UnboundSlot) child).getName();
+            } else if (child instanceof IntegerLikeLiteral) {
+                args.add(((IntegerLikeLiteral) child).getIntValue());
+            } else if (child instanceof Literal) {
+                Object v = ((Literal) child).getValue();
+                if (v instanceof Number) {
+                    args.add(((Number) v).intValue());
+                }
+            }
+        }
+        if (columnName == null) {
+            columnName = fn.toString();
+        }
+        return new ConnectorPartitionField(columnName, transform, args);
+    }
+
+    // -------- bucket --------
+
+    private static ConnectorBucketSpec convertBucket(DistributionDescriptor d) {
+        if (d == null) {
+            return null;
+        }
+        List<String> cols = d.getCols() == null
+                ? Collections.emptyList()
+                : d.getCols();
+        // bucketNum is private; read it off the translated catalog desc so we
+        // do not depend on private internals.
+        int numBuckets = readBucketNum(d);
+        String algorithm = d.isHash() ? "doris_default" : "doris_random";
+        return new ConnectorBucketSpec(cols, numBuckets, algorithm);
+    }
+
+    private static int readBucketNum(DistributionDescriptor d) {
+        try {
+            return d.translateToCatalogStyle().getBuckets();
+        } catch (Exception ignored) {
+            return 0;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/PluginDrivenExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/PluginDrivenExternalCatalog.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.datasource;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.connector.ConnectorFactory;
 import org.apache.doris.connector.ConnectorSessionBuilder;
 import org.apache.doris.connector.DefaultConnectorContext;
@@ -25,7 +27,11 @@ import org.apache.doris.connector.DefaultConnectorValidationContext;
 import org.apache.doris.connector.api.Connector;
 import org.apache.doris.connector.api.ConnectorSession;
 import org.apache.doris.connector.api.ConnectorTestResult;
+import org.apache.doris.connector.api.DorisConnectorException;
+import org.apache.doris.connector.api.ddl.ConnectorCreateTableRequest;
+import org.apache.doris.connector.ddl.CreateTableInfoToConnectorRequestConverter;
 import org.apache.doris.datasource.property.metastore.MetastoreProperties;
+import org.apache.doris.nereids.trees.plans.commands.info.CreateTableInfo;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.transaction.PluginDrivenTransactionManager;
 
@@ -230,6 +236,44 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
     public Connector getConnector() {
         makeSureInitialized();
         return connector;
+    }
+
+    /**
+     * Routes {@code CREATE TABLE} through the SPI's
+     * {@code ConnectorTableOps.createTable(session, request)} instead of the
+     * legacy {@code metadataOps} path used by other {@link ExternalCatalog}
+     * subclasses.
+     *
+     * <p>Connectors that have not overridden the new SPI default fall through
+     * to the SPI's "CREATE TABLE not supported" exception, which is wrapped
+     * here as a {@link DdlException} to match the existing caller contract.</p>
+     *
+     * <p>The SPI signature is {@code void}: it does not distinguish
+     * "newly created" from "already existed (IF NOT EXISTS)". This override
+     * conservatively assumes creation happened and writes the edit log, matching
+     * the more common branch of the legacy path. Refining this when a connector
+     * actually needs the distinction is left to P5/P6/P7 connector migrations.</p>
+     */
+    @Override
+    public boolean createTable(CreateTableInfo createTableInfo) throws UserException {
+        makeSureInitialized();
+        ConnectorSession session = buildConnectorSession();
+        ConnectorCreateTableRequest request = CreateTableInfoToConnectorRequestConverter
+                .convert(createTableInfo, createTableInfo.getDbName());
+        try {
+            connector.getMetadata(session).createTable(session, request);
+        } catch (DorisConnectorException e) {
+            throw new DdlException(e.getMessage(), e);
+        }
+        org.apache.doris.persist.CreateTableInfo persistInfo =
+                new org.apache.doris.persist.CreateTableInfo(
+                        getName(),
+                        createTableInfo.getDbName(),
+                        createTableInfo.getTableName());
+        Env.getCurrentEnv().getEditLog().logCreateTable(persistInfo);
+        LOG.info("finished to create table {}.{}.{}", getName(),
+                createTableInfo.getDbName(), createTableInfo.getTableName());
+        return false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PluginDrivenTransactionManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PluginDrivenTransactionManager.java
@@ -19,21 +19,33 @@ package org.apache.doris.transaction;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.UserException;
+import org.apache.doris.connector.api.handle.ConnectorTransaction;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Transaction manager for plugin-driven external catalogs.
  *
- * <p>This is a lightweight implementation that generates transaction IDs via
- * {@link Env#getNextId()} and tracks them in a local map. The actual commit
- * and rollback logic is handled by the connector's {@code ConnectorWriteOps}
- * through the insert executor — this manager simply provides the transaction
- * lifecycle bookkeeping required by {@link org.apache.doris.nereids.trees.plans
- * .commands.insert.BaseExternalTableInsertExecutor}.</p>
+ * <p>Two entry points:</p>
+ * <ul>
+ *   <li>{@link #begin()} — legacy auto-commit path used by
+ *       {@code BaseExternalTableInsertExecutor}. The manager allocates a txn id via
+ *       {@link Env#getNextId()} and stores a no-op transaction; the actual write side
+ *       effects are produced by {@code ConnectorWriteOps.finishInsert/abortInsert}.
+ *       This path is used by connectors that do not implement SPI transactions
+ *       (e.g. JDBC, ES).</li>
+ *   <li>{@link #begin(ConnectorTransaction)} — SPI path for connectors that return a
+ *       real {@link ConnectorTransaction} from {@code ConnectorWriteOps.beginTransaction}.
+ *       The manager uses {@link ConnectorTransaction#getTransactionId()} as the txn id
+ *       and delegates commit/rollback/close to the connector.</li>
+ * </ul>
+ *
+ * <p>Both paths share the same {@link #commit(long)} / {@link #rollback(long)} surface
+ * required by {@link TransactionManager}.</p>
  */
 public class PluginDrivenTransactionManager implements TransactionManager {
 
@@ -45,9 +57,22 @@ public class PluginDrivenTransactionManager implements TransactionManager {
     @Override
     public long begin() {
         long txnId = Env.getCurrentEnv().getNextId();
-        PluginDrivenTransaction txn = new PluginDrivenTransaction(txnId);
-        transactions.put(txnId, txn);
+        transactions.put(txnId, new PluginDrivenTransaction(txnId, null));
         LOG.debug("Plugin-driven transaction begun: {}", txnId);
+        return txnId;
+    }
+
+    /**
+     * Registers a connector-provided {@link ConnectorTransaction}. Commit / rollback
+     * lifecycle is delegated to it (including {@code close()}).
+     *
+     * @return the txn id, taken from {@code connectorTx.getTransactionId()}
+     */
+    public long begin(ConnectorTransaction connectorTx) {
+        Objects.requireNonNull(connectorTx, "connectorTx");
+        long txnId = connectorTx.getTransactionId();
+        transactions.put(txnId, new PluginDrivenTransaction(txnId, connectorTx));
+        LOG.debug("Plugin-driven transaction begun with SPI ConnectorTransaction: {}", txnId);
         return txnId;
     }
 
@@ -79,24 +104,50 @@ public class PluginDrivenTransactionManager implements TransactionManager {
     }
 
     /**
-     * Simple transaction that tracks state. Actual connector-level commit/rollback
-     * is performed by the insert executor via ConnectorWriteOps.
+     * Internal transaction record. When {@code connectorTx} is non-null the SPI is
+     * the source of truth and commit/rollback delegate to it; close() always runs
+     * after delegation. When null, this is the legacy no-op marker (the executor
+     * drives write side effects via {@code ConnectorWriteOps} directly).
      */
-    private static class PluginDrivenTransaction implements Transaction {
+    private static final class PluginDrivenTransaction implements Transaction {
         private final long id;
+        private final ConnectorTransaction connectorTx;
 
-        PluginDrivenTransaction(long id) {
+        PluginDrivenTransaction(long id, ConnectorTransaction connectorTx) {
             this.id = id;
+            this.connectorTx = connectorTx;
         }
 
         @Override
         public void commit() {
-            // No-op: actual commit is done via ConnectorWriteOps.finishInsert()
+            if (connectorTx == null) {
+                return;
+            }
+            try {
+                connectorTx.commit();
+            } finally {
+                closeQuietly();
+            }
         }
 
         @Override
         public void rollback() {
-            // No-op: actual rollback is done via ConnectorWriteOps.abortInsert()
+            if (connectorTx == null) {
+                return;
+            }
+            try {
+                connectorTx.rollback();
+            } finally {
+                closeQuietly();
+            }
+        }
+
+        private void closeQuietly() {
+            try {
+                connectorTx.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close ConnectorTransaction {}: {}", id, e.getMessage());
+            }
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/connector/ExternalMetaCacheInvalidatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/connector/ExternalMetaCacheInvalidatorTest.java
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+/**
+ * Verifies {@link ExternalMetaCacheInvalidator} routes each SPI invalidate*
+ * call to the right method on {@link ExternalMetaCacheMgr}, scoped to the
+ * catalog id captured at construction time.
+ *
+ * <p>The static {@code Env.getCurrentEnv()} is stubbed via Mockito so the
+ * test runs without bringing up the full FE.
+ */
+public class ExternalMetaCacheInvalidatorTest {
+
+    private static final long CATALOG_ID = 42L;
+
+    @Test
+    public void invalidateAllRoutesToInvalidateCatalog() {
+        runWithMockedMgr(mgr -> {
+            new ExternalMetaCacheInvalidator(CATALOG_ID).invalidateAll();
+            Mockito.verify(mgr).invalidateCatalog(CATALOG_ID);
+            Mockito.verifyNoMoreInteractions(mgr);
+        });
+    }
+
+    @Test
+    public void invalidateDatabaseRoutesToInvalidateDb() {
+        runWithMockedMgr(mgr -> {
+            new ExternalMetaCacheInvalidator(CATALOG_ID).invalidateDatabase("sales");
+            Mockito.verify(mgr).invalidateDb(CATALOG_ID, "sales");
+            Mockito.verifyNoMoreInteractions(mgr);
+        });
+    }
+
+    @Test
+    public void invalidateTableRoutesToInvalidateTable() {
+        runWithMockedMgr(mgr -> {
+            new ExternalMetaCacheInvalidator(CATALOG_ID).invalidateTable("sales", "orders");
+            Mockito.verify(mgr).invalidateTable(CATALOG_ID, "sales", "orders");
+            Mockito.verifyNoMoreInteractions(mgr);
+        });
+    }
+
+    /**
+     * Partition-scope invalidation currently falls back to table-level invalidation
+     * because the SPI carries partition column values, not names — see the inline
+     * comment in {@link ExternalMetaCacheInvalidator#invalidatePartition}. This
+     * test pins the documented behavior so a future SPI extension that allows the
+     * scope to narrow is forced to update the bridge AND this test together.
+     */
+    @Test
+    public void invalidatePartitionFallsBackToInvalidateTable() {
+        runWithMockedMgr(mgr -> {
+            new ExternalMetaCacheInvalidator(CATALOG_ID)
+                    .invalidatePartition("sales", "orders", Arrays.asList("2024", "01"));
+            Mockito.verify(mgr).invalidateTable(CATALOG_ID, "sales", "orders");
+            Mockito.verifyNoMoreInteractions(mgr);
+        });
+    }
+
+    /**
+     * Stats-only invalidation is intentionally a no-op today — see the inline
+     * comment in {@link ExternalMetaCacheInvalidator#invalidateStatistics}.
+     * Verifying zero interactions makes any silent change visible.
+     */
+    @Test
+    public void invalidateStatisticsIsNoopForNow() {
+        runWithMockedMgr(mgr -> {
+            new ExternalMetaCacheInvalidator(CATALOG_ID).invalidateStatistics("sales", "orders");
+            Mockito.verifyNoInteractions(mgr);
+        });
+    }
+
+    private static void runWithMockedMgr(java.util.function.Consumer<ExternalMetaCacheMgr> body) {
+        ExternalMetaCacheMgr mgr = Mockito.mock(ExternalMetaCacheMgr.class);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getExtMetaCacheMgr()).thenReturn(mgr);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            body.accept(mgr);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/connector/ddl/CreateTableInfoToConnectorRequestConverterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/connector/ddl/CreateTableInfoToConnectorRequestConverterTest.java
@@ -1,0 +1,264 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.ddl;
+
+import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.connector.api.ConnectorColumn;
+import org.apache.doris.connector.api.ddl.ConnectorBucketSpec;
+import org.apache.doris.connector.api.ddl.ConnectorCreateTableRequest;
+import org.apache.doris.connector.api.ddl.ConnectorPartitionField;
+import org.apache.doris.connector.api.ddl.ConnectorPartitionSpec;
+import org.apache.doris.nereids.analyzer.UnboundFunction;
+import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.plans.commands.info.ColumnDefinition;
+import org.apache.doris.nereids.trees.plans.commands.info.CreateTableInfo;
+import org.apache.doris.nereids.trees.plans.commands.info.DistributionDescriptor;
+import org.apache.doris.nereids.trees.plans.commands.info.PartitionTableInfo;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.StringType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Covers each branch of {@link CreateTableInfoToConnectorRequestConverter}:
+ * the four partition styles (IDENTITY, TRANSFORM, LIST, RANGE) and both
+ * bucket flavors (hash, random), plus the no-partition / no-distribution
+ * fall-throughs.
+ *
+ * <p>{@link CreateTableInfo} is mocked because its full constructor pulls in
+ * heavy nereids analyzer state; the converter only reads a handful of
+ * getters from it, all of which are easy to stub.
+ */
+public class CreateTableInfoToConnectorRequestConverterTest {
+
+    @Test
+    public void columnsAndScalarFieldsArePassedThrough() {
+        ColumnDefinition idCol = new ColumnDefinition(
+                "id", IntegerType.INSTANCE, false, "primary key");
+        ColumnDefinition nameCol = new ColumnDefinition(
+                "name", StringType.INSTANCE, true, "display name");
+        CreateTableInfo info = stubInfo(
+                "orders",
+                Arrays.asList(idCol, nameCol),
+                null,
+                null,
+                "an orders table",
+                ImmutableMap.of("k", "v"),
+                true,
+                true);
+
+        ConnectorCreateTableRequest req = CreateTableInfoToConnectorRequestConverter
+                .convert(info, "sales");
+
+        Assertions.assertEquals("sales", req.getDbName());
+        Assertions.assertEquals("orders", req.getTableName());
+        Assertions.assertEquals("an orders table", req.getComment());
+        Assertions.assertEquals(ImmutableMap.of("k", "v"), req.getProperties());
+        Assertions.assertTrue(req.isIfNotExists());
+        Assertions.assertTrue(req.isExternal());
+
+        Assertions.assertEquals(2, req.getColumns().size());
+        ConnectorColumn col0 = req.getColumns().get(0);
+        Assertions.assertEquals("id", col0.getName());
+        Assertions.assertFalse(col0.isNullable());
+        Assertions.assertEquals("primary key", col0.getComment());
+        ConnectorColumn col1 = req.getColumns().get(1);
+        Assertions.assertEquals("name", col1.getName());
+        Assertions.assertTrue(col1.isNullable());
+
+        // No partition / distribution in this fixture.
+        Assertions.assertNull(req.getPartitionSpec());
+        Assertions.assertNull(req.getBucketSpec());
+    }
+
+    @Test
+    public void identityPartitionStyle() {
+        // PARTITIONED BY (dt) on a Hive-style external table.
+        PartitionTableInfo partition = new PartitionTableInfo(
+                false,
+                PartitionType.UNPARTITIONED.name(),
+                null,
+                ImmutableList.of(new UnboundSlot("dt")));
+        ConnectorPartitionSpec spec = convertWithPartition(partition).getPartitionSpec();
+
+        Assertions.assertNotNull(spec);
+        Assertions.assertEquals(ConnectorPartitionSpec.Style.IDENTITY, spec.getStyle());
+        Assertions.assertEquals(1, spec.getFields().size());
+        ConnectorPartitionField field = spec.getFields().get(0);
+        Assertions.assertEquals("dt", field.getColumnName());
+        Assertions.assertEquals("identity", field.getTransform());
+        Assertions.assertTrue(field.getTransformArgs().isEmpty());
+        Assertions.assertTrue(spec.getInitialValues().isEmpty());
+    }
+
+    @Test
+    public void transformPartitionStyleWithIcebergStyleFunctions() {
+        // PARTITIONED BY (bucket(16, id), year(d)) — Iceberg style.
+        Expression bucket = new UnboundFunction("bucket",
+                Arrays.asList(new UnboundSlot("id"), new IntegerLiteral(16)));
+        Expression year = new UnboundFunction("YEAR",
+                Collections.singletonList(new UnboundSlot("d")));
+        PartitionTableInfo partition = new PartitionTableInfo(
+                false,
+                PartitionType.UNPARTITIONED.name(),
+                null,
+                ImmutableList.of(bucket, year));
+
+        ConnectorPartitionSpec spec = convertWithPartition(partition).getPartitionSpec();
+        Assertions.assertNotNull(spec);
+        Assertions.assertEquals(ConnectorPartitionSpec.Style.TRANSFORM, spec.getStyle());
+
+        Assertions.assertEquals(2, spec.getFields().size());
+        ConnectorPartitionField bucketField = spec.getFields().get(0);
+        Assertions.assertEquals("id", bucketField.getColumnName());
+        Assertions.assertEquals("bucket", bucketField.getTransform());
+        Assertions.assertEquals(Collections.singletonList(16), bucketField.getTransformArgs());
+
+        ConnectorPartitionField yearField = spec.getFields().get(1);
+        Assertions.assertEquals("d", yearField.getColumnName());
+        // transform name is lower-cased even though the source was uppercase.
+        Assertions.assertEquals("year", yearField.getTransform());
+        Assertions.assertTrue(yearField.getTransformArgs().isEmpty());
+    }
+
+    @Test
+    public void listPartitionStyle() {
+        // PARTITION BY LIST (region) — Doris native list partitioning.
+        PartitionTableInfo partition = new PartitionTableInfo(
+                false,
+                PartitionType.LIST.name(),
+                null,
+                ImmutableList.of(new UnboundSlot("region")));
+
+        ConnectorPartitionSpec spec = convertWithPartition(partition).getPartitionSpec();
+        Assertions.assertNotNull(spec);
+        Assertions.assertEquals(ConnectorPartitionSpec.Style.LIST, spec.getStyle());
+        Assertions.assertEquals(1, spec.getFields().size());
+        Assertions.assertEquals("region", spec.getFields().get(0).getColumnName());
+        // initialValues lowering is deferred — see converter inline comment.
+        Assertions.assertTrue(spec.getInitialValues().isEmpty());
+    }
+
+    @Test
+    public void rangePartitionStyle() {
+        // PARTITION BY RANGE (dt) — Doris native range partitioning.
+        PartitionTableInfo partition = new PartitionTableInfo(
+                false,
+                PartitionType.RANGE.name(),
+                null,
+                ImmutableList.of(new UnboundSlot("dt")));
+
+        ConnectorPartitionSpec spec = convertWithPartition(partition).getPartitionSpec();
+        Assertions.assertNotNull(spec);
+        Assertions.assertEquals(ConnectorPartitionSpec.Style.RANGE, spec.getStyle());
+        Assertions.assertEquals(1, spec.getFields().size());
+        Assertions.assertEquals("dt", spec.getFields().get(0).getColumnName());
+        Assertions.assertTrue(spec.getInitialValues().isEmpty());
+    }
+
+    @Test
+    public void hashDistributionMapsToDorisDefaultAlgorithm() {
+        DistributionDescriptor dd = new DistributionDescriptor(
+                true, false, 4, Arrays.asList("id"));
+        ConnectorBucketSpec bucket = convertWithDistribution(dd).getBucketSpec();
+
+        Assertions.assertNotNull(bucket);
+        Assertions.assertEquals(Arrays.asList("id"), bucket.getColumns());
+        Assertions.assertEquals(4, bucket.getNumBuckets());
+        Assertions.assertEquals("doris_default", bucket.getAlgorithm());
+    }
+
+    @Test
+    public void randomDistributionMapsToDorisRandomAlgorithm() {
+        DistributionDescriptor dd = new DistributionDescriptor(
+                false, false, 8, Collections.emptyList());
+        ConnectorBucketSpec bucket = convertWithDistribution(dd).getBucketSpec();
+
+        Assertions.assertNotNull(bucket);
+        Assertions.assertEquals(Collections.emptyList(), bucket.getColumns());
+        Assertions.assertEquals(8, bucket.getNumBuckets());
+        Assertions.assertEquals("doris_random", bucket.getAlgorithm());
+    }
+
+    // ──────────────────── helpers ────────────────────
+
+    private static ConnectorCreateTableRequest convertWithPartition(
+            PartitionTableInfo partition) {
+        return CreateTableInfoToConnectorRequestConverter.convert(
+                stubInfo("t",
+                        Collections.singletonList(new ColumnDefinition(
+                                "id", IntegerType.INSTANCE, true)),
+                        partition,
+                        null,
+                        "",
+                        Collections.emptyMap(),
+                        false,
+                        false),
+                "db");
+    }
+
+    private static ConnectorCreateTableRequest convertWithDistribution(
+            DistributionDescriptor distribution) {
+        return CreateTableInfoToConnectorRequestConverter.convert(
+                stubInfo("t",
+                        Collections.singletonList(new ColumnDefinition(
+                                "id", IntegerType.INSTANCE, true)),
+                        null,
+                        distribution,
+                        "",
+                        Collections.emptyMap(),
+                        false,
+                        false),
+                "db");
+    }
+
+    /**
+     * Builds a mock {@link CreateTableInfo} answering only the getters that
+     * the converter actually reads. Saves the test from threading 18 args
+     * through the real ctor (which also calls {@code PropertyAnalyzer}).
+     */
+    private static CreateTableInfo stubInfo(String tableName,
+            List<ColumnDefinition> columns,
+            PartitionTableInfo partition,
+            DistributionDescriptor distribution,
+            String comment,
+            java.util.Map<String, String> properties,
+            boolean ifNotExists,
+            boolean external) {
+        CreateTableInfo info = Mockito.mock(CreateTableInfo.class);
+        Mockito.when(info.getTableName()).thenReturn(tableName);
+        Mockito.when(info.getColumnDefinitions()).thenReturn(columns);
+        Mockito.when(info.getPartitionTableInfo()).thenReturn(partition);
+        Mockito.when(info.getDistribution()).thenReturn(distribution);
+        Mockito.when(info.getComment()).thenReturn(comment);
+        Mockito.when(info.getProperties()).thenReturn(properties);
+        Mockito.when(info.isIfNotExists()).thenReturn(ifNotExists);
+        Mockito.when(info.isExternal()).thenReturn(external);
+        return info;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/connector/fake/FakeConnectorPlugin.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/connector/fake/FakeConnectorPlugin.java
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.fake;
+
+import org.apache.doris.connector.api.Connector;
+import org.apache.doris.connector.api.ConnectorMetadata;
+import org.apache.doris.connector.api.ConnectorSession;
+import org.apache.doris.connector.spi.ConnectorContext;
+import org.apache.doris.connector.spi.ConnectorProvider;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * "Empty" connector plugin used as a baseline by P0 batch-2 tests.
+ *
+ * <p>Implements only the bare minimum of the SPI surface so that every
+ * other method on {@link Connector}, {@link ConnectorMetadata},
+ * {@link ConnectorSession}, and {@link ConnectorContext} exercises its
+ * default implementation. Tests that depend on a particular default
+ * behavior (e.g. {@code listPartitionNames()} returning an empty list,
+ * {@code beginTransaction()} throwing) can construct a fake catalog from
+ * this plugin without having to stub each interface by hand.
+ *
+ * <p>NOT registered via {@code META-INF/services} — tests instantiate it
+ * directly to keep production discovery deterministic.
+ */
+public final class FakeConnectorPlugin implements ConnectorProvider {
+
+    public static final String TYPE = "fake";
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public Connector create(Map<String, String> properties, ConnectorContext context) {
+        return new FakeConnector();
+    }
+
+    /** Connector exposing a metadata that overrides nothing. */
+    public static final class FakeConnector implements Connector {
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorSession session) {
+            return new FakeMetadata();
+        }
+    }
+
+    /** {@link ConnectorMetadata} with zero overrides — every method uses the default. */
+    public static final class FakeMetadata implements ConnectorMetadata {
+    }
+
+    /** {@link ConnectorSession} that only fills the always-required fields. */
+    public static final class FakeSession implements ConnectorSession {
+
+        private final String catalogName;
+        private final long catalogId;
+
+        public FakeSession(String catalogName, long catalogId) {
+            this.catalogName = catalogName;
+            this.catalogId = catalogId;
+        }
+
+        @Override
+        public String getQueryId() {
+            return "fake-query";
+        }
+
+        @Override
+        public String getUser() {
+            return "fake-user";
+        }
+
+        @Override
+        public String getTimeZone() {
+            return "UTC";
+        }
+
+        @Override
+        public String getLocale() {
+            return "en_US";
+        }
+
+        @Override
+        public long getCatalogId() {
+            return catalogId;
+        }
+
+        @Override
+        public String getCatalogName() {
+            return catalogName;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getProperty(String name, Class<T> type) {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getCatalogProperties() {
+            return Collections.emptyMap();
+        }
+    }
+
+    /** {@link ConnectorContext} that only fills catalog name + id. */
+    public static final class FakeContext implements ConnectorContext {
+
+        private final String catalogName;
+        private final long catalogId;
+
+        public FakeContext(String catalogName, long catalogId) {
+            this.catalogName = catalogName;
+            this.catalogId = catalogId;
+        }
+
+        @Override
+        public String getCatalogName() {
+            return catalogName;
+        }
+
+        @Override
+        public long getCatalogId() {
+            return catalogId;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/connector/fake/FakeConnectorPluginTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/connector/fake/FakeConnectorPluginTest.java
@@ -1,0 +1,187 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.fake;
+
+import org.apache.doris.connector.api.Connector;
+import org.apache.doris.connector.api.ConnectorMetadata;
+import org.apache.doris.connector.api.ConnectorSession;
+import org.apache.doris.connector.api.DorisConnectorException;
+import org.apache.doris.connector.api.ddl.ConnectorCreateTableRequest;
+import org.apache.doris.connector.api.handle.ConnectorTableHandle;
+import org.apache.doris.connector.spi.ConnectorContext;
+import org.apache.doris.connector.spi.ConnectorMetaInvalidator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Exercises the SPI default fall-throughs through {@link FakeConnectorPlugin}.
+ *
+ * <p>The fake overrides nothing beyond the minimum required to compile — every
+ * assertion below targets a default method body added during P0 batches 0+1.
+ * If a future change accidentally drops or alters a default, this test fails
+ * before the change reaches any real connector.
+ */
+public class FakeConnectorPluginTest {
+
+    private FakeConnectorPlugin plugin;
+    private Connector connector;
+    private ConnectorSession session;
+    private ConnectorMetadata metadata;
+
+    @BeforeEach
+    void setUp() {
+        plugin = new FakeConnectorPlugin();
+        ConnectorContext context = new FakeConnectorPlugin.FakeContext("fake_cat", 1L);
+        connector = plugin.create(Collections.emptyMap(), context);
+        session = new FakeConnectorPlugin.FakeSession("fake_cat", 1L);
+        metadata = connector.getMetadata(session);
+    }
+
+    // ──────────────────── ConnectorContext defaults ────────────────────
+
+    @Test
+    void contextMetaInvalidatorDefaultsToNoop() {
+        ConnectorContext context = new FakeConnectorPlugin.FakeContext("fake_cat", 1L);
+        // T04: default getMetaInvalidator() returns NOOP — exercising it must not throw.
+        Assertions.assertSame(ConnectorMetaInvalidator.NOOP,
+                context.getMetaInvalidator(),
+                "default ConnectorContext.getMetaInvalidator() should return NOOP");
+        context.getMetaInvalidator().invalidateAll();
+        context.getMetaInvalidator().invalidateDatabase("db");
+        context.getMetaInvalidator().invalidateTable("db", "t");
+        context.getMetaInvalidator().invalidatePartition(
+                "db", "t", Collections.singletonList("2024"));
+        context.getMetaInvalidator().invalidateStatistics("db", "t");
+    }
+
+    // ──────────────────── ConnectorSession defaults ────────────────────
+
+    @Test
+    void sessionCurrentTransactionDefaultsToEmpty() {
+        // T07: default getCurrentTransaction() returns Optional.empty().
+        Assertions.assertEquals(Optional.empty(), session.getCurrentTransaction());
+    }
+
+    @Test
+    void sessionSessionPropertiesDefaultsToEmpty() {
+        Assertions.assertTrue(session.getSessionProperties().isEmpty());
+    }
+
+    // ──────────────────── ConnectorMetadata defaults (E5 MVCC) ────────────────────
+
+    @Test
+    void mvccSnapshotMethodsDefaultToEmpty() {
+        ConnectorTableHandle handle = new ConnectorTableHandle() { };
+        // T08: all three mvcc defaults return Optional.empty() — connector opts out of MVCC.
+        Assertions.assertEquals(Optional.empty(),
+                metadata.beginQuerySnapshot(session, handle));
+        Assertions.assertEquals(Optional.empty(),
+                metadata.getSnapshotAt(session, handle, 0L));
+        Assertions.assertEquals(Optional.empty(),
+                metadata.getSnapshotById(session, handle, 0L));
+    }
+
+    // ──────────────────── ConnectorSchemaOps defaults ────────────────────
+
+    @Test
+    void schemaOpsDefaults() {
+        Assertions.assertTrue(metadata.listDatabaseNames(session).isEmpty());
+        Assertions.assertFalse(metadata.databaseExists(session, "anydb"));
+    }
+
+    // ──────────────────── ConnectorTableOps defaults ────────────────────
+
+    @Test
+    void tableOpsListDefaults() {
+        // SHOW TABLES against an unimplemented connector returns empty rather than throwing.
+        Assertions.assertTrue(metadata.listTableNames(session, "any_db").isEmpty());
+
+        Assertions.assertEquals(Optional.empty(),
+                metadata.getTableHandle(session, "db", "t"));
+        Assertions.assertTrue(metadata.getPrimaryKeys(session, "db", "t").isEmpty());
+        Assertions.assertEquals("", metadata.getTableComment(session, "db", "t"));
+    }
+
+    @Test
+    void partitionListingDefaultsToEmpty() {
+        ConnectorTableHandle handle = new ConnectorTableHandle() { };
+        // T17-T19: all three listing defaults return empty.
+        Assertions.assertTrue(
+                metadata.listPartitionNames(session, handle).isEmpty());
+        Assertions.assertTrue(
+                metadata.listPartitions(session, handle, Optional.empty()).isEmpty());
+        Assertions.assertTrue(
+                metadata.listPartitionValues(session, handle,
+                        Collections.singletonList("dt")).isEmpty());
+    }
+
+    @Test
+    void createTableRequestDefaultDegradesToLegacy() {
+        ConnectorCreateTableRequest request = ConnectorCreateTableRequest.builder()
+                .dbName("db")
+                .tableName("t")
+                .columns(Collections.emptyList())
+                .properties(Collections.emptyMap())
+                .build();
+        // T14: default createTable(request) falls through to legacy createTable(schema,
+        // props), whose own default throws "CREATE TABLE not supported". This proves
+        // the fall-through chain is wired correctly, even if the connector ultimately
+        // rejects the request.
+        DorisConnectorException ex = Assertions.assertThrows(
+                DorisConnectorException.class,
+                () -> metadata.createTable(session, request));
+        Assertions.assertTrue(ex.getMessage().contains("CREATE TABLE not supported"),
+                "should propagate legacy createTable's error, got: " + ex.getMessage());
+    }
+
+    // ──────────────────── ConnectorWriteOps defaults ────────────────────
+
+    @Test
+    void writeOpsCapabilitiesDefaultToFalse() {
+        Assertions.assertFalse(metadata.supportsInsert());
+        Assertions.assertFalse(metadata.supportsDelete());
+        Assertions.assertFalse(metadata.supportsMerge());
+    }
+
+    @Test
+    void beginTransactionDefaultThrows() {
+        // T06: default beginTransaction throws — engine treats statement as auto-commit.
+        DorisConnectorException ex = Assertions.assertThrows(
+                DorisConnectorException.class,
+                () -> metadata.beginTransaction(session));
+        Assertions.assertTrue(ex.getMessage().contains("Transactions not supported"),
+                "expected transaction-not-supported message, got: " + ex.getMessage());
+    }
+
+    // ──────────────────── Connector-level defaults ────────────────────
+
+    @Test
+    void connectorTopLevelDefaults() {
+        Assertions.assertNull(connector.getScanPlanProvider());
+        Assertions.assertTrue(connector.getCapabilities().isEmpty());
+        Assertions.assertTrue(connector.getTableProperties().isEmpty());
+        Assertions.assertTrue(connector.getSessionProperties().isEmpty());
+        Assertions.assertFalse(connector.defaultTestConnection());
+        Assertions.assertTrue(connector.testConnection(session).isSuccess());
+    }
+}

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -8,138 +8,139 @@
 
 ## 📅 最后一次 handoff
 
-- **日期 / 时间**：2026-05-24（深夜）
+- **日期 / 时间**：2026-05-24（夜 ②，含 commit）
 - **本 session 主导者**：Claude Opus 4.7（1M context）
-- **本 session 主题**：P0 批 0 fe-core 桥接（T09-T12）—— 把新 SPI 接通到现有 fe-core 实现
-- **预估 context 使用**：~40%（健康范围）
+- **本 session 主题**：P0 批 1 DDL + Partition SPI（T13-T20）—— `ConnectorCreateTableRequest` + 4 spec POJO + 4 个 default 方法 + 1 fe-core converter + PluginDrivenExternalCatalog 路由；**已 commit**（用户人工 review 通过；hash 见 `git log --oneline -3`，subject `[feat](connector) add P0 batch 1 SPI: CreateTableRequest + listPartitions (T13-T20)`）
+- **预估 context 使用**：~55%（健康）
 
 ---
 
 ## ✅ 本 session 完成项
 
-### 1. P0 批 0：fe-core 桥接（T09-T12）
+### 1. P0 批 1：DDL + Partition SPI（T13-T20）
 
 | ID | 任务 | 文件 | 备注 |
 |---|---|---|---|
-| T09 ✅ | `DefaultConnectorContext.getMetaInvalidator()` override | edit `fe-core/.../connector/DefaultConnectorContext.java` | 返回 `new ExternalMetaCacheInvalidator(catalogId)` |
-| T10 ✅ | `ExternalMetaCacheInvalidator`（fe-core 新类）| **新** `fe-core/.../connector/ExternalMetaCacheInvalidator.java` | 3 个方法直接代理 `ExternalMetaCacheMgr.invalidateCatalog/Db/Table`；`invalidatePartition` 暂回退到 `invalidateTable`；`invalidateStatistics` 暂 no-op |
-| T11 ✅ | `PluginDrivenTransactionManager` 通用化 | edit `fe-core/.../transaction/PluginDrivenTransactionManager.java` | 新增 `begin(ConnectorTransaction)` 重载 + inner class 加 nullable `connectorTx` 字段，承接 SPI tx commit/rollback/close；legacy `long begin()` 路径行为完全不变 → JDBC/ES auto-commit 零回归 |
-| T12 ✅ | `ConnectorMvccSnapshotAdapter`（fe-core 新类）| **新** `fe-core/.../connector/ConnectorMvccSnapshotAdapter.java` | 包装 `ConnectorMvccSnapshot` + implements `MvccSnapshot`（marker 接口） |
+| T13 ✅ | `ConnectorCreateTableRequest` + 4 spec POJO | **新** 5 个文件 在 `fe-connector-api/.../connector/api/ddl/` | Request 带 Builder；PartitionSpec 含 4 个 Style（IDENTITY/TRANSFORM/LIST/RANGE） |
+| T14 ✅ | `ConnectorTableOps.createTable(session, request)` default | edit `fe-connector-api/.../ConnectorTableOps.java` | 退化到 legacy `createTable(session, schema, props)` |
+| T15 ✅ | `CreateTableInfoToConnectorRequestConverter`（fe-core） | **新** `fe-core/.../connector/ddl/CreateTableInfoToConnectorRequestConverter.java` | 4 种 partition style + hash/random bucket；DataType→ConnectorType 复用 `ConnectorColumnConverter.toConnectorType()` |
+| T16 ✅ | `PluginDrivenExternalCatalog.createTable` 路由 SPI | edit `fe-core/.../datasource/PluginDrivenExternalCatalog.java` | override `createTable(CreateTableInfo)`；wrap `DorisConnectorException` → `DdlException`；写 edit log；总返回 false（=新建） |
+| T17 ✅ | `ConnectorTableOps.listPartitionNames` default | edit `ConnectorTableOps.java` | `Collections.emptyList()` |
+| T18 ✅ | `ConnectorTableOps.listPartitions(handle, filter)` default | edit `ConnectorTableOps.java` | filter 用 `Optional<ConnectorExpression>` |
+| T19 ✅ | `ConnectorTableOps.listPartitionValues` default | edit `ConnectorTableOps.java` | `Collections.emptyList()` |
+| T20 ✅ | `ConnectorPartitionInfo` 追加 3 字段 | edit `fe-connector-api/.../ConnectorPartitionInfo.java` | rowCount/sizeBytes/lastModifiedMillis（`UNKNOWN = -1L`）；3-arg 旧构造器委托到 6-arg；equals/hashCode/toString 同步更新 |
 
 ### 2. 验证
 
-- `mvn -pl fe-core -am compile -Dmaven.build.cache.enabled=false` → **BUILD SUCCESS**
+- `mvn -pl fe-connector/fe-connector-api -am compile` → **BUILD SUCCESS**
+- `mvn -pl fe-core -am compile -Dmaven.build.cache.enabled=false` → **BUILD SUCCESS**（1 次因 unused import checkstyle 失败 → fix → green）
 - `mvn -pl fe-core checkstyle:check` → **0 violations**
-- `mvn -pl fe-connector/fe-connector-jdbc,fe-connector-es -am compile` → **BUILD SUCCESS**（下游 connector 零影响）
+- `mvn -pl fe-connector/fe-connector-jdbc,fe-connector/fe-connector-es -am compile` → **BUILD SUCCESS**（下游连接器零修改）
 
 ### 3. 文档同步（§5.1 五步纪律）
 
-- ✅ `tasks/P0-spi-foundation.md`：T09-T12 状态翻 ✅，新增 2026-05-24（深夜）日志条目
-- ✅ `PROGRESS.md`：§一 P0 进度条 30% → 44%（12/27 任务）；§三 P0 表更新；§四加 2026-05-24（深夜）条目；§七 session 状态滚动
+- ✅ `tasks/P0-spi-foundation.md`：T13-T20 状态翻 ✅，新增 2026-05-24（夜 ②）日志条目（含 4 项 trade-off 说明）
+- ✅ `PROGRESS.md`：§一 P0 进度条 44% → 74%（20/27 任务）；§三 P0 表追加 T13-T20 行；§四加 2026-05-24（夜 ②）条目；§七 session 状态滚动
 - ✅ 本 HANDOFF.md 覆写
 - N/A `connectors/<name>.md`（本次工作不属任何具体连接器）
-- N/A `decisions-log.md` / `deviations-log.md`（本次完全遵循 RFC §6.4 / §7.4 / §8.4，未产生新决策或偏差）
+- N/A `decisions-log.md` / `deviations-log.md`（trade-off 在 RFC 范围内，未升 DV——见下"开放问题"）
+
+### 4. Commit（用户人工 review 通过后）
+
+- ✅ `[feat](connector) add P0 batch 1 SPI: CreateTableRequest + listPartitions (T13-T20)`（hash 见 `git log --oneline -3`）
+- 12 files changed：6 新文件（5 ddl POJO + 1 fe-core converter）+ 3 surgical edits（ConnectorTableOps / ConnectorPartitionInfo / PluginDrivenExternalCatalog）+ 3 plan-doc 更新
+- 工作树 clean
 
 ---
 
 ## 🚧 本 session 进行中 / 未完成
 
-**无**。批 0 全部 10 项任务（T03-T12）+ 编译验证 + 文档同步全部收尾。
+**无**。批 1 全部 8 项任务（T13-T20）+ 编译验证 + 文档同步 + commit 全部收尾。
 
 ---
 
 ## 📝 关键认知 / 临时发现
 
-继承上版 HANDOFF 认知不变。**本场新增**：
+继承上版认知不变。**本场新增**：
 
-1. **`ConnectorMetaInvalidator.invalidatePartition(values)` 与 fe-core `ExternalMetaCacheMgr.invalidatePartitions(names)` 语义不对齐**——SPI 给的是 partition column VALUES（如 `["2024", "01"]`），engine 缓存按 partition NAMES（如 `"year=2024/month=01"`）键控。重构 partition name 需要 partition column names，SPI 目前没带。**本场决策**：fallback 到 `invalidateTable`（正确但过粗），等 SPI 后续补 partition column metadata 时再做精确路由。**待评估是否走 DV 流程**——目前是 RFC §6.4 的实现 trade-off 而非偏差，先列为开放问题。
-2. **`ConnectorMetaInvalidator.invalidateStatistics(db, t)` 当前 no-op**——SPI 契约要求"不能 drop schema cache"，但 fe-core `ExternalMetaCacheMgr` 没有 per-table stats-only invalidation 入口（`ExternalRowCountCache` 按 id 键控，与 SPI 的 name-based 调用不匹配）。先 no-op + 注释解释；待 P7 hive ACID 统计场景出现时再补。
-3. **`PluginDrivenTransactionManager` 通用化策略**——RFC §7.4 的设计示例（`ConnectorTransaction begin(Connector, ConnectorSession)`）与现有 `TransactionManager.begin() -> long` 接口签名冲突。**本场决策**：surgical 路径——保留 legacy `long begin()`（JDBC/ES auto-commit 必需），新增 `long begin(ConnectorTransaction)` 重载。inner class 加 nullable `connectorTx` 字段。无 caller 现在调用新方法（是 forward-compat plumbing，等 P5/P6/P7 连接器迁移时接通）。
-4. **`MvccSnapshot` 是 marker 接口**（fe-core 侧），所以 `ConnectorMvccSnapshotAdapter` 极简——只一个 `getSnapshot()` 暴露 SPI 类型。Iceberg / Paimon / Hudi 各自的 `*MvccSnapshot` 实现也都只是 wrapper。
-5. **跨模块依赖方向重新确认**：`fe-core` → `fe-connector-api`（imports `org.apache.doris.connector.api.*`）；`fe-core` → `fe-connector-spi`（imports `org.apache.doris.connector.spi.*`）。**无循环**。本场 `ExternalMetaCacheInvalidator` 放 fe-core 是对的（因为它要 import `Env` + `ExternalMetaCacheMgr`，反向是禁止的）。
+1. **`ColumnDefinition.defaultValue` 没有 public getter**——字段是 private `Optional<DefaultValue>`，只有 `hasDefaultValue()`。converter 当前传 `null`，等 SPI 在 `ConnectorColumn` 上增加 typed default-value carrier 时再补。这是 SPI 设计层面的 follow-up，不是 fe-core 侧补丁。
+2. **`PartitionTableInfo` 的 partition style 判别**：discriminator 不是单字段，需要两步——
+   - `getPartitionType()` 等于 `LIST` / `RANGE` → Doris 自有风格
+   - `getPartitionType() == UNPARTITIONED` 但 `getPartitionList()` 非空 → 进一步看 expressions：全 `UnboundSlot` → IDENTITY（Hive 风格）；含 `UnboundFunction` → TRANSFORM（Iceberg 风格）
+3. **LIST/RANGE 的 `initialValues` 暂未下沉**——`PartitionDefinition` 子类（InPartition/LessThanPartition/FixedRangePartition/StepPartition）携带 nereids `Expression`，需要完整 analyzer 才能 flatten 到 `List<List<String>>`。目前 Iceberg/Hive 走 TRANSFORM/IDENTITY 路径不依赖此，先返回空 list 延迟到具体连接器需要时再补。
+4. **`DistributionDescriptor` 的 `bucketNum` 字段是 private 且无 public getter**——只能通过 `translateToCatalogStyle().getBuckets()` 间接读取。converter 已封装为 `readBucketNum()` 私有 helper，未来 DistributionDescriptor 加 getter 可一行替换。
+5. **`PluginDrivenExternalCatalog.createTable` 的返回值语义**：SPI 的 `createTable(session, request)` 是 void，不区分"已存在 + IF NOT EXISTS"与"新建"。当前 override 总返回 false（=新建）并写 edit log。这是保守选择——对 P0 forward-compat plumbing 够用；真正需要"存在判定"的连接器（P5/P6/P7）可扩展 SPI 返回 boolean。
+6. **bucket 算法名硬编码为 `"doris_default"` / `"doris_random"`**——RFC §4.2 列了 `hive_hash` / `iceberg_bucket` 等真实算法，但 Doris 内部 `DistributionDescriptor` 只携带 `isHash` 布尔。真实算法名由 Hive/Iceberg 连接器在自己的 metadata.createTable 里根据 properties 推导（P7/P6）。
+7. **fe-core 编译验证的 cwd 是 `fe/`**，不是 workspace 根目录——`mvn -pl fe-core` 要从 `fe/` 跑。沿用上版认知。
 
 ---
 
 ## 🎯 下一个 session 第一件事
 
-### 强烈建议先 review 本场 4 文件改动再开始 P0-T13+
+### Track A 已收尾（batch 1 commit 已合入 catalog-spi-00）
 
-理由：T09-T12 是"SPI ↔ fe-core 互通"的实际胶水层。错了影响范围是 P0 之后所有连接器（每个都会读这层桥接）。
+无需再开 Track A。新 session 直接进 Track B（批 2）。
 
-→ 新 session 第一步：用户人工/agent 评审本场 4 文件：
-- `fe-core/.../connector/ExternalMetaCacheInvalidator.java` (新)
-- `fe-core/.../connector/ConnectorMvccSnapshotAdapter.java` (新)
-- `fe-core/.../connector/DefaultConnectorContext.java` (edit)
-- `fe-core/.../transaction/PluginDrivenTransactionManager.java` (edit)
-
-如有调整建议，走 DV 流程登记（特别是上面"关键认知 #1"的 `invalidatePartition` trade-off 是否要做精确路由）。
-
-### Track A：本场 4 文件 commit
+### Track B：P0 批 2（守门 + 测试，T21-T27）
 
 ```
-1. cd /Users/morningman/workspace/git/wt-fs-spi
-2. git status
-3. git add fe/fe-core/src/main/java/org/apache/doris/connector/ExternalMetaCacheInvalidator.java \
-           fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorMvccSnapshotAdapter.java \
-           fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java \
-           fe/fe-core/src/main/java/org/apache/doris/transaction/PluginDrivenTransactionManager.java \
-           plan-doc/PROGRESS.md plan-doc/HANDOFF.md plan-doc/tasks/P0-spi-foundation.md
-4. git commit -m "[P0-T09..T12][fe-core] wire MetaInvalidator / Transaction / MvccSnapshot into fe-core"
+1. git branch --show-current  → 确认仍在 catalog-spi-00
+2. Read plan-doc/PROGRESS.md + plan-doc/HANDOFF.md（本文件）
+3. Read plan-doc/01-spi-extensions-rfc.md §15 (Testing) + §17 (Acceptance)
+4. T21: tools/check-connector-imports.sh —— 禁用 import 守门脚本（grep 禁词如 fe-core 包名出现在 fe-connector 模块内）
+5. T22: 在 fe-connector pom 接 maven-enforcer-plugin 调用 T21 脚本
+6. T23: FakeConnectorPlugin（fe-core test 包）—— 覆盖所有 default 行为路径（不实现任何 SPI 方法也应跑通基本 SHOW DATABASES / CREATE TABLE / listPartitions 调用，验证 fallback）
+7. T24-T25: JDBC + ES 全套 regression-test
+8. T26: ConnectorMetaInvalidator 路由测试（mock ExternalMetaCacheMgr）
+9. T27: CreateTableInfoToConnectorRequestConverter 单元测试（覆盖 IDENTITY / TRANSFORM / LIST / RANGE 四种 partition + hash/random bucket）
+10. 更新 tasks / PROGRESS / HANDOFF + commit
 ```
 
-### Track B：P0 批 1（DDL + Partition SPI，T13-T20）
+预计 context 用量 ~55%（T23 FakeConnectorPlugin 与 T27 converter 单测较重；其余偏脚本/regression-driver）。
 
-仅在 Track A commit + review 后启动：
+### Track C（可选，仅在 P0 全部收尾后）：批 2 同步评估开放问题 #1-#3
 
-```
-1. Read plan-doc/PROGRESS.md + plan-doc/HANDOFF.md
-2. Read plan-doc/01-spi-extensions-rfc.md §4 (E1 CreateTableRequest) + §13 (E10 listPartitions)
-3. 新增 8 个任务（T13-T20）：
-   - T13: `ConnectorCreateTableRequest` + Partition/Bucket Spec POJO（5 个类）放 ddl 包
-   - T14: `ConnectorTableOps.createTable(request)` default → 退化到旧 createTable
-   - T15: `CreateTableInfoToConnectorRequestConverter`（fe-core 新类）
-   - T16: `PluginDrivenExternalCatalog.createTable(stmt)` 接通 SPI
-   - T17-T19: `ConnectorTableOps.listPartitionNames / listPartitions / listPartitionValues` default
-   - T20: `ConnectorPartitionInfo` 追加字段（rowCount/sizeBytes/lastModifiedMillis）+ 向后兼容构造器
-4. mvn -pl fe-connector -am compile + JDBC/ES 回归
-5. 更新 tasks / PROGRESS / HANDOFF
-```
-
-预计 context 用量 ~50-60%（批 1 主要在 fe-connector-api 侧，文件相对独立）。
+如果在写 FakeConnectorPlugin / converter 单测过程中触发了"开放问题 #1 default 值 / #2 LIST initialValues / #3 createTable 返回值"中的实际需求，**走 DV 流程登记** 再调整 SPI，不要 silent edit。
 
 ---
 
 ## ⚠️ 开放问题 / 风险提示
 
-继承上版 5 项不变。**本场新增 / 更新**：
+继承上版 6 项不变。**本场新增 / 更新**（删除了"未 commit"项；batch 1 commit 已收尾）：
 
-1. **`invalidatePartition` 的 SPI 设计 trade-off**（新）：当前 fallback 到 `invalidateTable`。是否要给 SPI `ConnectorMetaInvalidator.invalidatePartition` 加 `List<String> partitionColumnNames` 参数？若加，则 fe-core adapter 能精确路由到 `mgr.invalidatePartitions(...)`。**先收集 Hive/Iceberg 实际使用频率再决定**（P7 评估），目前的过粗 invalidation 在正确性上无问题，只是缓存命中率会差。
-2. **`invalidateStatistics` no-op**（新）：fe-core `ExternalMetaCacheMgr` 缺 stats-only invalidation 入口。**可能需要**在 P7 hive ACID 写路径完工时补一个 `mgr.invalidateTableStats(catalogId, db, t)` 方法。**记到 R-014 之后**作为新风险？暂不加，先 no-op + 注释，等具体场景出现。
-3. **Maven build cache 误导问题**（沿用上版）：所有 SPI 改动验证步骤强制加 `-Dmaven.build.cache.enabled=false` 或 `clean`。
-4. **本次 7 文件改动尚未 commit**——见 Track A。
-5. **`PluginDrivenTransactionManager.begin(ConnectorTransaction)` 暂无 caller**（forward-compat plumbing）。当 P5/P6/P7 连接器开始实现 `ConnectorWriteOps.beginTransaction` 时，`BaseExternalTableInsertExecutor`（或同等位置）需要改为 if-else：连接器实现了 → 调新方法；否则 → 走 legacy `begin()`。**这一步留在 P5/P6/P7**，不在 P0 范围。
-6. （沿用）`PluginDrivenTransactionManager` 通用化对 JDBC auto-commit 的回归——本场已通过 fe-connector-jdbc clean compile 验证语法层无回归；**行为层回归留 P0-T24 跑全套 JDBC regression test**。
+1. **`ColumnDefinition.defaultValue` 在 SPI 层缺位**：converter 当前传 null。是否在 `ConnectorColumn` 上加 typed default-value carrier？建议 P5/P6 Hive/Iceberg 真正用到 CREATE TABLE 时再评估——如必要可走 DV 流程。
+2. **LIST/RANGE `initialValues` flatten 缺位**：当前 converter 返回空。是否在 `PartitionDefinition` 上加 `toFlatValues(): List<List<String>>` helper？建议同上：P5 Paimon / P7 Hive 真正用到时再评估。
+3. **`PluginDrivenExternalCatalog.createTable` 返回值丢失"已存在"信息**：是否扩展 SPI `createTable(session, request)` 返回 boolean 或 `CreateTableResult`？建议留到 P5/P6/P7 连接器迁移时再决定——目前 forward-compat plumbing 不影响。
+4. **bucket 算法名占位**：`"doris_default"` / `"doris_random"`。Hive/Iceberg 连接器侧需在自己的 metadata.createTable 里根据 properties 推导真实算法。
+5. （沿用）Maven build cache 误导问题：所有 SPI 改动验证步骤强制加 `-Dmaven.build.cache.enabled=false` 或 `clean`；并且 `mvn -pl fe-core` 的 cwd 必须是 `fe/`，不是 workspace 根。
+6. （沿用）`PluginDrivenTransactionManager.begin(ConnectorTransaction)` 暂无 caller（P5/P6/P7 接通）。
+7. （沿用）`invalidatePartition` fallback 到 `invalidateTable`；`invalidateStatistics` no-op——P7 hive ACID 场景再评估。
 
 ---
 
 ## 📂 当前关键文件清单
 
-### 本场新增 / 修改
+### 本场新增 / 修改（已 commit）
 
 ```
-NEW  fe/fe-core/src/main/java/org/apache/doris/connector/ExternalMetaCacheInvalidator.java
-NEW  fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorMvccSnapshotAdapter.java
-MOD  fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java
-MOD  fe/fe-core/src/main/java/org/apache/doris/transaction/PluginDrivenTransactionManager.java
+NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorCreateTableRequest.java
+NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionSpec.java
+NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionField.java
+NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionValueDef.java
+NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorBucketSpec.java
+NEW  fe/fe-core/src/main/java/org/apache/doris/connector/ddl/CreateTableInfoToConnectorRequestConverter.java
+MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorTableOps.java
+MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorPartitionInfo.java
+MOD  fe/fe-core/src/main/java/org/apache/doris/datasource/PluginDrivenExternalCatalog.java
 MOD  plan-doc/PROGRESS.md
 MOD  plan-doc/tasks/P0-spi-foundation.md
-MOD  plan-doc/HANDOFF.md（本文件）
+MOD  plan-doc/HANDOFF.md（本文件——post-commit roll 通过 git amend 与 batch 1 同 commit 落盘）
 ```
 
 ### 跟踪体系（沿用不变）
 
 ```
-plan-doc/  (~220K, 17 文件)
+plan-doc/  (~225K, 17 文件)
 ├── 00-connector-migration-master-plan.md / 01-spi-extensions-rfc.md
 ├── README.md / PROGRESS.md / AGENT-PLAYBOOK.md / HANDOFF.md
 ├── decisions-log.md (18) / deviations-log.md (0) / risks.md (14)
@@ -152,8 +153,10 @@ plan-doc/  (~220K, 17 文件)
 ## 🧠 给下一个 agent 的 meta 建议
 
 - **当前分支是 `catalog-spi-00`**。新 session 开场 `git branch --show-current` 确认。
-- 接 Track B（批 1 DDL+Partition SPI）前**强烈建议人工 review 本场 4 文件改动**——它们是 SPI ↔ fe-core 胶水层，错了影响所有后续连接器。
-- 上版 meta 建议#3 仍然成立："scope 判定以 tasks/Pn-*.md 为准，HANDOFF 只是建议起点"。批 0 在 tasks 表中明确划分为"SPI 接口三件套（T03-T08）"+"fe-core 桥接（T09-T12）"两个子批，本场补完后者，整批 0 收尾。下一 session 进入批 1（T13-T20）。
-- 本场没动 RFC 一个字，无新 decision / deviation。沿用 meta 建议 "不要重新打开 D-001..D-018"。
-- **本场对 `PluginDrivenTransactionManager` 的改造方式是个值得学习的 surgical change 模板**：保持接口签名 + 加重载 + nullable 字段 + 文档化两条路径——避免了对 `TransactionManager` 接口、`BaseExternalTableInsertExecutor` 调用方、JDBC/ES auto-commit 的任何破坏。批 1+ 的迁移如果遇到类似"老路径不能动 / 新功能要加"的情况，可参照此 pattern。
+- **批 1（T13-T20）已合入 `catalog-spi-00`**（subject `[feat](connector) add P0 batch 1 SPI: CreateTableRequest + listPartitions (T13-T20)`），无需 review 老代码；直接读最新源即可。如果对 6 个新/改文件有调整建议，走 DV 流程登记后再改，不要 silent edit。
+- **Maven build 的 cwd 必须是 `fe/`**，不是 workspace 根。`mvn -pl fe-core -am compile` 从根目录跑会报"Could not find the selected project in the reactor"。
+- 本场无 RFC 修改、无新 decision / deviation——所有 trade-off 都在 RFC §4 / §13 设计范围内，由代码注释 + 本 HANDOFF "开放问题" 列出。沿用 meta 建议 "不要重新打开 D-001..D-018"。
+- **本场对 `CreateTableInfoToConnectorRequestConverter` 的写法值得参考**：先 `convert(info, dbName)` 顶层 → 4 个 private helper（convertColumns/convertPartition/convertBucket/convertField + convertTransformField）。Helper 之间互相不调用、各自处理一种维度，方便后续 T27 单测分别覆盖。
 - **必读 AGENT-PLAYBOOK §六 anti-patterns** 再开始动手。
+- 本场用 Explore subagent 调研了 nereids `CreateTableInfo` / `ColumnDefinition` / `PartitionTableInfo` / `DistributionDescriptor` 4 个文件，把整源代码读取摊到 subagent，节省主 context（CreateTableInfo 单文件 1714 行）——批 2 如果要写 FakeConnectorPlugin 也建议同样套路。
+- **本 HANDOFF roll 已通过 git amend 与 batch 1 代码同 commit 落盘**（HANDOFF 不内嵌 commit hash——hash 在 amend 后会变；用 `git log --oneline -3` 或 `git log --grep="P0 batch 1"` 即可定位）。下一个 session 不需要再处理 HANDOFF 落盘。

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -8,143 +8,161 @@
 
 ## 📅 最后一次 handoff
 
-- **日期 / 时间**：2026-05-24（同日两次更新）
+- **日期 / 时间**：2026-05-24（晚）
 - **本 session 主导者**：Claude Opus 4.7（1M context）
-- **本 session 主题**：建立项目跟踪机制（完整版）
-- **预估 context 使用**：~70%（进入"警觉"区，已停止接新任务）
+- **本 session 主题**：P0 批 0 SPI 接口三件套实现（E3 MetaInvalidator + E4 Transaction + E5 MvccSnapshot）
+- **预估 context 使用**：~50%（健康范围；§7.2 "代码实现 session" 模板预算 60%）
 
 ---
 
 ## ✅ 本 session 完成项
 
-### 1. 决策闭环（前半段）
-- ✅ Master plan §5 — 12 个项目决策点（D1-D12）全部按推荐确认
-- ✅ SPI RFC §16.2 — 6 个未决问题（U1-U6）全部决议（U4 改批量化）
+### 1. P0-T02 闭环（doc 维护）
 
-### 2. 跟踪机制建立（后半段，全部完成）
-- ✅ `plan-doc/README.md` — 跟踪机制使用指南 + 文档索引
-- ✅ `plan-doc/PROGRESS.md` — 全局仪表盘（阶段进度、连接器看板、活跃 task、风险监控、session 状态）
-- ✅ `plan-doc/AGENT-PLAYBOOK.md` — Agent 协作规范（context 预算、subagent 使用、handoff 触发、强制纪律、anti-patterns）
-- ✅ `plan-doc/HANDOFF.md` — 本文件（滚动）
-- ✅ `plan-doc/decisions-log.md` — 18 条 ADR（D-001..D-018）
-- ✅ `plan-doc/deviations-log.md` — 空模板（DV-NNN 待用）
-- ✅ `plan-doc/risks.md` — 14 个风险条目（R-001..R-014），含状态矩阵
-- ✅ `plan-doc/tasks/_template.md` — 阶段任务模板
-- ✅ `plan-doc/tasks/P0-spi-foundation.md` — P0 全部 27 个子任务清单
-- ✅ `plan-doc/connectors/_template.md` — 连接器跟踪模板
-- ✅ `plan-doc/connectors/{jdbc,es,trino-connector,hudi,maxcompute,paimon,iceberg,hive}.md` — 8 个连接器跟踪文件
-- ✅ `plan-doc/00-connector-migration-master-plan.md` 顶部加入跟踪体系入口链接
+上一 session 完成 17 文件跟踪机制并已 commit `63159837043`，但 `tasks/P0-spi-foundation.md` 中 P0-T02 仍是 🚧。**本场 session 翻状态为 ✅** —— 一处文档/§5.1 同步纪律的修复，无代码改动。
 
-总计 **17 个文件**，220K，覆盖项目战略 + 进度 + 决策 + 风险 + 任务 + 连接器 + agent 协作 6 个维度。
+### 2. P0 批 0：SPI 接口三件套（T03–T08）
+
+| ID | 任务 | 文件 | 备注 |
+|---|---|---|---|
+| T03 ✅ | E3 `ConnectorMetaInvalidator` 接口 | **新** `fe-connector-spi/.../spi/ConnectorMetaInvalidator.java` | 5 个 invalidate default + `NOOP` 常量；放 spi 包以便 `ConnectorContext` 引用 |
+| T04 ✅ | `ConnectorContext.getMetaInvalidator()` default | edit `fe-connector-spi/.../spi/ConnectorContext.java` | 返回 `ConnectorMetaInvalidator.NOOP` |
+| T05 ✅ | `ConnectorTransaction` 接口 | **新** `fe-connector-api/.../api/handle/ConnectorTransaction.java` | `extends ConnectorTransactionHandle, Closeable`；保留旧 24 行 marker 不破坏现有引用 |
+| T06 ✅ | `ConnectorWriteOps.beginTransaction` default | edit `fe-connector-api/.../api/ConnectorWriteOps.java` | 默认抛 `DorisConnectorException("Transactions not supported")` |
+| T07 ✅ | `ConnectorSession.getCurrentTransaction` default | edit `fe-connector-api/.../api/ConnectorSession.java` | 默认 `Optional.empty()` |
+| T08 ✅ | `ConnectorMvccSnapshot` 类型 + 3 default 方法 | **新** `fe-connector-api/.../api/mvcc/ConnectorMvccSnapshot.java` + edit `fe-connector-api/.../api/ConnectorMetadata.java` | final value class + Builder；3 default：`beginQuerySnapshot` / `getSnapshotAt` / `getSnapshotById` 全返回 `Optional.empty()` |
+
+### 3. 验证
+
+- `mvn -pl fe-connector/fe-connector-api,spi -am clean compile -DskipTests` → **BUILD SUCCESS**（4 spi 源文件、checkstyle 0 violations）
+- `mvn -pl fe-connector/fe-connector-jdbc,fe-connector-es -am compile` → **BUILD SUCCESS**（26 JDBC 源 + ES 全编译，零下游修改）
+- 即 P0 验收清单中 **「JDBC、ES 现有 compile 通过」基线成立**（regression test 留 P0-T24/T25 单独验）
+
+### 4. 文档同步（§5.1 五步纪律）
+
+- ✅ `tasks/P0-spi-foundation.md`：T02-T08 状态翻 ✅，新增 2026-05-24（晚）日志条目
+- ✅ `PROGRESS.md`：§一 P0 进度条 10% → 30%；§三 P0 表更新；§四加 2026-05-24（晚）条目；§七 session 状态滚动
+- ✅ 本 HANDOFF.md 覆写
+- N/A `connectors/<name>.md`（本次工作不属任何具体连接器）
+- N/A `decisions-log.md` / `deviations-log.md`（本次完全遵循 RFC §6/§7/§8，未产生新决策或偏差）
 
 ---
 
 ## 🚧 本 session 进行中 / 未完成
 
-**无**。本 session 工作完整收尾，跟踪机制已就位且自洽。
+**无**。批 0 SPI 接口 + 编译验证 + 文档同步全部收尾。
 
 ---
 
 ## 📝 关键认知 / 临时发现
 
-（沿用上一版 HANDOFF 的认知，本次 session 未产生新代码层面发现）
+继承上版 HANDOFF 7 条认知不变。**本场新增**：
 
-1. **`fe-connector/` 反向边界当前是干净的**（0 处禁用 import）—— grep 守门脚本只需维护现状即可。
-2. **`PluginDrivenExternalCatalog.gsonPostProcess` 已实现 ES/JDBC 兼容范本**（line 274-297）—— 后续连接器迁移直接复制该模式。
-3. **`PhysicalPlanTranslator.visitPhysicalFileScan` line 734-790 是 7-way switch 的单点收口** —— P1 首要清理目标。
-4. **`ConnectorTransactionHandle` 是 24 行空 marker 接口** —— `ConnectorTransaction` 计划继承它，不破坏现有引用。
-5. **`ConnectorPartitionInfo` 已存在** —— RFC E10 复用并扩展 3 个 long 字段（向后兼容构造器）。
-6. **`SPI_READY_TYPES` 白名单当前只含 `jdbc`, `es`** —— 后续连接器加入这个 ImmutableSet 即可生效。
-7. **`fe-connector-hms` 是共享库不是插件** —— 无 `META-INF/services/...ConnectorProvider`，被 hive / hudi / iceberg-HMS / paimon-HMS 依赖。
-
-### 本 session 新增认知
-8. **跟踪机制的"决策 vs 偏差"区分是必须**：先前混在一起会让审查者无法判断"事前想清楚 vs 事后被现实纠正"。
-9. **`AGENT-PLAYBOOK` §2.1 的 context 预算分级**对当前 session 已生效——我自己在 ~70% 时停止接新任务。后续 session 应严格执行。
-10. **未来 agent 切 session 时的强制开场流程在 README §7.3 和 PLAYBOOK §4.5** —— **不读 HANDOFF 直接问"上次到哪了"是失败模式**。
+1. **`fe-connector-spi` 模块 `pom.xml` 已依赖 `fe-connector-api`** —— `ConnectorContext.java` 早就 import `org.apache.doris.connector.api.ConnectorHttpSecurityHook`，所以 spi → api 方向可用。`ConnectorMetaInvalidator` 放 spi 包没有循环依赖问题。
+2. **`ConnectorTransactionHandle` 与 `ConnectorTransaction` 共存策略验证可行** —— 旧 24 行 marker 保留；`ConnectorTransaction extends ConnectorTransactionHandle` 让现有所有 `*Handle` 占位代码（fe-core / fe-connector 中）无须修改即可继续编译。这条与 HANDOFF 旧认知 #4 一致，本场实操确认。
+3. **Maven `build-cache-extension` 默认会按 checksum 复用 jar，可能导致"看似 BUILD SUCCESS 但实际没编译我的新源文件"** —— 验证编译时必须加 `-Dmaven.build.cache.enabled=false` 或显式 `clean`，否则会看到 `Skipping plugin execution (cached): compiler:compile` 误导。**这条要进 PLAYBOOK** —— 见下方"开放问题 #1"。
+4. **`ConnectorMvccSnapshot` 用 Builder 模式** —— RFC §8.2 写的 "builder + getters" 我做成了 final class + 静态嵌套 `Builder`，符合 immutable value 类惯例。Map 用 `Collections.unmodifiableMap(new HashMap<>(...))` 拷贝。
+5. **`ConnectorMetadata` 上的 3 个 MVCC default 方法**直接放在 `ConnectorMetadata` 自己（不放在子接口）——因为它们是横切关注，且 RFC §8.3 明确放这里。
 
 ---
 
 ## 🎯 下一个 session 第一件事
 
-**两种路径，由 user 决定：**
+### 强烈建议先 review 再继续
 
-### Track A（推荐）：开 P0 编码
+`tasks/P0-spi-foundation.md` 注意事项 #1：**「批 0 三个 SPI 是后续所有连接器迁移的 baseline。一旦合入主线，每个连接器都开始用，调整成本急剧上升。先在批 0 完成后让用户 review，再开始批 1。」**
 
-第一件事：
-```
-1. Read plan-doc/PROGRESS.md + plan-doc/HANDOFF.md
-2. Read plan-doc/tasks/P0-spi-foundation.md（找批 0 第一个 task = P0-T03）
-3. Read plan-doc/01-spi-extensions-rfc.md §6（E3 MetaInvalidator 设计）
-4. 实现：
-   - 新建 fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorMetaInvalidator.java
-   - 修改 ConnectorContext.java 加 getMetaInvalidator() default 方法
-5. 编译：mvn -pl fe/fe-connector/fe-connector-spi compile
-6. 完成后：
-   - 更新 tasks/P0-spi-foundation.md 中 P0-T03 状态为 ✅
-   - 更新 PROGRESS.md §三和§四
-   - 写新 HANDOFF.md
-```
+→ 新 session 第一步：用户人工/agent 评审本次 6 个文件（3 新 + 3 改）。如有调整建议，走 DV 流程登记。
 
-### Track B：建 git commit 沉淀本次工作
+### Track A（review 后推荐）：本次批 SPI 接口先 commit
 
-第一件事：
 ```
 1. cd /Users/morningman/workspace/git/wt-fs-spi
 2. git status
-3. git add plan-doc/
-4. git commit -m "[plan-doc] establish project tracking system with decision/deviation/risk logs"
-5. 然后进入 Track A
+3. git add fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/handle/ConnectorTransaction.java \
+           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/mvcc/ \
+           fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorMetaInvalidator.java \
+           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorMetadata.java \
+           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorSession.java \
+           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorWriteOps.java \
+           fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java \
+           plan-doc/PROGRESS.md plan-doc/HANDOFF.md plan-doc/tasks/P0-spi-foundation.md
+4. git commit -m "[P0-T03..T08][spi] add MetaInvalidator/Transaction/MvccSnapshot baseline"
 ```
 
-**强烈推荐 Track B → Track A**：本次 session 创建了 17 个文档但都没提交；先 commit 沉淀，否则一旦本地文件意外丢失，所有跟踪机制要重做。
+### Track B：fe-core 桥接（P0-T09..T12）
+
+只在 Track A commit 后启动：
+
+```
+1. Read plan-doc/PROGRESS.md + plan-doc/HANDOFF.md
+2. Read plan-doc/01-spi-extensions-rfc.md §6.4 / §7.4 / §8.4
+3. 找到现有 fe-core 类：
+   - DefaultConnectorContext（实现 ConnectorContext）
+   - ExternalMetaCacheMgr（被包装目标）
+   - PluginDrivenTransactionManager（要通用化）
+   - MvccSnapshot 接口（fe-core 侧）
+4. 实现：
+   - DefaultConnectorContext.getMetaInvalidator() override → new ExternalMetaCacheInvalidator(catalogId)
+   - ExternalMetaCacheInvalidator (fe-core 新类) 包装 ExternalMetaCacheMgr 的 5 个 invalidate*
+   - PluginDrivenTransactionManager 删 type-specific 分支，改用 ConnectorTransaction map
+   - ConnectorMvccSnapshotAdapter (fe-core 新类) implements MvccSnapshot
+5. mvn -pl fe-core -am compile（注意 fe-core 体量，预估 2-3 分钟）
+6. 跑 JDBC 简单测试验证回归
+7. 更新 tasks / PROGRESS / HANDOFF
+```
+
+预计 context 用量 ~70%（fe-core 体量大，会涉及多文件读）。**如果上手就觉得读 ExternalMetaCacheMgr / PluginDrivenTransactionManager 单文件超过 800 行，先 grep 定位再 offset+limit 精读**（PLAYBOOK §2.3 #1）。
 
 ---
 
 ## ⚠️ 开放问题 / 风险提示
 
-1. **跟踪机制本身从未被实际"使用"过**——所有文件都是预期模板，实际产生 deviation / 周维护时是否好用还要看。后续 session 第一次 append decision-log 或 deviation-log 时如果发现模板缺字段，按 DV 流程改 README §3。
-2. **`tools/check-connector-imports.sh` 守门脚本仍未实现**（RFC §15.4 + tasks/P0 P0-T21）—— P0 末必须完成。
-3. **`maven enforcer` 接入方式未敲定**——技术决策，留 P0 实施时定。
-4. **本 session 大量决策（D-001..D-018）尚未进入 git history** —— 见 Track B 推荐。
-5. **本跟踪机制没有 PMC review**——单人推进风险。建议在开 P0 编码前至少让一位 reviewer 看一遍 README + AGENT-PLAYBOOK。
+1. **Maven build cache 误导问题**（本场新发现）：默认开启的 `build-cache-extension` 会按 input checksum 复用 jar，可能产生 "BUILD SUCCESS 但实际没编译"。建议：
+   - **短期**：所有 SPI 改动验证步骤强制加 `-Dmaven.build.cache.enabled=false` 或 `clean`
+   - **长期**：在 `AGENT-PLAYBOOK.md` §五新加一条纪律 / 在 P0-T22（maven enforcer 接入）任务中评估是否禁掉 cache 用于 CI
+   - 暂未走 DV 登记（不是 RFC 偏差，是工具链 finding）；若决定写 PLAYBOOK 改动，走 DV 流程。
+2. **本次 6 文件改动尚未 commit**（同上一 session 模式）—— 见 Track A。
+3. **`PluginDrivenTransactionManager` 通用化（P0-T11）需要回归测试保证 JDBC auto-commit 不退化** —— 已在 tasks/P0 注意事项 #2 标注；下一 session 实操时务必跑 JDBC regression。
+4. **`ConnectorMvccSnapshot` 的 `properties` Map 是否需要类型化字段**（如 Iceberg 用 `manifest-list-location`、`schema-id`）—— 暂用 `Map<String, String>` 通用承接，待 Iceberg/Paimon 接入时（P5/P6）发现具体需求再补强类型 / 走 DV。
+5. **`getCurrentTransaction()` default 的 fe-core 侧填充逻辑**（RFC §7.6 末："fe-core 用 `ConnectorSessionImpl` 在事务期间填入"）—— 留到 P0-T11 同步实现。
 
 ---
 
-## 📂 当前 plan-doc/ 目录全景
+## 📂 当前关键文件清单
+
+### 本场新增 / 修改
 
 ```
-plan-doc/  (220K, 17 文件)
-├── 00-connector-migration-master-plan.md         ← 战略
-├── 01-spi-extensions-rfc.md                      ← SPI 详细设计
-├── README.md                                     ← 跟踪机制指南
-├── PROGRESS.md                                   ← 全局仪表盘 ★
-├── AGENT-PLAYBOOK.md                             ← Agent 协作规范 ★
-├── HANDOFF.md                                    ← 本文件（滚动）
-├── decisions-log.md                              ← 18 条决策
-├── deviations-log.md                             ← 0 条偏差（空）
-├── risks.md                                      ← 14 个风险
-├── tasks/
-│   ├── _template.md
-│   └── P0-spi-foundation.md                      ← 27 个子任务
-└── connectors/
-    ├── _template.md
-    ├── jdbc.md            ← 95% (P1 清理残留)
-    ├── es.md              ← 100% ✅
-    ├── trino-connector.md ← 30% (P2)
-    ├── hudi.md            ← 20% (P3)
-    ├── maxcompute.md      ← 25% (P4)
-    ├── paimon.md          ← 20% (P5)
-    ├── iceberg.md         ← 5%  (P6)
-    └── hive.md            ← 10% (P7)
+NEW  fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorMetaInvalidator.java
+NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/handle/ConnectorTransaction.java
+NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/mvcc/ConnectorMvccSnapshot.java
+MOD  fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java
+MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorMetadata.java
+MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorSession.java
+MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorWriteOps.java
+MOD  plan-doc/PROGRESS.md
+MOD  plan-doc/tasks/P0-spi-foundation.md
+MOD  plan-doc/HANDOFF.md（本文件）
+```
+
+### 跟踪体系（上场建立，沿用不变）
+
+```
+plan-doc/  (~220K, 17 文件)
+├── 00-connector-migration-master-plan.md / 01-spi-extensions-rfc.md
+├── README.md / PROGRESS.md / AGENT-PLAYBOOK.md / HANDOFF.md
+├── decisions-log.md (18) / deviations-log.md (0) / risks.md (14)
+├── tasks/{_template.md, P0-spi-foundation.md}
+└── connectors/{_template.md, jdbc, es, trino-connector, hudi, maxcompute, paimon, iceberg, hive}.md
 ```
 
 ---
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- 本项目所有"事实陈述"（代码行数、文件位置、import 引用关系）基于 2026-05-24 这天的 `catalog-spi-2` 分支状态。如 session 跨多天且分支有更新，先 `git log --oneline catalog-spi-2 -10` 确认 base。
-- 用户偏好简洁、第一性原理、不绕弯。直接给推荐方案，等他说"这里改一下"再调整。**不要列 6 个选项让他选**——除非真的有 trade-off。
-- 用户经常在工作中途插入新需求（本次 session 加了 "context 管理" 要求）——用 PLAYBOOK §2.2 的"主动报告 context 占用"应对，不要默默吞掉。
-- 用户已确认 18 个决策（D-001..D-018），**不要重新打开**这些讨论，除非有强证据原决策不可行（此时走 DV 流程）。
-- 本次 session 的"建立跟踪机制"是一次性投资。后续 session 不要 re-design，**只用、不改**——除非走 DV 流程明确改进。
-- **必读 AGENT-PLAYBOOK 全文**再开始动手——特别是 §6 anti-patterns。
+- **当前分支是 `catalog-spi-00`**（HANDOFF 历史版本写 `catalog-spi-2`，那是 git status 快照失准；本场 session 全程在 `catalog-spi-00` 上工作并验证）。新 session 开场 `git branch --show-current` 确认。
+- 接 Track B（fe-core 桥接）前**强烈建议人工 review 本场 6 文件改动**——这是后续所有连接器迁移的 baseline，错了影响面巨大。
+- 用户在 Q&A 中纠正过我"为什么只 T03/T04 不做完整批 0"——**说明用户读 task 文件比 HANDOFF 仔细，scope 判定以 tasks/Pn-*.md 为准，HANDOFF 只是建议起点**。下一 session 启动时不要再被 HANDOFF 的"下一个 session 第一件事"窄化思维误导，先看 tasks 文件确认完整 batch。
+- 本场没动 RFC 一个字，无新 decision / deviation。**沿用上版 meta 建议第 4 条："不要重新打开 D-001..D-018"**。
+- **必读 AGENT-PLAYBOOK §六 anti-patterns** 再开始动手（特别是 "把 RFC 当 PROGRESS 用" 和 "跨 session 凭记忆继续工作"）。

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -8,54 +8,54 @@
 
 ## 📅 最后一次 handoff
 
-- **日期 / 时间**：2026-05-24（夜 ②，含 commit）
+- **日期 / 时间**：2026-05-24（夜 ③）
 - **本 session 主导者**：Claude Opus 4.7（1M context）
-- **本 session 主题**：P0 批 1 DDL + Partition SPI（T13-T20）—— `ConnectorCreateTableRequest` + 4 spec POJO + 4 个 default 方法 + 1 fe-core converter + PluginDrivenExternalCatalog 路由；**已 commit**（用户人工 review 通过；hash 见 `git log --oneline -3`，subject `[feat](connector) add P0 batch 1 SPI: CreateTableRequest + listPartitions (T13-T20)`）
+- **本 session 主题**：P0 批 2 守门 + 单测（T21-T23, T26-T27；T24-T25 转交用户在本地跑）—— **已 commit**（用户人工 review 通过；hash 见 `git log --oneline -3`，subject `[feat](connector) add P0 batch 2 gate + unit tests (T21-T23, T26-T27)`）
 - **预估 context 使用**：~55%（健康）
 
 ---
 
 ## ✅ 本 session 完成项
 
-### 1. P0 批 1：DDL + Partition SPI（T13-T20）
+### 1. P0 批 2：守门 + 单测（T21-T23, T26-T27）
 
 | ID | 任务 | 文件 | 备注 |
 |---|---|---|---|
-| T13 ✅ | `ConnectorCreateTableRequest` + 4 spec POJO | **新** 5 个文件 在 `fe-connector-api/.../connector/api/ddl/` | Request 带 Builder；PartitionSpec 含 4 个 Style（IDENTITY/TRANSFORM/LIST/RANGE） |
-| T14 ✅ | `ConnectorTableOps.createTable(session, request)` default | edit `fe-connector-api/.../ConnectorTableOps.java` | 退化到 legacy `createTable(session, schema, props)` |
-| T15 ✅ | `CreateTableInfoToConnectorRequestConverter`（fe-core） | **新** `fe-core/.../connector/ddl/CreateTableInfoToConnectorRequestConverter.java` | 4 种 partition style + hash/random bucket；DataType→ConnectorType 复用 `ConnectorColumnConverter.toConnectorType()` |
-| T16 ✅ | `PluginDrivenExternalCatalog.createTable` 路由 SPI | edit `fe-core/.../datasource/PluginDrivenExternalCatalog.java` | override `createTable(CreateTableInfo)`；wrap `DorisConnectorException` → `DdlException`；写 edit log；总返回 false（=新建） |
-| T17 ✅ | `ConnectorTableOps.listPartitionNames` default | edit `ConnectorTableOps.java` | `Collections.emptyList()` |
-| T18 ✅ | `ConnectorTableOps.listPartitions(handle, filter)` default | edit `ConnectorTableOps.java` | filter 用 `Optional<ConnectorExpression>` |
-| T19 ✅ | `ConnectorTableOps.listPartitionValues` default | edit `ConnectorTableOps.java` | `Collections.emptyList()` |
-| T20 ✅ | `ConnectorPartitionInfo` 追加 3 字段 | edit `fe-connector-api/.../ConnectorPartitionInfo.java` | rowCount/sizeBytes/lastModifiedMillis（`UNKNOWN = -1L`）；3-arg 旧构造器委托到 6-arg；equals/hashCode/toString 同步更新 |
+| T21 ✅ | `tools/check-connector-imports.sh` | **新** `tools/check-connector-imports.sh` | grep 守门；接受可选 ROOT 参数；正负冒烟均通过 |
+| T22 ✅ | exec-maven-plugin 接入脚本 | edit `fe-connector/pom.xml` | 绑 `validate` 阶段；`inherited=false`；用 `${project.basedir}/../../tools/...` 避开 `fe.dir` 解析时序 |
+| T23 ✅ | `FakeConnectorPlugin` + 默认行为测试 | **新** `fe-core/src/test/java/.../connector/fake/{FakeConnectorPlugin,FakeConnectorPluginTest}.java` | 11 个 @Test；零 override 的 `FakeMetadata` 验证所有 default 路径 |
+| T24 ⏳ | JDBC regression-test | — | **转交用户**在本地跑 |
+| T25 ⏳ | ES regression-test | — | **转交用户**在本地跑 |
+| T26 ✅ | `ExternalMetaCacheInvalidator` 路由测试 | **新** `fe-core/src/test/java/.../connector/ExternalMetaCacheInvalidatorTest.java` | 5 个 @Test；`MockedStatic<Env>` + `mock(ExternalMetaCacheMgr)`；pin partition fallback & stats no-op |
+| T27 ✅ | converter 单测 | **新** `fe-core/src/test/java/.../connector/ddl/CreateTableInfoToConnectorRequestConverterTest.java` | 7 个 @Test；`mock(CreateTableInfo)` 绕开 18-arg ctor；4 partition style + 2 bucket + 列穿透 |
 
 ### 2. 验证
 
-- `mvn -pl fe-connector/fe-connector-api -am compile` → **BUILD SUCCESS**
-- `mvn -pl fe-core -am compile -Dmaven.build.cache.enabled=false` → **BUILD SUCCESS**（1 次因 unused import checkstyle 失败 → fix → green）
+- `tools/check-connector-imports.sh` 正/负冒烟测试通过
+- `mvn -pl fe-connector validate -Dmaven.build.cache.enabled=false` → **BUILD SUCCESS**（exec-maven-plugin 调起脚本）
+- `mvn -pl fe-core -am test -Dtest='FakeConnectorPluginTest,ExternalMetaCacheInvalidatorTest,CreateTableInfoToConnectorRequestConverterTest,ConnectorPluginManagerTest,ConnectorSessionImplTest' -DfailIfNoTests=false -Dmaven.build.cache.enabled=false` → **39/39 tests green**
 - `mvn -pl fe-core checkstyle:check` → **0 violations**
-- `mvn -pl fe-connector/fe-connector-jdbc,fe-connector/fe-connector-es -am compile` → **BUILD SUCCESS**（下游连接器零修改）
 
 ### 3. 文档同步（§5.1 五步纪律）
 
-- ✅ `tasks/P0-spi-foundation.md`：T13-T20 状态翻 ✅，新增 2026-05-24（夜 ②）日志条目（含 4 项 trade-off 说明）
-- ✅ `PROGRESS.md`：§一 P0 进度条 44% → 74%（20/27 任务）；§三 P0 表追加 T13-T20 行；§四加 2026-05-24（夜 ②）条目；§七 session 状态滚动
+- ✅ `tasks/P0-spi-foundation.md`：T21-T23, T26-T27 状态翻 ✅；T24-T25 owner 改 @用户；新增 2026-05-24（夜 ③）日志条目（含 4 项 trade-off 说明）；顶部验收清单 5 项翻 [x]
+- ✅ `PROGRESS.md`：§一 P0 进度条 74% → 93%；§三 P0 表追加批 2 7 行；§四加 2026-05-24（夜 ③）条目；§七 session 状态滚动
 - ✅ 本 HANDOFF.md 覆写
-- N/A `connectors/<name>.md`（本次工作不属任何具体连接器）
-- N/A `decisions-log.md` / `deviations-log.md`（trade-off 在 RFC 范围内，未升 DV——见下"开放问题"）
+- N/A `connectors/<name>.md`（本场不属任何具体连接器）
+- N/A `decisions-log.md` / `deviations-log.md`（trade-off 都在 RFC §15 范围内，未升 DV）
 
 ### 4. Commit（用户人工 review 通过后）
 
-- ✅ `[feat](connector) add P0 batch 1 SPI: CreateTableRequest + listPartitions (T13-T20)`（hash 见 `git log --oneline -3`）
-- 12 files changed：6 新文件（5 ddl POJO + 1 fe-core converter）+ 3 surgical edits（ConnectorTableOps / ConnectorPartitionInfo / PluginDrivenExternalCatalog）+ 3 plan-doc 更新
+- ✅ `[feat](connector) add P0 batch 2 gate + unit tests (T21-T23, T26-T27)`（hash 见 `git log --oneline -3`）
+- 9 files changed：1 个 pom edit（fe-connector）+ 5 个新文件（1 脚本 + 4 测试相关）+ 3 个 plan-doc 更新
 - 工作树 clean
 
 ---
 
 ## 🚧 本 session 进行中 / 未完成
 
-**无**。批 1 全部 8 项任务（T13-T20）+ 编译验证 + 文档同步 + commit 全部收尾。
+- **T24/T25**：JDBC + ES regression-test 转交用户在本地跑（containers / docker 在本地更稳）。任务状态保持 ⏳，owner 改为 @用户。完成后用户在 PROGRESS / tasks 上翻 ✅ 即可
+- **本 HANDOFF 在 commit 内**——内容写的是 post-commit 状态，与 batch 2 代码、plan-doc 更新一并 commit。不需要后续 amend
 
 ---
 
@@ -63,58 +63,57 @@
 
 继承上版认知不变。**本场新增**：
 
-1. **`ColumnDefinition.defaultValue` 没有 public getter**——字段是 private `Optional<DefaultValue>`，只有 `hasDefaultValue()`。converter 当前传 `null`，等 SPI 在 `ConnectorColumn` 上增加 typed default-value carrier 时再补。这是 SPI 设计层面的 follow-up，不是 fe-core 侧补丁。
-2. **`PartitionTableInfo` 的 partition style 判别**：discriminator 不是单字段，需要两步——
-   - `getPartitionType()` 等于 `LIST` / `RANGE` → Doris 自有风格
-   - `getPartitionType() == UNPARTITIONED` 但 `getPartitionList()` 非空 → 进一步看 expressions：全 `UnboundSlot` → IDENTITY（Hive 风格）；含 `UnboundFunction` → TRANSFORM（Iceberg 风格）
-3. **LIST/RANGE 的 `initialValues` 暂未下沉**——`PartitionDefinition` 子类（InPartition/LessThanPartition/FixedRangePartition/StepPartition）携带 nereids `Expression`，需要完整 analyzer 才能 flatten 到 `List<List<String>>`。目前 Iceberg/Hive 走 TRANSFORM/IDENTITY 路径不依赖此，先返回空 list 延迟到具体连接器需要时再补。
-4. **`DistributionDescriptor` 的 `bucketNum` 字段是 private 且无 public getter**——只能通过 `translateToCatalogStyle().getBuckets()` 间接读取。converter 已封装为 `readBucketNum()` 私有 helper，未来 DistributionDescriptor 加 getter 可一行替换。
-5. **`PluginDrivenExternalCatalog.createTable` 的返回值语义**：SPI 的 `createTable(session, request)` 是 void，不区分"已存在 + IF NOT EXISTS"与"新建"。当前 override 总返回 false（=新建）并写 edit log。这是保守选择——对 P0 forward-compat plumbing 够用；真正需要"存在判定"的连接器（P5/P6/P7）可扩展 SPI 返回 boolean。
-6. **bucket 算法名硬编码为 `"doris_default"` / `"doris_random"`**——RFC §4.2 列了 `hive_hash` / `iceberg_bucket` 等真实算法，但 Doris 内部 `DistributionDescriptor` 只携带 `isHash` 布尔。真实算法名由 Hive/Iceberg 连接器在自己的 metadata.createTable 里根据 properties 推导（P7/P6）。
-7. **fe-core 编译验证的 cwd 是 `fe/`**，不是 workspace 根目录——`mvn -pl fe-core` 要从 `fe/` 跑。沿用上版认知。
+1. **maven-enforcer-plugin 不能原生 exec shell**——RFC §15.4 原文写"挂到 maven enforcer plugin"，但 enforcer 只有 `requireXxx` 系列 rule 和 `EvaluateBeanshell`，没有内置的 shell-exec rule。要么写 Java 自定义 Rule 类（重）要么走 `EvaluateBeanshell`（不直观）。**最终选择 `exec-maven-plugin`**——fe-common 已用它跑 make + protoc，零新依赖；脚本 non-zero exit 即触发 `BUILD FAILURE`，效果等价
+2. **`directory-maven-plugin` 的 `fe.dir` 属性在 `validate` 阶段还没 set**——它绑 `initialize` 阶段（晚于 validate）。第一次写 pom 用了 `${doris.home}/tools/...`（`doris.home=${fe.dir}/../`），结果路径解析为字面值 `${fe.dir}/..//tools/...`。改用 `${project.basedir}/../../tools/...`（fe-connector aggregator basedir → workspace root → tools）避开属性时序问题
+3. **exec-maven-plugin 在 aggregator pom 的继承默认是 `inherited=true`**——会让 11 个 fe-connector-* 子模块每次都重跑同一份扫描。本场设 `inherited=false`，只在 aggregator 自身 lifecycle 跑一次。Trade-off：dev 跑单个子模块 `mvn -pl fe-connector/fe-connector-iceberg compile` 时不会自动触发守门，但顶层 `mvn install` 必扫
+4. **`ConnectorMetaInvalidator` 的方法名是 `invalidateAll()` 不是 `invalidateCatalog()`**——第一稿测试写错卡了一次 test-compile。SPI 接口侧明确写 `invalidateAll`（"Invalidates the entire catalog's metadata caches"），fe-core 侧 `ExternalMetaCacheInvalidator.invalidateAll() → mgr.invalidateCatalog(catalogId)` 这才是路由
+5. **`Mockito.mockStatic(Env.class)`** 模式在 fe-core 已有先例（`BDBDebuggerTest:115`），mockito-inline 是 fe 顶层 pom 已声明的 test dep，新测试可以直接用，无需修改任何 pom
+6. **`Mockito.mock(CreateTableInfo.class)`** 比真正构造 18-arg `CreateTableInfo` 更便捷——converter 只读 8 个 getter，全部 stub 即可。如未来 converter 用到更多 getter，在 `stubInfo` helper 加新 stub
+7. **`mvn -pl fe-core test` 不带 `-am` 失败**（缺 fe-grpc / fe-filesystem-* 等本地未 install 的 SNAPSHOT）。本场所有 fe-core 测试运行都用 `mvn -pl fe-core -am test -Dtest=... -DfailIfNoTests=false -Dmaven.build.cache.enabled=false`。`-DfailIfNoTests=false` 是必须的——`-am` 会带上 fe-foundation 等 upstream，它们没有匹配 `-Dtest=` 的测试就会爆 surefire 错
+8. **fe-connector 模块当前 import 现状**：`grep -rEn "^import org\.apache\.doris\." fe/fe-connector/*/src/main/java | awk` → 仅 4 个根包 `connector / extension / thrift / trinoconnector`。所有禁词包（catalog/common/datasource/qe/analysis/nereids/planner）都被守门，baseline 已经合规
 
 ---
 
 ## 🎯 下一个 session 第一件事
 
-### Track A 已收尾（batch 1 commit 已合入 catalog-spi-00）
-
-无需再开 Track A。新 session 直接进 Track B（批 2）。
-
-### Track B：P0 批 2（守门 + 测试，T21-T27）
+### Track A：等 T24/T25 收尾
 
 ```
-1. git branch --show-current  → 确认仍在 catalog-spi-00
-2. Read plan-doc/PROGRESS.md + plan-doc/HANDOFF.md（本文件）
-3. Read plan-doc/01-spi-extensions-rfc.md §15 (Testing) + §17 (Acceptance)
-4. T21: tools/check-connector-imports.sh —— 禁用 import 守门脚本（grep 禁词如 fe-core 包名出现在 fe-connector 模块内）
-5. T22: 在 fe-connector pom 接 maven-enforcer-plugin 调用 T21 脚本
-6. T23: FakeConnectorPlugin（fe-core test 包）—— 覆盖所有 default 行为路径（不实现任何 SPI 方法也应跑通基本 SHOW DATABASES / CREATE TABLE / listPartitions 调用，验证 fallback）
-7. T24-T25: JDBC + ES 全套 regression-test
-8. T26: ConnectorMetaInvalidator 路由测试（mock ExternalMetaCacheMgr）
-9. T27: CreateTableInfoToConnectorRequestConverter 单元测试（覆盖 IDENTITY / TRANSFORM / LIST / RANGE 四种 partition + hash/random bucket）
-10. 更新 tasks / PROGRESS / HANDOFF + commit
+1. 用户跑完 JDBC + ES regression-test 后
+2. tasks/P0-spi-foundation.md 把 T24/T25 翻 ✅
+3. PROGRESS.md 进度条 93% → 100%；状态 🚧 → ✅
+4. 写 P0 阶段收尾 commit（如果 T24/T25 有微调代码）
 ```
 
-预计 context 用量 ~55%（T23 FakeConnectorPlugin 与 T27 converter 单测较重；其余偏脚本/regression-driver）。
+### Track B：选 P0 末加项 vs 直接进 P1
 
-### Track C（可选，仅在 P0 全部收尾后）：批 2 同步评估开放问题 #1-#3
+- **选项 B1**：P0-T28 benchmark（R-006 缓解，1k catalog × `listTableNames` 性能基线）。原列入 P1，可前置到 P0 末加，让 P0 出阶段干净
+- **选项 B2**：直接进 P1（scan-node 收口 + 重复清理）。P0 既然 93% 接近收尾，T24/T25 跑完即关阶段
+- 推荐 B2（B1 在 P1 阶段开题更自然，benchmark 跟 scan-node 工作正好同期）
 
-如果在写 FakeConnectorPlugin / converter 单测过程中触发了"开放问题 #1 default 值 / #2 LIST initialValues / #3 createTable 返回值"中的实际需求，**走 DV 流程登记** 再调整 SPI，不要 silent edit。
+### ~~Track C：commit 批 2~~（已收尾）
+
+批 2 已合入 `catalog-spi-00`；无需再开 Track C。
 
 ---
 
 ## ⚠️ 开放问题 / 风险提示
 
-继承上版 6 项不变。**本场新增 / 更新**（删除了"未 commit"项；batch 1 commit 已收尾）：
+继承上版 7 项不变（删了"未 commit batch 1"项；增加本场 trade-off）：
 
-1. **`ColumnDefinition.defaultValue` 在 SPI 层缺位**：converter 当前传 null。是否在 `ConnectorColumn` 上加 typed default-value carrier？建议 P5/P6 Hive/Iceberg 真正用到 CREATE TABLE 时再评估——如必要可走 DV 流程。
-2. **LIST/RANGE `initialValues` flatten 缺位**：当前 converter 返回空。是否在 `PartitionDefinition` 上加 `toFlatValues(): List<List<String>>` helper？建议同上：P5 Paimon / P7 Hive 真正用到时再评估。
-3. **`PluginDrivenExternalCatalog.createTable` 返回值丢失"已存在"信息**：是否扩展 SPI `createTable(session, request)` 返回 boolean 或 `CreateTableResult`？建议留到 P5/P6/P7 连接器迁移时再决定——目前 forward-compat plumbing 不影响。
-4. **bucket 算法名占位**：`"doris_default"` / `"doris_random"`。Hive/Iceberg 连接器侧需在自己的 metadata.createTable 里根据 properties 推导真实算法。
-5. （沿用）Maven build cache 误导问题：所有 SPI 改动验证步骤强制加 `-Dmaven.build.cache.enabled=false` 或 `clean`；并且 `mvn -pl fe-core` 的 cwd 必须是 `fe/`，不是 workspace 根。
-6. （沿用）`PluginDrivenTransactionManager.begin(ConnectorTransaction)` 暂无 caller（P5/P6/P7 接通）。
-7. （沿用）`invalidatePartition` fallback 到 `invalidateTable`；`invalidateStatistics` no-op——P7 hive ACID 场景再评估。
+1. **守门挂 `exec-maven-plugin` 而非 `maven-enforcer-plugin`**：RFC §15.4 原文写后者。本场用前者（等价实现，0 新依赖）。是否在 RFC §15.4 加脚注说明这个偏差？**判断**：trade-off 在 RFC 范围内，不升 DV；若有 reviewer 强烈要求 enforcer 写 Java Rule 类再重做
+2. **守门 `inherited=false`**：dev 跑单连接器 `mvn -pl fe-connector/fe-connector-iceberg compile` 时不会触发。是否要改 `inherited=true`？**判断**：现状没人手动跑这条命令日常迭代，重复扫的成本（11 × ~50ms）也不大；如未来某个连接器开发体感差再改
+3. **`invalidatePartition` 测试 pin 当前 fallback**：一旦 SPI 在该方法签名上加 column 名携带能力，bridge 和测试必须同步更新。测试已留 inline comment 描述意图
+4. **`CreateTableInfo` 用 mock**：converter 改用 mock 之外的 getter 时，需在 `stubInfo` helper 加新 stub。Trade-off：测试更聚焦但代价是输入对象不"真实"
+5. **partition 风格的 IDENTITY vs TRANSFORM 判别**：测试覆盖了"全 UnboundSlot → IDENTITY"和"含 UnboundFunction → TRANSFORM"两路径，但没覆盖"UnboundSlot + UnboundFunction 混合"——按 converter 当前实现，只要有任意一个 UnboundFunction 就走 TRANSFORM 路径，UnboundSlot 在 `convertFields()` 里也会被识别为 `identity` transform。这个混合场景的语义是否符合预期？**判断**：RFC §4.2 未明确混合用法，留待 P5/P6 Iceberg 真正用到时评估
+6. （沿用）`ColumnDefinition.defaultValue` SPI 缺位
+7. （沿用）LIST/RANGE `initialValues` flatten 缺位
+8. （沿用）`PluginDrivenExternalCatalog.createTable` 返回值丢失"已存在"信息
+9. （沿用）bucket 算法名 `"doris_default"` / `"doris_random"` 占位
+10. （沿用）Maven build cache 误导问题；`mvn -pl fe-core` 必须 cwd=`fe/`
+11. （沿用）`PluginDrivenTransactionManager.begin(ConnectorTransaction)` 暂无 caller
+12. （沿用）`invalidatePartition` fallback；`invalidateStatistics` no-op
+13. （沿用，本场强化）**`mvn -pl fe-core test` 不带 `-am` 失败**：必须 `-am -DfailIfNoTests=false`
 
 ---
 
@@ -123,18 +122,15 @@
 ### 本场新增 / 修改（已 commit）
 
 ```
-NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorCreateTableRequest.java
-NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionSpec.java
-NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionField.java
-NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorPartitionValueDef.java
-NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ddl/ConnectorBucketSpec.java
-NEW  fe/fe-core/src/main/java/org/apache/doris/connector/ddl/CreateTableInfoToConnectorRequestConverter.java
-MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorTableOps.java
-MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorPartitionInfo.java
-MOD  fe/fe-core/src/main/java/org/apache/doris/datasource/PluginDrivenExternalCatalog.java
+NEW  tools/check-connector-imports.sh                                            (gate script)
+MOD  fe/fe-connector/pom.xml                                                     (exec-maven-plugin)
+NEW  fe/fe-core/src/test/java/org/apache/doris/connector/fake/FakeConnectorPlugin.java
+NEW  fe/fe-core/src/test/java/org/apache/doris/connector/fake/FakeConnectorPluginTest.java        (11 tests)
+NEW  fe/fe-core/src/test/java/org/apache/doris/connector/ExternalMetaCacheInvalidatorTest.java    (5 tests)
+NEW  fe/fe-core/src/test/java/org/apache/doris/connector/ddl/CreateTableInfoToConnectorRequestConverterTest.java  (7 tests)
 MOD  plan-doc/PROGRESS.md
 MOD  plan-doc/tasks/P0-spi-foundation.md
-MOD  plan-doc/HANDOFF.md（本文件——post-commit roll 通过 git amend 与 batch 1 同 commit 落盘）
+MOD  plan-doc/HANDOFF.md（本文件）
 ```
 
 ### 跟踪体系（沿用不变）
@@ -152,11 +148,11 @@ plan-doc/  (~225K, 17 文件)
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- **当前分支是 `catalog-spi-00`**。新 session 开场 `git branch --show-current` 确认。
-- **批 1（T13-T20）已合入 `catalog-spi-00`**（subject `[feat](connector) add P0 batch 1 SPI: CreateTableRequest + listPartitions (T13-T20)`），无需 review 老代码；直接读最新源即可。如果对 6 个新/改文件有调整建议，走 DV 流程登记后再改，不要 silent edit。
-- **Maven build 的 cwd 必须是 `fe/`**，不是 workspace 根。`mvn -pl fe-core -am compile` 从根目录跑会报"Could not find the selected project in the reactor"。
-- 本场无 RFC 修改、无新 decision / deviation——所有 trade-off 都在 RFC §4 / §13 设计范围内，由代码注释 + 本 HANDOFF "开放问题" 列出。沿用 meta 建议 "不要重新打开 D-001..D-018"。
-- **本场对 `CreateTableInfoToConnectorRequestConverter` 的写法值得参考**：先 `convert(info, dbName)` 顶层 → 4 个 private helper（convertColumns/convertPartition/convertBucket/convertField + convertTransformField）。Helper 之间互相不调用、各自处理一种维度，方便后续 T27 单测分别覆盖。
-- **必读 AGENT-PLAYBOOK §六 anti-patterns** 再开始动手。
-- 本场用 Explore subagent 调研了 nereids `CreateTableInfo` / `ColumnDefinition` / `PartitionTableInfo` / `DistributionDescriptor` 4 个文件，把整源代码读取摊到 subagent，节省主 context（CreateTableInfo 单文件 1714 行）——批 2 如果要写 FakeConnectorPlugin 也建议同样套路。
-- **本 HANDOFF roll 已通过 git amend 与 batch 1 代码同 commit 落盘**（HANDOFF 不内嵌 commit hash——hash 在 amend 后会变；用 `git log --oneline -3` 或 `git log --grep="P0 batch 1"` 即可定位）。下一个 session 不需要再处理 HANDOFF 落盘。
+- **当前分支是 `catalog-spi-00`**。新 session 开场 `git branch --show-current` 确认
+- **批 2（T21-T23, T26-T27）已合入 `catalog-spi-00`**（subject `[feat](connector) add P0 batch 2 gate + unit tests (T21-T23, T26-T27)`），无需 review 老代码；直接读最新源即可。如果对 6 个新/改文件有调整建议，走 DV 流程登记后再改，不要 silent edit
+- **T24/T25 owner 是用户**，不要自己尝试跑 docker regression-test
+- **Maven build 的 cwd 必须是 `fe/`**，不是 workspace 根；`mvn -pl fe-core` 需要 `-am`；运行 `-Dtest=` 时务必带 `-DfailIfNoTests=false`，否则 upstream 模块（fe-foundation 等）找不到匹配 test 会爆 surefire 错
+- 本场没产生新 decision / deviation——所有 trade-off 在 RFC §15 范围内，由代码注释 + 本 HANDOFF "开放问题" 列出
+- 本场用 `Mockito.mockStatic` + `Mockito.mock(CreateTableInfo)` 两个套路绕开了重度 fe-core bootstrap——批 1 的 `CreateTableInfoToConnectorRequestConverter` 同样可以这样测，套路通用。后续 P1/P2 写 unit-test 可以复用
+- **必读 AGENT-PLAYBOOK §六 anti-patterns** 再开始动手
+- **本 HANDOFF 不内嵌 commit hash**——hash 通过 `git log --grep="P0 batch 2"` 或 `git log --oneline -3` 定位。本场无 amend，HANDOFF 与代码同 commit 落盘

--- a/plan-doc/HANDOFF.md
+++ b/plan-doc/HANDOFF.md
@@ -8,124 +8,117 @@
 
 ## 📅 最后一次 handoff
 
-- **日期 / 时间**：2026-05-24（晚）
+- **日期 / 时间**：2026-05-24（深夜）
 - **本 session 主导者**：Claude Opus 4.7（1M context）
-- **本 session 主题**：P0 批 0 SPI 接口三件套实现（E3 MetaInvalidator + E4 Transaction + E5 MvccSnapshot）
-- **预估 context 使用**：~50%（健康范围；§7.2 "代码实现 session" 模板预算 60%）
+- **本 session 主题**：P0 批 0 fe-core 桥接（T09-T12）—— 把新 SPI 接通到现有 fe-core 实现
+- **预估 context 使用**：~40%（健康范围）
 
 ---
 
 ## ✅ 本 session 完成项
 
-### 1. P0-T02 闭环（doc 维护）
-
-上一 session 完成 17 文件跟踪机制并已 commit `63159837043`，但 `tasks/P0-spi-foundation.md` 中 P0-T02 仍是 🚧。**本场 session 翻状态为 ✅** —— 一处文档/§5.1 同步纪律的修复，无代码改动。
-
-### 2. P0 批 0：SPI 接口三件套（T03–T08）
+### 1. P0 批 0：fe-core 桥接（T09-T12）
 
 | ID | 任务 | 文件 | 备注 |
 |---|---|---|---|
-| T03 ✅ | E3 `ConnectorMetaInvalidator` 接口 | **新** `fe-connector-spi/.../spi/ConnectorMetaInvalidator.java` | 5 个 invalidate default + `NOOP` 常量；放 spi 包以便 `ConnectorContext` 引用 |
-| T04 ✅ | `ConnectorContext.getMetaInvalidator()` default | edit `fe-connector-spi/.../spi/ConnectorContext.java` | 返回 `ConnectorMetaInvalidator.NOOP` |
-| T05 ✅ | `ConnectorTransaction` 接口 | **新** `fe-connector-api/.../api/handle/ConnectorTransaction.java` | `extends ConnectorTransactionHandle, Closeable`；保留旧 24 行 marker 不破坏现有引用 |
-| T06 ✅ | `ConnectorWriteOps.beginTransaction` default | edit `fe-connector-api/.../api/ConnectorWriteOps.java` | 默认抛 `DorisConnectorException("Transactions not supported")` |
-| T07 ✅ | `ConnectorSession.getCurrentTransaction` default | edit `fe-connector-api/.../api/ConnectorSession.java` | 默认 `Optional.empty()` |
-| T08 ✅ | `ConnectorMvccSnapshot` 类型 + 3 default 方法 | **新** `fe-connector-api/.../api/mvcc/ConnectorMvccSnapshot.java` + edit `fe-connector-api/.../api/ConnectorMetadata.java` | final value class + Builder；3 default：`beginQuerySnapshot` / `getSnapshotAt` / `getSnapshotById` 全返回 `Optional.empty()` |
+| T09 ✅ | `DefaultConnectorContext.getMetaInvalidator()` override | edit `fe-core/.../connector/DefaultConnectorContext.java` | 返回 `new ExternalMetaCacheInvalidator(catalogId)` |
+| T10 ✅ | `ExternalMetaCacheInvalidator`（fe-core 新类）| **新** `fe-core/.../connector/ExternalMetaCacheInvalidator.java` | 3 个方法直接代理 `ExternalMetaCacheMgr.invalidateCatalog/Db/Table`；`invalidatePartition` 暂回退到 `invalidateTable`；`invalidateStatistics` 暂 no-op |
+| T11 ✅ | `PluginDrivenTransactionManager` 通用化 | edit `fe-core/.../transaction/PluginDrivenTransactionManager.java` | 新增 `begin(ConnectorTransaction)` 重载 + inner class 加 nullable `connectorTx` 字段，承接 SPI tx commit/rollback/close；legacy `long begin()` 路径行为完全不变 → JDBC/ES auto-commit 零回归 |
+| T12 ✅ | `ConnectorMvccSnapshotAdapter`（fe-core 新类）| **新** `fe-core/.../connector/ConnectorMvccSnapshotAdapter.java` | 包装 `ConnectorMvccSnapshot` + implements `MvccSnapshot`（marker 接口） |
 
-### 3. 验证
+### 2. 验证
 
-- `mvn -pl fe-connector/fe-connector-api,spi -am clean compile -DskipTests` → **BUILD SUCCESS**（4 spi 源文件、checkstyle 0 violations）
-- `mvn -pl fe-connector/fe-connector-jdbc,fe-connector-es -am compile` → **BUILD SUCCESS**（26 JDBC 源 + ES 全编译，零下游修改）
-- 即 P0 验收清单中 **「JDBC、ES 现有 compile 通过」基线成立**（regression test 留 P0-T24/T25 单独验）
+- `mvn -pl fe-core -am compile -Dmaven.build.cache.enabled=false` → **BUILD SUCCESS**
+- `mvn -pl fe-core checkstyle:check` → **0 violations**
+- `mvn -pl fe-connector/fe-connector-jdbc,fe-connector-es -am compile` → **BUILD SUCCESS**（下游 connector 零影响）
 
-### 4. 文档同步（§5.1 五步纪律）
+### 3. 文档同步（§5.1 五步纪律）
 
-- ✅ `tasks/P0-spi-foundation.md`：T02-T08 状态翻 ✅，新增 2026-05-24（晚）日志条目
-- ✅ `PROGRESS.md`：§一 P0 进度条 10% → 30%；§三 P0 表更新；§四加 2026-05-24（晚）条目；§七 session 状态滚动
+- ✅ `tasks/P0-spi-foundation.md`：T09-T12 状态翻 ✅，新增 2026-05-24（深夜）日志条目
+- ✅ `PROGRESS.md`：§一 P0 进度条 30% → 44%（12/27 任务）；§三 P0 表更新；§四加 2026-05-24（深夜）条目；§七 session 状态滚动
 - ✅ 本 HANDOFF.md 覆写
 - N/A `connectors/<name>.md`（本次工作不属任何具体连接器）
-- N/A `decisions-log.md` / `deviations-log.md`（本次完全遵循 RFC §6/§7/§8，未产生新决策或偏差）
+- N/A `decisions-log.md` / `deviations-log.md`（本次完全遵循 RFC §6.4 / §7.4 / §8.4，未产生新决策或偏差）
 
 ---
 
 ## 🚧 本 session 进行中 / 未完成
 
-**无**。批 0 SPI 接口 + 编译验证 + 文档同步全部收尾。
+**无**。批 0 全部 10 项任务（T03-T12）+ 编译验证 + 文档同步全部收尾。
 
 ---
 
 ## 📝 关键认知 / 临时发现
 
-继承上版 HANDOFF 7 条认知不变。**本场新增**：
+继承上版 HANDOFF 认知不变。**本场新增**：
 
-1. **`fe-connector-spi` 模块 `pom.xml` 已依赖 `fe-connector-api`** —— `ConnectorContext.java` 早就 import `org.apache.doris.connector.api.ConnectorHttpSecurityHook`，所以 spi → api 方向可用。`ConnectorMetaInvalidator` 放 spi 包没有循环依赖问题。
-2. **`ConnectorTransactionHandle` 与 `ConnectorTransaction` 共存策略验证可行** —— 旧 24 行 marker 保留；`ConnectorTransaction extends ConnectorTransactionHandle` 让现有所有 `*Handle` 占位代码（fe-core / fe-connector 中）无须修改即可继续编译。这条与 HANDOFF 旧认知 #4 一致，本场实操确认。
-3. **Maven `build-cache-extension` 默认会按 checksum 复用 jar，可能导致"看似 BUILD SUCCESS 但实际没编译我的新源文件"** —— 验证编译时必须加 `-Dmaven.build.cache.enabled=false` 或显式 `clean`，否则会看到 `Skipping plugin execution (cached): compiler:compile` 误导。**这条要进 PLAYBOOK** —— 见下方"开放问题 #1"。
-4. **`ConnectorMvccSnapshot` 用 Builder 模式** —— RFC §8.2 写的 "builder + getters" 我做成了 final class + 静态嵌套 `Builder`，符合 immutable value 类惯例。Map 用 `Collections.unmodifiableMap(new HashMap<>(...))` 拷贝。
-5. **`ConnectorMetadata` 上的 3 个 MVCC default 方法**直接放在 `ConnectorMetadata` 自己（不放在子接口）——因为它们是横切关注，且 RFC §8.3 明确放这里。
+1. **`ConnectorMetaInvalidator.invalidatePartition(values)` 与 fe-core `ExternalMetaCacheMgr.invalidatePartitions(names)` 语义不对齐**——SPI 给的是 partition column VALUES（如 `["2024", "01"]`），engine 缓存按 partition NAMES（如 `"year=2024/month=01"`）键控。重构 partition name 需要 partition column names，SPI 目前没带。**本场决策**：fallback 到 `invalidateTable`（正确但过粗），等 SPI 后续补 partition column metadata 时再做精确路由。**待评估是否走 DV 流程**——目前是 RFC §6.4 的实现 trade-off 而非偏差，先列为开放问题。
+2. **`ConnectorMetaInvalidator.invalidateStatistics(db, t)` 当前 no-op**——SPI 契约要求"不能 drop schema cache"，但 fe-core `ExternalMetaCacheMgr` 没有 per-table stats-only invalidation 入口（`ExternalRowCountCache` 按 id 键控，与 SPI 的 name-based 调用不匹配）。先 no-op + 注释解释；待 P7 hive ACID 统计场景出现时再补。
+3. **`PluginDrivenTransactionManager` 通用化策略**——RFC §7.4 的设计示例（`ConnectorTransaction begin(Connector, ConnectorSession)`）与现有 `TransactionManager.begin() -> long` 接口签名冲突。**本场决策**：surgical 路径——保留 legacy `long begin()`（JDBC/ES auto-commit 必需），新增 `long begin(ConnectorTransaction)` 重载。inner class 加 nullable `connectorTx` 字段。无 caller 现在调用新方法（是 forward-compat plumbing，等 P5/P6/P7 连接器迁移时接通）。
+4. **`MvccSnapshot` 是 marker 接口**（fe-core 侧），所以 `ConnectorMvccSnapshotAdapter` 极简——只一个 `getSnapshot()` 暴露 SPI 类型。Iceberg / Paimon / Hudi 各自的 `*MvccSnapshot` 实现也都只是 wrapper。
+5. **跨模块依赖方向重新确认**：`fe-core` → `fe-connector-api`（imports `org.apache.doris.connector.api.*`）；`fe-core` → `fe-connector-spi`（imports `org.apache.doris.connector.spi.*`）。**无循环**。本场 `ExternalMetaCacheInvalidator` 放 fe-core 是对的（因为它要 import `Env` + `ExternalMetaCacheMgr`，反向是禁止的）。
 
 ---
 
 ## 🎯 下一个 session 第一件事
 
-### 强烈建议先 review 再继续
+### 强烈建议先 review 本场 4 文件改动再开始 P0-T13+
 
-`tasks/P0-spi-foundation.md` 注意事项 #1：**「批 0 三个 SPI 是后续所有连接器迁移的 baseline。一旦合入主线，每个连接器都开始用，调整成本急剧上升。先在批 0 完成后让用户 review，再开始批 1。」**
+理由：T09-T12 是"SPI ↔ fe-core 互通"的实际胶水层。错了影响范围是 P0 之后所有连接器（每个都会读这层桥接）。
 
-→ 新 session 第一步：用户人工/agent 评审本次 6 个文件（3 新 + 3 改）。如有调整建议，走 DV 流程登记。
+→ 新 session 第一步：用户人工/agent 评审本场 4 文件：
+- `fe-core/.../connector/ExternalMetaCacheInvalidator.java` (新)
+- `fe-core/.../connector/ConnectorMvccSnapshotAdapter.java` (新)
+- `fe-core/.../connector/DefaultConnectorContext.java` (edit)
+- `fe-core/.../transaction/PluginDrivenTransactionManager.java` (edit)
 
-### Track A（review 后推荐）：本次批 SPI 接口先 commit
+如有调整建议，走 DV 流程登记（特别是上面"关键认知 #1"的 `invalidatePartition` trade-off 是否要做精确路由）。
+
+### Track A：本场 4 文件 commit
 
 ```
 1. cd /Users/morningman/workspace/git/wt-fs-spi
 2. git status
-3. git add fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/handle/ConnectorTransaction.java \
-           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/mvcc/ \
-           fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorMetaInvalidator.java \
-           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorMetadata.java \
-           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorSession.java \
-           fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorWriteOps.java \
-           fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java \
+3. git add fe/fe-core/src/main/java/org/apache/doris/connector/ExternalMetaCacheInvalidator.java \
+           fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorMvccSnapshotAdapter.java \
+           fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java \
+           fe/fe-core/src/main/java/org/apache/doris/transaction/PluginDrivenTransactionManager.java \
            plan-doc/PROGRESS.md plan-doc/HANDOFF.md plan-doc/tasks/P0-spi-foundation.md
-4. git commit -m "[P0-T03..T08][spi] add MetaInvalidator/Transaction/MvccSnapshot baseline"
+4. git commit -m "[P0-T09..T12][fe-core] wire MetaInvalidator / Transaction / MvccSnapshot into fe-core"
 ```
 
-### Track B：fe-core 桥接（P0-T09..T12）
+### Track B：P0 批 1（DDL + Partition SPI，T13-T20）
 
-只在 Track A commit 后启动：
+仅在 Track A commit + review 后启动：
 
 ```
 1. Read plan-doc/PROGRESS.md + plan-doc/HANDOFF.md
-2. Read plan-doc/01-spi-extensions-rfc.md §6.4 / §7.4 / §8.4
-3. 找到现有 fe-core 类：
-   - DefaultConnectorContext（实现 ConnectorContext）
-   - ExternalMetaCacheMgr（被包装目标）
-   - PluginDrivenTransactionManager（要通用化）
-   - MvccSnapshot 接口（fe-core 侧）
-4. 实现：
-   - DefaultConnectorContext.getMetaInvalidator() override → new ExternalMetaCacheInvalidator(catalogId)
-   - ExternalMetaCacheInvalidator (fe-core 新类) 包装 ExternalMetaCacheMgr 的 5 个 invalidate*
-   - PluginDrivenTransactionManager 删 type-specific 分支，改用 ConnectorTransaction map
-   - ConnectorMvccSnapshotAdapter (fe-core 新类) implements MvccSnapshot
-5. mvn -pl fe-core -am compile（注意 fe-core 体量，预估 2-3 分钟）
-6. 跑 JDBC 简单测试验证回归
-7. 更新 tasks / PROGRESS / HANDOFF
+2. Read plan-doc/01-spi-extensions-rfc.md §4 (E1 CreateTableRequest) + §13 (E10 listPartitions)
+3. 新增 8 个任务（T13-T20）：
+   - T13: `ConnectorCreateTableRequest` + Partition/Bucket Spec POJO（5 个类）放 ddl 包
+   - T14: `ConnectorTableOps.createTable(request)` default → 退化到旧 createTable
+   - T15: `CreateTableInfoToConnectorRequestConverter`（fe-core 新类）
+   - T16: `PluginDrivenExternalCatalog.createTable(stmt)` 接通 SPI
+   - T17-T19: `ConnectorTableOps.listPartitionNames / listPartitions / listPartitionValues` default
+   - T20: `ConnectorPartitionInfo` 追加字段（rowCount/sizeBytes/lastModifiedMillis）+ 向后兼容构造器
+4. mvn -pl fe-connector -am compile + JDBC/ES 回归
+5. 更新 tasks / PROGRESS / HANDOFF
 ```
 
-预计 context 用量 ~70%（fe-core 体量大，会涉及多文件读）。**如果上手就觉得读 ExternalMetaCacheMgr / PluginDrivenTransactionManager 单文件超过 800 行，先 grep 定位再 offset+limit 精读**（PLAYBOOK §2.3 #1）。
+预计 context 用量 ~50-60%（批 1 主要在 fe-connector-api 侧，文件相对独立）。
 
 ---
 
 ## ⚠️ 开放问题 / 风险提示
 
-1. **Maven build cache 误导问题**（本场新发现）：默认开启的 `build-cache-extension` 会按 input checksum 复用 jar，可能产生 "BUILD SUCCESS 但实际没编译"。建议：
-   - **短期**：所有 SPI 改动验证步骤强制加 `-Dmaven.build.cache.enabled=false` 或 `clean`
-   - **长期**：在 `AGENT-PLAYBOOK.md` §五新加一条纪律 / 在 P0-T22（maven enforcer 接入）任务中评估是否禁掉 cache 用于 CI
-   - 暂未走 DV 登记（不是 RFC 偏差，是工具链 finding）；若决定写 PLAYBOOK 改动，走 DV 流程。
-2. **本次 6 文件改动尚未 commit**（同上一 session 模式）—— 见 Track A。
-3. **`PluginDrivenTransactionManager` 通用化（P0-T11）需要回归测试保证 JDBC auto-commit 不退化** —— 已在 tasks/P0 注意事项 #2 标注；下一 session 实操时务必跑 JDBC regression。
-4. **`ConnectorMvccSnapshot` 的 `properties` Map 是否需要类型化字段**（如 Iceberg 用 `manifest-list-location`、`schema-id`）—— 暂用 `Map<String, String>` 通用承接，待 Iceberg/Paimon 接入时（P5/P6）发现具体需求再补强类型 / 走 DV。
-5. **`getCurrentTransaction()` default 的 fe-core 侧填充逻辑**（RFC §7.6 末："fe-core 用 `ConnectorSessionImpl` 在事务期间填入"）—— 留到 P0-T11 同步实现。
+继承上版 5 项不变。**本场新增 / 更新**：
+
+1. **`invalidatePartition` 的 SPI 设计 trade-off**（新）：当前 fallback 到 `invalidateTable`。是否要给 SPI `ConnectorMetaInvalidator.invalidatePartition` 加 `List<String> partitionColumnNames` 参数？若加，则 fe-core adapter 能精确路由到 `mgr.invalidatePartitions(...)`。**先收集 Hive/Iceberg 实际使用频率再决定**（P7 评估），目前的过粗 invalidation 在正确性上无问题，只是缓存命中率会差。
+2. **`invalidateStatistics` no-op**（新）：fe-core `ExternalMetaCacheMgr` 缺 stats-only invalidation 入口。**可能需要**在 P7 hive ACID 写路径完工时补一个 `mgr.invalidateTableStats(catalogId, db, t)` 方法。**记到 R-014 之后**作为新风险？暂不加，先 no-op + 注释，等具体场景出现。
+3. **Maven build cache 误导问题**（沿用上版）：所有 SPI 改动验证步骤强制加 `-Dmaven.build.cache.enabled=false` 或 `clean`。
+4. **本次 7 文件改动尚未 commit**——见 Track A。
+5. **`PluginDrivenTransactionManager.begin(ConnectorTransaction)` 暂无 caller**（forward-compat plumbing）。当 P5/P6/P7 连接器开始实现 `ConnectorWriteOps.beginTransaction` 时，`BaseExternalTableInsertExecutor`（或同等位置）需要改为 if-else：连接器实现了 → 调新方法；否则 → 走 legacy `begin()`。**这一步留在 P5/P6/P7**，不在 P0 范围。
+6. （沿用）`PluginDrivenTransactionManager` 通用化对 JDBC auto-commit 的回归——本场已通过 fe-connector-jdbc clean compile 验证语法层无回归；**行为层回归留 P0-T24 跑全套 JDBC regression test**。
 
 ---
 
@@ -134,19 +127,16 @@
 ### 本场新增 / 修改
 
 ```
-NEW  fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorMetaInvalidator.java
-NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/handle/ConnectorTransaction.java
-NEW  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/mvcc/ConnectorMvccSnapshot.java
-MOD  fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java
-MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorMetadata.java
-MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorSession.java
-MOD  fe/fe-connector/fe-connector-api/src/main/java/org/apache/doris/connector/api/ConnectorWriteOps.java
+NEW  fe/fe-core/src/main/java/org/apache/doris/connector/ExternalMetaCacheInvalidator.java
+NEW  fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorMvccSnapshotAdapter.java
+MOD  fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java
+MOD  fe/fe-core/src/main/java/org/apache/doris/transaction/PluginDrivenTransactionManager.java
 MOD  plan-doc/PROGRESS.md
 MOD  plan-doc/tasks/P0-spi-foundation.md
 MOD  plan-doc/HANDOFF.md（本文件）
 ```
 
-### 跟踪体系（上场建立，沿用不变）
+### 跟踪体系（沿用不变）
 
 ```
 plan-doc/  (~220K, 17 文件)
@@ -161,8 +151,9 @@ plan-doc/  (~220K, 17 文件)
 
 ## 🧠 给下一个 agent 的 meta 建议
 
-- **当前分支是 `catalog-spi-00`**（HANDOFF 历史版本写 `catalog-spi-2`，那是 git status 快照失准；本场 session 全程在 `catalog-spi-00` 上工作并验证）。新 session 开场 `git branch --show-current` 确认。
-- 接 Track B（fe-core 桥接）前**强烈建议人工 review 本场 6 文件改动**——这是后续所有连接器迁移的 baseline，错了影响面巨大。
-- 用户在 Q&A 中纠正过我"为什么只 T03/T04 不做完整批 0"——**说明用户读 task 文件比 HANDOFF 仔细，scope 判定以 tasks/Pn-*.md 为准，HANDOFF 只是建议起点**。下一 session 启动时不要再被 HANDOFF 的"下一个 session 第一件事"窄化思维误导，先看 tasks 文件确认完整 batch。
-- 本场没动 RFC 一个字，无新 decision / deviation。**沿用上版 meta 建议第 4 条："不要重新打开 D-001..D-018"**。
-- **必读 AGENT-PLAYBOOK §六 anti-patterns** 再开始动手（特别是 "把 RFC 当 PROGRESS 用" 和 "跨 session 凭记忆继续工作"）。
+- **当前分支是 `catalog-spi-00`**。新 session 开场 `git branch --show-current` 确认。
+- 接 Track B（批 1 DDL+Partition SPI）前**强烈建议人工 review 本场 4 文件改动**——它们是 SPI ↔ fe-core 胶水层，错了影响所有后续连接器。
+- 上版 meta 建议#3 仍然成立："scope 判定以 tasks/Pn-*.md 为准，HANDOFF 只是建议起点"。批 0 在 tasks 表中明确划分为"SPI 接口三件套（T03-T08）"+"fe-core 桥接（T09-T12）"两个子批，本场补完后者，整批 0 收尾。下一 session 进入批 1（T13-T20）。
+- 本场没动 RFC 一个字，无新 decision / deviation。沿用 meta 建议 "不要重新打开 D-001..D-018"。
+- **本场对 `PluginDrivenTransactionManager` 的改造方式是个值得学习的 surgical change 模板**：保持接口签名 + 加重载 + nullable 字段 + 文档化两条路径——避免了对 `TransactionManager` 接口、`BaseExternalTableInsertExecutor` 调用方、JDBC/ES auto-commit 的任何破坏。批 1+ 的迁移如果遇到类似"老路径不能动 / 新功能要加"的情况，可参照此 pattern。
+- **必读 AGENT-PLAYBOOK §六 anti-patterns** 再开始动手。

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-05-24** | 当前阶段：**P0 SPI 缺口补齐** | 项目总进度：**5%**
+> 最后更新：**2026-05-24（晚）** | 当前阶段：**P0 SPI 缺口补齐**（批 0 SPI 接口完成，待 fe-core 桥接） | 项目总进度：**8%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -9,7 +9,7 @@
 
 | 阶段 | 范围 | 估时 | 进度 | 状态 | 任务文档 |
 |---|---|---|---|---|---|
-| **P0** | SPI 缺口补齐 | 2 周 | ▰▱▱▱▱▱▱▱▱▱ 10% | 🚧 进行中（2026-05-24 启动） | [tasks/P0](./tasks/P0-spi-foundation.md) |
+| **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▱▱▱▱▱▱▱ 30% | 🚧 进行中（批 0 SPI 接口完成；待 fe-core 桥接 T09-T12） | [tasks/P0](./tasks/P0-spi-foundation.md) |
 | P1 | scan-node 收口 + 重复清理 | 1 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动（被 P0 阻塞）| — |
 | P2 | trino-connector 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P3 | hudi 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -48,17 +48,21 @@
 | ID | Task | Owner | 状态 | 启动 | 备注 |
 |---|---|---|---|---|---|
 | P0-T01 | RFC §16.2 决策点闭环 | @me | ✅ | 2026-05-24 | 全部 18 条决策已敲定 |
-| P0-T02 | 项目跟踪机制建立 | @me | 🚧 | 2026-05-24 | 本仪表盘 / README / decisions-log 等 |
-| P0-T03 | E3 实现：`ConnectorMetaInvalidator` 接口 | — | ⏳ | — | 批 0 / spi 包 |
-| P0-T04 | E4 实现：`ConnectorTransaction` 替换占位 | — | ⏳ | — | 批 0 / handle 包 |
-| P0-T05 | E5 实现：`ConnectorMvccSnapshot` 类型 | — | ⏳ | — | 批 0 / mvcc 包 |
-| P0-T06 | `ConnectorContext.getMetaInvalidator()` default | — | ⏳ | — | 批 0 |
-| P0-T07 | `DefaultConnectorContext` impl + fe-core invalidator | — | ⏳ | — | 批 0 |
-| P0-T08 | `PluginDrivenTransactionManager` 通用化 | — | ⏳ | — | 批 0 |
-| P0-T09 | E1 实现：DDL request POJO + converter | — | ⏳ | — | 批 1 |
-| P0-T10 | E10 实现：partition 列举 SPI | — | ⏳ | — | 批 1 |
-| P0-T11 | CI grep 守门 + maven enforcer | — | ⏳ | — | 批 1 |
-| P0-T12 | FakeConnectorPlugin + 回归测试 | — | ⏳ | — | 批 1 |
+| P0-T02 | 项目跟踪机制建立 | @me | ✅ | 2026-05-24 | commit 63159837043 |
+| P0-T03 | E3：`ConnectorMetaInvalidator` 接口 | @me | ✅ | 2026-05-24 | spi 包 / 5 invalidate 方法 |
+| P0-T04 | E3：`ConnectorContext.getMetaInvalidator()` default | @me | ✅ | 2026-05-24 | 返回 NOOP |
+| P0-T05 | E4：`ConnectorTransaction` 继承 `ConnectorTransactionHandle` | @me | ✅ | 2026-05-24 | 新增不替换 |
+| P0-T06 | E4：`ConnectorWriteOps.beginTransaction` default | @me | ✅ | 2026-05-24 | throws unsupported |
+| P0-T07 | E4：`ConnectorSession.getCurrentTransaction` default | @me | ✅ | 2026-05-24 | Optional.empty() |
+| P0-T08 | E5：`ConnectorMvccSnapshot` 类型 + 3 default 方法 | @me | ✅ | 2026-05-24 | mvcc 包 + ConnectorMetadata 3 default |
+| **批 0 fe-core 桥接（next session）** | | | | | |
+| P0-T09 | `DefaultConnectorContext.getMetaInvalidator()` impl | — | ⏳ | — | fe-core 侧 |
+| P0-T10 | `ExternalMetaCacheInvalidator`（fe-core 新类） | — | ⏳ | — | 包装 ExternalMetaCacheMgr |
+| P0-T11 | `PluginDrivenTransactionManager` 通用化 | — | ⏳ | — | 删 type-specific 分支 |
+| P0-T12 | `ConnectorMvccSnapshotAdapter`（fe-core 新类） | — | ⏳ | — | impl MvccSnapshot |
+| **批 1 DDL + Partition SPI** | | | | | |
+| P0-T13..T20 | E1 CreateTableRequest + E10 listPartitions | — | ⏳ | — | 见 tasks/P0 |
+| P0-T21..T27 | 守门脚本 + 回归测试 | — | ⏳ | — | 见 tasks/P0 |
 
 完整 P0 任务清单：[tasks/P0-spi-foundation.md](./tasks/P0-spi-foundation.md)
 
@@ -68,6 +72,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-05-24（晚）** ✅ **P0 批 0 SPI 接口三件套完成**（T03-T08）：`ConnectorMetaInvalidator`、`ConnectorTransaction`、`ConnectorMvccSnapshot` 共 3 个新类型 + 4 个 default 方法；JDBC/ES clean compile 通过，零下游修改
 - **2026-05-24** ✅ 项目跟踪机制建立（README、PROGRESS、decisions-log、deviations-log、risks、tasks/、connectors/、AGENT-PLAYBOOK、HANDOFF）
 - **2026-05-24** ✅ SPI RFC §16.2 6 个未决问题（U1-U6）全部决议（D-013..D-018）
 - **2026-05-24** ✅ SPI RFC v1 落地（[01-spi-extensions-rfc.md](./01-spi-extensions-rfc.md)）
@@ -108,9 +113,9 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：跟踪机制建立（README / PROGRESS / 各类 log / 模板）
-- **下一个 session 应做**：执行 P0 批 0 第一个 task（P0-T03 实现 `ConnectorMetaInvalidator`）
-- **是否需要 handoff**：当前 session 工作正在收尾，预计本次 session 结束时填写 [HANDOFF.md](./HANDOFF.md)
+- **本 session 已完成**：P0 批 0 SPI 接口三件套（T02 闭环 + T03..T08 实现），clean compile + 下游 connector 兼容性验证通过
+- **下一个 session 应做**：fe-core 侧桥接（P0-T09..T12）—— 把新 SPI 接通现有 fe-core 实现（`DefaultConnectorContext`、`ExternalMetaCacheInvalidator`、`PluginDrivenTransactionManager` 通用化、`ConnectorMvccSnapshotAdapter`）；**先让用户 review 本次 SPI 改动再开始**（见 tasks/P0 注意事项 #1）
+- **是否需要 handoff**：是，已写新 [HANDOFF.md](./HANDOFF.md)
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 
 ---

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-05-24（深夜）** | 当前阶段：**P0 SPI 缺口补齐**（批 0 完成，下一步批 1 DDL+Partition） | 项目总进度：**10%**
+> 最后更新：**2026-05-24（夜 ②）** | 当前阶段：**P0 SPI 缺口补齐**（批 0 + 批 1 完成，下一步批 2 守门 + 回归 T21-T27） | 项目总进度：**12%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -9,7 +9,7 @@
 
 | 阶段 | 范围 | 估时 | 进度 | 状态 | 任务文档 |
 |---|---|---|---|---|---|
-| **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▱▱▱▱▱▱ 44% | 🚧 进行中（批 0 完成 T03-T12；下一步批 1 DDL+Partition T13-T20） | [tasks/P0](./tasks/P0-spi-foundation.md) |
+| **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▱▱▱ 74% | 🚧 进行中（批 0 + 批 1 完成 T03-T20；下一步批 2 守门 + 回归 T21-T27） | [tasks/P0](./tasks/P0-spi-foundation.md) |
 | P1 | scan-node 收口 + 重复清理 | 1 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动（被 P0 阻塞）| — |
 | P2 | trino-connector 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P3 | hudi 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -19,7 +19,7 @@
 | P7 | hive (+HMS) 迁移 | 6 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P8 | 收尾清理 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 
-**全局进度：5%**（25 周计划中处于第 1 周）
+**全局进度：6%**（25 周计划中处于第 1 周）
 
 ---
 
@@ -60,7 +60,14 @@
 | P0-T11 | `PluginDrivenTransactionManager` 通用化 | @me | ✅ | 2026-05-24 | 新增 `begin(ConnectorTransaction)` 重载；legacy 不变 |
 | P0-T12 | `ConnectorMvccSnapshotAdapter`（fe-core 新类） | @me | ✅ | 2026-05-24 | impl `MvccSnapshot` |
 | **批 1 DDL + Partition SPI** | | | | | |
-| P0-T13..T20 | E1 CreateTableRequest + E10 listPartitions | — | ⏳ | — | 见 tasks/P0 |
+| P0-T13 | `ConnectorCreateTableRequest` + 4 spec POJO（ddl 包） | @me | ✅ | 2026-05-24 | 5 个新 final 类 |
+| P0-T14 | `ConnectorTableOps.createTable(request)` default | @me | ✅ | 2026-05-24 | 退化到 legacy createTable |
+| P0-T15 | `CreateTableInfoToConnectorRequestConverter`（fe-core） | @me | ✅ | 2026-05-24 | 覆盖 4 种 partition + hash/random bucket |
+| P0-T16 | `PluginDrivenExternalCatalog.createTable(stmt)` 接通 SPI | @me | ✅ | 2026-05-24 | override + edit log |
+| P0-T17 | `listPartitionNames` default | @me | ✅ | 2026-05-24 | emptyList |
+| P0-T18 | `listPartitions(handle, filter)` default | @me | ✅ | 2026-05-24 | filter 用 Optional&lt;ConnectorExpression&gt; |
+| P0-T19 | `listPartitionValues` default | @me | ✅ | 2026-05-24 | emptyList |
+| P0-T20 | `ConnectorPartitionInfo` 追加 rowCount/sizeBytes/lastModifiedMillis | @me | ✅ | 2026-05-24 | UNKNOWN=-1L；3-arg 委托到 6-arg |
 | P0-T21..T27 | 守门脚本 + 回归测试 | — | ⏳ | — | 见 tasks/P0 |
 
 完整 P0 任务清单：[tasks/P0-spi-foundation.md](./tasks/P0-spi-foundation.md)
@@ -71,6 +78,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-05-24（夜 ②）** ✅ **P0 批 1 DDL + Partition SPI 完成**（T13-T20）：新增 `connector.api.ddl` 包 5 个 POJO（CreateTableRequest + 4 spec）；`ConnectorTableOps` 加 4 个 default（createTable(request) + listPartitionNames/listPartitions/listPartitionValues）；`ConnectorPartitionInfo` 追加 rowCount/sizeBytes/lastModifiedMillis；fe-core 新 `CreateTableInfoToConnectorRequestConverter` 覆盖 IDENTITY/TRANSFORM/LIST/RANGE 四种 partition + hash/random bucket；`PluginDrivenExternalCatalog.createTable` 路由到 SPI；fe-core BUILD SUCCESS + checkstyle 0；JDBC/ES 下游 zero-impact
 - **2026-05-24（深夜）** ✅ **P0 批 0 fe-core 桥接完成**（T09-T12）：`ExternalMetaCacheInvalidator` + `ConnectorMvccSnapshotAdapter` 新类、`DefaultConnectorContext.getMetaInvalidator()` override、`PluginDrivenTransactionManager` 加 SPI `ConnectorTransaction` 重载（legacy auto-commit 不变）；fe-core 全编译通过 + checkstyle 0 violations；JDBC/ES 下游 zero-impact
 - **2026-05-24（晚）** ✅ **P0 批 0 SPI 接口三件套完成**（T03-T08）：`ConnectorMetaInvalidator`、`ConnectorTransaction`、`ConnectorMvccSnapshot` 共 3 个新类型 + 4 个 default 方法；JDBC/ES clean compile 通过，零下游修改
 - **2026-05-24** ✅ 项目跟踪机制建立（README、PROGRESS、decisions-log、deviations-log、risks、tasks/、connectors/、AGENT-PLAYBOOK、HANDOFF）
@@ -113,8 +121,8 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：P0 批 0 fe-core 桥接（T09-T12）—— 2 个新类（`ExternalMetaCacheInvalidator`、`ConnectorMvccSnapshotAdapter`）+ 2 个 surgical edits（`DefaultConnectorContext.getMetaInvalidator()` override、`PluginDrivenTransactionManager` 加 SPI `ConnectorTransaction` 重载）；fe-core clean compile + checkstyle 0；JDBC/ES 零回归
-- **下一个 session 应做**：批 1 DDL + Partition SPI（P0-T13..T20）—— `ConnectorCreateTableRequest` + `Partition/Bucket Spec` POJO、`ConnectorTableOps.createTable(request)` default、`CreateTableInfoToConnectorRequestConverter`（fe-core），以及 `listPartitionNames` / `listPartitions(handle, filter)` / `listPartitionValues` 三个 default 方法
+- **本 session 已完成**：P0 批 1 DDL + Partition SPI（T13-T20）—— 6 个新文件（5 ddl 包 POJO + 1 fe-core converter）+ 3 个 surgical edits（`ConnectorTableOps` 加 4 个 default、`ConnectorPartitionInfo` 加 3 字段、`PluginDrivenExternalCatalog` 加 createTable override）；fe-core BUILD SUCCESS + checkstyle 0；JDBC/ES 下游零回归
+- **下一个 session 应做**：批 2 守门 + 测试（P0-T21..T27）—— `tools/check-connector-imports.sh` 守门脚本 + maven enforcer 接入、`FakeConnectorPlugin` 覆盖所有 default 行为、JDBC/ES 全 regression-test、`ConnectorMetaInvalidator` 路由测试、`CreateTableInfoToConnectorRequestConverter` 单测（4 种 partition 风格 + bucket）
 - **是否需要 handoff**：是，已写新 [HANDOFF.md](./HANDOFF.md)
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-05-24（晚）** | 当前阶段：**P0 SPI 缺口补齐**（批 0 SPI 接口完成，待 fe-core 桥接） | 项目总进度：**8%**
+> 最后更新：**2026-05-24（深夜）** | 当前阶段：**P0 SPI 缺口补齐**（批 0 完成，下一步批 1 DDL+Partition） | 项目总进度：**10%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -9,7 +9,7 @@
 
 | 阶段 | 范围 | 估时 | 进度 | 状态 | 任务文档 |
 |---|---|---|---|---|---|
-| **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▱▱▱▱▱▱▱ 30% | 🚧 进行中（批 0 SPI 接口完成；待 fe-core 桥接 T09-T12） | [tasks/P0](./tasks/P0-spi-foundation.md) |
+| **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▱▱▱▱▱▱ 44% | 🚧 进行中（批 0 完成 T03-T12；下一步批 1 DDL+Partition T13-T20） | [tasks/P0](./tasks/P0-spi-foundation.md) |
 | P1 | scan-node 收口 + 重复清理 | 1 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动（被 P0 阻塞）| — |
 | P2 | trino-connector 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P3 | hudi 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -55,11 +55,10 @@
 | P0-T06 | E4：`ConnectorWriteOps.beginTransaction` default | @me | ✅ | 2026-05-24 | throws unsupported |
 | P0-T07 | E4：`ConnectorSession.getCurrentTransaction` default | @me | ✅ | 2026-05-24 | Optional.empty() |
 | P0-T08 | E5：`ConnectorMvccSnapshot` 类型 + 3 default 方法 | @me | ✅ | 2026-05-24 | mvcc 包 + ConnectorMetadata 3 default |
-| **批 0 fe-core 桥接（next session）** | | | | | |
-| P0-T09 | `DefaultConnectorContext.getMetaInvalidator()` impl | — | ⏳ | — | fe-core 侧 |
-| P0-T10 | `ExternalMetaCacheInvalidator`（fe-core 新类） | — | ⏳ | — | 包装 ExternalMetaCacheMgr |
-| P0-T11 | `PluginDrivenTransactionManager` 通用化 | — | ⏳ | — | 删 type-specific 分支 |
-| P0-T12 | `ConnectorMvccSnapshotAdapter`（fe-core 新类） | — | ⏳ | — | impl MvccSnapshot |
+| P0-T09 | `DefaultConnectorContext.getMetaInvalidator()` impl | @me | ✅ | 2026-05-24 | 返回新建 invalidator |
+| P0-T10 | `ExternalMetaCacheInvalidator`（fe-core 新类） | @me | ✅ | 2026-05-24 | 包装 `ExternalMetaCacheMgr`；2 个 no-op 限制留 TODO |
+| P0-T11 | `PluginDrivenTransactionManager` 通用化 | @me | ✅ | 2026-05-24 | 新增 `begin(ConnectorTransaction)` 重载；legacy 不变 |
+| P0-T12 | `ConnectorMvccSnapshotAdapter`（fe-core 新类） | @me | ✅ | 2026-05-24 | impl `MvccSnapshot` |
 | **批 1 DDL + Partition SPI** | | | | | |
 | P0-T13..T20 | E1 CreateTableRequest + E10 listPartitions | — | ⏳ | — | 见 tasks/P0 |
 | P0-T21..T27 | 守门脚本 + 回归测试 | — | ⏳ | — | 见 tasks/P0 |
@@ -72,6 +71,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-05-24（深夜）** ✅ **P0 批 0 fe-core 桥接完成**（T09-T12）：`ExternalMetaCacheInvalidator` + `ConnectorMvccSnapshotAdapter` 新类、`DefaultConnectorContext.getMetaInvalidator()` override、`PluginDrivenTransactionManager` 加 SPI `ConnectorTransaction` 重载（legacy auto-commit 不变）；fe-core 全编译通过 + checkstyle 0 violations；JDBC/ES 下游 zero-impact
 - **2026-05-24（晚）** ✅ **P0 批 0 SPI 接口三件套完成**（T03-T08）：`ConnectorMetaInvalidator`、`ConnectorTransaction`、`ConnectorMvccSnapshot` 共 3 个新类型 + 4 个 default 方法；JDBC/ES clean compile 通过，零下游修改
 - **2026-05-24** ✅ 项目跟踪机制建立（README、PROGRESS、decisions-log、deviations-log、risks、tasks/、connectors/、AGENT-PLAYBOOK、HANDOFF）
 - **2026-05-24** ✅ SPI RFC §16.2 6 个未决问题（U1-U6）全部决议（D-013..D-018）
@@ -113,8 +113,8 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：P0 批 0 SPI 接口三件套（T02 闭环 + T03..T08 实现），clean compile + 下游 connector 兼容性验证通过
-- **下一个 session 应做**：fe-core 侧桥接（P0-T09..T12）—— 把新 SPI 接通现有 fe-core 实现（`DefaultConnectorContext`、`ExternalMetaCacheInvalidator`、`PluginDrivenTransactionManager` 通用化、`ConnectorMvccSnapshotAdapter`）；**先让用户 review 本次 SPI 改动再开始**（见 tasks/P0 注意事项 #1）
+- **本 session 已完成**：P0 批 0 fe-core 桥接（T09-T12）—— 2 个新类（`ExternalMetaCacheInvalidator`、`ConnectorMvccSnapshotAdapter`）+ 2 个 surgical edits（`DefaultConnectorContext.getMetaInvalidator()` override、`PluginDrivenTransactionManager` 加 SPI `ConnectorTransaction` 重载）；fe-core clean compile + checkstyle 0；JDBC/ES 零回归
+- **下一个 session 应做**：批 1 DDL + Partition SPI（P0-T13..T20）—— `ConnectorCreateTableRequest` + `Partition/Bucket Spec` POJO、`ConnectorTableOps.createTable(request)` default、`CreateTableInfoToConnectorRequestConverter`（fe-core），以及 `listPartitionNames` / `listPartitions(handle, filter)` / `listPartitionValues` 三个 default 方法
 - **是否需要 handoff**：是，已写新 [HANDOFF.md](./HANDOFF.md)
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 

--- a/plan-doc/PROGRESS.md
+++ b/plan-doc/PROGRESS.md
@@ -1,6 +1,6 @@
 # 📊 项目进度仪表盘
 
-> 最后更新：**2026-05-24（夜 ②）** | 当前阶段：**P0 SPI 缺口补齐**（批 0 + 批 1 完成，下一步批 2 守门 + 回归 T21-T27） | 项目总进度：**12%**
+> 最后更新：**2026-05-24（夜 ③）** | 当前阶段：**P0 SPI 缺口补齐**（批 0 + 批 1 + 批 2 代码侧完成；待 T24-T25 用户跑 JDBC/ES regression-test） | 项目总进度：**13%**
 > [README](./README.md) · [Master Plan](./00-connector-migration-master-plan.md) · [SPI RFC](./01-spi-extensions-rfc.md) · [Decisions](./decisions-log.md) · [Deviations](./deviations-log.md) · [Risks](./risks.md) · [Agent Playbook](./AGENT-PLAYBOOK.md) · [Handoff](./HANDOFF.md)
 
 ---
@@ -9,7 +9,7 @@
 
 | 阶段 | 范围 | 估时 | 进度 | 状态 | 任务文档 |
 |---|---|---|---|---|---|
-| **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▱▱▱ 74% | 🚧 进行中（批 0 + 批 1 完成 T03-T20；下一步批 2 守门 + 回归 T21-T27） | [tasks/P0](./tasks/P0-spi-foundation.md) |
+| **P0** | SPI 缺口补齐 | 2 周 | ▰▰▰▰▰▰▰▰▰▱ 93% | 🚧 收尾（批 0 + 1 + 2 代码侧完成 T03-T23, T26-T27；T24-T25 用户在本地跑 regression-test） | [tasks/P0](./tasks/P0-spi-foundation.md) |
 | P1 | scan-node 收口 + 重复清理 | 1 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动（被 P0 阻塞）| — |
 | P2 | trino-connector 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P3 | hudi 迁移 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
@@ -19,7 +19,7 @@
 | P7 | hive (+HMS) 迁移 | 6 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 | P8 | 收尾清理 | 2 周 | ▱▱▱▱▱▱▱▱▱▱ 0% | ⏸ 待启动 | — |
 
-**全局进度：6%**（25 周计划中处于第 1 周）
+**全局进度：7%**（25 周计划中处于第 1 周末）
 
 ---
 
@@ -68,7 +68,14 @@
 | P0-T18 | `listPartitions(handle, filter)` default | @me | ✅ | 2026-05-24 | filter 用 Optional&lt;ConnectorExpression&gt; |
 | P0-T19 | `listPartitionValues` default | @me | ✅ | 2026-05-24 | emptyList |
 | P0-T20 | `ConnectorPartitionInfo` 追加 rowCount/sizeBytes/lastModifiedMillis | @me | ✅ | 2026-05-24 | UNKNOWN=-1L；3-arg 委托到 6-arg |
-| P0-T21..T27 | 守门脚本 + 回归测试 | — | ⏳ | — | 见 tasks/P0 |
+| **批 2 守门 + 测试** | | | | | |
+| P0-T21 | `tools/check-connector-imports.sh` 实现 | @me | ✅ | 2026-05-24 | grep 守门；正/负冒烟均通过 |
+| P0-T22 | exec-maven-plugin 接入脚本（fe-connector aggregator validate） | @me | ✅ | 2026-05-24 | `inherited=false`；RFC §15.4 等价实现 |
+| P0-T23 | `FakeConnectorPlugin` + 11 个 default 行为测试 | @me | ✅ | 2026-05-24 | 覆盖 Connector/Metadata/TableOps/WriteOps/Session/Context 全 default |
+| P0-T24 | JDBC regression-test 全套跑通 | @用户 | ⏳ | — | 用户在本地跑 |
+| P0-T25 | ES regression-test 全套跑通 | @用户 | ⏳ | — | 用户在本地跑 |
+| P0-T26 | `ConnectorMetaInvalidator` 路由测试 | @me | ✅ | 2026-05-24 | 5 个 @Test；MockedStatic&lt;Env&gt; |
+| P0-T27 | `CreateTableInfoToConnectorRequestConverter` 单元测试 | @me | ✅ | 2026-05-24 | 7 个 @Test；4 partition style + 2 bucket |
 
 完整 P0 任务清单：[tasks/P0-spi-foundation.md](./tasks/P0-spi-foundation.md)
 
@@ -78,6 +85,7 @@
 
 > 倒序，新内容置顶；超过 14 天的条目移除（git log 保留历史）。
 
+- **2026-05-24（夜 ③）** ✅ **P0 批 2 守门 + 单测完成**（T21-T23, T26-T27；T24-T25 用户跑）：新增 `tools/check-connector-imports.sh` grep 守门 + 通过 exec-maven-plugin 在 `fe-connector` aggregator validate 阶段调起（`inherited=false`）；新增 `FakeConnectorPlugin`（fe-core test）+ 23 个新 @Test 覆盖 11 个 default 路径 + ConnectorMetaInvalidator 5 个 routing + Converter 7 个（4 partition style × IDENTITY/TRANSFORM/LIST/RANGE + hash/random bucket + 列穿透）；39/39 tests green；checkstyle 0；JDBC/ES regression-test 转交用户在本地执行
 - **2026-05-24（夜 ②）** ✅ **P0 批 1 DDL + Partition SPI 完成**（T13-T20）：新增 `connector.api.ddl` 包 5 个 POJO（CreateTableRequest + 4 spec）；`ConnectorTableOps` 加 4 个 default（createTable(request) + listPartitionNames/listPartitions/listPartitionValues）；`ConnectorPartitionInfo` 追加 rowCount/sizeBytes/lastModifiedMillis；fe-core 新 `CreateTableInfoToConnectorRequestConverter` 覆盖 IDENTITY/TRANSFORM/LIST/RANGE 四种 partition + hash/random bucket；`PluginDrivenExternalCatalog.createTable` 路由到 SPI；fe-core BUILD SUCCESS + checkstyle 0；JDBC/ES 下游 zero-impact
 - **2026-05-24（深夜）** ✅ **P0 批 0 fe-core 桥接完成**（T09-T12）：`ExternalMetaCacheInvalidator` + `ConnectorMvccSnapshotAdapter` 新类、`DefaultConnectorContext.getMetaInvalidator()` override、`PluginDrivenTransactionManager` 加 SPI `ConnectorTransaction` 重载（legacy auto-commit 不变）；fe-core 全编译通过 + checkstyle 0 violations；JDBC/ES 下游 zero-impact
 - **2026-05-24（晚）** ✅ **P0 批 0 SPI 接口三件套完成**（T03-T08）：`ConnectorMetaInvalidator`、`ConnectorTransaction`、`ConnectorMvccSnapshot` 共 3 个新类型 + 4 个 default 方法；JDBC/ES clean compile 通过，零下游修改
@@ -121,8 +129,8 @@
 
 > 当本项目通过 Claude Code 这类 LLM agent 推进时，跟踪当前 session 状态、handoff 状况和 context 健康度。
 
-- **本 session 已完成**：P0 批 1 DDL + Partition SPI（T13-T20）—— 6 个新文件（5 ddl 包 POJO + 1 fe-core converter）+ 3 个 surgical edits（`ConnectorTableOps` 加 4 个 default、`ConnectorPartitionInfo` 加 3 字段、`PluginDrivenExternalCatalog` 加 createTable override）；fe-core BUILD SUCCESS + checkstyle 0；JDBC/ES 下游零回归
-- **下一个 session 应做**：批 2 守门 + 测试（P0-T21..T27）—— `tools/check-connector-imports.sh` 守门脚本 + maven enforcer 接入、`FakeConnectorPlugin` 覆盖所有 default 行为、JDBC/ES 全 regression-test、`ConnectorMetaInvalidator` 路由测试、`CreateTableInfoToConnectorRequestConverter` 单测（4 种 partition 风格 + bucket）
+- **本 session 已完成**：P0 批 2 守门 + 单测（T21-T23, T26-T27）—— 1 个新脚本（`tools/check-connector-imports.sh`）+ 1 个 fe-connector aggregator pom 加 exec-maven-plugin + 4 个 fe-core test 新文件（`FakeConnectorPlugin` + 3 个 *Test）；39/39 tests green；checkstyle 0；T24/T25 转交用户在本地跑 JDBC/ES regression-test
+- **下一个 session 应做**：等 T24/T25 用户跑完后翻 ✅ → P0 阶段全收尾 → 启动 P1（scan-node 收口）；或在等待期间开 P0-T28 benchmark（R-006 缓解，原列入 P1）作为 P0 末加项
 - **是否需要 handoff**：是，已写新 [HANDOFF.md](./HANDOFF.md)
 - **协作规范**：[AGENT-PLAYBOOK.md](./AGENT-PLAYBOOK.md)（context 预算、subagent 使用、handoff 触发条件）
 

--- a/plan-doc/tasks/P0-spi-foundation.md
+++ b/plan-doc/tasks/P0-spi-foundation.md
@@ -73,14 +73,14 @@
 
 | ID | 任务 | 设计参考 | Owner | 状态 | PR | 启动 | 完成 | 备注 |
 |---|---|---|---|---|---|---|---|---|
-| P0-T13 | E1：`ConnectorCreateTableRequest` + `Partition/Bucket Spec` POJO（ddl 包） | RFC §4.2 | — | ⏳ | — | — | — | 5 个类 |
-| P0-T14 | E1：`ConnectorTableOps.createTable(request)` default | RFC §4.3 | — | ⏳ | — | — | — | 退化到旧 createTable |
-| P0-T15 | E1：`CreateTableInfoToConnectorRequestConverter`（fe-core） | RFC §4.4 | — | ⏳ | — | — | — | |
-| P0-T16 | E1：`PluginDrivenExternalCatalog.createTable(stmt)` 接通 SPI | RFC §4.4 | — | ⏳ | — | — | — | |
-| P0-T17 | E10：`ConnectorTableOps.listPartitionNames` default | RFC §13.2 | — | ⏳ | — | — | — | |
-| P0-T18 | E10：`ConnectorTableOps.listPartitions(handle, filter)` default | RFC §13.2 | — | ⏳ | — | — | — | |
-| P0-T19 | E10：`ConnectorTableOps.listPartitionValues` default | RFC §13.2 | — | ⏳ | — | — | — | |
-| P0-T20 | E10：`ConnectorPartitionInfo` 追加字段（rowCount/sizeBytes/lastModifiedMillis） | RFC §13.3 | — | ⏳ | — | — | — | 向后兼容构造器 |
+| P0-T13 | E1：`ConnectorCreateTableRequest` + `Partition/Bucket Spec` POJO（ddl 包） | RFC §4.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 5 个类（Request + PartitionSpec/Field/ValueDef + BucketSpec） |
+| P0-T14 | E1：`ConnectorTableOps.createTable(request)` default | RFC §4.3 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 退化到旧 `createTable(schema, props)` |
+| P0-T15 | E1：`CreateTableInfoToConnectorRequestConverter`（fe-core） | RFC §4.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 覆盖 IDENTITY / TRANSFORM / LIST / RANGE 四种 partition + hash/random bucket |
+| P0-T16 | E1：`PluginDrivenExternalCatalog.createTable(stmt)` 接通 SPI | RFC §4.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | override `createTable(CreateTableInfo)`；包 DorisConnectorException → DdlException |
+| P0-T17 | E10：`ConnectorTableOps.listPartitionNames` default | RFC §13.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 返回 `Collections.emptyList()` |
+| P0-T18 | E10：`ConnectorTableOps.listPartitions(handle, filter)` default | RFC §13.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | filter 用 `Optional<ConnectorExpression>` |
+| P0-T19 | E10：`ConnectorTableOps.listPartitionValues` default | RFC §13.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 返回 `Collections.emptyList()` |
+| P0-T20 | E10：`ConnectorPartitionInfo` 追加字段（rowCount/sizeBytes/lastModifiedMillis） | RFC §13.3 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 3 个 long 字段（UNKNOWN=-1）；3-arg 构造器委托到 6-arg；equals/hashCode 更新 |
 
 ### 批 1：守门 + 测试（W1 D4-5）
 
@@ -97,6 +97,27 @@
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-05-24（夜 ②）— 批 1 DDL + Partition SPI 完成（T13-T20）
+
+- P0-T13 ✅：新增 `connector.api.ddl` 包 5 个 POJO：`ConnectorCreateTableRequest`（带 Builder）、`ConnectorPartitionSpec`（Style enum：IDENTITY/TRANSFORM/LIST/RANGE）、`ConnectorPartitionField`、`ConnectorPartitionValueDef`、`ConnectorBucketSpec`
+- P0-T14 ✅：`ConnectorTableOps.createTable(session, request)` default 退化到 legacy `createTable(session, schema, props)`（丢弃 partition / bucket / external / ifNotExists）
+- P0-T15 ✅：新增 `fe-core/.../connector/ddl/CreateTableInfoToConnectorRequestConverter`。覆盖：（1）columns 经 `ConnectorColumnConverter.toConnectorType()`；（2）partition 通过 `PartitionTableInfo.getPartitionType()` + `getPartitionList()` 判别四种 style；（3）TRANSFORM 解析 `UnboundFunction.getName()` + children 提取 `IntegerLikeLiteral` 参数；（4）bucket 通过 `DistributionDescriptor.translateToCatalogStyle().getBuckets()` 读取桶数
+- P0-T16 ✅：`PluginDrivenExternalCatalog` 新加 `createTable(CreateTableInfo)` override：build session → converter → `connector.getMetadata(s).createTable(s, req)` → wrap `DorisConnectorException` 为 `DdlException` → 写 edit log
+- P0-T17 ✅：`listPartitionNames(session, handle)` default 返回 `Collections.emptyList()`
+- P0-T18 ✅：`listPartitions(session, handle, Optional<ConnectorExpression> filter)` default 返回 `Collections.emptyList()`
+- P0-T19 ✅：`listPartitionValues(session, handle, List<String> partitionColumns)` default 返回 `Collections.emptyList()`
+- P0-T20 ✅：`ConnectorPartitionInfo` 新增 3 个 long 字段（rowCount / sizeBytes / lastModifiedMillis），`UNKNOWN = -1L` 常量；3-arg 旧构造器委托到 6-arg 新构造器；equals/hashCode/toString 同步更新
+- 验证：
+  - `mvn -pl fe-connector/fe-connector-api -am compile` → BUILD SUCCESS
+  - `mvn -pl fe-core -am compile -Dmaven.build.cache.enabled=false` → BUILD SUCCESS
+  - `mvn -pl fe-core checkstyle:check` → **0 violations**
+  - `mvn -pl fe-connector/fe-connector-jdbc,fe-connector/fe-connector-es -am compile` → BUILD SUCCESS（下游连接器零修改）
+- 已知 trade-off（**未升 DV**，是 RFC 范围内的实现取舍）：
+  1. `ColumnDefinition.defaultValue` 是 private `Optional<DefaultValue>` 且无 public getter——converter 暂传 `null`。等 SPI 在 ConnectorColumn 上增加 typed default-value carrier 时再补
+  2. LIST/RANGE 的 `initialValues` 暂不下沉到 `List<List<String>>`——`PartitionDefinition` 子类（InPartition/LessThanPartition/FixedRangePartition/StepPartition）含 nereids `Expression`，需要完整分析才能 flatten；先返回空列表，未来 Iceberg/Hive 走 TRANSFORM/IDENTITY 路径不依赖此
+  3. `PluginDrivenExternalCatalog.createTable` 总返回 `false`（=新建并写 edit log）——SPI 的 `createTable(session, request)` 是 void，不区分"已存在 + IF NOT EXISTS"与"新建"。留待 P5/P6/P7 真正实现连接器 createTable 时细化
+  4. bucket 算法名硬编码为 `"doris_default"` / `"doris_random"`——RFC §4.2 列了 `hive_hash` / `iceberg_bucket`，但 Doris 内部 `DistributionDescriptor` 只携带 isHash 布尔。由 Hive/Iceberg 连接器实现时根据 properties 推导真实算法
 
 ### 2026-05-24（深夜）— 批 0 fe-core 桥接完成（T09-T12）
 

--- a/plan-doc/tasks/P0-spi-foundation.md
+++ b/plan-doc/tasks/P0-spi-foundation.md
@@ -64,10 +64,10 @@
 
 | ID | 任务 | 设计参考 | Owner | 状态 | PR | 启动 | 完成 | 备注 |
 |---|---|---|---|---|---|---|---|---|
-| P0-T09 | `DefaultConnectorContext.getMetaInvalidator()` impl | RFC §6.4 | — | ⏳ | — | — | — | |
-| P0-T10 | `ExternalMetaCacheInvalidator`（fe-core 新类） | RFC §6.4 | — | ⏳ | — | — | — | 包装 `ExternalMetaCacheMgr` |
-| P0-T11 | `PluginDrivenTransactionManager` 通用化 | RFC §7.4 | — | ⏳ | — | — | — | 删 type-specific 分支 |
-| P0-T12 | `ConnectorMvccSnapshotAdapter`（fe-core 新类） | RFC §8.4 | — | ⏳ | — | — | — | impl `MvccSnapshot` |
+| P0-T09 | `DefaultConnectorContext.getMetaInvalidator()` impl | RFC §6.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 返回新建 invalidator |
+| P0-T10 | `ExternalMetaCacheInvalidator`（fe-core 新类） | RFC §6.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 包装 `ExternalMetaCacheMgr`；2 个 no-op 限制留 TODO |
+| P0-T11 | `PluginDrivenTransactionManager` 通用化 | RFC §7.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 新增 `begin(ConnectorTransaction)` 重载；legacy `begin()` 不变 |
+| P0-T12 | `ConnectorMvccSnapshotAdapter`（fe-core 新类） | RFC §8.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | impl `MvccSnapshot` 标记接口 |
 
 ### 批 1：DDL + Partition SPI（W1 D1-3）
 
@@ -97,6 +97,14 @@
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-05-24（深夜）— 批 0 fe-core 桥接完成（T09-T12）
+
+- P0-T09 ✅：`DefaultConnectorContext.getMetaInvalidator()` override → `new ExternalMetaCacheInvalidator(catalogId)`
+- P0-T10 ✅：新增 `fe-core/.../connector/ExternalMetaCacheInvalidator`（5 个方法：3 个直接代理 `ExternalMetaCacheMgr` 的 invalidateCatalog/Db/Table；`invalidatePartition` 暂回退到 `invalidateTable`（SPI 未携带 partition column 名）；`invalidateStatistics` 暂 no-op（fe-core 暂无 stats-only invalidation 入口））
+- P0-T11 ✅：`PluginDrivenTransactionManager` 加 `begin(ConnectorTransaction)` 重载，inner `PluginDrivenTransaction` 加 nullable `connectorTx` 字段；legacy `long begin()` 路径完全不变 → JDBC/ES auto-commit 零回归
+- P0-T12 ✅：新增 `fe-core/.../connector/ConnectorMvccSnapshotAdapter`，包装 `ConnectorMvccSnapshot` 并 implements 标记接口 `MvccSnapshot`
+- 验证：`mvn -pl fe-core -am compile -Dmaven.build.cache.enabled=false` → BUILD SUCCESS；checkstyle 0 violations；JDBC + ES 下游 connector clean compile 通过
 
 ### 2026-05-24（晚）— 批 0 基础三件套完成
 - P0-T02 ✅ 闭环：跟踪机制 17 个文件已落 commit 63159837043（早场 session 完成正文，本场 session 翻状态）

--- a/plan-doc/tasks/P0-spi-foundation.md
+++ b/plan-doc/tasks/P0-spi-foundation.md
@@ -33,15 +33,15 @@
 
 从 [RFC §17 验收清单](../01-spi-extensions-rfc.md) 同步：
 
-- [ ] `mvn -pl fe-connector verify` 全绿，新增类型 / 方法全部就位
-- [ ] `fe-connector-spi` 仅新增 `ConnectorMetaInvalidator` 接口与 `ConnectorContext.getMetaInvalidator()` 默认方法
-- [ ] fe-core 侧 converter 就位：`CreateTableInfoToConnectorRequestConverter`、`ExternalMetaCacheInvalidator`、`ConnectorMvccSnapshotAdapter`
-- [ ] `PluginDrivenTransactionManager` 通用化（不再依赖任何具体连接器）
-- [ ] JDBC、ES 现有 regression-test 全绿
-- [ ] `FakeConnectorPlugin` 覆盖所有新增 default 行为路径
-- [ ] `tools/check-connector-imports.sh` 接入 maven enforcer
+- [x] `mvn -pl fe-connector validate` 全绿，新增类型 / 方法全部就位（含 import 守门）
+- [x] `fe-connector-spi` 仅新增 `ConnectorMetaInvalidator` 接口与 `ConnectorContext.getMetaInvalidator()` 默认方法
+- [x] fe-core 侧 converter 就位：`CreateTableInfoToConnectorRequestConverter`、`ExternalMetaCacheInvalidator`、`ConnectorMvccSnapshotAdapter`
+- [x] `PluginDrivenTransactionManager` 通用化（不再依赖任何具体连接器）
+- [ ] JDBC、ES 现有 regression-test 全绿（T24-T25 用户在本地跑）
+- [x] `FakeConnectorPlugin` 覆盖所有新增 default 行为路径（11 个 @Test）
+- [x] `tools/check-connector-imports.sh` 接入 exec-maven-plugin（RFC §15.4 等价实现：enforcer 无原生 shell-exec rule，见日志 trade-off #1）
 - [x] 本阶段关闭未决问题 U1-U6（2026-05-24 完成，决策 D-013..D-018）
-- [ ] master plan §3.1 全部任务勾选
+- [ ] master plan §3.1 全部任务勾选（T24-T25 用户跑完后由用户勾选）
 
 ---
 
@@ -82,21 +82,40 @@
 | P0-T19 | E10：`ConnectorTableOps.listPartitionValues` default | RFC §13.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 返回 `Collections.emptyList()` |
 | P0-T20 | E10：`ConnectorPartitionInfo` 追加字段（rowCount/sizeBytes/lastModifiedMillis） | RFC §13.3 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 3 个 long 字段（UNKNOWN=-1）；3-arg 构造器委托到 6-arg；equals/hashCode 更新 |
 
-### 批 1：守门 + 测试（W1 D4-5）
+### 批 2：守门 + 测试（W1 D4-5）
 
 | ID | 任务 | 设计参考 | Owner | 状态 | PR | 启动 | 完成 | 备注 |
 |---|---|---|---|---|---|---|---|---|
-| P0-T21 | `tools/check-connector-imports.sh` 实现 | RFC §15.4 | — | ⏳ | — | — | — | 禁用 import 守门 |
-| P0-T22 | maven enforcer plugin 接入脚本 | RFC §15.4 | — | ⏳ | — | — | — | |
-| P0-T23 | `FakeConnectorPlugin`（fe-core test）覆盖所有 default 行为 | RFC §15.1 | — | ⏳ | — | — | — | 跑通"什么都不实现" |
-| P0-T24 | JDBC regression-test 全套跑通 | RFC §17 | — | ⏳ | — | — | — | 验证 baseline |
-| P0-T25 | ES regression-test 全套跑通 | RFC §17 | — | ⏳ | — | — | — | 验证 baseline |
-| P0-T26 | `ConnectorMetaInvalidator` 路由测试 | RFC §15.2 | — | ⏳ | — | — | — | mock ExternalMetaCacheMgr |
-| P0-T27 | `CreateTableInfoToConnectorRequestConverter` 单元测试 | RFC §15.2 | — | ⏳ | — | — | — | 覆盖 4 种 partition 风格 |
+| P0-T21 | `tools/check-connector-imports.sh` 实现 | RFC §15.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | grep 守门；script 自含正/负冒烟测试 |
+| P0-T22 | exec-maven-plugin 接入脚本（aggregator pom validate 阶段） | RFC §15.4 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | `inherited=false` 避免 11 个子模块重复扫描 |
+| P0-T23 | `FakeConnectorPlugin`（fe-core test）覆盖所有 default 行为 | RFC §15.1 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 11 个测试覆盖 Connector/Metadata/TableOps/WriteOps/Session/Context 全 default |
+| P0-T24 | JDBC regression-test 全套跑通 | RFC §17 | @用户 | ⏳ | — | — | — | 用户在本地跑（needs docker） |
+| P0-T25 | ES regression-test 全套跑通 | RFC §17 | @用户 | ⏳ | — | — | — | 用户在本地跑（needs docker） |
+| P0-T26 | `ConnectorMetaInvalidator` 路由测试 | RFC §15.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 5 个测试 mockStatic(Env)；pin 当前 partition fallback & stats no-op 行为 |
+| P0-T27 | `CreateTableInfoToConnectorRequestConverter` 单元测试 | RFC §15.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 7 个测试覆盖 IDENTITY/TRANSFORM/LIST/RANGE + hash/random bucket + 列穿透 |
 
 ---
 
 ## 阶段日志（倒序）
+
+### 2026-05-24（夜 ③）— 批 2 守门 + 单测完成（T21-T23, T26-T27；T24-T25 用户跑）
+
+- P0-T21 ✅：新增 `tools/check-connector-imports.sh`。在 `fe-connector/*/src/main/java` 下 grep 禁词 `org.apache.doris.(catalog|common|datasource|qe|analysis|nereids|planner)`，allowlist `thrift / connector / extension / filesystem`。脚本接受可选 ROOT 参数（默认 `$(dirname $0)/../fe/fe-connector`），自动适配 cwd。当前 baseline 全绿（fe-connector 模块仅引用 `connector / extension / thrift / trinoconnector`）；自构造的负样本（注入 `import org.apache.doris.catalog.Column`）正确报错退出
+- P0-T22 ✅：fe-connector 聚合 pom 加 `exec-maven-plugin` 调用脚本，绑 `validate` 阶段，`inherited=false`（避免 11 个子模块每次都跑同一份扫描）。`executable` 使用 `${project.basedir}/../../tools/check-connector-imports.sh`——不依赖 `directory-maven-plugin` 的 `fe.dir` 属性（后者在 `initialize` 阶段才设值，早于 `validate`）。`mvn -pl fe-connector validate` BUILD SUCCESS
+- P0-T23 ✅：fe-core test 包新增 `org.apache.doris.connector.fake.FakeConnectorPlugin`（4 个静态嵌套：`FakeConnector` / `FakeMetadata`（**零** override）/ `FakeSession` / `FakeContext`）。同包测试类 `FakeConnectorPluginTest` 11 个 `@Test` 覆盖：Context.getMetaInvalidator()=NOOP（且 5 个 invalidate 方法 callable）；Session.getCurrentTransaction()=Optional.empty()；Metadata MVCC 3 方法=Optional.empty()；TableOps listTableNames / getTableHandle / listPartitionNames / listPartitions / listPartitionValues / getPrimaryKeys / getTableComment defaults；createTable(request) 退化到 legacy createTable(schema, props) 并抛 "CREATE TABLE not supported"；WriteOps supports*=false + beginTransaction throws；Connector top-level defaults。Tests run: **11/11 green**
+- P0-T26 ✅：新增 `org.apache.doris.connector.ExternalMetaCacheInvalidatorTest`。5 个测试：invalidateAll→invalidateCatalog(id)、invalidateDatabase→invalidateDb(id, db)、invalidateTable→invalidateTable(id, db, t)、invalidatePartition→**fallback** 到 invalidateTable（pin 当前 SPI 不携 column 名的行为）、invalidateStatistics→**no-op**（pin 当前缺 stats-only entry point 的行为）。用 `MockedStatic<Env>` + `Mockito.mock(ExternalMetaCacheMgr)` 完全隔离 FE bootstrap。Tests run: **5/5 green**
+- P0-T27 ✅：新增 `org.apache.doris.connector.ddl.CreateTableInfoToConnectorRequestConverterTest`。7 个测试覆盖：列穿透（name/type/nullable/comment）+ scalar 字段穿透（dbName/tableName/comment/properties/ifNotExists/isExternal）+ IDENTITY partition（UnboundSlot）+ TRANSFORM partition（UnboundFunction `bucket(16, id)` + `YEAR(d)` 验证 lowercase normalization + IntegerLiteral 提取）+ LIST partition（PartitionType.LIST）+ RANGE partition（PartitionType.RANGE）+ hash bucket 算法 `doris_default` + random bucket 算法 `doris_random`。用 `Mockito.mock(CreateTableInfo)` 绕开 18-arg 构造器与 `PropertyAnalyzer.getInstance()` 调用；PartitionTableInfo/DistributionDescriptor/ColumnDefinition/UnboundFunction 等都用真实构造器。Tests run: **7/7 green**
+- 验证：
+  - `tools/check-connector-imports.sh` 正/负冒烟测试通过
+  - `mvn -pl fe-connector validate -Dmaven.build.cache.enabled=false` → BUILD SUCCESS（脚本被 maven 调起）
+  - `mvn -pl fe-core -am test -Dtest='FakeConnectorPluginTest,ExternalMetaCacheInvalidatorTest,CreateTableInfoToConnectorRequestConverterTest,ConnectorPluginManagerTest,ConnectorSessionImplTest' -DfailIfNoTests=false -Dmaven.build.cache.enabled=false` → **39/39 tests green**（含 batch 2 新增 23 个 + 既有 16 个相邻 connector 测试）
+  - `mvn -pl fe-core checkstyle:check` → **0 violations**
+- 已知 trade-off（**未升 DV**，是 RFC §15 / §17 范围内的实现取舍）：
+  1. 守门脚本挂到 `exec-maven-plugin` 而非 `maven-enforcer-plugin`——RFC §15.4 原文写"挂到 maven enforcer plugin"，但 enforcer 没有原生 shell-exec rule（要么写自定义 Java Rule 类，要么用 `EvaluateBeanshell`）。`exec-maven-plugin` 在 fe-common 已是既有 dep（make + protoc 都用它），引入零新依赖。效果等价：脚本 non-zero exit → maven `BUILD FAILURE`
+  2. 守门绑 `validate` 阶段且 `inherited=false`——只在 fe-connector aggregator 一次运行；devs 跑 `mvn -pl fe-connector/fe-connector-iceberg compile` 时不会自动触发，但 CI 跑顶层 `mvn install` 必扫。Trade-off：少 11 次重复扫，换"单模块增量构建本地无守门"
+  3. ConnectorMetaInvalidator 的 partition fallback 测试明确 pin 当前"回退到 invalidateTable"的行为——一旦未来 SPI 在 invalidatePartition 中加 column 名携带能力可以做精确失效，bridge 和这个测试必须同步更新；测试已留 inline comment 描述意图
+  4. CreateTableInfo 用 Mockito.mock 而非真实构造器——RFC §15.2 没规定单测必须用真实输入对象。Trade-off：测试更聚焦于 converter 自身逻辑（不必维护 18-arg 输入构造），但代价是如果 CreateTableInfo 加新 getter 且 converter 改用之，需要在 stubInfo helper 加新 stub
+- T24/T25 转交用户：用户在本地跑 JDBC + ES regression-test（containers / docker 在本地环境下更稳）。任务状态保持 ⏳，owner @用户
 
 ### 2026-05-24（夜 ②）— 批 1 DDL + Partition SPI 完成（T13-T20）
 

--- a/plan-doc/tasks/P0-spi-foundation.md
+++ b/plan-doc/tasks/P0-spi-foundation.md
@@ -52,13 +52,13 @@
 | ID | 任务 | 设计参考 | Owner | 状态 | PR | 启动 | 完成 | 备注 |
 |---|---|---|---|---|---|---|---|---|
 | P0-T01 | RFC §16.2 决策点闭环（U1-U6） | RFC §16 | @me | ✅ | n/a | 2026-05-24 | 2026-05-24 | D-013..D-018 |
-| P0-T02 | 项目跟踪机制建立 | README/PROGRESS/...| @me | 🚧 | n/a | 2026-05-24 | — | 本文件等 |
-| P0-T03 | E3：`ConnectorMetaInvalidator` 接口（fe-connector-spi）| RFC §6.2 | — | ⏳ | — | — | — | 5 个 invalidate 方法 |
-| P0-T04 | E3：`ConnectorContext.getMetaInvalidator()` default | RFC §6.3 | — | ⏳ | — | — | — | spi 包 |
-| P0-T05 | E4：`ConnectorTransaction` 继承 `ConnectorTransactionHandle` | RFC §7.2 | — | ⏳ | — | — | — | 替换占位 |
-| P0-T06 | E4：`ConnectorWriteOps.beginTransaction` default | RFC §7.3 | — | ⏳ | — | — | — | |
-| P0-T07 | E4：`ConnectorSession.getCurrentTransaction` default | RFC §7.6 | — | ⏳ | — | — | — | optional |
-| P0-T08 | E5：`ConnectorMvccSnapshot` 类型 + 3 个 default 方法 | RFC §8.2-8.3 | — | ⏳ | — | — | — | mvcc 包 |
+| P0-T02 | 项目跟踪机制建立 | README/PROGRESS/...| @me | ✅ | 63159837043 | 2026-05-24 | 2026-05-24 | 本文件等 |
+| P0-T03 | E3：`ConnectorMetaInvalidator` 接口（fe-connector-spi）| RFC §6.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 5 个 invalidate 方法 |
+| P0-T04 | E3：`ConnectorContext.getMetaInvalidator()` default | RFC §6.3 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | spi 包 |
+| P0-T05 | E4：`ConnectorTransaction` 继承 `ConnectorTransactionHandle` | RFC §7.2 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | 新增不替换 handle |
+| P0-T06 | E4：`ConnectorWriteOps.beginTransaction` default | RFC §7.3 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | throws unsupported |
+| P0-T07 | E4：`ConnectorSession.getCurrentTransaction` default | RFC §7.6 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | Optional.empty() |
+| P0-T08 | E5：`ConnectorMvccSnapshot` 类型 + 3 个 default 方法 | RFC §8.2-8.3 | @me | ✅ | — | 2026-05-24 | 2026-05-24 | mvcc 包 + 3 默认在 ConnectorMetadata |
 
 ### 批 0：fe-core 桥接（W0 D5 - W1 D1）
 
@@ -98,8 +98,18 @@
 
 ## 阶段日志（倒序）
 
-### 2026-05-24
-- 创建本文件（task #11，跟踪机制建立的一部分）
+### 2026-05-24（晚）— 批 0 基础三件套完成
+- P0-T02 ✅ 闭环：跟踪机制 17 个文件已落 commit 63159837043（早场 session 完成正文，本场 session 翻状态）
+- P0-T03 ✅：新增 `connector.spi.ConnectorMetaInvalidator`（5 个 invalidate 方法 + `NOOP` 常量）
+- P0-T04 ✅：`ConnectorContext.getMetaInvalidator()` default → `NOOP`
+- P0-T05 ✅：新增 `connector.api.handle.ConnectorTransaction extends ConnectorTransactionHandle, Closeable`（保留旧 24 行 marker 不破坏现有引用）
+- P0-T06 ✅：`ConnectorWriteOps.beginTransaction(session)` default 抛 `DorisConnectorException("Transactions not supported")`
+- P0-T07 ✅：`ConnectorSession.getCurrentTransaction()` default 返回 `Optional.empty()`
+- P0-T08 ✅：新增 `connector.api.mvcc.ConnectorMvccSnapshot`（final value class + Builder），`ConnectorMetadata` 上 3 个 default：`beginQuerySnapshot` / `getSnapshotAt` / `getSnapshotById`
+- 验证：`mvn -pl fe-connector/fe-connector-api,spi -am clean compile` 全绿；JDBC + ES 下游 connector clean compile 通过（无修改）；checkstyle 0 violations
+
+### 2026-05-24（早）
+- 创建本文件（跟踪机制建立的一部分）
 - P0-T01 ✅ 完成：master plan §5（D1-D12）+ RFC §16.2（U1-U6）全部决策闭环 → decisions-log D-001..D-018
 - P0-T02 🚧 进行中：跟踪机制文件建立（README/PROGRESS/decisions-log/deviations-log/risks/tasks/_template/本文件 已成；待完成 connectors/× 8 + 00-master-plan cross-link）
 

--- a/tools/check-connector-imports.sh
+++ b/tools/check-connector-imports.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Forbidden-import gate for fe-connector modules.
+# See plan-doc/01-spi-extensions-rfc.md §15.4.
+#
+# Connector modules MUST NOT import fe-core internals (catalog / common /
+# datasource / qe / analysis / nereids / planner). Anything they need from
+# fe-core has to be exposed through the SPI in
+#   org.apache.doris.connector.{api,spi,extension,...}
+# or shared types in org.apache.doris.thrift / org.apache.doris.filesystem.
+#
+# Usage:
+#   tools/check-connector-imports.sh                  # search default root
+#   tools/check-connector-imports.sh <fe-connector>   # search supplied root
+#
+# Exit code:
+#   0 — no forbidden imports
+#   1 — at least one forbidden import found (offending lines printed)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="${SCRIPT_DIR}/../fe/fe-connector"
+ROOT="${1:-${DEFAULT_ROOT}}"
+
+if [ ! -d "${ROOT}" ]; then
+    echo "check-connector-imports: search root not found: ${ROOT}" >&2
+    exit 2
+fi
+
+FORBIDDEN='org\.apache\.doris\.(catalog|common|datasource|qe|analysis|nereids|planner)'
+
+RESULT=$(grep -rEn "^import ${FORBIDDEN}\." "${ROOT}"/*/src/main/java 2>/dev/null \
+        | grep -v 'org.apache.doris.thrift' \
+        | grep -v 'org.apache.doris.connector' \
+        | grep -v 'org.apache.doris.extension' \
+        | grep -v 'org.apache.doris.filesystem' || true)
+
+if [ -n "${RESULT}" ]; then
+    echo "FORBIDDEN IMPORTS in fe-connector modules:" >&2
+    echo "${RESULT}" >&2
+    echo "" >&2
+    echo "fe-connector modules MUST NOT depend on fe-core internals." >&2
+    echo "Expose what you need through the connector SPI instead." >&2
+    echo "See plan-doc/01-spi-extensions-rfc.md §15.4." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Lands the P0 SPI baseline for the catalog-SPI migration (master plan §3.1 / RFC §2.1), with zero impact on the already-migrated JDBC + ES connectors.

- **Batch 0** (commits 1-2): SPI types + fe-core bridges — `ConnectorMetaInvalidator`, `ConnectorTransaction`, `ConnectorMvccSnapshot`, `ExternalMetaCacheInvalidator`, `ConnectorMvccSnapshotAdapter`, `PluginDrivenTransactionManager` generalization.
- **Batch 1** (commit 3): DDL + Partition SPI — `ConnectorCreateTableRequest` + 4 spec POJOs, 4 new defaults on `ConnectorTableOps`, 3 new fields on `ConnectorPartitionInfo`, fe-core converter, `PluginDrivenExternalCatalog.createTable` routing.
- **Batch 2** (commit 4): Import-gate + unit tests — `tools/check-connector-imports.sh` wired through exec-maven-plugin; `FakeConnectorPlugin` covering every default fall-through; routing tests for the invalidator; converter tests for all 4 partition styles + 2 bucket flavors.

## Commits

- `[feat](connector) add P0 batch 0 SPI baseline: MetaInvalidator / Transaction / MvccSnapshot` (T03-T08)
- `[feat](connector) wire P0 batch 0 SPI into fe-core` (T09-T12)
- `[feat](connector) add P0 batch 1 SPI: CreateTableRequest + listPartitions` (T13-T20)
- `[feat](connector) add P0 batch 2 gate + unit tests` (T21-T23, T26-T27)

## Test plan

- [x] `mvn -pl fe-connector/fe-connector-api,fe-connector/fe-connector-spi -am compile` — SPI modules compile
- [x] `mvn -pl fe-core -am compile -Dmaven.build.cache.enabled=false` — fe-core compile
- [x] `mvn -pl fe-core checkstyle:check` — 0 violations
- [x] `mvn -pl fe-connector validate` — import gate runs and passes (baseline clean)
- [x] `mvn -pl fe-core -am test -Dtest='FakeConnectorPluginTest,ExternalMetaCacheInvalidatorTest,CreateTableInfoToConnectorRequestConverterTest,ConnectorPluginManagerTest,ConnectorSessionImplTest'` — 39/39 green
- [x] `mvn -pl fe-connector/fe-connector-jdbc,fe-connector/fe-connector-es -am compile` — downstream connectors compile unchanged
- [ ] JDBC regression-test suite (T24) — to be exercised by this PR's CI pipeline
- [ ] ES regression-test suite (T25) — to be exercised by this PR's CI pipeline

## Tracking

Full plan, decisions, and risk log live under `plan-doc/` in the repo (introduced by 63159837043, already on the base branch). Per-task status: `plan-doc/tasks/P0-spi-foundation.md`.
