### PR TITLE
[fix](compile) disambiguate Aws::Utils::DateTime ctor in kinesis_conf

### DIFF
--- a/be/src/load/routine_load/kinesis_conf.cpp
+++ b/be/src/load/routine_load/kinesis_conf.cpp
@@ -115,7 +115,8 @@ Status KinesisConf::apply_to_get_shard_iterator_request(
     it = _get_shard_iterator_params.find("timestamp");
     if (it != _get_shard_iterator_params.end()) {
         try {
-            request.SetTimestamp(Aws::Utils::DateTime(std::stol(it->second)));
+            request.SetTimestamp(
+                    Aws::Utils::DateTime(static_cast<int64_t>(std::stoll(it->second))));
         } catch (const std::exception&) {
             return Status::InternalError("Failed to apply get_shard_iterator.timestamp: {}",
                                          it->second);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

`be/src/load/routine_load/kinesis_conf.cpp:118` constructs `Aws::Utils::DateTime` from `std::stol(...)`. The AWS SDK declares two constructors:

```cpp
DateTime(int64_t millisSinceEpoch);
DateTime(double epoch_millis);
```

On macOS ARM64 (Apple LP64 with libc++), `int64_t` is typedef'd to `long long` — distinct from the `long` that `std::stol` returns. Both `long -> long long` and `long -> double` are same-rank conversions, so overload resolution is ambiguous and the build fails:

```
error: ambiguous conversion for functional-style cast from 'long' to 'Aws::Utils::DateTime'
  118 |             request.SetTimestamp(Aws::Utils::DateTime(std::stol(it->second)));
note: candidate constructor   DateTime(int64_t millisSinceEpoch);
note: candidate constructor   DateTime(double epoch_millis);
```

Note: a naive switch to `std::stoll` would *symmetrically* break Linux x86_64 (glibc) builds, where `int64_t` is typedef'd to `long` — there, `long long` is ambiguous against `(long)` vs `(double)` for the same reason.

The portable fix is to parse with `std::stoll` (explicit 64-bit, semantically correct for milliseconds-since-epoch) and `static_cast<int64_t>` to bind to the integer constructor regardless of what `int64_t` resolves to on the target platform:

```cpp
request.SetTimestamp(
        Aws::Utils::DateTime(static_cast<int64_t>(std::stoll(it->second))));
```

Verified with an overload-resolution mini-repro using the same clang-20 toolchain: only the explicit-cast form is unambiguous on both `int64_t = long long` (macOS) and `int64_t = long` (Linux x86_64) targets.

### Release note

None

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.

  Manual test: verified `./build.sh --be -j 20` now succeeds on macOS ARM64. The runtime value is identical (`std::stoll` parses the same string to a 64-bit integer; `static_cast<int64_t>` is a no-op cast on every supported platform).

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label