### PR TITLE
[fix](paimon) Validate JDBC catalog driver checksum

### DIFF
--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jdbc/JdbcDriverUtils.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jdbc/JdbcDriverUtils.java
@@ -19,9 +19,17 @@ package org.apache.doris.common.jdbc;
 
 import org.apache.doris.common.classloader.JniScannerClassLoader;
 
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -31,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class JdbcDriverUtils {
+    private static final int HTTP_TIMEOUT_MS = 10000;
     private static final ConcurrentHashMap<URL, ClassLoader> DRIVER_CLASS_LOADER_CACHE = new ConcurrentHashMap<>();
     private static final Set<String> REGISTERED_DRIVER_KEYS = ConcurrentHashMap.newKeySet();
 
@@ -38,6 +47,18 @@ public final class JdbcDriverUtils {
     }
 
     public static void registerDriver(String driverUrl, String driverClassName, ClassLoader classLoader) {
+        registerDriver(driverUrl, driverClassName, "", classLoader);
+    }
+
+    public static void registerDriver(String driverUrl, String driverClassName, String expectedChecksum,
+            ClassLoader classLoader) {
+        if (StringUtils.isBlank(driverClassName)) {
+            throw new IllegalArgumentException("JDBC driver class is required when driver url is specified.");
+        }
+        if (StringUtils.isNotBlank(expectedChecksum)) {
+            validateDriverChecksum(driverUrl, expectedChecksum);
+        }
+
         try {
             URL url = new URL(driverUrl);
             String driverKey = driverUrl + "#" + driverClassName;
@@ -49,12 +70,53 @@ public final class JdbcDriverUtils {
                 Class<?> loadedDriverClass = Class.forName(driverClassName, true, driverClassLoader);
                 Driver driver = (Driver) loadedDriverClass.getDeclaredConstructor().newInstance();
                 DriverManager.registerDriver(new DriverShim(driver));
+            } catch (ClassNotFoundException e) {
+                REGISTERED_DRIVER_KEYS.remove(driverKey);
+                throw new IllegalArgumentException("Failed to load JDBC driver class: " + driverClassName, e);
             } catch (Exception e) {
                 REGISTERED_DRIVER_KEYS.remove(driverKey);
                 throw new RuntimeException("Failed to register JDBC driver: " + driverClassName, e);
             }
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Invalid JDBC driver URL: " + driverUrl, e);
+        }
+    }
+
+    public static String validateDriverChecksum(String driverUrl, String expectedChecksum) {
+        String actualChecksum = computeObjectChecksum(driverUrl);
+        if (StringUtils.isNotBlank(expectedChecksum) && !expectedChecksum.equals(actualChecksum)) {
+            throw new IllegalArgumentException("Checksum mismatch for JDBC driver. expected: "
+                    + expectedChecksum + ", actual: " + actualChecksum);
+        }
+        return actualChecksum;
+    }
+
+    public static String computeObjectChecksum(String urlStr) {
+        try (InputStream inputStream = getInputStreamFromUrl(urlStr, HTTP_TIMEOUT_MS, HTTP_TIMEOUT_MS)) {
+            // Keep the checksum format compatible with FE JdbcResource.
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] buf = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buf)) != -1) {
+                digest.update(buf, 0, bytesRead);
+            }
+            return Hex.encodeHexString(digest.digest());
+        } catch (IOException | NoSuchAlgorithmException e) {
+            throw new RuntimeException("Compute driver checksum from url: " + urlStr
+                    + " encountered an error: " + e.getMessage(), e);
+        }
+    }
+
+    private static InputStream getInputStreamFromUrl(String urlStr, int connectTimeoutMs, int readTimeoutMs)
+            throws IOException {
+        try {
+            URL url = new URL(urlStr);
+            URLConnection conn = url.openConnection();
+            conn.setConnectTimeout(connectTimeoutMs);
+            conn.setReadTimeout(readTimeoutMs);
+            return conn.getInputStream();
+        } catch (Exception e) {
+            throw new IOException("Failed to open URL connection: " + urlStr, e);
         }
     }
 

