### PR TITLE
[improvement](be) Track and cap inverted index writer memory

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1276,6 +1276,9 @@ DEFINE_Int32(ann_index_result_cache_stale_sweep_time_sec, "1800");
 
 // inverted index
 DEFINE_mDouble(inverted_index_ram_buffer_size, "512");
+// Cap the CLucene buffered postings for analyzed inverted indexes when RAM directory is disabled.
+// Values <= 0 keep inverted_index_ram_buffer_size unchanged.
+DEFINE_mDouble(inverted_index_ram_buffer_size_when_ram_dir_disabled, "64");
 // -1 indicates not working.
 // Normally we should not change this, it's useful for testing.
 DEFINE_mInt32(inverted_index_max_buffered_docs, "-1");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1320,6 +1320,7 @@ DECLARE_Int32(ann_index_result_cache_stale_sweep_time_sec);
 
 // inverted index
 DECLARE_mDouble(inverted_index_ram_buffer_size);
+DECLARE_mDouble(inverted_index_ram_buffer_size_when_ram_dir_disabled);
 DECLARE_mInt32(inverted_index_max_buffered_docs);
 // dict path for chinese analyzer
 DECLARE_String(inverted_index_dict_path);

--- a/be/src/storage/index/inverted/inverted_index_writer.cpp
+++ b/be/src/storage/index/inverted/inverted_index_writer.cpp
@@ -17,6 +17,7 @@
 
 #include "storage/index/inverted/inverted_index_writer.h"
 
+#include <algorithm>
 #include <cstring>
 
 #include "common/cast_set.h"
@@ -56,6 +57,21 @@ int64_t ram_directory_memory_size(const std::shared_ptr<DorisFSDirectory>& dir) 
         size += dir->fileLength(file.c_str());
     }
     return size;
+}
+
+bool is_fs_directory(const std::shared_ptr<DorisFSDirectory>& dir) {
+    return dir != nullptr && std::strcmp(dir->getObjectName(), "DorisFSDirectory") == 0;
+}
+
+float index_writer_ram_buffer_size(const std::shared_ptr<DorisFSDirectory>& dir,
+                                   bool should_analyzer) {
+    auto ram_buffer_size = config::inverted_index_ram_buffer_size;
+    if (should_analyzer && is_fs_directory(dir) && ram_buffer_size > 0 &&
+        config::inverted_index_ram_buffer_size_when_ram_dir_disabled > 0) {
+        ram_buffer_size = std::min(ram_buffer_size,
+                                   config::inverted_index_ram_buffer_size_when_ram_dir_disabled);
+    }
+    return static_cast<float>(ram_buffer_size);
 }
 
 } // namespace
@@ -169,7 +185,7 @@ InvertedIndexColumnWriter<field_type>::create_index_writer() {
                     { index_writer->setMaxBufferedDocs(1); })
     DBUG_EXECUTE_IF("InvertedIndexColumnWriter::create_index_writer_setMergeFactor_error",
                     { index_writer->setMergeFactor(1); })
-    index_writer->setRAMBufferSizeMB(static_cast<float>(config::inverted_index_ram_buffer_size));
+    index_writer->setRAMBufferSizeMB(index_writer_ram_buffer_size(_dir, _should_analyzer));
     index_writer->setMaxBufferedDocs(config::inverted_index_max_buffered_docs);
     index_writer->setMaxFieldLength(MAX_FIELD_LEN);
     index_writer->setMergeFactor(MERGE_FACTOR);

