### PR TITLE
[improvement](fe) Add --fast-compile option to run-fe-ut.sh

### DIFF
--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -31,6 +31,7 @@ Usage: $0 <options>
   Optional options:
      --coverage           build and run coverage statistic
      --run                build and run ut
+     --fast-compile       use fast incremental compile (tools/fast-compile-fe.sh) instead of full mvn build
 
   Eg.
     $0                                                                      build and run ut
@@ -38,6 +39,7 @@ Usage: $0 <options>
     $0 --run org.apache.doris.utframe.Demo                                  build and run the test named Demo
     $0 --run org.apache.doris.utframe.Demo#testCreateDbAndTable+test2       build and run testCreateDbAndTable in Demo test
     $0 --run org.apache.doris.Demo,org.apache.doris.Demo2                   build and run Demo and Demo2 test
+    $0 --fast-compile                                                       fast incremental compile, then run ut
   "
     exit 1
 }
@@ -47,6 +49,7 @@ if ! OPTS="$(getopt \
     -o '' \
     -l 'coverage' \
     -l 'run' \
+    -l 'fast-compile' \
     -- "$@")"; then
     usage
 fi
@@ -55,13 +58,16 @@ eval set -- "${OPTS}"
 
 RUN=0
 COVERAGE=0
+FAST_COMPILE=0
 if [[ "$#" == 1 ]]; then
     #default
     RUN=0
     COVERAGE=0
+    FAST_COMPILE=0
 else
     RUN=0
     COVERAGE=0
+    FAST_COMPILE=0
     while true; do
         case "$1" in
         --coverage)
@@ -70,6 +76,10 @@ else
             ;;
         --run)
             RUN=1
+            shift
+            ;;
+        --fast-compile)
+            FAST_COMPILE=1
             shift
             ;;
         --)
@@ -83,6 +93,74 @@ else
         esac
     done
 fi