--- a/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jdbc/JdbcDriverUtilsTest.java
+++ b/fe/be-java-extensions/java-common/src/test/java/org/apache/doris/common/jdbc/JdbcDriverUtilsTest.java
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.jdbc;
+
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class JdbcDriverUtilsTest {
+    private static final String DRIVER_BYTES = "doris-jdbc-driver";
+    private static final String DRIVER_CHECKSUM = "ef2b3218a863c98bc78fdf447331b206";
+    private static final String DUMMY_JDBC_URL = "jdbc:doris-common-dummy:test";
+
+    @After
+    public void tearDown() throws Exception {
+        deregisterDummyDrivers();
+    }
+
+    @Test
+    public void testValidateDriverChecksumRejectsMismatch() throws Exception {
+        runWithDriverUrl(driverUrl -> {
+            IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+                    () -> JdbcDriverUtils.validateDriverChecksum(driverUrl, "bad-checksum"));
+            Assert.assertTrue(exception.getMessage().contains("Checksum mismatch for JDBC driver"));
+        });
+    }
+
+    @Test
+    public void testValidateDriverChecksumReturnsComputedChecksum() throws Exception {
+        runWithDriverUrl(driverUrl -> Assert.assertEquals(DRIVER_CHECKSUM,
+                JdbcDriverUtils.validateDriverChecksum(driverUrl, DRIVER_CHECKSUM)));
+    }
+
+    @Test
+    public void testRegisterDriverWithoutChecksumKeepsOriginalLoadingBehavior() throws Exception {
+        String missingDriverUrl = "file:///tmp/doris-missing-driver-" + System.nanoTime() + ".jar";
+
+        JdbcDriverUtils.registerDriver(missingDriverUrl, DummyJdbcDriver.class.getName(), getClass().getClassLoader());
+
+        Driver driver = DriverManager.getDriver(DUMMY_JDBC_URL);
+        Assert.assertTrue(driver.acceptsURL(DUMMY_JDBC_URL));
+    }
+
+    private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
+        Path driverPath = Files.createTempFile("doris-jdbc-driver", ".jar");
+        try {
+            Files.write(driverPath, DRIVER_BYTES.getBytes(StandardCharsets.UTF_8));
+            consumer.accept(driverPath.toUri().toString());
+        } finally {
+            Files.deleteIfExists(driverPath);
+        }
+    }
+
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
+    }
+
+    private void deregisterDummyDrivers() throws Exception {
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver driver = drivers.nextElement();
+            if (driver.acceptsURL(DUMMY_JDBC_URL)) {
+                DriverManager.deregisterDriver(driver);
+            }
+        }
+    }
+
+    public static class DummyJdbcDriver implements Driver {
+        @Override
+        public java.sql.Connection connect(String url, Properties info) {
+            return null;
+        }
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return DUMMY_JDBC_URL.equals(url);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new SQLFeatureNotSupportedException("not supported");
+        }
+    }
+}

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJdbcDriverUtils.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJdbcDriverUtils.java
@@ -24,8 +24,10 @@ import java.util.Map;
 final class PaimonJdbcDriverUtils {
     static final String PAIMON_JDBC_DRIVER_URL = "paimon.jdbc.driver_url";
     static final String PAIMON_JDBC_DRIVER_CLASS = "paimon.jdbc.driver_class";
+    static final String PAIMON_JDBC_DRIVER_CHECKSUM = "paimon.jdbc.driver_checksum";
     static final String JDBC_DRIVER_URL = "jdbc.driver_url";
     static final String JDBC_DRIVER_CLASS = "jdbc.driver_class";
+    static final String JDBC_DRIVER_CHECKSUM = "jdbc.driver_checksum";
 
     private PaimonJdbcDriverUtils() {
     }
@@ -40,11 +42,14 @@ final class PaimonJdbcDriverUtils {
             throw new IllegalArgumentException("paimon.jdbc.driver_class or jdbc.driver_class is required when "
                     + "paimon.jdbc.driver_url or jdbc.driver_url is specified");
         }
-        registerDriver(driverUrl, driverClassName, parentClassLoader);
+        String driverChecksum = firstNonBlank(
+                params.get(PAIMON_JDBC_DRIVER_CHECKSUM), params.get(JDBC_DRIVER_CHECKSUM));
+        registerDriver(driverUrl, driverClassName, driverChecksum == null ? "" : driverChecksum, parentClassLoader);
     }
 
