### PR TITLE
[fix](docker) support DNS readiness for Doris pods

### DIFF
--- a/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
+++ b/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
@@ -25,9 +25,13 @@ PROBE_TIMEOUT=60
 PROBE_INTERVAL=2
 # rpc port for fe communicate with be.
 HEARTBEAT_PORT=9050
+# timeout for fqdn ready check.
+DNS_READY_TIMEOUT=${DNS_READY_TIMEOUT:-120}
+# interval for fqdn ready check.
+DNS_READY_INTERVAL=${DNS_READY_INTERVAL:-2}
 # fqdn or ip
 MY_SELF=
-MY_IP=`hostname -i`
+MY_IP=${POD_IP:-$(hostname -I | awk '{print $1}')}
 MY_HOSTNAME=`hostname -f`
 DORIS_ROOT=${DORIS_ROOT:-"/opt/apache-doris"}
 # if config secret for basic auth about operate node of doris, the path must be `/etc/basic_auth`. This is set by operator and the key of password must be `password`.
@@ -232,6 +236,33 @@ collect_env_info()
     fi
 }
 
+wait_for_fqdn_ready()
+{
+    if [[ "x$HOST_TYPE" == "xIP" ]] ; then
+        return 0
+    fi
+
+    local fqdn=$MY_HOSTNAME
+    local start=`date +%s`
+    while true
+    do
+        if getent hosts "$fqdn" >/dev/null 2>&1 || nslookup "$fqdn" >/dev/null 2>&1 ; then
+            log_stderr "[info] fqdn $fqdn is ready."
+            return 0
+        fi
+
+        local now=`date +%s`
+        let "expire=start+DNS_READY_TIMEOUT"
+        if [[ $expire -le $now ]] ; then
+            log_stderr "[error] timeout waiting fqdn ready: $fqdn"
+            return 1
+        fi
+
+        log_stderr "[info] fqdn $fqdn not ready, sleep ${DNS_READY_INTERVAL}s ..."
+        sleep $DNS_READY_INTERVAL
+    done
+}
+
 parse_tls_connection_variables()
 {
     ENABLE_TLS=$(parse_confval_from_conf "enable_tls")
@@ -290,6 +321,10 @@ function get_compute_group_name()
     local pod_index=`echo $MY_HOSTNAME | awk -F'.' '{print $1}' | awk -F '-' '{print $NF}'`
     if [[ "$pod_index" -eq 0 ]]; then
         log_stderr "when first deploying, the first pod use the COMPUTE_GROUP_NAME environment as compute group name."
+        return 0
+    fi
+    if [[ "x$HOST_TYPE" == "xIP" ]]; then
+        log_stderr "IP mode uses the COMPUTE_GROUP_NAME environment as compute group name."
         return 0
     fi
 
@@ -352,18 +387,34 @@ function create_account()
 add_self_as_backend_with_no_tls()
 {
     local add_sql=$1
-     add_result=`timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "$add_sql" 2>&1`
+    log_stderr "[info] add backend sql: $add_sql"
+    add_result=`timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "$add_sql" 2>&1`
+    add_status=$?
     if echo $add_result | grep -w "1045" | grep -q -w "28000" &>/dev/null ; then
-        timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "$add_sql"
+        add_result=`timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "$add_sql" 2>&1`
+        add_status=$?
+    fi
+    log_stderr "[info] add backend result: $add_result"
+    if [[ $add_status -ne 0 ]]; then
+        log_stderr "[error] add backend failed with status $add_status."
+        return $add_status
     fi
 }
 
 add_self_as_backend_with_tls()
 {
     local add_sql=$1
-     add_result=`timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "$add_sql" 2>&1`
+    log_stderr "[info] add backend sql: $add_sql"
+    add_result=`timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "$add_sql" 2>&1`
+    add_status=$?
     if echo $add_result | grep -w "1045" | grep -q -w "28000" &>/dev/null ; then
-        timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "$add_sql"
+        add_result=`timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "$add_sql" 2>&1`
+        add_status=$?
+    fi
+    log_stderr "[info] add backend result: $add_result"
+    if [[ $add_status -ne 0 ]]; then
+        log_stderr "[error] add backend failed with status $add_status."
+        return $add_status
     fi
 }
 
@@ -431,6 +482,9 @@ function first_deploy_start()
             log_stderr "[info] myself ($MY_SELF:$HEARTBEAT_PORT)  not exist in FE and fe have leader register myself into fe."
             # add self as backend node.
             add_self_as_backend "$add_sql"
+            if [[ "$?" -ne 0 ]]; then
+                return 1
+            fi
             let "expire=start+timeout"
             now=`date +%s`
             if [[ $expire -le $now ]] ; then
@@ -575,6 +629,7 @@ resolve_password_from_secret
 # parse tls connection variables, if config `enbale_tls=true`, use tls connection to manage node.
 parse_tls_connection_variables
 collect_env_info
+wait_for_fqdn_ready || exit 1
 ./doris-debug --component be
 #add_self $fe_addr || exit $?
 check_and_register $fe_addrs

--- a/docker/runtime/be/resource/be_disaggregated_probe.sh
+++ b/docker/runtime/be/resource/be_disaggregated_probe.sh
@@ -85,6 +85,9 @@ ready_probe_with_tls()
     local webserver_port=$(parse_config_file_with_key "webserver_port")
     webserver_port=${webserver_port:=$DEFAULT_WEBSERVER_PORT}
     local fqdn=`hostname -f`
+    if ! getent hosts "$fqdn" >/dev/null 2>&1 && ! nslookup "$fqdn" >/dev/null 2>&1; then
+        exit 1
+    fi
     local url="https://${fqdn}:${webserver_port}/api/health"
     local response=$(curl --tlsv1.2 --cert $TLS_CERTIFICATE_PATH --cacert $TLS_CA_CERTIFICATE_PATH --key $TLS_PRIVATE_KEY_PATH -s -w "\n%{http_code}" $url)
     local http_code=$(echo "$response" | tail -n1)
@@ -109,6 +112,9 @@ ready_probe_with_no_tls()
     local webserver_port=$(parse_config_file_with_key "webserver_port")
     webserver_port=${webserver_port:=$DEFAULT_WEBSERVER_PORT}
     local host=`hostname -f`
+    if ! getent hosts "$host" >/dev/null 2>&1 && ! nslookup "$host" >/dev/null 2>&1; then
+        exit 1
+    fi
     local url="http://${host}:${webserver_port}/api/health"
 
     local response=$(curl -s -w "\n%{http_code}" $url)

--- a/docker/runtime/be/resource/be_entrypoint.sh
+++ b/docker/runtime/be/resource/be_entrypoint.sh
@@ -25,9 +25,13 @@ PROBE_TIMEOUT=60
 PROBE_INTERVAL=2
 # rpc port for fe communicate with be.
 HEARTBEAT_PORT=9050
+# timeout for fqdn ready check.
+DNS_READY_TIMEOUT=${DNS_READY_TIMEOUT:-120}
+# interval for fqdn ready check.
+DNS_READY_INTERVAL=${DNS_READY_INTERVAL:-2}
 # fqdn or ip
 MY_SELF=
-MY_IP=`hostname -i`
+MY_IP=${POD_IP:-$(hostname -I | awk '{print $1}')}
 MY_HOSTNAME=`hostname -f`
 DORIS_ROOT=${DORIS_ROOT:-"/opt/apache-doris"}
 # if config secret for basic auth about operate node of doris, the path must be `/etc/basic_auth`. This is set by operator and the key of password must be `password`.
@@ -263,6 +267,33 @@ collect_env_info()
     fi
 }
 
