### PR TITLE
[feature](jdbc) support snowflake jdbc catalog

### DIFF
--- a/be/src/exec/scan/jdbc_scanner.h
+++ b/be/src/exec/scan/jdbc_scanner.h
@@ -103,6 +103,8 @@ private:
             return "DB2";
         case TOdbcTableType::GBASE:
             return "GBASE";
+        case TOdbcTableType::SNOWFLAKE:
+            return "SNOWFLAKE";
         default:
             return "MYSQL";
         }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1087,6 +1087,9 @@ void PInternalService::test_jdbc_connection(google::protobuf::RpcController* con
             case 14:
                 type_name = "GBASE";
                 break;
+            case 15:
+                type_name = "SNOWFLAKE";
+                break;
             default:
                 break;
             }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/BaseJdbcExecutor.java
@@ -475,6 +475,7 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
                         ds.setJdbcUrl(SecurityChecker.getInstance().getSafeJdbcUrl(config.getJdbcUrl()));
                         ds.setUsername(config.getJdbcUser());
                         ds.setPassword(config.getJdbcPassword());
+                        SnowflakeJdbcAuthUtils.configure(ds, config.getJdbcUrl(), config.getJdbcPassword());
                         ds.setMinimumIdle(config.getConnectionPoolMinSize()); // default 1
                         ds.setMaximumPoolSize(config.getConnectionPoolMaxSize()); // default 10
                         ds.setConnectionTimeout(config.getConnectionPoolMaxWaitTime()); // default 5000
@@ -844,6 +845,5 @@ public abstract class BaseJdbcExecutor implements JdbcExecutor {
         return hexString.toString();
     }
 }
-
 
 

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcConnectionTester.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcConnectionTester.java
@@ -46,6 +46,7 @@ import java.util.Map;
  * <p>Parameters:
  * <ul>
  *   <li>jdbc_url, jdbc_user, jdbc_password, jdbc_driver_class, jdbc_driver_url</li>
+ *   <li>snowflake.oauth.access_token - Snowflake OAuth access token</li>
  *   <li>query_sql — the test query to run</li>
  *   <li>catalog_id, connection_pool_min_size, connection_pool_max_size, etc.</li>
  *   <li>clean_datasource — if "true", close the datasource pool on close()</li>
