### PR TITLE
[fix](fe) Cascade revoke privileges when dropping resources

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3658,6 +3658,7 @@ public class Env {
             if (externalCatalog != null) {
                 externalCatalog.replayDropDb(info.getDbName());
             }
+            Env.getCurrentEnv().getAuth().onDropDatabase(info.getCtlName(), info.getDbName(), true);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ResourceMgr.java
@@ -124,6 +124,7 @@ public class ResourceMgr implements Writable {
             throw new DdlException("Can not drop resource, since it's used in policy " + policy.getPolicyName());
         }
         nameToResource.remove(resourceName);
+        Env.getCurrentEnv().getAuth().onDropResource(resourceName, false);
         // log drop
         Env.getCurrentEnv().getEditLog().logDropResource(new DropResourceOperationLog(resourceName));
         LOG.info("Drop resource success. Resource resourceName: {}", resourceName);
@@ -139,6 +140,7 @@ public class ResourceMgr implements Writable {
 
     public void replayDropResource(DropResourceOperationLog operationLog) {
         nameToResource.remove(operationLog.getName());
+        Env.getCurrentEnv().getAuth().onDropResource(operationLog.getName(), true);
     }
 
     public void alterResource(String resourceName, Map<String, String> properties) throws DdlException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -136,13 +136,14 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         return new RemovedCatalog(catalog, catalogName);
     }
 
-    private void cleanupRemovedCatalog(RemovedCatalog removedCatalog) {
+    private void cleanupRemovedCatalog(RemovedCatalog removedCatalog, boolean isReplay) {
         if (removedCatalog == null) {
             return;
         }
         CatalogIf catalog = removedCatalog.catalog;
         catalog.onClose();
         Env.getCurrentEnv().getConstraintManager().dropCatalogConstraints(removedCatalog.catalogName);
+        Env.getCurrentEnv().getAuth().onDropCatalog(removedCatalog.catalogName, isReplay);
         ConnectContext ctx = ConnectContext.get();
         if (ctx != null) {
             ctx.removeLastDBOfCatalog(removedCatalog.catalogName);
@@ -317,7 +318,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             Env.getCurrentEnv().getEditLog().logCatalogLog(OperationType.OP_DROP_CATALOG, log);
         } finally {
             writeUnlock();
-            cleanupRemovedCatalog(removedCatalog);
+            cleanupRemovedCatalog(removedCatalog, false);
         }
         if (removedCatalog == null) {
             return;
@@ -351,7 +352,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         } finally {
             writeUnlock();
         }
-        cleanupRemovedCatalog(removedCatalog);
+        cleanupRemovedCatalog(removedCatalog, false);
         if (removedCatalog == null) {
             throw new IllegalStateException("No catalog found with name: " + catalogName);
         }
@@ -585,7 +586,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         } finally {
             writeUnlock();
         }
-        cleanupRemovedCatalog(removedCatalog);
+        cleanupRemovedCatalog(removedCatalog, true);
     }
 
     /**
@@ -599,7 +600,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         } finally {
             writeUnlock();
         }
-        cleanupRemovedCatalog(removedCatalog);
+        cleanupRemovedCatalog(removedCatalog, true);
 
         if (removedCatalog == null) {
             throw new IllegalStateException("No catalog found with id: " + log.getCatalogId());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -1032,6 +1032,7 @@ public abstract class ExternalCatalog
         }
         try {
             metadataOps.dropDb(dbName, ifExists, force);
+            Env.getCurrentEnv().getAuth().onDropDatabase(getName(), dbName, false);
             DropDbInfo info = new DropDbInfo(getName(), dbName);
             Env.getCurrentEnv().getEditLog().logDropDb(info);
         } catch (Exception e) {
@@ -1120,6 +1121,7 @@ public abstract class ExternalCatalog
         }
         try {
             metadataOps.dropTable(dorisTable, ifExists);
+            Env.getCurrentEnv().getAuth().onDropTable(getName(), dbName, tableName, false);
             DropInfo info = new DropInfo(getName(), dbName, tableName);
             Env.getCurrentEnv().getEditLog().logDropTable(info);
         } catch (Exception e) {
@@ -1132,6 +1134,7 @@ public abstract class ExternalCatalog
         if (metadataOps != null) {
             metadataOps.afterDropTable(dbName, tblName);
         }
+        Env.getCurrentEnv().getAuth().onDropTable(getName(), dbName, tblName, true);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -544,6 +544,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             DropDbInfo info = new DropDbInfo(dbName, force, recycleTime);
             Env.getCurrentEnv().getQueryStats().clear(Env.getCurrentEnv().getCurrentCatalog().getId(), db.getId());
             Env.getCurrentEnv().getDictionaryManager().dropDbDictionaries(dbName);
+            Env.getCurrentEnv().getAuth().onDropDatabase(INTERNAL_CATALOG_NAME, dbName, false);
             Env.getCurrentEnv().getEditLog().logDropDb(info);
         } finally {
             unlock();
@@ -600,6 +601,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             fullNameToDb.remove(dbName);
             idToDb.remove(db.getId());
             Env.getCurrentEnv().getFunctionRegistry().dropUdfByDb(dbName);
+            Env.getCurrentEnv().getAuth().onDropDatabase(INTERNAL_CATALOG_NAME, dbName, true);
         } finally {
             unlock();
         }
@@ -1056,6 +1058,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         Env.getCurrentEnv().getConstraintManager().checkAndDropTableConstraints(
                 TableNameInfoUtils.fromDb(db, table.getName()),
                 !isForceDrop && !isReplay);
+        Env.getCurrentEnv().getAuth().onDropTable(INTERNAL_CATALOG_NAME, db.getFullName(), table.getName(), isReplay);
         db.unregisterTable(table.getId());
         StopWatch watch = StopWatch.createStarted();
         Env.getCurrentRecycleBin().recycleTable(db.getId(), table, isReplay, isForceDrop, recycleTime);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -1111,6 +1111,76 @@ public class Auth implements Writable {
         dropRoleInternal(role, ignoreIfNonExists, false);
     }
 
+    public void onDropCatalog(String ctl, boolean isReplay) {
+        writeLock();
+        try {
+            List<PrivInfo> removed = roleManager.removeCatalogPrivs(ctl);
+            if (!isReplay) {
+                for (PrivInfo info : removed) {
+                    Env.getCurrentEnv().getEditLog().logRevokePriv(info);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void onDropDatabase(String ctl, String db, boolean isReplay) {
+        writeLock();
+        try {
+            List<PrivInfo> removed = roleManager.removeDbPrivs(ctl, db);
+            if (!isReplay) {
+                for (PrivInfo info : removed) {
+                    Env.getCurrentEnv().getEditLog().logRevokePriv(info);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void onDropTable(String ctl, String db, String tbl, boolean isReplay) {
+        writeLock();
+        try {
+            List<PrivInfo> removed = roleManager.removeTablePrivs(ctl, db, tbl);
+            if (!isReplay) {
+                for (PrivInfo info : removed) {
+                    Env.getCurrentEnv().getEditLog().logRevokePriv(info);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void onDropResource(String resourceName, boolean isReplay) {
+        writeLock();
+        try {
+            List<PrivInfo> removed = roleManager.removeResourcePrivs(resourceName);
+            if (!isReplay) {
+                for (PrivInfo info : removed) {
+                    Env.getCurrentEnv().getEditLog().logRevokePriv(info);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void onDropWorkloadGroup(String workloadGroupName, boolean isReplay) {
+        writeLock();
+        try {
+            List<PrivInfo> removed = roleManager.removeWorkloadGroupPrivs(workloadGroupName);
+            if (!isReplay) {
+                for (PrivInfo info : removed) {
+                    Env.getCurrentEnv().getEditLog().logRevokePriv(info);
+                }
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
     public void replayDropRole(PrivInfo info) {
         try {
             dropRoleInternal(info.getRole(), false, true);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -41,6 +41,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -770,7 +771,7 @@ public class Role implements GsonPostProcessable {
     public void revokePrivs(TablePattern tblPattern, PrivBitSet privs, Map<ColPrivilegeKey, Set<String>> colPrivileges,
             boolean errOnNonExist)
             throws DdlException {
-        if (!colPrivileges.isEmpty()) {
+        if (colPrivileges != null && !colPrivileges.isEmpty()) {
             revokeCols(colPrivileges);
         } else {
             PrivBitSet existingPriv = tblPatternToPrivs.get(tblPattern);
@@ -906,6 +907,82 @@ public class Role implements GsonPostProcessable {
             throw new DdlException(e.getMessage());
         }
         workloadGroupPrivTable.revoke(entry, false, true);
+    }
+
+    public List<Map.Entry<TablePattern, PrivBitSet>> removeCatalogPrivs(String ctl) {
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = new ArrayList<>();
+        tblPatternToPrivs.entrySet().removeIf(entry -> {
+            TablePattern pattern = entry.getKey();
+            if (pattern.getQualifiedCtl().equals(ctl)) {
+                removed.add(entry);
+                return true;
+            }
+            return false;
+        });
+        colPrivMap.keySet().removeIf(key -> key.getCtl().equals(ctl));
+        rebuildPrivTables();
+        return removed;
+    }
+
+    public List<Map.Entry<TablePattern, PrivBitSet>> removeDbPrivs(String ctl, String db) {
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = new ArrayList<>();
+        tblPatternToPrivs.entrySet().removeIf(entry -> {
+            TablePattern pattern = entry.getKey();
+            if ((pattern.getPrivLevel() == PrivLevel.DATABASE || pattern.getPrivLevel() == PrivLevel.TABLE)
+                    && pattern.getQualifiedCtl().equals(ctl) && pattern.getQualifiedDb().equals(db)) {
+                removed.add(entry);
+                return true;
+            }
+            return false;
+        });
+        colPrivMap.keySet().removeIf(key -> key.getCtl().equals(ctl) && key.getDb().equals(db));
+        rebuildPrivTables();
+        return removed;
+    }
+
+    public List<Map.Entry<TablePattern, PrivBitSet>> removeTablePrivs(String ctl, String db, String tbl) {
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = new ArrayList<>();
+        tblPatternToPrivs.entrySet().removeIf(entry -> {
+            TablePattern pattern = entry.getKey();
+            if (pattern.getPrivLevel() == PrivLevel.TABLE
+                    && pattern.getQualifiedCtl().equals(ctl)
+                    && pattern.getQualifiedDb().equals(db)
+                    && pattern.getTbl().equals(tbl)) {
+                removed.add(entry);
+                return true;
+            }
+            return false;
+        });
+        colPrivMap.keySet().removeIf(key ->
+                key.getCtl().equals(ctl) && key.getDb().equals(db) && key.getTbl().equals(tbl));
+        rebuildPrivTables();
+        return removed;
+    }
+
+    public List<Map.Entry<ResourcePattern, PrivBitSet>> removeResourcePrivs(String resourceName) {
+        List<Map.Entry<ResourcePattern, PrivBitSet>> removed = new ArrayList<>();
+        resourcePatternToPrivs.entrySet().removeIf(entry -> {
+            if (entry.getKey().getResourceName().equals(resourceName)) {
+                removed.add(entry);
+                return true;
+            }
+            return false;
+        });
+        rebuildPrivTables();
+        return removed;
+    }
+
+    public List<Map.Entry<WorkloadGroupPattern, PrivBitSet>> removeWorkloadGroupPrivs(String workloadGroupName) {
+        List<Map.Entry<WorkloadGroupPattern, PrivBitSet>> removed = new ArrayList<>();
+        workloadGroupPatternToPrivs.entrySet().removeIf(entry -> {
+            if (entry.getKey().getworkloadGroupName().equals(workloadGroupName)) {
+                removed.add(entry);
+                return true;
+            }
+            return false;
+        });
+        rebuildPrivTables();
+        return removed;
     }
 
     private void revokePrivs(TablePattern tblPattern, PrivBitSet privs) throws DdlException {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
@@ -30,6 +30,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.mysql.privilege.Auth.PrivLevel;
+import org.apache.doris.persist.PrivInfo;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
@@ -47,6 +48,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -147,6 +149,59 @@ public class RoleManager implements Writable {
         }
         existingRole.revokePrivs(workloadGroupPattern, privs, errOnNonExist);
         return existingRole;
+    }
+
+    public List<PrivInfo> removeCatalogPrivs(String ctl) {
+        List<PrivInfo> removedPrivInfos = Lists.newArrayList();
+        for (Role role : roles.values()) {
+            for (Map.Entry<TablePattern, PrivBitSet> entry : role.removeCatalogPrivs(ctl)) {
+                removedPrivInfos.add(new PrivInfo(null, entry.getKey(), entry.getValue(),
+                        null, role.getRoleName(), Collections.emptyMap()));
+            }
+        }
+        return removedPrivInfos;
+    }
+
+    public List<PrivInfo> removeDbPrivs(String ctl, String db) {
+        List<PrivInfo> removedPrivInfos = Lists.newArrayList();
+        for (Role role : roles.values()) {
+            for (Map.Entry<TablePattern, PrivBitSet> entry : role.removeDbPrivs(ctl, db)) {
+                removedPrivInfos.add(new PrivInfo(null, entry.getKey(), entry.getValue(),
+                        null, role.getRoleName(), Collections.emptyMap()));
+            }
+        }
+        return removedPrivInfos;
+    }
+
+    public List<PrivInfo> removeTablePrivs(String ctl, String db, String tbl) {
+        List<PrivInfo> removedPrivInfos = Lists.newArrayList();
+        for (Role role : roles.values()) {
+            for (Map.Entry<TablePattern, PrivBitSet> entry : role.removeTablePrivs(ctl, db, tbl)) {
+                removedPrivInfos.add(new PrivInfo(null, entry.getKey(), entry.getValue(),
+                        null, role.getRoleName(), Collections.emptyMap()));
+            }
+        }
+        return removedPrivInfos;
+    }
+
+    public List<PrivInfo> removeResourcePrivs(String resourceName) {
+        List<PrivInfo> removedPrivInfos = Lists.newArrayList();
+        for (Role role : roles.values()) {
+            for (Map.Entry<ResourcePattern, PrivBitSet> entry : role.removeResourcePrivs(resourceName)) {
+                removedPrivInfos.add(new PrivInfo(null, entry.getKey(), entry.getValue(), null, role.getRoleName()));
+            }
+        }
+        return removedPrivInfos;
+    }
+
+    public List<PrivInfo> removeWorkloadGroupPrivs(String workloadGroupName) {
+        List<PrivInfo> removedPrivInfos = Lists.newArrayList();
+        for (Role role : roles.values()) {
+            for (Map.Entry<WorkloadGroupPattern, PrivBitSet> entry : role.removeWorkloadGroupPrivs(workloadGroupName)) {
+                removedPrivInfos.add(new PrivInfo(null, entry.getKey(), entry.getValue(), null, role.getRoleName()));
+            }
+        }
+        return removedPrivInfos;
     }
 
     public void getRoleInfo(List<List<String>> results) {

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -363,6 +363,7 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
             WorkloadGroup workloadGroup = keyToWorkloadGroup.get(wgKey);
             keyToWorkloadGroup.remove(wgKey);
             idToWorkloadGroup.remove(workloadGroup.getId());
+            Env.getCurrentEnv().getAuth().onDropWorkloadGroup(workloadGroupName, false);
             Env.getCurrentEnv().getEditLog()
                     .logDropWorkloadGroup(new DropWorkloadGroupOperationLog(workloadGroup.getId()));
         } finally {
@@ -404,6 +405,7 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
             WorkloadGroup workloadGroup = idToWorkloadGroup.get(id);
             keyToWorkloadGroup.remove(workloadGroup.getWorkloadGroupKey());
             idToWorkloadGroup.remove(id);
+            Env.getCurrentEnv().getAuth().onDropWorkloadGroup(workloadGroup.getName(), true);
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/RoleCascadeRevokeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/RoleCascadeRevokeTest.java
@@ -1,0 +1,198 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mysql.privilege;
+
+import org.apache.doris.analysis.ResourcePattern;
+import org.apache.doris.analysis.ResourceTypeEnum;
+import org.apache.doris.analysis.TablePattern;
+import org.apache.doris.analysis.WorkloadGroupPattern;
+import org.apache.doris.common.AnalysisException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class RoleCascadeRevokeTest {
+
+    @Test
+    public void testRemoveCatalogPrivs() throws AnalysisException {
+        Role role = new Role("test_role");
+        TablePattern catalogPat = new TablePattern("ctl1", "*", "*");
+        catalogPat.analyze();
+        TablePattern dbPat = new TablePattern("ctl1", "db1", "*");
+        dbPat.analyze();
+        TablePattern tblPat = new TablePattern("ctl1", "db1", "tbl1");
+        tblPat.analyze();
+        TablePattern otherCtlPat = new TablePattern("ctl2", "db2", "*");
+        otherCtlPat.analyze();
+
+        PrivBitSet selectPriv = PrivBitSet.of(Privilege.SELECT_PRIV);
+        PrivBitSet alterPriv = PrivBitSet.of(Privilege.ALTER_PRIV);
+
+        role.getTblPatternToPrivs().put(catalogPat, selectPriv);
+        role.getTblPatternToPrivs().put(dbPat, alterPriv);
+        role.getTblPatternToPrivs().put(tblPat, selectPriv);
+        role.getTblPatternToPrivs().put(otherCtlPat, alterPriv);
+
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = role.removeCatalogPrivs("ctl1");
+        Assert.assertEquals(3, removed.size());
+        Assert.assertEquals(1, role.getTblPatternToPrivs().size());
+        Assert.assertTrue(role.getTblPatternToPrivs().containsKey(otherCtlPat));
+    }
+
+    @Test
+    public void testRemoveDbPrivs() throws AnalysisException {
+        Role role = new Role("test_role");
+        TablePattern catalogPat = new TablePattern("internal", "*", "*");
+        catalogPat.analyze();
+        TablePattern dbPat = new TablePattern("internal", "db1", "*");
+        dbPat.analyze();
+        TablePattern tblPat = new TablePattern("internal", "db1", "tbl1");
+        tblPat.analyze();
+        TablePattern otherDbPat = new TablePattern("internal", "db2", "*");
+        otherDbPat.analyze();
+
+        PrivBitSet selectPriv = PrivBitSet.of(Privilege.SELECT_PRIV);
+        PrivBitSet alterPriv = PrivBitSet.of(Privilege.ALTER_PRIV);
+
+        role.getTblPatternToPrivs().put(catalogPat, selectPriv);
+        role.getTblPatternToPrivs().put(dbPat, alterPriv);
+        role.getTblPatternToPrivs().put(tblPat, selectPriv);
+        role.getTblPatternToPrivs().put(otherDbPat, alterPriv);
+
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = role.removeDbPrivs("internal", "db1");
+        Assert.assertEquals(2, removed.size());
+        Assert.assertEquals(2, role.getTblPatternToPrivs().size());
+        Assert.assertTrue(role.getTblPatternToPrivs().containsKey(catalogPat));
+        Assert.assertTrue(role.getTblPatternToPrivs().containsKey(otherDbPat));
+    }
+
+    @Test
+    public void testRemoveTablePrivs() throws AnalysisException {
+        Role role = new Role("test_role");
+        TablePattern dbPat = new TablePattern("internal", "db1", "*");
+        dbPat.analyze();
+        TablePattern tbl1Pat = new TablePattern("internal", "db1", "tbl1");
+        tbl1Pat.analyze();
+        TablePattern tbl2Pat = new TablePattern("internal", "db1", "tbl2");
+        tbl2Pat.analyze();
+
+        PrivBitSet selectPriv = PrivBitSet.of(Privilege.SELECT_PRIV);
+        PrivBitSet alterPriv = PrivBitSet.of(Privilege.ALTER_PRIV);
+
+        role.getTblPatternToPrivs().put(dbPat, selectPriv);
+        role.getTblPatternToPrivs().put(tbl1Pat, alterPriv);
+        role.getTblPatternToPrivs().put(tbl2Pat, selectPriv);
+
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = role.removeTablePrivs("internal", "db1", "tbl1");
+        Assert.assertEquals(1, removed.size());
+        Assert.assertEquals(2, role.getTblPatternToPrivs().size());
+        Assert.assertTrue(role.getTblPatternToPrivs().containsKey(dbPat));
+        Assert.assertTrue(role.getTblPatternToPrivs().containsKey(tbl2Pat));
+    }
+
+    @Test
+    public void testRemoveResourcePrivs() throws AnalysisException {
+        Role role = new Role("test_role");
+        ResourcePattern res1 = new ResourcePattern("res1", ResourceTypeEnum.GENERAL);
+        ResourcePattern res2 = new ResourcePattern("res2", ResourceTypeEnum.GENERAL);
+
+        PrivBitSet usagePriv = PrivBitSet.of(Privilege.USAGE_PRIV);
+
+        role.getResourcePatternToPrivs().put(res1, usagePriv);
+        role.getResourcePatternToPrivs().put(res2, usagePriv);
+
+        List<Map.Entry<ResourcePattern, PrivBitSet>> removed = role.removeResourcePrivs("res1");
+        Assert.assertEquals(1, removed.size());
+        Assert.assertEquals(1, role.getResourcePatternToPrivs().size());
+        Assert.assertTrue(role.getResourcePatternToPrivs().containsKey(res2));
+    }
+
+    @Test
+    public void testRemoveWorkloadGroupPrivs() throws AnalysisException {
+        Role role = new Role("test_role");
+        WorkloadGroupPattern wg1 = new WorkloadGroupPattern("wg1");
+        WorkloadGroupPattern wg2 = new WorkloadGroupPattern("wg2");
+
+        PrivBitSet usagePriv = PrivBitSet.of(Privilege.USAGE_PRIV);
+
+        role.getWorkloadGroupPatternToPrivs().put(wg1, usagePriv);
+        role.getWorkloadGroupPatternToPrivs().put(wg2, usagePriv);
+
+        List<Map.Entry<WorkloadGroupPattern, PrivBitSet>> removed = role.removeWorkloadGroupPrivs("wg1");
+        Assert.assertEquals(1, removed.size());
+        Assert.assertEquals(1, role.getWorkloadGroupPatternToPrivs().size());
+        Assert.assertTrue(role.getWorkloadGroupPatternToPrivs().containsKey(wg2));
+    }
+
+    @Test
+    public void testRemoveNonExistentPrivs() {
+        Role role = new Role("test_role");
+        List<Map.Entry<TablePattern, PrivBitSet>> dbRemoved = role.removeDbPrivs("internal", "nonexistent");
+        Assert.assertTrue(dbRemoved.isEmpty());
+
+        List<Map.Entry<ResourcePattern, PrivBitSet>> resRemoved = role.removeResourcePrivs("nonexistent");
+        Assert.assertTrue(resRemoved.isEmpty());
+
+        List<Map.Entry<WorkloadGroupPattern, PrivBitSet>> wgRemoved = role.removeWorkloadGroupPrivs("nonexistent");
+        Assert.assertTrue(wgRemoved.isEmpty());
+    }
+
+    @Test
+    public void testRemoveDbPrivsPreservesCatalogLevel() throws AnalysisException {
+        Role role = new Role("test_role");
+        TablePattern catalogPat = new TablePattern("internal", "*", "*");
+        catalogPat.analyze();
+        TablePattern dbPat = new TablePattern("internal", "db1", "*");
+        dbPat.analyze();
+
+        PrivBitSet selectPriv = PrivBitSet.of(Privilege.SELECT_PRIV);
+        PrivBitSet alterPriv = PrivBitSet.of(Privilege.ALTER_PRIV);
+
+        role.getTblPatternToPrivs().put(catalogPat, selectPriv);
+        role.getTblPatternToPrivs().put(dbPat, alterPriv);
+
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = role.removeDbPrivs("internal", "db1");
+        Assert.assertEquals(1, removed.size());
+        Assert.assertEquals(1, role.getTblPatternToPrivs().size());
+        Assert.assertTrue(role.getTblPatternToPrivs().containsKey(catalogPat));
+    }
+
+    @Test
+    public void testRemoveCatalogPrivsReturnsCorrectEntries() throws AnalysisException {
+        Role role = new Role("test_role");
+        TablePattern catalogPat = new TablePattern("ctl1", "*", "*");
+        catalogPat.analyze();
+        TablePattern dbPat = new TablePattern("ctl1", "db1", "*");
+        dbPat.analyze();
+
+        PrivBitSet selectPriv = PrivBitSet.of(Privilege.SELECT_PRIV);
+        PrivBitSet alterPriv = PrivBitSet.of(Privilege.ALTER_PRIV);
+
+        role.getTblPatternToPrivs().put(catalogPat, selectPriv);
+        role.getTblPatternToPrivs().put(dbPat, alterPriv);
+
+        List<Map.Entry<TablePattern, PrivBitSet>> removed = role.removeCatalogPrivs("ctl1");
+        Assert.assertEquals(2, removed.size());
+        for (Map.Entry<TablePattern, PrivBitSet> entry : removed) {
+            Assert.assertEquals("ctl1", entry.getKey().getQualifiedCtl());
+        }
+    }
+}

--- a/regression-test/suites/auth_p0/test_drop_cascade_revoke_privs.groovy
+++ b/regression-test/suites/auth_p0/test_drop_cascade_revoke_privs.groovy
@@ -1,0 +1,107 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_drop_cascade_revoke_privs", "auth") {
+    def user1 = 'test_drop_cascade_revoke_user1'
+    def role1 = 'test_drop_cascade_revoke_role1'
+    def pwd = '123456'
+    def dbName = 'test_drop_cascade_revoke_db'
+    def tableName = 'test_drop_cascade_revoke_tbl'
+    def resourceName = 'test_drop_cascade_revoke_resource'
+    def workloadGroupName = 'test_drop_cascade_revoke_wg'
+    def tokens = context.config.jdbcUrl.split('/')
+    def url = tokens[0] + "//" + tokens[2] + "/" + "information_schema" + "?"
+
+    def forComputeGroupStr = ""
+    if (isCloudMode()) {
+        def clusters = sql " SHOW CLUSTERS; "
+        assertTrue(!clusters.isEmpty())
+        def validCluster = clusters[0][0]
+        forComputeGroupStr = " for  $validCluster "
+    }
+
+    sql """drop user if exists ${user1}"""
+    sql """drop role if exists ${role1}"""
+    sql """DROP DATABASE IF EXISTS ${dbName}"""
+    sql """CREATE USER '${user1}' IDENTIFIED BY '${pwd}'"""
+    sql """CREATE ROLE ${role1}"""
+    sql """GRANT '${role1}' TO ${user1}"""
+
+    // ========== Test 1: drop database should cascade revoke db and table privs ==========
+    sql """CREATE DATABASE ${dbName}"""
+    sql """GRANT SELECT_PRIV ON ${dbName}.* TO ROLE '${role1}'"""
+    sql """GRANT ALTER_PRIV ON ${dbName}.* TO ROLE '${role1}'"""
+
+    def result = sql """SHOW GRANTS FOR ${user1}"""
+    assertTrue(result.any { row -> row.any { it != null && it.contains("${dbName}") } })
+
+    sql """DROP DATABASE ${dbName}"""
+
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertFalse(result.any { row -> row.any { it != null && it.contains("${dbName}") } })
+
+    // ========== Test 2: drop table should cascade revoke table privs ==========
+    sql """CREATE DATABASE ${dbName}"""
+    sql """USE ${dbName}"""
+    sql """CREATE TABLE ${tableName} (k INT) DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("replication_num" = "1")"""
+    sql """GRANT SELECT_PRIV ON ${dbName}.${tableName} TO ROLE '${role1}'"""
+    sql """GRANT ALTER_PRIV ON ${dbName}.${tableName} TO ROLE '${role1}'"""
+
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertTrue(result.any { row -> row.any { it != null && it.contains("${tableName}") } })
+
+    sql """DROP TABLE ${dbName}.${tableName}"""
+
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertFalse(result.any { row -> row.any { it != null && it.contains("${tableName}") } })
+
+    // db-level privs should still exist
+    sql """GRANT SELECT_PRIV ON ${dbName}.* TO ROLE '${role1}'"""
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertTrue(result.any { row -> row.any { it != null && it.contains("${dbName}") } })
+
+    sql """DROP DATABASE ${dbName}"""
+
+    // ========== Test 3: drop resource should cascade revoke resource privs ==========
+    sql """CREATE RESOURCE ${resourceName} PROPERTIES("type"="hdfs", "hadoop.fs.defaultFS"="hdfs://localhost:8020")"""
+    sql """GRANT USAGE_PRIV ON RESOURCE ${resourceName} TO ROLE '${role1}'"""
+
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertTrue(result.any { row -> row.any { it != null && it.contains("${resourceName}") } })
+
+    sql """DROP RESOURCE ${resourceName}"""
+
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertFalse(result.any { row -> row.any { it != null && it.contains("${resourceName}") } })
+
+    // ========== Test 4: drop workload group should cascade revoke workload group privs ==========
+    sql """CREATE WORKLOAD GROUP IF NOT EXISTS ${workloadGroupName} ${forComputeGroupStr} PROPERTIES('min_cpu_percent'='0')"""
+    sql """GRANT USAGE_PRIV ON WORKLOAD GROUP ${workloadGroupName} TO ROLE '${role1}'"""
+
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertTrue(result.any { row -> row.any { it != null && it.contains("${workloadGroupName}") } })
+
+    sql """DROP WORKLOAD GROUP ${workloadGroupName} ${forComputeGroupStr}"""
+
+    result = sql """SHOW GRANTS FOR ${user1}"""
+    assertFalse(result.any { row -> row.any { it != null && it.contains("${workloadGroupName}") } })
+
+    // cleanup
+    sql """DROP DATABASE IF EXISTS ${dbName}"""
+    sql """DROP USER IF EXISTS ${user1}"""
+    sql """DROP ROLE IF EXISTS ${role1}"""
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: When a resource (database, table, resource, workload group, or catalog) is dropped, the corresponding privilege entries in roles are not cleaned up. This causes `SHOW GRANTS` to display orphan privileges that reference non-existent resources. These orphan entries persist across FE restarts because the original GRANT records are replayed from BDB edit logs without any corresponding cleanup.

### Release note

Fix orphan privilege entries displayed by `SHOW GRANTS` after dropping databases, tables, resources, workload groups, or catalogs. Privileges referencing dropped resources are now cascade-revoked automatically.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Dropping a database/table/resource/workload group/catalog now cascade-revokes all privilege entries referencing that resource across all roles.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label