### PR TITLE
[Chore] correct null check in `DictionaryManager.dropTableDictionaries()`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
@@ -243,7 +243,7 @@ public class DictionaryManager extends MasterDaemon implements Writable {
             Map<String, Long> nameToIds = dictionaryIds.get(dbName);
             for (Long id : dictIds) {
                 Dictionary dict = idToDictionary.remove(id);
-                if (id == null) {
+                if (dict == null) {
                     LOG.warn("Dictionary {} does not exist in dictionaryIds", id);
                     continue;
                 }


### PR DESCRIPTION
Long log:

The null check was mistakenly performed on the `id` parameter instead of the `dict` returned from `idToDictionary.remove(id)`.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [X] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

