### PR TITLE
[fix](env) fix beut build

### DIFF
--- a/be/test/exprs/function/geo/functions_geo_test.cpp
+++ b/be/test/exprs/function/geo/functions_geo_test.cpp
@@ -372,7 +372,7 @@ TEST(VGeoFunctionsTest, function_geo_st_geometries_invalid) {
     // Insert non-null but invalid data
     auto* nullable_input = assert_cast<ColumnNullable*>(input_col.get());
     nullable_input->get_nested_column_ptr()->insert_data(invalid_buf.data(), invalid_buf.size());
-    assert_cast<ColumnUInt8*>(nullable_input->get_null_map_column_ptr().get())->insert_value(0);
+    nullable_input->get_null_map_column_ptr()->insert_value(0);
     block.insert({std::move(input_col), input_type, "shape"});
 
     FunctionBasePtr func = SimpleFunctionFactory::instance().get_function(


### PR DESCRIPTION
### What problem does this PR solve?


https://github.com/apache/doris/pull/63491
https://github.com/apache/doris/pull/63049


```
../src/core/assert_cast.h:54:19: error: static assertion failed due to requirement '!std::is_same_v<doris::ColumnVector<doris::TYPE_BOOLEAN> *, doris::ColumnVector<doris::TYPE_BOOLEAN> *>': assert_cast is redundant for the same type after removing cv/ref qualifiers
   54 |     static_assert(!std::is_same_v<AssertCastNormalizedType_t<To>, AssertCastNormalizedType_t<From>>,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../test/exprs/function/geo/functions_geo_test.cpp:375:5: note: in instantiation of function template specialization 'assert_cast<doris::ColumnVector<doris::TYPE_BOOLEAN> *, TypeCheckOnRelease::ENABLE, doris::ColumnVector<doris::TYPE_BOOLEAN> *>' requested here
  375 |     assert_cast<ColumnUInt8*>(nullable_input->get_null_map_column_ptr().get())->insert_value(0);
      |     ^
1 error generated.
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

