### PR TITLE
[fix](build) Upgrade Maven from 3.6.3 to 3.9.9 in build-env images

### DIFF
--- a/docker/compilation/Dockerfile
+++ b/docker/compilation/Dockerfile
@@ -41,9 +41,9 @@ RUN wget https://doris-thirdparty-1308700295.cos.ap-beijing.myqcloud.com/tools/o
     && cp -r jdk-17.0.2/ /usr/lib/jvm/ \
     && rm /tmp/openjdk-17.0.2_linux-x64_bin.tar.gz && rm -rf /tmp/jdk-17.0.2/
 
-# install maven 3.6.3
+# install maven 3.9.9
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-    && wget -q -O /tmp/apache-maven.tar.gz https://doris-thirdparty-1308700295.cos.ap-beijing.myqcloud.com/tools/apache-maven-3.6.3-bin.tar.gz \
+    && wget -q -O /tmp/apache-maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz \
     && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
     && rm -f /tmp/apache-maven.tar.gz \
     && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn

--- a/docker/compilation/Dockerfile.gcc10
+++ b/docker/compilation/Dockerfile.gcc10
@@ -40,9 +40,9 @@ RUN wget -q ${NINJA_BASE_URL}/ninja-linux.zip -O /tmp/ninja-linux.zip && \
     unzip /tmp/ninja-linux.zip -d /usr/bin/ && \
     rm /tmp/ninja-linux.zip
 
-# install maven 3.6.3
-ARG MAVEN_VERSION=3.6.3
-ARG MAVEN_BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
+# install maven 3.9.9
+ARG MAVEN_VERSION=3.9.9
+ARG MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref && \
     wget -q -O /tmp/apache-maven.tar.gz ${MAVEN_BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \

--- a/docker/compilation/Dockerfile.gcc7
+++ b/docker/compilation/Dockerfile.gcc7
@@ -77,9 +77,9 @@ RUN wget --no-cookies --no-check-certificate --header "Cookie: oraclelicense=acc
 
 ENV JAVA_HOME /usr/java/jdk
 
-# install maven 3.6.3
-ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
-ARG MAVEN_URL=http://mirror.bit.edu.cn/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+# install maven 3.9.9
+ARG SHA=a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+ARG MAVEN_URL=https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_URL} \

--- a/docker/compilation/arm/Dockerfile
+++ b/docker/compilation/arm/Dockerfile
@@ -27,9 +27,9 @@ RUN yum install -y byacc patch automake libtool perf vim make which file ncurses
 # clean cache
 RUN yum clean all
 
-# install maven 3.6.3
+# install maven 3.9.9
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref && \
-    wget -q -O /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
+    wget -q -O /tmp/apache-maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \
     rm -f /tmp/apache-maven.tar.gz && \
     ln -s /usr/share/maven/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62412

Problem Summary:

The FE build enforces Maven `>= 3.9.0` via the `maven-enforcer-plugin` (`fe/pom.xml`, `requireMavenVersion` `[3.9.0,)`), which is required by the Maven build cache extension configured under `fe/.mvn`. However, every build-env Docker image under `docker/compilation/` still installs Maven **3.6.3**:

- `docker/compilation/Dockerfile` (source of the recommended `build-env-ldb-toolchain-latest` image)
- `docker/compilation/Dockerfile.gcc10`
- `docker/compilation/Dockerfile.gcc7`
- `docker/compilation/arm/Dockerfile`

As a result, building Doris `master` inside the recommended `apache/doris:build-env-ldb-toolchain-latest` image fails during the FE phase with the enforcer check:

```
[ERROR] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion failed with message:
[ERROR] Detected Maven Version: 3.6.3 is not in the allowed range [3.9.0,).
```

This PR upgrades Maven to **3.9.9** in all four build-env Dockerfiles so the images satisfy the enforced version range.

Additional notes:

- All four images now download the artifact from the permanent `archive.apache.org` location, so the pinned version keeps resolving after it rolls off the current-release mirrors (`downloads.apache.org` / `dlcdn.apache.org` only retain recent releases).
- This also repairs the `gcc7` image, which fetched Maven from the long-defunct `mirror.bit.edu.cn` host; its `SHA-512` checksum is updated to the official value for `apache-maven-3.9.9-bin.tar.gz`.

Verification (the build-env images are published out-of-band, not rebuilt per PR):

- `https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz` returns `HTTP 200`.
- The downloaded tarball's `SHA-512` matches both the value committed in `Dockerfile.gcc7` and Apache's published `.sha512`.
- `3.9.9` satisfies the FE enforcer range `[3.9.0,)`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: Build-environment Dockerfile change only. The build-env images are published out-of-band and are not built per PR (`.github/workflows/code-checks.yml` excludes `docker/compilation` and `Dockerfile`s). Correctness was verified by confirming the new `archive.apache.org` artifact URL resolves, the committed `SHA-512` matches Apache's published checksum, and `3.9.9` satisfies the FE enforcer range `[3.9.0,)`.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.
