### PR TITLE
[fix](jdbc) Add shared JDBC driver checksum loader

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1034,6 +1034,7 @@ void PInternalService::test_jdbc_connection(google::protobuf::RpcController* con
         params["jdbc_password"] = jdbc_table.jdbc_password;
         params["jdbc_driver_class"] = jdbc_table.jdbc_driver_class;
         params["jdbc_driver_url"] = driver_url;
+        params["jdbc_driver_checksum"] = jdbc_table.jdbc_driver_checksum;
         params["query_sql"] = request->query_str();
         params["catalog_id"] = std::to_string(jdbc_table.catalog_id);
         params["connection_pool_min_size"] = std::to_string(jdbc_table.connection_pool_min_size);

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jdbc/JdbcDriverUtils.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jdbc/JdbcDriverUtils.java
@@ -19,9 +19,17 @@ package org.apache.doris.common.jdbc;
 
 import org.apache.doris.common.classloader.JniScannerClassLoader;
 
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -31,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class JdbcDriverUtils {
+    private static final int HTTP_TIMEOUT_MS = 10000;
     private static final ConcurrentHashMap<URL, ClassLoader> DRIVER_CLASS_LOADER_CACHE = new ConcurrentHashMap<>();
     private static final Set<String> REGISTERED_DRIVER_KEYS = ConcurrentHashMap.newKeySet();
 
@@ -38,6 +47,18 @@ public final class JdbcDriverUtils {
     }
 
     public static void registerDriver(String driverUrl, String driverClassName, ClassLoader classLoader) {
+        registerDriver(driverUrl, driverClassName, "", classLoader);
+    }
+
+    public static void registerDriver(String driverUrl, String driverClassName, String expectedChecksum,
+            ClassLoader classLoader) {
+        if (StringUtils.isBlank(driverClassName)) {
+            throw new IllegalArgumentException("JDBC driver class is required when driver url is specified.");
+        }
+        if (StringUtils.isNotBlank(expectedChecksum)) {
+            validateDriverChecksum(driverUrl, expectedChecksum);
+        }
+
         try {
             URL url = new URL(driverUrl);
             String driverKey = driverUrl + "#" + driverClassName;
@@ -49,12 +70,53 @@ public final class JdbcDriverUtils {
                 Class<?> loadedDriverClass = Class.forName(driverClassName, true, driverClassLoader);
                 Driver driver = (Driver) loadedDriverClass.getDeclaredConstructor().newInstance();
                 DriverManager.registerDriver(new DriverShim(driver));
+            } catch (ClassNotFoundException e) {
+                REGISTERED_DRIVER_KEYS.remove(driverKey);
+                throw new IllegalArgumentException("Failed to load JDBC driver class: " + driverClassName, e);
             } catch (Exception e) {
                 REGISTERED_DRIVER_KEYS.remove(driverKey);
                 throw new RuntimeException("Failed to register JDBC driver: " + driverClassName, e);
             }
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid JDBC driver URL: " + driverUrl, e);
+        }
+    }
+
+    public static String validateDriverChecksum(String driverUrl, String expectedChecksum) {
+        String actualChecksum = computeObjectChecksum(driverUrl);
+        if (StringUtils.isNotBlank(expectedChecksum) && !expectedChecksum.equals(actualChecksum)) {
+            throw new IllegalArgumentException("Checksum mismatch for JDBC driver. expected: "
+                    + expectedChecksum + ", actual: " + actualChecksum);
+        }
+        return actualChecksum;
+    }
+
+    public static String computeObjectChecksum(String urlStr) {
+        try (InputStream inputStream = getInputStreamFromUrl(urlStr, HTTP_TIMEOUT_MS, HTTP_TIMEOUT_MS)) {
+            // Keep the checksum format compatible with FE JdbcResource.
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] buf = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buf)) != -1) {
+                digest.update(buf, 0, bytesRead);
+            }
+            return Hex.encodeHexString(digest.digest());
+        } catch (IOException | NoSuchAlgorithmException e) {
+            throw new RuntimeException("Compute driver checksum from url: " + urlStr
+                    + " encountered an error: " + e.getMessage(), e);
+        }
+    }
+
+    private static InputStream getInputStreamFromUrl(String urlStr, int connectTimeoutMs, int readTimeoutMs)
+            throws IOException {
+        try {
+            URL url = new URL(urlStr);
+            URLConnection conn = url.openConnection();
+            conn.setConnectTimeout(connectTimeoutMs);
+            conn.setReadTimeout(readTimeoutMs);
+            return conn.getInputStream();
+        } catch (Exception e) {
+            throw new IOException("Failed to open URL connection: " + urlStr, e);
         }
     }
 

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jdbc/JdbcDriverUtils.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jdbc/JdbcDriverUtils.java
@@ -55,9 +55,6 @@ public final class JdbcDriverUtils {
         if (StringUtils.isBlank(driverClassName)) {
             throw new IllegalArgumentException("JDBC driver class is required when driver url is specified.");
         }
-        if (StringUtils.isNotBlank(expectedChecksum)) {
-            validateDriverChecksum(driverUrl, expectedChecksum);
-        }
 
         try {
             URL url = new URL(driverUrl);
@@ -66,7 +63,7 @@ public final class JdbcDriverUtils {
                 return;
             }
             try {
-                ClassLoader driverClassLoader = prepareDriverClassLoader(url, classLoader);
+                ClassLoader driverClassLoader = prepareDriverClassLoader(url, expectedChecksum, classLoader);
                 Class<?> loadedDriverClass = Class.forName(driverClassName, true, driverClassLoader);
                 Driver driver = (Driver) loadedDriverClass.getDeclaredConstructor().newInstance();
                 DriverManager.registerDriver(new DriverShim(driver));
@@ -77,6 +74,15 @@ public final class JdbcDriverUtils {
                 REGISTERED_DRIVER_KEYS.remove(driverKey);
                 throw new RuntimeException("Failed to register JDBC driver: " + driverClassName, e);
             }
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid JDBC driver URL: " + driverUrl, e);
+        }
+    }
+
+    public static ClassLoader prepareDriverClassLoader(String driverUrl, String expectedChecksum,
+            ClassLoader classLoader) {
+        try {
+            return prepareDriverClassLoader(new URL(driverUrl), expectedChecksum, classLoader);
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid JDBC driver URL: " + driverUrl, e);
         }
@@ -120,7 +126,11 @@ public final class JdbcDriverUtils {
         }
     }
 
-    private static ClassLoader prepareDriverClassLoader(URL driverUrl, ClassLoader classLoader) {
+    private static ClassLoader prepareDriverClassLoader(URL driverUrl, String expectedChecksum,
+            ClassLoader classLoader) {
+        if (StringUtils.isNotBlank(expectedChecksum)) {
+            validateDriverChecksum(driverUrl.toString(), expectedChecksum);
+        }
         if (classLoader instanceof JniScannerClassLoader) {
             JniScannerClassLoader scannerClassLoader = (JniScannerClassLoader) classLoader;
             scannerClassLoader.addURLIfAbsent(driverUrl);

--- a/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jdbc/JdbcDriverUtilsTest.java
+++ b/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jdbc/JdbcDriverUtilsTest.java
@@ -67,6 +67,20 @@ public class JdbcDriverUtilsTest {
         Assert.assertTrue(driver.acceptsURL(DUMMY_JDBC_URL));
     }
 
+    @Test
+    public void testPrepareDriverClassLoaderValidatesChecksum() throws Exception {
+        runWithDriverUrl(driverUrl -> {
+            ClassLoader classLoader = JdbcDriverUtils.prepareDriverClassLoader(
+                    driverUrl, DRIVER_CHECKSUM, getClass().getClassLoader());
+            Assert.assertNotNull(classLoader);
+
+            IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+                    () -> JdbcDriverUtils.prepareDriverClassLoader(
+                            driverUrl, "bad-checksum", getClass().getClassLoader()));
+            Assert.assertTrue(exception.getMessage().contains("Checksum mismatch for JDBC driver"));
+        });
+    }
+
     private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
         Path driverPath = Files.createTempFile("doris-jdbc-driver", ".jar");
         try {

--- a/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jdbc/JdbcDriverUtilsTest.java
+++ b/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jdbc/JdbcDriverUtilsTest.java
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.jdbc;
+
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class JdbcDriverUtilsTest {
+    private static final String DRIVER_BYTES = "doris-jdbc-driver";
+    private static final String DRIVER_CHECKSUM = "ef2b3218a863c98bc78fdf447331b206";
+    private static final String DUMMY_JDBC_URL = "jdbc:doris-common-dummy:test";
+
+    @After
+    public void tearDown() throws Exception {
+        deregisterDummyDrivers();
+    }
+
+    @Test
+    public void testValidateDriverChecksumRejectsMismatch() throws Exception {
+        runWithDriverUrl(driverUrl -> {
+            IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+                    () -> JdbcDriverUtils.validateDriverChecksum(driverUrl, "bad-checksum"));
+            Assert.assertTrue(exception.getMessage().contains("Checksum mismatch for JDBC driver"));
+        });
+    }
+
+    @Test
+    public void testValidateDriverChecksumReturnsComputedChecksum() throws Exception {
+        runWithDriverUrl(driverUrl -> Assert.assertEquals(DRIVER_CHECKSUM,
+                JdbcDriverUtils.validateDriverChecksum(driverUrl, DRIVER_CHECKSUM)));
+    }
+
+    @Test
+    public void testRegisterDriverWithoutChecksumKeepsOriginalLoadingBehavior() throws Exception {
+        String missingDriverUrl = "file:///tmp/doris-missing-driver-" + System.nanoTime() + ".jar";
+
+        JdbcDriverUtils.registerDriver(missingDriverUrl, DummyJdbcDriver.class.getName(), getClass().getClassLoader());
+
+        Driver driver = DriverManager.getDriver(DUMMY_JDBC_URL);
+        Assert.assertTrue(driver.acceptsURL(DUMMY_JDBC_URL));
+    }
+
+    private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
+        Path driverPath = Files.createTempFile("doris-jdbc-driver", ".jar");
+        try {
+            Files.write(driverPath, DRIVER_BYTES.getBytes(StandardCharsets.UTF_8));
+            consumer.accept(driverPath.toUri().toString());
+        } finally {
+            Files.deleteIfExists(driverPath);
+        }
+    }
+
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
+    }
+
+    private void deregisterDummyDrivers() throws Exception {
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver driver = drivers.nextElement();
+            if (driver.acceptsURL(DUMMY_JDBC_URL)) {
+                DriverManager.deregisterDriver(driver);
+            }
+        }
+    }
+
+    public static class DummyJdbcDriver implements Driver {
+        @Override
+        public java.sql.Connection connect(String url, Properties info) {
+            return null;
+        }
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return DUMMY_JDBC_URL.equals(url);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new SQLFeatureNotSupportedException("not supported");
+        }
+    }
+}

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcConnectionTester.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcConnectionTester.java
@@ -18,6 +18,7 @@
 package org.apache.doris.jdbc;
 
 import org.apache.doris.cloud.security.SecurityChecker;
