### PR TITLE
[fix](be) Validate TDigest sizes in quantile state

### DIFF
--- a/be/src/core/value/quantile_state.cpp
+++ b/be/src/core/value/quantile_state.cpp
@@ -64,7 +64,7 @@ void QuantileState::set_compression(float compression) {
 }
 
 bool QuantileState::is_valid(const Slice& slice) {
-    if (slice.size < 1) {
+    if (slice.data == nullptr || slice.size < sizeof(float) + sizeof(uint8_t)) {
         return false;
     }
     const uint8_t* ptr = (uint8_t*)slice.data;
@@ -93,6 +93,10 @@ bool QuantileState::is_valid(const Slice& slice) {
         }
         uint16_t num_explicits = decode_fixed16_le(ptr);
         ptr += sizeof(uint16_t);
+        const size_t remaining_size = static_cast<size_t>(end - ptr);
+        if (num_explicits > remaining_size / sizeof(double)) {
+            return false;
+        }
         ptr += num_explicits * sizeof(double);
         break;
     }
@@ -101,6 +105,11 @@ bool QuantileState::is_valid(const Slice& slice) {
             return false;
         }
         uint32_t tdigest_serialized_length = decode_fixed32_le(ptr);
+        const size_t remaining_size = static_cast<size_t>(end - ptr);
+        if (tdigest_serialized_length > remaining_size ||
+            !TDigest::is_serialized_valid(ptr, tdigest_serialized_length)) {
+            return false;
+        }
         ptr += tdigest_serialized_length;
         break;
     }

--- a/be/src/util/tdigest.h
+++ b/be/src/util/tdigest.h
@@ -438,11 +438,57 @@ public:
         }
     }
 
