### PR TITLE
[fix](be) Fix unused constant/function build errors in md5.cpp 

### DIFF
--- a/be/src/util/md5.cpp
+++ b/be/src/util/md5.cpp
@@ -31,10 +31,6 @@ namespace doris {
 
 namespace {
 
-constexpr uint32_t MD5_A0 = 0x67452301;
-constexpr uint32_t MD5_B0 = 0xefcdab89;
-constexpr uint32_t MD5_C0 = 0x98badcfe;
-constexpr uint32_t MD5_D0 = 0x10325476;
 constexpr unsigned char MD5_DUMMY_INPUT = 0;
 
 void md5_to_hex(const unsigned char* digest, char* out) {
@@ -44,6 +40,13 @@ void md5_to_hex(const unsigned char* digest, char* out) {
         *out++ = DIGITS[digest[i] & 0x0F];
     }
 }
+
+#ifdef __AVX2__
+
+constexpr uint32_t MD5_A0 = 0x67452301;
+constexpr uint32_t MD5_B0 = 0xefcdab89;
+constexpr uint32_t MD5_C0 = 0x98badcfe;
+constexpr uint32_t MD5_D0 = 0x10325476;
 
 size_t md5_num_blocks(size_t len) {
     return (len + 9 + 63) / 64;
@@ -62,8 +65,6 @@ size_t md5_pad_final_blocks(const unsigned char* data, size_t len, unsigned char
 
     return final_count;
 }
-
-#ifdef __AVX2__
 
 struct AVX2MD5Ops {
     using Vec = __m256i;


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #63484

Problem Summary:

The constants `MD5_A0/B0/C0/D0` and the helper functions `md5_num_blocks` / `md5_pad_final_blocks` in `be/src/util/md5.cpp` are only referenced inside the `#ifdef __AVX2__` multi-buffer code path. On builds without AVX2 support, the compiler reports `-Wunused-const-variable` and `-Wunused-function`, which are promoted to errors via `-Werror` and break the build.

Move these AVX2-only declarations under the same `#ifdef __AVX2__` guard that protects their sole consumer. `MD5_DUMMY_INPUT` and `md5_to_hex` remain outside the guard since both code paths use them.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