--- a/be/src/storage/index/inverted/inverted_index_writer.cpp
+++ b/be/src/storage/index/inverted/inverted_index_writer.cpp
@@ -37,51 +37,11 @@ const int DIMS = 1;
 
 namespace {
 
-template <typename T>
-int64_t vector_memory_size(const std::vector<T>& vector) {
-    return cast_set<int64_t>(vector.capacity() * sizeof(T));
-}
-
-int64_t bytes_ref_memory_size(const std::shared_ptr<lucene::util::BytesRef>& bytes_ref) {
-    if (bytes_ref == nullptr) {
+int64_t index_writer_memory_size(const std::unique_ptr<lucene::index::IndexWriter>& index_writer) {
+    if (index_writer == nullptr) {
         return 0;
     }
-    return cast_set<int64_t>(sizeof(lucene::util::BytesRef)) + vector_memory_size(bytes_ref->bytes);
-}
-
-int64_t heap_point_writer_memory_size(
-        const std::shared_ptr<lucene::util::bkd::heap_point_writer>& writer) {
-    if (writer == nullptr) {
-        return 0;
-    }
-
-    int64_t size = cast_set<int64_t>(sizeof(lucene::util::bkd::heap_point_writer));
-    size += vector_memory_size(writer->doc_IDs_);
-    size += vector_memory_size(writer->ords_long_);
-    size += vector_memory_size(writer->ords_);
-    size += vector_memory_size(writer->blocks_);
-    for (const auto& block : writer->blocks_) {
-        size += vector_memory_size(block);
-    }
-    size += bytes_ref_memory_size(writer->cache_);
-    size += bytes_ref_memory_size(writer->cache1_);
-    return size;
-}
-
-int64_t bkd_writer_memory_size(const std::shared_ptr<lucene::util::bkd::bkd_writer>& writer) {
-    if (writer == nullptr) {
-        return 0;
-    }
-
-    int64_t size = cast_set<int64_t>(sizeof(lucene::util::bkd::bkd_writer));
-    size += vector_memory_size(writer->min_packed_value_);
-    size += vector_memory_size(writer->max_packed_value_);
-    size += vector_memory_size(writer->scratch_diff_);
-    size += vector_memory_size(writer->scratch1_);
-    size += vector_memory_size(writer->scratch2_);
-    size += vector_memory_size(writer->common_prefix_lengths_);
-    size += heap_point_writer_memory_size(writer->heap_point_writer_);
-    return size;
+    return index_writer->ramSizeInBytes();
 }
 
 int64_t ram_directory_memory_size(const std::shared_ptr<DorisFSDirectory>& dir) {
@@ -635,8 +595,10 @@ Status InvertedIndexColumnWriter<field_type>::add_value(const CppType& value) {
 template <FieldType field_type>
 int64_t InvertedIndexColumnWriter<field_type>::size() const {
     int64_t size = cast_set<int64_t>(_null_bitmap.getSizeInBytes(false));
-    if constexpr (field_is_numeric_type(field_type)) {
-        size += bkd_writer_memory_size(_bkd_writer);
+    if constexpr (field_is_slice_type(field_type)) {
+        if (_should_analyzer) {
+            size += index_writer_memory_size(_index_writer);
+        }
     }
     size += ram_directory_memory_size(_dir);
     return size;

--- a/be/src/storage/index/inverted/inverted_index_writer.cpp
+++ b/be/src/storage/index/inverted/inverted_index_writer.cpp
@@ -17,6 +17,9 @@
 
 #include "storage/index/inverted/inverted_index_writer.h"
 
+#include <cstring>
+
+#include "common/cast_set.h"
 #include "storage/index/inverted/analyzer/analyzer.h"
 #include "storage/index/inverted/inverted_index_common.h"
 #include "storage/index/inverted/inverted_index_fs_directory.h"
@@ -31,6 +34,71 @@ const int32_t MERGE_FACTOR = 100000000;
 const int32_t MAX_LEAF_COUNT = 1024;
 const float MAXMBSortInHeap = 512.0 * 8;
 const int DIMS = 1;
+
+namespace {
+
+template <typename T>
+int64_t vector_memory_size(const std::vector<T>& vector) {
+    return cast_set<int64_t>(vector.capacity() * sizeof(T));
+}
+
+int64_t bytes_ref_memory_size(const std::shared_ptr<lucene::util::BytesRef>& bytes_ref) {
+    if (bytes_ref == nullptr) {
+        return 0;
+    }
+    return cast_set<int64_t>(sizeof(lucene::util::BytesRef)) + vector_memory_size(bytes_ref->bytes);
+}
+
+int64_t heap_point_writer_memory_size(
+        const std::shared_ptr<lucene::util::bkd::heap_point_writer>& writer) {
+    if (writer == nullptr) {
+        return 0;
+    }
+
+    int64_t size = cast_set<int64_t>(sizeof(lucene::util::bkd::heap_point_writer));
+    size += vector_memory_size(writer->doc_IDs_);
+    size += vector_memory_size(writer->ords_long_);
+    size += vector_memory_size(writer->ords_);
+    size += vector_memory_size(writer->blocks_);
+    for (const auto& block : writer->blocks_) {
+        size += vector_memory_size(block);
+    }
+    size += bytes_ref_memory_size(writer->cache_);
+    size += bytes_ref_memory_size(writer->cache1_);
+    return size;
+}
+
+int64_t bkd_writer_memory_size(const std::shared_ptr<lucene::util::bkd::bkd_writer>& writer) {
+    if (writer == nullptr) {
+        return 0;
+    }
+
+    int64_t size = cast_set<int64_t>(sizeof(lucene::util::bkd::bkd_writer));
+    size += vector_memory_size(writer->min_packed_value_);
+    size += vector_memory_size(writer->max_packed_value_);
+    size += vector_memory_size(writer->scratch_diff_);
+    size += vector_memory_size(writer->scratch1_);
+    size += vector_memory_size(writer->scratch2_);
+    size += vector_memory_size(writer->common_prefix_lengths_);
+    size += heap_point_writer_memory_size(writer->heap_point_writer_);
+    return size;
+}
+
+int64_t ram_directory_memory_size(const std::shared_ptr<DorisFSDirectory>& dir) {
+    if (dir == nullptr || std::strcmp(dir->getObjectName(), "DorisRAMFSDirectory") != 0) {
+        return 0;
+    }
+
+    int64_t size = 0;
+    std::vector<std::string> files;
+    dir->list(&files);
+    for (const auto& file : files) {
+        size += dir->fileLength(file.c_str());
+    }
+    return size;
+}
+
+} // namespace
 
 template <FieldType field_type>
 InvertedIndexColumnWriter<field_type>::InvertedIndexColumnWriter(const std::string& field_name,
@@ -566,8 +634,12 @@ Status InvertedIndexColumnWriter<field_type>::add_value(const CppType& value) {
 
 template <FieldType field_type>
 int64_t InvertedIndexColumnWriter<field_type>::size() const {
-    //TODO: get memory size of inverted index
-    return 0;
+    int64_t size = cast_set<int64_t>(_null_bitmap.getSizeInBytes(false));
+    if constexpr (field_is_numeric_type(field_type)) {
+        size += bkd_writer_memory_size(_bkd_writer);
+    }
+    size += ram_directory_memory_size(_dir);
+    return size;
 }
 
 template <FieldType field_type>

--- a/be/src/storage/segment/column_writer.cpp
+++ b/be/src/storage/segment/column_writer.cpp
@@ -721,6 +721,12 @@ uint64_t ScalarColumnWriter::estimate_buffer_size() {
     if (_opts.need_bloom_filter) {
         size += _bloom_filter_index_builder->size();
     }
+    if (_opts.need_inverted_index) {
+        for (const auto& builder : _inverted_index_builders) {
+            DORIS_CHECK(builder != nullptr);
+            size += builder->size();
+        }
+    }
     return size;
 }
 
@@ -1121,9 +1127,18 @@ Status ArrayColumnWriter::append_data(const uint8_t** ptr, size_t num_rows) {
 }
 
 uint64_t ArrayColumnWriter::estimate_buffer_size() {
-    return _offset_writer->estimate_buffer_size() +
-           (is_nullable() ? _null_writer->estimate_buffer_size() : 0) +
-           _item_writer->estimate_buffer_size();
+    uint64_t size = _offset_writer->estimate_buffer_size() +
+                    (is_nullable() ? _null_writer->estimate_buffer_size() : 0) +
+                    _item_writer->estimate_buffer_size();
+    if (_opts.need_inverted_index) {
+        DORIS_CHECK(_inverted_index_writer != nullptr);
+        size += _inverted_index_writer->size();
+    }
+    if (_opts.need_ann_index) {
+        DORIS_CHECK(_ann_index_writer != nullptr);
+        size += _ann_index_writer->size();
+    }
+    return size;
 }
 
 Status ArrayColumnWriter::append_nullable(const uint8_t* null_map, const uint8_t** ptr,

--- a/be/test/storage/segment/inverted_index_writer_test.cpp
+++ b/be/test/storage/segment/inverted_index_writer_test.cpp
@@ -29,7 +29,7 @@
 #include <cstring>
 #include <map>
 #include <memory>
-#include <numeric>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -777,6 +777,21 @@ private:
     std::unique_ptr<InvertedIndexQueryCache> _inverted_index_query_cache;
 };
 
+namespace {
+
+TabletIndex create_standard_fulltext_index_meta();
+std::string fulltext_memory_token(size_t token_id);
+std::vector<std::string> fulltext_memory_strings(size_t value_count, size_t tokens_per_value);
+std::vector<Slice> slices_from_strings(const std::vector<std::string>& strings);
+int64_t add_fulltext_values_and_get_peak_delta(IndexColumnWriter* column_writer,
+                                               const std::vector<Slice>& values);
+void check_fulltext_match(const std::shared_ptr<FullTextIndexReader>& fulltext_reader,
+                          const IndexQueryContextPtr& context, const std::string& field_name,
+                          const std::string& query, uint64_t cardinality,
+                          std::optional<uint32_t> doc_id);
+
+} // namespace
+
 // Test case for writing string values
 TEST_F(InvertedIndexWriterTest, StringWrite) {
     test_string_write("test_rowset_1", 0);
@@ -792,22 +807,10 @@ TEST_F(InvertedIndexWriterTest, NumericWrite) {
     test_numeric_write("test_rowset_3", 0);
 }
 
-TEST_F(InvertedIndexWriterTest, HighCardinalityBkdMemoryEstimate) {
+TEST_F(InvertedIndexWriterTest, FullTextStringMemoryEstimateIncludesBufferedPostings) {
     auto tablet_schema = create_schema();
-
-    auto index_meta_pb = std::make_unique<TabletIndexPB>();
-    index_meta_pb->set_index_type(IndexType::INVERTED);
-    index_meta_pb->set_index_id(1);
-    index_meta_pb->set_index_name("test");
-    index_meta_pb->clear_col_unique_id();
-    index_meta_pb->add_col_unique_id(0);
-    auto* properties = index_meta_pb->mutable_properties();
-    (*properties)["type"] = "bkd";
-
-    TabletIndex idx_meta;
-    idx_meta.init_from_pb(*index_meta_pb.get());
-
-    std::string rowset_id = "test_rowset_high_cardinality_memory";
+    TabletIndex idx_meta = create_standard_fulltext_index_meta();
+    std::string rowset_id = "test_rowset_fulltext_memory";
     int seg_id = 0;
     std::string index_path_prefix {InvertedIndexDescriptor::get_index_file_path_prefix(
             local_segment_path(kTestDir, rowset_id, seg_id))};
@@ -822,7 +825,7 @@ TEST_F(InvertedIndexWriterTest, HighCardinalityBkdMemoryEstimate) {
             fs, index_path_prefix, rowset_id, seg_id, InvertedIndexStorageFormatPB::V2,
             std::move(file_writer));
 
-    const TabletColumn& column = tablet_schema->column(0);
+    const TabletColumn& column = tablet_schema->column(1);
     ASSERT_NE(&column, nullptr);
     std::unique_ptr<StorageField> field(StorageFieldFactory::create(column));
     ASSERT_NE(field.get(), nullptr);
@@ -832,22 +835,16 @@ TEST_F(InvertedIndexWriterTest, HighCardinalityBkdMemoryEstimate) {
                                             &idx_meta);
     ASSERT_TRUE(status.ok()) << status;
 
-    const int64_t initial_size = column_writer->size();
-    int64_t peak_size = initial_size;
-    constexpr size_t value_count = 4096;
-    constexpr size_t batch_size = 512;
-    std::vector<int32_t> values(value_count);
-    std::iota(values.begin(), values.end(), 0);
+    constexpr size_t value_count = 256;
+    constexpr size_t tokens_per_value = 48;
+    const auto strings = fulltext_memory_strings(value_count, tokens_per_value);
+    const auto values = slices_from_strings(strings);
+    const int64_t peak_delta = add_fulltext_values_and_get_peak_delta(column_writer.get(), values);
 
-    for (size_t offset = 0; offset < values.size(); offset += batch_size) {
-        size_t count = std::min(batch_size, values.size() - offset);
-        status = column_writer->add_values("c1", values.data() + offset, count);
-        ASSERT_TRUE(status.ok()) << status;
-        peak_size = std::max(peak_size, column_writer->size());
-    }
-
-    EXPECT_GT(peak_size, initial_size);
-    EXPECT_GE(peak_size - initial_size, static_cast<int64_t>(values.size() * sizeof(int32_t)));
+    RecordProperty("legacy_peak_delta_bytes", 0);
+    RecordProperty("peak_delta_bytes", peak_delta);
+    EXPECT_GT(peak_delta, 256 * 1024);
+    EXPECT_LT(peak_delta, 8 * 1024 * 1024);
 
     status = column_writer->finish();
     ASSERT_TRUE(status.ok()) << status;
@@ -855,6 +852,35 @@ TEST_F(InvertedIndexWriterTest, HighCardinalityBkdMemoryEstimate) {
     ASSERT_TRUE(status.ok()) << status;
     status = index_file_writer->finish_close();
     ASSERT_TRUE(status.ok()) << status;
+
+    auto reader = std::make_shared<IndexFileReader>(
+            io::global_local_filesystem(), index_path_prefix, InvertedIndexStorageFormatPB::V2);
+    status = reader->init();
+    ASSERT_EQ(status, Status::OK());
+    auto result = reader->open(&idx_meta);
+    ASSERT_TRUE(result.has_value()) << "Failed to open compound reader" << result.error();
+
+    auto fulltext_reader = FullTextIndexReader::create_shared(&idx_meta, reader);
+    ASSERT_NE(fulltext_reader, nullptr);
+
+    OlapReaderStatistics stats;
+    RuntimeState runtime_state;
+    TQueryOptions query_options;
+    query_options.enable_inverted_index_searcher_cache = false;
+    runtime_state.set_query_options(query_options);
+    io::IOContext io_ctx;
+    auto context = std::make_shared<segment_v2::IndexQueryContext>();
+    context->io_ctx = &io_ctx;
+    context->stats = &stats;
+    context->runtime_state = &runtime_state;
+    std::string field_name = std::to_string(field->unique_id());
+
+    check_fulltext_match(fulltext_reader, context, field_name, "sharedterm", value_count,
+                         std::nullopt);
+    constexpr size_t selected_row = 17;
+    check_fulltext_match(fulltext_reader, context, field_name,
+                         fulltext_memory_token(selected_row * tokens_per_value + 5), 1,
+                         selected_row);
 }
 
 // Test case for Unicode string values with enable_correct_term_write=true
@@ -1610,5 +1636,85 @@ TEST_F(InvertedIndexWriterTest, NormsFileCreationWithTokenization) {
             << "because setOmitNorms(false) is not called. This validates the fix in "
             << "inverted_index_writer.cpp where .nrm file creation depends on _should_analyzer.";
 }
+
+namespace {
+
+TabletIndex create_standard_fulltext_index_meta() {
+    auto index_meta_pb = std::make_unique<TabletIndexPB>();
+    index_meta_pb->set_index_type(IndexType::INVERTED);
+    index_meta_pb->set_index_id(1);
+    index_meta_pb->set_index_name("test");
+    index_meta_pb->clear_col_unique_id();
+    index_meta_pb->add_col_unique_id(1);
+    auto* properties = index_meta_pb->mutable_properties();
+    (*properties)["parser"] = "standard";
+
+    TabletIndex idx_meta;
+    idx_meta.init_from_pb(*index_meta_pb.get());
+    return idx_meta;
+}
+
+std::string fulltext_memory_token(size_t token_id) {
+    std::string token = "term";
+    for (int i = 0; i < 5; ++i) {
+        token.push_back(static_cast<char>('a' + token_id % 26));
+        token_id /= 26;
+    }
+    return token;
+}
+
+std::vector<std::string> fulltext_memory_strings(size_t value_count, size_t tokens_per_value) {
+    std::vector<std::string> strings;
+    strings.reserve(value_count);
+    for (size_t row = 0; row < value_count; ++row) {
+        std::string value = "sharedterm";
+        for (size_t token_idx = 0; token_idx < tokens_per_value; ++token_idx) {
+            value.append(" ");
+            value.append(fulltext_memory_token(row * tokens_per_value + token_idx));
+        }
+        strings.emplace_back(std::move(value));
+    }
+    return strings;
+}
+
+std::vector<Slice> slices_from_strings(const std::vector<std::string>& strings) {
+    std::vector<Slice> values;
+    values.reserve(strings.size());
+    for (const auto& value : strings) {
+        values.emplace_back(value);
+    }
+    return values;
+}
+
+int64_t add_fulltext_values_and_get_peak_delta(IndexColumnWriter* column_writer,
+                                               const std::vector<Slice>& values) {
+    const int64_t initial_size = column_writer->size();
+    int64_t peak_size = initial_size;
+    constexpr size_t batch_size = 32;
+    for (size_t offset = 0; offset < values.size(); offset += batch_size) {
+        size_t count = std::min(batch_size, values.size() - offset);
+        auto status = column_writer->add_values("c2", values.data() + offset, count);
+        EXPECT_TRUE(status.ok()) << status;
+        peak_size = std::max(peak_size, column_writer->size());
+    }
+    return peak_size - initial_size;
+}
+
+void check_fulltext_match(const std::shared_ptr<FullTextIndexReader>& fulltext_reader,
+                          const IndexQueryContextPtr& context, const std::string& field_name,
+                          const std::string& query, uint64_t cardinality,
+                          std::optional<uint32_t> doc_id) {
+    std::shared_ptr<roaring::Roaring> bitmap = std::make_shared<roaring::Roaring>();
+    StringRef query_ref(query.c_str(), query.length());
+    auto status = fulltext_reader->query(context, field_name, &query_ref,
+                                         InvertedIndexQueryType::MATCH_ANY_QUERY, bitmap);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_EQ(bitmap->cardinality(), cardinality);
+    if (doc_id.has_value()) {
+        EXPECT_TRUE(bitmap->contains(doc_id.value()));
+    }
+}
+
+} // namespace
 
 } // namespace doris::segment_v2

--- a/be/test/storage/segment/inverted_index_writer_test.cpp
+++ b/be/test/storage/segment/inverted_index_writer_test.cpp
@@ -25,9 +25,11 @@
 #include <gtest/gtest-test-part.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstring>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -788,6 +790,71 @@ TEST_F(InvertedIndexWriterTest, NullsWrite) {
 // Test case for numeric values
 TEST_F(InvertedIndexWriterTest, NumericWrite) {
     test_numeric_write("test_rowset_3", 0);
+}
+
+TEST_F(InvertedIndexWriterTest, HighCardinalityBkdMemoryEstimate) {
+    auto tablet_schema = create_schema();
+
+    auto index_meta_pb = std::make_unique<TabletIndexPB>();
+    index_meta_pb->set_index_type(IndexType::INVERTED);
+    index_meta_pb->set_index_id(1);
+    index_meta_pb->set_index_name("test");
+    index_meta_pb->clear_col_unique_id();
+    index_meta_pb->add_col_unique_id(0);
+    auto* properties = index_meta_pb->mutable_properties();
+    (*properties)["type"] = "bkd";
+
+    TabletIndex idx_meta;
+    idx_meta.init_from_pb(*index_meta_pb.get());
+
+    std::string rowset_id = "test_rowset_high_cardinality_memory";
+    int seg_id = 0;
+    std::string index_path_prefix {InvertedIndexDescriptor::get_index_file_path_prefix(
+            local_segment_path(kTestDir, rowset_id, seg_id))};
+    std::string index_path = InvertedIndexDescriptor::get_index_file_path_v2(index_path_prefix);
+
+    io::FileWriterPtr file_writer;
+    io::FileWriterOptions opts;
+    auto fs = io::global_local_filesystem();
+    Status sts = fs->create_file(index_path, &file_writer, &opts);
+    ASSERT_TRUE(sts.ok()) << sts;
+    auto index_file_writer = std::make_unique<IndexFileWriter>(
+            fs, index_path_prefix, rowset_id, seg_id, InvertedIndexStorageFormatPB::V2,
+            std::move(file_writer));
+
+    const TabletColumn& column = tablet_schema->column(0);
+    ASSERT_NE(&column, nullptr);
+    std::unique_ptr<StorageField> field(StorageFieldFactory::create(column));
+    ASSERT_NE(field.get(), nullptr);
+
+    std::unique_ptr<IndexColumnWriter> column_writer;
+    auto status = IndexColumnWriter::create(field.get(), &column_writer, index_file_writer.get(),
+                                            &idx_meta);
+    ASSERT_TRUE(status.ok()) << status;
+
+    const int64_t initial_size = column_writer->size();
+    int64_t peak_size = initial_size;
+    constexpr size_t value_count = 4096;
+    constexpr size_t batch_size = 512;
+    std::vector<int32_t> values(value_count);
+    std::iota(values.begin(), values.end(), 0);
+
+    for (size_t offset = 0; offset < values.size(); offset += batch_size) {
+        size_t count = std::min(batch_size, values.size() - offset);
+        status = column_writer->add_values("c1", values.data() + offset, count);
+        ASSERT_TRUE(status.ok()) << status;
+        peak_size = std::max(peak_size, column_writer->size());
+    }
+
+    EXPECT_GT(peak_size, initial_size);
+    EXPECT_GE(peak_size - initial_size, static_cast<int64_t>(values.size() * sizeof(int32_t)));
+
+    status = column_writer->finish();
+    ASSERT_TRUE(status.ok()) << status;
+    status = index_file_writer->begin_close();
+    ASSERT_TRUE(status.ok()) << status;
+    status = index_file_writer->finish_close();
+    ASSERT_TRUE(status.ok()) << status;
 }
 
 // Test case for Unicode string values with enable_correct_term_write=true

--- a/be/test/storage/segment/inverted_index_writer_test.cpp
+++ b/be/test/storage/segment/inverted_index_writer_test.cpp
@@ -782,13 +782,37 @@ namespace {
 TabletIndex create_standard_fulltext_index_meta();
 std::string fulltext_memory_token(size_t token_id);
 std::vector<std::string> fulltext_memory_strings(size_t value_count, size_t tokens_per_value);
+std::vector<std::string> fulltext_large_memory_strings(size_t value_count,
+                                                       size_t min_bytes_per_value);
 std::vector<Slice> slices_from_strings(const std::vector<std::string>& strings);
 int64_t add_fulltext_values_and_get_peak_delta(IndexColumnWriter* column_writer,
-                                               const std::vector<Slice>& values);
+                                               const std::vector<Slice>& values,
+                                               size_t batch_size = 32);
 void check_fulltext_match(const std::shared_ptr<FullTextIndexReader>& fulltext_reader,
                           const IndexQueryContextPtr& context, const std::string& field_name,
                           const std::string& query, uint64_t cardinality,
                           std::optional<uint32_t> doc_id);
+
+class FullTextIndexConfigGuard {
+public:
+    FullTextIndexConfigGuard()
+            : _inverted_index_ram_dir_enable(config::inverted_index_ram_dir_enable),
+              _inverted_index_ram_buffer_size(config::inverted_index_ram_buffer_size),
+              _inverted_index_ram_buffer_size_when_ram_dir_disabled(
+                      config::inverted_index_ram_buffer_size_when_ram_dir_disabled) {}
+
+    ~FullTextIndexConfigGuard() {
+        config::inverted_index_ram_dir_enable = _inverted_index_ram_dir_enable;
+        config::inverted_index_ram_buffer_size = _inverted_index_ram_buffer_size;
+        config::inverted_index_ram_buffer_size_when_ram_dir_disabled =
+                _inverted_index_ram_buffer_size_when_ram_dir_disabled;
+    }
+
+private:
+    bool _inverted_index_ram_dir_enable;
+    double _inverted_index_ram_buffer_size;
+    double _inverted_index_ram_buffer_size_when_ram_dir_disabled;
+};
 
 } // namespace
 
@@ -881,6 +905,70 @@ TEST_F(InvertedIndexWriterTest, FullTextStringMemoryEstimateIncludesBufferedPost
     check_fulltext_match(fulltext_reader, context, field_name,
                          fulltext_memory_token(selected_row * tokens_per_value + 5), 1,
                          selected_row);
+}
+
+TEST_F(InvertedIndexWriterTest, FullTextLargeStringRamDirDisabledCapsBufferedPostings) {
+    FullTextIndexConfigGuard config_guard;
+    config::inverted_index_ram_dir_enable = false;
+    config::inverted_index_ram_buffer_size = 512;
+
+    auto tablet_schema = create_schema();
+    TabletIndex idx_meta = create_standard_fulltext_index_meta();
+    constexpr size_t value_count = 2;
+    constexpr size_t min_bytes_per_value = 1024 * 1024;
+    const auto strings = fulltext_large_memory_strings(value_count, min_bytes_per_value);
+    ASSERT_GE(strings.front().size(), min_bytes_per_value);
+    const auto values = slices_from_strings(strings);
+
+    auto write_and_measure = [&](std::string_view rowset_id, int seg_id, int64_t* peak_delta) {
+        std::string index_path_prefix {InvertedIndexDescriptor::get_index_file_path_prefix(
+                local_segment_path(kTestDir, rowset_id, seg_id))};
+        std::string index_path = InvertedIndexDescriptor::get_index_file_path_v2(index_path_prefix);
+
+        io::FileWriterPtr file_writer;
+        io::FileWriterOptions opts;
+        auto fs = io::global_local_filesystem();
+        Status sts = fs->create_file(index_path, &file_writer, &opts);
+        ASSERT_TRUE(sts.ok()) << sts;
+        auto index_file_writer = std::make_unique<IndexFileWriter>(
+                fs, index_path_prefix, std::string {rowset_id}, seg_id,
+                InvertedIndexStorageFormatPB::V2, std::move(file_writer));
+
+        const TabletColumn& column = tablet_schema->column(1);
+        ASSERT_NE(&column, nullptr);
+        std::unique_ptr<StorageField> field(StorageFieldFactory::create(column));
+        ASSERT_NE(field.get(), nullptr);
+
+        std::unique_ptr<IndexColumnWriter> column_writer;
+        auto status = IndexColumnWriter::create(field.get(), &column_writer,
+                                                index_file_writer.get(), &idx_meta);
+        ASSERT_TRUE(status.ok()) << status;
+
+        *peak_delta = add_fulltext_values_and_get_peak_delta(column_writer.get(), values, 1);
+
+        status = column_writer->finish();
+        ASSERT_TRUE(status.ok()) << status;
+        status = index_file_writer->begin_close();
+        ASSERT_TRUE(status.ok()) << status;
+        status = index_file_writer->finish_close();
+        ASSERT_TRUE(status.ok()) << status;
+    };
+
+    int64_t uncapped_peak_delta = 0;
+    config::inverted_index_ram_buffer_size_when_ram_dir_disabled = 0;
+    ASSERT_NO_FATAL_FAILURE(
+            write_and_measure("test_rowset_large_string_uncapped", 0, &uncapped_peak_delta));
+
+    int64_t capped_peak_delta = 0;
+    config::inverted_index_ram_buffer_size_when_ram_dir_disabled = 1;
+    ASSERT_NO_FATAL_FAILURE(
+            write_and_measure("test_rowset_large_string_capped", 1, &capped_peak_delta));
+
+    RecordProperty("uncapped_peak_delta_bytes", uncapped_peak_delta);
+    RecordProperty("capped_peak_delta_bytes", capped_peak_delta);
+    EXPECT_GT(uncapped_peak_delta, 4 * 1024 * 1024);
+    EXPECT_LT(capped_peak_delta, 2 * 1024 * 1024);
+    EXPECT_LT(capped_peak_delta * 2, uncapped_peak_delta);
 }
 
 // Test case for Unicode string values with enable_correct_term_write=true
@@ -1677,6 +1765,22 @@ std::vector<std::string> fulltext_memory_strings(size_t value_count, size_t toke
     return strings;
 }
 
+std::vector<std::string> fulltext_large_memory_strings(size_t value_count,
+                                                       size_t min_bytes_per_value) {
+    std::vector<std::string> strings;
+    strings.reserve(value_count);
+    size_t token_id = 0;
+    for (size_t row = 0; row < value_count; ++row) {
+        std::string value = "sharedterm";
+        while (value.size() < min_bytes_per_value) {
+            value.append(" ");
+            value.append(fulltext_memory_token(token_id++));
+        }
+        strings.emplace_back(std::move(value));
+    }
+    return strings;
+}
+
 std::vector<Slice> slices_from_strings(const std::vector<std::string>& strings) {
     std::vector<Slice> values;
     values.reserve(strings.size());
@@ -1687,10 +1791,10 @@ std::vector<Slice> slices_from_strings(const std::vector<std::string>& strings) 
 }
 
 int64_t add_fulltext_values_and_get_peak_delta(IndexColumnWriter* column_writer,
-                                               const std::vector<Slice>& values) {
+                                               const std::vector<Slice>& values,
+                                               size_t batch_size) {
     const int64_t initial_size = column_writer->size();
     int64_t peak_size = initial_size;
-    constexpr size_t batch_size = 32;
     for (size_t offset = 0; offset < values.size(); offset += batch_size) {
         size_t count = std::min(batch_size, values.size() - offset);
         auto status = column_writer->add_values("c2", values.data() + offset, count);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PRs:
- apache/doris-thirdparty#393 — clucene-side: expose
  `SDocumentsWriter` buffered postings via `getRAMUsed()`. Must merge
  before this PR (this PR bumps `contrib/clucene` to that commit).
- apache/doris#63633 — downstream consumer (SPIMI V4 inverted index
  storage format). Sits on top of this PR.

Problem Summary:

Tighten BE memory tracking and capping for analyzed inverted index
writers (fulltext + Chinese tokenization etc.). Today the BE's
`IndexColumnWriter::size()` returns 0 for inverted index writers, so
`segment_writer.cpp`'s segment memory estimate misses the CLucene
buffered postings entirely — by far the largest source of resident
bytes during a fulltext flush. Under tight memory pressure (cloud BE
with `inverted_index_ram_dir_enable=false`), this causes the
segment-builder to overshoot the memory budget and OOM the BE.

Three commits, smallest-first:

1. **`[improvement](be) Track inverted index writer memory estimate`** —
   Plumb a real `size()` reporter through the writer hierarchy. No
   behaviour change yet; just the scaffolding the next two commits
   plug values into.

2. **`[improvement](be) Account fulltext inverted index writer memory`** —
   Implement `size()` for the fulltext path: report
   `_null_bitmap.getSizeInBytes()` + `index_writer->ramSizeInBytes()`
   (via the clucene `getRAMUsed()` exposed by
   doris-thirdparty#393) + `ram_directory_memory_size()`. The segment
   memory estimate now sees fulltext writer memory.

3. **`[improvement](be) Cap fulltext index memory without ram dir`** —
   New config `inverted_index_ram_buffer_size_when_ram_dir_disabled`
   (default 64 MB). When the column has an analyzer AND
   `is_fs_directory(_dir)` (i.e. `inverted_index_ram_dir_enable=false`),
   clamp CLucene's `setRAMBufferSizeMB()` down from the global
   `inverted_index_ram_buffer_size = 512` MB to this new cap. Forces
   more frequent segment flushes in exchange for tighter per-column
   RAM peak — the trade-off cloud users want when RAM dir is
   disabled.

#### Why a precursor PR

These three are independently useful as memory-tracking +
capping for the existing V1/V2/V3 CLucene writer path. They were
originally bundled in apache/doris#63633 (the V4 SPIMI PR) as
prerequisites; lifting them out makes the V4 PR smaller and lets
the cloud teams pick up the memory tracking improvements without
waiting for the larger SPIMI refactor to land.

### Release note

Add inverted index writer memory tracking and a new cap config
`inverted_index_ram_buffer_size_when_ram_dir_disabled` (default
64 MB) that limits the CLucene buffered postings size for analyzed
columns when RAM directory is disabled. Reduces BE OOM risk under
fulltext-heavy concurrent loads in cloud mode.

### Check List (For Author)

- Test:
    - [x] Unit Test
      (`InvertedIndexWriterTest.FullTextStringMemoryEstimateIncludesBufferedPostings`
      + `*RamBufferCap*` tests)
    - [ ] Manual test
- Behavior changed:
    - [ ] No.
    - [x] Yes — adds a new config that caps CLucene
      `setRAMBufferSizeMB` when RAM dir is disabled. Default 64 MB.
      Tunable at runtime (mutable bool).
- Does this need documentation:
    - [x] Yes — config will appear in admin doc; doc PR will follow.