+    static constexpr size_t fixed_serialized_size() {
+        return sizeof(uint32_t) + sizeof(Value) * 5 + sizeof(Index) * 2 + sizeof(uint32_t) * 3;
+    }
+
+    static bool is_serialized_valid(const uint8_t* reader, size_t length) {
+        if (reader == nullptr || length < fixed_serialized_size()) {
+            return false;
+        }
+
+        size_t offset = 0;
+        uint32_t total_length = 0;
+        memcpy(&total_length, reader + offset, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+        if (total_length != length) {
+            return false;
+        }
+
+        offset += sizeof(Value) * 5 + sizeof(Index) * 2;
+        auto read_size = [&reader, &offset, length](uint32_t* size) {
+            if (length - offset < sizeof(uint32_t)) {
+                return false;
+            }
+            memcpy(size, reader + offset, sizeof(uint32_t));
+            offset += sizeof(uint32_t);
+            return true;
+        };
+        auto skip_items = [&offset, length](uint32_t size, size_t item_size) {
+            if (size > (length - offset) / item_size) {
+                return false;
+            }
+            offset += size * item_size;
+            return true;
+        };
+
+        uint32_t size = 0;
+        if (!read_size(&size) || !skip_items(size, sizeof(Centroid))) {
+            return false;
+        }
+        if (!read_size(&size) || !skip_items(size, sizeof(Centroid))) {
+            return false;
+        }
+        if (!read_size(&size) || !skip_items(size, sizeof(Weight))) {
+            return false;
+        }
+        return offset == length;
+    }
+
     uint32_t serialized_size() {
-        return static_cast<uint32_t>(sizeof(uint32_t) + sizeof(Value) * 5 + sizeof(Index) * 2 +
-                                     sizeof(uint32_t) * 3 + _processed.size() * sizeof(Centroid) +
-                                     _unprocessed.size() * sizeof(Centroid) +
-                                     _cumulative.size() * sizeof(Weight));
+        return static_cast<uint32_t>(
+                fixed_serialized_size() + _processed.size() * sizeof(Centroid) +
+                _unprocessed.size() * sizeof(Centroid) + _cumulative.size() * sizeof(Weight));
     }
 
     size_t serialize(uint8_t* writer) {

--- a/be/test/exprs/function/function_quantile_state_test.cpp
+++ b/be/test/exprs/function/function_quantile_state_test.cpp
@@ -16,7 +16,10 @@
 // under the License.
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <cstring>
 #include <string>
+#include <vector>
 
 #include "core/data_type/data_type_quantilestate.h"
 #include "core/data_type/data_type_string.h"
@@ -24,9 +27,17 @@
 #include "core/types.h"
 #include "core/value/quantile_state.h"
 #include "exprs/function/function_test_util.h"
+#include "util/tdigest.h"
 #include "util/url_coding.h"
 
 namespace doris {
+namespace {
+
+constexpr size_t QUANTILE_STATE_HEADER_SIZE = sizeof(float) + sizeof(uint8_t);
+constexpr size_t TDIGEST_PROCESSED_COUNT_OFFSET =
+        sizeof(uint32_t) + sizeof(Value) * 5 + sizeof(Index) * 2;
+
+} // namespace
 
 TEST(function_quantile_state_test, function_quantile_state_to_base64) {
     std::string func_name = "quantile_state_to_base64";
@@ -211,6 +222,37 @@ TEST(function_quantile_state_test, function_quantile_state_roundtrip) {
                 0.01);
     EXPECT_NEAR(original.get_value_by_percentile(0.9), recovered.get_value_by_percentile(0.9),
                 0.01);
+}
+
+TEST(function_quantile_state_test, rejects_tdigest_base64_with_corrupted_inner_count) {
+    QuantileState original;
+    for (int i = 0; i < 3000; i++) {
+        original.add_value(static_cast<double>(i));
+    }
+
+    std::vector<uint8_t> serialized(original.get_serialized_size());
+    const size_t serialized_len = original.serialize(serialized.data());
+    ASSERT_EQ(serialized.size(), serialized_len);
+    ASSERT_GT(serialized_len,
+              QUANTILE_STATE_HEADER_SIZE + TDIGEST_PROCESSED_COUNT_OFFSET + sizeof(uint32_t));
+    ASSERT_EQ(serialized[sizeof(float)], TDIGEST);
+
+    const uint32_t corrupted_processed_count = 1024 * 1024;
+    memcpy(serialized.data() + QUANTILE_STATE_HEADER_SIZE + TDIGEST_PROCESSED_COUNT_OFFSET,
+           &corrupted_processed_count, sizeof(corrupted_processed_count));
+
+    std::vector<unsigned char> encoded(serialized_len * 2);
+    const size_t encoded_len = base64_encode(serialized.data(), serialized_len, encoded.data());
+    const std::string base64_str(reinterpret_cast<char*>(encoded.data()), encoded_len);
+
+    std::vector<char> decoded(serialized_len);
+    const int decoded_len = base64_decode(base64_str.c_str(), base64_str.length(), decoded.data());
+    ASSERT_EQ(serialized_len, decoded_len);
+
+    QuantileState recovered;
+    Slice decoded_slice(decoded.data(), decoded_len);
+    EXPECT_FALSE(recovered.is_valid(decoded_slice));
+    EXPECT_FALSE(recovered.deserialize(decoded_slice));
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: `quantile_state_from_base64()` decodes user-provided base64 strings into `QuantileState::deserialize()`. `QuantileState::is_valid()` previously checked only the outer TDigest serialized length, while `TDigest::unserialize()` trusted nested vector count fields before resizing and copying from the input buffer. A malformed TDigest payload could therefore pass validation and drive out-of-bounds reads or oversized allocations during deserialization.

This PR validates the serialized TDigest layout against the available buffer before `QuantileState` accepts it, including the total length and all nested vector count fields. It also tightens `QuantileState` length checks for explicit and TDigest payloads, and adds a BE unit test that starts from a real TDigest-backed `QuantileState`, corrupts one nested count after a base64 roundtrip, and verifies validation and deserialization reject the payload.

### Release note

Malformed TDigest quantile state payloads are now rejected during deserialization.

### Check List (For Author)

- Test:
    - Unit Test: `./run-be-ut.sh --run --filter=function_quantile_state_test.rejects_tdigest_base64_with_corrupted_inner_count -j 90`
    - Unit Test: `./run-be-ut.sh --run --filter=function_quantile_state_test.* -j 90`
    - Static Analysis: `build-support/run-clang-tidy.sh`
    - Code Style: `python3 build-support/run_clang_format.py --clang-format-executable /mnt/disk6/common/ldb_toolchain_toucan/bin/clang-format --inplace false ...`
- Behavior changed: Yes. Malformed TDigest-backed quantile state payloads are rejected instead of being accepted for deserialization.
- Does this need documentation: No
