### PR TITLE
[test](geo) drop redundant assert_cast on already-typed null_map column

### DIFF
--- a/be/test/exprs/function/geo/functions_geo_test.cpp
+++ b/be/test/exprs/function/geo/functions_geo_test.cpp
@@ -372,7 +372,10 @@ TEST(VGeoFunctionsTest, function_geo_st_geometries_invalid) {
     // Insert non-null but invalid data
     auto* nullable_input = assert_cast<ColumnNullable*>(input_col.get());
     nullable_input->get_nested_column_ptr()->insert_data(invalid_buf.data(), invalid_buf.size());
-    assert_cast<ColumnUInt8*>(nullable_input->get_null_map_column_ptr().get())->insert_value(0);
+    // After #63491, ColumnNullable::get_null_map_column() already returns
+    // ColumnUInt8&, so the previous assert_cast<ColumnUInt8*>(...) is now
+    // rejected by the same-type static_assert in src/core/assert_cast.h.
+    nullable_input->get_null_map_column().insert_value(0);
     block.insert({std::move(input_col), input_type, "shape"});
 
     FunctionBasePtr func = SimpleFunctionFactory::instance().get_function(


### PR DESCRIPTION
## Proposed changes

Issue Number: close #N/A

### What problem does this PR solve?

BE-UT has been failing master-wide since both #63491 (strongly typed `ColumnNullable::get_null_map_column[_ptr]()` to \`ColumnUInt8\`) and #63049 (added \`functions_geo_test.cpp\`) landed today. The new test calls:

\`\`\`cpp
assert_cast<ColumnUInt8*>(nullable_input->get_null_map_column_ptr().get())
        ->insert_value(0);
\`\`\`

The inner expression is now already \`ColumnUInt8*\`, so the cast hits the same-type static_assert added by #63133 in \`src/core/assert_cast.h\`:

\`\`\`
static assertion failed due to requirement
'!std::is_same_v<doris::ColumnVector<doris::TYPE_BOOLEAN> *,
                 doris::ColumnVector<doris::TYPE_BOOLEAN> *>':
    assert_cast is redundant for the same type after removing cv/ref qualifiers
\`\`\`

That kills \`doris_be_test\` compilation on every PR that exercises BE-UT (e.g. #63692 953796, ##63637 953796).

Use the strongly typed \`get_null_map_column()\` (which returns \`ColumnUInt8&\`) directly so no cast is needed.

### Release note

None (test-only change, restores BE-UT compilation on master).

### Check List (For Author)

- [x] Test: Local ASAN ninja build of the affected translation unit (\`test/CMakeFiles/doris_be_test.dir/exprs/function/geo/functions_geo_test.cpp.o\`) is clean after this change.
- [x] Behavior changed: No
- [x] Does this need documentation: No