### PR TITLE
[refine](column) use concrete ColumnUInt8 for vertical delete filter

### DIFF
--- a/be/src/storage/iterator/vertical_block_reader.cpp
+++ b/be/src/storage/iterator/vertical_block_reader.cpp
@@ -484,12 +484,9 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
             DCHECK(delete_sign_idx > 0);
             auto target_columns_guard = block->mutate_columns_scoped();
             auto& target_columns = target_columns_guard.mutable_columns();
-            auto delete_filter_column = IColumn::mutate(std::move(_delete_filter_column));
-            auto* delete_filter_data_column =
-                    reinterpret_cast<ColumnUInt8*>(delete_filter_column.get());
-            delete_filter_data_column->resize(block_rows);
+            _delete_filter_column->resize(block_rows);
 
-            auto* __restrict filter_data = delete_filter_data_column->get_data().data();
+            auto* __restrict filter_data = _delete_filter_column->get_data().data();
             auto* __restrict delete_data =
                     reinterpret_cast<ColumnInt8*>(target_columns[delete_sign_idx].get())
                             ->get_data()
@@ -520,12 +517,15 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
 
             const auto column_to_keep = target_columns.size();
             target_columns_guard.restore();
-            _delete_filter_column = std::move(delete_filter_column);
-            ColumnWithTypeAndName column_with_type_and_name {_delete_filter_column,
-                                                             std::make_shared<DataTypeUInt8>(),
-                                                             "__DORIS_COMPACTION_FILTER__"};
-            block->insert(column_with_type_and_name);
-            RETURN_IF_ERROR(Block::filter_block(block, column_to_keep, column_to_keep));
+            ColumnPtr delete_filter_column =
+                    ColumnUInt8::cast_to_column_ptr(_delete_filter_column.get());
+            block->insert({std::move(delete_filter_column), std::make_shared<DataTypeUInt8>(),
+                           "__DORIS_COMPACTION_FILTER__"});
+            auto filter_status = Block::filter_block(block, column_to_keep, column_to_keep);
+            if (UNLIKELY(!filter_status.ok())) {
+                _delete_filter_column = ColumnUInt8::create();
+                return filter_status;
+            }
             _stats.rows_del_filtered += block_rows - block->rows();
             if (UNLIKELY(_reader_context.record_rowids)) {
                 DCHECK_EQ(_block_row_locations.size(), block->rows() + delete_count);

--- a/be/src/storage/iterator/vertical_block_reader.h
+++ b/be/src/storage/iterator/vertical_block_reader.h
@@ -30,6 +30,7 @@
 #include "common/status.h"
 #include "core/block/block.h"
 #include "core/column/column.h"
+#include "core/column/column_vector.h"
 #include "core/data_type/data_type.h"
 #include "exprs/aggregate/aggregate_function.h"
 #include "storage/iterators.h"
@@ -113,7 +114,7 @@ private:
     Status (VerticalBlockReader::*_next_block_func)(Block* block, bool* eof) = nullptr;
 
     RowSourcesBuffer* _row_sources_buffer;
-    ColumnPtr _delete_filter_column;
+    ColumnUInt8::MutablePtr _delete_filter_column;
 
     // for agg mode
     std::vector<AggregateFunctionPtr> _agg_functions;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The vertical block reader kept the delete filter column as the base `ColumnPtr` type even though the column is always created as `ColumnUInt8` and later mutated as a byte filter column. Root cause: `_delete_filter_column` used the generic column pointer type, so the reader had to call `IColumn::mutate` and reinterpret the result as `ColumnUInt8` before resizing and filling the filter data. This PR changes the member to `ColumnUInt8::MutablePtr`, directly operates on the concrete filter column, and moves it into the temporary block filter column when applying `Block::filter_block`. The filter column is recreated after filtering so the reader state remains valid on both success and error paths.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

