### PR TITLE
[fix](compile) guard MD5 AVX2-only symbols under __AVX2__

### DIFF
--- a/be/src/util/md5.cpp
+++ b/be/src/util/md5.cpp
@@ -31,10 +31,6 @@ namespace doris {
 
 namespace {
 
-constexpr uint32_t MD5_A0 = 0x67452301;
-constexpr uint32_t MD5_B0 = 0xefcdab89;
-constexpr uint32_t MD5_C0 = 0x98badcfe;
-constexpr uint32_t MD5_D0 = 0x10325476;
 constexpr unsigned char MD5_DUMMY_INPUT = 0;
 
 void md5_to_hex(const unsigned char* digest, char* out) {
@@ -44,6 +40,13 @@ void md5_to_hex(const unsigned char* digest, char* out) {
         *out++ = DIGITS[digest[i] & 0x0F];
     }
 }
+
+#ifdef __AVX2__
+
+constexpr uint32_t MD5_A0 = 0x67452301;
+constexpr uint32_t MD5_B0 = 0xefcdab89;
+constexpr uint32_t MD5_C0 = 0x98badcfe;
+constexpr uint32_t MD5_D0 = 0x10325476;
 
 size_t md5_num_blocks(size_t len) {
     return (len + 9 + 63) / 64;
@@ -62,8 +65,6 @@ size_t md5_pad_final_blocks(const unsigned char* data, size_t len, unsigned char
 
     return final_count;
 }
-
-#ifdef __AVX2__
 
 struct AVX2MD5Ops {
     using Vec = __m256i;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

The constants `MD5_A0`/`MD5_B0`/`MD5_C0`/`MD5_D0` and the helpers `md5_num_blocks()` and `md5_pad_final_blocks()` in `be/src/util/md5.cpp` are only referenced by the AVX2 multi-buffer code path (`md5_multi_buffer_compute` / `md5_binary_batch_avx2`). On non-AVX2 builds (e.g. macOS ARM64) the AVX2 block is `#ifdef`'d out, leaving these symbols orphaned and triggering compile errors under the project's strict warnings:

```
error: unused variable 'MD5_A0' [-Werror,-Wunused-const-variable]
error: unused variable 'MD5_B0' [-Werror,-Wunused-const-variable]
error: unused variable 'MD5_C0' [-Werror,-Wunused-const-variable]
error: unused variable 'MD5_D0' [-Werror,-Wunused-const-variable]
error: unused function 'md5_pad_final_blocks' [-Werror,-Wunused-function]
```

This PR moves those AVX2-only constants and helpers inside the existing `#ifdef __AVX2__` block where they belong. `MD5_DUMMY_INPUT` and `md5_to_hex` stay outside the guard because the non-AVX2 fallback in `md5_hex_batch` still uses them. No behavior change on x86_64; restores build on ARM/non-AVX2 targets.

### Release note

None

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.

  Manual test: verified `./build.sh --be -j 20` now succeeds on macOS ARM64.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label