### PR TITLE
[refine](pipeline) stop splitting distinct streaming agg output by batch size

### DIFF
--- a/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
+++ b/be/src/exec/operator/distinct_streaming_aggregation_operator.cpp
@@ -36,7 +36,6 @@ namespace doris {
 DistinctStreamingAggLocalState::DistinctStreamingAggLocalState(RuntimeState* state,
                                                                OperatorXBase* parent)
         : PipelineXLocalState<FakeSharedState>(state, parent),
-          batch_size(state->batch_size()),
           _agg_data(std::make_unique<DistinctDataVariants>()),
           _child_block(Block::create_unique()),
           _aggregated_block(Block::create_unique()),
@@ -195,8 +194,7 @@ Status DistinctStreamingAggLocalState::_distinct_pre_agg_with_serialized_key(
     SCOPED_TIMER(_insert_keys_to_column_timer);
     if (mem_reuse) {
         if (_stop_emplace_flag && !out_block->empty()) {
-            // when out_block row >= batch_size, push it to data_queue, so when _stop_emplace_flag = true, maybe have some data in block
-            // need output those data firstly
+            // Output existing aggregated rows before switching to passthrough mode.
             DCHECK(_distinct_row.empty());
             _distinct_row.resize(rows);
             std::iota(_distinct_row.begin(), _distinct_row.end(), 0);
@@ -211,28 +209,10 @@ Status DistinctStreamingAggLocalState::_distinct_pre_agg_with_serialized_key(
                 in_block->replace_by_position(result_idxs[i], output_column);
             }
         } else {
-            DCHECK_EQ(_cache_block.rows(), 0);
-            // is output row > batch_size, split some to cache_block
-            if (out_block->rows() + _distinct_row.size() > batch_size) {
-                size_t split_size = batch_size - out_block->rows();
-                for (int i = 0; i < key_size; ++i) {
-                    auto output_dst =
-                            IColumn::mutate(std::move(out_block->get_by_position(i).column));
-                    key_columns[i]->append_data_by_selector(output_dst, _distinct_row, 0,
-                                                            split_size);
-                    out_block->get_by_position(i).column = std::move(output_dst);
-                    auto cache_dst =
-                            IColumn::mutate(std::move(_cache_block.get_by_position(i).column));
-                    key_columns[i]->append_data_by_selector(cache_dst, _distinct_row, split_size,
-                                                            _distinct_row.size());
-                    _cache_block.get_by_position(i).column = std::move(cache_dst);
-                }
-            } else {
-                for (int i = 0; i < key_size; ++i) {
-                    auto dst = IColumn::mutate(std::move(out_block->get_by_position(i).column));
-                    key_columns[i]->append_data_by_selector(dst, _distinct_row);
-                    out_block->get_by_position(i).column = std::move(dst);
-                }
+            for (int i = 0; i < key_size; ++i) {
+                auto dst = IColumn::mutate(std::move(out_block->get_by_position(i).column));
+                key_columns[i]->append_data_by_selector(dst, _distinct_row);
+                out_block->get_by_position(i).column = std::move(dst);
             }
         }
     } else {
@@ -252,7 +232,6 @@ Status DistinctStreamingAggLocalState::_distinct_pre_agg_with_serialized_key(
             }
         }
         out_block->swap(Block(columns_with_schema));
-        _cache_block = out_block->clone_empty();
         if (_stop_emplace_flag) {
             in_block->clear(); // clear the column ref with stop_emplace_flag = true
         }
@@ -379,10 +358,6 @@ Status DistinctStreamingAggOperatorX::pull(RuntimeState* state, Block* block, bo
     if (!local_state._aggregated_block->empty()) {
         block->swap(*local_state._aggregated_block);
         local_state._aggregated_block->clear_column_data(block->columns());
-        // The cache block may have additional data due to exceeding the batch size.
-        if (!local_state._cache_block.empty()) {
-            local_state._swap_cache_block(local_state._aggregated_block.get());
-        }
     }
 
     local_state._make_nullable_output_key(block);
@@ -428,15 +403,6 @@ Status DistinctStreamingAggLocalState::close(RuntimeState* state) {
         return Status::OK();
     }
     _aggregated_block->clear();
-    // If the limit is reached, there may still be remaining data in the cache block.
-    // If the limit is not reached, the cache block must be empty.
-    // If the query is canceled, it might not satisfy the above conditions.
-    if (!state->is_cancelled()) {
-        if (!_reach_limit && !_cache_block.empty()) {
-            LOG_WARNING("If the limit is not reached, the cache block must be empty.");
-        }
-    }
-    _cache_block.clear();
 
     _arena.clear();
     return Base::close(state);

--- a/be/src/exec/operator/distinct_streaming_aggregation_operator.h
+++ b/be/src/exec/operator/distinct_streaming_aggregation_operator.h
@@ -56,18 +56,11 @@ private:
     void _make_nullable_output_key(Block* block);
     bool _should_expand_preagg_hash_tables();
 
-    void _swap_cache_block(Block* block) {
-        DCHECK(!_cache_block.is_empty_column());
-        block->swap(_cache_block);
-        _cache_block = block->clone_empty();
-    }
-
     IColumn::Selector _distinct_row;
     Arena _arena;
     size_t _input_num_rows = 0;
     bool _should_expand_hash_table = true;
     bool _stop_emplace_flag = false;
-    const int batch_size;
     std::unique_ptr<DistinctDataVariants> _agg_data = nullptr;
     // group by k1,k2
     VExprContextSPtrs _probe_expr_ctxs;
@@ -75,7 +68,6 @@ private:
     bool _child_eos = false;
     bool _reach_limit = false;
     std::unique_ptr<Block> _aggregated_block = nullptr;
-    Block _cache_block;
     RuntimeProfile::Counter* _build_timer = nullptr;
     RuntimeProfile::Counter* _expr_timer = nullptr;
     RuntimeProfile::Counter* _hash_table_compute_timer = nullptr;

--- a/be/test/exec/operator/distinct_streaming_aggregation_operator_test.cpp
+++ b/be/test/exec/operator/distinct_streaming_aggregation_operator_test.cpp
@@ -127,7 +127,6 @@ TEST_F(DistinctStreamingAggOperatorTest, test3) {
         auto block =
                 ColumnHelper::create_block<DataTypeInt64>({1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4});
         EXPECT_TRUE(op->push(state.get(), &block, false));
-        EXPECT_EQ(local_state->_cache_block.rows(), 0);
         EXPECT_EQ(local_state->_aggregated_block->rows(), 4);
         EXPECT_TRUE(op->need_more_input_data(state.get()));
     }
@@ -135,7 +134,6 @@ TEST_F(DistinctStreamingAggOperatorTest, test3) {
     {
         auto block = ColumnHelper::create_block<DataTypeInt64>({5, 6, 7, 8});
         EXPECT_TRUE(op->push(state.get(), &block, false));
-        EXPECT_EQ(local_state->_cache_block.rows(), 0);
         EXPECT_EQ(local_state->_aggregated_block->rows(), 8);
         EXPECT_TRUE(op->need_more_input_data(state.get()));
     }
@@ -143,8 +141,7 @@ TEST_F(DistinctStreamingAggOperatorTest, test3) {
     {
         auto block = ColumnHelper::create_block<DataTypeInt64>({9, 10, 11, 12});
         EXPECT_TRUE(op->push(state.get(), &block, false));
-        EXPECT_EQ(local_state->_cache_block.rows(), 2);
-        EXPECT_EQ(local_state->_aggregated_block->rows(), 10);
+        EXPECT_EQ(local_state->_aggregated_block->rows(), 12);
         EXPECT_FALSE(op->need_more_input_data(state.get()));
     }
 
@@ -153,32 +150,13 @@ TEST_F(DistinctStreamingAggOperatorTest, test3) {
         bool eos = false;
         EXPECT_TRUE(op->pull(state.get(), &block, &eos));
         EXPECT_FALSE(eos);
-        EXPECT_EQ(local_state->_cache_block.rows(), 0);
-        EXPECT_EQ(local_state->_aggregated_block->rows(), 2);
-    }
-    {
-        local_state->_stop_emplace_flag = true;
-        auto block = ColumnHelper::create_block<DataTypeInt64>({13, 14, 15});
-        EXPECT_TRUE(op->push(state.get(), &block, false));
-        EXPECT_EQ(local_state->_cache_block.rows(), 0);
-        EXPECT_EQ(local_state->_aggregated_block->rows(), 5);
-        EXPECT_FALSE(op->need_more_input_data(state.get()));
-    }
-    {
-        Block block;
-        bool eos = false;
-        EXPECT_TRUE(op->pull(state.get(), &block, &eos));
-        EXPECT_FALSE(eos);
-        EXPECT_EQ(block.rows(), 5);
-        EXPECT_EQ(local_state->_cache_block.rows(), 0);
+        EXPECT_EQ(block.rows(), 12);
         EXPECT_EQ(local_state->_aggregated_block->rows(), 0);
     }
     {
-        EXPECT_TRUE(op->need_more_input_data(state.get()));
         local_state->_stop_emplace_flag = true;
         auto block = ColumnHelper::create_block<DataTypeInt64>({13, 14, 15});
         EXPECT_TRUE(op->push(state.get(), &block, false));
-        EXPECT_EQ(local_state->_cache_block.rows(), 0);
         EXPECT_EQ(local_state->_aggregated_block->rows(), 3);
         EXPECT_FALSE(op->need_more_input_data(state.get()));
     }
@@ -188,7 +166,22 @@ TEST_F(DistinctStreamingAggOperatorTest, test3) {
         EXPECT_TRUE(op->pull(state.get(), &block, &eos));
         EXPECT_FALSE(eos);
         EXPECT_EQ(block.rows(), 3);
-        EXPECT_EQ(local_state->_cache_block.rows(), 0);
+        EXPECT_EQ(local_state->_aggregated_block->rows(), 0);
+    }
+    {
+        EXPECT_TRUE(op->need_more_input_data(state.get()));
+        local_state->_stop_emplace_flag = true;
+        auto block = ColumnHelper::create_block<DataTypeInt64>({13, 14, 15});
+        EXPECT_TRUE(op->push(state.get(), &block, false));
+        EXPECT_EQ(local_state->_aggregated_block->rows(), 3);
+        EXPECT_FALSE(op->need_more_input_data(state.get()));
+    }
+    {
+        Block block;
+        bool eos = false;
+        EXPECT_TRUE(op->pull(state.get(), &block, &eos));
+        EXPECT_FALSE(eos);
+        EXPECT_EQ(block.rows(), 3);
         EXPECT_EQ(local_state->_aggregated_block->rows(), 0);
     }
     { EXPECT_TRUE(op->close(state.get())); }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
DistinctStreamingAggOperatorX kept each output block at or below batch_size by splitting rows between _aggregated_block and an extra _cache_block, then replaying the cached tail on the next pull. Root cause: the operator coupled its accumulation threshold with a hard output-size cap. This change removes the cache path and appends all distinct rows directly into _aggregated_block. The operator still uses batch_size in need_more_input_data() to decide when to stop reading more input, but once one append crosses the threshold it now returns the full block instead of splitting it.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

