### PR TITLE
[fix](cache) Follower FE sql cache not invalidated on table metadata replay

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -41,7 +41,6 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.cache.NereidsSqlCacheManager;
 import org.apache.doris.common.util.DynamicPartitionUtil;
 import org.apache.doris.common.util.MetaLockUtils;
 import org.apache.doris.common.util.PropertyAnalyzer;
@@ -363,8 +362,7 @@ public class Alter {
 
         olapTable.writeLock();
         try {
-            NereidsSqlCacheManager sqlCacheManager = Env.getCurrentEnv().getSqlCacheManager();
-            sqlCacheManager.invalidateAboutTable(olapTable);
+            Env.getCurrentEnv().notifyTableMetaChange(olapTable);
         } finally {
             olapTable.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -360,11 +360,11 @@ public class Alter {
                 .alterTable(oldBaseTableInfo, newBaseTableInfo, currentAlterOps.hasReplaceTableOp());
         }
 
-        olapTable.writeLock();
+        olapTable.readLock();
         try {
             Env.getCurrentEnv().notifyTableMetaChange(olapTable);
         } finally {
-            olapTable.writeUnlock();
+            olapTable.readUnlock();
         }
         return needProcessOutsideTableLock;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -234,6 +234,7 @@ import org.apache.doris.persist.SetTableStatusOperationLog;
 import org.apache.doris.persist.Storage;
 import org.apache.doris.persist.StorageInfo;
 import org.apache.doris.persist.TableInfo;
+import org.apache.doris.persist.TableMetaChange;
 import org.apache.doris.persist.TablePropertyInfo;
 import org.apache.doris.persist.TableRenameColumnInfo;
 import org.apache.doris.persist.TruncateTableInfo;
@@ -7131,7 +7132,9 @@ public class Env {
                 LOG.warn("ignore set same state {} for table {}. is replay: {}.",
                             olapTable.getState(), tableName, isReplay);
             }
-            Env.getCurrentEnv().getSqlCacheManager().invalidateAboutTable(olapTable);
+            if (!isReplay) {
+                notifyTableMetaChange(olapTable);
+            }
         } finally {
             olapTable.writeUnlock();
         }
@@ -7239,7 +7242,9 @@ public class Env {
                 LOG.info("set replica {} of tablet {} on backend {} as version {}, last success version {}, "
                         + "last failed version {}, update time {}. is replay: {}", replica.getId(), tabletId,
                         backendId, version, lastSuccessVersion, lastFailedVersion, updateTime, isReplay);
-                Env.getCurrentEnv().getSqlCacheManager().invalidateAboutTable(table);
+                if (!isReplay) {
+                    notifyTableMetaChange(table);
+                }
             } finally {
                 table.writeUnlock();
             }
@@ -7320,7 +7325,9 @@ public class Env {
                         + " {}.", partitionId, oldVersion, visibleVersion, database, table, isReplay);
             }
 
-            Env.getCurrentEnv().getSqlCacheManager().invalidateAboutTable(olapTable);
+            if (!isReplay) {
+                notifyTableMetaChange(olapTable);
+            }
         } finally {
             olapTable.writeUnlock();
         }
