### PR TITLE
[fix](be ut) Skip custom memcpy on ARM+ASAN to fix segfault at process startup

### DIFF
--- a/be/src/glibc-compatibility/CMakeLists.txt
+++ b/be/src/glibc-compatibility/CMakeLists.txt
@@ -59,7 +59,16 @@ if (GLIBC_COMPATIBILITY)
     list(REMOVE_ITEM glibc_compatibility_sources musl/getrandom.c)
     # NOTE(amos): sanitizers might generate memcpy references that are too late to
     # refer. Let's also extract memcpy definitions explicitly to avoid UNDEF GLIBC 2.14.
-    add_library(glibc-compatibility-explicit OBJECT musl/getrandom.c ${MEMCPY_SOURCE})
+    #
+    # NOTE: On ARM (aarch64) with ASAN, the custom memcpy (memcpy_aarch64.cpp) overrides
+    # the global memcpy symbol. libpthread's __pthread_initialize_minimal() calls memcpy
+    # before ASAN shadow memory is initialized, causing SIGSEGV. Skip custom memcpy in
+    # this case and fall back to glibc's memcpy.
+    if (ARCH_ARM AND (CMAKE_BUILD_TYPE STREQUAL "ASAN_UT" OR CMAKE_BUILD_TYPE STREQUAL "ASAN"))
+        add_library(glibc-compatibility-explicit OBJECT musl/getrandom.c)
+    else()
+        add_library(glibc-compatibility-explicit OBJECT musl/getrandom.c ${MEMCPY_SOURCE})
+    endif()
     target_compile_options(glibc-compatibility-explicit PRIVATE -fPIC)
     add_library(glibc-compatibility STATIC ${glibc_compatibility_sources})
     target_compile_options(


### PR DESCRIPTION
### What problem does this PR solve?

The glibc-compatibility module provides a custom memcpy implementation (memcpy_aarch64.cpp) that overrides the global memcpy symbol via extern "C". This is done to avoid dependency on a specific glibc symbol version (e.g., memcpy@@GLIBC_2.14) for portability.

However, libpthread's __pthread_initialize_minimal() calls memcpy during very early process startup — before main(), before C++ static initialization, and before ASAN shadow memory is set up. When ASAN is enabled, the custom memcpy accesses memory that ASAN shadow has not yet mapped, resulting in SIGSEGV.

This only affects aarch64 + ASAN because:

RELEASE builds have no ASAN shadow memory checks
x86_64 + ASAN does not exhibit this crash (different shadow memory layout and initialization timing)

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    
[问题及修复.docx](https://github.com/user-attachments/files/28259928/default.docx)

    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

