### PR TITLE
[fix](show variables) Fix changed variable output in show variables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -6515,28 +6515,28 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     @Override
     public LogicalPlan visitShowVariables(ShowVariablesContext ctx) {
         SetType statementScope = visitStatementScope(ctx.statementScope());
-        if (ctx.wildWhere() != null) {
-            if (ctx.wildWhere().LIKE() != null) {
-                return new ShowVariablesCommand(statementScope,
-                        stripQuotes(ctx.wildWhere().STRING_LITERAL().getText()));
-            } else {
-                StringBuilder sb = new StringBuilder();
-                sb.append("SELECT `VARIABLE_NAME` AS `Variable_name`, `VARIABLE_VALUE` AS `Value` FROM ");
-                sb.append("`").append(InternalCatalog.INTERNAL_CATALOG_NAME).append("`");
-                sb.append(".");
-                sb.append("`").append(InfoSchemaDb.DATABASE_NAME).append("`");
-                sb.append(".");
-                if (statementScope == SetType.GLOBAL) {
-                    sb.append("`global_variables` ");
-                } else {
-                    sb.append("`session_variables` ");
-                }
-                sb.append(getOriginSql(ctx.wildWhere()));
-                return new NereidsParser().parseSingle(sb.toString());
-            }
+        LogicalPlan plan;
+        if (ctx.wildWhere() == null) {
+            plan = new ShowVariablesCommand(statementScope, null);
+        } else if (ctx.wildWhere().LIKE() != null) {
+            plan = new ShowVariablesCommand(statementScope,
+                    stripQuotes(ctx.wildWhere().STRING_LITERAL().getText()));
         } else {
-            return new ShowVariablesCommand(statementScope, null);
+            StringBuilder sb = new StringBuilder();
+            sb.append("SELECT `VARIABLE_NAME` AS `Variable_name`, `VARIABLE_VALUE` AS `Value` FROM ");
+            sb.append("`").append(InternalCatalog.INTERNAL_CATALOG_NAME).append("`");
+            sb.append(".");
+            sb.append("`").append(InfoSchemaDb.DATABASE_NAME).append("`");
+            sb.append(".");
+            if (statementScope == SetType.GLOBAL) {
+                sb.append("`global_variables` ");
+            } else {
+                sb.append("`session_variables` ");
+            }
+            sb.append(getOriginSql(ctx.wildWhere()));
+            plan = new NereidsParser().parseSingle(sb.toString());
         }
+        return plan;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -120,6 +120,7 @@ import org.apache.doris.qe.MysqlConnectProcessor;
 import org.apache.doris.qe.NereidsCoordinator;
 import org.apache.doris.qe.QeProcessorImpl;
 import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.service.arrowflight.FlightSqlConnectProcessor;
@@ -1007,7 +1008,17 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (ctx == null) {
             return result;
         }
-        vars = VariableMgr.dump(SetType.fromThrift(params.getVarType()), ctx.getSessionVariable(), null);
+        // SHOW VARIABLES can be evaluated through an internal schema query. Planning that internal
+        // query may call setVarOnce() and temporarily change the live session variable
+        // (for example disable_join_reorder). Dump a reverted clone so Changed only
+        // reflects user-visible session settings, while the real session remains untouched.
+        SessionVariable sessionVariable = VariableMgr.cloneSessionVariable(ctx.getSessionVariable());
+        try {
+            VariableMgr.revertSessionValue(sessionVariable);
+        } catch (DdlException e) {
+            throw new TException(e);
+        }
+        vars = VariableMgr.dump(SetType.fromThrift(params.getVarType()), sessionVariable, null);
         result.setVariables(vars);
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1008,10 +1008,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (ctx == null) {
             return result;
         }
-        // SHOW VARIABLES can be evaluated through an internal schema query. Planning that internal
-        // query may call setVarOnce() and temporarily change the live session variable
-        // (for example disable_join_reorder). Dump a reverted clone so Changed only
-        // reflects user-visible session settings, while the real session remains untouched.
+        // SHOW VARIABLES can be evaluated through an internal schema query. Planning that
+        // internal query may call setVarOnce() and temporarily change the live session
+        // variable (for example disable_join_reorder). Cloning alone is not enough,
+        // because the clone would keep both the temporary value and its recorded origin.
+        // Revert only the clone so Changed reflects user-visible session settings,
+        // while the real session remains untouched.
         SessionVariable sessionVariable = VariableMgr.cloneSessionVariable(ctx.getSessionVariable());
         try {
             VariableMgr.revertSessionValue(sessionVariable);

--- a/regression-test/data/query_p0/ddl/show_variables/show_variables_command.out
+++ b/regression-test/data/query_p0/ddl/show_variables/show_variables_command.out
@@ -8,3 +8,11 @@ license	Apache License, Version 2.0
 -- !cmd --
 license	Apache License, Version 2.0
 
+-- !changed --
+enable_profile	true
+
+-- !not_changed --
+
+-- !global --
+license	Apache License, Version 2.0
+

--- a/regression-test/suites/query_p0/ddl/show_variables/show_variables_command.groovy
+++ b/regression-test/suites/query_p0/ddl/show_variables/show_variables_command.groovy
@@ -20,7 +20,15 @@ suite("show_variables_command") {
     checkNereidsExecute("""show variables like 'li_ense'""")
     checkNereidsExecute("""show variables where variable_name like 'li_ense'""")
     checkNereidsExecute("""show variables where variable_name = 'license'""")
+    checkNereidsExecute("""show variables where changed = 1""")
+    checkNereidsExecute("""show global variables where variable_name = 'license'""")
     qt_cmd("""show variables like 'li_ense'""")
     qt_cmd("""show variables where variable_name like 'li_ense'""")
     qt_cmd("""show variables where variable_name = 'license'""")
+
+    sql "set enable_profile = true"
+    qt_changed("""show variables where changed = 1 and variable_name = 'enable_profile'""")
+    qt_not_changed("""show variables where changed = 1 and variable_name = 'license'""")
+    qt_global("""show global variables where variable_name = 'license'""")
+    sql "UNSET VARIABLE ALL"
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #0

Related PR: #

Problem Summary: SHOW VARIABLES WHERE is evaluated through an internal schema query. During planning of that internal query, FE may call setVarOnce() and temporarily change session variables such as disable_join_reorder. The schema scan then dumps those temporary values and reports them as Changed, even though they are not user-visible session changes. This patch dumps variables from a reverted clone so one-shot internal values do not affect SHOW VARIABLES output, while preserving the existing information_schema WHERE execution behavior.

### Release note

Fix incorrect SHOW VARIABLES WHERE changed = 1 output caused by internal one-shot session variables.

### Check List (For Author)

- Test: Regression test / Manual test
    - tools/fast-compile-fe.sh LogicalPlanBuilder.java ShowVariablesCommand.java FrontendServiceImpl.java
    - tools/fast-compile-fe.sh FrontendServiceImpl.java
    - run-regression-test.sh --run -d query_p0/ddl/show_variables -s show_variables_command
    - Manual test: SET enable_profile=true and SHOW VARIABLES WHERE variable_name = enable_profile
- Behavior changed: Yes. SHOW VARIABLES no longer reports internal one-shot session variables as user changed values.
- Does this need documentation: No