-    static void registerDriver(String driverUrl, String driverClassName, ClassLoader parentClassLoader) {
-        JdbcDriverUtils.registerDriver(driverUrl, driverClassName, parentClassLoader);
+    static void registerDriver(String driverUrl, String driverClassName, String driverChecksum,
+            ClassLoader parentClassLoader) {
+        JdbcDriverUtils.registerDriver(driverUrl, driverClassName, driverChecksum, parentClassLoader);
     }
 
     private static String firstNonBlank(String first, String second) {

--- a/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJdbcDriverUtilsTest.java
+++ b/fe/be-java-extensions/paimon-scanner/src/test/java/org/apache/doris/paimon/PaimonJdbcDriverUtilsTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Driver;
@@ -80,6 +81,21 @@ public class PaimonJdbcDriverUtilsTest {
         IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
                 () -> PaimonJdbcDriverUtils.registerDriverIfNeeded(params, getClass().getClassLoader()));
         Assert.assertTrue(exception.getMessage().contains("driver_class"));
+    }
+
+    @Test
+    public void testRegisterDriverIfNeededRejectsChecksumMismatchBeforeClassLoad() throws Exception {
+        Path driverJar = Files.createTempFile("paimon-jdbc-driver", ".jar");
+        tempJars.add(driverJar);
+        Files.write(driverJar, "paimon-jdbc-driver".getBytes(StandardCharsets.UTF_8));
+        Map<String, String> params = new HashMap<>();
+        params.put(PaimonJdbcDriverUtils.PAIMON_JDBC_DRIVER_URL, driverJar.toUri().toString());
+        params.put(PaimonJdbcDriverUtils.PAIMON_JDBC_DRIVER_CLASS, "not.existing.Driver");
+        params.put(PaimonJdbcDriverUtils.PAIMON_JDBC_DRIVER_CHECKSUM, "driver-checksum");
+
+        IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+                () -> PaimonJdbcDriverUtils.registerDriverIfNeeded(params, getClass().getClassLoader()));
+        Assert.assertTrue(exception.getMessage().contains("Checksum mismatch"));
     }
 
     private Path createDriverJar() throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcDriverLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcDriverLoader.java
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.DdlException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class JdbcDriverLoader {
+    private static final Logger LOG = LogManager.getLogger(JdbcDriverLoader.class);
+    private static final Map<URL, ClassLoader> DRIVER_CLASS_LOADER_CACHE = new ConcurrentHashMap<>();
+    private static final Set<String> REGISTERED_DRIVER_KEYS = ConcurrentHashMap.newKeySet();
+
+    private JdbcDriverLoader() {
+    }
+
+    public static String validateDriverChecksum(String driverUrl, String expectedChecksum) throws DdlException {
+        String actualChecksum = JdbcResource.computeObjectChecksum(driverUrl);
+        if (StringUtils.isNotBlank(expectedChecksum) && !expectedChecksum.equals(actualChecksum)) {
+            throw new DdlException("The provided checksum (" + expectedChecksum
+                    + ") does not match the computed checksum (" + actualChecksum
+                    + ") for the driver_url.");
+        }
+        return actualChecksum;
+    }
+
+    public static String registerDriver(String driverUrl, String driverClassName, String expectedChecksum,
+            ClassLoader parentClassLoader) {
+        if (StringUtils.isBlank(driverClassName)) {
+            throw new IllegalArgumentException("JDBC driver class is required when driver url is specified.");
+        }
+
+        try {
+            String fullDriverUrl = JdbcResource.getFullDriverUrl(driverUrl);
+            try {
+                validateDriverChecksum(fullDriverUrl, expectedChecksum);
+            } catch (DdlException e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
+            URL url = new URL(fullDriverUrl);
+            String driverKey = fullDriverUrl + "#" + driverClassName;
+            if (!REGISTERED_DRIVER_KEYS.add(driverKey)) {
+                LOG.info("JDBC driver already registered: {} from {}", driverClassName, fullDriverUrl);
+                return fullDriverUrl;
+            }
+            try {
+                ClassLoader classLoader = DRIVER_CLASS_LOADER_CACHE.computeIfAbsent(url, u ->
+                        URLClassLoader.newInstance(new URL[] {u}, parentClassLoader));
+                Class<?> loadedDriverClass = Class.forName(driverClassName, true, classLoader);
+                Driver driver = (Driver) loadedDriverClass.getDeclaredConstructor().newInstance();
+                DriverManager.registerDriver(new DriverShim(driver));
+                LOG.info("Successfully registered JDBC driver: {} from {}", driverClassName, fullDriverUrl);
+                return fullDriverUrl;
+            } catch (ClassNotFoundException e) {
+                REGISTERED_DRIVER_KEYS.remove(driverKey);
+                throw new IllegalArgumentException("Failed to load JDBC driver class: " + driverClassName, e);
+            } catch (Exception e) {
+                REGISTERED_DRIVER_KEYS.remove(driverKey);
+                throw new RuntimeException("Failed to register JDBC driver: " + driverClassName, e);
+            }
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid driver URL: " + driverUrl, e);
+        }
+    }
+
+    private static class DriverShim implements Driver {
+        private final Driver delegate;
+
+        DriverShim(Driver delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            return delegate.connect(url, info);
+        }
+
+        @Override
+        public boolean acceptsURL(String url) throws SQLException {
+            return delegate.acceptsURL(url);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+            return delegate.getPropertyInfo(url, info);
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return delegate.getMajorVersion();
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return delegate.getMinorVersion();
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return delegate.jdbcCompliant();
+        }
+
+        @Override
+        public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return delegate.getParentLogger();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -18,6 +18,8 @@
 package org.apache.doris.datasource.paimon;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.JdbcDriverLoader;
+import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.ExternalCatalog;
@@ -26,7 +28,9 @@ import org.apache.doris.datasource.NameMapping;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.datasource.metacache.CacheSpec;
 import org.apache.doris.datasource.property.metastore.AbstractPaimonProperties;
+import org.apache.doris.datasource.property.metastore.PaimonJdbcMetaStoreProperties;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -167,6 +171,45 @@ public class PaimonExternalCatalog extends ExternalCatalog {
         CacheSpec.checkLongProperty(catalogProperty.getOrDefault(PAIMON_TABLE_CACHE_CAPACITY, null),
                 0L, PAIMON_TABLE_CACHE_CAPACITY);
         catalogProperty.checkMetaStoreAndStorageProperties(AbstractPaimonProperties.class);
+    }
+
+    @Override
+    public void checkWhenCreating() throws DdlException {
+        validateJdbcDriverChecksumIfNeeded();
+        super.checkWhenCreating();
+    }
+
+    private void validateJdbcDriverChecksumIfNeeded() throws DdlException {
+        Map<String, String> properties = catalogProperty.getProperties();
+        if (!PAIMON_JDBC.equalsIgnoreCase(properties.get(PAIMON_CATALOG_TYPE))) {
+            return;
+        }
+
+        String driverUrl = firstNonBlank(
+                properties.get(PaimonJdbcMetaStoreProperties.PAIMON_JDBC_DRIVER_URL),
+                properties.get(PaimonJdbcMetaStoreProperties.JDBC_DRIVER_URL));
+        if (driverUrl == null) {
+            return;
+        }
+
+        String providedChecksum = firstNonBlank(
+                properties.get(PaimonJdbcMetaStoreProperties.PAIMON_JDBC_DRIVER_CHECKSUM),
+                properties.get(PaimonJdbcMetaStoreProperties.JDBC_DRIVER_CHECKSUM),
+                properties.get(JdbcResource.CHECK_SUM));
+        String computedChecksum = JdbcDriverLoader.validateDriverChecksum(driverUrl, providedChecksum);
+        if (StringUtils.isBlank(providedChecksum)) {
+            catalogProperty.addProperty(PaimonJdbcMetaStoreProperties.PAIMON_JDBC_DRIVER_CHECKSUM,
+                    computedChecksum);
+        }
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (StringUtils.isNotBlank(value)) {
+                return value;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStoreProperties.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.datasource.property.metastore;
 
+import org.apache.doris.catalog.JdbcDriverLoader;
 import org.apache.doris.catalog.JdbcResource;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.security.authentication.HadoopExecutionAuthenticator;
 import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
 import org.apache.doris.datasource.property.storage.HdfsProperties;
@@ -34,23 +36,20 @@ import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.jdbc.JdbcCatalogFactory;
 import org.apache.paimon.options.CatalogOptions;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class PaimonJdbcMetaStoreProperties extends AbstractPaimonProperties {
     private static final Logger LOG = LogManager.getLogger(PaimonJdbcMetaStoreProperties.class);
     private static final String JDBC_PREFIX = "jdbc.";
-    private static final String JDBC_DRIVER_URL = JDBC_PREFIX + JdbcResource.DRIVER_URL;
-    private static final String JDBC_DRIVER_CLASS = JDBC_PREFIX + JdbcResource.DRIVER_CLASS;
-    private static final Map<URL, ClassLoader> DRIVER_CLASS_LOADER_CACHE = new ConcurrentHashMap<>();
-    private static final Set<String> REGISTERED_DRIVER_KEYS = ConcurrentHashMap.newKeySet();
+    public static final String PAIMON_JDBC_DRIVER_URL = "paimon.jdbc." + JdbcResource.DRIVER_URL;
+    public static final String PAIMON_JDBC_DRIVER_CLASS = "paimon.jdbc." + JdbcResource.DRIVER_CLASS;
+    public static final String PAIMON_JDBC_DRIVER_CHECKSUM = "paimon.jdbc.driver_checksum";
+    public static final String JDBC_DRIVER_URL = JDBC_PREFIX + JdbcResource.DRIVER_URL;
+    public static final String JDBC_DRIVER_CLASS = JDBC_PREFIX + JdbcResource.DRIVER_CLASS;
+    public static final String JDBC_DRIVER_CHECKSUM = JDBC_PREFIX + "driver_checksum";
 
     @ConnectorProperty(
             names = {"uri", "paimon.jdbc.uri"},
@@ -75,7 +74,7 @@ public class PaimonJdbcMetaStoreProperties extends AbstractPaimonProperties {
     private String jdbcPassword;
 
     @ConnectorProperty(
-            names = {"paimon.jdbc.driver_url", "jdbc.driver_url"},
+            names = {PAIMON_JDBC_DRIVER_URL, JDBC_DRIVER_URL},
             required = false,
             description = "JDBC driver JAR file path or URL. "
                     + "Can be a local file name (will look in $DORIS_HOME/plugins/jdbc_drivers/) "
@@ -84,12 +83,19 @@ public class PaimonJdbcMetaStoreProperties extends AbstractPaimonProperties {
     private String driverUrl;
 
     @ConnectorProperty(
-            names = {"paimon.jdbc.driver_class", "jdbc.driver_class"},
+            names = {PAIMON_JDBC_DRIVER_CLASS, JDBC_DRIVER_CLASS},
             required = false,
             description = "JDBC driver class name. If specified with paimon.jdbc.driver_url, "
                     + "the driver will be loaded dynamically."
     )
     private String driverClass;
+
+    @ConnectorProperty(
+            names = {PAIMON_JDBC_DRIVER_CHECKSUM, JDBC_DRIVER_CHECKSUM, JdbcResource.CHECK_SUM},
+            required = false,
+            description = "Expected checksum for the JDBC driver JAR."
+    )
+    private String driverChecksum;
 
     protected PaimonJdbcMetaStoreProperties(Map<String, String> props) {
         super(props);
@@ -123,8 +129,10 @@ public class PaimonJdbcMetaStoreProperties extends AbstractPaimonProperties {
         }
         appendUserHadoopConfig(conf);
         if (StringUtils.isNotBlank(driverUrl)) {
-            registerJdbcDriver(driverUrl, driverClass);
-            LOG.info("Using dynamic JDBC driver for Paimon JDBC catalog from: {}", driverUrl);
+            checkDriverClass();
+            String fullDriverUrl = JdbcDriverLoader.registerDriver(
+                    driverUrl, driverClass, getOrComputeDriverChecksum(), getClass().getClassLoader());
+            LOG.info("Using dynamic JDBC driver for Paimon JDBC catalog from: {}", fullDriverUrl);
         }
         CatalogContext catalogContext = CatalogContext.create(catalogOptions, conf);
         try {
@@ -165,101 +173,29 @@ public class PaimonJdbcMetaStoreProperties extends AbstractPaimonProperties {
         if (StringUtils.isBlank(driverUrl)) {
             return Collections.emptyMap();
         }
-        if (StringUtils.isBlank(driverClass)) {
-            throw new IllegalArgumentException("jdbc.driver_class or paimon.jdbc.driver_class is required when "
-                    + "jdbc.driver_url or paimon.jdbc.driver_url is specified");
-        }
+        checkDriverClass();
         Map<String, String> backendPaimonOptions = new HashMap<>();
         backendPaimonOptions.put(JDBC_DRIVER_URL, JdbcResource.getFullDriverUrl(driverUrl));
         backendPaimonOptions.put(JDBC_DRIVER_CLASS, driverClass);
+        backendPaimonOptions.put(JDBC_DRIVER_CHECKSUM, getOrComputeDriverChecksum());
         return backendPaimonOptions;
     }
 
-    /**
-     * Register JDBC driver with DriverManager.
-     * This is necessary because DriverManager.getConnection() doesn't use Thread.contextClassLoader.
-     */
-    private void registerJdbcDriver(String driverUrl, String driverClassName) {
+    private String getOrComputeDriverChecksum() {
+        if (StringUtils.isNotBlank(driverChecksum)) {
+            return driverChecksum;
+        }
         try {
-            if (StringUtils.isBlank(driverClassName)) {
-                throw new IllegalArgumentException(
-                        "jdbc.driver_class or paimon.jdbc.driver_class is required when jdbc.driver_url "
-                                + "or paimon.jdbc.driver_url is specified");
-            }
-
-            String fullDriverUrl = JdbcResource.getFullDriverUrl(driverUrl);
-            URL url = new URL(fullDriverUrl);
-            String driverKey = fullDriverUrl + "#" + driverClassName;
-            if (!REGISTERED_DRIVER_KEYS.add(driverKey)) {
-                LOG.info("JDBC driver already registered for Paimon catalog: {} from {}",
-                        driverClassName, fullDriverUrl);
-                return;
-            }
-            try {
-                ClassLoader classLoader = DRIVER_CLASS_LOADER_CACHE.computeIfAbsent(url, u -> {
-                    ClassLoader parent = getClass().getClassLoader();
-                    return URLClassLoader.newInstance(new URL[] {u}, parent);
-                });
-                Class<?> loadedDriverClass = Class.forName(driverClassName, true, classLoader);
-                java.sql.Driver driver = (java.sql.Driver) loadedDriverClass.getDeclaredConstructor().newInstance();
-                java.sql.DriverManager.registerDriver(new DriverShim(driver));
-                LOG.info("Successfully registered JDBC driver for Paimon catalog: {} from {}",
-                        driverClassName, fullDriverUrl);
-            } catch (ClassNotFoundException e) {
-                REGISTERED_DRIVER_KEYS.remove(driverKey);
-                throw new IllegalArgumentException("Failed to load JDBC driver class: " + driverClassName, e);
-            } catch (Exception e) {
-                REGISTERED_DRIVER_KEYS.remove(driverKey);
-                throw new RuntimeException("Failed to register JDBC driver: " + driverClassName, e);
-            }
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid driver URL: " + driverUrl, e);
-        } catch (IllegalArgumentException e) {
-            throw e;
+            return JdbcDriverLoader.validateDriverChecksum(driverUrl, driverChecksum);
+        } catch (DdlException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
         }
     }
 
-    private static class DriverShim implements java.sql.Driver {
-        private final java.sql.Driver delegate;
-
-        DriverShim(java.sql.Driver delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public java.sql.Connection connect(String url, java.util.Properties info) throws java.sql.SQLException {
-            return delegate.connect(url, info);
-        }
-
-        @Override
-        public boolean acceptsURL(String url) throws java.sql.SQLException {
-            return delegate.acceptsURL(url);
-        }
-
-        @Override
-        public java.sql.DriverPropertyInfo[] getPropertyInfo(String url, java.util.Properties info)
-                throws java.sql.SQLException {
-            return delegate.getPropertyInfo(url, info);
-        }
-
-        @Override
-        public int getMajorVersion() {
-            return delegate.getMajorVersion();
-        }
-
-        @Override
-        public int getMinorVersion() {
-            return delegate.getMinorVersion();
-        }
-
-        @Override
-        public boolean jdbcCompliant() {
-            return delegate.jdbcCompliant();
-        }
-
-        @Override
-        public java.util.logging.Logger getParentLogger() throws java.sql.SQLFeatureNotSupportedException {
-            return delegate.getParentLogger();
+    private void checkDriverClass() {
+        if (StringUtils.isBlank(driverClass)) {
+            throw new IllegalArgumentException("jdbc.driver_class or paimon.jdbc.driver_class is required when "
+                    + "jdbc.driver_url or paimon.jdbc.driver_url is specified");
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcDriverLoaderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/JdbcDriverLoaderTest.java
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class JdbcDriverLoaderTest {
+    private static final String DRIVER_BYTES = "doris-jdbc-driver";
+    private static final String DRIVER_CHECKSUM = "ef2b3218a863c98bc78fdf447331b206";
+
+    @Test
+    public void testValidateDriverChecksumRejectsMismatch() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            DdlException exception = Assert.assertThrows(DdlException.class,
+                    () -> JdbcDriverLoader.validateDriverChecksum(driverUrl, "bad-checksum"));
+            Assert.assertTrue(exception.getMessage().contains("does not match the computed checksum"));
+        }));
+    }
+
+    @Test
+    public void testRegisterDriverValidatesChecksumBeforeLoadingClass() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+                    () -> JdbcDriverLoader.registerDriver(driverUrl,
+                            "org.apache.doris.catalog.NotExistingDriver", "bad-checksum",
+                            getClass().getClassLoader()));
+            Assert.assertTrue(exception.getMessage().contains("does not match the computed checksum"));
+        }));
+    }
+
+    @Test
+    public void testValidateDriverChecksumReturnsComputedChecksum() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            Assert.assertEquals(DRIVER_CHECKSUM, JdbcDriverLoader.validateDriverChecksum(driverUrl, DRIVER_CHECKSUM));
+            Assert.assertEquals(DRIVER_CHECKSUM, JdbcDriverLoader.validateDriverChecksum(driverUrl, ""));
+        }));
+    }
+
+    private void runWithChecksumEnabled(ThrowingRunnable runnable) throws Exception {
+        synchronized (FeConstants.class) {
+            boolean oldRunningUnitTest = FeConstants.runningUnitTest;
+            FeConstants.runningUnitTest = false;
+            try {
+                runnable.run();
+            } finally {
+                FeConstants.runningUnitTest = oldRunningUnitTest;
+            }
+        }
+    }
+
+    private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
+        Path driverPath = Files.createTempFile("doris-jdbc-driver", ".jar");
+        try {
+            Files.write(driverPath, DRIVER_BYTES.getBytes(StandardCharsets.UTF_8));
+            consumer.accept(driverPath.toUri().toString());
+        } finally {
+            Files.deleteIfExists(driverPath);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/PaimonExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/PaimonExternalCatalogTest.java
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.paimon;
+
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.property.metastore.PaimonJdbcMetaStoreProperties;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaimonExternalCatalogTest {
+    private static final String DRIVER_BYTES = "paimon-jdbc-driver";
+    private static final String DRIVER_CHECKSUM = "fcf85686ee55f29a45de9c562410d5e4";
+
+    @Test
+    public void testCheckWhenCreatingAddsJdbcDriverChecksum() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            PaimonExternalCatalog catalog = createPaimonJdbcCatalog(driverUrl);
+
+            catalog.checkWhenCreating();
+
+            Assert.assertEquals(DRIVER_CHECKSUM, catalog.getCatalogProperty().getProperties()
+                    .get(PaimonJdbcMetaStoreProperties.PAIMON_JDBC_DRIVER_CHECKSUM));
+        }));
+    }
+
+    @Test
+    public void testCheckWhenCreatingRejectsJdbcDriverChecksumMismatch() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            PaimonExternalCatalog catalog = createPaimonJdbcCatalog(driverUrl);
+            catalog.getCatalogProperty().addProperty(PaimonJdbcMetaStoreProperties.PAIMON_JDBC_DRIVER_CHECKSUM,
+                    "bad-checksum");
+
+            DdlException exception = Assert.assertThrows(DdlException.class, catalog::checkWhenCreating);
+            Assert.assertTrue(exception.getMessage().contains("does not match the computed checksum"));
+        }));
+    }
+
+    private PaimonExternalCatalog createPaimonJdbcCatalog(String driverUrl) {
+        Map<String, String> props = new HashMap<>();
+        props.put("type", "paimon");
+        props.put(PaimonExternalCatalog.PAIMON_CATALOG_TYPE, PaimonExternalCatalog.PAIMON_JDBC);
+        props.put("uri", "jdbc:postgresql://127.0.0.1:5442/postgres");
+        props.put("warehouse", "s3://warehouse/path");
+        props.put(PaimonJdbcMetaStoreProperties.PAIMON_JDBC_DRIVER_URL, driverUrl);
+        props.put(PaimonJdbcMetaStoreProperties.PAIMON_JDBC_DRIVER_CLASS, "org.postgresql.Driver");
+        return new PaimonExternalCatalog(1L, "paimon_catalog", null, props, "");
+    }
+
+    private void runWithChecksumEnabled(ThrowingRunnable runnable) throws Exception {
+        synchronized (FeConstants.class) {
+            boolean oldRunningUnitTest = FeConstants.runningUnitTest;
+            FeConstants.runningUnitTest = false;
+            try {
+                runnable.run();
+            } finally {
+                FeConstants.runningUnitTest = oldRunningUnitTest;
+            }
+        }
+    }
+
+    private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
+        Path driverPath = Files.createTempFile("paimon-jdbc-driver", ".jar");
+        try {
+            Files.write(driverPath, DRIVER_BYTES.getBytes(StandardCharsets.UTF_8));
+            consumer.accept(driverPath.toUri().toString());
+        } finally {
+            Files.deleteIfExists(driverPath);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/paimon/source/PaimonScanNodeTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.datasource.paimon.source;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
 import org.apache.doris.common.ExceptionChecker;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.FileQueryScanNode;
@@ -50,6 +51,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +63,9 @@ import java.util.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaimonScanNodeTest {
+    private static final String DRIVER_BYTES = "paimon-jdbc-driver";
+    private static final String DRIVER_CHECKSUM = "fcf85686ee55f29a45de9c562410d5e4";
+
     @Mock
     private SessionVariable sv;
 
@@ -483,34 +490,37 @@ public class PaimonScanNodeTest {
 
     @Test
     public void testGetBackendPaimonOptionsForJdbcCatalog() throws Exception {
-        String driverUrl = "file:///tmp/postgresql-42.5.0.jar";
-        Map<String, String> props = new HashMap<>();
-        props.put("type", "paimon");
-        props.put("paimon.catalog.type", "jdbc");
-        props.put("uri", "jdbc:postgresql://127.0.0.1:5442/postgres");
-        props.put("warehouse", "s3://warehouse/path");
-        props.put("paimon.jdbc.driver_url", driverUrl);
-        props.put("paimon.jdbc.driver_class", "org.postgresql.Driver");
-        PaimonJdbcMetaStoreProperties jdbcMetaStoreProperties =
-                (PaimonJdbcMetaStoreProperties) MetastoreProperties.create(props);
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            Map<String, String> props = new HashMap<>();
+            props.put("type", "paimon");
+            props.put("paimon.catalog.type", "jdbc");
+            props.put("uri", "jdbc:postgresql://127.0.0.1:5442/postgres");
+            props.put("warehouse", "s3://warehouse/path");
+            props.put("paimon.jdbc.driver_url", driverUrl);
+            props.put("paimon.jdbc.driver_class", "org.postgresql.Driver");
+            props.put("paimon.jdbc.driver_checksum", DRIVER_CHECKSUM);
+            PaimonJdbcMetaStoreProperties jdbcMetaStoreProperties =
+                    (PaimonJdbcMetaStoreProperties) MetastoreProperties.create(props);
 
-        CatalogProperty catalogProperty = Mockito.mock(CatalogProperty.class);
-        Mockito.when(catalogProperty.getMetastoreProperties()).thenReturn(jdbcMetaStoreProperties);
+            CatalogProperty catalogProperty = Mockito.mock(CatalogProperty.class);
+            Mockito.when(catalogProperty.getMetastoreProperties()).thenReturn(jdbcMetaStoreProperties);
 
-        PaimonExternalCatalog catalog = Mockito.mock(PaimonExternalCatalog.class);
-        Mockito.when(catalog.getCatalogProperty()).thenReturn(catalogProperty);
+            PaimonExternalCatalog catalog = Mockito.mock(PaimonExternalCatalog.class);
+            Mockito.when(catalog.getCatalogProperty()).thenReturn(catalogProperty);
 
-        PaimonSource source = Mockito.mock(PaimonSource.class);
-        Mockito.when(source.getCatalog()).thenReturn(catalog);
+            PaimonSource source = Mockito.mock(PaimonSource.class);
+            Mockito.when(source.getCatalog()).thenReturn(catalog);
 
-        PaimonScanNode node = new PaimonScanNode(new PlanNodeId(0), new TupleDescriptor(new TupleId(0)),
-                false, sv, ScanContext.EMPTY);
-        node.setSource(source);
+            PaimonScanNode node = new PaimonScanNode(new PlanNodeId(0), new TupleDescriptor(new TupleId(0)),
+                    false, sv, ScanContext.EMPTY);
+            node.setSource(source);
 
-        Map<String, String> backendOptions = node.getBackendPaimonOptions();
-        Assert.assertEquals("org.postgresql.Driver", backendOptions.get("jdbc.driver_class"));
-        Assert.assertEquals(driverUrl, backendOptions.get("jdbc.driver_url"));
-        Assert.assertEquals(2, backendOptions.size());
+            Map<String, String> backendOptions = node.getBackendPaimonOptions();
+            Assert.assertEquals(driverUrl, backendOptions.get("jdbc.driver_url"));
+            Assert.assertEquals("org.postgresql.Driver", backendOptions.get("jdbc.driver_class"));
+            Assert.assertEquals(DRIVER_CHECKSUM, backendOptions.get("jdbc.driver_checksum"));
+            Assert.assertEquals(3, backendOptions.size());
+        }));
     }
 
     @Test
