### PR TITLE
[fix](fe) Add role existence validation in DropRowPolicyCommand

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommand.java
@@ -32,6 +32,8 @@ import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * DropRowPolicyCommand
  **/
@@ -70,15 +72,20 @@ public class DropRowPolicyCommand extends DropCommand {
      * validate
      */
     public void validate(ConnectContext ctx) throws AnalysisException {
-        tableNameInfo.analyze(ctx.getNameSpaceContext());
-        if (user != null) {
-            user.analyze();
-        }
-        // check auth
+        // check auth first to prevent information leakage
         if (!Env.getCurrentEnv().getAccessManager()
                 .checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR,
                     PrivPredicate.GRANT.getPrivs().toString());
+        }
+        tableNameInfo.analyze(ctx.getNameSpaceContext());
+        if (user != null) {
+            user.analyze();
+        }
+        if (!ifExists && !StringUtils.isEmpty(roleName)) {
+            if (!Env.getCurrentEnv().getAuth().doesRoleExist(roleName)) {
+                throw new AnalysisException("role not exist: " + roleName);
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DropRowPolicyCommandTest.java
@@ -20,8 +20,10 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.TableNameInfo;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.utframe.TestWithFeService;
@@ -54,7 +56,75 @@ public class DropRowPolicyCommandTest extends TestWithFeService {
         Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
                 Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
         Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(env.getAuth());
+        Mockito.doReturn(true).when(spyAuth).doesRoleExist(Mockito.eq("role1"));
+        Deencapsulation.setField(env, "auth", spyAuth);
         DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "role1");
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testValidateNonExistRole() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(env.getAuth());
+        Mockito.doReturn(false).when(spyAuth).doesRoleExist(Mockito.eq("non_exist_role"));
+        Deencapsulation.setField(env, "auth", spyAuth);
+        DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user,
+                "non_exist_role");
+        Assertions.assertThrows(AnalysisException.class, () -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testValidateNonExistRoleWithIfExists() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(true).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(env.getAuth());
+        Mockito.doReturn(false).when(spyAuth).doesRoleExist(Mockito.eq("non_exist_role"));
+        Deencapsulation.setField(env, "auth", spyAuth);
+        DropRowPolicyCommand command = new DropRowPolicyCommand(true, "test_policy", tableNameInfo, user,
+                "non_exist_role");
+        Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testValidateWithoutGrantPriv() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(env.getAuth());
+        Mockito.doReturn(false).when(spyAuth).doesRoleExist(Mockito.eq("non_exist_role"));
+        Deencapsulation.setField(env, "auth", spyAuth);
+        DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user,
+                "non_exist_role");
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(ex.getMessage().contains("Access denied"),
+                "Expected access denied error but got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testValidateWithoutGrantPrivForExistingRole() throws Exception {
+        runBefore();
+        AccessControllerManager spyAcm = Mockito.spy(accessControllerManager);
+        Mockito.doReturn(false).when(spyAcm).checkGlobalPriv(
+                Mockito.nullable(ConnectContext.class), Mockito.eq(PrivPredicate.GRANT));
+        Deencapsulation.setField(env, "accessManager", spyAcm);
+        Auth spyAuth = Mockito.spy(env.getAuth());
+        Mockito.doReturn(true).when(spyAuth).doesRoleExist(Mockito.eq("role1"));
+        Deencapsulation.setField(env, "auth", spyAuth);
+        DropRowPolicyCommand command = new DropRowPolicyCommand(false, "test_policy", tableNameInfo, user, "role1");
+        AnalysisException ex = Assertions.assertThrows(AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(ex.getMessage().contains("Access denied"),
+                "Expected access denied error but got: " + ex.getMessage());
     }
 }

--- a/regression-test/suites/auth_p0/test_drop_policy_auth.groovy
+++ b/regression-test/suites/auth_p0/test_drop_policy_auth.groovy
@@ -38,6 +38,12 @@ suite("test_drop_policy_auth","p0,auth") {
             log.info(e.getMessage())
             assertTrue(e.getMessage().contains("Admin_priv"))
         }
+        // test: user without GRANT priv should get access denied error
+        // regardless of whether the role exists or not (privilege-first validation)
+        test {
+            sql "DROP ROW POLICY test_row_policy_1 on table1 FOR ROLE non_exist_role"
+            exception "denied"
+        }
     }
     try_sql("DROP USER ${user}")
 }

--- a/regression-test/suites/query_p0/test_row_policy.groovy
+++ b/regression-test/suites/query_p0/test_row_policy.groovy
@@ -90,4 +90,11 @@ suite("test_row_policy") {
           """
           exception "system user"
     }
+
+    test {
+          sql """
+              DROP ROW POLICY policy_01 ON ${tableName} FOR ROLE non_exist_role
+          """
+          exception "non_exist_role"
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: `DROP ROW POLICY ... FOR ROLE <role_name>` does not validate whether the role exists, while `CREATE ROW POLICY ... FOR ROLE <role_name>` does validate. This inconsistency allows dropping a row policy with a non-existent role name without any error.

Additionally, when `IF EXISTS` is specified, the role existence check should be skipped because if the role doesn't exist, the corresponding policy cannot exist either (since creation validates the role). The `IF EXISTS` semantics should silently return in this case.

### Release note

Fix: `DROP ROW POLICY ... FOR ROLE <non_exist_role>` now throws an error when the role does not exist, consistent with `CREATE ROW POLICY` behavior. `DROP ROW POLICY IF EXISTS ... FOR ROLE <non_exist_role>` silently returns as expected.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason? -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. `DROP ROW POLICY ... FOR ROLE <non_exist_role>` now throws AnalysisException when role does not exist. `DROP ROW POLICY IF EXISTS ... FOR ROLE <non_exist_role>` silently returns.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label