### PR TITLE
[fix](build) upgrade license-maven-plugin from 2.0.0 to 2.5.0 in apache_hdfs_broker

### DIFF
--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -460,7 +460,7 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>add-third-party</id>


### PR DESCRIPTION
## Problem

  `license-maven-plugin 2.0.0` has a known `ConcurrentModificationException` bug in `AddThirdPartyMojo` initialization, especially in parallel builds (`-T` flag).

  ## Solution

  Upgrade `license-maven-plugin` from `2.0.0` to `2.5.0` (latest stable) in `fs_brokers/apache_hdfs_broker/pom.xml`.

  `fe/pom.xml` already uses `2.1.0+`, this change brings the broker module into alignment.

  ## Error before fix
  ```
  Failed to execute goal org.codehaus.mojo:license-maven-plugin:2.0.0:add-third-party
  could not init goal AddThirdPartyMojo for reason: ConcurrentModificationException
  ```