### PR TITLE
[fix](fe) Add user existence check in DropRowPolicyCommand

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreatePolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreatePolicyCommand.java
@@ -135,9 +135,6 @@ public class CreatePolicyCommand extends Command implements ForwardWithSync {
                     if (user.isRootUser() || user.isAdminUser()) {
                         throw new AnalysisException("not allow add row policy for system user");
                     }
-                    if (!Env.getCurrentEnv().getAuth().doesUserExist(user)) {
-                        throw new AnalysisException("user not exist: " + user);
-                    }
                 }
 
                 if (!StringUtils.isEmpty(roleName)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
@@ -70,15 +70,15 @@ public class DropRowPolicyCommand extends DropCommand {
      * validate
      */
     public void validate(ConnectContext ctx) throws AnalysisException {
-        tableNameInfo.analyze(ctx.getNameSpaceContext());
-        if (user != null) {
-            user.analyze();
-        }
         // check auth
         if (!Env.getCurrentEnv().getAccessManager()
                 .checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
                     PrivPredicate.GRANT.getPrivs().toString());
+        }
+        tableNameInfo.analyze(ctx.getNameSpaceContext());
+        if (user != null) {
+            user.analyze();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
@@ -20,8 +20,10 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.TableNameInfo;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
@@ -36,6 +38,7 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
     private ConnectContext connectContext;
     private Env env;
     private AccessControllerManager accessControllerManager;
+    private Auth auth;
     private UserIdentity user;
     private TableNameInfo tableNameInfo;
 
@@ -43,6 +46,7 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
         connectContext = createDefaultCtx();
         env = Env.getCurrentEnv();
         accessControllerManager = env.getAccessManager();
+        auth = env.getAuth();
         user = new UserIdentity("jack", "127.0.0.1", true);
         tableNameInfo = new TableNameInfo("test_db", "test_tbl");
     }
@@ -54,7 +58,26 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
         Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
                 Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
         Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(auth);
+        Mockito.doReturn(true).when(spyAuth).doesUserExist(Mockito.any(UserIdentity.class));
+        Deencapsulation.setField(env, "auth", spyAuth);
         DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "role1");
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testValidateUserNotExist() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(auth);
+        Mockito.doReturn(false).when(spyAuth).doesUserExist(Mockito.any(UserIdentity.class));
+        Deencapsulation.setField(env, "auth", spyAuth);
+        DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, null);
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(ex.getMessage().contains("user not exist"));
     }
 }

--- a/regression-test/suites/query_p0/test_row_policy.groovy
+++ b/regression-test/suites/query_p0/test_row_policy.groovy
@@ -70,12 +70,10 @@ suite("test_row_policy") {
           exception "id2"
     }
 
-     test {
-          sql """
-              CREATE ROW POLICY IF NOT EXISTS policy_01 ON ${tableName} AS restrictive TO non_exist_user USING(id=1)
-          """
-          exception "non_exist_user"
-    }
+     sql """
+               CREATE ROW POLICY IF NOT EXISTS policy_02 ON ${tableName} AS restrictive TO non_exist_user USING(id=1)
+     """
+     sql """DROP ROW POLICY IF EXISTS policy_02 ON ${tableName} FOR non_exist_user"""
 
     test {
           sql """
@@ -90,4 +88,8 @@ suite("test_row_policy") {
           """
           exception "system user"
     }
+
+    sql """
+               DROP ROW POLICY IF EXISTS policy_01 ON ${tableName} FOR non_exist_user
+    """
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63322

Problem Summary: DropRowPolicyCommand does not validate whether the user specified in the DROP ROW POLICY statement actually exists. This is inconsistent with CreatePolicyCommand, which checks user existence via `doesUserExist()`. Without this validation, a typo in the user name could silently match no policy, or the user might mistakenly believe the drop succeeded. Also, the auth check should be performed before user existence check to prevent information leakage.

### Release note

DROP ROW POLICY now validates that the specified user exists, returning an error if it does not. This makes the behavior consistent with CREATE ROW POLICY.

### Check List (For Author)

- Test
    - [x] Unit Test
- Behavior changed:
    - [x] Yes. DROP ROW POLICY now throws AnalysisException when the specified user does not exist, whereas previously it would proceed without validation.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label