@@ -57,6 +58,7 @@ public class JdbcConnectionTester extends JniScanner {
     private final String jdbcUrl;
     private final String jdbcUser;
     private final String jdbcPassword;
+    private final String snowflakeOauthAccessToken;
     private final String jdbcDriverClass;
     private final String jdbcDriverUrl;
     private final String querySql;
@@ -78,6 +80,8 @@ public class JdbcConnectionTester extends JniScanner {
         this.jdbcUrl = params.getOrDefault("jdbc_url", "");
         this.jdbcUser = params.getOrDefault("jdbc_user", "");
         this.jdbcPassword = params.getOrDefault("jdbc_password", "");
+        this.snowflakeOauthAccessToken = params.getOrDefault(
+                SnowflakeJdbcAuthUtils.OAUTH_ACCESS_TOKEN_PARAM, "");
         this.jdbcDriverClass = params.getOrDefault("jdbc_driver_class", "");
         this.jdbcDriverUrl = params.getOrDefault("jdbc_driver_url", "");
         this.querySql = params.getOrDefault("query_sql", "SELECT 1");
@@ -126,7 +130,9 @@ public class JdbcConnectionTester extends JniScanner {
                         ds.setDriverClassName(jdbcDriverClass);
                         ds.setJdbcUrl(SecurityChecker.getInstance().getSafeJdbcUrl(jdbcUrl));
                         ds.setUsername(jdbcUser);
-                        ds.setPassword(jdbcPassword);
+                        ds.setPassword(getConnectionPassword());
+                        SnowflakeJdbcAuthUtils.configure(ds, jdbcUrl, jdbcPassword,
+                                snowflakeOauthAccessToken);
                         ds.setMinimumIdle(connectionPoolMinSize);
                         ds.setMaximumPoolSize(connectionPoolMaxSize);
                         ds.setConnectionTimeout(connectionPoolMaxWaitTime);
@@ -196,6 +202,12 @@ public class JdbcConnectionTester extends JniScanner {
     }
 
     private String createCacheKey() {
-        return catalogId + "#" + jdbcUrl + "#" + jdbcUser + "#" + jdbcDriverClass;
+        return catalogId + "#" + jdbcUrl + "#" + jdbcUser + "#"
+                + getConnectionPassword() + "#" + jdbcDriverClass;
+    }
+
+    private String getConnectionPassword() {
+        return SnowflakeJdbcAuthUtils.resolveCredential(jdbcUrl, jdbcPassword,
+                snowflakeOauthAccessToken);
     }
 }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcJniScanner.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcJniScanner.java
@@ -50,6 +50,7 @@ import java.util.Map;
  *   <li>jdbc_url - JDBC connection URL</li>
  *   <li>jdbc_user - database user</li>
  *   <li>jdbc_password - database password</li>
+ *   <li>snowflake.oauth.access_token - Snowflake OAuth access token</li>
  *   <li>jdbc_driver_class - JDBC driver class name</li>
  *   <li>jdbc_driver_url - path to driver JAR</li>
  *   <li>query_sql - the SELECT SQL to execute</li>
@@ -70,6 +71,7 @@ public class JdbcJniScanner extends JniScanner {
     private final String jdbcUrl;
     private final String jdbcUser;
     private final String jdbcPassword;
+    private final String snowflakeOauthAccessToken;
     private final String jdbcDriverClass;
     private final String jdbcDriverUrl;
     private final String querySql;
@@ -109,6 +111,8 @@ public class JdbcJniScanner extends JniScanner {
         this.jdbcUrl = params.getOrDefault("jdbc_url", "");
         this.jdbcUser = params.getOrDefault("jdbc_user", "");
         this.jdbcPassword = params.getOrDefault("jdbc_password", "");
+        this.snowflakeOauthAccessToken = params.getOrDefault(
+                SnowflakeJdbcAuthUtils.OAUTH_ACCESS_TOKEN_PARAM, "");
         this.jdbcDriverClass = params.getOrDefault("jdbc_driver_class", "");
         this.jdbcDriverUrl = params.getOrDefault("jdbc_driver_url", "");
         this.querySql = params.getOrDefault("query_sql", "");
@@ -356,7 +360,9 @@ public class JdbcJniScanner extends JniScanner {
                     ds.setDriverClassName(jdbcDriverClass);
                     ds.setJdbcUrl(SecurityChecker.getInstance().getSafeJdbcUrl(jdbcUrl));
                     ds.setUsername(jdbcUser);
-                    ds.setPassword(jdbcPassword);
+                    ds.setPassword(getConnectionPassword());
+                    SnowflakeJdbcAuthUtils.configure(ds, jdbcUrl, jdbcPassword,
+                            snowflakeOauthAccessToken);
                     ds.setMinimumIdle(connectionPoolMinSize);
                     ds.setMaximumPoolSize(connectionPoolMaxSize);
                     ds.setConnectionTimeout(connectionPoolMaxWaitTime);
@@ -376,8 +382,13 @@ public class JdbcJniScanner extends JniScanner {
     }
 
     private String createCacheKey() {
-        return JdbcDataSource.createCacheKey(catalogId, jdbcUrl, jdbcUser, jdbcPassword,
+        return JdbcDataSource.createCacheKey(catalogId, jdbcUrl, jdbcUser, getConnectionPassword(),
                 jdbcDriverUrl, jdbcDriverClass, connectionPoolMinSize, connectionPoolMaxSize,
                 connectionPoolMaxLifeTime, connectionPoolMaxWaitTime, connectionPoolKeepAlive);
+    }
+
+    private String getConnectionPassword() {
+        return SnowflakeJdbcAuthUtils.resolveCredential(jdbcUrl, jdbcPassword,
+                snowflakeOauthAccessToken);
     }
 }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcJniWriter.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcJniWriter.java
@@ -54,6 +54,7 @@ import java.util.Map;
  *   <li>jdbc_url - JDBC connection URL</li>
  *   <li>jdbc_user - database user</li>
  *   <li>jdbc_password - database password</li>
+ *   <li>snowflake.oauth.access_token - Snowflake OAuth access token</li>
  *   <li>jdbc_driver_class - JDBC driver class name</li>
  *   <li>jdbc_driver_url - path to driver JAR</li>
  *   <li>jdbc_driver_checksum - MD5 checksum of driver JAR</li>
@@ -73,6 +74,7 @@ public class JdbcJniWriter extends JniWriter {
     private final String jdbcUrl;
     private final String jdbcUser;
     private final String jdbcPassword;
+    private final String snowflakeOauthAccessToken;
     private final String jdbcDriverClass;
     private final String jdbcDriverUrl;
     private final String jdbcDriverChecksum;
@@ -99,6 +101,8 @@ public class JdbcJniWriter extends JniWriter {
         this.jdbcUrl = params.getOrDefault("jdbc_url", "");
         this.jdbcUser = params.getOrDefault("jdbc_user", "");
         this.jdbcPassword = params.getOrDefault("jdbc_password", "");
+        this.snowflakeOauthAccessToken = params.getOrDefault(
+                SnowflakeJdbcAuthUtils.OAUTH_ACCESS_TOKEN_PARAM, "");
         this.jdbcDriverClass = params.getOrDefault("jdbc_driver_class", "");
         this.jdbcDriverUrl = params.getOrDefault("jdbc_driver_url", "");
         this.jdbcDriverChecksum = params.getOrDefault("jdbc_driver_checksum", "");
@@ -381,7 +385,9 @@ public class JdbcJniWriter extends JniWriter {
                     ds.setDriverClassName(jdbcDriverClass);
                     ds.setJdbcUrl(SecurityChecker.getInstance().getSafeJdbcUrl(jdbcUrl));
                     ds.setUsername(jdbcUser);
-                    ds.setPassword(jdbcPassword);
+                    ds.setPassword(getConnectionPassword());
+                    SnowflakeJdbcAuthUtils.configure(ds, jdbcUrl, jdbcPassword,
+                            snowflakeOauthAccessToken);
                     ds.setMinimumIdle(connectionPoolMinSize);
                     ds.setMaximumPoolSize(connectionPoolMaxSize);
                     ds.setConnectionTimeout(connectionPoolMaxWaitTime);
@@ -401,8 +407,13 @@ public class JdbcJniWriter extends JniWriter {
     }
 
     private String createCacheKey() {
-        return JdbcDataSource.createCacheKey(catalogId, jdbcUrl, jdbcUser, jdbcPassword,
+        return JdbcDataSource.createCacheKey(catalogId, jdbcUrl, jdbcUser, getConnectionPassword(),
                 jdbcDriverUrl, jdbcDriverClass, connectionPoolMinSize, connectionPoolMaxSize,
                 connectionPoolMaxLifeTime, connectionPoolMaxWaitTime, connectionPoolKeepAlive);
+    }
+
+    private String getConnectionPassword() {
+        return SnowflakeJdbcAuthUtils.resolveCredential(jdbcUrl, jdbcPassword,
+                snowflakeOauthAccessToken);
     }
 }

--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/SnowflakeJdbcAuthUtils.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/SnowflakeJdbcAuthUtils.java
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jdbc;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+/**
+ * Snowflake JDBC accepts OAuth credentials through the "token" connection
+ * property. Doris keeps password authentication on jdbc_password, and lets
+ * Snowflake OAuth callers provide a separate access token when available.
+ */
+public final class SnowflakeJdbcAuthUtils {
+
+    public static final String OAUTH_ACCESS_TOKEN_PARAM = "snowflake.oauth.access_token";
+
+    private SnowflakeJdbcAuthUtils() {
+    }
+
+    public static void configure(HikariDataSource dataSource, String jdbcUrl, String jdbcPassword) {
+        configure(dataSource, jdbcUrl, jdbcPassword, "");
+    }
+
+    public static void configure(HikariDataSource dataSource, String jdbcUrl, String jdbcPassword,
+            String oauthAccessToken) {
+        String credential = resolveCredential(jdbcUrl, jdbcPassword, oauthAccessToken);
+        if (dataSource == null || !hasText(credential) || !isSnowflakeOauthUrl(jdbcUrl)) {
+            return;
+        }
+        dataSource.addDataSourceProperty("token", credential);
+    }
+
+    static String resolveCredential(String jdbcUrl, String jdbcPassword, String oauthAccessToken) {
+        if (!isSnowflakeOauthUrl(jdbcUrl)) {
+            return jdbcPassword;
+        }
+        if (hasText(oauthAccessToken)) {
+            return oauthAccessToken;
+        }
+        return jdbcPassword;
+    }
+
+    static boolean isSnowflakeOauthUrl(String jdbcUrl) {
+        if (jdbcUrl == null || !jdbcUrl.toLowerCase(Locale.ROOT).startsWith("jdbc:snowflake:")) {
+            return false;
+        }
+        int queryStart = jdbcUrl.indexOf('?');
+        if (queryStart < 0 || queryStart == jdbcUrl.length() - 1) {
+            return false;
+        }
+        String query = jdbcUrl.substring(queryStart + 1);
+        for (String part : query.split("&")) {
+            int equal = part.indexOf('=');
+            String rawName = equal >= 0 ? part.substring(0, equal) : part;
+            String rawValue = equal >= 0 ? part.substring(equal + 1) : "";
+            String name = URLDecoder.decode(rawName, StandardCharsets.UTF_8).trim();
+            String value = URLDecoder.decode(rawValue, StandardCharsets.UTF_8).trim();
+            if ("authenticator".equalsIgnoreCase(name) && "oauth".equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/fe/be-java-extensions/jdbc-scanner/src/test/java/org/apache/doris/jdbc/SnowflakeJdbcAuthUtilsTest.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/test/java/org/apache/doris/jdbc/SnowflakeJdbcAuthUtilsTest.java
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jdbc;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SnowflakeJdbcAuthUtilsTest {
+
+    @Test
+    public void testConfigureAddsTokenForSnowflakeOauthUrl() {
+        HikariDataSource dataSource = new HikariDataSource();
+
+        SnowflakeJdbcAuthUtils.configure(dataSource,
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=OAUTH",
+                "snowflake-oauth-token");
+
+        Assert.assertEquals("snowflake-oauth-token",
+                dataSource.getDataSourceProperties().getProperty("token"));
+    }
+
+    @Test
+    public void testConfigurePrefersExplicitOauthAccessToken() {
+        HikariDataSource dataSource = new HikariDataSource();
+
+        SnowflakeJdbcAuthUtils.configure(dataSource,
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=OAUTH",
+                "snowflake-password",
+                "snowflake-oauth-token");
+
+        Assert.assertEquals("snowflake-oauth-token",
+                dataSource.getDataSourceProperties().getProperty("token"));
+    }
+
+    @Test
+    public void testResolveCredentialDoesNotOverridePasswordAuth() {
+        String credential = SnowflakeJdbcAuthUtils.resolveCredential(
+                "jdbc:snowflake://example.snowflakecomputing.com/?warehouse=COMPUTE_WH",
+                "snowflake-password",
+                "snowflake-oauth-token");
+
+        Assert.assertEquals("snowflake-password", credential);
+    }
+
+    @Test
+    public void testResolveCredentialDoesNotOverrideProgrammaticAccessTokenPassword() {
+        String credential = SnowflakeJdbcAuthUtils.resolveCredential(
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=programmatic_access_token",
+                "snowflake-pat",
+                "snowflake-oauth-token");
+
+        Assert.assertEquals("snowflake-pat", credential);
+    }
+
+    @Test
+    public void testConfigureSkipsPasswordUrl() {
+        HikariDataSource dataSource = new HikariDataSource();
+
+        SnowflakeJdbcAuthUtils.configure(dataSource,
+                "jdbc:snowflake://example.snowflakecomputing.com/?warehouse=COMPUTE_WH",
+                "password");
+
+        Assert.assertNull(dataSource.getDataSourceProperties().getProperty("token"));
+    }
+
+    @Test
+    public void testConfigureSkipsOauthPrefixValue() {
+        HikariDataSource dataSource = new HikariDataSource();
+
+        SnowflakeJdbcAuthUtils.configure(dataSource,
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=oauth2",
+                "password");
+
+        Assert.assertNull(dataSource.getDataSourceProperties().getProperty("token"));
+    }
+
+    @Test
+    public void testConfigureSkipsOtherJdbcUrl() {
+        HikariDataSource dataSource = new HikariDataSource();
+
+        SnowflakeJdbcAuthUtils.configure(dataSource,
+                "jdbc:mysql://127.0.0.1:3306/test?authenticator=oauth",
+                "password");
+
+        Assert.assertNull(dataSource.getDataSourceProperties().getProperty("token"));
+    }
+}

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorMetadata.java
@@ -187,7 +187,7 @@ public class JdbcConnectorMetadata implements ConnectorMetadata {
         tJdbcTable.setCatalogId(catalogId);
         tJdbcTable.setJdbcUrl(properties.getOrDefault(JdbcConnectorProperties.JDBC_URL, ""));
         tJdbcTable.setJdbcUser(properties.getOrDefault(JdbcConnectorProperties.USER, ""));
-        tJdbcTable.setJdbcPassword(properties.getOrDefault(JdbcConnectorProperties.PASSWORD, ""));
+        tJdbcTable.setJdbcPassword(getConnectionPassword());
         tJdbcTable.setJdbcTableName(remoteName);
         tJdbcTable.setJdbcDriverClass(properties.getOrDefault(JdbcConnectorProperties.DRIVER_CLASS, ""));
         tJdbcTable.setJdbcDriverUrl(properties.getOrDefault(JdbcConnectorProperties.DRIVER_URL, ""));
@@ -314,7 +314,7 @@ public class JdbcConnectorMetadata implements ConnectorMetadata {
         Map<String, String> writeProps = new HashMap<>();
         writeProps.put("jdbc_url", properties.getOrDefault(JdbcConnectorProperties.JDBC_URL, ""));
         writeProps.put("jdbc_user", properties.getOrDefault(JdbcConnectorProperties.USER, ""));
-        writeProps.put("jdbc_password", properties.getOrDefault(JdbcConnectorProperties.PASSWORD, ""));
+        writeProps.put("jdbc_password", getConnectionPassword());
         writeProps.put("jdbc_driver_url", properties.getOrDefault(JdbcConnectorProperties.DRIVER_URL, ""));
         writeProps.put("jdbc_driver_class", properties.getOrDefault(JdbcConnectorProperties.DRIVER_CLASS, ""));
         writeProps.put("jdbc_driver_checksum",
@@ -351,6 +351,13 @@ public class JdbcConnectorMetadata implements ConnectorMetadata {
         return ConnectorWriteConfig.builder(ConnectorWriteType.JDBC_WRITE)
                 .properties(writeProps)
                 .build();
+    }
+
+    private String getConnectionPassword() {
+        return JdbcConnectorClient.resolveSnowflakeOauthToken(
+                properties,
+                properties.getOrDefault(JdbcConnectorProperties.JDBC_URL, ""),
+                properties.getOrDefault(JdbcConnectorProperties.PASSWORD, ""));
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorProperties.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorProperties.java
@@ -37,6 +37,11 @@ public final class JdbcConnectorProperties {
     public static final String DRIVER_URL = "driver_url";
     public static final String TYPE = "type";
 
+    // -- Snowflake connection --
+    public static final String SNOWFLAKE_DATABASE = "snowflake.database";
+    public static final String SNOWFLAKE_WAREHOUSE = "snowflake.warehouse";
+    public static final String SNOWFLAKE_OAUTH_ACCESS_TOKEN = "snowflake.oauth.access_token";
+
     // -- connection pool --
     public static final String CONNECTION_POOL_MIN_SIZE = "connection_pool_min_size";
     public static final String CONNECTION_POOL_MAX_SIZE = "connection_pool_max_size";

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorProvider.java
@@ -22,8 +22,11 @@ import org.apache.doris.connector.api.DorisConnectorException;
 import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorProvider;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -58,7 +61,11 @@ public class JdbcConnectorProvider implements ConnectorProvider {
             }
         }
 
-        // 2. Reject deprecated lower_case_table_names
+        // 2. Snowflake keeps database and warehouse as dedicated catalog
+        // properties. Doris maps its database layer to Snowflake schemas.
+        validateSnowflakeProperties(properties);
+
+        // 3. Reject deprecated lower_case_table_names
         if (properties.containsKey(JdbcConnectorProperties.LOWER_CASE_TABLE_NAMES)
                 || properties.containsKey(
                         JdbcDorisConnector.JDBC_PROPERTIES_PREFIX
@@ -68,13 +75,13 @@ public class JdbcConnectorProvider implements ConnectorProvider {
                             + " please use lower_case_meta_names instead");
         }
 
-        // 3. Boolean property validation
+        // 4. Boolean property validation
         checkBooleanProperty(properties, JdbcConnectorProperties.ONLY_SPECIFIED_DATABASE);
         checkBooleanProperty(properties, JdbcConnectorProperties.LOWER_CASE_META_NAMES);
         checkBooleanProperty(properties, JdbcConnectorProperties.CONNECTION_POOL_KEEP_ALIVE);
         checkBooleanProperty(properties, JdbcConnectorProperties.TEST_CONNECTION);
 
-        // 4. Database list consistency: include/exclude cannot be set when only_specified_database=false
+        // 5. Database list consistency: include/exclude cannot be set when only_specified_database=false
         String onlySpecified = resolve(properties, JdbcConnectorProperties.ONLY_SPECIFIED_DATABASE);
         if (onlySpecified == null || !onlySpecified.equalsIgnoreCase("true")) {
             String includeList = resolve(properties, JdbcConnectorProperties.INCLUDE_DATABASE_LIST);
@@ -87,10 +94,10 @@ public class JdbcConnectorProvider implements ConnectorProvider {
             }
         }
 
-        // 5. Connection pool settings
+        // 6. Connection pool settings
         checkConnectionPoolProperties(properties);
 
-        // 6. Validate meta_names_mapping with actual lower_case_meta_names setting.
+        // 7. Validate meta_names_mapping with actual lower_case_meta_names setting.
         // At runtime, JdbcConnectorMetadata builds the mapper with lower_case_meta_names
         // from catalog properties and lower_case_table_names from session. We validate
         // with the real lower_case_meta_names and both possible lower_case_table_names
@@ -108,6 +115,63 @@ public class JdbcConnectorProvider implements ConnectorProvider {
             } catch (DorisConnectorException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);
             }
+        }
+    }
+
+    private static void validateSnowflakeProperties(Map<String, String> properties) {
+        String jdbcUrl = resolve(properties, JdbcConnectorProperties.JDBC_URL);
+        if (jdbcUrl == null || !jdbcUrl.toLowerCase(Locale.ROOT).startsWith("jdbc:snowflake:")) {
+            return;
+        }
+        if (hasQueryParameter(jdbcUrl, "db") || hasQueryParameter(jdbcUrl, "database")) {
+            throw new IllegalArgumentException(
+                    "Snowflake JDBC catalog uses dedicated properties. "
+                            + "Do not set db or database in jdbc_url; set "
+                            + JdbcConnectorProperties.SNOWFLAKE_DATABASE + " instead.");
+        }
+        if (hasQueryParameter(jdbcUrl, "warehouse")) {
+            throw new IllegalArgumentException(
+                    "Snowflake JDBC catalog uses dedicated properties. "
+                            + "Do not set warehouse in jdbc_url; set "
+                            + JdbcConnectorProperties.SNOWFLAKE_WAREHOUSE + " instead.");
+        }
+        String database = resolve(properties, JdbcConnectorProperties.SNOWFLAKE_DATABASE);
+        if (database == null || database.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Snowflake JDBC catalog requires property '"
+                            + JdbcConnectorProperties.SNOWFLAKE_DATABASE
+                            + "'. Doris maps Doris databases to Snowflake schemas within this database.");
+        }
+        String warehouse = resolve(properties, JdbcConnectorProperties.SNOWFLAKE_WAREHOUSE);
+        if (warehouse == null || warehouse.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Snowflake JDBC catalog requires property '"
+                            + JdbcConnectorProperties.SNOWFLAKE_WAREHOUSE + "'.");
+        }
+    }
+
+    private static boolean hasQueryParameter(String jdbcUrl, String key) {
+        int queryStart = jdbcUrl.indexOf('?');
+        if (queryStart < 0 || queryStart == jdbcUrl.length() - 1) {
+            return false;
+        }
+        String query = jdbcUrl.substring(queryStart + 1);
+        for (String part : query.split("&")) {
+            int equal = part.indexOf('=');
+            String rawName = equal >= 0 ? part.substring(0, equal) : part;
+            String name = urlDecode(rawName).trim();
+            if (key.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String urlDecode(String value) {
+        try {
+            return URLDecoder.decode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return value;
         }
     }
 

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcDbType.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcDbType.java
@@ -35,7 +35,8 @@ public enum JdbcDbType {
     OCEANBASE("OCEANBASE"),
     OCEANBASE_ORACLE("OCEANBASE_ORACLE"),
     DB2("DB2"),
-    GBASE("GBASE");
+    GBASE("GBASE"),
+    SNOWFLAKE("SNOWFLAKE");
 
     private final String label;
 
@@ -77,6 +78,8 @@ public enum JdbcDbType {
             return DB2;
         } else if (url.startsWith("jdbc:gbase")) {
             return GBASE;
+        } else if (url.startsWith("jdbc:snowflake")) {
+            return SNOWFLAKE;
         }
         throw new DorisConnectorException("Unsupported JDBC URL prefix: " + url);
     }

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcDorisConnector.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcDorisConnector.java
@@ -38,6 +38,8 @@ import org.apache.thrift.TSerializer;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -81,8 +83,12 @@ public class JdbcDorisConnector implements Connector {
         String rawUrl = normalized.get(JdbcConnectorProperties.JDBC_URL);
         if (rawUrl != null && !rawUrl.isEmpty()) {
             JdbcDbType dbType = JdbcDbType.parseFromUrl(rawUrl);
+            String effectiveUrl = rawUrl;
+            if (dbType == JdbcDbType.SNOWFLAKE) {
+                effectiveUrl = applySnowflakeConnectionProperties(rawUrl, normalized);
+            }
             normalized.put(JdbcConnectorProperties.JDBC_URL,
-                    JdbcUrlNormalizer.normalize(rawUrl, dbType, context.getEnvironment()));
+                    JdbcUrlNormalizer.normalize(effectiveUrl, dbType, context.getEnvironment()));
         }
         this.properties = Collections.unmodifiableMap(normalized);
         this.context = context;
@@ -289,7 +295,7 @@ public class JdbcDorisConnector implements Connector {
         tJdbcTable.setCatalogId(context.getCatalogId());
         tJdbcTable.setJdbcUrl(properties.getOrDefault(JdbcConnectorProperties.JDBC_URL, ""));
         tJdbcTable.setJdbcUser(properties.getOrDefault(JdbcConnectorProperties.USER, ""));
-        tJdbcTable.setJdbcPassword(properties.getOrDefault(JdbcConnectorProperties.PASSWORD, ""));
+        tJdbcTable.setJdbcPassword(getConnectionPassword());
         tJdbcTable.setJdbcTableName("test_jdbc_connection");
         tJdbcTable.setJdbcDriverClass(
                 properties.getOrDefault(JdbcConnectorProperties.DRIVER_CLASS, ""));
@@ -323,11 +329,41 @@ public class JdbcDorisConnector implements Connector {
     private TOdbcTableType parseOdbcType() {
         String jdbcUrl = properties.getOrDefault(JdbcConnectorProperties.JDBC_URL, "");
         JdbcDbType dbType = JdbcDbType.parseFromUrl(jdbcUrl);
+        return toOdbcTableType(dbType);
+    }
+
+    static TOdbcTableType toOdbcTableType(JdbcDbType dbType) {
         try {
             return TOdbcTableType.valueOf(dbType.name());
         } catch (Exception e) {
             return TOdbcTableType.MYSQL;
         }
+    }
+
+    static String applySnowflakeConnectionProperties(String jdbcUrl, Map<String, String> properties) {
+        String database = properties.get(JdbcConnectorProperties.SNOWFLAKE_DATABASE);
+        String warehouse = properties.get(JdbcConnectorProperties.SNOWFLAKE_WAREHOUSE);
+        if (database == null || database.trim().isEmpty()
+                || warehouse == null || warehouse.trim().isEmpty()) {
+            return jdbcUrl;
+        }
+        String separator = jdbcUrl.contains("?") ? "&" : "?";
+        if (jdbcUrl.endsWith("?") || jdbcUrl.endsWith("&")) {
+            separator = "";
+        }
+        return jdbcUrl + separator + "db=" + encodeQueryParameter(database.trim())
+                + "&warehouse=" + encodeQueryParameter(warehouse.trim());
+    }
+
+    private static String encodeQueryParameter(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private String getConnectionPassword() {
+        return JdbcConnectorClient.resolveSnowflakeOauthToken(
+                properties,
+                properties.getOrDefault(JdbcConnectorProperties.JDBC_URL, ""),
+                properties.getOrDefault(JdbcConnectorProperties.PASSWORD, ""));
     }
 
     private String getTestQuery() {

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcIdentifierQuoter.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcIdentifierQuoter.java
@@ -57,6 +57,7 @@ public final class JdbcIdentifierQuoter {
             case PRESTO:
             case OCEANBASE_ORACLE:
             case SAP_HANA:
+            case SNOWFLAKE:
                 return "\"" + name + "\"";
             default:
                 return name;
@@ -83,6 +84,7 @@ public final class JdbcIdentifierQuoter {
             case ORACLE:
             case SAP_HANA:
             case DB2:
+            case SNOWFLAKE:
                 return "\"" + remoteName + "\"";
             default:
                 return remoteName;

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcQueryBuilder.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcQueryBuilder.java
@@ -215,6 +215,7 @@ public final class JdbcQueryBuilder {
             case PRESTO:
             case OCEANBASE:
             case GBASE:
+            case SNOWFLAKE:
                 return true;
             default:
                 return false;

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcScanPlanProvider.java
@@ -25,6 +25,7 @@ import org.apache.doris.connector.api.pushdown.ConnectorExpression;
 import org.apache.doris.connector.api.scan.ConnectorScanPlanProvider;
 import org.apache.doris.connector.api.scan.ConnectorScanRange;
 import org.apache.doris.connector.api.scan.ConnectorScanRangeType;
+import org.apache.doris.connector.jdbc.client.JdbcConnectorClient;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -107,7 +108,8 @@ public class JdbcScanPlanProvider implements ConnectorScanPlanProvider {
         // Build the scan range with all JDBC connection parameters
         String jdbcUrl = getProperty(JdbcConnectorProperties.JDBC_URL, "");
         String user = getProperty(JdbcConnectorProperties.USER, "");
-        String password = getProperty(JdbcConnectorProperties.PASSWORD, "");
+        String password = JdbcConnectorClient.resolveSnowflakeOauthToken(
+                catalogProperties, jdbcUrl, getProperty(JdbcConnectorProperties.PASSWORD, ""));
         String driverClass = getProperty(JdbcConnectorProperties.DRIVER_CLASS, "");
         String driverUrl = getProperty(JdbcConnectorProperties.DRIVER_URL, "");
         String checksum = getProperty("checksum", "");

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/client/JdbcConnectorClient.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/client/JdbcConnectorClient.java
@@ -19,6 +19,7 @@ package org.apache.doris.connector.jdbc.client;
 
 import org.apache.doris.connector.api.ConnectorType;
 import org.apache.doris.connector.api.DorisConnectorException;
+import org.apache.doris.connector.jdbc.JdbcConnectorProperties;
 import org.apache.doris.connector.jdbc.JdbcDbType;
 
 import com.zaxxer.hikari.HikariDataSource;
@@ -29,6 +30,8 @@ import java.io.Closeable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -40,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -180,12 +184,19 @@ public abstract class JdbcConnectorClient implements Closeable {
                         includeMap, excludeMap, enableMappingVarbinary,
                         enableMappingTimestampTz);
                 break;
+            case SNOWFLAKE:
+                client = new JdbcSnowflakeConnectorClient(
+                        catalogName, dbType, jdbcUrl, onlySpecifiedDatabase,
+                        includeMap, excludeMap, enableMappingVarbinary,
+                        enableMappingTimestampTz);
+                break;
             default:
                 throw new DorisConnectorException("Unsupported JDBC DB type: " + dbType);
         }
         client.initializeClassLoader(driverUrl);
         String sanitizedUrl = urlSanitizer.apply(jdbcUrl);
-        client.initializeDataSource(sanitizedUrl, user, password, driverClass,
+        String connectionPassword = resolveSnowflakeOauthToken(allProperties, jdbcUrl, password);
+        client.initializeDataSource(sanitizedUrl, user, connectionPassword, driverClass,
                 poolMinSize, poolMaxSize, poolMaxWaitTime, poolMaxLifeTime);
         client.postInitialize();
         return client;
@@ -227,6 +238,7 @@ public abstract class JdbcConnectorClient implements Closeable {
             dataSource.setJdbcUrl(url);
             dataSource.setUsername(user);
             dataSource.setPassword(password);
+            configureSnowflakeOauth(dataSource, url, password);
             dataSource.setMinimumIdle(poolMin);
             dataSource.setMaximumPoolSize(poolMax);
             dataSource.setConnectionTimeout(maxWait);
@@ -240,6 +252,50 @@ public abstract class JdbcConnectorClient implements Closeable {
         } finally {
             Thread.currentThread().setContextClassLoader(old);
         }
+    }
+
+    private void configureSnowflakeOauth(HikariDataSource dataSource, String url, String password) {
+        if (dbType != JdbcDbType.SNOWFLAKE || password == null || password.isEmpty() || url == null) {
+            return;
+        }
+        if (isSnowflakeOauthUrl(url)) {
+            dataSource.addDataSourceProperty("token", password);
+        }
+    }
+
+    public static String resolveSnowflakeOauthToken(
+            Map<String, String> properties, String jdbcUrl, String password) {
+        if (!isSnowflakeOauthUrl(jdbcUrl)) {
+            return password;
+        }
+        String explicitToken = properties == null ? null
+                : properties.get(JdbcConnectorProperties.SNOWFLAKE_OAUTH_ACCESS_TOKEN);
+        if (explicitToken != null && !explicitToken.isEmpty()) {
+            return explicitToken;
+        }
+        return password;
+    }
+
+    static boolean isSnowflakeOauthUrl(String jdbcUrl) {
+        if (jdbcUrl == null || !jdbcUrl.toLowerCase(Locale.ROOT).startsWith("jdbc:snowflake:")) {
+            return false;
+        }
+        int queryStart = jdbcUrl.indexOf('?');
+        if (queryStart < 0 || queryStart == jdbcUrl.length() - 1) {
+            return false;
+        }
+        String query = jdbcUrl.substring(queryStart + 1);
+        for (String part : query.split("&")) {
+            int equal = part.indexOf('=');
+            String rawName = equal >= 0 ? part.substring(0, equal) : part;
+            String rawValue = equal >= 0 ? part.substring(equal + 1) : "";
+            String name = URLDecoder.decode(rawName, StandardCharsets.UTF_8).trim();
+            String value = URLDecoder.decode(rawValue, StandardCharsets.UTF_8).trim();
+            if ("authenticator".equalsIgnoreCase(name) && "oauth".equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private synchronized void initializeClassLoader(String driverUrl) {

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/client/JdbcSnowflakeConnectorClient.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/client/JdbcSnowflakeConnectorClient.java
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.jdbc.client;
+
+import org.apache.doris.connector.api.ConnectorType;
+import org.apache.doris.connector.jdbc.JdbcDbType;
+
+import java.sql.Types;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Snowflake-specific JDBC connector client.
+ */
+public class JdbcSnowflakeConnectorClient extends JdbcConnectorClient {
+
+    public JdbcSnowflakeConnectorClient(
+            String catalogName, JdbcDbType dbType, String jdbcUrl,
+            boolean onlySpecifiedDatabase,
+            Map<String, Boolean> includeDatabaseMap,
+            Map<String, Boolean> excludeDatabaseMap,
+            boolean enableMappingVarbinary,
+            boolean enableMappingTimestampTz) {
+        super(catalogName, dbType, jdbcUrl, onlySpecifiedDatabase,
+                includeDatabaseMap, excludeDatabaseMap,
+                enableMappingVarbinary, enableMappingTimestampTz);
+    }
+
+    @Override
+    protected Set<String> getFilterInternalDatabases() {
+        Set<String> set = new HashSet<>();
+        set.add("information_schema");
+        return set;
+    }
+
+    @Override
+    public ConnectorType jdbcTypeToConnectorType(JdbcFieldInfo fieldInfo) {
+        String typeName = fieldInfo.getDataTypeName().orElse("").toUpperCase(Locale.ROOT);
+        switch (typeName) {
+            case "BOOLEAN":
+                return ConnectorType.of("BOOLEAN");
+            case "BYTEINT":
+            case "TINYINT":
+                return ConnectorType.of("TINYINT");
+            case "SMALLINT":
+                return ConnectorType.of("SMALLINT");
+            case "INTEGER":
+            case "INT":
+                return ConnectorType.of("INT");
+            case "BIGINT":
+                return ConnectorType.of("BIGINT");
+            case "NUMBER":
+            case "DECIMAL":
+            case "NUMERIC":
+            case "FIXED":
+                return createDecimalOrString(fieldInfo.requiredColumnSize(), fieldInfo.requiredDecimalDigits());
+            case "REAL":
+            case "FLOAT":
+            case "FLOAT4":
+            case "FLOAT8":
+            case "DOUBLE":
+            case "DOUBLE PRECISION":
+                return ConnectorType.of("DOUBLE");
+            case "DATE":
+                return ConnectorType.of("DATEV2");
+            case "TIME":
+                return ConnectorType.of("STRING");
+            case "TIMESTAMP":
+            case "DATETIME":
+            case "TIMESTAMP_NTZ":
+                return ConnectorType.of("DATETIMEV2", timestampScale(fieldInfo), -1);
+            case "TIMESTAMP_LTZ":
+            case "TIMESTAMP_TZ":
+                if (enableMappingTimestampTz) {
+                    return ConnectorType.of("TIMESTAMPTZ", timestampScale(fieldInfo), -1);
+                }
+                return ConnectorType.of("DATETIMEV2", timestampScale(fieldInfo), -1);
+            case "CHAR":
+            case "CHARACTER":
+            case "VARCHAR":
+            case "TEXT":
+            case "STRING":
+                return ConnectorType.of("STRING");
+            case "BINARY":
+            case "VARBINARY":
+                return enableMappingVarbinary
+                        ? ConnectorType.of("VARBINARY", fieldInfo.requiredColumnSize(), -1)
+                        : ConnectorType.of("STRING");
+            case "VARIANT":
+            case "OBJECT":
+            case "ARRAY":
+            case "GEOGRAPHY":
+            case "GEOMETRY":
+            case "VECTOR":
+                return ConnectorType.of("STRING");
+            default:
+                return fallbackByJdbcType(fieldInfo);
+        }
+    }
+
+    private ConnectorType fallbackByJdbcType(JdbcFieldInfo fieldInfo) {
+        switch (fieldInfo.getDataType()) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return ConnectorType.of("BOOLEAN");
+            case Types.TINYINT:
+                return ConnectorType.of("TINYINT");
+            case Types.SMALLINT:
+                return ConnectorType.of("SMALLINT");
+            case Types.INTEGER:
+                return ConnectorType.of("INT");
+            case Types.BIGINT:
+                return ConnectorType.of("BIGINT");
+            case Types.FLOAT:
+            case Types.REAL:
+            case Types.DOUBLE:
+                return ConnectorType.of("DOUBLE");
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return createDecimalOrString(fieldInfo.requiredColumnSize(), fieldInfo.requiredDecimalDigits());
+            case Types.DATE:
+                return ConnectorType.of("DATEV2");
+            case Types.TIMESTAMP:
+                return ConnectorType.of("DATETIMEV2", timestampScale(fieldInfo), -1);
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return enableMappingTimestampTz
+                        ? ConnectorType.of("TIMESTAMPTZ", timestampScale(fieldInfo), -1)
+                        : ConnectorType.of("DATETIMEV2", timestampScale(fieldInfo), -1);
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.TIME:
+            case Types.OTHER:
+                return ConnectorType.of("STRING");
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                return enableMappingVarbinary
+                        ? ConnectorType.of("VARBINARY", fieldInfo.requiredColumnSize(), -1)
+                        : ConnectorType.of("STRING");
+            default:
+                return ConnectorType.of("UNSUPPORTED");
+        }
+    }
+
+    private int timestampScale(JdbcFieldInfo fieldInfo) {
+        int scale = fieldInfo.getDecimalDigits().orElse(0);
+        if (scale < 0) {
+            return 0;
+        }
+        return Math.min(scale, JDBC_DATETIME_SCALE);
+    }
+}

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcConnectorProviderValidateTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcConnectorProviderValidateTest.java
@@ -83,6 +83,73 @@ public class JdbcConnectorProviderValidateTest {
     }
 
     @Test
+    public void testSnowflakeRequiresDedicatedDatabaseProperty() {
+        Map<String, String> props = validProps();
+        props.put("jdbc_url", "jdbc:snowflake://example.snowflakecomputing.com");
+        props.put("driver_class", "net.snowflake.client.jdbc.SnowflakeDriver");
+        props.put("snowflake.warehouse", "COMPUTE_WH");
+
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> provider.validateProperties(props));
+        Assertions.assertTrue(ex.getMessage().contains("snowflake.database"));
+    }
+
+    @Test
+    public void testSnowflakeRequiresDedicatedWarehouseProperty() {
+        Map<String, String> props = validProps();
+        props.put("jdbc_url", "jdbc:snowflake://example.snowflakecomputing.com");
+        props.put("driver_class", "net.snowflake.client.jdbc.SnowflakeDriver");
+        props.put("snowflake.database", "DORIS_HORIZON_DB");
+
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> provider.validateProperties(props));
+        Assertions.assertTrue(ex.getMessage().contains("snowflake.warehouse"));
+    }
+
+    @Test
+    public void testSnowflakeRejectsDatabaseInUrl() {
+        Map<String, String> props = validProps();
+        props.put("jdbc_url",
+                "jdbc:snowflake://example.snowflakecomputing.com/?db=DORIS_HORIZON_DB");
+        props.put("driver_class", "net.snowflake.client.jdbc.SnowflakeDriver");
+        props.put("snowflake.database", "DORIS_HORIZON_DB");
+        props.put("snowflake.warehouse", "COMPUTE_WH");
+
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> provider.validateProperties(props));
+        Assertions.assertTrue(ex.getMessage().contains("Do not set db or database in jdbc_url"));
+    }
+
+    @Test
+    public void testSnowflakeRejectsWarehouseInUrl() {
+        Map<String, String> props = validProps();
+        props.put("jdbc_url",
+                "jdbc:snowflake://example.snowflakecomputing.com/?warehouse=COMPUTE_WH");
+        props.put("driver_class", "net.snowflake.client.jdbc.SnowflakeDriver");
+        props.put("snowflake.database", "DORIS_HORIZON_DB");
+        props.put("snowflake.warehouse", "COMPUTE_WH");
+
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> provider.validateProperties(props));
+        Assertions.assertTrue(ex.getMessage().contains("Do not set warehouse in jdbc_url"));
+    }
+
+    @Test
+    public void testSnowflakeAcceptsDedicatedProperties() {
+        Map<String, String> props = validProps();
+        props.put("jdbc_url", "jdbc:snowflake://example.snowflakecomputing.com");
+        props.put("driver_class", "net.snowflake.client.jdbc.SnowflakeDriver");
+        props.put("snowflake.database", "DORIS_HORIZON_DB");
+        props.put("snowflake.warehouse", "COMPUTE_WH");
+
+        Assertions.assertDoesNotThrow(() -> provider.validateProperties(props));
+    }
+
+    @Test
     public void testInvalidBooleanProperty() {
         Map<String, String> props = validProps();
         props.put("only_specified_database", "yes");

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcDbTypeTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcDbTypeTest.java
@@ -101,6 +101,13 @@ public class JdbcDbTypeTest {
     }
 
     @Test
+    public void testParseFromUrlSnowflake() {
+        Assertions.assertEquals(JdbcDbType.SNOWFLAKE,
+                JdbcDbType.parseFromUrl("jdbc:snowflake://example.snowflakecomputing.com/"
+                        + "?db=PLAUD_TEST&schema=ADS&warehouse=COMPUTE_WH"));
+    }
+
+    @Test
     public void testParseFromUrlNull() {
         Assertions.assertThrows(DorisConnectorException.class,
                 () -> JdbcDbType.parseFromUrl(null));

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcDorisConnectorTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcDorisConnectorTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.connector.jdbc;
 
 import org.apache.doris.connector.api.DorisConnectorException;
 import org.apache.doris.connector.spi.ConnectorContext;
+import org.apache.doris.thrift.TOdbcTableType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -147,5 +148,40 @@ class JdbcDorisConnectorTest {
                 "JDBC connector metadata should not support DELETE by default");
         Assertions.assertFalse(metadata.supportsMerge(),
                 "JDBC connector metadata should not support MERGE by default");
+    }
+
+    @Test
+    void testSnowflakeMapsToOdbcTableType() {
+        Assertions.assertEquals(TOdbcTableType.SNOWFLAKE,
+                JdbcDorisConnector.toOdbcTableType(JdbcDbType.SNOWFLAKE));
+    }
+
+    @Test
+    void testApplySnowflakeConnectionProperties() {
+        Map<String, String> props = new HashMap<>();
+        props.put("snowflake.database", "DORIS_HORIZON_DB");
+        props.put("snowflake.warehouse", "COMPUTE_WH");
+
+        String jdbcUrl = JdbcDorisConnector.applySnowflakeConnectionProperties(
+                "jdbc:snowflake://example.snowflakecomputing.com", props);
+
+        Assertions.assertEquals(
+                "jdbc:snowflake://example.snowflakecomputing.com?db=DORIS_HORIZON_DB&warehouse=COMPUTE_WH",
+                jdbcUrl);
+    }
+
+    @Test
+    void testApplySnowflakeConnectionPropertiesKeepsExistingQueryParams() {
+        Map<String, String> props = new HashMap<>();
+        props.put("snowflake.database", "DORIS_HORIZON_DB");
+        props.put("snowflake.warehouse", "COMPUTE_WH");
+
+        String jdbcUrl = JdbcDorisConnector.applySnowflakeConnectionProperties(
+                "jdbc:snowflake://example.snowflakecomputing.com?role=DORIS_DEBUG", props);
+
+        Assertions.assertEquals(
+                "jdbc:snowflake://example.snowflakecomputing.com?role=DORIS_DEBUG"
+                        + "&db=DORIS_HORIZON_DB&warehouse=COMPUTE_WH",
+                jdbcUrl);
     }
 }

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcIdentifierQuoterTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcIdentifierQuoterTest.java
@@ -92,6 +92,12 @@ class JdbcIdentifierQuoterTest {
                 JdbcIdentifierQuoter.quoteIdentifier(JdbcDbType.OCEANBASE_ORACLE, "myCol"));
     }
 
+    @Test
+    void testQuoteIdentifierSnowflakePreservesCase() {
+        Assertions.assertEquals("\"MY_COLUMN\"",
+                JdbcIdentifierQuoter.quoteIdentifier(JdbcDbType.SNOWFLAKE, "MY_COLUMN"));
+    }
+
     // === quoteRemoteIdentifier: never uppercases ===
 
     @Test
@@ -139,6 +145,12 @@ class JdbcIdentifierQuoterTest {
         Assertions.assertEquals("[dbo].[Orders]", result);
     }
 
+    @Test
+    void testQuoteFullTableNameSnowflake() {
+        String result = JdbcIdentifierQuoter.quoteFullTableName(JdbcDbType.SNOWFLAKE, "ADS", "DIM_USER");
+        Assertions.assertEquals("\"ADS\".\"DIM_USER\"", result);
+    }
+
     // === buildInsertSql ===
 
     @Test
@@ -183,5 +195,18 @@ class JdbcIdentifierQuoterTest {
                 Arrays.asList("col1"));
         Assertions.assertEquals(
                 "INSERT INTO [dbo].[items]([col1]) VALUES (?)", sql);
+    }
+
+    @Test
+    void testBuildInsertSqlSnowflake() {
+        Map<String, String> remoteNames = new HashMap<>();
+        remoteNames.put("id", "ID");
+        remoteNames.put("name", "NAME");
+
+        String sql = JdbcIdentifierQuoter.buildInsertSql(
+                JdbcDbType.SNOWFLAKE, "ADS", "DIM_USER", remoteNames,
+                Arrays.asList("id", "name"));
+        Assertions.assertEquals(
+                "INSERT INTO \"ADS\".\"DIM_USER\"(\"ID\",\"NAME\") VALUES (?, ?)", sql);
     }
 }

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcQueryBuilderTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcQueryBuilderTest.java
@@ -59,6 +59,10 @@ class JdbcQueryBuilderTest {
         return new JdbcQueryBuilder(JdbcDbType.SQLSERVER);
     }
 
+    private JdbcQueryBuilder snowflakeBuilder() {
+        return new JdbcQueryBuilder(JdbcDbType.SNOWFLAKE);
+    }
+
     private List<ConnectorColumnHandle> columns(String... names) {
         ConnectorColumnHandle[] cols = new ConnectorColumnHandle[names.length];
         for (int i = 0; i < names.length; i++) {
@@ -206,6 +210,16 @@ class JdbcQueryBuilderTest {
                 "Simple comparison should be pushed. SQL: " + sql);
         Assertions.assertTrue(sql.contains("`id`") && sql.contains("`name`"),
                 "Column names should be quoted. SQL: " + sql);
+    }
+
+    @Test
+    void testSnowflakeQueryUsesDoubleQuotesAndLimit() {
+        JdbcQueryBuilder builder = snowflakeBuilder();
+        String sql = builder.buildQuery("ADS", "DIM_USER", columns("ID", "NAME"),
+                Optional.of(simpleComparison("ID", 42)), 10);
+        Assertions.assertEquals(
+                "SELECT \"ID\", \"NAME\" FROM \"ADS\".\"DIM_USER\" WHERE (\"ID\" = 42) LIMIT 10",
+                sql);
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcScanRangeAndPropertiesTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcScanRangeAndPropertiesTest.java
@@ -17,13 +17,18 @@
 
 package org.apache.doris.connector.jdbc;
 
+import org.apache.doris.connector.api.ConnectorSession;
+import org.apache.doris.connector.api.scan.ConnectorScanRange;
 import org.apache.doris.connector.api.scan.ConnectorScanRangeType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 class JdbcScanRangeAndPropertiesTest {
 
@@ -71,6 +76,37 @@ class JdbcScanRangeAndPropertiesTest {
         Assertions.assertEquals("3000", props.get("connection_pool_max_wait_time"));
         Assertions.assertEquals("600000", props.get("connection_pool_max_life_time"));
         Assertions.assertEquals("true", props.get("connection_pool_keep_alive"));
+    }
+
+    @Test
+    void testBuildSnowflakeScanRangeTableType() {
+        JdbcScanRange range = new JdbcScanRange.Builder()
+                .tableType(JdbcDbType.SNOWFLAKE)
+                .build();
+        Assertions.assertEquals("SNOWFLAKE", range.getProperties().get("table_type"));
+    }
+
+    @Test
+    void testSnowflakeOauthScanUsesExplicitTokenAsJdbcPassword() {
+        Map<String, String> props = new HashMap<>();
+        props.put(JdbcConnectorProperties.JDBC_URL,
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=oauth");
+        props.put(JdbcConnectorProperties.USER, "snowflake-user");
+        props.put(JdbcConnectorProperties.PASSWORD, "snowflake-password");
+        props.put(JdbcConnectorProperties.SNOWFLAKE_OAUTH_ACCESS_TOKEN, "snowflake-oauth-token");
+        props.put(JdbcConnectorProperties.DRIVER_CLASS, "net.snowflake.client.jdbc.SnowflakeDriver");
+        props.put(JdbcConnectorProperties.DRIVER_URL, "file:///tmp/snowflake-jdbc.jar");
+
+        JdbcScanPlanProvider provider = new JdbcScanPlanProvider(JdbcDbType.SNOWFLAKE, props, 42L);
+
+        List<ConnectorScanRange> ranges = provider.planScan(
+                emptySession(),
+                new JdbcTableHandle("PUBLIC", "T1"),
+                Collections.emptyList(),
+                Optional.empty());
+
+        Assertions.assertEquals("snowflake-oauth-token",
+                ranges.get(0).getProperties().get("jdbc_password"));
     }
 
     @Test
@@ -172,5 +208,54 @@ class JdbcScanRangeAndPropertiesTest {
         Map<String, String> props = new HashMap<>();
         props.put("key", "0");
         Assertions.assertEquals(0, JdbcConnectorProperties.getInt(props, "key", 99));
+    }
+
+    private ConnectorSession emptySession() {
+        return new ConnectorSession() {
+            @Override
+            public String getQueryId() {
+                return "test-query";
+            }
+
+            @Override
+            public String getUser() {
+                return "root";
+            }
+
+            @Override
+            public String getTimeZone() {
+                return "UTC";
+            }
+
+            @Override
+            public String getLocale() {
+                return "en_US";
+            }
+
+            @Override
+            public long getCatalogId() {
+                return 42L;
+            }
+
+            @Override
+            public String getCatalogName() {
+                return "test";
+            }
+
+            @Override
+            public <T> T getProperty(String name, Class<T> type) {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> getCatalogProperties() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public Map<String, String> getSessionProperties() {
+                return Collections.emptyMap();
+            }
+        };
     }
 }

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcUrlNormalizerSnowflakeTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/JdbcUrlNormalizerSnowflakeTest.java
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.jdbc;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JdbcUrlNormalizerSnowflakeTest {
+
+    @Test
+    void testSnowflakeUrlIsPreserved() {
+        String url = "jdbc:snowflake://example.snowflakecomputing.com/"
+                + "?db=PLAUD_TEST&schema=ADS&warehouse=COMPUTE_WH&role=DORIS_DEBUG";
+        Assertions.assertEquals(url, JdbcUrlNormalizer.normalize(url, JdbcDbType.SNOWFLAKE));
+    }
+}

--- a/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/client/JdbcSnowflakeConnectorClientTest.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/test/java/org/apache/doris/connector/jdbc/client/JdbcSnowflakeConnectorClientTest.java
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.jdbc.client;
+
+import org.apache.doris.connector.api.ConnectorType;
+import org.apache.doris.connector.jdbc.JdbcDbType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+class JdbcSnowflakeConnectorClientTest {
+
+    private JdbcSnowflakeConnectorClient createClient(boolean enableVarbinary, boolean enableTimestampTz) {
+        return new JdbcSnowflakeConnectorClient(
+                "test_catalog",
+                JdbcDbType.SNOWFLAKE,
+                "jdbc:snowflake://example.snowflakecomputing.com/?db=PLAUD_TEST&schema=ADS",
+                false,
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                enableVarbinary,
+                enableTimestampTz);
+    }
+
+    @Test
+    void testNumberMapsToDecimalV3() {
+        ConnectorType type = createClient(false, false).jdbcTypeToConnectorType(
+                field(Types.NUMERIC, "NUMBER", 38, 0));
+        Assertions.assertEquals("DECIMALV3", type.getTypeName());
+        Assertions.assertEquals(38, type.getPrecision());
+        Assertions.assertEquals(0, type.getScale());
+    }
+
+    @Test
+    void testTimestampNtzScaleIsCappedAtMicrosecond() {
+        ConnectorType type = createClient(false, false).jdbcTypeToConnectorType(
+                field(Types.TIMESTAMP, "TIMESTAMP_NTZ", 0, 9));
+        Assertions.assertEquals("DATETIMEV2", type.getTypeName());
+        Assertions.assertEquals(6, type.getPrecision());
+    }
+
+    @Test
+    void testTimestampTzMappingIsOptIn() {
+        ConnectorType defaultType = createClient(false, false).jdbcTypeToConnectorType(
+                field(Types.TIMESTAMP_WITH_TIMEZONE, "TIMESTAMP_TZ", 0, 6));
+        Assertions.assertEquals("DATETIMEV2", defaultType.getTypeName());
+
+        ConnectorType timestampTz = createClient(false, true).jdbcTypeToConnectorType(
+                field(Types.TIMESTAMP_WITH_TIMEZONE, "TIMESTAMP_TZ", 0, 6));
+        Assertions.assertEquals("TIMESTAMPTZ", timestampTz.getTypeName());
+    }
+
+    @Test
+    void testComplexTypesMapToString() {
+        JdbcSnowflakeConnectorClient client = createClient(false, false);
+        Assertions.assertEquals("STRING", client.jdbcTypeToConnectorType(
+                field(Types.OTHER, "VARIANT", 0, 0)).getTypeName());
+        Assertions.assertEquals("STRING", client.jdbcTypeToConnectorType(
+                field(Types.OTHER, "ARRAY", 0, 0)).getTypeName());
+        Assertions.assertEquals("STRING", client.jdbcTypeToConnectorType(
+                field(Types.OTHER, "OBJECT", 0, 0)).getTypeName());
+    }
+
+    @Test
+    void testBinaryMappingIsOptIn() {
+        ConnectorType defaultType = createClient(false, false).jdbcTypeToConnectorType(
+                field(Types.BINARY, "BINARY", 16, 0));
+        Assertions.assertEquals("STRING", defaultType.getTypeName());
+
+        ConnectorType varbinary = createClient(true, false).jdbcTypeToConnectorType(
+                field(Types.BINARY, "BINARY", 16, 0));
+        Assertions.assertEquals("VARBINARY", varbinary.getTypeName());
+        Assertions.assertEquals(16, varbinary.getPrecision());
+    }
+
+    @Test
+    void testFallbackFloatTypesMapToDouble() {
+        JdbcSnowflakeConnectorClient client = createClient(false, false);
+        Assertions.assertEquals("DOUBLE", client.jdbcTypeToConnectorType(
+                field(Types.FLOAT, "", 0, 0)).getTypeName());
+        Assertions.assertEquals("DOUBLE", client.jdbcTypeToConnectorType(
+                field(Types.REAL, "", 0, 0)).getTypeName());
+    }
+
+    @Test
+    void testOauthAuthenticatorRequiresExactValue() {
+        Assertions.assertTrue(JdbcConnectorClient.isSnowflakeOauthUrl(
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=OAUTH"));
+        Assertions.assertFalse(JdbcConnectorClient.isSnowflakeOauthUrl(
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=oauth2"));
+        Assertions.assertFalse(JdbcConnectorClient.isSnowflakeOauthUrl(
+                "jdbc:mysql://127.0.0.1:3306/test?authenticator=oauth"));
+    }
+
+    @Test
+    void testExplicitOauthAccessTokenTakesPrecedenceOverPassword() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("password", "snowflake-password");
+        properties.put("snowflake.oauth.access_token", "snowflake-oauth-token");
+
+        String token = JdbcConnectorClient.resolveSnowflakeOauthToken(
+                properties,
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=oauth",
+                properties.get("password"));
+
+        Assertions.assertEquals("snowflake-oauth-token", token);
+    }
+
+    @Test
+    void testPasswordRemainsBackwardCompatibleForOauthToken() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("password", "legacy-oauth-token");
+
+        String token = JdbcConnectorClient.resolveSnowflakeOauthToken(
+                properties,
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=oauth",
+                properties.get("password"));
+
+        Assertions.assertEquals("legacy-oauth-token", token);
+    }
+
+    @Test
+    void testExplicitOauthAccessTokenDoesNotOverridePasswordAuth() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("password", "snowflake-password");
+        properties.put("snowflake.oauth.access_token", "snowflake-oauth-token");
+
+        String credential = JdbcConnectorClient.resolveSnowflakeOauthToken(
+                properties,
+                "jdbc:snowflake://example.snowflakecomputing.com/?warehouse=COMPUTE_WH",
+                properties.get("password"));
+
+        Assertions.assertEquals("snowflake-password", credential);
+    }
+
+    @Test
+    void testExplicitOauthAccessTokenDoesNotOverrideProgrammaticAccessTokenPassword() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("password", "snowflake-pat");
+        properties.put("snowflake.oauth.access_token", "snowflake-oauth-token");
+
+        String credential = JdbcConnectorClient.resolveSnowflakeOauthToken(
+                properties,
+                "jdbc:snowflake://example.snowflakecomputing.com/?authenticator=programmatic_access_token",
+                properties.get("password"));
+
+        Assertions.assertEquals("snowflake-pat", credential);
+    }
+
+    private JdbcFieldInfo field(int jdbcType, String typeName, int precision, int scale) {
+        return new JdbcFieldInfo(
+                "C1",
+                Optional.of(typeName),
+                jdbcType,
+                Optional.of(precision),
+                Optional.of(scale),
+                Optional.empty());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DatasourcePrintableMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DatasourcePrintableMap.java
@@ -54,6 +54,7 @@ public class DatasourcePrintableMap<K, V> extends BasicPrintableMap<K, V> {
         SENSITIVE_KEY.add("bos_secret_accesskey");
         SENSITIVE_KEY.add("jdbc.password");
         SENSITIVE_KEY.add("elasticsearch.password");
+        SENSITIVE_KEY.add("snowflake.oauth.access_token");
         SENSITIVE_KEY.addAll(Arrays.asList(
                 MCProperties.SECRET_KEY));
         SENSITIVE_KEY.addAll(ConnectorPropertiesUtils.getSensitiveKeys(S3Properties.class));

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DatasourcePrintableMapTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DatasourcePrintableMapTest.java
@@ -45,6 +45,7 @@ public class DatasourcePrintableMapTest {
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("elasticsearch.password"));
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("iceberg.rest.oauth2.credential"));
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("iceberg.rest.oauth2.token"));
+        Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("snowflake.oauth.access_token"));
 
         // Verify cloud storage related sensitive keys (these are constants added in static initialization block)
         Assertions.assertTrue(DatasourcePrintableMap.SENSITIVE_KEY.contains("s3.secret_key"));

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -437,7 +437,8 @@ enum TOdbcTableType {
     OCEANBASE_ORACLE = 11,
     NEBULA = 12, // Deprecated
     DB2 = 13,
-    GBASE = 14
+    GBASE = 14,
+    SNOWFLAKE = 15
 }
 
 struct TJdbcExecutorCtorParams {


### PR DESCRIPTION
## Proposed changes

- Add Snowflake as a JDBC catalog database type, including identifier quoting, LIMIT query generation, scan table type propagation, and Snowflake-specific type mapping.
- Add Snowflake JDBC catalog connection validation that requires dedicated `snowflake.database` and `snowflake.warehouse` properties, and rejects `db` / `database` / `warehouse` in `jdbc_url`.
- Add Snowflake OAuth handling for FE connection tests and BE JDBC scanner/writer Hikari data sources.
- Split Snowflake OAuth access token from password authentication: normal password auth uses `password`, OAuth auth uses `snowflake.oauth.access_token`. The old `password`-as-OAuth-token behavior remains as a fallback when `snowflake.oauth.access_token` is absent.
- Preserve Snowflake PAT behavior: `authenticator=programmatic_access_token` continues to use `password` as the PAT and is not overridden by `snowflake.oauth.access_token`.
- Mask `snowflake.oauth.access_token` in `SHOW CREATE CATALOG` output.

## Example

Password authentication:

```sql
CREATE CATALOG snowflake_jdbc PROPERTIES (
    "type" = "jdbc",
    "jdbc_url" = "jdbc:snowflake://<account>.snowflakecomputing.com",
    "snowflake.database" = "<snowflake_database>",
    "snowflake.warehouse" = "<snowflake_warehouse>",
    "user" = "<snowflake_user>",
    "password" = "<snowflake_password>",
    "driver_url" = "file:///path/to/snowflake-jdbc-thin-4.0.1.jar",
    "driver_class" = "net.snowflake.client.jdbc.SnowflakeDriver",
    "only_specified_database" = "false"
);
```

OAuth authentication:

```sql
CREATE CATALOG snowflake_jdbc_oauth PROPERTIES (
    "type" = "jdbc",
    "jdbc_url" = "jdbc:snowflake://<account>.snowflakecomputing.com/?authenticator=oauth",
    "snowflake.database" = "<snowflake_database>",
    "snowflake.warehouse" = "<snowflake_warehouse>",
    "user" = "<snowflake_user>",
    "snowflake.oauth.access_token" = "<oauth_access_token>",
    "driver_url" = "file:///path/to/snowflake-jdbc-thin-4.0.1.jar",
    "driver_class" = "net.snowflake.client.jdbc.SnowflakeDriver",
    "only_specified_database" = "false"
);
```

Programmatic access token authentication:

```sql
CREATE CATALOG snowflake_jdbc_pat PROPERTIES (
    "type" = "jdbc",
    "jdbc_url" = "jdbc:snowflake://<account>.snowflakecomputing.com/?authenticator=programmatic_access_token",
    "snowflake.database" = "<snowflake_database>",
    "snowflake.warehouse" = "<snowflake_warehouse>",
    "user" = "<snowflake_user>",
    "password" = "<snowflake_pat>",
    "driver_url" = "file:///path/to/snowflake-jdbc-thin-4.0.1.jar",
    "driver_class" = "net.snowflake.client.jdbc.SnowflakeDriver",
    "only_specified_database" = "false"
);
```

Do not put `db`, `database`, or `warehouse` in `jdbc_url`. Doris maps Snowflake as: Doris catalog -> Snowflake account + fixed database, Doris database -> Snowflake schema, Doris table -> Snowflake table.

## Notes

- Snowflake maps as: Doris catalog -> Snowflake account + fixed database, Doris database -> Snowflake schema, Doris table -> Snowflake table.
- No regression-test suite is added because real Snowflake validation requires external account credentials, driver jar, and network access. Coverage is added through focused FE/BE unit tests.

## Testing

- `mvn -Dmaven.build.cache.enabled=false -pl fe-connector/fe-connector-jdbc -am -Dtest=JdbcSnowflakeConnectorClientTest -DfailIfNoTests=false test`
  - Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
- `mvn -Dmaven.build.cache.enabled=false -pl be-java-extensions/jdbc-scanner -am -Dtest=SnowflakeJdbcAuthUtilsTest -DfailIfNoTests=false test`
  - Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
- `mvn -Dmaven.build.cache.enabled=false -pl fe-connector/fe-connector-jdbc -am -Dtest=JdbcSnowflakeConnectorClientTest,JdbcScanRangeAndPropertiesTest -DfailIfNoTests=false test`
  - Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
- `mvn -Dmaven.build.cache.enabled=false -pl fe-core -am -Dtest=DatasourcePrintableMapTest -DfailIfNoTests=false test`
  - Tests run: 17, Failures: 0, Errors: 0, Skipped: 0
