### PR TITLE
[fix](be) Fix DCHECK in LocalExchangeSharedState::sub_total_mem_usage

### DIFF
--- a/be/src/exec/pipeline/dependency.h
+++ b/be/src/exec/pipeline/dependency.h
@@ -927,7 +927,8 @@ public:
 
     void sub_total_mem_usage(size_t delta) {
         auto prev_usage = mem_usage.fetch_sub(delta);
-        DCHECK_GE(prev_usage - delta, 0) << "prev_usage: " << prev_usage << " delta: " << delta;
+        DCHECK_GE(prev_usage, cast_set<int64_t>(delta))
+                << "prev_usage: " << prev_usage << " delta: " << delta;
         if (cast_set<int64_t>(prev_usage - delta) <= _buffer_mem_limit) {
             sink_deps.front()->set_ready();
         }


### PR DESCRIPTION
Issue Number: close #xxx

Problem Summary: In LocalExchangeSharedState::sub_total_mem_usage(), `mem_usage` is `std::atomic<int64_t>` but `delta` is `size_t`. The existing debug check

    DCHECK_GE(prev_usage - delta, 0);

was never effective: the usual arithmetic conversions promote `prev_usage - delta` to `size_t`, and an unsigned expression is trivially `>= 0`. So the guard against `mem_usage` underflow (subtracting more than was added) silently passed in all debug builds, leaving any over-subtraction undetected.

Fix: compare `prev_usage` (int64_t) against `cast_set<int64_t>(delta)` so the comparison is performed entirely in signed space, and a real underflow will actually trip the DCHECK with the original prev_usage and delta values in the failure message. The release-mode guard on the next line (`cast_set<int64_t>(prev_usage - delta)` throws on underflow because the wrapped size_t result exceeds INT64_MAX) is preserved as-is.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

