### PR TITLE
[bug](cloud restore) rewrite table properties and partition info in cloud restore

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1162,9 +1162,20 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
                     if (reserveReplica) {
                         restoreReplicaAlloc = remotePartitionInfo.getReplicaAllocation(remotePartId);
                     }
+                    boolean isInMemory = remotePartitionInfo.getIsInMemory(remotePartId);
+                    if (Config.isCloudMode()) {
+                        // In cloud mode, storage_medium, cooldown_time, storage_policy and in_memory
+                        // from the source cluster are not applicable. Reset them to defaults.
+                        remoteDataProperty = new DataProperty(
+                                DataProperty.DEFAULT_STORAGE_MEDIUM,
+                                DataProperty.MAX_COOLDOWN_TIME_MS,
+                                "",
+                                remoteDataProperty.isMutable());
+                        isInMemory = false;
+                    }
                     localPartitionInfo.addPartition(restoredPart.getId(), false, remoteItem,
                             remoteDataProperty, restoreReplicaAlloc,
-                            remotePartitionInfo.getIsInMemory(remotePartId),
+                            isInMemory,
                             remotePartitionInfo.getIsMutable(remotePartId));
                 }
                 localTbl.addPartition(restoredPart);
@@ -1707,9 +1718,20 @@ public class RestoreJob extends AbstractJob implements GsonPostProcessable {
             if (reserveReplica) {
                 restoreReplicaAlloc = remotePartitionInfo.getReplicaAllocation(remotePartId);
             }
+            boolean isInMemory = remotePartitionInfo.getIsInMemory(remotePartId);
+            if (Config.isCloudMode()) {
+                // In cloud mode, storage_medium, cooldown_time, storage_policy and in_memory
+                // from the source cluster are not applicable. Reset them to defaults.
+                remoteDataProperty = new DataProperty(
+                        DataProperty.DEFAULT_STORAGE_MEDIUM,
+                        DataProperty.MAX_COOLDOWN_TIME_MS,
+                        "",
+                        remoteDataProperty.isMutable());
+                isInMemory = false;
+            }
             localPartitionInfo.addPartition(restorePart.getId(), false, remotePartitionInfo.getItem(remotePartId),
                     remoteDataProperty, restoreReplicaAlloc,
-                    remotePartitionInfo.getIsInMemory(remotePartId),
+                    isInMemory,
                     remotePartitionInfo.getIsMutable(remotePartId));
             localTbl.addPartition(restorePart);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -427,15 +427,33 @@ public class PartitionInfo {
         idToStoragePolicy = Maps.newHashMap();
 
         for (Map.Entry<Long, Long> entry : partitionIdMap.entrySet()) {
-            idToDataProperty.put(entry.getKey(), origIdToDataProperty.get(entry.getValue()));
-            idToReplicaAllocation.put(entry.getKey(),
-                    restoreReplicaAlloc == null ? origIdToReplicaAllocation.get(entry.getValue())
+            long newPartId = entry.getKey();
+            long origPartId = entry.getValue();
+
+            if (Config.isCloudMode()) {
+                // In cloud mode, storage_medium, cooldown_time, and storage_policy are not applicable.
+                // Reset DataProperty to default and clear storage policy to avoid carrying over
+                // source cluster's storage settings that have no meaning in cloud mode.
+                DataProperty origDataProperty = origIdToDataProperty.get(origPartId);
+                idToDataProperty.put(newPartId, new DataProperty(
+                        DataProperty.DEFAULT_STORAGE_MEDIUM,
+                        DataProperty.MAX_COOLDOWN_TIME_MS,
+                        "",
+                        origDataProperty != null ? origDataProperty.isMutable() : true));
+                idToStoragePolicy.put(newPartId, "");
+                idToInMemory.put(newPartId, false);
+            } else {
+                idToDataProperty.put(newPartId, origIdToDataProperty.get(origPartId));
+                idToStoragePolicy.put(newPartId, origIdToStoragePolicy.getOrDefault(origPartId, ""));
+                idToInMemory.put(newPartId, origIdToInMemory.get(origPartId));
+            }
+
+            idToReplicaAllocation.put(newPartId,
+                    restoreReplicaAlloc == null ? origIdToReplicaAllocation.get(origPartId)
                             : restoreReplicaAlloc);
             if (!isSinglePartitioned) {
-                idToItem.put(entry.getKey(), origIdToItem.get(entry.getValue()));
+                idToItem.put(newPartId, origIdToItem.get(origPartId));
             }
-            idToInMemory.put(entry.getKey(), origIdToInMemory.get(entry.getValue()));
-            idToStoragePolicy.put(entry.getKey(), origIdToStoragePolicy.getOrDefault(entry.getValue(), ""));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.PartitionDesc;
 import org.apache.doris.analysis.PartitionValue;
 import org.apache.doris.analysis.SinglePartitionDesc;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TTabletType;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -199,10 +199,22 @@ public class TableProperty implements GsonPostProcessable {
             if (!reserveDynamicPartitionEnable) {
                 properties.put(DynamicPartitionProperty.ENABLE, "false");
             }
-            executeBuildDynamicProperty();
         }
         if (!reserveReplica) {
             setReplicaAlloc(replicaAlloc);
+        }
+        if (Config.isCloudMode()) {
+            // In cloud mode, remove all unsupported dynamic partition properties from the source
+            // cluster. These properties (e.g., replication_num, replication_allocation, storage_policy)
+            // are not applicable in cloud mode. If kept, they would cause dynamic partition scheduler
+            // to create new partitions with incorrect settings, leading to write failures like:
+            // "alive replica num < 1 load required replica num 2"..
+            for (String unsupported : CloudDynamicPartitionProperty.UNSUPPORTED_PROPERTIES) {
+                properties.remove(unsupported);
+            }
+            executeBuildDynamicProperty();
+        } else if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
+            executeBuildDynamicProperty();
         }
         // reset storage vault
         clearStorageVault();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -196,10 +196,15 @@ public class TableProperty implements GsonPostProcessable {
     public TableProperty resetPropertiesForRestore(boolean reserveDynamicPartitionEnable, boolean reserveReplica,
                                                    ReplicaAllocation replicaAlloc) {
         if (Config.isCloudMode()) {
-            // In cloud mode, rewrite all properties that are not supported or need to be forced.
-            // This handles: replication_num, replication_allocation, dynamic_partition.replication_num,
-            // dynamic_partition.replication_allocation, storage_policy, storage_medium, in_memory, etc.
+            // In cloud mode, rewrite all unsupported or forced properties from the source cluster.
+            // These properties (e.g., replication_num, replication_allocation, storage_policy,
+            // storage_medium, in_memory, etc.) are not applicable in cloud mode. If kept, they would
+            // cause some critical problems.
             PropertyAnalyzer.getInstance().rewriteForceProperties(properties);
+            buildInMemory();
+            buildStorageMedium();
+            buildStoragePolicy();
+            buildMinLoadReplicaNum();
         }
         // disable dynamic partition
         if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -18,7 +18,6 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.DataSortInfo;
-import org.apache.doris.cloud.catalog.CloudDynamicPartitionProperty;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.util.PropertyAnalyzer;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -210,10 +210,10 @@ public class TableProperty implements GsonPostProcessable {
             // cluster. These properties (e.g., replication_num, replication_allocation, storage_policy)
             // are not applicable in cloud mode. If kept, they would cause dynamic partition scheduler
             // to create new partitions with incorrect settings, leading to write failures like:
-            // "alive replica num < 1 load required replica num 2"..
-            for (String unsupported : CloudDynamicPartitionProperty.UNSUPPORTED_PROPERTIES) {
-                properties.remove(unsupported);
-            }
+            // "alive replica num < 1 load required replica num 2".
+            properties.remove(DynamicPartitionProperty.REPLICATION_NUM);
+            properties.remove(DynamicPartitionProperty.REPLICATION_ALLOCATION);
+            properties.remove(DynamicPartitionProperty.STORAGE_POLICY);
             executeBuildDynamicProperty();
         } else if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
             executeBuildDynamicProperty();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -195,27 +195,21 @@ public class TableProperty implements GsonPostProcessable {
      */
     public TableProperty resetPropertiesForRestore(boolean reserveDynamicPartitionEnable, boolean reserveReplica,
                                                    ReplicaAllocation replicaAlloc) {
+        if (Config.isCloudMode()) {
+            // In cloud mode, rewrite all properties that are not supported or need to be forced.
+            // This handles: replication_num, replication_allocation, dynamic_partition.replication_num,
+            // dynamic_partition.replication_allocation, storage_policy, storage_medium, in_memory, etc.
+            PropertyAnalyzer.getInstance().rewriteForceProperties(properties);
+        }
         // disable dynamic partition
         if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
             if (!reserveDynamicPartitionEnable) {
                 properties.put(DynamicPartitionProperty.ENABLE, "false");
             }
+            executeBuildDynamicProperty();
         }
         if (!reserveReplica) {
             setReplicaAlloc(replicaAlloc);
-        }
-        if (Config.isCloudMode()) {
-            // In cloud mode, remove all unsupported dynamic partition properties from the source
-            // cluster. These properties (e.g., replication_num, replication_allocation, storage_policy)
-            // are not applicable in cloud mode. If kept, they would cause dynamic partition scheduler
-            // to create new partitions with incorrect settings, leading to write failures like:
-            // "alive replica num < 1 load required replica num 2".
-            properties.remove(DynamicPartitionProperty.REPLICATION_NUM);
-            properties.remove(DynamicPartitionProperty.REPLICATION_ALLOCATION);
-            properties.remove(DynamicPartitionProperty.STORAGE_POLICY);
-            executeBuildDynamicProperty();
-        } else if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
-            executeBuildDynamicProperty();
         }
         // reset storage vault
         clearStorageVault();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -18,7 +18,9 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.DataSortInfo;
+import org.apache.doris.cloud.catalog.CloudDynamicPartitionProperty;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.persist.OperationType;
 import org.apache.doris.persist.gson.GsonPostProcessable;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudDynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudDynamicPartitionProperty.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 public class CloudDynamicPartitionProperty extends DynamicPartitionProperty {
 
-    private static Set<String> unsupportedProperties = Sets.newHashSet(
+    public static final Set<String> UNSUPPORTED_PROPERTIES = Sets.newHashSet(
             DynamicPartitionProperty.REPLICATION_NUM,
             DynamicPartitionProperty.REPLICATION_ALLOCATION,
             DynamicPartitionProperty.STORAGE_POLICY);
@@ -37,7 +37,7 @@ public class CloudDynamicPartitionProperty extends DynamicPartitionProperty {
 
     @Override
     protected boolean supportProperty(String property) {
-        return !unsupportedProperties.contains(property);
+        return !UNSUPPORTED_PROPERTIES.contains(property);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudDynamicPartitionProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudDynamicPartitionProperty.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 public class CloudDynamicPartitionProperty extends DynamicPartitionProperty {
 
-    public static final Set<String> UNSUPPORTED_PROPERTIES = Sets.newHashSet(
+    private static Set<String> unsupportedProperties = Sets.newHashSet(
             DynamicPartitionProperty.REPLICATION_NUM,
             DynamicPartitionProperty.REPLICATION_ALLOCATION,
             DynamicPartitionProperty.STORAGE_POLICY);
@@ -37,7 +37,7 @@ public class CloudDynamicPartitionProperty extends DynamicPartitionProperty {
 
     @Override
     protected boolean supportProperty(String property) {
-        return !UNSUPPORTED_PROPERTIES.contains(property);
+        return !unsupportedProperties.contains(property);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/common/util/CloudPropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/common/util/CloudPropertyAnalyzer.java
@@ -41,6 +41,7 @@ public class CloudPropertyAnalyzer extends PropertyAnalyzer {
                 RewriteProperty.delete("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM),
                 RewriteProperty.delete("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_ALLOCATION),
                 RewriteProperty.delete(DynamicPartitionProperty.STORAGE_MEDIUM),
+                RewriteProperty.delete(DynamicPartitionProperty.STORAGE_POLICY),
                 RewriteProperty.replace(DynamicPartitionProperty.REPLICATION_NUM,
                         String.valueOf(ReplicaAllocation.DEFAULT_ALLOCATION.getTotalReplicaNum())),
                 RewriteProperty.replace(DynamicPartitionProperty.REPLICATION_ALLOCATION,

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -162,7 +162,7 @@ public class OlapTableTest {
         olapTable.setTableProperty(tableProperty);
 
         try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
-                    MockedStatic<PropertyAnalyzer> mockedPA = 
+                    MockedStatic<PropertyAnalyzer> mockedPA =
                             Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
             mockedConfig.when(Config::isCloudMode).thenReturn(true);
             mockedConfig.when(Config::isNotCloudMode).thenReturn(false);
@@ -233,7 +233,7 @@ public class OlapTableTest {
         ReplicaAllocation cloudReplicaAlloc = new ReplicaAllocation((short) 1);
 
         try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
-                    MockedStatic<PropertyAnalyzer> mockedPA =                     
+                    MockedStatic<PropertyAnalyzer> mockedPA =
                             Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
             mockedConfig.when(Config::isCloudMode).thenReturn(true);
             mockedConfig.when(Config::isNotCloudMode).thenReturn(false);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.info.IndexType;
+import org.apache.doris.cloud.common.util.CloudPropertyAnalyzer;
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.cloud.rpc.VersionHelper;
 import org.apache.doris.common.Config;
@@ -28,6 +29,7 @@ import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.UnitTestUtil;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.collect.Lists;
@@ -129,6 +131,125 @@ public class OlapTableTest {
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().isExist());
         Assert.assertFalse(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
         Assert.assertEquals((short) 3, olapTable.getDefaultReplicaAllocation().getTotalReplicaNum());
+    }
+
+    @Test
+    public void testResetPropertiesForRestoreInCloudMode() {
+        // simulate a restoring table with properties that are unsupported in cloud mode
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(DynamicPartitionProperty.ENABLE, "true");
+        properties.put(DynamicPartitionProperty.TIME_UNIT, "DAY");
+        properties.put(DynamicPartitionProperty.TIME_ZONE, "Asia/Shanghai");
+        properties.put(DynamicPartitionProperty.START, "-3");
+        properties.put(DynamicPartitionProperty.END, "3");
+        properties.put(DynamicPartitionProperty.PREFIX, "p");
+        properties.put(DynamicPartitionProperty.BUCKETS, "10");
+        properties.put(DynamicPartitionProperty.REPLICATION_NUM, "3");
+        properties.put(DynamicPartitionProperty.REPLICATION_ALLOCATION, "tag.location.default:3");
+        properties.put(DynamicPartitionProperty.STORAGE_MEDIUM, "SSD");
+        properties.put(PropertyAnalyzer.PROPERTIES_INMEMORY, "true");
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "SSD");
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, "s3_policy");
+        properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME, "2025-01-01 00:00:00");
+        properties.put(PropertyAnalyzer.PROPERTIES_MIN_LOAD_REPLICA_NUM, "2");
+        properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "3");
+        properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_ALLOCATION, "tag.location.default:3");
+        properties.put("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "3");
+        properties.put("default." + PropertyAnalyzer.PROPERTIES_REPLICATION_ALLOCATION, "tag.location.default:3");
+
+        TableProperty tableProperty = new TableProperty(properties);
+        OlapTable olapTable = new OlapTable();
+        olapTable.setTableProperty(tableProperty);
+
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<PropertyAnalyzer> mockedPA = 
+                        Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedConfig.when(Config::isCloudMode).thenReturn(true);
+            mockedConfig.when(Config::isNotCloudMode).thenReturn(false);
+            mockedPA.when(PropertyAnalyzer::getInstance).thenReturn(new CloudPropertyAnalyzer());
+
+            ReplicaAllocation cloudReplicaAlloc = new ReplicaAllocation((short) 1);
+            // reserveDynamicPartitionEnable=true, reserveReplica=false (forced in cloud mode)
+            olapTable.resetPropertiesForRestore(true, false, cloudReplicaAlloc, false);
+
+            Map<String, String> resultProps = olapTable.getTableProperty().getProperties();
+            Assert.assertFalse(resultProps.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY));
+            Assert.assertFalse(resultProps.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM));
+            Assert.assertFalse(resultProps.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY));
+            Assert.assertFalse(resultProps.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME));
+            Assert.assertFalse(resultProps.containsKey(PropertyAnalyzer.PROPERTIES_MIN_LOAD_REPLICA_NUM));
+            Assert.assertEquals((short) 1, olapTable.getDefaultReplicaAllocation().getTotalReplicaNum());
+            Assert.assertFalse(olapTable.getTableProperty().isInMemory());
+            Assert.assertNull(olapTable.getTableProperty().getStorageMedium());
+            Assert.assertEquals("", olapTable.getTableProperty().getStoragePolicy());
+            Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
+            DynamicPartitionProperty dynProp = olapTable.getTableProperty().getDynamicPartitionProperty();
+            Assert.assertTrue(resultProps.containsKey(DynamicPartitionProperty.REPLICATION_NUM));
+            Assert.assertTrue(resultProps.containsKey(DynamicPartitionProperty.REPLICATION_ALLOCATION));
+            Assert.assertFalse(resultProps.containsKey(DynamicPartitionProperty.STORAGE_MEDIUM));
+        }
+    }
+
+    @Test
+    public void testResetPartitionIdForRestore() {
+        PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
+        long origPartId = 1000L;
+        DataProperty origDataProperty = new DataProperty(TStorageMedium.SSD, 1735689600000L, "s3_policy");
+        ReplicaAllocation origReplicaAlloc = new ReplicaAllocation((short) 3);
+        partitionInfo.addPartition(origPartId, origDataProperty, origReplicaAlloc, true, true);
+
+        Map<Long, Long> partitionIdMap = Maps.newHashMap();
+        long newPartId = 2000L;
+        partitionIdMap.put(newPartId, origPartId);
+
+        ReplicaAllocation restoreReplicaAlloc = new ReplicaAllocation((short) 2);
+
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedConfig.when(Config::isCloudMode).thenReturn(false);
+            mockedConfig.when(Config::isNotCloudMode).thenReturn(true);
+
+            partitionInfo.resetPartitionIdForRestore(partitionIdMap, restoreReplicaAlloc, false);
+            Assert.assertEquals((short) 2,
+                    partitionInfo.getReplicaAllocation(newPartId).getTotalReplicaNum());
+            DataProperty newDataProperty = partitionInfo.getDataProperty(newPartId);
+            Assert.assertEquals(TStorageMedium.SSD, newDataProperty.getStorageMedium());
+            Assert.assertEquals(1735689600000L, newDataProperty.getCooldownTimeMs());
+            Assert.assertEquals("s3_policy", newDataProperty.getStoragePolicy());
+            Assert.assertTrue(partitionInfo.getIsInMemory(newPartId));
+        }
+    }
+
+    @Test
+    public void testResetPartitionIdForRestoreInCloudMode() {
+        PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
+        long origPartId = 1000L;
+        DataProperty origDataProperty = new DataProperty(TStorageMedium.SSD, 1735689600000L, "s3_policy");
+        ReplicaAllocation origReplicaAlloc = new ReplicaAllocation((short) 3);
+        partitionInfo.addPartition(origPartId, origDataProperty, origReplicaAlloc, true, true);
+        
+        Map<Long, Long> partitionIdMap = Maps.newHashMap();
+        long newPartId = 2000L;
+        partitionIdMap.put(newPartId, origPartId);
+
+        ReplicaAllocation cloudReplicaAlloc = new ReplicaAllocation((short) 1);
+
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<PropertyAnalyzer> mockedPA =                     
+                        Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedConfig.when(Config::isCloudMode).thenReturn(true);
+            mockedConfig.when(Config::isNotCloudMode).thenReturn(false);
+            mockedPA.when(PropertyAnalyzer::getInstance).thenReturn(new CloudPropertyAnalyzer());
+
+            partitionInfo.resetPartitionIdForRestore(partitionIdMap, cloudReplicaAlloc, false);
+            Assert.assertEquals((short) 1,
+                    partitionInfo.getReplicaAllocation(newPartId).getTotalReplicaNum());
+            DataProperty newDataProperty = partitionInfo.getDataProperty(newPartId);
+            Assert.assertEquals(DataProperty.DEFAULT_STORAGE_MEDIUM, newDataProperty.getStorageMedium());
+            Assert.assertEquals(DataProperty.MAX_COOLDOWN_TIME_MS, newDataProperty.getCooldownTimeMs());
+            Assert.assertEquals("", newDataProperty.getStoragePolicy());
+            Assert.assertTrue(newDataProperty.isMutable());
+            Assert.assertFalse(partitionInfo.getIsInMemory(newPartId));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -162,8 +162,8 @@ public class OlapTableTest {
         olapTable.setTableProperty(tableProperty);
 
         try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
-                MockedStatic<PropertyAnalyzer> mockedPA = 
-                        Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
+                    MockedStatic<PropertyAnalyzer> mockedPA = 
+                            Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
             mockedConfig.when(Config::isCloudMode).thenReturn(true);
             mockedConfig.when(Config::isNotCloudMode).thenReturn(false);
             mockedPA.when(PropertyAnalyzer::getInstance).thenReturn(new CloudPropertyAnalyzer());
@@ -183,7 +183,6 @@ public class OlapTableTest {
             Assert.assertNull(olapTable.getTableProperty().getStorageMedium());
             Assert.assertEquals("", olapTable.getTableProperty().getStoragePolicy());
             Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
-            DynamicPartitionProperty dynProp = olapTable.getTableProperty().getDynamicPartitionProperty();
             Assert.assertTrue(resultProps.containsKey(DynamicPartitionProperty.REPLICATION_NUM));
             Assert.assertTrue(resultProps.containsKey(DynamicPartitionProperty.REPLICATION_ALLOCATION));
             Assert.assertFalse(resultProps.containsKey(DynamicPartitionProperty.STORAGE_MEDIUM));
@@ -226,7 +225,7 @@ public class OlapTableTest {
         DataProperty origDataProperty = new DataProperty(TStorageMedium.SSD, 1735689600000L, "s3_policy");
         ReplicaAllocation origReplicaAlloc = new ReplicaAllocation((short) 3);
         partitionInfo.addPartition(origPartId, origDataProperty, origReplicaAlloc, true, true);
-        
+
         Map<Long, Long> partitionIdMap = Maps.newHashMap();
         long newPartId = 2000L;
         partitionIdMap.put(newPartId, origPartId);
@@ -234,8 +233,8 @@ public class OlapTableTest {
         ReplicaAllocation cloudReplicaAlloc = new ReplicaAllocation((short) 1);
 
         try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS);
-                MockedStatic<PropertyAnalyzer> mockedPA =                     
-                        Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
+                    MockedStatic<PropertyAnalyzer> mockedPA =                     
+                            Mockito.mockStatic(PropertyAnalyzer.class, Mockito.CALLS_REAL_METHODS)) {
             mockedConfig.when(Config::isCloudMode).thenReturn(true);
             mockedConfig.when(Config::isNotCloudMode).thenReturn(false);
             mockedPA.when(PropertyAnalyzer::getInstance).thenReturn(new CloudPropertyAnalyzer());

--- a/regression-test/suites/show_p0/test_show_create_table_with_storage_policy.groovy
+++ b/regression-test/suites/show_p0/test_show_create_table_with_storage_policy.groovy
@@ -90,7 +90,11 @@ suite("test_show_create_table_with_storage_policy") {
     String createSql = ret[0][1]
 
     ret = sql """ SHOW PARTITIONS FROM ${tableName} """
-    assertEquals(ret[9][12], storagePolicyName)
+    if (!isCloudMode()) {
+        assertEquals(ret[9][12], storagePolicyName)
+    } else {
+        assertEquals(ret[9][12], "")
+    }
 
     sql """ DROP TABLE IF EXISTS ${tableName} """
     // create table successfully with stmt from show create table


### PR DESCRIPTION
### What problem does this PR solve?

In cloud mode, rewrite all unsupported table properties and some partition info from the source cluster. 

These table properties (e.g., dynamic_partition.replication_num, dynamic_partition.replication_allocation, dynamic_partition.storage_policy, in_memory, storage_medium,min_load_replica_num...) are not applicable in cloud mode. 

And rewrite some non-applicable partition info as well.

If kept, they would cause some critical problems.

For example, dynamic partition scheduler creates new partitions with source cluster replication settings, leading to write failures like: "alive replica num < 1 load required replica num 2".

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