+wait_for_fqdn_ready()
+{
+    if [[ "x$HOST_TYPE" == "xIP" ]] ; then
+        return 0
+    fi
+
+    local fqdn=$MY_HOSTNAME
+    local start=`date +%s`
+    while true
+    do
+        if getent hosts "$fqdn" >/dev/null 2>&1 || nslookup "$fqdn" >/dev/null 2>&1 ; then
+            log_stderr "[info] fqdn $fqdn is ready."
+            return 0
+        fi
+
+        local now=`date +%s`
+        let "expire=start+DNS_READY_TIMEOUT"
+        if [[ $expire -le $now ]] ; then
+            log_stderr "[error] timeout waiting fqdn ready: $fqdn"
+            return 1
+        fi
+
+        log_stderr "[info] fqdn $fqdn not ready, sleep ${DNS_READY_INTERVAL}s ..."
+        sleep $DNS_READY_INTERVAL
+    done
+}
+
 parse_tls_connection_variables()
 {
     ENABLE_TLS=$(parse_confval_from_conf "enable_tls")
@@ -288,18 +319,36 @@ add_self_as_backend()
 add_self_as_backend_with_no_tls()
 {
     local svc=$1
-    add_result=`timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "ALTER SYSTEM ADD BACKEND \"$MY_SELF:$HEARTBEAT_PORT\";" 2>&1`
+    local add_sql="ALTER SYSTEM ADD BACKEND \"$MY_SELF:$HEARTBEAT_PORT\";"
+    log_stderr "[info] add backend sql: $add_sql"
+    add_result=`timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "$add_sql" 2>&1`
+    add_status=$?
     if echo $add_result | grep -w "1045" | grep -q -w "28000" &>/dev/null ; then
-        timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "ALTER SYSTEM ADD BACKEND \"$MY_SELF:$HEARTBEAT_PORT\";"
+        add_result=`timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "$add_sql" 2>&1`
+        add_status=$?
+    fi
+    log_stderr "[info] add backend result: $add_result"
+    if [[ $add_status -ne 0 ]]; then
+        log_stderr "[error] add backend failed with status $add_status."
+        return $add_status
     fi
 }
 
 add_self_as_backend_with_tls()
 {
     local svc=$1
-    add_result=`timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "ALTER SYSTEM ADD BACKEND \"$MY_SELF:$HEARTBEAT_PORT\";" 2>&1`
+    local add_sql="ALTER SYSTEM ADD BACKEND \"$MY_SELF:$HEARTBEAT_PORT\";"
+    log_stderr "[info] add backend sql: $add_sql"
+    add_result=`timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -uroot --skip-column-names --batch -e "$add_sql" 2>&1`
+    add_status=$?
     if echo $add_result | grep -w "1045" | grep -q -w "28000" &>/dev/null ; then
-        timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "ALTER SYSTEM ADD BACKEND \"$MY_SELF:$HEARTBEAT_PORT\";"
+        add_result=`timeout 15 mysql --ssl-mode=VERIFY_CA --tls-version="TLSv1.2" --ssl-ca=$TLS_CA_CERTIFICATE_PATH --ssl-cert=$TLS_CERTIFICATE_PATH --ssl-key=$TLS_PRIVATE_KEY_PATH --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u$DB_ADMIN_USER -p$DB_ADMIN_PASSWD --skip-column-names --batch -e "$add_sql" 2>&1`
+        add_status=$?
+    fi
+    log_stderr "[info] add backend result: $add_result"
+    if [[ $add_status -ne 0 ]]; then
+        log_stderr "[error] add backend failed with status $add_status."
+        return $add_status
     fi
 }
 
@@ -337,6 +386,9 @@ add_self()
             create_account $leader
             log_stderr "[info] myself ($MY_SELF:$HEARTBEAT_PORT)  not exist in FE and fe have leader register myself into fe."
             add_self_as_backend $svc
+            if [[ "$?" -ne 0 ]]; then
+                return 1
+            fi
 
             let "expire=start+timeout"
             now=`date +%s`
@@ -476,6 +528,7 @@ resolve_password_from_secret
 # parse tls connection variables, if config `enable_tls=true`, use tls connection to manage node.
 parse_tls_connection_variables
 collect_env_info
+wait_for_fqdn_ready || exit 1
 #add_self $fe_addr || exit $?
 check_and_register $fe_addrs
 ./doris-debug --component be

--- a/docker/runtime/fe/resource/fe_disaggregated_entrypoint.sh
+++ b/docker/runtime/fe/resource/fe_disaggregated_entrypoint.sh
@@ -42,6 +42,10 @@ POD_INDEX=$(hostname | awk -F '-' '{print $NF}')
 
 # probe interval: 2 seconds
 PROBE_INTERVAL=2
+# timeout for fqdn ready check.
+DNS_READY_TIMEOUT=${DNS_READY_TIMEOUT:-120}
+# interval for fqdn ready check.
+DNS_READY_INTERVAL=${DNS_READY_INTERVAL:-2}
 ## timeout for probe master: 60 seconds
 PROBE_MASTER_POD0_TIMEOUT=30 # at most 30 attempts, no less than the times needed for an election
 # no-0 ordinal pod timeout for probe master: 90 times
@@ -131,6 +135,33 @@ collect_env_info()
         doris_meta_path="/opt/apache-doris/fe/doris-meta"
     fi
     DORIS_META_DIR=$doris_meta_path
+}
+
+wait_for_fqdn_ready()
+{
+    if [[ "x$START_TYPE" != "xtrue" ]] ; then
+        return 0
+    fi
+
+    local fqdn=$POD_FQDN
+    local start=`date +%s`
+    while true
+    do
+        if getent hosts "$fqdn" >/dev/null 2>&1 || nslookup "$fqdn" >/dev/null 2>&1 ; then
+            log_stderr "[info] fqdn $fqdn is ready."
+            return 0
+        fi
+
+        local now=`date +%s`
+        let "expire=start+DNS_READY_TIMEOUT"
+        if [[ $expire -le $now ]] ; then
+            log_stderr "[error] timeout waiting fqdn ready: $fqdn"
+            return 1
+        fi
+
+        log_stderr "[info] fqdn $fqdn not ready, sleep ${DNS_READY_INTERVAL}s ..."
+        sleep $DNS_READY_INTERVAL
+    done
 }
 
 show_frontends()
