### PR TITLE
[fix](be) Validate dictionary codewords before decoding

### DIFF
--- a/be/src/core/column/column_dictionary.h
+++ b/be/src/core/column/column_dictionary.h
@@ -188,6 +188,9 @@ public:
     void insert_many_dict_data(const int32_t* data_array, size_t start_index,
                                const StringRef* dict_array, size_t data_num,
                                uint32_t dict_num) override {
+        for (size_t i = 0; i < data_num; ++i) {
+            check_dict_codeword(data_array[start_index + i], dict_num);
+        }
         if (_dict.empty()) {
             _dict.reserve(dict_num);
             for (uint32_t i = 0; i < dict_num; ++i) {

--- a/be/src/core/column/column_string.h
+++ b/be/src/core/column/column_string.h
@@ -388,10 +388,18 @@ public:
         size_t old_size = chars.size();
         size_t new_size = old_size;
 
+        bool offsets_committed = false;
+        offsets.resize(offset_size + num);
+        Defer rollback_offsets {[&] {
+            if (!offsets_committed) {
+                offsets.resize(offset_size);
+            }
+        }};
         for (size_t i = 0; i < num; i++) {
             int32_t codeword = data_array[i + start_index];
             check_dict_codeword(codeword, dict_num);
             new_size += dict[codeword].size;
+            offsets[offset_size + i] = static_cast<T>(new_size);
         }
 
         if (new_size > std::numeric_limits<T>::max()) {
@@ -400,15 +408,9 @@ public:
                                    typeid(T).name(), std::numeric_limits<T>::min(),
                                    std::numeric_limits<T>::max());
         }
-        check_chars_length(new_size, offset_size + num);
-        offsets.resize(offset_size + num);
-        size_t current_size = old_size;
-        for (size_t i = 0; i < num; i++) {
-            int32_t codeword = data_array[i + start_index];
-            current_size += dict[codeword].size;
-            offsets[offset_size + i] = static_cast<T>(current_size);
-        }
+        check_chars_length(new_size, offsets.size());
         chars.resize(new_size);
+        offsets_committed = true;
 
         for (size_t i = start_index; i < start_index + num; i++) {
             int32_t codeword = data_array[i];

--- a/be/src/core/column/column_string.h
+++ b/be/src/core/column/column_string.h
@@ -50,6 +50,21 @@ namespace doris {
 class Arena;
 class ColumnSorter;
 
+inline bool is_valid_dict_codeword(int32_t codeword, uint32_t dict_num) {
+    return codeword >= 0 && static_cast<uint32_t>(codeword) < dict_num;
+}
+
+inline Status invalid_dict_codeword_status(int32_t codeword, uint32_t dict_num) {
+    return Status::Corruption("invalid dictionary codeword {} for dictionary size {}", codeword,
+                              dict_num);
+}
+
+inline void check_dict_codeword(int32_t codeword, uint32_t dict_num) {
+    if (UNLIKELY(!is_valid_dict_codeword(codeword, dict_num))) {
+        throw Exception(invalid_dict_codeword_status(codeword, dict_num));
+    }
+}
+
 /** Column for String values.
   * Note: In string functions, we assume that ColumnStr contains valid UTF-8 encoded data.
   * However, ColumnStr is not guaranteed to always hold valid UTF-8, since it is also used
@@ -368,16 +383,15 @@ public:
     }
 
     void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict,
-                               size_t num, uint32_t /*dict_num*/) override {
+                               size_t num, uint32_t dict_num) override {
         size_t offset_size = offsets.size();
         size_t old_size = chars.size();
         size_t new_size = old_size;
-        offsets.resize(offsets.size() + num);
 
         for (size_t i = 0; i < num; i++) {
             int32_t codeword = data_array[i + start_index];
+            check_dict_codeword(codeword, dict_num);
             new_size += dict[codeword].size;
-            offsets[offset_size + i] = static_cast<T>(new_size);
         }
 
         if (new_size > std::numeric_limits<T>::max()) {
@@ -386,7 +400,14 @@ public:
                                    typeid(T).name(), std::numeric_limits<T>::min(),
                                    std::numeric_limits<T>::max());
         }
-        check_chars_length(new_size, offsets.size());
+        check_chars_length(new_size, offset_size + num);
+        offsets.resize(offset_size + num);
+        size_t current_size = old_size;
+        for (size_t i = 0; i < num; i++) {
+            int32_t codeword = data_array[i + start_index];
+            current_size += dict[codeword].size;
+            offsets[offset_size + i] = static_cast<T>(current_size);
+        }
         chars.resize(new_size);
 
         for (size_t i = start_index; i < start_index + num; i++) {

--- a/be/src/core/column/predicate_column.h
+++ b/be/src/core/column/predicate_column.h
@@ -226,10 +226,14 @@ public:
     }
 
     void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict,
-                               size_t num, uint32_t /*dict_num*/) override {
+                               size_t num, uint32_t dict_num) override {
         if constexpr (std::is_same_v<T, StringRef>) {
-            for (size_t end_index = start_index + num; start_index < end_index; ++start_index) {
-                int32_t codeword = data_array[start_index];
+            const size_t end_index = start_index + num;
+            for (size_t i = start_index; i < end_index; ++i) {
+                check_dict_codeword(data_array[i], dict_num);
+            }
+            for (size_t i = start_index; i < end_index; ++i) {
+                int32_t codeword = data_array[i];
                 insert_string_value(dict[codeword].data, dict[codeword].size);
             }
         }

--- a/be/src/storage/segment/binary_dict_page.cpp
+++ b/be/src/storage/segment/binary_dict_page.cpp
@@ -302,6 +302,9 @@ Status BinaryDictPageDecoder::next_batch(size_t* n, MutableColumnPtr& dst) {
         _buffer.resize(max_fetch);
         for (size_t i = 0; i < max_fetch; ++i) {
             int32_t codeword = data_array[start_index + i];
+            if (UNLIKELY(!is_valid_dict_codeword(codeword, _num_dict_items))) {
+                return invalid_dict_codeword_status(codeword, _num_dict_items);
+            }
             _buffer[i] = static_cast<int32_t>(_dict_word_info[codeword].size);
         }
         dst->insert_offsets_from_lengths(reinterpret_cast<const uint32_t*>(_buffer.data()),
@@ -310,8 +313,8 @@ Status BinaryDictPageDecoder::next_batch(size_t* n, MutableColumnPtr& dst) {
         const auto* data_array = reinterpret_cast<const int32_t*>(_bit_shuffle_ptr->get_data(0));
         size_t start_index = _bit_shuffle_ptr->_cur_index;
 
-        dst->insert_many_dict_data(data_array, start_index, _dict_word_info, max_fetch,
-                                   _num_dict_items);
+        RETURN_IF_CATCH_EXCEPTION(dst->insert_many_dict_data(
+                data_array, start_index, _dict_word_info, max_fetch, _num_dict_items));
     }
 
     _bit_shuffle_ptr->_cur_index += max_fetch;
@@ -350,6 +353,9 @@ Status BinaryDictPageDecoder::read_by_rowids(const rowid_t* rowids, ordinal_t pa
                 break;
             }
             int32_t codeword = data_array[ord];
+            if (UNLIKELY(!is_valid_dict_codeword(codeword, _num_dict_items))) {
+                return invalid_dict_codeword_status(codeword, _num_dict_items);
+            }
             _buffer[read_count] = static_cast<int32_t>(_dict_word_info[codeword].size);
             read_count++;
         }
@@ -374,7 +380,8 @@ Status BinaryDictPageDecoder::read_by_rowids(const rowid_t* rowids, ordinal_t pa
     }
 
     if (LIKELY(read_count > 0)) {
-        dst->insert_many_dict_data(_buffer.data(), 0, _dict_word_info, read_count, _num_dict_items);
+        RETURN_IF_CATCH_EXCEPTION(dst->insert_many_dict_data(_buffer.data(), 0, _dict_word_info,
+                                                             read_count, _num_dict_items));
     }
     *n = read_count;
     return Status::OK();

--- a/be/test/core/column/column_array_view_test.cpp
+++ b/be/test/core/column/column_array_view_test.cpp
@@ -66,7 +66,7 @@ static ColumnPtr build_int32_array_column(const std::vector<std::vector<int32_t>
         for (auto v : row_nulls) {
             outer_null->insert_value(v);
         }
-        array_col = ColumnNullable::create(array_col->assume_mutable(), std::move(outer_null));
+        array_col = ColumnNullable::create(array_col->assert_mutable(), std::move(outer_null));
     }
     return array_col;
 }
@@ -101,7 +101,7 @@ static ColumnPtr build_string_array_column(const std::vector<std::vector<std::st
         for (auto v : row_nulls) {
             outer_null->insert_value(v);
         }
-        array_col = ColumnNullable::create(array_col->assume_mutable(), std::move(outer_null));
+        array_col = ColumnNullable::create(array_col->assert_mutable(), std::move(outer_null));
     }
     return array_col;
 }

--- a/be/test/core/column/column_dictionary_test.cpp
+++ b/be/test/core/column/column_dictionary_test.cpp
@@ -288,6 +288,25 @@ TEST_F(ColumnDictionaryTest, insert_many_dict_data) {
         EXPECT_EQ(tmp_column_dict->get_value(i), dict_array[i]);
     }
 }
+
+TEST_F(ColumnDictionaryTest, insert_many_dict_data_rejects_invalid_codeword) {
+    ColumnDictI32::MutablePtr tmp_column_dict =
+            ColumnDictI32::create(FieldType::OLAP_FIELD_TYPE_CHAR);
+    int32_t codewords[] = {0, static_cast<int32_t>(dict_array.size())};
+
+    bool thrown = false;
+    try {
+        tmp_column_dict->insert_many_dict_data(codewords, 0, dict_array.data(), 2,
+                                               dict_array.size());
+    } catch (const Exception& e) {
+        thrown = true;
+        EXPECT_EQ(e.code(), ErrorCode::CORRUPTION);
+    }
+    EXPECT_TRUE(thrown);
+    EXPECT_EQ(tmp_column_dict->size(), 0);
+    EXPECT_TRUE(tmp_column_dict->is_dict_empty());
+}
+
 TEST_F(ColumnDictionaryTest, convert_dict_codes_if_necessary) {
     {
         ColumnDictI32::MutablePtr tmp_column_dict =

--- a/be/test/core/column/column_string_test.cpp
+++ b/be/test/core/column/column_string_test.cpp
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "common/exception.h"
 #include "core/block/block.h"
 #include "core/column/column_vector.h"
 #include "core/column/common_column_test.h"
@@ -701,6 +702,34 @@ TEST_F(ColumnStringTest, insert_many_dict_data) {
     test_func(0, ColumnString64(), column_str64_json);
     test_func(10, ColumnString64(), column_str64_json);
 }
+
+TEST_F(ColumnStringTest, insert_many_dict_data_rejects_invalid_codeword) {
+    StringRef dict[] = {StringRef("a", 1), StringRef("bb", 2)};
+    auto expect_corruption = [](auto& column, const int32_t* codewords, size_t num,
+                                const StringRef* dict, uint32_t dict_num) {
+        bool thrown = false;
+        try {
+            column.insert_many_dict_data(codewords, 0, dict, num, dict_num);
+        } catch (const Exception& e) {
+            thrown = true;
+            EXPECT_EQ(e.code(), ErrorCode::CORRUPTION);
+        }
+        EXPECT_TRUE(thrown);
+        EXPECT_EQ(column.size(), 0);
+    };
+
+    {
+        ColumnString column;
+        int32_t codewords[] = {0, 2};
+        expect_corruption(column, codewords, 2, dict, 2);
+    }
+    {
+        ColumnString64 column;
+        int32_t codewords[] = {-1};
+        expect_corruption(column, codewords, 1, dict, 2);
+    }
+}
+
 TEST_F(ColumnStringTest, pop_back_test) {
     column_string_common_test(assert_column_vector_pop_back_callback, false);
 }

--- a/be/test/core/column/predicate_column_test.cpp
+++ b/be/test/core/column/predicate_column_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 
+#include "common/exception.h"
 #include "common/status.h"
 #include "core/column/column_decimal.h"
 #include "core/column/column_nullable.h"
@@ -628,6 +629,22 @@ TEST(PredicateColumnTest, InsertManyDictDataVarchar) {
     EXPECT_EQ(std::string(col->get_data()[0].data, col->get_data()[0].size), "x");
     EXPECT_EQ(std::string(col->get_data()[1].data, col->get_data()[1].size), "yy");
     EXPECT_EQ(std::string(col->get_data()[2].data, col->get_data()[2].size), "x");
+}
+
+TEST(PredicateColumnTest, InsertManyDictDataRejectsInvalidCodeword) {
+    auto col = PredicateColumnType<TYPE_STRING>::create();
+    StringRef dict[] = {StringRef("x", 1), StringRef("yy", 2)};
+    int32_t codewords[] = {0, 2};
+
+    bool thrown = false;
+    try {
+        col->insert_many_dict_data(codewords, 0, dict, 2, 2);
+    } catch (const Exception& e) {
+        thrown = true;
+        EXPECT_EQ(e.code(), ErrorCode::CORRUPTION);
+    }
+    EXPECT_TRUE(thrown);
+    EXPECT_EQ(col->size(), 0);
 }
 
 // ============================================================================

--- a/be/test/storage/segment/binary_dict_page_test.cpp
+++ b/be/test/storage/segment/binary_dict_page_test.cpp
@@ -36,6 +36,7 @@
 #include "storage/segment/page_builder.h"
 #include "storage/segment/page_decoder.h"
 #include "storage/types.h"
+#include "util/coding.h"
 #include "util/debug_util.h"
 
 namespace doris {
@@ -554,6 +555,32 @@ public:
         }
     }
 
+    Status build_dict_codeword_page(const std::vector<int32_t>& codewords, OwnedSlice* page) {
+        PageBuilderOptions options;
+        options.data_page_size = 1024;
+        const EncodingInfo* encoding_info = nullptr;
+        RETURN_IF_ERROR(EncodingInfo::get(FieldType::OLAP_FIELD_TYPE_INT, BIT_SHUFFLE,
+                                          EncodingPreference(), &encoding_info));
+        std::unique_ptr<PageBuilder> page_builder;
+        RETURN_IF_ERROR(encoding_info->create_page_builder(options, page_builder));
+        size_t count = codewords.size();
+        RETURN_IF_ERROR(
+                page_builder->add(reinterpret_cast<const uint8_t*>(codewords.data()), &count));
+        if (count != codewords.size()) {
+            return Status::InternalError("failed to add all dict codewords, added {}, expected {}",
+                                         count, codewords.size());
+        }
+
+        OwnedSlice codeword_slice;
+        RETURN_IF_ERROR(page_builder->finish(&codeword_slice));
+        faststring buffer;
+        buffer.resize(BINARY_DICT_PAGE_HEADER_SIZE);
+        encode_fixed32_le(&buffer[0], DICT_ENCODING);
+        buffer.append(codeword_slice.slice().data, codeword_slice.slice().size);
+        *page = buffer.build();
+        return Status::OK();
+    }
+
 private:
     std::unique_ptr<segment_v2::EncodingInfoResolver> _resolver;
 };
@@ -587,6 +614,55 @@ TEST_F(BinaryDictPageTest, TestConfigSwitchBetweenEncodings) {
 
     // Test with config = true
     test_encoding_type(true, slices, PLAIN_ENCODING_V2);
+}
+
+TEST_F(BinaryDictPageTest, TestRejectInvalidDictCodeword) {
+    OwnedSlice page;
+    ASSERT_TRUE(build_dict_codeword_page({0, 1}, &page).ok());
+
+    Slice page_slice = page.slice();
+    std::unique_ptr<DataPage> decoded_page;
+    ASSERT_TRUE(apply_pre_decode(page_slice, decoded_page).ok());
+
+    PageDecoderOptions decoder_options;
+    BinaryDictPageDecoder page_decoder(page_slice, decoder_options);
+    ASSERT_TRUE(page_decoder.init().ok());
+
+    StringRef dict[] = {StringRef("a", 1)};
+    page_decoder.set_dict_decoder(1, dict);
+    MutableColumnPtr column = ColumnString::create();
+    size_t size = 2;
+    Status status = page_decoder.next_batch(&size, column);
+    EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
+    EXPECT_EQ(column->size(), 0);
+}
+
+TEST_F(BinaryDictPageTest, TestRejectInvalidDictCodewordOnlyReadOffsets) {
+    OwnedSlice page;
+    ASSERT_TRUE(build_dict_codeword_page({0, 1}, &page).ok());
+
+    Slice page_slice = page.slice();
+    std::unique_ptr<DataPage> decoded_page;
+    ASSERT_TRUE(apply_pre_decode(page_slice, decoded_page).ok());
+
+    PageDecoderOptions decoder_options;
+    decoder_options.only_read_offsets = true;
+    BinaryDictPageDecoder page_decoder(page_slice, decoder_options);
+    ASSERT_TRUE(page_decoder.init().ok());
+
+    StringRef dict[] = {StringRef("a", 1)};
+    page_decoder.set_dict_decoder(1, dict);
+    MutableColumnPtr column = ColumnString::create();
+    size_t size = 2;
+    Status status = page_decoder.next_batch(&size, column);
+    EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
+    EXPECT_EQ(column->size(), 0);
+
+    ASSERT_TRUE(page_decoder.seek_to_position_in_page(0).ok());
+    rowid_t rowids[] = {1};
+    size = 1;
+    status = page_decoder.read_by_rowids(rowids, 0, &size, column);
+    EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
 }
 
 // Test that encoding preference affects the dictionary page encoding type


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary: Dictionary-encoded string pages use codewords from the data page to index the page dictionary during decoding. Corrupted codeword data can reference entries outside the dictionary and lead to out-of-bounds dictionary reads. This PR validates dictionary codewords against the dictionary size before materializing string columns, predicate columns, dictionary columns, and offset-only length reads. Invalid codewords now fail with a corruption status instead of indexing outside the dictionary.

This PR also updates a stale column array view unit test helper usage required by the current master build after rebasing.

### Release note

None

### Check List (For Author)

- Test:
    - Unit Test: ./run-be-ut.sh --run --filter=ColumnStringTest.insert_many_dict_data*:PredicateColumnTest.InsertManyDictData*:ColumnDictionaryTest.insert_many_dict_data*:BinaryDictPageTest.TestRejectInvalidDictCodeword* -j 16
    - Manual test: build-support/clang-format.sh
    - Manual test: build-support/check-format.sh
    - Manual test: git diff --check
- Behavior changed: Yes. Corrupted dictionary-encoded string pages with invalid codewords are rejected as corruption instead of being decoded.
- Does this need documentation: No
