### PR TITLE
[fix](pipeline) detect unread local exchange data on eos

### DIFF
--- a/be/src/exec/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/exchange/local_exchange_source_operator.cpp
@@ -95,6 +95,9 @@ Status LocalExchangeSourceOperatorX::get_block(RuntimeState* state, Block* block
     RETURN_IF_ERROR(local_state._exchanger->get_block(
             state, block, eos, {nullptr, nullptr, local_state._copy_data_timer},
             {local_state._channel_id, &local_state}));
+    if (UNLIKELY(limit() == -1 && *eos)) {
+        RETURN_IF_ERROR(local_state._exchanger->check_no_data_left(local_state._channel_id));
+    }
     local_state.reached_limit(block, eos);
     return Status::OK();
 }

--- a/be/src/exec/exchange/local_exchanger.cpp
+++ b/be/src/exec/exchange/local_exchanger.cpp
@@ -111,6 +111,44 @@ bool Exchanger<BlockType>::_dequeue_data(BlockType& block, bool* eos, Block* dat
     return false;
 }
 
+template <typename BlockType>
+Status Exchanger<BlockType>::check_no_data_left(int channel_id) {
+    DCHECK_GE(channel_id, 0);
+    DCHECK_LT(static_cast<size_t>(channel_id), _data_queue.size());
+
+    std::unique_lock l(*_m[channel_id]);
+    BlockType block;
+    if (_data_queue[channel_id].try_dequeue(block)) {
+        auto queue_info = data_queue_debug_string(channel_id);
+        std::string unread_block_info;
+        if constexpr (std::is_same_v<PartitionedBlock, BlockType>) {
+            unread_block_info = fmt::format(
+                    "rows={}, bytes={}, allocated_bytes={}, offset_start={}, length={}, "
+                    "has_row_idxs={}",
+                    block.first ? block.first->_data_block.rows() : 0,
+                    block.first ? block.first->_data_block.bytes() : 0,
+                    block.first ? block.first->_allocated_bytes : 0, block.second.offset_start,
+                    block.second.length, block.second.row_idxs != nullptr);
+        } else if constexpr (std::is_same_v<BroadcastBlock, BlockType>) {
+            unread_block_info =
+                    fmt::format("rows={}, bytes={}, allocated_bytes={}, offset_start={}, length={}",
+                                block.first ? block.first->_data_block.rows() : 0,
+                                block.first ? block.first->_data_block.bytes() : 0,
+                                block.first ? block.first->_allocated_bytes : 0,
+                                block.second.offset_start, block.second.length);
+        } else {
+            unread_block_info = fmt::format(
+                    "rows={}, bytes={}, allocated_bytes={}", block ? block->_data_block.rows() : 0,
+                    block ? block->_data_block.bytes() : 0, block ? block->_allocated_bytes : 0);
+        }
+        return Status::InternalError(
+                "Local exchange returned eos with unread data left in channel {}. type={}, "
+                "queue_info={}, unread_block_info=[{}]",
+                channel_id, get_exchange_type_name(get_type()), queue_info, unread_block_info);
+    }
+    return Status::OK();
+}
+
 Status ShuffleExchanger::sink(RuntimeState* state, Block* in_block, bool eos, Profile&& profile,
                               SinkInfo& sink_info) {
     if (in_block->empty()) {
@@ -563,6 +601,19 @@ Status AdaptivePassthroughExchanger::get_block(RuntimeState* state, Block* block
         } while (mutable_block.rows() < state->batch_size() && !*eos &&
                  _dequeue_data(source_info.local_state, partitioned_block, eos, block,
                                source_info.channel_id));
+    }
+    return Status::OK();
+}
+
+Status AdaptivePassthroughExchanger::check_no_data_left(int channel_id) {
+    RETURN_IF_ERROR(Exchanger<PartitionedBlock>::check_no_data_left(channel_id));
+    if (!_tmp_block[channel_id].empty()) {
+        return Status::InternalError(
+                "Local exchange returned eos with unread passthrough block left in channel {}. "
+                "type={}, tmp_block_info=[rows={}, bytes={}, allocated_bytes={}], tmp_eos={}",
+                channel_id, get_exchange_type_name(get_type()), _tmp_block[channel_id].rows(),
+                _tmp_block[channel_id].bytes(), _tmp_block[channel_id].allocated_bytes(),
+                _tmp_eos[channel_id]);
     }
     return Status::OK();
 }

--- a/be/src/exec/exchange/local_exchanger.h
+++ b/be/src/exec/exchange/local_exchanger.h
@@ -143,6 +143,7 @@ public:
     virtual Status sink(RuntimeState* state, Block* in_block, bool eos, Profile&& profile,
                         SinkInfo& sink_info) = 0;
     virtual ExchangeType get_type() const = 0;
