### PR TITLE
[fix](regression) Make Iceberg rewrite where init script idempotent

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run21.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run21.sql
@@ -8,7 +8,8 @@ use demo.test_db;
 -- =====================================================================================
 
 -- Table 1: For baseline test (rewrite without WHERE condition)
-CREATE TABLE IF NOT EXISTS test_rewrite_where_conditions_baseline (
+DROP TABLE IF EXISTS test_rewrite_where_conditions_baseline;
+CREATE TABLE test_rewrite_where_conditions_baseline (
     id BIGINT,
     name STRING,
     age INT,
@@ -56,7 +57,8 @@ INSERT INTO test_rewrite_where_conditions_baseline VALUES
 (30, 'Dana', 49, 99000.0);
 
 -- Table 2: For test with WHERE condition matching subset (id >= 11 AND id <= 20)
-CREATE TABLE IF NOT EXISTS test_rewrite_where_conditions_with_where (
+DROP TABLE IF EXISTS test_rewrite_where_conditions_with_where;
+CREATE TABLE test_rewrite_where_conditions_with_where (
     id BIGINT,
     name STRING,
     age INT,
@@ -104,7 +106,8 @@ INSERT INTO test_rewrite_where_conditions_with_where VALUES
 (30, 'Dana', 49, 99000.0);
 
 -- Table 3: For test with WHERE condition matching no data (id = 99999)
-CREATE TABLE IF NOT EXISTS test_rewrite_where_conditions_no_match (
+DROP TABLE IF EXISTS test_rewrite_where_conditions_no_match;
+CREATE TABLE test_rewrite_where_conditions_no_match (
     id BIGINT,
     name STRING,
     age INT,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:

`test_iceberg_rewrite_data_files_where_conditions` depends on three Iceberg tables created by the Spark bootstrap script `run21.sql`. The script used `CREATE TABLE IF NOT EXISTS` and then always inserted the test rows. If the table already exists or the bootstrap SQL is re-entered after partial execution, the insert statements append data to the existing table, so the regression case may fail before running `rewrite_data_files` because `COUNT(*)` is no longer the expected 30 rows.

This PR makes the init SQL for this case idempotent by dropping and recreating the three test tables before inserting the fixed test data.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `git diff --check -- docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run21.sql`
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change --> The Iceberg bootstrap SQL now recreates the dedicated rewrite-where-condition test tables before loading fixed test data.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