+
+# Try fast incremental compilation using tools/fast-compile-fe.sh.
+# Returns 0 on success, 1 if fallback to full build is needed.
+try_fast_compile() {
+    local fe_core="${DORIS_HOME}/fe/fe-core"
+    local target_classes="$fe_core/target/classes"
+    local target_test_classes="$fe_core/target/test-classes"
+    local output_jar="${DORIS_HOME}/output/fe/lib/doris-fe.jar"
+    local target_jar="$fe_core/target/doris-fe.jar"
+    local main_src="$fe_core/src/main/java"
+    local test_src="$fe_core/src/test/java"
+
+    # Basic sanity: target/classes must exist and be complete (ref: fast-compile-fe.sh check_env)
+    if [[ ! -d "$target_classes" ]]; then
+        echo "target/classes does not exist, need full build"
+        return 1
+    fi
+    local class_count
+    class_count=$(find "$target_classes" -name "*.class" 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$class_count" -lt 1000 ]]; then
+        echo "target/classes incomplete (${class_count} classes), need full build"
+        return 1
+    fi
+    if [[ ! -f "$output_jar" && ! -f "$target_jar" ]]; then
+        echo "doris-fe.jar not found, need full build"
+        return 1
+    fi
+
+    # Count changed files. Use -newer for speed; new files without a matching
+    # .class are rare in incremental workflows and fast-compile-fe.sh handles them.
+    local changed=0
+    local limit=1001
+
+    if [[ -d "$main_src" ]]; then
+        local main_changed
+        main_changed=$(find "$main_src" -name "*.java" -newer "$target_classes" 2>/dev/null \
+            | head -n "$limit" | wc -l | tr -d ' ')
+        changed=$((changed + main_changed))
+    fi
+
+    if [[ $changed -lt $limit && -d "$test_src" && -d "$target_test_classes" ]]; then
+        local test_changed
+        test_changed=$(find "$test_src" -name "*.java" -newer "$target_test_classes" 2>/dev/null \
+            | head -n "$limit" | wc -l | tr -d ' ')
+        changed=$((changed + test_changed))
+    fi
+
+    if [[ $changed -ge $limit ]]; then
+        echo "Too many changed files (>= ${limit}), falling back to full build"
+        return 1
+    fi
+
+    echo "Fast-compiling changed files..."
+
+    # Compile main sources
+    if ! "${DORIS_HOME}"/tools/fast-compile-fe.sh; then
+        echo "Fast compile (main) failed, falling back to full build"
+        return 1
+    fi
+
+    # Compile test sources
+    if ! "${DORIS_HOME}"/tools/fast-compile-fe.sh --test; then
+        echo "Fast compile (test) failed, falling back to full build"
+        return 1
+    fi
+
+    return 0
+}
 
 echo "Build Frontend UT"
 
@@ -107,6 +185,28 @@ if [[ -z "${FE_UT_PARALLEL}" ]]; then
 fi
 echo "Unit test parallel is: ${FE_UT_PARALLEL}"
 
+# Decide whether to use fast compile or full build.
+# Coverage mode requires lifecycle phases for jacoco agent setup, so always use full build.
+if [[ "${FAST_COMPILE}" -eq 1 ]]; then
+    if [[ "${COVERAGE}" -eq 1 ]]; then
+        echo "--fast-compile is incompatible with --coverage, will use full build"
+        MVN_GOAL="test"
+        MVN_OPTS=""
+    elif try_fast_compile; then
+        MVN_GOAL="surefire:test"
+        # Only test fe-core (the module fast-compile-fe.sh just compiled).
+        # Running from fe/ would trigger the full reactor including modules
+        # like hadoop-hudi-scanner, causing unnecessary downloads and builds.
+        MVN_OPTS="-pl fe-core"
+    else
+        MVN_GOAL="test"
+        MVN_OPTS=""
+    fi
+else
+    MVN_GOAL="test"
+    MVN_OPTS=""
+fi
+
 if [[ "${RUN}" -eq 1 ]]; then
     echo "Run the specified class: $1"
     # eg:
@@ -114,15 +214,15 @@ if [[ "${RUN}" -eq 1 ]]; then
     # sh run-fe-ut.sh --run org.apache.doris.utframe.DemoTest#testCreateDbAndTable+test2
 
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" -Pcoverage test jacoco:report -DfailIfNoTests=false -Dtest="$1"
+        "${MVN_CMD}" ${MVN_OPTS} -Pcoverage ${MVN_GOAL} jacoco:report -DfailIfNoTests=false -Dtest="$1"
     else
-        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false -Dtest="$1"
+        "${MVN_CMD}" ${MVN_OPTS} ${MVN_GOAL} -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false -Dtest="$1"
     fi
 else
     echo "Run Frontend UT"
     if [[ "${COVERAGE}" -eq 1 ]]; then
-        "${MVN_CMD}" -Pcoverage test jacoco:report -DfailIfNoTests=false -Dmaven.test.failure.ignore=true
+        "${MVN_CMD}" ${MVN_OPTS} -Pcoverage ${MVN_GOAL} jacoco:report -DfailIfNoTests=false -Dmaven.test.failure.ignore=true
     else
-        "${MVN_CMD}" test -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false
+        "${MVN_CMD}" ${MVN_OPTS} ${MVN_GOAL} -Dcheckstyle.skip=true -DfailIfNoTests=false -Dmaven.build.cache.enabled=false
     fi
 fi


### PR DESCRIPTION
When --fast-compile is specified, use tools/fast-compile-fe.sh for incremental compilation instead of a full mvn build. This avoids recompiling unchanged FE code and speeds up the edit-test cycle.

- Checks target/classes completeness and doris-fe.jar existence (references fast-compile-fe.sh check_env)
- Counts changed files; falls back to full build if > 1000
- Falls back to full build on any fast-compile failure
- Limits surefire:test scope to fe-core via -pl to avoid unnecessary reactor processing of other modules
- Without --fast-compile, behaviour is unchanged for QA compatibility

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