+    virtual Status check_no_data_left(int channel_id) = 0;
     // Called if a local exchanger source operator are closed. Free the unused data block in data_queue.
     virtual void close(SourceInfo&& source_info) = 0;
     // Called if all local exchanger source operators are closed. We free the memory in
@@ -248,6 +249,7 @@ public:
         return fmt::format("Data Queue {}: [size approx = {}, eos = {}]", i,
                            _data_queue[i].data_queue.size_approx(), _data_queue[i].eos);
     }
+    Status check_no_data_left(int channel_id) override;
 
 protected:
     // Enqueue data block and set downstream source operator to read.
@@ -369,6 +371,7 @@ public:
     Status get_block(RuntimeState* state, Block* block, bool* eos, Profile&& profile,
                      SourceInfo&& source_info) override;
     ExchangeType get_type() const override { return ExchangeType::ADAPTIVE_PASSTHROUGH; }
+    Status check_no_data_left(int channel_id) override;
 
     void close(SourceInfo&& source_info) override;
 

--- a/be/test/exec/pipeline/local_exchanger_test.cpp
+++ b/be/test/exec/pipeline/local_exchanger_test.cpp
@@ -1162,6 +1162,139 @@ TEST_F(LocalExchangerTest, AdaptivePassthroughExchanger) {
     }
 }
 
