### PR TITLE
manual pick #62141 into branch 4.1 to keep consistency with used test framework

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -1129,7 +1129,7 @@ userIdentify
     ;
 
 grantUserIdentify
-    : userIdentify (IDENTIFIED BY PASSWORD? STRING_LITERAL)?
+    : userIdentify (IDENTIFIED BY PASSWORD? pwd=STRING_LITERAL)?
     ;
 
 explain

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderForEncryption.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.parser;
 
 import org.apache.doris.analysis.BrokerDesc;
+import org.apache.doris.analysis.UserDesc;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.nereids.DorisParser;
@@ -83,6 +84,15 @@ public class LogicalPlanBuilderForEncryption extends LogicalPlanBuilder {
     public SetVarOp visitSetPassword(DorisParser.SetPasswordContext ctx) {
         encryptPassword(ctx.pwd.getStartIndex(), ctx.pwd.getStopIndex());
         return super.visitSetPassword(ctx);
+    }
+
+    // grant user identity clause
+    @Override
+    public UserDesc visitGrantUserIdentify(DorisParser.GrantUserIdentifyContext ctx) {
+        if (ctx.pwd != null) {
+            encryptPassword(ctx.pwd.getStartIndex(), ctx.pwd.getStopIndex());
+        }
+        return super.visitGrantUserIdentify(ctx);
     }
 
     // set ldap password clause

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterUserCommand.java
@@ -29,7 +29,7 @@ import org.apache.doris.qe.StmtExecutor;
 /**
  * AlterUserCommand
  */
-public class AlterUserCommand extends AlterCommand {
+public class AlterUserCommand extends AlterCommand implements NeedAuditEncryption {
 
     private final AlterUserInfo alterUserInfo;
 
@@ -56,5 +56,10 @@ public class AlterUserCommand extends AlterCommand {
     @Override
     public StmtType stmtType() {
         return StmtType.ALTER;
+    }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/EncryptSQLTest.java
@@ -405,6 +405,40 @@ public class EncryptSQLTest extends ParserTestBase {
         Assertions.assertTrue(event.errorMessage.contains(errorMsg));
     }
 
+    @Test
+    //when mockito framework will be introduced into release branch
+    //then version of tests for mockito can be found in #62141
+    public void testCreateUserPasswordMasking() throws Exception {
+        ctx.setDatabase("test");
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public boolean isForwardToMaster() {
+                return false;
+            }
+        };
+        ctx.setEnv(env);
+        // testing for https://github.com/apache/doris/issues/62140
+        String sql = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        String res = "CREATE USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        parseAndCheck(sql, res);
+    }
+
+    @Test
+    public void testAlterUserPasswordMasking() throws Exception {
+        ctx.setDatabase("test");
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public boolean isForwardToMaster() {
+                return false;
+            }
+        };
+        ctx.setEnv(env);
+        // testing for https://github.com/apache/doris/issues/62140
+        String sql = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '123456'";
+        String res = "ALTER USER 'test_user62140'@'%' IDENTIFIED BY '*XXX'";
+        parseAndCheck(sql, res);
+    }
+
     private void parseAndCheck(String sql, String expected) throws Exception {
         processor.executeQuery(sql);
         AuditEvent event = auditEvents.get(auditEvents.size() - 1);


### PR DESCRIPTION
### What problem does this PR solve?

This PR adds masking for users passwords for **CREATE USER** and **ALTER USER** commands.
The masked values will be stored in audit table and audit files instead of actual values.
The same functionality already exists for **SET USER PASSWORD** and **SET LDAP_ADMIN_PASSWORD** commands, so we other commands related to passwords should be masked as well.

#62141 can't be automatically merged into branch-4.1 as it depends on new test framework.
so I've executed manual merge with previous test framework to keep compatibility

**Could you please include this PR into 4.x branches, please!**

Issue Number: close #62140

(cherry picked from commit 8209b79a35ea2d241a3af94a722aae4187787d4b)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #62141, #63038

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [X] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [X] Yes. 


- Does this need documentation?
    - [X] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