@@ -516,6 +547,7 @@ resolve_password_from_secret
 parse_tls_connection_variables
 
 collect_env_info
+wait_for_fqdn_ready || exit 1
 doris_meta_dir=$(eval "echo \"$DORIS_META_DIR\"")
 if [[ -f "$doris_meta_dir/image/ROLE" ]]; then
     log_stderr "start fe with exist meta."

--- a/docker/runtime/fe/resource/fe_disaggregated_probe.sh
+++ b/docker/runtime/fe/resource/fe_disaggregated_probe.sh
@@ -70,6 +70,9 @@ ready_probe_with_no_tls()
     local http_port=$(parse_config_file_with_key "http_port")
     http_port=${http_port:=$DEFAULT_HTTP_PORT}
     local host=`hostname -f`
+    if ! getent hosts "$host" >/dev/null 2>&1 && ! nslookup "$host" >/dev/null 2>&1; then
+        exit 1
+    fi
     local url="http://${host}:${http_port}/api/health"
 
     local response=$(curl -s -w "\n%{http_code}" $url)
@@ -93,6 +96,9 @@ ready_probe_with_tls()
     local http_port=$(parse_config_file_with_key "http_port")
     http_port=${http_port:=$DEFAULT_HTTP_PORT}
     local host=`hostname -f`
