### PR TITLE
[fix](filecache) Make file cache sync clear wait for async cleanup

### DIFF
--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -1101,47 +1101,6 @@ void BlockFileCache::fill_holes_with_empty_file_blocks(FileBlocks& file_blocks,
     }
 }
 
-void BlockFileCache::fill_holes_with_skip_cache_blocks(FileBlocks& file_blocks,
-                                                       const UInt128Wrapper& hash,
-                                                       const CacheContext& context,
-                                                       const FileBlock::Range& range) {
-    auto it = file_blocks.begin();
-    auto block_range = (*it)->range();
-
-    size_t current_pos = 0;
-    if (block_range.left < range.left) {
-        current_pos = block_range.right + 1;
-        ++it;
-    } else {
-        current_pos = range.left;
-    }
-
-    while (current_pos <= range.right && it != file_blocks.end()) {
-        block_range = (*it)->range();
-
-        if (current_pos == block_range.left) {
-            current_pos = block_range.right + 1;
-            ++it;
-            continue;
-        }
-
-        DCHECK(current_pos < block_range.left);
-
-        auto hole_size = block_range.left - current_pos;
-        file_blocks.splice(
-                it, split_range_into_skip_cache_blocks(hash, context, current_pos, hole_size));
-
-        current_pos = block_range.right + 1;
-        ++it;
-    }
-
-    if (current_pos <= range.right) {
-        auto hole_size = range.right - current_pos + 1;
-        file_blocks.splice(file_blocks.end(), split_range_into_skip_cache_blocks(
-                                                      hash, context, current_pos, hole_size));
-    }
-}
-
 FileBlocksHolder BlockFileCache::get_or_set(const UInt128Wrapper& hash, size_t offset, size_t size,
                                             CacheContext& context) {
     FileBlock::Range range(offset, offset + size - 1);
@@ -1161,24 +1120,21 @@ FileBlocksHolder BlockFileCache::get_or_set(const UInt128Wrapper& hash, size_t o
         stats->lock_wait_timer += sw.elapsed_time();
         SCOPED_RAW_TIMER(&duration);
         /// Get all blocks which intersect with the given range.
-        {
-            SCOPED_RAW_TIMER(&stats->get_timer);
-            file_blocks = get_impl(hash, context, range, cache_lock);
-        }
-
-        if (_clear_file_cache_sync_running && file_blocks.empty()) {
+        if (_clear_file_cache_sync_running) {
             SCOPED_RAW_TIMER(&stats->set_timer);
             file_blocks = split_range_into_skip_cache_blocks(hash, context, offset, size);
-        } else if (_clear_file_cache_sync_running) {
-            SCOPED_RAW_TIMER(&stats->set_timer);
-            fill_holes_with_skip_cache_blocks(file_blocks, hash, context, range);
-        } else if (file_blocks.empty()) {
-            SCOPED_RAW_TIMER(&stats->set_timer);
-            file_blocks = split_range_into_cells(hash, context, offset, size,
-                                                 FileBlock::State::EMPTY, cache_lock);
         } else {
-            SCOPED_RAW_TIMER(&stats->set_timer);
-            fill_holes_with_empty_file_blocks(file_blocks, hash, context, range, cache_lock);
+            SCOPED_RAW_TIMER(&stats->get_timer);
+            file_blocks = get_impl(hash, context, range, cache_lock);
+
+            if (file_blocks.empty()) {
+                SCOPED_RAW_TIMER(&stats->set_timer);
+                file_blocks = split_range_into_cells(hash, context, offset, size,
+                                                     FileBlock::State::EMPTY, cache_lock);
+            } else {
+                SCOPED_RAW_TIMER(&stats->set_timer);
+                fill_holes_with_empty_file_blocks(file_blocks, hash, context, range, cache_lock);
+            }
         }
         DCHECK(!file_blocks.empty());
         *_num_read_blocks << file_blocks.size();

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -38,8 +38,10 @@
 #endif
 
 #include <chrono> // IWYU pragma: keep
+#include <condition_variable>
 #include <mutex>
 #include <ranges>
+#include <string_view>
 
 #include "common/cast_set.h"
 #include "common/config.h"
@@ -653,22 +655,56 @@ void BlockFileCache::add_need_update_lru_block(FileBlockSPtr block) {
     }
 }
 
+std::string BlockFileCache::ClearFileCacheResult::to_string(const std::string& path,
+                                                            std::string_view action) const {
+    std::stringstream ss;
+    ss << "finish " << action << ", path=" << path << " num_files_all=" << num_files_all
+       << " num_cells_all=" << num_cells_all << " num_cells_to_delete=" << num_cells_to_delete
+       << " num_cells_wait_recycle=" << num_cells_wait_recycle
+       << " num_recycle_drained=" << num_recycle_drained
+       << " wait_deleting_rounds=" << wait_deleting_rounds << " cancelled=" << cancelled
+       << " time_elapsed_ms=" << elapsed_ms;
+    if (!status.ok()) {
+        ss << " status=" << status.to_string();
+    }
+    return ss.str();
+}
+
+void BlockFileCache::append_clear_result(ClearFileCacheResult& result,
+                                         const ClearFileCacheResult& other) {
+    result.num_files_all += other.num_files_all;
+    result.num_cells_all += other.num_cells_all;
+    result.num_cells_to_delete += other.num_cells_to_delete;
+    result.num_cells_wait_recycle += other.num_cells_wait_recycle;
+    result.num_recycle_drained += other.num_recycle_drained;
+    result.wait_deleting_rounds += other.wait_deleting_rounds;
+    result.cancelled = result.cancelled || other.cancelled;
+    if (result.status.ok() && !other.status.ok()) {
+        result.status = other.status;
+    }
+}
+
 std::string BlockFileCache::clear_file_cache_async() {
+    std::lock_guard clear_lock(_clear_mutex);
+    auto result = clear_file_cache_async_impl();
+    auto msg = result.to_string(_cache_base_path, "clear_file_cache_async");
+    LOG(INFO) << msg;
+    return msg;
+}
+
+BlockFileCache::ClearFileCacheResult BlockFileCache::clear_file_cache_async_impl() {
     LOG(INFO) << "start clear_file_cache_async, path=" << _cache_base_path;
     _lru_dumper->remove_lru_dump_files();
-    int64_t num_cells_all = 0;
-    int64_t num_cells_to_delete = 0;
-    int64_t num_cells_wait_recycle = 0;
-    int64_t num_files_all = 0;
+    ClearFileCacheResult result;
     TEST_SYNC_POINT_CALLBACK("BlockFileCache::clear_file_cache_async");
     {
         SCOPED_CACHE_LOCK(_mutex, this);
 
         std::vector<FileBlockCell*> deleting_cells;
         for (auto& [_, offset_to_cell] : _files) {
-            ++num_files_all;
+            ++result.num_files_all;
             for (auto& [_1, cell] : offset_to_cell) {
-                ++num_cells_all;
+                ++result.num_cells_all;
                 deleting_cells.push_back(&cell);
             }
         }
@@ -679,27 +715,201 @@ std::string BlockFileCache::clear_file_cache_async() {
                 LOG(INFO) << "cell is not releasable, hash="
                           << " offset=" << cell->file_block->offset();
                 cell->file_block->set_deleting();
-                ++num_cells_wait_recycle;
+                ++result.num_cells_wait_recycle;
                 continue;
             }
             FileBlockSPtr file_block = cell->file_block;
             if (file_block) {
                 std::lock_guard block_lock(file_block->_mutex);
                 remove(file_block, cache_lock, block_lock, false);
-                ++num_cells_to_delete;
+                ++result.num_cells_to_delete;
             }
         }
         clear_need_update_lru_blocks();
     }
 
-    std::stringstream ss;
-    ss << "finish clear_file_cache_async, path=" << _cache_base_path
-       << " num_files_all=" << num_files_all << " num_cells_all=" << num_cells_all
-       << " num_cells_to_delete=" << num_cells_to_delete
-       << " num_cells_wait_recycle=" << num_cells_wait_recycle;
-    auto msg = ss.str();
-    LOG(INFO) << msg;
     _lru_dumper->remove_lru_dump_files();
+    return result;
+}
+
+size_t BlockFileCache::count_deleting_blocks_unlocked(
+        std::lock_guard<std::mutex>& /* cache_lock */) const {
+    size_t deleting_blocks = 0;
+    for (const auto& [_, offset_to_cell] : _files) {
+        for (const auto& [_1, cell] : offset_to_cell) {
+            if (cell.file_block->is_deleting()) {
+                ++deleting_blocks;
+            }
+        }
+    }
+    return deleting_blocks;
+}
+
+bool BlockFileCache::try_dequeue_recycle_key(FileCacheKey* key) {
+    std::lock_guard lock(_recycle_keys_mutex);
+    if (!_recycle_keys.try_dequeue(*key)) {
+        return false;
+    }
+    ++_recycle_remove_inflight;
+    return true;
+}
+
+Status BlockFileCache::remove_dequeued_recycle_key(const FileCacheKey& key) {
+    FileCacheStorageRemoveContextPtr context;
+    Status st;
+    int64_t duration_ns = 0;
+    {
+        SCOPED_RAW_TIMER(&duration_ns);
+        st = _storage->remove(key, &context);
+    }
+    *_storage_async_remove_latency_us << (duration_ns / 1000);
+    if (context) {
+        Status fence_st = context->wait();
+        if (st.ok() && !fence_st.ok()) {
+            st = fence_st;
+        }
+    }
+    {
+        std::lock_guard lock(_recycle_keys_mutex);
+        DCHECK_GT(_recycle_remove_inflight, 0);
+        --_recycle_remove_inflight;
+    }
+    _recycle_keys_cv.notify_all();
+    return st;
+}
+
+BlockFileCache::ClearFileCacheResult BlockFileCache::drain_recycle_keys(
+        const std::shared_ptr<ClearFileCacheCancelToken>& cancel_token) {
+    ClearFileCacheResult result;
+    auto is_cancelled = [&]() {
+        return cancel_token != nullptr && cancel_token->cancelled.load(std::memory_order_acquire);
+    };
+    FileCacheKey key;
+    while (!is_cancelled() && try_dequeue_recycle_key(&key)) {
+        Status st = remove_dequeued_recycle_key(key);
+        ++result.num_recycle_drained;
+        if (!st.ok()) {
+            LOG_WARNING("").error(st);
+            if (result.status.ok()) {
+                result.status = st;
+            }
+        }
+        if (is_cancelled()) {
+            result.cancelled = true;
+            break;
+        }
+    }
+    if (is_cancelled()) {
+        result.cancelled = true;
+    }
+    *_recycle_keys_length_recorder << _recycle_keys.size_approx();
+    return result;
+}
+
+bool BlockFileCache::recycle_keys_idle() {
+    std::unique_lock lock(_recycle_keys_mutex);
+    return _recycle_keys.size_approx() == 0 && _recycle_remove_inflight == 0;
+}
+
+void BlockFileCache::refresh_metrics_unlocked(std::lock_guard<std::mutex>& cache_lock) {
+    _cur_cache_size_metrics->set_value(_cur_cache_size);
+    _cur_ttl_cache_size_metrics->set_value(_cur_ttl_size);
+    _cur_ttl_cache_lru_queue_cache_size_metrics->set_value(_ttl_queue.get_capacity(cache_lock));
+    _cur_ttl_cache_lru_queue_element_count_metrics->set_value(
+            _ttl_queue.get_elements_num(cache_lock));
+    _cur_normal_queue_cache_size_metrics->set_value(_normal_queue.get_capacity(cache_lock));
+    _cur_normal_queue_element_count_metrics->set_value(_normal_queue.get_elements_num(cache_lock));
+    _cur_index_queue_cache_size_metrics->set_value(_index_queue.get_capacity(cache_lock));
+    _cur_index_queue_element_count_metrics->set_value(_index_queue.get_elements_num(cache_lock));
+    _cur_disposable_queue_cache_size_metrics->set_value(_disposable_queue.get_capacity(cache_lock));
+    _cur_disposable_queue_element_count_metrics->set_value(
+            _disposable_queue.get_elements_num(cache_lock));
+}
+
+std::string BlockFileCache::clear_file_cache_sync(
+        std::shared_ptr<ClearFileCacheCancelToken> cancel_token) {
+    LOG(INFO) << "start clear_file_cache_sync, path=" << _cache_base_path;
+    std::lock_guard clear_lock(_clear_mutex);
+    using namespace std::chrono;
+    auto start = steady_clock::now();
+    ClearFileCacheResult result;
+
+    class TtlManagerPauseGuard {
+    public:
+        explicit TtlManagerPauseGuard(BlockFileCache* cache) : _cache(cache) {
+            _cache->pause_ttl_manager();
+        }
+        ~TtlManagerPauseGuard() { _cache->resume_ttl_manager(); }
+
+    private:
+        BlockFileCache* _cache;
+    } ttl_pause_guard(this);
+
+    append_clear_result(result, clear_file_cache_async_impl());
+
+    while (true) {
+        size_t deleting_blocks = 0;
+        {
+            SCOPED_CACHE_LOCK(_mutex, this);
+            deleting_blocks = count_deleting_blocks_unlocked(cache_lock);
+        }
+
+        auto drain_result = drain_recycle_keys(cancel_token);
+        append_clear_result(result, drain_result);
+        if (result.cancelled) {
+            break;
+        }
+
+        if (deleting_blocks == 0 && recycle_keys_idle()) {
+            auto final_drain_result = drain_recycle_keys(cancel_token);
+            append_clear_result(result, final_drain_result);
+            if (result.cancelled) {
+                break;
+            }
+            if (!recycle_keys_idle()) {
+                ++result.wait_deleting_rounds;
+                std::unique_lock lock(_recycle_keys_mutex);
+                _recycle_keys_cv.wait_for(lock, milliseconds(10));
+                continue;
+            }
+            break;
+        }
+
+        ++result.wait_deleting_rounds;
+        if (cancel_token != nullptr && cancel_token->cancelled.load(std::memory_order_acquire)) {
+            result.cancelled = true;
+            break;
+        }
+
+        {
+            std::unique_lock lock(_recycle_keys_mutex);
+            _recycle_keys_cv.wait_for(lock, milliseconds(10));
+        }
+    }
+
+    if (!result.cancelled) {
+        while (!recycle_keys_idle()) {
+            append_clear_result(result, drain_recycle_keys(cancel_token));
+            if (result.cancelled) {
+                break;
+            }
+            std::unique_lock lock(_recycle_keys_mutex);
+            _recycle_keys_cv.wait_for(lock, milliseconds(10));
+        }
+    }
+
+    if (!result.cancelled) {
+        clear_need_update_lru_blocks();
+        _lru_dumper->remove_lru_dump_files();
+        {
+            SCOPED_CACHE_LOCK(_mutex, this);
+            refresh_metrics_unlocked(cache_lock);
+        }
+    }
+
+    result.elapsed_ms = duration_cast<milliseconds>(steady_clock::now() - start).count();
+    auto msg = result.to_string(_cache_base_path, "clear_file_cache_sync");
+    LOG(INFO) << msg;
     return msg;
 }
 
@@ -2086,15 +2296,8 @@ void BlockFileCache::run_background_gc() {
             }
         }
 