+TEST_F(LocalExchangerTest, AdaptivePassthroughExchangerReturnsCopiedSliceWithSharedOutputColumn) {
+    int num_sink = 1;
+    int num_sources = 4;
+    int free_block_limit = 0;
+    const auto num_rows_per_block = num_sources * 3;
+    const auto expected_rows_per_source = num_rows_per_block / num_sources;
+    config::local_exchange_buffer_mem_limit = 1024 * 1024;
+
+    std::vector<std::unique_ptr<LocalExchangeSinkLocalState>> sink_local_states;
+    std::vector<std::unique_ptr<LocalExchangeSourceLocalState>> source_local_states;
+    sink_local_states.resize(num_sink);
+    source_local_states.resize(num_sources);
+    auto profile = std::make_shared<RuntimeProfile>("");
+    auto shared_state = LocalExchangeSharedState::create_shared(num_sources);
+    shared_state->exchanger =
+            AdaptivePassthroughExchanger::create_unique(num_sink, num_sources, free_block_limit);
+    auto sink_dep = std::make_shared<Dependency>(0, 0, "LOCAL_EXCHANGE_SINK_DEPENDENCY", true);
+    sink_dep->set_shared_state(shared_state.get());
+    shared_state->sink_deps.push_back(sink_dep);
+    shared_state->create_source_dependencies(num_sources, 0, 0, "TEST");
+
+    auto* exchanger = (AdaptivePassthroughExchanger*)shared_state->exchanger.get();
+    for (size_t i = 0; i < num_sink; i++) {
+        sink_local_states[i] = std::make_unique<LocalExchangeSinkLocalState>(nullptr, nullptr);
+        sink_local_states[i]->_exchanger = shared_state->exchanger.get();
+        sink_local_states[i]->_compute_hash_value_timer =
+                ADD_TIMER(profile, "ComputeHashValueTime" + std::to_string(i));
+        sink_local_states[i]->_distribute_timer =
+                ADD_TIMER(profile, "distribute_timer" + std::to_string(i));
+        sink_local_states[i]->_channel_id = i;
+        sink_local_states[i]->_ins_idx = i;
+        sink_local_states[i]->_shared_state = shared_state.get();
+        sink_local_states[i]->_dependency = sink_dep.get();
+        sink_local_states[i]->_memory_used_counter = profile->AddHighWaterMarkCounter(
+                "SinkMemoryUsage" + std::to_string(i), TUnit::BYTES, "", 1);
+    }
+    for (size_t i = 0; i < num_sources; i++) {
+        source_local_states[i] =
+                std::make_unique<LocalExchangeSourceLocalState>(_runtime_state.get(), nullptr);
+        source_local_states[i]->_exchanger = shared_state->exchanger.get();
+        source_local_states[i]->_get_block_failed_counter =
+                ADD_TIMER(profile, "_get_block_failed_counter" + std::to_string(i));
+        source_local_states[i]->_copy_data_timer =
+                ADD_TIMER(profile, "_copy_data_timer" + std::to_string(i));
+        source_local_states[i]->_channel_id = i;
+        source_local_states[i]->_shared_state = shared_state.get();
+        source_local_states[i]->_dependency = shared_state->get_dep_by_channel_id(i).front().get();
+        source_local_states[i]->_memory_used_counter = profile->AddHighWaterMarkCounter(
+                "MemoryUsage" + std::to_string(i), TUnit::BYTES, "", 1);
+        shared_state->mem_counters[i] = source_local_states[i]->_memory_used_counter;
+    }
+
+    Block in_block;
+    DataTypePtr int_type = std::make_shared<DataTypeInt32>();
+    auto int_col0 = ColumnInt32::create();
+    for (int i = 0; i < num_rows_per_block; ++i) {
+        int_col0->insert_value(i);
+    }
+    in_block.insert({std::move(int_col0), int_type, "test_int_col0"});
+    bool in_eos = false;
+    SinkInfo sink_info = {.channel_id = &sink_local_states[0]->_channel_id,
+                          .partitioner = sink_local_states[0]->_partitioner.get(),
+                          .local_state = sink_local_states[0].get(),
+                          .shuffle_idx_to_instance_idx = nullptr,
+                          .ins_idx = 0};
+    ASSERT_EQ(exchanger->sink(_runtime_state.get(), &in_block, in_eos,
+                              {sink_local_states[0]->_compute_hash_value_timer,
+                               sink_local_states[0]->_distribute_timer, nullptr},
+                              sink_info),
+              Status::OK());
+
+    Block output_block;
+    output_block.insert({ColumnInt32::create(), int_type, "test_int_col0"});
+    ColumnPtr shared_empty_column = output_block.get_by_position(0).column;
+    ASSERT_EQ(shared_empty_column->size(), 0);
+
+    bool eos = false;
+    ASSERT_EQ(exchanger->get_block(_runtime_state.get(), &output_block, &eos,
+                                   {nullptr, nullptr, source_local_states[0]->_copy_data_timer},
+                                   {cast_set<int>(source_local_states[0]->_channel_id),
+                                    source_local_states[0].get()}),
+              Status::OK());
+    EXPECT_FALSE(eos);
+    ASSERT_EQ(output_block.rows(), expected_rows_per_source);
+
+    const auto& result_column =
+            assert_cast<const ColumnInt32&>(*output_block.get_by_position(0).column);
+    EXPECT_EQ(result_column.get_element(0), 0);
+    EXPECT_EQ(result_column.get_element(1), 4);
+    EXPECT_EQ(result_column.get_element(2), 8);
+}
+
+TEST_F(LocalExchangerTest, CheckNoDataLeftDetectsQueueResidual) {
+    auto shared_state = LocalExchangeSharedState::create_shared(1);
+    shared_state->exchanger = AdaptivePassthroughExchanger::create_unique(1, 1, 0);
+    auto* exchanger = (AdaptivePassthroughExchanger*)shared_state->exchanger.get();
+
+    Block in_block;
+    DataTypePtr int_type = std::make_shared<DataTypeInt32>();
+    auto int_col0 = ColumnInt32::create();
+    int_col0->insert_value(1);
+    in_block.insert({std::move(int_col0), int_type, "test_int_col0"});
+
+    auto wrapper = ExchangerBase::BlockWrapper::create_shared(std::move(in_block), nullptr, -1);
+    auto row_idx = std::make_shared<PODArray<uint32_t>>(1);
+    (*row_idx)[0] = 0;
+    ASSERT_TRUE(exchanger->_data_queue[0].enqueue(
+            {wrapper, {.row_idxs = row_idx, .offset_start = 0, .length = 1}}));
+
+    auto st = exchanger->check_no_data_left(0);
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("unread data left in channel 0"), std::string::npos);
+    EXPECT_NE(st.to_string().find("unread_block_info=[rows=1"), std::string::npos);
+}
+
+TEST_F(LocalExchangerTest, CheckNoDataLeftDetectsAdaptiveTmpBlockResidual) {
+    auto shared_state = LocalExchangeSharedState::create_shared(1);
+    shared_state->exchanger = AdaptivePassthroughExchanger::create_unique(1, 1, 0);
+    auto* exchanger = (AdaptivePassthroughExchanger*)shared_state->exchanger.get();
+
+    DataTypePtr int_type = std::make_shared<DataTypeInt32>();
+    auto int_col0 = ColumnInt32::create();
+    int_col0->insert_value(7);
+    exchanger->_tmp_block[0].insert({std::move(int_col0), int_type, "test_int_col0"});
+    exchanger->_tmp_eos[0] = true;
+
+    auto st = exchanger->check_no_data_left(0);
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("unread passthrough block left in channel 0"), std::string::npos);
+    EXPECT_NE(st.to_string().find("tmp_block_info=[rows=1"), std::string::npos);
+    EXPECT_NE(st.to_string().find("tmp_eos=true"), std::string::npos);
+}
+
 TEST_F(LocalExchangerTest, TestShuffleExchangerWrongMap) {
     int num_sink = 1;
     int num_sources = 4;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

A local exchange source without a limit can currently trust eos even when unread data is still buffered in the exchanger. In that case the pipeline may finish with fewer output rows than input rows and the failure is hidden behind a normal end-of-stream. Root cause: the source path did not validate exchanger state after eos, and AdaptivePassthroughExchanger also has a tmp block path outside the normal queue state. This change adds a post-eos residual-data check for the no-limit source path, reports detailed queue and buffered-block diagnostics when unread data remains, and adds unit tests that cover both queue residuals and adaptive passthrough tmp-block residuals.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