+    if ! getent hosts "$host" >/dev/null 2>&1 && ! nslookup "$host" >/dev/null 2>&1; then
+        exit 1
+    fi
     local url="https://${host}:${http_port}/api/health"
     local response=$(curl --tlsv1.2 --cert $TLS_CERTIFICATE_PATH --cacert $TLS_CA_CERTIFICATE_PATH --key $TLS_PRIVATE_KEY_PATH -s -w "\n%{http_code}" $url)
     local http_code=$(echo "$response" | tail -n1)

--- a/docker/runtime/fe/resource/fe_entrypoint.sh
+++ b/docker/runtime/fe/resource/fe_entrypoint.sh
@@ -39,6 +39,10 @@ FE_MASTER=
 POD_INDEX=
 # probe interval: 2 seconds
 PROBE_INTERVAL=2
+# timeout for fqdn ready check.
+DNS_READY_TIMEOUT=${DNS_READY_TIMEOUT:-120}
+# interval for fqdn ready check.
+DNS_READY_INTERVAL=${DNS_READY_INTERVAL:-2}
 # timeout for probe master: 60 seconds
 PROBE_MASTER_POD0_TIMEOUT=60 # at most 30 attempts, no less than the times needed for an election
 # no-0 ordinal pod timeout for probe master: 90 times