-        while (batch_count < batch_limit && _recycle_keys.try_dequeue(key)) {
-            int64_t duration_ns = 0;
-            Status st;
-            {
-                SCOPED_RAW_TIMER(&duration_ns);
-                st = _storage->remove(key);
-            }
-            *_storage_async_remove_latency_us << (duration_ns / 1000);
-
+        while (batch_count < batch_limit && try_dequeue_recycle_key(&key)) {
+            Status st = remove_dequeued_recycle_key(key);
             if (!st.ok()) {
                 LOG_WARNING("").error(st);
             }
@@ -2263,6 +2466,7 @@ void BlockFileCache::resume_ttl_manager() {
     }
 }
 
+#ifdef BE_TEST
 std::string BlockFileCache::clear_file_cache_directly() {
     pause_ttl_manager();
     _lru_dumper->remove_lru_dump_files();
@@ -2340,6 +2544,7 @@ std::string BlockFileCache::clear_file_cache_directly() {
     resume_ttl_manager();
     return result;
 }
+#endif
 
 std::map<size_t, FileBlockSPtr> BlockFileCache::get_blocks_by_key(const UInt128Wrapper& hash) {
     std::map<size_t, FileBlockSPtr> offset_to_block;

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -845,6 +845,45 @@ std::string BlockFileCache::clear_file_cache_sync(
         BlockFileCache* _cache;
     } ttl_pause_guard(this);
 
+    while (!_async_open_done.load(std::memory_order_acquire)) {
+        if (cancel_token != nullptr && cancel_token->cancelled.load(std::memory_order_acquire)) {
+            result.cancelled = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    if (!result.cancelled) {
+        {
+            SCOPED_CACHE_LOCK(_mutex, this);
+            DCHECK(!_clear_file_cache_sync_running);
+            _clear_file_cache_sync_running = true;
+        }
+        TEST_SYNC_POINT_CALLBACK("BlockFileCache::clear_file_cache_sync:barrier_ready");
+    }
+    class ClearInProgressGuard {
+    public:
+        ClearInProgressGuard(BlockFileCache* cache, bool active) : _cache(cache), _active(active) {}
+        ~ClearInProgressGuard() {
+            if (!_active) {
+                return;
+            }
+            SCOPED_CACHE_LOCK(_cache->_mutex, _cache);
+            DCHECK(_cache->_clear_file_cache_sync_running);
+            _cache->_clear_file_cache_sync_running = false;
+        }
+
+    private:
+        BlockFileCache* _cache;
+        bool _active;
+    } clear_in_progress_guard(this, !result.cancelled);
+
+    if (result.cancelled) {
+        result.elapsed_ms = duration_cast<milliseconds>(steady_clock::now() - start).count();
+        auto msg = result.to_string(_cache_base_path, "clear_file_cache_sync");
+        LOG(INFO) << msg;
+        return msg;
+    }
+
     append_clear_result(result, clear_file_cache_async_impl());
 
     while (true) {
@@ -962,6 +1001,36 @@ FileBlocks BlockFileCache::split_range_into_cells(const UInt128Wrapper& hash,
     return file_blocks;
 }
 
+FileBlocks BlockFileCache::split_range_into_skip_cache_blocks(const UInt128Wrapper& hash,
+                                                              const CacheContext& context,
+                                                              size_t offset, size_t size) {
+    DCHECK(size > 0);
+
+    auto current_pos = offset;
+    auto end_pos_non_included = offset + size;
+    size_t remaining_size = size;
+
+    FileBlocks file_blocks;
+    while (current_pos < end_pos_non_included) {
+        size_t current_size = std::min(remaining_size, _max_file_block_size);
+        remaining_size -= current_size;
+
+        FileCacheKey key;
+        key.hash = hash;
+        key.offset = current_pos;
+        key.meta.type = context.cache_type;
+        key.meta.expiration_time = context.expiration_time;
+        key.meta.tablet_id = context.tablet_id;
+        file_blocks.push_back(
+                std::make_shared<FileBlock>(key, current_size, this, FileBlock::State::SKIP_CACHE));
+
+        current_pos += current_size;
+    }
+
+    DCHECK(file_blocks.empty() || offset + size - 1 == file_blocks.back()->range().right);
+    return file_blocks;
+}
+
 void BlockFileCache::fill_holes_with_empty_file_blocks(FileBlocks& file_blocks,
                                                        const UInt128Wrapper& hash,
                                                        const CacheContext& context,
@@ -1027,6 +1096,47 @@ void BlockFileCache::fill_holes_with_empty_file_blocks(FileBlocks& file_blocks,
     }
 }
 
+void BlockFileCache::fill_holes_with_skip_cache_blocks(FileBlocks& file_blocks,
+                                                       const UInt128Wrapper& hash,
+                                                       const CacheContext& context,
+                                                       const FileBlock::Range& range) {
+    auto it = file_blocks.begin();
+    auto block_range = (*it)->range();
+
+    size_t current_pos = 0;
+    if (block_range.left < range.left) {
+        current_pos = block_range.right + 1;
+        ++it;
+    } else {
+        current_pos = range.left;
+    }
+
+    while (current_pos <= range.right && it != file_blocks.end()) {
+        block_range = (*it)->range();
+
+        if (current_pos == block_range.left) {
+            current_pos = block_range.right + 1;
+            ++it;
+            continue;
+        }
+
+        DCHECK(current_pos < block_range.left);
+
+        auto hole_size = block_range.left - current_pos;
+        file_blocks.splice(
+                it, split_range_into_skip_cache_blocks(hash, context, current_pos, hole_size));
+
+        current_pos = block_range.right + 1;
+        ++it;
+    }
+
+    if (current_pos <= range.right) {
+        auto hole_size = range.right - current_pos + 1;
+        file_blocks.splice(file_blocks.end(), split_range_into_skip_cache_blocks(
+                                                      hash, context, current_pos, hole_size));
+    }
+}
+
 FileBlocksHolder BlockFileCache::get_or_set(const UInt128Wrapper& hash, size_t offset, size_t size,
                                             CacheContext& context) {
     FileBlock::Range range(offset, offset + size - 1);
@@ -1051,7 +1161,13 @@ FileBlocksHolder BlockFileCache::get_or_set(const UInt128Wrapper& hash, size_t o
             file_blocks = get_impl(hash, context, range, cache_lock);
         }
 
-        if (file_blocks.empty()) {
+        if (_clear_file_cache_sync_running && file_blocks.empty()) {
+            SCOPED_RAW_TIMER(&stats->set_timer);
+            file_blocks = split_range_into_skip_cache_blocks(hash, context, offset, size);
+        } else if (_clear_file_cache_sync_running) {
+            SCOPED_RAW_TIMER(&stats->set_timer);
+            fill_holes_with_skip_cache_blocks(file_blocks, hash, context, range);
+        } else if (file_blocks.empty()) {
             SCOPED_RAW_TIMER(&stats->set_timer);
             file_blocks = split_range_into_cells(hash, context, offset, size,
                                                  FileBlock::State::EMPTY, cache_lock);

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -745,8 +745,25 @@ size_t BlockFileCache::count_deleting_blocks_unlocked(
     return deleting_blocks;
 }
 
-bool BlockFileCache::try_dequeue_recycle_key(FileCacheKey* key) {
+bool BlockFileCache::enqueue_recycle_key(const FileCacheKey& key) {
+    bool ret = false;
+    {
+        std::lock_guard lock(_recycle_keys_mutex);
+        ret = _recycle_keys.enqueue(key);
+    }
+    if (ret) {
+        _recycle_keys_cv.notify_all();
+    }
+    return ret;
+}
+
+bool BlockFileCache::try_dequeue_recycle_key(FileCacheKey* key, bool for_sync_clear) {
     std::lock_guard lock(_recycle_keys_mutex);
+    // Only the sync clear drain path waits for metadata delete fences. Keep keys in the queue
+    // while sync clear is active so background GC cannot finish them with async meta delete.
+    if (_clear_file_cache_sync_running.load(std::memory_order_acquire) && !for_sync_clear) {
+        return false;
+    }
     if (!_recycle_keys.try_dequeue(*key)) {
         return false;
     }
@@ -790,7 +807,7 @@ BlockFileCache::ClearFileCacheResult BlockFileCache::drain_recycle_keys(
         return cancel_token != nullptr && cancel_token->cancelled.load(std::memory_order_acquire);
     };
     FileCacheKey key;
-    while (!is_cancelled() && try_dequeue_recycle_key(&key)) {
+    while (!is_cancelled() && try_dequeue_recycle_key(&key, true)) {
         Status st = remove_dequeued_recycle_key(key, true);
         ++result.num_recycle_drained;
         if (!st.ok()) {
@@ -859,9 +876,9 @@ std::string BlockFileCache::clear_file_cache_sync(
     }
     if (!result.cancelled) {
         {
-            SCOPED_CACHE_LOCK(_mutex, this);
-            DCHECK(!_clear_file_cache_sync_running);
-            _clear_file_cache_sync_running = true;
+            std::lock_guard lock(_recycle_keys_mutex);
+            DCHECK(!_clear_file_cache_sync_running.load(std::memory_order_acquire));
+            _clear_file_cache_sync_running.store(true, std::memory_order_release);
         }
         TEST_SYNC_POINT_CALLBACK("BlockFileCache::clear_file_cache_sync:barrier_ready");
     }
@@ -872,9 +889,12 @@ std::string BlockFileCache::clear_file_cache_sync(
             if (!_active) {
                 return;
             }
-            SCOPED_CACHE_LOCK(_cache->_mutex, _cache);
-            DCHECK(_cache->_clear_file_cache_sync_running);
-            _cache->_clear_file_cache_sync_running = false;
+            {
+                std::lock_guard lock(_cache->_recycle_keys_mutex);
+                DCHECK(_cache->_clear_file_cache_sync_running.load(std::memory_order_acquire));
+                _cache->_clear_file_cache_sync_running.store(false, std::memory_order_release);
+            }
+            _cache->_recycle_keys_cv.notify_all();
         }
 
     private:
@@ -890,6 +910,7 @@ std::string BlockFileCache::clear_file_cache_sync(
     }
 
     append_clear_result(result, clear_file_cache_async_impl());
+    TEST_SYNC_POINT_CALLBACK("BlockFileCache::clear_file_cache_sync:before_drain_recycle_keys");
 
     while (true) {
         size_t deleting_blocks = 0;
@@ -1120,7 +1141,7 @@ FileBlocksHolder BlockFileCache::get_or_set(const UInt128Wrapper& hash, size_t o
         stats->lock_wait_timer += sw.elapsed_time();
         SCOPED_RAW_TIMER(&duration);
         /// Get all blocks which intersect with the given range.
-        if (_clear_file_cache_sync_running) {
+        if (_clear_file_cache_sync_running.load(std::memory_order_acquire)) {
             SCOPED_RAW_TIMER(&stats->set_timer);
             file_blocks = split_range_into_skip_cache_blocks(hash, context, offset, size);
         } else {
@@ -1791,7 +1812,7 @@ void BlockFileCache::remove(FileBlockSPtr file_block, T& cache_lock, U& block_lo
             // the file will be deleted in the bottom half
             // so there will be a window that the file is not in the cache but still in the storage
             // but it's ok, because the rowset is stale already
-            bool ret = _recycle_keys.enqueue(key);
+            bool ret = enqueue_recycle_key(key);
             if (ret) [[likely]] {
                 *_recycle_keys_length_recorder << _recycle_keys.size_approx();
             } else {
@@ -2373,7 +2394,7 @@ void BlockFileCache::run_background_gc() {
             }
         }
 
-        while (batch_count < batch_limit && try_dequeue_recycle_key(&key)) {
+        while (batch_count < batch_limit && try_dequeue_recycle_key(&key, false)) {
             Status st = remove_dequeued_recycle_key(key, false);
             if (!st.ok()) {
                 LOG_WARNING("").error(st);

--- a/be/src/io/cache/block_file_cache.cpp
+++ b/be/src/io/cache/block_file_cache.cpp
@@ -754,16 +754,21 @@ bool BlockFileCache::try_dequeue_recycle_key(FileCacheKey* key) {
     return true;
 }
 
-Status BlockFileCache::remove_dequeued_recycle_key(const FileCacheKey& key) {
+Status BlockFileCache::remove_dequeued_recycle_key(const FileCacheKey& key,
+                                                   bool wait_meta_delete_fence) {
     FileCacheStorageRemoveContextPtr context;
     Status st;
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);
-        st = _storage->remove(key, &context);
+        if (wait_meta_delete_fence) {
+            st = _storage->remove(key, &context);
+        } else {
+            st = _storage->remove(key);
+        }
     }
     *_storage_async_remove_latency_us << (duration_ns / 1000);
-    if (context) {
+    if (wait_meta_delete_fence && context) {
         Status fence_st = context->wait();
         if (st.ok() && !fence_st.ok()) {
             st = fence_st;
@@ -786,7 +791,7 @@ BlockFileCache::ClearFileCacheResult BlockFileCache::drain_recycle_keys(
     };
     FileCacheKey key;
     while (!is_cancelled() && try_dequeue_recycle_key(&key)) {
-        Status st = remove_dequeued_recycle_key(key);
+        Status st = remove_dequeued_recycle_key(key, true);
         ++result.num_recycle_drained;
         if (!st.ok()) {
             LOG_WARNING("").error(st);
@@ -2413,7 +2418,7 @@ void BlockFileCache::run_background_gc() {
         }
 
         while (batch_count < batch_limit && try_dequeue_recycle_key(&key)) {
-            Status st = remove_dequeued_recycle_key(key);
+            Status st = remove_dequeued_recycle_key(key, false);
             if (!st.ok()) {
                 LOG_WARNING("").error(st);
             }

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -246,7 +247,16 @@ public:
      * @returns summary message
      */
     std::string clear_file_cache_async();
+    struct ClearFileCacheCancelToken {
+        std::atomic_bool cancelled {false};
+    };
+    std::string clear_file_cache_sync(
+            std::shared_ptr<ClearFileCacheCancelToken> cancel_token = nullptr);
+#ifdef BE_TEST
+    // Test-only helper. It bypasses FileBlock holder lifecycle and must not be used
+    // by production clear paths.
     std::string clear_file_cache_directly();
+#endif
 
     /**
      * Reset the cache capacity. If the new_capacity is smaller than _capacity, the redundant data will be remove async.
@@ -396,6 +406,30 @@ public:
     Status check_file_cache_consistency(InconsistencyContext& inconsistency_context);
 
 private:
+    struct ClearFileCacheResult {
+        int64_t num_files_all = 0;
+        int64_t num_cells_all = 0;
+        int64_t num_cells_to_delete = 0;
+        int64_t num_cells_wait_recycle = 0;
+        int64_t num_recycle_drained = 0;
+        int64_t wait_deleting_rounds = 0;
+        int64_t elapsed_ms = 0;
+        bool cancelled = false;
+        Status status = Status::OK();
+
+        std::string to_string(const std::string& path, std::string_view action) const;
+    };
+
+    ClearFileCacheResult clear_file_cache_async_impl();
+    void append_clear_result(ClearFileCacheResult& result, const ClearFileCacheResult& other);
+    size_t count_deleting_blocks_unlocked(std::lock_guard<std::mutex>& cache_lock) const;
+    ClearFileCacheResult drain_recycle_keys(
+            const std::shared_ptr<ClearFileCacheCancelToken>& cancel_token = nullptr);
+    bool recycle_keys_idle();
+    bool try_dequeue_recycle_key(FileCacheKey* key);
+    Status remove_dequeued_recycle_key(const FileCacheKey& key);
+    void refresh_metrics_unlocked(std::lock_guard<std::mutex>& cache_lock);
+
     LRUQueue& get_queue(FileCacheType type);
     const LRUQueue& get_queue(FileCacheType type) const;
 
@@ -552,6 +586,10 @@ private:
 
     // keys for async remove
     RecycleFileCacheKeys _recycle_keys;
+    std::mutex _clear_mutex;
+    std::mutex _recycle_keys_mutex;
+    std::condition_variable _recycle_keys_cv;
+    size_t _recycle_remove_inflight = 0;
 
     std::unique_ptr<LRUQueueRecorder> _lru_recorder;
     std::unique_ptr<CacheLRUDumper> _lru_dumper;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -488,10 +488,6 @@ private:
                                            const CacheContext& context,
                                            const FileBlock::Range& range,
                                            std::lock_guard<std::mutex>& cache_lock);
-    void fill_holes_with_skip_cache_blocks(FileBlocks& file_blocks, const UInt128Wrapper& hash,
-                                           const CacheContext& context,
-                                           const FileBlock::Range& range);
-
     size_t get_used_cache_size_unlocked(FileCacheType type,
                                         std::lock_guard<std::mutex>& cache_lock) const;
 

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -427,7 +427,7 @@ private:
             const std::shared_ptr<ClearFileCacheCancelToken>& cancel_token = nullptr);
     bool recycle_keys_idle();
     bool try_dequeue_recycle_key(FileCacheKey* key);
-    Status remove_dequeued_recycle_key(const FileCacheKey& key);
+    Status remove_dequeued_recycle_key(const FileCacheKey& key, bool wait_meta_delete_fence);
     void refresh_metrics_unlocked(std::lock_guard<std::mutex>& cache_lock);
 
     LRUQueue& get_queue(FileCacheType type);

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -474,6 +474,9 @@ private:
     FileBlocks split_range_into_cells(const UInt128Wrapper& hash, const CacheContext& context,
                                       size_t offset, size_t size, FileBlock::State state,
                                       std::lock_guard<std::mutex>& cache_lock);
+    FileBlocks split_range_into_skip_cache_blocks(const UInt128Wrapper& hash,
+                                                  const CacheContext& context, size_t offset,
+                                                  size_t size);
 
     std::string dump_structure_unlocked(const UInt128Wrapper& hash,
                                         std::lock_guard<std::mutex>& cache_lock);
@@ -485,6 +488,9 @@ private:
                                            const CacheContext& context,
                                            const FileBlock::Range& range,
                                            std::lock_guard<std::mutex>& cache_lock);
+    void fill_holes_with_skip_cache_blocks(FileBlocks& file_blocks, const UInt128Wrapper& hash,
+                                           const CacheContext& context,
+                                           const FileBlock::Range& range);
 
     size_t get_used_cache_size_unlocked(FileCacheType type,
                                         std::lock_guard<std::mutex>& cache_lock) const;
@@ -563,6 +569,8 @@ private:
     bool _disk_resource_limit_mode {false};
     bool _need_evict_cache_in_advance {false};
     bool _is_initialized {false};
+    // Guarded by _mutex. Cache misses skip insertion while sync clear is draining old blocks.
+    bool _clear_file_cache_sync_running {false};
 
     // strategy
     using FileBlocksByOffset = std::map<size_t, FileBlockCell>;

--- a/be/src/io/cache/block_file_cache.h
+++ b/be/src/io/cache/block_file_cache.h
@@ -426,7 +426,8 @@ private:
     ClearFileCacheResult drain_recycle_keys(
             const std::shared_ptr<ClearFileCacheCancelToken>& cancel_token = nullptr);
     bool recycle_keys_idle();
-    bool try_dequeue_recycle_key(FileCacheKey* key);
+    bool enqueue_recycle_key(const FileCacheKey& key);
+    bool try_dequeue_recycle_key(FileCacheKey* key, bool for_sync_clear);
     Status remove_dequeued_recycle_key(const FileCacheKey& key, bool wait_meta_delete_fence);
     void refresh_metrics_unlocked(std::lock_guard<std::mutex>& cache_lock);
 
@@ -565,8 +566,9 @@ private:
     bool _disk_resource_limit_mode {false};
     bool _need_evict_cache_in_advance {false};
     bool _is_initialized {false};
-    // Guarded by _mutex. Cache misses skip insertion while sync clear is draining old blocks.
-    bool _clear_file_cache_sync_running {false};
+    // Set under _recycle_keys_mutex. Cache reads use the atomic value to skip insertion, and
+    // background GC uses it to leave recycle keys for the sync clear drain path.
+    std::atomic_bool _clear_file_cache_sync_running {false};
 
     // strategy
     using FileBlocksByOffset = std::map<size_t, FileBlockCell>;

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -247,20 +247,21 @@ FileCacheFactory::get_query_context_holders(const TUniqueId& query_id,
     return holders;
 }
 
-std::string FileCacheFactory::clear_file_caches(bool sync) {
+std::string FileCacheFactory::clear_file_caches(
+        bool sync, std::shared_ptr<BlockFileCache::ClearFileCacheCancelToken> cancel_token) {
     std::vector<std::string> results(_caches.size());
 #ifndef USE_LIBCPP
     std::for_each(std::execution::par, _caches.begin(), _caches.end(), [&](const auto& cache) {
         size_t index = &cache - &_caches[0];
         results[index] =
-                sync ? cache->clear_file_cache_directly() : cache->clear_file_cache_async();
+                sync ? cache->clear_file_cache_sync(cancel_token) : cache->clear_file_cache_async();
     });
 #else
     // libcpp do not support std::execution::par
     std::for_each(_caches.begin(), _caches.end(), [&](const auto& cache) {
         size_t index = &cache - &_caches[0];
         results[index] =
-                sync ? cache->clear_file_cache_directly() : cache->clear_file_cache_async();
+                sync ? cache->clear_file_cache_sync(cancel_token) : cache->clear_file_cache_async();
     });
 #endif
     std::stringstream ss;

--- a/be/src/io/cache/block_file_cache_factory.h
+++ b/be/src/io/cache/block_file_cache_factory.h
@@ -84,7 +84,9 @@ public:
      * @param sync wait until all data cleared
      * @return summary message
      */
-    std::string clear_file_caches(bool sync);
+    std::string clear_file_caches(
+            bool sync,
+            std::shared_ptr<BlockFileCache::ClearFileCacheCancelToken> cancel_token = nullptr);
 
     /**
      * dump lru queue info for all file cache instances

--- a/be/src/io/cache/cache_block_meta_store.cpp
+++ b/be/src/io/cache/cache_block_meta_store.cpp
@@ -367,6 +367,34 @@ void CacheBlockMetaStore::delete_key(const BlockMetaKey& key) {
     _write_queue.enqueue(op);
 }
 
+CacheBlockMetaStore::DeleteFence CacheBlockMetaStore::delete_key_with_fence(
+        const BlockMetaKey& key) {
+    std::string key_str = serialize_key(key);
+
+    WriteOperation op;
+    op.type = OperationType::DELETE;
+    op.key = key_str;
+    op.status = std::make_shared<Status>(Status::OK());
+    op.done = std::make_shared<std::atomic_bool>(false);
+
+    DeleteFence fence {.status = op.status, .done = op.done};
+    if (!_write_queue.enqueue(std::move(op))) {
+        *fence.status = Status::InternalError("failed to enqueue file cache meta delete operation");
+        fence.done->store(true, std::memory_order_release);
+    }
+    return fence;
+}
+
+Status CacheBlockMetaStore::wait_for_fence(const DeleteFence& fence) {
+    if (!fence.done) {
+        return Status::OK();
+    }
+    std::unique_lock lock(_fence_mutex);
+    _fence_cv.wait(lock,
+                   [&] { return fence.done->load(std::memory_order_acquire); });
+    return fence.status ? *fence.status : Status::OK();
+}
+
 void CacheBlockMetaStore::clear() {
     // First, stop the async worker thread
     _stop_worker.store(true, std::memory_order_release);
@@ -377,6 +405,7 @@ void CacheBlockMetaStore::clear() {
     // Clear the write queue to remove any pending operations
     WriteOperation op;
     while (_write_queue.try_dequeue(op)) {
+        finish_write_operation(op, rocksdb::Status::OK());
         // Just discard all pending operations
     }
 
@@ -398,6 +427,29 @@ void CacheBlockMetaStore::clear() {
     _write_thread = std::thread(&CacheBlockMetaStore::async_write_worker, this);
 }
 
+void CacheBlockMetaStore::finish_write_operation(WriteOperation& op,
+                                                 const rocksdb::Status& status) {
+    if (!op.status && !op.done) {
+        return;
+    }
+    if (op.status) {
+        if (status.ok()) {
+            *op.status = Status::OK();
+        } else {
+            *op.status = Status::InternalError("Failed to {} file cache meta: {}",
+                                               op.type == OperationType::PUT ? "write" : "delete",
+                                               status.ToString());
+        }
+    }
+    if (op.done) {
+        {
+            std::lock_guard lock(_fence_mutex);
+            op.done->store(true, std::memory_order_release);
+        }
+        _fence_cv.notify_all();
+    }
+}
+
 void CacheBlockMetaStore::async_write_worker() {
     Thread::set_self_name("cache_block_meta_store_async_write_worker");
     while (!_stop_worker.load(std::memory_order_acquire)) {
@@ -408,6 +460,8 @@ void CacheBlockMetaStore::async_write_worker() {
 
             if (!_db) {
                 LOG(WARNING) << "Database not initialized, skipping operation";
+                finish_write_operation(
+                        op, rocksdb::Status::IOError("Database not initialized"));
                 continue;
             }
 
@@ -428,6 +482,7 @@ void CacheBlockMetaStore::async_write_worker() {
                     g_rocksdb_delete_failed_num << 1;
                 }
             }
+            finish_write_operation(op, status);
         } else {
             // Queue is empty, sleep briefly
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -441,6 +496,7 @@ void CacheBlockMetaStore::async_write_worker() {
 
         if (!_db) {
             LOG(WARNING) << "Database not initialized, skipping operation";
+            finish_write_operation(op, rocksdb::Status::IOError("Database not initialized"));
             continue;
         }
 
@@ -455,6 +511,7 @@ void CacheBlockMetaStore::async_write_worker() {
             LOG(WARNING) << "Failed to " << (op.type == OperationType::PUT ? "write" : "delete")
                          << " to rocksdb: " << status.ToString();
         }
+        finish_write_operation(op, status);
     }
 }
 

--- a/be/src/io/cache/cache_block_meta_store.cpp
+++ b/be/src/io/cache/cache_block_meta_store.cpp
@@ -390,8 +390,7 @@ Status CacheBlockMetaStore::wait_for_fence(const DeleteFence& fence) {
         return Status::OK();
     }
     std::unique_lock lock(_fence_mutex);
-    _fence_cv.wait(lock,
-                   [&] { return fence.done->load(std::memory_order_acquire); });
+    _fence_cv.wait(lock, [&] { return fence.done->load(std::memory_order_acquire); });
     return fence.status ? *fence.status : Status::OK();
 }
 
@@ -460,8 +459,7 @@ void CacheBlockMetaStore::async_write_worker() {
 
             if (!_db) {
                 LOG(WARNING) << "Database not initialized, skipping operation";
-                finish_write_operation(
-                        op, rocksdb::Status::IOError("Database not initialized"));
+                finish_write_operation(op, rocksdb::Status::IOError("Database not initialized"));
                 continue;
             }
 

--- a/be/src/io/cache/cache_block_meta_store.h
+++ b/be/src/io/cache/cache_block_meta_store.h
@@ -25,6 +25,7 @@
 #include <rocksdb/status.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -105,6 +106,16 @@ public:
     // Asynchronously delete specified BlockMeta
     void delete_key(const BlockMetaKey& key);
 
+    struct DeleteFence {
+        std::shared_ptr<Status> status;
+        std::shared_ptr<std::atomic_bool> done;
+    };
+
+    // Asynchronously delete specified BlockMeta and return a fence for this delete operation.
+    DeleteFence delete_key_with_fence(const BlockMetaKey& key);
+
+    Status wait_for_fence(const DeleteFence& fence);
+
     // Clear all records from rocksdb and the async queue
     void clear();
 
@@ -128,11 +139,17 @@ private:
         OperationType type;
         std::string key;
         std::string value; // Only used for PUT operations
+        std::shared_ptr<Status> status;
+        std::shared_ptr<std::atomic_bool> done;
     };
+    void finish_write_operation(WriteOperation& op, const rocksdb::Status& status);
+
     moodycamel::ConcurrentQueue<WriteOperation> _write_queue;
     std::atomic<bool> _stop_worker {false};
     std::thread _write_thread;
     std::mutex _queue_mutex;
+    std::mutex _fence_mutex;
+    std::condition_variable _fence_cv;
 
     std::unique_ptr<ThreadPool> _thread_pool;
 };

--- a/be/src/io/cache/file_block.h
+++ b/be/src/io/cache/file_block.h
@@ -137,9 +137,9 @@ public:
     FileBlock& operator=(const FileBlock&) = delete;
     FileBlock(const FileBlock&) = delete;
 
-    // block is being using by other thread when deleting, so tag it is_deleting and delete later on¬
-    void set_deleting() { _is_deleting = true; }
-    bool is_deleting() const { return _is_deleting; };
+    // Block is still held by another thread when clear/evict wants to delete it.
+    void set_deleting() { _is_deleting.store(true, std::memory_order_release); }
+    bool is_deleting() const { return _is_deleting.load(std::memory_order_acquire); };
 
 public:
     std::atomic<bool> _owned_by_cached_reader {
@@ -170,7 +170,7 @@ private:
     std::condition_variable _cv;
     FileCacheKey _key;
     size_t _downloaded_size {0};
-    bool _is_deleting {false};
+    std::atomic_bool _is_deleting {false};
 
     FileBlockCell* cell {nullptr};
 };

--- a/be/src/io/cache/file_cache_storage.h
+++ b/be/src/io/cache/file_cache_storage.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 
 #include "common/status.h"
@@ -26,6 +27,13 @@
 namespace doris::io {
 
 class BlockFileCache;
+
+struct FileCacheStorageRemoveContext {
+    virtual ~FileCacheStorageRemoveContext() = default;
+    virtual Status wait() { return Status::OK(); }
+};
+
+using FileCacheStorageRemoveContextPtr = std::shared_ptr<FileCacheStorageRemoveContext>;
 
 using FileWriterMapKey = std::pair<UInt128Wrapper, size_t>;
 
@@ -58,6 +66,13 @@ public:
     virtual Status read(const FileCacheKey& key, size_t value_offset, Slice result) = 0;
     // remove the block
     virtual Status remove(const FileCacheKey& key) = 0;
+    // remove the block and optionally return a context that waits for durable metadata cleanup
+    virtual Status remove(const FileCacheKey& key, FileCacheStorageRemoveContextPtr* context) {
+        if (context != nullptr) {
+            context->reset();
+        }
+        return remove(key);
+    }
     // change the block meta
     virtual Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type,
                                         const size_t size) = 0;

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -281,6 +281,14 @@ Status FSFileCacheStorage::read(const FileCacheKey& key, size_t value_offset, Sl
 }
 
 Status FSFileCacheStorage::remove(const FileCacheKey& key) {
+    return remove(key, nullptr);
+}
+
+Status FSFileCacheStorage::remove(const FileCacheKey& key,
+                                  FileCacheStorageRemoveContextPtr* context) {
+    if (context != nullptr) {
+        context->reset();
+    }
     const std::string v3_dir = get_path_in_local_cache_v3(key.hash);
     const std::string v3_file = get_path_in_local_cache_v3(v3_dir, key.offset);
     FDCache::instance()->remove_file_reader(std::make_pair(key.hash, key.offset));
@@ -295,7 +303,22 @@ Status FSFileCacheStorage::remove(const FileCacheKey& key) {
     }
 
     BlockMetaKey mkey(key.meta.tablet_id, UInt128Wrapper(key.hash), key.offset);
-    _meta_store->delete_key(mkey);
+    if (context == nullptr) {
+        _meta_store->delete_key(mkey);
+    } else {
+        struct MetaDeleteContext final : public FileCacheStorageRemoveContext {
+            MetaDeleteContext(CacheBlockMetaStore* meta_store,
+                              CacheBlockMetaStore::DeleteFence delete_fence)
+                    : meta_store(meta_store), delete_fence(std::move(delete_fence)) {}
+
+            Status wait() override { return meta_store->wait_for_fence(delete_fence); }
+
+            CacheBlockMetaStore* meta_store;
+            CacheBlockMetaStore::DeleteFence delete_fence;
+        };
+        *context = std::make_shared<MetaDeleteContext>(_meta_store.get(),
+                                                       _meta_store->delete_key_with_fence(mkey));
+    }
     std::vector<FileInfo> files;
     bool exists {false};
     RETURN_IF_ERROR(fs->list(v2_dir, true, &files, &exists));

--- a/be/src/io/cache/fs_file_cache_storage.h
+++ b/be/src/io/cache/fs_file_cache_storage.h
@@ -78,6 +78,7 @@ public:
     Status finalize(const FileCacheKey& key, const size_t size) override;
     Status read(const FileCacheKey& key, size_t value_offset, Slice buffer) override;
     Status remove(const FileCacheKey& key) override;
+    Status remove(const FileCacheKey& key, FileCacheStorageRemoveContextPtr* context) override;
     Status change_key_meta_type(const FileCacheKey& key, const FileCacheType type,
                                 const size_t size) override;
     void load_blocks_directly_unlocked(BlockFileCache* _mgr, const FileCacheKey& key,

--- a/be/src/service/http/action/file_cache_action.cpp
+++ b/be/src/service/http/action/file_cache_action.cpp
@@ -19,8 +19,8 @@
 
 #include <glog/logging.h>
 
-#include <atomic>
 #include <algorithm>
+#include <atomic>
 #include <memory>
 #include <shared_mutex>
 #include <sstream>
@@ -98,9 +98,8 @@ Status FileCacheAction::_handle_header(
         const std::string& sync = req->param(std::string(SYNC));
         const std::string& segment_path = req->param(std::string(VALUE));
         if (segment_path.empty()) {
-            *json_metrics =
-                    io::FileCacheFactory::instance()->clear_file_caches(to_lower(sync) == "true",
-                                                                        cancel_token);
+            *json_metrics = io::FileCacheFactory::instance()->clear_file_caches(
+                    to_lower(sync) == "true", cancel_token);
         } else {
             io::UInt128Wrapper hash = io::BlockFileCache::hash(segment_path);
             io::BlockFileCache* cache = io::FileCacheFactory::instance()->get_by_path(hash);
@@ -224,11 +223,9 @@ void FileCacheAction::handle(HttpRequest* req) {
         const std::string header_json(HEADER_JSON);
         req->add_output_header(HttpHeaders::CONTENT_TYPE, header_json.c_str());
         req->mark_send_reply();
-        auto cancel_token =
-                std::make_shared<io::BlockFileCache::ClearFileCacheCancelToken>();
-        req->set_cancel_callback([cancel_token] {
-            cancel_token->cancelled.store(true, std::memory_order_release);
-        });
+        auto cancel_token = std::make_shared<io::BlockFileCache::ClearFileCacheCancelToken>();
+        req->set_cancel_callback(
+                [cancel_token] { cancel_token->cancelled.store(true, std::memory_order_release); });
         std::thread([this, req, cancel_token] {
             std::string json_metrics;
             Status status = _handle_header(req, &json_metrics, cancel_token, false);

--- a/be/src/service/http/action/file_cache_action.cpp
+++ b/be/src/service/http/action/file_cache_action.cpp
@@ -34,6 +34,7 @@
 #include "io/cache/block_file_cache_factory.h"
 #include "io/cache/file_cache_common.h"
 #include "io/cache/fs_file_cache_storage.h"
+#include "runtime/thread_context.h"
 #include "service/http/http_channel.h"
 #include "service/http/http_headers.h"
 #include "service/http/http_request.h"
@@ -227,6 +228,7 @@ void FileCacheAction::handle(HttpRequest* req) {
         req->set_cancel_callback(
                 [cancel_token] { cancel_token->cancelled.store(true, std::memory_order_release); });
         std::thread([this, req, cancel_token] {
+            SCOPED_INIT_THREAD_CONTEXT();
             std::string json_metrics;
             Status status = _handle_header(req, &json_metrics, cancel_token, false);
             std::string status_result = status.to_json();

--- a/be/src/service/http/action/file_cache_action.cpp
+++ b/be/src/service/http/action/file_cache_action.cpp
@@ -19,12 +19,14 @@
 
 #include <glog/logging.h>
 
+#include <atomic>
 #include <algorithm>
 #include <memory>
 #include <shared_mutex>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #include "common/status.h"
@@ -60,9 +62,20 @@ constexpr static std::string_view DUMP = "dump";
 constexpr static std::string_view VALUE = "value";
 constexpr static std::string_view RELOAD = "reload";
 
-Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metrics) {
+bool FileCacheAction::_is_sync_clear_request(HttpRequest* req) const {
+    return req->param(std::string(OP)) == CLEAR &&
+           to_lower(req->param(std::string(SYNC))) == "true" &&
+           req->param(std::string(VALUE)).empty();
+}
+
+Status FileCacheAction::_handle_header(
+        HttpRequest* req, std::string* json_metrics,
+        std::shared_ptr<io::BlockFileCache::ClearFileCacheCancelToken> cancel_token,
+        bool add_header) {
     const std::string header_json(HEADER_JSON);
-    req->add_output_header(HttpHeaders::CONTENT_TYPE, header_json.c_str());
+    if (add_header) {
+        req->add_output_header(HttpHeaders::CONTENT_TYPE, header_json.c_str());
+    }
     std::string operation = req->param(std::string(OP));
     Status st = Status::OK();
     if (operation == RELEASE) {
@@ -85,7 +98,9 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
         const std::string& sync = req->param(std::string(SYNC));
         const std::string& segment_path = req->param(std::string(VALUE));
         if (segment_path.empty()) {
-            io::FileCacheFactory::instance()->clear_file_caches(to_lower(sync) == "true");
+            *json_metrics =
+                    io::FileCacheFactory::instance()->clear_file_caches(to_lower(sync) == "true",
+                                                                        cancel_token);
         } else {
             io::UInt128Wrapper hash = io::BlockFileCache::hash(segment_path);
             io::BlockFileCache* cache = io::FileCacheFactory::instance()->get_by_path(hash);
@@ -205,6 +220,29 @@ Status FileCacheAction::_handle_header(HttpRequest* req, std::string* json_metri
 }
 
 void FileCacheAction::handle(HttpRequest* req) {
+    if (_is_sync_clear_request(req)) {
+        const std::string header_json(HEADER_JSON);
+        req->add_output_header(HttpHeaders::CONTENT_TYPE, header_json.c_str());
+        req->mark_send_reply();
+        auto cancel_token =
+                std::make_shared<io::BlockFileCache::ClearFileCacheCancelToken>();
+        req->set_cancel_callback([cancel_token] {
+            cancel_token->cancelled.store(true, std::memory_order_release);
+        });
+        std::thread([this, req, cancel_token] {
+            std::string json_metrics;
+            Status status = _handle_header(req, &json_metrics, cancel_token, false);
+            std::string status_result = status.to_json();
+            if (status.ok()) {
+                HttpChannel::send_reply(req, HttpStatus::OK,
+                                        json_metrics.empty() ? status.to_json() : json_metrics);
+            } else {
+                HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, status_result);
+            }
+        }).detach();
+        return;
+    }
+
     std::string json_metrics;
     Status status = _handle_header(req, &json_metrics);
     std::string status_result = status.to_json();

--- a/be/src/service/http/action/file_cache_action.h
+++ b/be/src/service/http/action/file_cache_action.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "common/status.h"
+#include "io/cache/block_file_cache.h"
 #include "service/http/http_handler.h"
 #include "service/http/http_handler_with_auth.h"
 
@@ -37,6 +39,10 @@ public:
     void handle(HttpRequest* req) override;
 
 private:
-    Status _handle_header(HttpRequest* req, std::string* json_metrics);
+    bool _is_sync_clear_request(HttpRequest* req) const;
+    Status _handle_header(
+            HttpRequest* req, std::string* json_metrics,
+            std::shared_ptr<io::BlockFileCache::ClearFileCacheCancelToken> cancel_token = nullptr,
+            bool add_header = true);
 };
 } // namespace doris

--- a/be/src/service/http/http_request.cpp
+++ b/be/src/service/http/http_request.cpp
@@ -161,6 +161,22 @@ const char* HttpRequest::remote_host() const {
     return _ev_req->remote_host;
 }
 
+void HttpRequest::set_cancel_callback(std::function<void()> callback) {
+    std::lock_guard lock(_cancel_callback_mutex);
+    _cancel_callback = std::move(callback);
+}
+
+void HttpRequest::cancel_async_reply() {
+    std::function<void()> cancel_callback;
+    {
+        std::lock_guard lock(_cancel_callback_mutex);
+        cancel_callback = _cancel_callback;
+    }
+    if (cancel_callback) {
+        cancel_callback();
+    }
+}
+
 void HttpRequest::finish_send_reply() {
     if (_send_reply_type == REPLY_SYNC) {
         return;
@@ -187,6 +203,15 @@ void HttpRequest::wait_finish_send_reply() {
     }
 
     VLOG_NOTICE << "start to wait send reply, infos=" << infos;
+    if (_http_reply_future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+        cancel_async_reply();
+    }
+    if (ctx == nullptr) {
+        _http_reply_future.wait();
+        VLOG_NOTICE << "wait send reply finished";
+        return;
+    }
+
     auto status = _http_reply_future.wait_for(std::chrono::seconds(config::async_reply_timeout_s));
     // if request is timeout and can't cancel fragment in time, it will cause some new request block
     // so we will free cancelled request in time.

--- a/be/src/service/http/http_request.h
+++ b/be/src/service/http/http_request.h
@@ -19,9 +19,11 @@
 
 #include <glog/logging.h>
 
+#include <functional>
 #include <future>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "common/config.h"
@@ -86,11 +88,14 @@ public:
     const char* remote_host() const;
 
     void mark_send_reply(SendReplyType type = REPLY_ASYNC) { _send_reply_type = type; }
+    void set_cancel_callback(std::function<void()> callback);
 
     void finish_send_reply();
     void wait_finish_send_reply();
 
 private:
+    void cancel_async_reply();
+
     SendReplyType _send_reply_type = REPLY_SYNC;
     HttpMethod _method;
     std::string _uri;
@@ -109,6 +114,8 @@ private:
     // ensure send_reply finished
     std::promise<bool> _http_reply_promise;
     std::future<bool> _http_reply_future = _http_reply_promise.get_future();
+    std::mutex _cancel_callback_mutex;
+    std::function<void()> _cancel_callback;
 };
 
 } // namespace doris

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -8557,7 +8557,13 @@ TEST_F(BlockFileCacheTest, clear_file_cache_sync_skips_new_blocks_during_clear) 
     EXPECT_EQ(new_holder.file_blocks.front()->state(), io::FileBlock::State::SKIP_CACHE);
     EXPECT_TRUE(cache.get_blocks_by_key(new_key).empty());
 
+    auto old_holder_after_barrier = cache.get_or_set(old_key, 0, 5, context);
+    ASSERT_EQ(old_holder_after_barrier.file_blocks.size(), 1);
+    EXPECT_EQ(old_holder_after_barrier.file_blocks.front()->state(),
+              io::FileBlock::State::SKIP_CACHE);
+
     holder.reset();
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
     auto msg = future.get();
     EXPECT_NE(msg.find("cancelled=0"), std::string::npos);
     EXPECT_TRUE(cache.get_blocks_by_key(old_key).empty());

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -21,6 +21,8 @@
 #include "io/cache/block_file_cache_test_common.h"
 #include "storage/olap_define.h"
 
+#include <future>
+
 namespace doris::io {
 
 class FileBlockTestAccessor {
@@ -8447,6 +8449,215 @@ TEST_F(BlockFileCacheTest, lru_restore_size_mismatch_does_not_underflow_on_clear
     if (fs::exists(my_cache_path)) {
         fs::remove_all(my_cache_path);
     }
+}
+
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_waits_deleting_block) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    auto key = io::BlockFileCache::hash("sync_clear_waits_deleting_block");
+
+    std::optional<io::FileBlocksHolder> holder;
+    holder.emplace(cache.get_or_set(key, 0, 5, context));
+    ASSERT_EQ(holder->file_blocks.size(), 1);
+    auto& block = holder->file_blocks.front();
+    ASSERT_TRUE(block->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(block);
+
+    auto future = std::async(std::launch::async, [&cache] { return cache.clear_file_cache_sync(); });
+    ASSERT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+    EXPECT_EQ(cache.get_used_cache_size(io::FileCacheType::NORMAL), 5);
+
+    holder.reset();
+    auto msg = future.get();
+    EXPECT_NE(msg.find("cancelled=0"), std::string::npos);
+    EXPECT_EQ(cache.get_used_cache_size(io::FileCacheType::NORMAL), 0);
+    EXPECT_TRUE(cache.get_blocks_by_key(key).empty());
+}
+
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_cancel_waiting_keeps_async_cleanup_safe) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    auto key = io::BlockFileCache::hash("sync_clear_cancel");
+
+    std::optional<io::FileBlocksHolder> holder;
+    holder.emplace(cache.get_or_set(key, 0, 5, context));
+    ASSERT_EQ(holder->file_blocks.size(), 1);
+    auto& block = holder->file_blocks.front();
+    ASSERT_TRUE(block->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(block);
+
+    auto token = std::make_shared<io::BlockFileCache::ClearFileCacheCancelToken>();
+    auto future =
+            std::async(std::launch::async, [&cache, token] { return cache.clear_file_cache_sync(token); });
+    ASSERT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+    token->cancelled.store(true, std::memory_order_release);
+    auto msg = future.get();
+    EXPECT_NE(msg.find("cancelled=1"), std::string::npos);
+    EXPECT_EQ(cache.get_used_cache_size(io::FileCacheType::NORMAL), 5);
+    EXPECT_FALSE(cache.get_blocks_by_key(key).empty());
+
+    holder.reset();
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_used_cache_size(io::FileCacheType::NORMAL) == 0) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(cache.get_used_cache_size(io::FileCacheType::NORMAL), 0);
+    EXPECT_TRUE(cache.get_blocks_by_key(key).empty());
+}
+
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_waits_meta_store_fence) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    context.tablet_id = 101;
+    auto key = io::BlockFileCache::hash("sync_clear_meta_fence");
+    {
+        auto holder = cache.get_or_set(key, 0, 5, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+
+    auto* storage = dynamic_cast<io::FSFileCacheStorage*>(cache.get_storage());
+    ASSERT_NE(storage, nullptr);
+    io::BlockMetaKey meta_key(context.tablet_id, key, 0);
+    for (int i = 0; i < 100; ++i) {
+        if (storage->get_meta_store()->get(meta_key).has_value()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(storage->get_meta_store()->get(meta_key).has_value());
+
+    auto msg = cache.clear_file_cache_sync();
+    EXPECT_NE(msg.find("cancelled=0"), std::string::npos);
+    EXPECT_FALSE(storage->get_meta_store()->get(meta_key).has_value());
+}
+
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_drains_recycle_queue) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    auto key = io::BlockFileCache::hash("sync_clear_recycle_queue");
+    {
+        auto holder = cache.get_or_set(key, 0, 5, context);
+        auto blocks = fromHolder(holder);
+        ASSERT_EQ(blocks.size(), 1);
+        ASSERT_TRUE(blocks[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        download(blocks[0]);
+    }
+
+    auto* storage = dynamic_cast<io::FSFileCacheStorage*>(cache.get_storage());
+    ASSERT_NE(storage, nullptr);
+    io::FileCacheKey file_key {};
+    file_key.hash = key;
+    file_key.offset = 0;
+    file_key.meta.type = io::FileCacheType::NORMAL;
+    auto file = storage->get_local_file(file_key);
+    ASSERT_TRUE(fs::exists(file));
+
+    auto msg = cache.clear_file_cache_sync();
+    EXPECT_NE(msg.find("cancelled=0"), std::string::npos);
+    EXPECT_EQ(cache._recycle_keys.size_approx(), 0);
+    EXPECT_FALSE(fs::exists(file));
 }
 
 } // namespace doris::io

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -8499,6 +8499,71 @@ TEST_F(BlockFileCacheTest, clear_file_cache_sync_waits_deleting_block) {
     EXPECT_TRUE(cache.get_blocks_by_key(key).empty());
 }
 
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_skips_new_blocks_during_clear) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    auto old_key = io::BlockFileCache::hash("sync_clear_existing_block");
+    auto new_key = io::BlockFileCache::hash("sync_clear_new_block");
+
+    std::optional<io::FileBlocksHolder> holder;
+    holder.emplace(cache.get_or_set(old_key, 0, 5, context));
+    ASSERT_EQ(holder->file_blocks.size(), 1);
+    auto& block = holder->file_blocks.front();
+    ASSERT_TRUE(block->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(block);
+
+    auto sp = SyncPoint::get_instance();
+    std::promise<void> barrier_ready_promise;
+    auto barrier_ready_future = barrier_ready_promise.get_future();
+    SyncPoint::CallbackGuard barrier_ready_guard;
+    sp->set_call_back(
+            "BlockFileCache::clear_file_cache_sync:barrier_ready",
+            [&barrier_ready_promise](auto&&) { barrier_ready_promise.set_value(); },
+            &barrier_ready_guard);
+    sp->enable_processing();
+    Defer defer {[sp] { sp->disable_processing(); }};
+
+    auto future =
+            std::async(std::launch::async, [&cache] { return cache.clear_file_cache_sync(); });
+    ASSERT_EQ(barrier_ready_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    ASSERT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+    auto new_holder = cache.get_or_set(new_key, 0, 5, context);
+    ASSERT_EQ(new_holder.file_blocks.size(), 1);
+    EXPECT_EQ(new_holder.file_blocks.front()->state(), io::FileBlock::State::SKIP_CACHE);
+    EXPECT_TRUE(cache.get_blocks_by_key(new_key).empty());
+
+    holder.reset();
+    auto msg = future.get();
+    EXPECT_NE(msg.find("cancelled=0"), std::string::npos);
+    EXPECT_TRUE(cache.get_blocks_by_key(old_key).empty());
+    EXPECT_TRUE(cache.get_blocks_by_key(new_key).empty());
+}
+
 TEST_F(BlockFileCacheTest, clear_file_cache_sync_cancel_waiting_keeps_async_cleanup_safe) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -18,10 +18,10 @@
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Interpreters/tests/gtest_lru_file_cache.cpp
 // and modified by Doris
 
+#include <future>
+
 #include "io/cache/block_file_cache_test_common.h"
 #include "storage/olap_define.h"
-
-#include <future>
 
 namespace doris::io {
 
@@ -8487,7 +8487,8 @@ TEST_F(BlockFileCacheTest, clear_file_cache_sync_waits_deleting_block) {
     ASSERT_TRUE(block->get_or_set_downloader() == io::FileBlock::get_caller_id());
     download(block);
 
-    auto future = std::async(std::launch::async, [&cache] { return cache.clear_file_cache_sync(); });
+    auto future =
+            std::async(std::launch::async, [&cache] { return cache.clear_file_cache_sync(); });
     ASSERT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
     EXPECT_EQ(cache.get_used_cache_size(io::FileCacheType::NORMAL), 5);
 
@@ -8535,8 +8536,8 @@ TEST_F(BlockFileCacheTest, clear_file_cache_sync_cancel_waiting_keeps_async_clea
     download(block);
 
     auto token = std::make_shared<io::BlockFileCache::ClearFileCacheCancelToken>();
-    auto future =
-            std::async(std::launch::async, [&cache, token] { return cache.clear_file_cache_sync(token); });
+    auto future = std::async(std::launch::async,
+                             [&cache, token] { return cache.clear_file_cache_sync(token); });
     ASSERT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
 
     token->cancelled.store(true, std::memory_order_release);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -8733,6 +8733,91 @@ TEST_F(BlockFileCacheTest, clear_file_cache_sync_waits_meta_store_fence) {
     EXPECT_FALSE(storage->get_meta_store()->get(meta_key).has_value());
 }
 
+TEST_F(BlockFileCacheTest, clear_file_cache_sync_keeps_background_gc_from_stealing_recycle_keys) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    context.tablet_id = 102;
+    auto key = io::BlockFileCache::hash("sync_clear_background_gc_no_steal");
+
+    std::optional<io::FileBlocksHolder> holder;
+    holder.emplace(cache.get_or_set(key, 0, 5, context));
+    ASSERT_EQ(holder->file_blocks.size(), 1);
+    auto& block = holder->file_blocks.front();
+    ASSERT_TRUE(block->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(block);
+
+    auto* storage = dynamic_cast<io::FSFileCacheStorage*>(cache.get_storage());
+    ASSERT_NE(storage, nullptr);
+    io::BlockMetaKey meta_key(context.tablet_id, key, 0);
+    for (int i = 0; i < 100; ++i) {
+        if (storage->get_meta_store()->get(meta_key).has_value()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(storage->get_meta_store()->get(meta_key).has_value());
+
+    auto sp = SyncPoint::get_instance();
+    std::promise<void> before_drain_promise;
+    auto before_drain_future = before_drain_promise.get_future();
+    std::promise<void> release_clear_promise;
+    auto release_clear_future = release_clear_promise.get_future().share();
+    SyncPoint::CallbackGuard before_drain_guard;
+    sp->set_call_back(
+            "BlockFileCache::clear_file_cache_sync:before_drain_recycle_keys",
+            [&before_drain_promise, release_clear_future](auto&&) mutable {
+                before_drain_promise.set_value();
+                release_clear_future.wait();
+            },
+            &before_drain_guard);
+    sp->enable_processing();
+    Defer defer {[sp] {
+        sp->disable_processing();
+        sp->clear_all_call_backs();
+    }};
+
+    auto future =
+            std::async(std::launch::async, [&cache] { return cache.clear_file_cache_sync(); });
+    ASSERT_EQ(before_drain_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    holder.reset();
+    ASSERT_EQ(cache._recycle_keys.size_approx(), 1);
+
+    io::FileCacheKey dequeued_key;
+    EXPECT_FALSE(cache.try_dequeue_recycle_key(&dequeued_key, false));
+    EXPECT_EQ(cache._recycle_keys.size_approx(), 1);
+
+    release_clear_promise.set_value();
+    auto msg = future.get();
+    EXPECT_NE(msg.find("cancelled=0"), std::string::npos);
+    EXPECT_EQ(cache._recycle_keys.size_approx(), 0);
+    EXPECT_FALSE(storage->get_meta_store()->get(meta_key).has_value());
+}
+
 TEST_F(BlockFileCacheTest, clear_file_cache_sync_drains_recycle_queue) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);

--- a/be/test/io/cache/block_file_cache_test.cpp
+++ b/be/test/io/cache/block_file_cache_test.cpp
@@ -8564,6 +8564,58 @@ TEST_F(BlockFileCacheTest, clear_file_cache_sync_skips_new_blocks_during_clear) 
     EXPECT_TRUE(cache.get_blocks_by_key(new_key).empty());
 }
 
+TEST_F(BlockFileCacheTest, remove_if_cached_async_recycles_held_deleting_block) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+
+    auto old_gc_interval_ms = config::file_cache_background_gc_interval_ms;
+    config::file_cache_background_gc_interval_ms = 10000000;
+    Defer defer {[old_gc_interval_ms] {
+        config::file_cache_background_gc_interval_ms = old_gc_interval_ms;
+    }};
+
+    io::FileCacheSettings settings;
+    settings.query_queue_size = 30;
+    settings.query_queue_elements = 5;
+    settings.capacity = 90;
+    settings.max_file_block_size = 30;
+    settings.max_query_cache_size = 30;
+
+    io::BlockFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    for (int i = 0; i < 100; ++i) {
+        if (cache.get_async_open_success()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(cache.get_async_open_success());
+
+    io::CacheContext context;
+    ReadStatistics rstats;
+    context.stats = &rstats;
+    context.cache_type = io::FileCacheType::NORMAL;
+    auto key = io::BlockFileCache::hash("async_remove_held_deleting_block");
+
+    std::optional<io::FileBlocksHolder> holder;
+    holder.emplace(cache.get_or_set(key, 0, 5, context));
+    ASSERT_EQ(holder->file_blocks.size(), 1);
+    auto& block = holder->file_blocks.front();
+    ASSERT_TRUE(block->get_or_set_downloader() == io::FileBlock::get_caller_id());
+    download(block);
+    ASSERT_FALSE(block->is_deleting());
+
+    cache.remove_if_cached_async(key);
+    EXPECT_TRUE(block->is_deleting());
+    EXPECT_EQ(cache._recycle_keys.size_approx(), 0);
+
+    holder.reset();
+    EXPECT_TRUE(cache.get_blocks_by_key(key).empty());
+    EXPECT_EQ(cache._recycle_keys.size_approx(), 1);
+}
+
 TEST_F(BlockFileCacheTest, clear_file_cache_sync_cancel_waiting_keeps_async_cleanup_safe) {
     if (fs::exists(cache_base_path)) {
         fs::remove_all(cache_base_path);

--- a/be/test/service/http/file_cache_action_test.cpp
+++ b/be/test/service/http/file_cache_action_test.cpp
@@ -21,8 +21,10 @@
 #include <event2/http.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <future>
 #include <memory>
 #include <thread>
 
@@ -158,6 +160,39 @@ TEST_F(FileCacheActionTest, check_consistency_ok) {
 
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(json_metrics, "null");
+}
+
+TEST(HttpRequestAsyncReplyTest, wait_finish_send_reply_invokes_cancel_callback) {
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    std::atomic_bool cancelled {false};
+
+    req.mark_send_reply();
+    req.set_cancel_callback([&] { cancelled.store(true, std::memory_order_release); });
+
+    auto wait_future = std::async(std::launch::async, [&] { req.wait_finish_send_reply(); });
+    for (int i = 0; i < 100 && !cancelled.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    EXPECT_TRUE(cancelled.load(std::memory_order_acquire));
+    req.finish_send_reply();
+    wait_future.get();
+    evhttp_request_free(evhttp_req);
+}
+
+TEST(HttpRequestAsyncReplyTest, wait_finish_send_reply_does_not_cancel_finished_reply) {
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    std::atomic_bool cancelled {false};
+
+    req.mark_send_reply();
+    req.set_cancel_callback([&] { cancelled.store(true, std::memory_order_release); });
+    req.finish_send_reply();
+    req.wait_finish_send_reply();
+
+    EXPECT_FALSE(cancelled.load(std::memory_order_acquire));
+    evhttp_request_free(evhttp_req);
 }
 
 } // namespace doris


### PR DESCRIPTION
Problem Summary: The old sync file cache clear path bypassed the normal FileBlock lifecycle and was not safe with concurrent cache users, while the async clear path only marked or enqueued deletes and returned before held blocks, recycle-queue deletes, and file-cache meta deletes were finished. This change makes the factory sync clear path use a synchronous wrapper over the async clear semantics. The wrapper serializes clear operations, pauses the TTL manager during clear, marks existing blocks for deletion, drains recycled blocks, waits for held deleting blocks to be released, and waits for file-cache meta delete fences before reporting completion. The direct clear helper is kept only for BE tests. HTTP sync clear now runs through a cancellable async reply path so client disconnects can cancel waiting without adding a clear timeout config.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

