### PR TITLE
[fix](statistics) Avoid re-estimating pruned partition predicates in stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PrunePartitionPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PrunePartitionPredicate.java
@@ -17,26 +17,15 @@
 
 package org.apache.doris.nereids.processor.post;
 
-import org.apache.doris.analysis.Expr;
-import org.apache.doris.analysis.SlotRef;
-import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.Slot;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.PartitionPrunablePredicate;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
-import org.apache.doris.nereids.util.ExpressionUtils;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -67,25 +56,9 @@ public class PrunePartitionPredicate extends PlanPostProcessor {
         if (skipPrunePredicate) {
             return filter;
         }
-        Set<Long> scanPartitions = new HashSet<>(scan.getSelectedPartitionIds());
-        Map<String, Slot> nameToOutputSlot = buildNameToSlotMap(scan);
-
+        Set<Expression> prunableConjuncts = entryOpt.get().getRewrittenPrunableConjuncts(scan);
         Set<Expression> remaining = new LinkedHashSet<>(filter.getConjuncts());
-        boolean changed = false;
-        PartitionPrunablePredicate entry = entryOpt.get();
-        if (entry.getSelectedPartitionIds().containsAll(scanPartitions)) {
-            Map<Expression, Expression> slotReplaceMap =
-                    buildSlotReplaceMap(entry.getSnapshotPartitionSlots(), nameToOutputSlot);
-            if (slotReplaceMap != null) {
-                for (Expression conjunct : entry.getPrunableConjuncts()) {
-                    Expression rewritten = slotReplaceMap.isEmpty()
-                            ? conjunct : ExpressionUtils.replace(conjunct, slotReplaceMap);
-                    if (remaining.remove(rewritten)) {
-                        changed = true;
-                    }
-                }
-            }
-        }
+        boolean changed = remaining.removeAll(prunableConjuncts);
         if (!changed) {
             return filter;
         }
@@ -94,53 +67,5 @@ public class PrunePartitionPredicate extends PlanPostProcessor {
         }
         return filter.withConjunctsAndChild(remaining, scan)
                 .copyStatsAndGroupIdFrom((AbstractPhysicalPlan) filter);
-    }
-
-    private static Map<String, Slot> buildNameToSlotMap(PhysicalOlapScan scan) {
-        OlapTable table = scan.getTable();
-        List<Slot> slots = scan.getOutput();
-        Map<String, Slot> map = new HashMap<>(slots.size());
-        if (scan.getSelectedIndexId() == table.getBaseIndexId()) {
-            for (Slot slot : slots) {
-                map.put(slot.getName().toLowerCase(), slot);
-            }
-        } else {
-            for (Slot slot : slots) {
-                if (!(slot instanceof SlotReference)) {
-                    continue;
-                }
-                SlotReference slotReference = (SlotReference) slot;
-                Optional<Column> columnOptional = slotReference.getOriginalColumn();
-                if (!columnOptional.isPresent()) {
-                    continue;
-                }
-                Expr expr = columnOptional.get().getDefineExpr();
-                if (!(expr instanceof SlotRef)) {
-                    continue;
-                }
-                map.put(((SlotRef) expr).getColumnName().toLowerCase(), slot);
-            }
-        }
-        return map;
-    }
-
-    /**
-     * Map each recorded snapshot slot to the scan's current output slot of the
-     * same column name. Returns null when any snapshot slot cannot be located,
-     * so the caller can skip the entry.
-     */
-    private static Map<Expression, Expression> buildSlotReplaceMap(
-            List<Slot> snapshotSlots, Map<String, Slot> nameToOutputSlot) {
-        Map<Expression, Expression> replaceMap = new HashMap<>(snapshotSlots.size());
-        for (Slot snapshot : snapshotSlots) {
-            Slot current = nameToOutputSlot.get(snapshot.getName().toLowerCase());
-            if (current == null) {
-                return null;
-            }
-            if (!snapshot.equals(current)) {
-                replaceMap.put(snapshot, current);
-            }
-        }
-        return replaceMap;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -40,6 +40,7 @@ import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.ComparableLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -122,6 +123,13 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
     @Override
     public Statistics visit(Expression expr, EstimationContext context) {
         return context.statistics.withSel(DEFAULT_INEQUALITY_COEFFICIENT);
+    }
+
+    @Override
+    public Statistics visitBooleanLiteral(BooleanLiteral booleanLiteral, EstimationContext context) {
+        return new StatisticsBuilder(context.statistics)
+                .setRowCount(booleanLiteral.getValue() ? context.statistics.getRowCount() : 0)
+                .build();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -49,6 +49,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.PartitionPrunablePredicate;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Aggregate;
 import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
@@ -137,6 +138,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalWindow;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalWorkTableReference;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanVisitor;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.statistics.AnalysisManager;
@@ -165,6 +167,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -632,6 +635,10 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             }
             checkIfUnknownStatsUsedAsKey(builder);
             builder.setRowCount(selectedPartitionsRowCount);
+            Optional<PartitionPrunablePredicate> entryOpt = olapScan.getPartitionPrunablePredicates();
+            if (entryOpt.isPresent()) {
+                builder.setConjunctsAppliedToRowCount(entryOpt.get().getRewrittenPrunableConjuncts(olapScan));
+            }
         } else {
             // get table level stats
             for (SlotReference slot : visibleOutputSlots) {
@@ -1208,7 +1215,9 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
      * computeFilter
      */
     public Statistics computeFilter(Filter filter, Statistics inputStats) {
-        return new FilterEstimation().estimate(filter.getPredicate(), inputStats);
+        Set<Expression> conjuncts = new LinkedHashSet<>(filter.getConjuncts());
+        conjuncts.removeAll(inputStats.getConjunctsAppliedToRowCount());
+        return new FilterEstimation().estimate(ExpressionUtils.and(conjuncts), inputStats);
     }
 
     private ColumnStatistic getColumnStatistic(TableIf table, String colName, long idxId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PartitionPrunablePredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PartitionPrunablePredicate.java
@@ -17,14 +17,24 @@
 
 package org.apache.doris.nereids.trees.plans;
 
+import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
+import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -91,5 +101,72 @@ public class PartitionPrunablePredicate {
 
     public Set<Expression> getPrunableConjuncts() {
         return prunableConjuncts;
+    }
+
+    /** Get rewritten prunable conjuncts for the scan output slots. */
+    public Set<Expression> getRewrittenPrunableConjuncts(OlapScan scan) {
+        if (!selectedPartitionIds.containsAll(scan.getSelectedPartitionIds())) {
+            return ImmutableSet.of();
+        }
+        Map<Expression, Expression> slotReplaceMap = buildSlotReplaceMap(
+                snapshotPartitionSlots, buildNameToSlotMap(scan));
+        if (slotReplaceMap == null) {
+            return ImmutableSet.of();
+        }
+        ImmutableSet.Builder<Expression> rewrittenConjuncts =
+                ImmutableSet.builderWithExpectedSize(prunableConjuncts.size());
+        for (Expression conjunct : prunableConjuncts) {
+            rewrittenConjuncts.add(slotReplaceMap.isEmpty()
+                    ? conjunct : ExpressionUtils.replace(conjunct, slotReplaceMap));
+        }
+        return rewrittenConjuncts.build();
+    }
+
+    private static Map<String, Slot> buildNameToSlotMap(OlapScan scan) {
+        OlapTable table = scan.getTable();
+        List<Slot> output = scan.getOutput();
+        Map<String, Slot> map = new HashMap<>(output.size());
+        if (scan.getSelectedIndexId() == table.getBaseIndexId()) {
+            for (Slot slot : output) {
+                map.put(slot.getName().toLowerCase(), slot);
+            }
+        } else {
+            for (Slot slot : output) {
+                if (!(slot instanceof SlotReference)) {
+                    continue;
+                }
+                SlotReference slotReference = (SlotReference) slot;
+                Optional<Column> columnOptional = slotReference.getOriginalColumn();
+                if (!columnOptional.isPresent()) {
+                    continue;
+                }
+                Expr expr = columnOptional.get().getDefineExpr();
+                if (!(expr instanceof SlotRef)) {
+                    continue;
+                }
+                map.put(((SlotRef) expr).getColumnName().toLowerCase(), slot);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Map each recorded snapshot slot to the scan's current output slot of the
+     * same column name. Returns null when any snapshot slot cannot be located,
+     * so the caller can skip this record.
+     */
+    private static Map<Expression, Expression> buildSlotReplaceMap(
+            List<Slot> snapshotSlots, Map<String, Slot> nameToOutputSlot) {
+        Map<Expression, Expression> replaceMap = new HashMap<>(snapshotSlots.size());
+        for (Slot snapshot : snapshotSlots) {
+            Slot current = nameToOutputSlot.get(snapshot.getName().toLowerCase());
+            if (current == null) {
+                return null;
+            }
+            if (!snapshot.equals(current)) {
+                replaceMap.put(snapshot, current);
+            }
+        }
+        return replaceMap;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/OlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/OlapScan.java
@@ -18,8 +18,11 @@
 package org.apache.doris.nereids.trees.plans.algebra;
 
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.PartitionPrunablePredicate;
 
 import java.util.List;
+import java.util.Optional;
 
 /** OlapScan */
 public interface OlapScan {
@@ -31,6 +34,10 @@ public interface OlapScan {
     List<Long> getSelectedPartitionIds();
 
     List<Long> getSelectedTabletIds();
+
+    List<Slot> getOutput();
+
+    Optional<PartitionPrunablePredicate> getPartitionPrunablePredicates();
 
     /** getScanTabletNum */
     default int getScanTabletNum() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -24,7 +24,10 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +52,7 @@ public class Statistics {
 
     private long actualRowCount = -1L;
     private boolean isFromHbo = false;
+    private final Set<Expression> conjunctsAppliedToRowCount;
 
     public Statistics(Statistics another) {
         this.rowCount = another.rowCount;
@@ -57,24 +61,27 @@ public class Statistics {
         this.tupleSize = another.tupleSize;
         this.deltaRowCount = another.getDeltaRowCount();
         this.isFromHbo = another.isFromHbo;
+        this.conjunctsAppliedToRowCount = another.conjunctsAppliedToRowCount;
     }
 
     public Statistics(double rowCount, int widthInJoinCluster,
-            Map<Expression, ColumnStatistic> expressionToColumnStats, double deltaRowCount, boolean isFromHbo) {
+            Map<Expression, ColumnStatistic> expressionToColumnStats, double deltaRowCount, boolean isFromHbo,
+            Set<Expression> conjunctsAppliedToRowCount) {
         this.rowCount = rowCount;
         this.widthInJoinCluster = widthInJoinCluster;
         this.expressionToColumnStats = expressionToColumnStats;
         this.deltaRowCount = deltaRowCount;
         this.isFromHbo = isFromHbo;
+        this.conjunctsAppliedToRowCount = ImmutableSet.copyOf(conjunctsAppliedToRowCount);
     }
 
     public Statistics(double rowCount, Map<Expression, ColumnStatistic> expressionToColumnStats) {
-        this(rowCount, 1, expressionToColumnStats, 0, false);
+        this(rowCount, 1, expressionToColumnStats, 0, false, Collections.emptySet());
     }
 
     public Statistics(double rowCount, int widthInJoinCluster,
             Map<Expression, ColumnStatistic> expressionToColumnStats) {
-        this(rowCount, widthInJoinCluster, expressionToColumnStats, 0, false);
+        this(rowCount, widthInJoinCluster, expressionToColumnStats, 0, false, Collections.emptySet());
     }
 
     public ColumnStatistic findColumnStatistics(Expression expression) {
@@ -91,11 +98,12 @@ public class Statistics {
 
     public Statistics withRowCount(double rowCount) {
         return new Statistics(rowCount, widthInJoinCluster, new HashMap<>(expressionToColumnStats),
-                0, isFromHbo);
+                0, isFromHbo, conjunctsAppliedToRowCount);
     }
 
     public Statistics withExpressionToColumnStats(Map<Expression, ColumnStatistic> expressionToColumnStats) {
-        return new Statistics(rowCount, widthInJoinCluster, expressionToColumnStats, 0, isFromHbo);
+        return new Statistics(rowCount, widthInJoinCluster, expressionToColumnStats, 0, isFromHbo,
+                conjunctsAppliedToRowCount);
     }
 
     /**
@@ -103,7 +111,7 @@ public class Statistics {
      */
     public Statistics withRowCountAndEnforceValid(double rowCount) {
         Statistics statistics = new Statistics(rowCount, widthInJoinCluster,
-                expressionToColumnStats, 0, isFromHbo);
+                expressionToColumnStats, 0, isFromHbo, conjunctsAppliedToRowCount);
         statistics.normalizeColumnStatistics();
         return statistics;
     }
@@ -162,7 +170,7 @@ public class Statistics {
         }
         double newCount = rowCount * notNullSel + numNull;
         return new Statistics(newCount, widthInJoinCluster, new HashMap<>(expressionToColumnStats),
-                0, isFromHbo);
+                0, isFromHbo, conjunctsAppliedToRowCount);
     }
 
     public Statistics addColumnStats(Expression expression, ColumnStatistic columnStatistic) {
@@ -333,6 +341,10 @@ public class Statistics {
 
     public boolean isFromHbo() {
         return this.isFromHbo;
+    }
+
+    public Set<Expression> getConjunctsAppliedToRowCount() {
+        return conjunctsAppliedToRowCount;
     }
 
     public StatisticsBuilder cleanHotValues() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsBuilder.java
@@ -20,6 +20,7 @@ package org.apache.doris.statistics;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,6 +33,7 @@ public class StatisticsBuilder {
     private double deltaRowCount = 0.0;
 
     private boolean isFromHbo = false;
+    private final Set<Expression> conjunctsAppliedToRowCount = new LinkedHashSet<>();
 
     public StatisticsBuilder() {
         this.expressionToColumnStats = new HashMap<>();
@@ -44,6 +46,7 @@ public class StatisticsBuilder {
         this.expressionToColumnStats = new HashMap<>();
         this.expressionToColumnStats.putAll(statistics.columnStatistics());
         this.isFromHbo = statistics.isFromHbo();
+        this.conjunctsAppliedToRowCount.addAll(statistics.getConjunctsAppliedToRowCount());
     }
 
     public StatisticsBuilder setRowCount(double rowCount) {
@@ -58,6 +61,12 @@ public class StatisticsBuilder {
 
     public StatisticsBuilder setDeltaRowCount(double deltaRowCount) {
         this.deltaRowCount = deltaRowCount;
+        return this;
+    }
+
+    public StatisticsBuilder setConjunctsAppliedToRowCount(Set<Expression> conjunctsAppliedToRowCount) {
+        this.conjunctsAppliedToRowCount.clear();
+        this.conjunctsAppliedToRowCount.addAll(conjunctsAppliedToRowCount);
         return this;
     }
 
@@ -77,6 +86,7 @@ public class StatisticsBuilder {
     }
 
     public Statistics build() {
-        return new Statistics(rowCount, widthInJoinCluster, expressionToColumnStats, deltaRowCount, isFromHbo);
+        return new Statistics(rowCount, widthInJoinCluster, expressionToColumnStats, deltaRowCount, isFromHbo,
+                conjunctsAppliedToRowCount);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Left;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
@@ -61,6 +62,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 class FilterEstimationTest {
+    @Test
+    public void testBooleanLiteral() {
+        Statistics inputStats = new Statistics(1000, new HashMap<>());
+        FilterEstimation filterEstimation = new FilterEstimation();
+        Assertions.assertEquals(1000, filterEstimation.estimate(BooleanLiteral.TRUE, inputStats).getRowCount(), 0);
+        Assertions.assertEquals(0, filterEstimation.estimate(BooleanLiteral.FALSE, inputStats).getRowCount(), 0);
+    }
+
     // a > 500 or b < 100
     // b isNaN
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -57,6 +57,7 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
 import org.apache.doris.statistics.Statistics;
+import org.apache.doris.statistics.StatisticsBuilder;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -133,6 +134,51 @@ public class StatsCalculatorTest {
         StatsCalculator.estimate(groupExpressionOr, null);
         Assertions.assertEquals(1448.555,
                 ownerGroupOr.getStatistics().getRowCount(), 0.1);
+    }
+
+    @Test
+    public void testFilterIgnoresRecordedPrunedPredicatesInStats() {
+        List<String> qualifier = ImmutableList.of("test", "t");
+        SlotReference partitionSlot = new SlotReference("p_col", IntegerType.INSTANCE, true, qualifier);
+        SlotReference dataSlot = new SlotReference("data_col", IntegerType.INSTANCE, true, qualifier);
+
+        EqualTo partitionEqual = new EqualTo(partitionSlot, new IntegerLiteral(1));
+        EqualTo dataEqual = new EqualTo(dataSlot, new IntegerLiteral(2));
+
+        ColumnStatisticBuilder partitionColumnStats = new ColumnStatisticBuilder();
+        partitionColumnStats.setNdv(100);
+        partitionColumnStats.setMinValue(0);
+        partitionColumnStats.setMaxValue(1000);
+        partitionColumnStats.setNumNulls(0);
+        ColumnStatisticBuilder dataColumnStats = new ColumnStatisticBuilder();
+        dataColumnStats.setNdv(10);
+        dataColumnStats.setMinValue(0);
+        dataColumnStats.setMaxValue(1000);
+        dataColumnStats.setNumNulls(0);
+
+        Map<Expression, ColumnStatistic> slotColumnStatsMap = new HashMap<>();
+        slotColumnStatsMap.put(partitionSlot, partitionColumnStats.build());
+        slotColumnStatsMap.put(dataSlot, dataColumnStats.build());
+        Statistics childStats = new StatisticsBuilder(new Statistics(1000, slotColumnStatsMap))
+                .setConjunctsAppliedToRowCount(ImmutableSet.of(partitionEqual))
+                .build();
+
+        Group childGroup = newFakeGroup();
+        childGroup.setStatistics(childStats);
+        GroupPlan groupPlan = new GroupPlan(childGroup);
+
+        LogicalFilter<GroupPlan> filter = new LogicalFilter<>(ImmutableSet.of(partitionEqual, dataEqual), groupPlan);
+        GroupExpression filterGroupExpression = new GroupExpression(filter, ImmutableList.of(childGroup));
+        Group ownerGroup = new Group(null, filterGroupExpression, null);
+        StatsCalculator.estimate(filterGroupExpression, null);
+        Assertions.assertEquals(100, ownerGroup.getStatistics().getRowCount(), 0.001);
+
+        LogicalFilter<GroupPlan> partitionOnlyFilter = new LogicalFilter<>(ImmutableSet.of(partitionEqual), groupPlan);
+        GroupExpression partitionOnlyGroupExpression =
+                new GroupExpression(partitionOnlyFilter, ImmutableList.of(childGroup));
+        Group partitionOnlyOwnerGroup = new Group(null, partitionOnlyGroupExpression, null);
+        StatsCalculator.estimate(partitionOnlyGroupExpression, null);
+        Assertions.assertEquals(1000, partitionOnlyOwnerGroup.getStatistics().getRowCount(), 0.001);
     }
 
     // a, b are in (0,100)


### PR DESCRIPTION
Problem Summary:

For OLAP scans, partition pruning can already reduce the scan row count to the selected partitions. However, the original partition predicate is intentionally kept in the filter until post-processing so MV rewrite can still match the original query predicate.

During CBO stats calculation, this means the filter estimator may apply the same partition predicate again on top of the already-pruned scan row count, causing row count underestimation. For example, after pruning to one partition, `id = 1` may already be reflected in the scan cardinality, but `computeFilter` still estimates selectivity for `id = 1`.

This change reuses the recorded `PartitionPrunablePredicate` on OLAP scans and skips those already-pruned conjuncts during filter statistics estimation, while preserving the existing plan shape and post-processing behavior.