@@ -524,6 +534,7 @@ public class PaimonScanNodeTest {
         Map<String, String> backendOptions = new HashMap<>();
         backendOptions.put("jdbc.driver_url", "file:///tmp/postgresql-42.5.0.jar");
         backendOptions.put("jdbc.driver_class", "org.postgresql.Driver");
+        backendOptions.put("jdbc.driver_checksum", "driver-checksum");
         setField(FileQueryScanNode.class, node, "params", new TFileScanRangeParams());
         setField(PaimonScanNode.class, node, "backendPaimonOptions", backendOptions);
         setField(PaimonScanNode.class, node, "storagePropertiesMap", Collections.emptyMap());
@@ -575,5 +586,35 @@ public class PaimonScanNodeTest {
                 .withBucketPath("file://b1")
                 .withDataFiles(Collections.singletonList(dataFileMeta))
                 .build();
+    }
+
+    private void runWithChecksumEnabled(ThrowingRunnable runnable) throws Exception {
+        synchronized (FeConstants.class) {
+            boolean oldRunningUnitTest = FeConstants.runningUnitTest;
+            FeConstants.runningUnitTest = false;
+            try {
+                runnable.run();
+            } finally {
+                FeConstants.runningUnitTest = oldRunningUnitTest;
+            }
+        }
+    }
+
+    private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
+        Path driverPath = Files.createTempFile("paimon-jdbc-driver", ".jar");
+        try {
+            Files.write(driverPath, DRIVER_BYTES.getBytes(StandardCharsets.UTF_8));
+            consumer.accept(driverPath.toUri().toString());
+        } finally {
+            Files.deleteIfExists(driverPath);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStorePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/PaimonJdbcMetaStorePropertiesTest.java
@@ -17,18 +17,23 @@
 
 package org.apache.doris.datasource.property.metastore;
 
-import org.apache.doris.catalog.JdbcResource;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
 
 import org.apache.paimon.options.CatalogOptions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class PaimonJdbcMetaStorePropertiesTest {
+    private static final String DRIVER_BYTES = "paimon-jdbc-driver";
+    private static final String DRIVER_CHECKSUM = "fcf85686ee55f29a45de9c562410d5e4";
 
     @Test
     public void testBasicJdbcProperties() throws Exception {
@@ -155,24 +160,26 @@ public class PaimonJdbcMetaStorePropertiesTest {
     }
 
     @Test
-    public void testGetBackendPaimonOptions() throws Exception {
-        String driverUrl = "file:///tmp/postgresql-42.5.0.jar";
-        Map<String, String> props = new HashMap<>();
-        props.put("type", "paimon");
-        props.put("paimon.catalog.type", "jdbc");
-        props.put("uri", "jdbc:postgresql://127.0.0.1:5442/postgres");
-        props.put("warehouse", "s3://warehouse/path");
-        props.put("paimon.jdbc.driver_url", driverUrl);
-        props.put("paimon.jdbc.driver_class", "org.postgresql.Driver");
+    public void testGetBackendPaimonOptionsIncludesDriverChecksum() throws Exception {
+        runWithChecksumEnabled(() -> runWithDriverUrl(driverUrl -> {
+            Map<String, String> props = new HashMap<>();
+            props.put("type", "paimon");
+            props.put("paimon.catalog.type", "jdbc");
+            props.put("uri", "jdbc:postgresql://127.0.0.1:5442/postgres");
+            props.put("warehouse", "s3://warehouse/path");
+            props.put("paimon.jdbc.driver_url", driverUrl);
+            props.put("paimon.jdbc.driver_class", "org.postgresql.Driver");
+            props.put("paimon.jdbc.driver_checksum", DRIVER_CHECKSUM);
 
-        PaimonJdbcMetaStoreProperties jdbcProps = (PaimonJdbcMetaStoreProperties) MetastoreProperties.create(props);
-        Map<String, String> backendOptions = jdbcProps.getBackendPaimonOptions();
+            PaimonJdbcMetaStoreProperties jdbcProps =
+                    (PaimonJdbcMetaStoreProperties) MetastoreProperties.create(props);
+            Map<String, String> backendOptions = jdbcProps.getBackendPaimonOptions();
 
-        Assertions.assertEquals(
-                JdbcResource.getFullDriverUrl(driverUrl),
-                backendOptions.get("jdbc.driver_url"));
-        Assertions.assertEquals("org.postgresql.Driver", backendOptions.get("jdbc.driver_class"));
-        Assertions.assertEquals(2, backendOptions.size());
+            Assertions.assertEquals(driverUrl, backendOptions.get("jdbc.driver_url"));
+            Assertions.assertEquals("org.postgresql.Driver", backendOptions.get("jdbc.driver_class"));
+            Assertions.assertEquals(DRIVER_CHECKSUM, backendOptions.get("jdbc.driver_checksum"));
+            Assertions.assertEquals(3, backendOptions.size());
+        }));
     }
 
     @Test
@@ -188,5 +195,35 @@ public class PaimonJdbcMetaStorePropertiesTest {
         IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class,
                 jdbcProps::getBackendPaimonOptions);
         Assertions.assertTrue(exception.getMessage().contains("driver_class"));
+    }
+
+    private void runWithChecksumEnabled(ThrowingRunnable runnable) throws Exception {
+        synchronized (FeConstants.class) {
+            boolean oldRunningUnitTest = FeConstants.runningUnitTest;
+            FeConstants.runningUnitTest = false;
+            try {
+                runnable.run();
+            } finally {
+                FeConstants.runningUnitTest = oldRunningUnitTest;
+            }
+        }
+    }
+
+    private void runWithDriverUrl(ThrowingConsumer<String> consumer) throws Exception {
+        Path driverPath = Files.createTempFile("paimon-jdbc-driver", ".jar");
+        try {
+            Files.write(driverPath, DRIVER_BYTES.getBytes(StandardCharsets.UTF_8));
+            consumer.accept(driverPath.toUri().toString());
+        } finally {
+            Files.deleteIfExists(driverPath);
+        }
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private interface ThrowingConsumer<T> {
+        void accept(T value) throws Exception;
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #63676

Problem Summary: Make Paimon JDBC catalog reuse the shared JDBC driver checksum loader introduced in #63676. The PR preserves the current dynamic JDBC driver loading behavior and only adds checksum propagation/validation for Paimon JDBC driver URLs.

This PR is stacked on #63676 intentionally. After #63676 is merged, this branch should be rebased onto master so the final diff only contains the Paimon integration.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.datasource.paimon.PaimonExternalCatalogTest,org.apache.doris.datasource.property.metastore.PaimonJdbcMetaStorePropertiesTest,org.apache.doris.datasource.paimon.source.PaimonScanNodeTest,org.apache.doris.paimon.PaimonJdbcDriverUtilsTest
- Behavior changed: No
- Does this need documentation: No