@@ -7551,6 +7558,35 @@ public class Env {
 
     public NereidsSortedPartitionsCacheManager getSortedPartitionsCacheManager() {
         return sortedPartitionsCacheManager;
+    }
+
+    public void notifyTableMetaChange(TableIf table) {
+        if (table == null) {
+            return;
+        }
+        TableMetaChange change =
+                TableMetaChange.fromTable(table);
+        fanOutTableMetaChange(change);
+        if (isMaster() && editLog != null) {
+            editLog.logTableMetaChange(change);
+        }
+    }
+
+    public void replayTableMetaChange(TableMetaChange change) {
+        if (change == null) {
+            return;
+        }
+        fanOutTableMetaChange(change);
+    }
+
+    private void fanOutTableMetaChange(TableMetaChange change) {
+        if (sqlCacheManager != null) {
+            sqlCacheManager.invalidateAboutTable(change);
+        }
+        if (sortedPartitionsCacheManager != null) {
+            sortedPartitionsCacheManager.invalidateTable(
+                    change.getCatalogName(), change.getDbName(), change.getTableName());
+        }
     }
 
     public SplitSourceManager getSplitSourceManager() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
@@ -59,6 +59,7 @@ import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.nereids.util.Utils;
+import org.apache.doris.persist.TableMetaChange;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.Types.PUniqueId;
 import org.apache.doris.qe.ConnectContext;
@@ -112,29 +113,31 @@ public class NereidsSqlCacheManager {
     }
 
     public void invalidateAboutTable(TableIf tableIf) {
-        Set<String> invalidateKeys = new LinkedHashSet<>();
+        invalidateAboutTable(TableMetaChange.fromTable(tableIf));
+    }
+
+    public void invalidateAboutTable(TableMetaChange event) {
         FullTableName invalidateTableName = null;
-        DatabaseIf database = tableIf.getDatabase();
-        if (database != null) {
-            CatalogIf catalog = database.getCatalog();
-            if (catalog != null) {
-                invalidateTableName = new FullTableName(
-                        database.getCatalog().getName(), database.getFullName(), tableIf.getName()
-                );
-            }
+        if (event.getCatalogName() != null && event.getDbName() != null && event.getTableName() != null) {
+            invalidateTableName = new FullTableName(
+                    event.getCatalogName(), event.getDbName(), event.getTableName());
         }
 
+        Set<String> invalidateKeys = new LinkedHashSet<>();
         for (Entry<String, SqlCacheContext> kv : sqlCaches.asMap().entrySet()) {
             String key = kv.getKey();
             SqlCacheContext context = kv.getValue();
+            if (context == null) {
+                continue;
+            }
             for (Entry<FullTableName, TableVersion> nameToVersion : context.getUsedTables().entrySet()) {
                 FullTableName tableName = nameToVersion.getKey();
                 TableVersion tableVersion = nameToVersion.getValue();
-                if (tableVersion.id == tableIf.getId()) {
+                if (tableVersion.id == event.getTableId()) {
                     invalidateKeys.add(key);
                     break;
                 }
-                if (tableName.equals(invalidateTableName)) {
+                if (invalidateTableName != null && tableName.equals(invalidateTableName)) {
                     invalidateKeys.add(key);
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/cache/NereidsSqlCacheManager.java
@@ -468,6 +468,9 @@ public class NereidsSqlCacheManager {
                 if (currentTableVersion != cacheTableVersion) {
                     return IsChanged.CHANGED_AND_INVALIDATE_CACHE;
                 }
+                if (olapTable.getBaseSchemaVersion() != tableVersion.schemaVersion) {
+                    return IsChanged.CHANGED_AND_INVALIDATE_CACHE;
+                }
                 if (tableIf instanceof MTMV) {
                     // mtmv maybe access old data when grace_period > 0, we should disable cache at this case
                     long gracePeriod = ((MTMV) tableIf).getGracePeriod();

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -128,6 +128,7 @@ import org.apache.doris.persist.TableAddOrDropColumnsInfo;
 import org.apache.doris.persist.TableAddOrDropInvertedIndicesInfo;
 import org.apache.doris.persist.TableBranchOrTagInfo;
 import org.apache.doris.persist.TableInfo;
+import org.apache.doris.persist.TableMetaChange;
 import org.apache.doris.persist.TablePropertyInfo;
 import org.apache.doris.persist.TableRenameColumnInfo;
 import org.apache.doris.persist.TableStatsDeletionLog;
@@ -1019,6 +1020,11 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_META_SYNC_POINT: {
                 data = CloudMetaSyncPoint.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_TABLE_META_CHANGE: {
+                data = TableMetaChange.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/SqlCacheContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/SqlCacheContext.java
@@ -203,12 +203,17 @@ public class SqlCacheContext {
             LOG.warn("table {}, can not get version", tableIf.getName(), e);
         }
 
+        int schemaVersion = 0;
+        if (tableIf instanceof OlapTable) {
+            schemaVersion = ((OlapTable) tableIf).getBaseSchemaVersion();
+        }
         usedTables.put(
                 new FullTableName(database.getCatalog().getName(), database.getFullName(), tableIf.getName()),
                 new TableVersion(
                         tableIf.getId(),
                         version,
-                        tableIf.getType()
+                        tableIf.getType(),
+                        schemaVersion
                 )
         );
     }
@@ -593,6 +598,7 @@ public class SqlCacheContext {
         public final long id;
         public final long version;
         public final TableType type;
+        public final int schemaVersion;
     }
 
     /** CacheKeyType */

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1479,6 +1479,11 @@ public class EditLog {
                     // This log is only used to keep FE/MS cut point in journal timeline.
                     break;
                 }
+                case OperationType.OP_TABLE_META_CHANGE: {
+                    TableMetaChange op = (TableMetaChange) journal.getData();
+                    env.replayTableMetaChange(op);
+                    break;
+                }
                 case OperationType.OP_TSO_TIMESTAMP_WINDOW_END: {
                     env.getTSOService().replayWindowEndTSO((TSOTimestamp) journal.getData());
                     break;
@@ -2623,5 +2628,9 @@ public class EditLog {
 
     public long logMetaSyncPoint(CloudMetaSyncPoint syncPoint) {
         return logEdit(OperationType.OP_META_SYNC_POINT, syncPoint);
+    }
+
+    public void logTableMetaChange(TableMetaChange op) {
+        logEdit(OperationType.OP_TABLE_META_CHANGE, op);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -433,6 +433,11 @@ public class OperationType {
     public static final short OP_BEGIN_SNAPSHOT = 1100;
     public static final short OP_META_SYNC_POINT = 1101;
 
+    // Generic "an operation modified this table's metadata" signal broadcast from
+    // master to followers so that every FE-local cache keyed by table can be
+    // invalidated (NereidsSqlCacheManager, NereidsSortedPartitionsCacheManager, …).
+    public static final short OP_TABLE_META_CHANGE = 1102;
+
     public static final short OP_TSO_TIMESTAMP_WINDOW_END = 1200;
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableMetaChange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableMetaChange.java
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Persist payload for {@link OperationType#OP_TABLE_META_OPERATION}.
+ * Generic "an operation modified this table's metadata" signal that follower
+ * FEs use to invalidate any local FE caches keyed by the table (sql cache,
+ * sorted partition cache, and future per-table caches). This is about
+ * metadata mutations (schema/properties/partitions/etc.), not data writes.
+ * Carries both ids and names of catalog / database / table so each subscriber
+ * can match by id (preferred) or by full name (fallback, e.g. when the table
+ * has been concurrently dropped/recreated and the id no longer matches but
+ * the name still does). Also carries the master-side timestamp so subscribers
+ * and audit tooling can correlate the event with the originating DDL.
+ */
+public class TableMetaChange implements Writable {
+    @SerializedName("ci")
+    private long catalogId;
+    @SerializedName("cn")
+    private String catalogName;
+    @SerializedName("di")
+    private long dbId;
+    @SerializedName("dn")
+    private String dbName;
+    @SerializedName("ti")
+    private long tableId;
+    @SerializedName("tn")
+    private String tableName;
+    // master-side millis-since-epoch when this event was emitted
+    @SerializedName("ts")
+    private long eventTimeMs;
+
+    public TableMetaChange() {
+        // for persist
+    }
+
+    /** Build a TableMetaChange from a TableIf (master-side helper). */
+    public static TableMetaChange fromTable(TableIf table) {
+        long catalogId = -1L;
+        String catalogName = "";
+        long dbId = -1L;
+        String dbName = "";
+        DatabaseIf<?> db = table.getDatabase();
+        if (db != null) {
+            dbId = db.getId();
+            dbName = db.getFullName();
+            CatalogIf<?> catalog = db.getCatalog();
+            if (catalog != null) {
+                catalogId = catalog.getId();
+                catalogName = catalog.getName();
+            }
+        }
+        return new TableMetaChange(catalogId, catalogName, dbId, dbName,
+                table.getId(), table.getName());
+    }
+
+    public TableMetaChange(long catalogId, String catalogName,
+                              long dbId, String dbName,
+                              long tableId, String tableName) {
+        this(catalogId, catalogName, dbId, dbName, tableId, tableName, System.currentTimeMillis());
+    }
+
+    public TableMetaChange(long catalogId, String catalogName,
+                              long dbId, String dbName,
+                              long tableId, String tableName,
+                              long eventTimeMs) {
+        this.catalogId = catalogId;
+        this.catalogName = catalogName;
+        this.dbId = dbId;
+        this.dbName = dbName;
+        this.tableId = tableId;
+        this.tableName = tableName;
+        this.eventTimeMs = eventTimeMs;
+    }
+
+    public long getCatalogId() {
+        return catalogId;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public long getTableId() {
+        return tableId;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public long getEventTimeMs() {
+        return eventTimeMs;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static TableMetaChange read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), TableMetaChange.class);
+    }
+
+    @Override
+    public String toString() {
+        return "TableMetaChange{catalogId=" + catalogId
+                + ", catalogName='" + catalogName + '\''
+                + ", dbId=" + dbId
+                + ", dbName='" + dbName + '\''
+                + ", tableId=" + tableId
+                + ", tableName='" + tableName + '\''
+                + ", eventTimeMs=" + eventTimeMs
+                + '}';
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableMetaChange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableMetaChange.java
@@ -31,7 +31,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 /**
- * Persist payload for {@link OperationType#OP_TABLE_META_OPERATION}.
+ * Persist payload for {@link OperationType#OP_TABLE_META_CHANGE}.
  * Generic "an operation modified this table's metadata" signal that follower
  * FEs use to invalidate any local FE caches keyed by the table (sql cache,
  * sorted partition cache, and future per-table caches). This is about


### PR DESCRIPTION
## Proposed changes

Follower FEs replay metadata changes (e.g. `ALTER TABLE ... RENAME COLUMN`,
alter table properties, etc.) but the replay paths never called
`NereidsSqlCacheManager.invalidateAboutTable()`, so stale sql-cache entries
survived and queries on follower FEs returned wrong results — old column
names, old schema, etc.

Since `enable_sql_cache` defaults to `true` since 4.0, every multi-FE
deployment is affected.

### Root cause

On the master FE, DDL operations invalidate the sql cache directly (e.g.
`Alter.java` calls `sqlCacheManager.invalidateAboutTable()`). But on
follower FEs, the replay paths (`Env.setTableStatusInternal`,
`Env.setReplicaVersionInternal`, `Env.setPartitionVersionInternal`, and
various `replay*` methods in `EditLog`) only mutate metadata — they never
fan out cache invalidation signals.

### Fix (three layers of defense)

| Layer | Mechanism | Scope | Crash window |
|-------|-----------|-------|-------------|
| 1 | `tablesOrDataChanged` visibleVersion (existing) | Data changes (INSERT/DELETE) | None |
| 2 | **`tablesOrDataChanged` baseSchemaVersion (new)** | OlapTable schema DDL (rename/add/drop column) | **None** |
| 3 | **OP_TABLE_META_CHANGE journal (new)** | All table types, all DDL | Tiny |

**Layer 2 — schemaVersion check (lazy validation, no crash window):**
Store `OlapTable.getBaseSchemaVersion()` in `SqlCacheContext.TableVersion` at
cache creation time. On lookup, compare with current value — if different,
invalidate. Automatically covers all DDLs that bump schemaVersion.

**Layer 3 — OP_TABLE_META_CHANGE (eager broadcast):**
Introduce `OP_TABLE_META_CHANGE` — the master emits this journal entry once
per table metadata mutation via `Env.notifyTableMetaChange(table)`, and
every follower fans it out to `NereidsSqlCacheManager` +
`NereidsSortedPartitionsCacheManager` on replay. This decouples cache
invalidation from the dozens of individual replay paths. Covers non-OlapTable
and DDLs that don't bump schemaVersion (e.g. alter properties).

### Changes

| File | Change |
|------|--------|
| `SqlCacheContext.java` | Add `schemaVersion` field to `TableVersion`; store `baseSchemaVersion` on cache put |
| `NereidsSqlCacheManager.java` | Check `baseSchemaVersion` on lookup; accept `TableMetaChange` payload; null-safe softValues iteration |
| `TableMetaChange.java` | **New** — persist payload carrying catalog/db/table id+name |
| `OperationType.java` | Add `OP_TABLE_META_CHANGE = 1102` |
| `JournalEntity.java` | Deserialize `TableMetaChange` |
| `EditLog.java` | Dispatch replay + `logTableMetaChange()` helper |
| `Env.java` | `notifyTableMetaChange` / `replayTableMetaChange` / `fanOutTableMetaChange`; 3 call sites add `!isReplay` guard |
| `Alter.java` | Route through `Env.notifyTableMetaChange()` with readLock |

## Further comments

Verified on both local 3-FE cluster and cloud 3-FE + MetaService + FDB cluster:
- `ALTER TABLE RENAME COLUMN` on master → follower query with old column name
  correctly fails (`Unknown column`) instead of returning stale cached result.