### PR TITLE
[fix](regression-test) fix two muted test cases (Groovy property access + flaky SHOW PROCESSLIST)

### DIFF
--- a/regression-test/plugins/plugins_create_table_nested_type.groovy
+++ b/regression-test/plugins/plugins_create_table_nested_type.groovy
@@ -133,9 +133,9 @@ Suite.metaClass.get_create_table_with_nested_type { int depth, String tb_name ->
     }
 
     backtrack();
-    for (int i = 0; i < res.size; i++) {
+    for (int i = 0; i < res.size(); i++) {
         def date_type_str = ""
-        for (int j = 0; j < res[i].size; j++) {
+        for (int j = 0; j < res[i].size(); j++) {
             date_type_str += res[i][j] + " "
         }
         logger.info(date_type_str)

--- a/regression-test/suites/auth_call/test_show_charset_auth.groovy
+++ b/regression-test/suites/auth_call/test_show_charset_auth.groovy
@@ -65,7 +65,8 @@ suite("test_show_no_auth","p0,auth_call") {
 
         def res1 = sql """SHOW PROCESSLIST"""
         logger.info("res1: " + res1)
-        assertTrue(res1.size() == 1)
+        def ownSessions = res1.findAll { it[2] == user }
+        assertTrue(ownSessions.size() >= 1)
     }
     sql """revoke grant_priv on *.*.* from ${user}"""
     sql """grant admin_priv on *.*.* to ${user}"""


### PR DESCRIPTION
## Summary

Fix two regression-test cases that are currently muted on branch-4.0 (and have the same bugs on master, just not yet observed/muted). Neither requires any FE/BE changes — both are Groovy / test-harness issues.

The companion back-port to `branch-4.0` is apache/doris#63644.

### 1. `datatype_p0.create_table_with_nested_type`

`regression-test/plugins/plugins_create_table_nested_type.groovy:136,138`

```diff
-    for (int i = 0; i < res.size; i++) {
+    for (int i = 0; i < res.size(); i++) {
         def date_type_str = ""
-        for (int j = 0; j < res[i].size; j++) {
+        for (int j = 0; j < res[i].size(); j++) {
             date_type_str += res[i][j] + " "
         }
```

On the Groovy runtime used by the regression framework, `java.util.ArrayList` does not expose `size` as a JavaBean property, so `res.size` falls through GPath into `getAt(Iterable, ...)`, iterates the outer list, and tries to read `.size` from each inner `Integer` — throwing `MissingPropertyException: No such property: size for class: java.lang.Integer`. The test fails in ~15 ms before any DDL is sent to FE.

Same root cause as #62454 / #62455.

### 2. `auth_call.test_show_charset_auth.test_show_no_auth`

`regression-test/suites/auth_call/test_show_charset_auth.groovy:68`

```diff
-        assertTrue(res1.size() == 1)
+        def ownSessions = res1.findAll { it[2] == user }
+        assertTrue(ownSessions.size() >= 1)
```

After granting `grant_priv`, `SHOW PROCESSLIST` returns *all* sessions to any caller that satisfies `PrivPredicate.ADMIN` (see `ConnectPoolMgr.listConnection`), so in the parallel pipeline this user sees 20+ concurrent sessions from other suites. The `== 1` assertion is structurally unsafe — replace it with a per-user filter that matches the same pattern already used at line 49 of the file. Column index 2 is the User column (`ConnectContext.ThreadInfo.toRow`).

## Test plan

- [ ] After merge, unmute the two test cases on TeamCity (branch-4.0):
  - `datatype_p0.nested_types.create_table.create_table_with_nested_type`
  - `auth_call.test_show_charset_auth.test_show_no_auth`
- [ ] Confirm each test passes (or surfaces a different, real failure) on the next P0 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)