@@ -140,6 +144,33 @@ collect_env_info()
         doris_meta_path="/opt/apache-doris/fe/doris-meta"
     fi
     DORIS_META_DIR=$doris_meta_path
+}
+
+wait_for_fqdn_ready()
+{
+    if [[ "x$START_TYPE" != "xtrue" ]] ; then
+        return 0
+    fi
+
+    local fqdn=$POD_FQDN
+    local start=`date +%s`
+    while true
+    do
+        if getent hosts "$fqdn" >/dev/null 2>&1 || nslookup "$fqdn" >/dev/null 2>&1 ; then
+            log_stderr "[info] fqdn $fqdn is ready."
+            return 0
+        fi
+
+        local now=`date +%s`
+        let "expire=start+DNS_READY_TIMEOUT"
+        if [[ $expire -le $now ]] ; then
+            log_stderr "[error] timeout waiting fqdn ready: $fqdn"
+            return 1
+        fi
+
+        log_stderr "[info] fqdn $fqdn not ready, sleep ${DNS_READY_INTERVAL}s ..."
+        sleep $DNS_READY_INTERVAL
+    done
 }
 
 # get all registered fe in cluster.
@@ -575,6 +606,7 @@ fi
 #first upate config
 update_conf_from_configmap
 collect_env_info
+wait_for_fqdn_ready || exit 1
 mount_kerberos_config
 # resolve password for root to manage nodes in doris.
 resolve_password_from_secret


### PR DESCRIPTION
## Proposed changes

Changes:
- Add DNS readiness gates before FE/BE startup in FQDN mode.
- Add DNS checks to disaggregated FE/BE readiness probes before calling `/api/health` by FQDN.
- Fix BE registration on dual-stack Kubernetes pods by using injected `POD_IP`, falling back to the first `hostname -I` address outside Kubernetes.
- In disaggregated BE `HOST_TYPE=IP` mode, use `COMPUTE_GROUP_NAME` directly instead of resolving pod-0 by FQDN.
- Log `ALTER SYSTEM ADD BACKEND` SQL/results and fail fast when backend registration fails.

No FE registration-address behavior is changed. Existing `stop_fe.sh --grace` and `stop_be.sh --grace` prestop behavior in apache/doris is kept unchanged.

## Validation

- `bash -n docker/runtime/fe/resource/fe_entrypoint.sh`
- `bash -n docker/runtime/fe/resource/fe_disaggregated_entrypoint.sh`
- `bash -n docker/runtime/fe/resource/fe_disaggregated_probe.sh`
- `bash -n docker/runtime/be/resource/be_entrypoint.sh`
- `bash -n docker/runtime/be/resource/be_disaggregated_entrypoint.sh`
- `bash -n docker/runtime/be/resource/be_disaggregated_probe.sh`
- `git diff --check`
