### PR TITLE
[fix](fe) Add user and role existence check in DropRowPolicyCommand

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
@@ -32,8 +32,6 @@ import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * DropRowPolicyCommand
  **/
@@ -83,11 +81,6 @@ public class DropRowPolicyCommand extends DropCommand {
             user.analyze();
             if (!Env.getCurrentEnv().getAuth().doesUserExist(user)) {
                 throw new AnalysisException("user not exist: " + user);
-            }
-        }
-        if (!StringUtils.isEmpty(roleName)) {
-            if (!Env.getCurrentEnv().getAuth().doesRoleExist(roleName)) {
-                throw new AnalysisException("role not exist: " + roleName);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
@@ -32,6 +32,8 @@ import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * DropRowPolicyCommand
  **/
@@ -73,6 +75,14 @@ public class DropRowPolicyCommand extends DropCommand {
         tableNameInfo.analyze(ctx.getNameSpaceContext());
         if (user != null) {
             user.analyze();
+            if (!Env.getCurrentEnv().getAuth().doesUserExist(user)) {
+                throw new AnalysisException("user not exist: " + user);
+            }
+        }
+        if (!StringUtils.isEmpty(roleName)) {
+            if (!Env.getCurrentEnv().getAuth().doesRoleExist(roleName)) {
+                throw new AnalysisException("role not exist: " + roleName);
+            }
         }
         // check auth
         if (!Env.getCurrentEnv().getAccessManager()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
@@ -72,6 +72,12 @@ public class DropRowPolicyCommand extends DropCommand {
      * validate
      */
     public void validate(ConnectContext ctx) throws AnalysisException {
+        // check auth
+        if (!Env.getCurrentEnv().getAccessManager()
+                .checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
+                    PrivPredicate.GRANT.getPrivs().toString());
+        }
         tableNameInfo.analyze(ctx.getNameSpaceContext());
         if (user != null) {
             user.analyze();
@@ -83,12 +89,6 @@ public class DropRowPolicyCommand extends DropCommand {
             if (!Env.getCurrentEnv().getAuth().doesRoleExist(roleName)) {
                 throw new AnalysisException("role not exist: " + roleName);
             }
-        }
-        // check auth
-        if (!Env.getCurrentEnv().getAccessManager()
-                .checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
-                    PrivPredicate.GRANT.getPrivs().toString());
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
@@ -60,7 +60,6 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
         Deencapsulation.setField(env, "accessManager", spyAcm);
         Auth spyAuth = Mockito.spy(auth);
         Mockito.doReturn(true).when(spyAuth).doesUserExist(Mockito.any(UserIdentity.class));
-        Mockito.doReturn(true).when(spyAuth).doesRoleExist(Mockito.anyString());
         Deencapsulation.setField(env, "auth", spyAuth);
         DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "role1");
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
@@ -80,22 +79,5 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
         AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
                 () -> command.validate(connectContext));
         Assertions.assertTrue(ex.getMessage().contains("user not exist"));
-    }
-
-    @Test
-    public void testValidateRoleNotExist() throws Exception {
-        runBefore();
-        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
-        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
-                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
-        Deencapsulation.setField(env, "accessManager", spyAcm);
-        Auth spyAuth = Mockito.spy(auth);
-        Mockito.doReturn(true).when(spyAuth).doesUserExist(Mockito.any(UserIdentity.class));
-        Mockito.doReturn(false).when(spyAuth).doesRoleExist(Mockito.anyString());
-        Deencapsulation.setField(env, "auth", spyAuth);
-        DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "nonexist_role");
-        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
-                () -> command.validate(connectContext));
-        Assertions.assertTrue(ex.getMessage().contains("role not exist"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
@@ -20,8 +20,10 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.TableNameInfo;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
@@ -36,6 +38,7 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
     private ConnectContext connectContext;
     private Env env;
     private AccessControllerManager accessControllerManager;
+    private Auth auth;
     private UserIdentity user;
     private TableNameInfo tableNameInfo;
 
@@ -43,6 +46,7 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
         connectContext = createDefaultCtx();
         env = Env.getCurrentEnv();
         accessControllerManager = env.getAccessManager();
+        auth = env.getAuth();
         user = new UserIdentity("jack", "127.0.0.1", true);
         tableNameInfo = new TableNameInfo("test_db", "test_tbl");
     }
@@ -54,7 +58,44 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
         Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
                 Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
         Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(auth);
+        Mockito.doReturn(true).when(spyAuth).doesUserExist(Mockito.any(UserIdentity.class));
+        Mockito.doReturn(true).when(spyAuth).doesRoleExist(Mockito.anyString());
+        Deencapsulation.setField(env, "auth", spyAuth);
         DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "role1");
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testValidateUserNotExist() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(auth);
+        Mockito.doReturn(false).when(spyAuth).doesUserExist(Mockito.any(UserIdentity.class));
+        Deencapsulation.setField(env, "auth", spyAuth);
+        DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, null);
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(ex.getMessage().contains("user not exist"));
+    }
+
+    @Test
+    public void testValidateRoleNotExist() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(auth);
+        Mockito.doReturn(true).when(spyAuth).doesUserExist(Mockito.any(UserIdentity.class));
+        Mockito.doReturn(false).when(spyAuth).doesRoleExist(Mockito.anyString());
+        Deencapsulation.setField(env, "auth", spyAuth);
+        DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "nonexist_role");
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(ex.getMessage().contains("role not exist"));
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63322

Problem Summary: DropRowPolicyCommand does not validate whether the user or role specified in the DROP ROW POLICY statement actually exists. This is inconsistent with CreatePolicyCommand, which checks user existence via `doesUserExist()` and role existence via `doesRoleExist()`. Without this validation, a typo in the user or role name could silently match no policy, or the user might mistakenly believe the drop succeeded.

### Release note

DROP ROW POLICY now validates that the specified user and role exist, returning an error if they do not. This makes the behavior consistent with CREATE ROW POLICY.

### Check List (For Author)

- Test
    - [x] Unit Test
- Behavior changed:
    - [x] Yes. DROP ROW POLICY now throws AnalysisException when the specified user or role does not exist, whereas previously it would proceed without validation.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label