+import org.apache.doris.common.jdbc.JdbcDriverUtils;
 import org.apache.doris.common.jni.JniScanner;
 import org.apache.doris.common.jni.vec.ColumnType;
 
@@ -25,8 +26,6 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -45,7 +44,7 @@ import java.util.Map;
  *
  * <p>Parameters:
  * <ul>
- *   <li>jdbc_url, jdbc_user, jdbc_password, jdbc_driver_class, jdbc_driver_url</li>
+ *   <li>jdbc_url, jdbc_user, jdbc_password, jdbc_driver_class, jdbc_driver_url, jdbc_driver_checksum</li>
  *   <li>query_sql — the test query to run</li>
  *   <li>catalog_id, connection_pool_min_size, connection_pool_max_size, etc.</li>
  *   <li>clean_datasource — if "true", close the datasource pool on close()</li>
@@ -59,6 +58,7 @@ public class JdbcConnectionTester extends JniScanner {
     private final String jdbcPassword;
     private final String jdbcDriverClass;
     private final String jdbcDriverUrl;
+    private final String jdbcDriverChecksum;
     private final String querySql;
     private final long catalogId;
     private final int connectionPoolMinSize;
@@ -80,6 +80,7 @@ public class JdbcConnectionTester extends JniScanner {
         this.jdbcPassword = params.getOrDefault("jdbc_password", "");
         this.jdbcDriverClass = params.getOrDefault("jdbc_driver_class", "");
         this.jdbcDriverUrl = params.getOrDefault("jdbc_driver_url", "");
+        this.jdbcDriverChecksum = params.getOrDefault("jdbc_driver_checksum", "");
         this.querySql = params.getOrDefault("query_sql", "SELECT 1");
         this.catalogId = Long.parseLong(params.getOrDefault("catalog_id", "0"));
         this.connectionPoolMinSize = Integer.parseInt(
@@ -111,9 +112,8 @@ public class JdbcConnectionTester extends JniScanner {
     public void open() throws IOException {
         ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
         try {
-            URL[] urls = {new URL(jdbcDriverUrl)};
-            ClassLoader parent = getClass().getClassLoader();
-            this.classLoader = URLClassLoader.newInstance(urls, parent);
+            this.classLoader = JdbcDriverUtils.prepareDriverClassLoader(
+                    jdbcDriverUrl, jdbcDriverChecksum, getClass().getClassLoader());
             Thread.currentThread().setContextClassLoader(classLoader);
 
             String cacheKey = createCacheKey();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcDriverLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcDriverLoader.java
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.DdlException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class JdbcDriverLoader {
+    private static final Logger LOG = LogManager.getLogger(JdbcDriverLoader.class);
+    private static final Map<URL, ClassLoader> DRIVER_CLASS_LOADER_CACHE = new ConcurrentHashMap<>();
+    private static final Set<String> REGISTERED_DRIVER_KEYS = ConcurrentHashMap.newKeySet();
+
+    private JdbcDriverLoader() {
+    }
+
+    public static String validateDriverChecksum(String driverUrl, String expectedChecksum) throws DdlException {
+        String actualChecksum = JdbcResource.computeObjectChecksum(driverUrl);
+        if (StringUtils.isNotBlank(expectedChecksum) && !expectedChecksum.equals(actualChecksum)) {
+            throw new DdlException("The provided checksum (" + expectedChecksum
+                    + ") does not match the computed checksum (" + actualChecksum
+                    + ") for the driver_url.");
+        }
+        return actualChecksum;
+    }
+
+    public static String registerDriver(String driverUrl, String driverClassName, String expectedChecksum,
+            ClassLoader parentClassLoader) {
+        if (StringUtils.isBlank(driverClassName)) {
+            throw new IllegalArgumentException("JDBC driver class is required when driver url is specified.");
+        }
+
+        try {
+            String fullDriverUrl = JdbcResource.getFullDriverUrl(driverUrl);
+            try {
+                validateDriverChecksum(fullDriverUrl, expectedChecksum);
+            } catch (DdlException e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
+            URL url = new URL(fullDriverUrl);
+            String driverKey = fullDriverUrl + "#" + driverClassName;
+            if (!REGISTERED_DRIVER_KEYS.add(driverKey)) {
+                LOG.info("JDBC driver already registered: {} from {}", driverClassName, fullDriverUrl);
+                return fullDriverUrl;
+            }
+            try {
+                ClassLoader classLoader = DRIVER_CLASS_LOADER_CACHE.computeIfAbsent(url, u ->
+                        URLClassLoader.newInstance(new URL[] {u}, parentClassLoader));
+                Class<?> loadedDriverClass = Class.forName(driverClassName, true, classLoader);
+                Driver driver = (Driver) loadedDriverClass.getDeclaredConstructor().newInstance();
+                DriverManager.registerDriver(new DriverShim(driver));
+                LOG.info("Successfully registered JDBC driver: {} from {}", driverClassName, fullDriverUrl);
+                return fullDriverUrl;
+            } catch (ClassNotFoundException e) {
+                REGISTERED_DRIVER_KEYS.remove(driverKey);
+                throw new IllegalArgumentException("Failed to load JDBC driver class: " + driverClassName, e);
+            } catch (Exception e) {
+                REGISTERED_DRIVER_KEYS.remove(driverKey);
+                throw new RuntimeException("Failed to register JDBC driver: " + driverClassName, e);
+            }
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid driver URL: " + driverUrl, e);
+        }
+    }
+
+    private static class DriverShim implements Driver {
+        private final Driver delegate;
+
+        DriverShim(Driver delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            return delegate.connect(url, info);
+        }
+
+        @Override
+        public boolean acceptsURL(String url) throws SQLException {
+            return delegate.acceptsURL(url);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+            return delegate.getPropertyInfo(url, info);
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return delegate.getMajorVersion();
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return delegate.getMinorVersion();
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return delegate.jdbcCompliant();
+        }
+
+        @Override
+        public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return delegate.getParentLogger();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcDriverLoaderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcDriverLoaderTest.java
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class JdbcDriverLoaderTest {
+    private static final String DRIVER_BYTES = "doris-jdbc-driver";
+    private static final String DRIVER_CHECKSUM = "ef2b3218a863c98bc78fdf447331b206";
+
+    @Test
+    public void testValidateDriverChecksumRejectsMismatch() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            DdlException exception = Assert.assertThrows(DdlException.class,
+                    () -> JdbcDriverLoader.validateDriverChecksum(driverUrl, "bad-checksum"));
+            Assert.assertTrue(exception.getMessage().contains("does not match the computed checksum"));
+        }));
+    }
+
+    @Test
+    public void testRegisterDriverValidatesChecksumBeforeLoadingClass() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+                    () -> JdbcDriverLoader.registerDriver(driverUrl,
+                            "org.apache.doris.catalog.NotExistingDriver", "bad-checksum",
+                            getClass().getClassLoader()));
+            Assert.assertTrue(exception.getMessage().contains("does not match the computed checksum"));
+        }));
+    }
+
+    @Test
+    public void testValidateDriverChecksumReturnsComputedChecksum() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            Assert.assertEquals(DRIVER_CHECKSUM, JdbcDriverLoader.validateDriverChecksum(driverUrl, DRIVER_CHECKSUM));
+            Assert.assertEquals(DRIVER_CHECKSUM, JdbcDriverLoader.validateDriverChecksum(driverUrl, ""));
+        }));
+    }
+
+    private void runWithChecksumEnabled(ThrowingRunnable runnable) throws Exception {
+        synchronized (FeConstants.class) {
+            boolean oldRunningUnitTest = FeConstants.runningUnitTest;
+            FeConstants.runningUnitTest = false;
+            try {
+                runnable.run();
+            } finally {
+                FeConstants.runningUnitTest = oldRunningUnitTest;
+            }
+        }
+    }
+
+    private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
+        Path driverPath = Files.createTempFile("doris-jdbc-driver", ".jar");
+        try {
+            Files.write(driverPath, DRIVER_BYTES.getBytes(StandardCharsets.UTF_8));
+            consumer.accept(driverPath.toUri().toString());
+        } finally {
+            Files.deleteIfExists(driverPath);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #61094

Problem Summary: Add shared FE and Java extension utilities to validate JDBC driver checksums before dynamically loading JDBC driver jars. This provides a common path for future JDBC-based connectors to verify driver jars before class loading.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - MAVEN_OPTS='-Dmaven.build.cache.enabled=false' ./run-fe-ut.sh --run org.apache.doris.catalog.JdbcDriverLoaderTest,org.apache.doris.common.jdbc.JdbcDriverUtilsTest,org.apache.doris.paimon.PaimonJdbcDriverUtilsTest
    - MAVEN_OPTS='-Dmaven.build.cache.enabled=false' ./run-fe-ut.sh --run org.apache.doris.catalog.JdbcDriverLoaderTest
- Behavior changed: No
- Does this need documentation: No