### PR TITLE
[opt](function) optimize repeat and trim string functions

### DIFF
--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -29,6 +29,7 @@
 #include "benchmark_string.hpp"
 #include "benchmark_string_replace.hpp"
 #include "benchmark_zone_map_index.hpp"
+#include "benchmark_trim.hpp"
 #include "binary_cast_benchmark.hpp"
 #include "core/block/block.h"
 #include "core/column/column_string.h"

--- a/be/benchmark/benchmark_string.hpp
+++ b/be/benchmark/benchmark_string.hpp
@@ -175,6 +175,63 @@ struct OldUnHexImpl {
     }
 };
 
+struct OldRepeatImpl {
+    static Status vector_vector(const ColumnString::Chars& data,
+                                const ColumnString::Offsets& offsets,
+                                const ColumnInt32::Container& repeats,
+                                ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                                ColumnUInt8::Container& null_map) {
+        const size_t input_row_size = offsets.size();
+
+        fmt::memory_buffer buffer;
+        res_offsets.resize(input_row_size);
+        null_map.resize_fill(input_row_size, 0);
+        for (size_t i = 0; i < input_row_size; ++i) {
+            buffer.clear();
+            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
+            const size_t size = offsets[i] - offsets[i - 1];
+            const int repeat = repeats[i];
+            if (repeat <= 0) {
+                StringOP::push_empty_string(i, res_data, res_offsets);
+                continue;
+            }
+
+            ColumnString::check_chars_length(static_cast<size_t>(repeat) * size + res_data.size(),
+                                             0);
+            for (int j = 0; j < repeat; ++j) {
+                buffer.append(raw_str, raw_str + size);
+            }
+            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
+                                        res_offsets);
+        }
+        return Status::OK();
+    }
+
+    static Status vector_const(const ColumnString::Chars& data,
+                               const ColumnString::Offsets& offsets, int repeat,
+                               ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                               ColumnUInt8::Container& null_map) {
+        const size_t input_row_size = offsets.size();
+
+        fmt::memory_buffer buffer;
+        res_offsets.resize(input_row_size);
+        null_map.resize_fill(input_row_size, 0);
+        for (size_t i = 0; i < input_row_size; ++i) {
+            buffer.clear();
+            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
+            const size_t size = offsets[i] - offsets[i - 1];
+            ColumnString::check_chars_length(static_cast<size_t>(repeat) * size + res_data.size(),
+                                             0);
+            for (int j = 0; j < repeat; ++j) {
+                buffer.append(raw_str, raw_str + size);
+            }
+            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
+                                        res_offsets);
+        }
+        return Status::OK();
+    }
+};
+
 static void generate_test_data(ColumnString::Chars& data, ColumnString::Offsets& offsets,
                                size_t num_rows, size_t str_len, unsigned char max_char) {
     const std::string base64_chars =
@@ -188,13 +245,28 @@ static void generate_test_data(ColumnString::Chars& data, ColumnString::Offsets&
     data.clear();
     data.reserve(num_rows * str_len);
 
-    size_t offset = 0;
+    uint32_t offset = 0;
     for (size_t i = 0; i < num_rows; ++i) {
         for (size_t j = 0; j < str_len; ++j) {
             data.push_back(static_cast<char>(base64_chars[dist(rng)]));
         }
         offset += str_len;
-        offsets[i] = cast_set<uint32_t>(offset);
+        offsets[i] = offset;
+    }
+}
+
+static ColumnString::MutablePtr generate_test_string_column(size_t num_rows, size_t str_len,
+                                                            unsigned char max_char) {
+    auto column = ColumnString::create();
+    generate_test_data(column->get_chars(), column->get_offsets(), num_rows, str_len, max_char);
+    return column;
+}
+
+static void generate_repeat_times(ColumnInt32::Container& repeats, size_t num_rows,
+                                  int32_t max_repeat) {
+    repeats.resize(num_rows);
+    for (size_t i = 0; i < num_rows; ++i) {
+        repeats[i] = max_repeat == 0 ? 0 : static_cast<int32_t>(i % max_repeat) + 1;
     }
 }
 
@@ -261,7 +333,7 @@ static void BM_FromBase64Impl_Old(benchmark::State& state) {
         dst_data.clear();
         dst_offsets.clear();
         auto status = OldFromBase64Impl::vector(data, offsets, dst_data, dst_offsets,
-                                                    null_map->get_data());
+                                                null_map->get_data());
         benchmark::DoNotOptimize(status);
     }
 }
@@ -329,8 +401,7 @@ static void BM_UnhexImpl_New(benchmark::State& state) {
     for (auto _ : state) {
         dst_data.clear();
         dst_offsets.clear();
-        auto status =
-                UnHexImpl<UnHexImplEmpty>::vector(data, offsets, dst_data, dst_offsets);
+        auto status = UnHexImpl<UnHexImplEmpty>::vector(data, offsets, dst_data, dst_offsets);
         benchmark::DoNotOptimize(status);
     }
 }
@@ -381,8 +452,8 @@ static void BM_UnhexNullImpl_New(benchmark::State& state) {
     for (auto _ : state) {
         dst_data.clear();
         dst_offsets.clear();
-        auto status = UnHexImpl<UnHexImplNull>::vector(
-                data, offsets, dst_data, dst_offsets, &null_map->get_data());
+        auto status = UnHexImpl<UnHexImplNull>::vector(data, offsets, dst_data, dst_offsets,
+                                                       &null_map->get_data());
         benchmark::DoNotOptimize(status);
     }
 }
@@ -397,6 +468,121 @@ BENCHMARK(BM_UnhexNullImpl_New)
         ->Args({1000, 256})
         ->Args({100, 65536})
         ->Args({100, 100000})
+        ->Unit(benchmark::kNanosecond);
+
+static void BM_RepeatVectorImpl_Old(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto max_repeat = static_cast<int32_t>(state.range(2));
+    ColumnString::Chars data;
+    ColumnString::Offsets offsets;
+    ColumnInt32::Container repeats;
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+
+    generate_test_data(data, offsets, rows, len, 63);
+    generate_repeat_times(repeats, rows, max_repeat);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        auto status = OldRepeatImpl::vector_vector(data, offsets, repeats, dst_data, dst_offsets,
+                                                   null_map);
+        benchmark::DoNotOptimize(status);
+    }
+}
+
+static void BM_RepeatVectorImpl_New(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto max_repeat = static_cast<int32_t>(state.range(2));
+    ColumnInt32::Container repeats;
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+    FunctionStringRepeat function;
+    auto source_column = generate_test_string_column(rows, len, 63);
+
+    generate_repeat_times(repeats, rows, max_repeat);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        auto status =
+                function.vector_vector(*source_column, repeats, dst_data, dst_offsets, null_map);
+        benchmark::DoNotOptimize(status);
+    }
+}
+
+BENCHMARK(BM_RepeatVectorImpl_Old)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
+        ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RepeatVectorImpl_New)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
+        ->Unit(benchmark::kNanosecond);
+
+static void BM_RepeatConstImpl_Old(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto repeat = static_cast<int32_t>(state.range(2));
+    ColumnString::Chars data;
+    ColumnString::Offsets offsets;
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+
+    generate_test_data(data, offsets, rows, len, 63);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        auto status =
+                OldRepeatImpl::vector_const(data, offsets, repeat, dst_data, dst_offsets, null_map);
+        benchmark::DoNotOptimize(status);
+    }
+}
+
+static void BM_RepeatConstImpl_New(benchmark::State& state) {
+    const size_t rows = state.range(0);
+    const size_t len = state.range(1);
+    const auto repeat = static_cast<int32_t>(state.range(2));
+    ColumnString::Chars dst_data;
+    ColumnString::Offsets dst_offsets;
+    ColumnUInt8::Container null_map;
+    FunctionStringRepeat function;
+    auto source_column = generate_test_string_column(rows, len, 63);
+
+    for (auto _ : state) {
+        dst_data.clear();
+        dst_offsets.clear();
+        null_map.clear();
+        static_cast<void>(
+                function.vector_const(*source_column, repeat, dst_data, dst_offsets, null_map));
+        benchmark::ClobberMemory();
+    }
+}
+
+BENCHMARK(BM_RepeatConstImpl_Old)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
+        ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RepeatConstImpl_New)
+        ->Args({4096, 16, 8})
+        ->Args({4096, 16, 64})
+        ->Args({1024, 128, 16})
+        ->Args({4096, 0, 64})
         ->Unit(benchmark::kNanosecond);
 
 } // namespace doris

--- a/be/benchmark/benchmark_trim.hpp
+++ b/be/benchmark/benchmark_trim.hpp
@@ -1,0 +1,598 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include <bitset>
+#include <random>
+#include <string>
+#include <unordered_set>
+
+#ifdef __SSE4_2__
+#include <nmmintrin.h>
+#endif
+
+#include "core/column/column_string.h"
+#include "exprs/function/url/find_symbols.h"
+#include "util/simd/vstring_function.h"
+
+namespace doris {
+
+// ==================== Old implementations (current Doris) ====================
+
+struct TrimInOld {
+    // Old ASCII path: std::bitset<128> + scalar loop
+    static void trim_in_ascii_old(const ColumnString::Chars& str_data,
+                                  const ColumnString::Offsets& str_offsets,
+                                  const StringRef& remove_str, ColumnString::Chars& res_data,
+                                  ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        std::bitset<128> char_lookup;
+        const char* remove_begin = remove_str.data;
+        const char* remove_end = remove_str.data + remove_str.size;
+
+        while (remove_begin < remove_end) {
+            char_lookup.set(static_cast<unsigned char>(*remove_begin));
+            remove_begin += 1;
+        }
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            while (left_trim_pos < str_end) {
+                if (!char_lookup.test(static_cast<unsigned char>(*left_trim_pos))) {
+                    break;
+                }
+                ++left_trim_pos;
+            }
+
+            // rtrim
+            while (right_trim_pos > left_trim_pos) {
+                --right_trim_pos;
+                if (!char_lookup.test(static_cast<unsigned char>(*right_trim_pos))) {
+                    ++right_trim_pos;
+                    break;
+                }
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+
+    // Old UTF-8 path: unordered_set<string_view> + hash lookup
+    static void trim_in_utf8_old(const ColumnString::Chars& str_data,
+                                 const ColumnString::Offsets& str_offsets,
+                                 const StringRef& remove_str, ColumnString::Chars& res_data,
+                                 ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        std::unordered_set<std::string_view> char_lookup;
+        const char* remove_begin = remove_str.data;
+        const char* remove_end = remove_str.data + remove_str.size;
+
+        while (remove_begin < remove_end) {
+            size_t byte_len, char_len;
+            std::tie(byte_len, char_len) = simd::VStringFunctions::iterate_utf8_with_limit_length(
+                    remove_begin, remove_end, 1);
+            char_lookup.insert(std::string_view(remove_begin, byte_len));
+            remove_begin += byte_len;
+        }
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            while (left_trim_pos < str_end) {
+                size_t byte_len, char_len;
+                std::tie(byte_len, char_len) =
+                        simd::VStringFunctions::iterate_utf8_with_limit_length(left_trim_pos,
+                                                                               str_end, 1);
+                if (char_lookup.find(std::string_view(left_trim_pos, byte_len)) ==
+                    char_lookup.end()) {
+                    break;
+                }
+                left_trim_pos += byte_len;
+            }
+
+            // rtrim
+            while (right_trim_pos > left_trim_pos) {
+                const char* prev_char_pos = right_trim_pos;
+                do {
+                    --prev_char_pos;
+                } while ((*prev_char_pos & 0xC0) == 0x80);
+                size_t byte_len = right_trim_pos - prev_char_pos;
+                if (char_lookup.find(std::string_view(prev_char_pos, byte_len)) ==
+                    char_lookup.end()) {
+                    break;
+                }
+                right_trim_pos = prev_char_pos;
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+};
+
+// TrimInNew — mirrors the optimized hot path from function_string.cpp
+// Inlined here because TrimInUtil is defined inside a .cpp and not visible to benchmarks.
+// Only covers the <=16 ASCII chars and <=32 UTF-8 codepoints paths (benchmark scenarios
+// do not exercise the fallback paths for larger trim sets).
+struct TrimInNew {
+    static void trim_in_ascii_new(const ColumnString::Chars& str_data,
+                                  const ColumnString::Offsets& str_offsets,
+                                  const StringRef& remove_str, ColumnString::Chars& res_data,
+                                  ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        SearchSymbols symbols(std::string(remove_str.data, remove_str.size));
+
+        bool char_lookup[256] = {};
+        for (size_t j = 0; j < remove_str.size; ++j) {
+            char_lookup[static_cast<unsigned char>(remove_str.data[j])] = true;
+        }
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            if (left_trim_pos < str_end &&
+                char_lookup[static_cast<unsigned char>(*left_trim_pos)]) {
+                left_trim_pos = find_first_not_symbols(
+                        std::string_view(str_begin, str_end - str_begin), symbols);
+            }
+
+            // rtrim
+            if (right_trim_pos > left_trim_pos &&
+                char_lookup[static_cast<unsigned char>(*(right_trim_pos - 1))]) {
+                const char* pos =
+                        find_last_not_symbols_or_null(left_trim_pos, right_trim_pos, symbols);
+                right_trim_pos = pos ? pos + 1 : left_trim_pos;
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+
+    static void trim_in_utf8_new(const ColumnString::Chars& str_data,
+                                 const ColumnString::Offsets& str_offsets,
+                                 const StringRef& remove_str, ColumnString::Chars& res_data,
+                                 ColumnString::Offsets& res_offsets) {
+        const size_t offset_size = str_offsets.size();
+        res_offsets.resize(offset_size);
+        res_data.reserve(str_data.size());
+
+        static constexpr size_t MAX_TRIM_CHARS = 32;
+        struct Utf8Char {
+            char data[6];
+            uint8_t len;
+        };
+        Utf8Char trim_chars[MAX_TRIM_CHARS];
+        size_t num_trim_chars = 0;
+
+        const char* remove_begin = remove_str.data;
+        const char* remove_end = remove_str.data + remove_str.size;
+
+        while (remove_begin < remove_end && num_trim_chars < MAX_TRIM_CHARS) {
+            uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*remove_begin));
+            if (remove_begin + byte_len > remove_end) break;
+            trim_chars[num_trim_chars].len = byte_len;
+            memcpy(trim_chars[num_trim_chars].data, remove_begin, byte_len);
+            ++num_trim_chars;
+            remove_begin += byte_len;
+        }
+
+        auto is_trim_char = [&](const char* pos, size_t byte_len) -> bool {
+            for (size_t c = 0; c < num_trim_chars; ++c) {
+                if (trim_chars[c].len == byte_len &&
+                    memcmp(trim_chars[c].data, pos, byte_len) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        for (size_t i = 0; i < offset_size; ++i) {
+            const char* str_begin =
+                    reinterpret_cast<const char*>(str_data.data() + str_offsets[i - 1]);
+            const char* str_end = reinterpret_cast<const char*>(str_data.data() + str_offsets[i]);
+            const char* left_trim_pos = str_begin;
+            const char* right_trim_pos = str_end;
+
+            // ltrim
+            while (left_trim_pos < str_end) {
+                uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*left_trim_pos));
+                if (left_trim_pos + byte_len > str_end) break;
+                if (!is_trim_char(left_trim_pos, byte_len)) break;
+                left_trim_pos += byte_len;
+            }
+
+            // rtrim
+            while (right_trim_pos > left_trim_pos) {
+                const char* prev_char_pos = right_trim_pos;
+                do {
+                    --prev_char_pos;
+                } while (prev_char_pos > left_trim_pos && (*prev_char_pos & 0xC0) == 0x80);
+                size_t byte_len = right_trim_pos - prev_char_pos;
+                if (!is_trim_char(prev_char_pos, byte_len)) break;
+                right_trim_pos = prev_char_pos;
+            }
+
+            res_data.insert_assume_reserved(left_trim_pos, right_trim_pos);
+            res_offsets[i] = (ColumnString::Offset)res_data.size();
+        }
+    }
+};
+
+// ==================== Benchmark helpers ====================
+
+static void prepare_ascii_column(ColumnString& col, size_t num_rows, size_t str_len,
+                                 const std::string& trim_chars_str) {
+    std::mt19937 gen(42);
+    std::uniform_int_distribution<int> char_dist(32, 126); // printable ASCII
+    std::uniform_int_distribution<int> trim_count_dist(0, 10);
+
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s;
+        // Add random trim chars at front
+        int front_count = trim_count_dist(gen);
+        for (int j = 0; j < front_count; ++j) {
+            s += trim_chars_str[gen() % trim_chars_str.size()];
+        }
+        // Add random non-trim content
+        for (size_t j = 0; j < str_len; ++j) {
+            char c;
+            do {
+                c = static_cast<char>(char_dist(gen));
+            } while (trim_chars_str.find(c) != std::string::npos);
+            s += c;
+        }
+        // Add random trim chars at back
+        int back_count = trim_count_dist(gen);
+        for (int j = 0; j < back_count; ++j) {
+            s += trim_chars_str[gen() % trim_chars_str.size()];
+        }
+        col.insert_data(s.data(), s.size());
+    }
+}
+
+static void prepare_utf8_column(ColumnString& col, size_t num_rows) {
+    // Use a mix of ASCII and multi-byte UTF-8 characters
+    // trim chars: "你好" (6 bytes, 2 chars)
+    std::mt19937 gen(42);
+
+    // some multi-byte chars for content
+    const char* content_chars[] = {"a", "b", "c", "世", "界", "测", "试"};
+    const size_t num_content = 7;
+    // trim chars
+    const char* trim_parts[] = {"你", "好"};
+    const size_t num_trim = 2;
+
+    std::uniform_int_distribution<int> trim_count_dist(0, 5);
+    std::uniform_int_distribution<int> content_dist(0, num_content - 1);
+    std::uniform_int_distribution<int> trim_dist(0, num_trim - 1);
+
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s;
+        int front = trim_count_dist(gen);
+        for (int j = 0; j < front; ++j) {
+            s += trim_parts[trim_dist(gen)];
+        }
+        // 10 content chars
+        for (int j = 0; j < 10; ++j) {
+            s += content_chars[content_dist(gen)];
+        }
+        int back = trim_count_dist(gen);
+        for (int j = 0; j < back; ++j) {
+            s += trim_parts[trim_dist(gen)];
+        }
+        col.insert_data(s.data(), s.size());
+    }
+}
+
+// ==================== Benchmark functions ====================
+
+static void BM_TrimInAscii_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check on both remove_str and column data
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_ascii_old(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInAscii_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check on both remove_str and column data
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInUtf8_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    auto col = ColumnString::create();
+    prepare_utf8_column(*col, num_rows);
+
+    std::string trim_chars = "你好";
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_utf8_old(col->get_chars(), col->get_offsets(), remove_str,
+                                    res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInUtf8_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    auto col = ColumnString::create();
+    prepare_utf8_column(*col, num_rows);
+
+    std::string trim_chars = "你好";
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInNew::trim_in_utf8_new(col->get_chars(), col->get_offsets(), remove_str,
+                                    res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+// ---- ASCII: many trim chars (8 chars) ----
+static void BM_TrimInAsciiManyChars_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r.,-;";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_ascii_old(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInAsciiManyChars_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = " \t\n\r.,-;";
+    auto col = ColumnString::create();
+    prepare_ascii_column(*col, num_rows, 20, trim_chars);
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+// ---- No-match scenario (nothing to trim) ----
+static void BM_TrimInAsciiNoMatch_Old(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = "xyz"; // chars unlikely in data
+    auto col = ColumnString::create();
+    // prepare data without any trim chars
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s(30, 'a');
+        col->insert_data(s.data(), s.size());
+    }
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInOld::trim_in_ascii_old(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+static void BM_TrimInAsciiNoMatch_New(benchmark::State& state) {
+    size_t num_rows = state.range(0);
+    std::string trim_chars = "xyz";
+    auto col = ColumnString::create();
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string s(30, 'a');
+        col->insert_data(s.data(), s.size());
+    }
+
+    StringRef remove_str(trim_chars.data(), trim_chars.size());
+
+    for (auto _ : state) {
+        // Match production overhead: is_ascii check
+        bool all_ascii = simd::VStringFunctions::is_ascii(remove_str) &&
+                         simd::VStringFunctions::is_ascii(
+                                 StringRef(reinterpret_cast<const char*>(col->get_chars().data()),
+                                           col->get_chars().size()));
+        benchmark::DoNotOptimize(all_ascii);
+        auto res = ColumnString::create();
+        TrimInNew::trim_in_ascii_new(col->get_chars(), col->get_offsets(), remove_str,
+                                     res->get_chars(), res->get_offsets());
+        benchmark::DoNotOptimize(res);
+    }
+
+    state.SetItemsProcessed(state.iterations() * num_rows);
+}
+
+} // namespace doris
+
+BENCHMARK(doris::BM_TrimInAscii_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAscii_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiManyChars_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiManyChars_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiNoMatch_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInAsciiNoMatch_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInUtf8_Old)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();
+
+BENCHMARK(doris::BM_TrimInUtf8_New)
+        ->Unit(benchmark::kMicrosecond)
+        ->Arg(1024)
+        ->Arg(4096)
+        ->Arg(65536)
+        ->Repetitions(3)
+        ->DisplayAggregatesOnly();

--- a/be/src/exprs/function/function_string.cpp
+++ b/be/src/exprs/function/function_string.cpp
@@ -23,10 +23,10 @@
 #include <unicode/unistr.h>
 #include <unicode/ustream.h>
 
-#include <bitset>
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
+#include <unordered_set>
 
 #include "common/cast_set.h"
 #include "common/status.h"
@@ -42,6 +42,7 @@
 #include "exprs/function/function_totype.h"
 #include "exprs/function/simple_function_factory.h"
 #include "exprs/function/string_hex_util.h"
+#include "exprs/function/url/find_symbols.h"
 #include "util/string_search.hpp"
 #include "util/url_coding.h"
 #include "util/utf8_check.h"
@@ -763,13 +764,18 @@ private:
                                      const StringRef& remove_str, ColumnString::Chars& res_data,
                                      ColumnString::Offsets& res_offsets) {
         const size_t offset_size = str_offsets.size();
-        std::bitset<128> char_lookup;
-        const char* remove_begin = remove_str.data;
-        const char* remove_end = remove_str.data + remove_str.size;
 
-        while (remove_begin < remove_end) {
-            char_lookup.set(static_cast<unsigned char>(*remove_begin));
-            remove_begin += 1;
+        // Build scalar lookup table (works for any number of trim chars)
+        bool char_lookup[256] = {};
+        for (size_t j = 0; j < remove_str.size; ++j) {
+            char_lookup[static_cast<unsigned char>(remove_str.data[j])] = true;
+        }
+
+        // SearchSymbols buffer is capped at 16 bytes; use SIMD only when within limit
+        const bool use_simd = remove_str.size <= SearchSymbols::BUFFER_SIZE;
+        SearchSymbols symbols;
+        if (use_simd) {
+            symbols = SearchSymbols(std::string(remove_str.data, remove_str.size));
         }
 
         for (size_t i = 0; i < offset_size; ++i) {
@@ -780,20 +786,32 @@ private:
             const char* right_trim_pos = str_end;
 
             if constexpr (is_ltrim) {
-                while (left_trim_pos < str_end) {
-                    if (!char_lookup.test(static_cast<unsigned char>(*left_trim_pos))) {
-                        break;
+                if (left_trim_pos < str_end &&
+                    char_lookup[static_cast<unsigned char>(*left_trim_pos)]) {
+                    if (use_simd) {
+                        left_trim_pos = find_first_not_symbols(
+                                std::string_view(str_begin, str_end - str_begin), symbols);
+                    } else {
+                        while (left_trim_pos < str_end &&
+                               char_lookup[static_cast<unsigned char>(*left_trim_pos)]) {
+                            ++left_trim_pos;
+                        }
                     }
-                    ++left_trim_pos;
                 }
             }
 
             if constexpr (is_rtrim) {
-                while (right_trim_pos > left_trim_pos) {
-                    --right_trim_pos;
-                    if (!char_lookup.test(static_cast<unsigned char>(*right_trim_pos))) {
-                        ++right_trim_pos;
-                        break;
+                if (right_trim_pos > left_trim_pos &&
+                    char_lookup[static_cast<unsigned char>(*(right_trim_pos - 1))]) {
+                    if (use_simd) {
+                        const char* pos = find_last_not_symbols_or_null(left_trim_pos,
+                                                                        right_trim_pos, symbols);
+                        right_trim_pos = pos ? pos + 1 : left_trim_pos;
+                    } else {
+                        while (right_trim_pos > left_trim_pos &&
+                               char_lookup[static_cast<unsigned char>(*(right_trim_pos - 1))]) {
+                            --right_trim_pos;
+                        }
                     }
                 }
             }
@@ -814,17 +832,53 @@ private:
         res_offsets.resize(offset_size);
         res_data.reserve(str_data.size());
 
-        std::unordered_set<std::string_view> char_lookup;
+        // Pre-decode trim characters into a small fixed-size array
+        // Avoids unordered_set hash lookup overhead for typical small character sets
+        static constexpr size_t MAX_TRIM_CHARS = 32;
+        struct Utf8Char {
+            char data[6];
+            uint8_t len;
+        };
+        Utf8Char trim_chars[MAX_TRIM_CHARS];
+        size_t num_trim_chars = 0;
+
         const char* remove_begin = remove_str.data;
         const char* remove_end = remove_str.data + remove_str.size;
 
-        while (remove_begin < remove_end) {
-            size_t byte_len, char_len;
-            std::tie(byte_len, char_len) = simd::VStringFunctions::iterate_utf8_with_limit_length(
-                    remove_begin, remove_end, 1);
-            char_lookup.insert(std::string_view(remove_begin, byte_len));
+        while (remove_begin < remove_end && num_trim_chars < MAX_TRIM_CHARS) {
+            uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*remove_begin));
+            if (remove_begin + byte_len > remove_end) break;
+            trim_chars[num_trim_chars].len = byte_len;
+            memcpy(trim_chars[num_trim_chars].data, remove_begin, byte_len);
+            ++num_trim_chars;
             remove_begin += byte_len;
         }
+
+        // Fall back to unordered_set if trim set exceeds fixed array capacity
+        const bool use_set = remove_begin < remove_end;
+        std::unordered_set<std::string_view> trim_set;
+        if (use_set) {
+            remove_begin = remove_str.data;
+            while (remove_begin < remove_end) {
+                uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*remove_begin));
+                if (remove_begin + byte_len > remove_end) break;
+                trim_set.emplace(remove_begin, byte_len);
+                remove_begin += byte_len;
+            }
+        }
+
+        auto is_trim_char = [&](const char* pos, size_t byte_len) -> bool {
+            if (use_set) {
+                return trim_set.count(std::string_view(pos, byte_len)) > 0;
+            }
+            for (size_t c = 0; c < num_trim_chars; ++c) {
+                if (trim_chars[c].len == byte_len &&
+                    memcmp(trim_chars[c].data, pos, byte_len) == 0) {
+                    return true;
+                }
+            }
+            return false;
+        };
 
         for (size_t i = 0; i < offset_size; ++i) {
             const char* str_begin =
@@ -835,12 +889,9 @@ private:
 
             if constexpr (is_ltrim) {
                 while (left_trim_pos < str_end) {
-                    size_t byte_len, char_len;
-                    std::tie(byte_len, char_len) =
-                            simd::VStringFunctions::iterate_utf8_with_limit_length(left_trim_pos,
-                                                                                   str_end, 1);
-                    if (char_lookup.find(std::string_view(left_trim_pos, byte_len)) ==
-                        char_lookup.end()) {
+                    uint8_t byte_len = get_utf8_byte_length(static_cast<uint8_t>(*left_trim_pos));
+                    if (left_trim_pos + byte_len > str_end) break;
+                    if (!is_trim_char(left_trim_pos, byte_len)) {
                         break;
                     }
                     left_trim_pos += byte_len;
@@ -852,10 +903,9 @@ private:
                     const char* prev_char_pos = right_trim_pos;
                     do {
                         --prev_char_pos;
-                    } while ((*prev_char_pos & 0xC0) == 0x80);
+                    } while (prev_char_pos > left_trim_pos && (*prev_char_pos & 0xC0) == 0x80);
                     size_t byte_len = right_trim_pos - prev_char_pos;
-                    if (char_lookup.find(std::string_view(prev_char_pos, byte_len)) ==
-                        char_lookup.end()) {
+                    if (!is_trim_char(prev_char_pos, byte_len)) {
                         break;
                     }
                     right_trim_pos = prev_char_pos;

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -636,18 +636,19 @@ private:
         res_offsets.resize(input_row_size);
         null_map.resize_fill(input_row_size, 0);
 
-        uint32_t total_size = 0;
+        size_t total_size = 0;
         for (size_t i = 0; i < input_row_size; ++i) {
             const int repeat = repeat_getter(i);
             if (repeat <= 0) {
-                res_offsets[i] = total_size;
+                res_offsets[i] = static_cast<ColumnString::Offset>(total_size);
                 continue;
             }
 
             const auto str_ref = source_column.get_data_at(i);
-            const uint32_t size = str_ref.size;
-            total_size += size * repeat;
-            res_offsets[i] = total_size;
+            const size_t repeated_size = str_ref.size * static_cast<size_t>(repeat);
+            total_size += repeated_size;
+            ColumnString::check_chars_length(total_size, input_row_size);
+            res_offsets[i] = static_cast<ColumnString::Offset>(total_size);
         }
 
         ColumnString::check_chars_length(total_size, input_row_size);

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -581,8 +581,7 @@ public:
 
         if (const auto* col1 = check_and_get_column<ColumnString>(*argument_ptr[0])) {
             if (const auto* col2 = check_and_get_column<ColumnInt32>(*argument_ptr[1])) {
-                RETURN_IF_ERROR(vector_vector(col1->get_chars(), col1->get_offsets(),
-                                              col2->get_data(), res->get_chars(),
+                RETURN_IF_ERROR(vector_vector(*col1, col2->get_data(), res->get_chars(),
                                               res->get_offsets(), null_map->get_data()));
                 block.replace_by_position(
                         result, ColumnNullable::create(std::move(res), std::move(null_map)));
@@ -595,8 +594,8 @@ public:
                     null_map->get_data().resize_fill(input_rows_count, 0);
                     res->insert_many_defaults(input_rows_count);
                 } else {
-                    vector_const(col1->get_chars(), col1->get_offsets(), repeat, res->get_chars(),
-                                 res->get_offsets(), null_map->get_data());
+                    RETURN_IF_ERROR(vector_const(*col1, repeat, res->get_chars(),
+                                                 res->get_offsets(), null_map->get_data()));
                 }
                 block.replace_by_position(
                         result, ColumnNullable::create(std::move(res), std::move(null_map)));
@@ -608,57 +607,70 @@ public:
                                     argument_ptr[0]->get_name(), argument_ptr[1]->get_name());
     }
 
-    Status vector_vector(const ColumnString::Chars& data, const ColumnString::Offsets& offsets,
-                         const ColumnInt32::Container& repeats, ColumnString::Chars& res_data,
-                         ColumnString::Offsets& res_offsets,
+    Status vector_vector(const ColumnString& source_column, const ColumnInt32::Container& repeats,
+                         ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
                          ColumnUInt8::Container& null_map) const {
-        size_t input_row_size = offsets.size();
-
-        fmt::memory_buffer buffer;
-        res_offsets.resize(input_row_size);
-        null_map.resize_fill(input_row_size, 0);
-        for (ssize_t i = 0; i < input_row_size; ++i) {
-            buffer.clear();
-            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
-            size_t size = offsets[i] - offsets[i - 1];
-            int repeat = repeats[i];
-            if (repeat <= 0) {
-                StringOP::push_empty_string(i, res_data, res_offsets);
-            } else {
-                ColumnString::check_chars_length(repeat * size + res_data.size(), 0);
-                for (int j = 0; j < repeat; ++j) {
-                    buffer.append(raw_str, raw_str + size);
-                }
-                StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i,
-                                            res_data, res_offsets);
-            }
-        }
-        return Status::OK();
+        return _repeat_execute(
+                source_column, [&repeats](size_t index) { return repeats[index]; }, res_data,
+                res_offsets, null_map);
     }
 
     // TODO: 1. use pmr::vector<char> replace fmt_buffer may speed up the code
     //       2. abstract the `vector_vector` and `vector_const`
     //       3. rethink we should use `DEFAULT_MAX_STRING_SIZE` to bigger here
-    void vector_const(const ColumnString::Chars& data, const ColumnString::Offsets& offsets,
-                      int repeat, ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
-                      ColumnUInt8::Container& null_map) const {
-        size_t input_row_size = offsets.size();
+    Status vector_const(const ColumnString& source_column, int repeat,
+                        ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                        ColumnUInt8::Container& null_map) const {
+        return _repeat_execute(
+                source_column, [repeat](size_t) { return repeat; }, res_data, res_offsets,
+                null_map);
+    }
 
-        fmt::memory_buffer buffer;
+private:
+    template <typename RepeatGetter>
+    Status _repeat_execute(const ColumnString& source_column, RepeatGetter&& repeat_getter,
+                           ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                           ColumnUInt8::Container& null_map) const {
+        const auto input_row_size = source_column.size();
+
         res_offsets.resize(input_row_size);
         null_map.resize_fill(input_row_size, 0);
-        for (ssize_t i = 0; i < input_row_size; ++i) {
-            buffer.clear();
-            const char* raw_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
-            size_t size = offsets[i] - offsets[i - 1];
-            ColumnString::check_chars_length(repeat * size + res_data.size(), 0);
 
-            for (int j = 0; j < repeat; ++j) {
-                buffer.append(raw_str, raw_str + size);
+        uint32_t total_size = 0;
+        for (size_t i = 0; i < input_row_size; ++i) {
+            const int repeat = repeat_getter(i);
+            if (repeat <= 0) {
+                res_offsets[i] = total_size;
+                continue;
             }
-            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
-                                        res_offsets);
+
+            const auto str_ref = source_column.get_data_at(i);
+            const uint32_t size = str_ref.size;
+            total_size += size * repeat;
+            res_offsets[i] = total_size;
         }
+
+        ColumnString::check_chars_length(total_size, input_row_size);
+        res_data.resize(total_size);
+
+        auto* res_data_ptr = res_data.data();
+        for (size_t i = 0; i < input_row_size; ++i) {
+            const int repeat = repeat_getter(i);
+            if (repeat <= 0) {
+                continue;
+            }
+
+            const auto str_ref = source_column.get_data_at(i);
+            if (UNLIKELY(str_ref.size == 0)) {
+                continue;
+            }
+
+            StringOP::fast_repeat(res_data_ptr + res_offsets[i - 1],
+                                  reinterpret_cast<const uint8_t*>(str_ref.data), str_ref.size,
+                                  repeat);
+        }
+
+        return Status::OK();
     }
 };
 

--- a/be/src/exprs/function/url/find_symbols.h
+++ b/be/src/exprs/function/url/find_symbols.h
@@ -349,9 +349,10 @@ inline const char* find_last_symbols_sse2(const char* const begin, const char* c
     }
 #endif
 
-    --pos;
-    for (; pos >= begin; --pos)
-        if (maybe_negate<positive>(is_in(*pos, symbols, num_chars))) return pos;
+    for (const char* p = pos; p != begin;) {
+        --p;
+        if (maybe_negate<positive>(is_in(*p, symbols, num_chars))) return p;
+    }
 
     return return_mode == ReturnMode::End ? end : nullptr;
 }

--- a/be/src/exprs/function/url/find_symbols.h
+++ b/be/src/exprs/function/url/find_symbols.h
@@ -129,11 +129,11 @@ inline AlignedArray mm_is_in_prepare(const char* symbols, size_t num_chars) {
     return result;
 }
 
-inline __m128i mm_is_in_execute(__m128i bytes, const AlignedArray& needles) {
+inline __m128i mm_is_in_execute(__m128i bytes, const AlignedArray& needles, size_t num_chars) {
     __m128i accumulator = _mm_setzero_si128();
 
-    for (const auto& needle : needles) {
-        __m128i eq = _mm_cmpeq_epi8(bytes, reinterpret_cast<const __m128i&>(needle));
+    for (size_t i = 0; i < num_chars; ++i) {
+        __m128i eq = _mm_cmpeq_epi8(bytes, reinterpret_cast<const __m128i&>(needles[i]));
         accumulator = _mm_or_si128(accumulator, eq);
     }
 
@@ -190,7 +190,7 @@ inline const char* find_first_symbols_sse2(const char* const begin, const char* 
     for (; pos + 15 < end; pos += 16) {
         __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos));
 
-        __m128i eq = mm_is_in_execute(bytes, needles);
+        __m128i eq = mm_is_in_execute(bytes, needles, num_chars);
 
         uint16_t bit_mask = maybe_negate<positive>(uint16_t(_mm_movemask_epi8(eq)));
         if (bit_mask) return pos + __builtin_ctz(bit_mask);
@@ -330,7 +330,68 @@ inline const char* find_first_symbols_sse42(const char* const begin, const char*
     return return_mode == ReturnMode::End ? end : nullptr;
 }
 
-/// NOTE No SSE 4.2 implementation for find_last_symbols_or_null. Not worth to do.
+template <bool positive, ReturnMode return_mode>
+inline const char* find_last_symbols_sse2(const char* const begin, const char* const end,
+                                          const char* symbols, size_t num_chars) {
+    if (begin >= end) return return_mode == ReturnMode::End ? end : nullptr;
+
+    const char* pos = end;
+
+#if defined(__SSE2__)
+    const auto needles = mm_is_in_prepare(symbols, num_chars);
+    for (; pos - 16 >= begin; pos -= 16) {
+        __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos - 16));
+
+        __m128i eq = mm_is_in_execute(bytes, needles, num_chars);
+
+        uint16_t bit_mask = maybe_negate<positive>(uint16_t(_mm_movemask_epi8(eq)));
+        if (bit_mask) return pos - 1 - (__builtin_clz(bit_mask) - 16);
+    }
+#endif
+
+    --pos;
+    for (; pos >= begin; --pos)
+        if (maybe_negate<positive>(is_in(*pos, symbols, num_chars))) return pos;
+
+    return return_mode == ReturnMode::End ? end : nullptr;
+}
+
+template <bool positive, ReturnMode return_mode>
+inline const char* find_last_symbols_sse42(const char* const begin, const char* const end,
+                                           const SearchSymbols& symbols) {
+    if (begin >= end) return return_mode == ReturnMode::End ? end : nullptr;
+
+    const char* pos = end;
+
+    const auto num_chars = symbols.str.size();
+
+#if defined(__SSE4_2__)
+    constexpr int mode = _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_MOST_SIGNIFICANT;
+
+    const __m128i set = symbols.simd_vector;
+
+    for (; static_cast<size_t>(pos - begin) >= 16; pos -= 16) {
+        __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(pos - 16));
+
+        if constexpr (positive) {
+            if (_mm_cmpestrc(set, num_chars, bytes, 16, mode))
+                return pos - 16 + _mm_cmpestri(set, num_chars, bytes, 16, mode);
+        } else {
+            if (_mm_cmpestrc(set, num_chars, bytes, 16, mode | _SIDD_NEGATIVE_POLARITY))
+                return pos - 16 +
+                       _mm_cmpestri(set, num_chars, bytes, 16, mode | _SIDD_NEGATIVE_POLARITY);
+        }
+    }
+#endif
+
+    // Scalar tail: scan remaining bytes from pos-1 down to begin
+    for (const char* p = pos; p != begin;) {
+        --p;
+        if (maybe_negate<positive>(is_in(*p, symbols.str.data(), num_chars))) return p;
+    }
+
+    return return_mode == ReturnMode::End ? end : nullptr;
+}
 
 template <bool positive, ReturnMode return_mode, char... symbols>
 inline const char* find_first_symbols_dispatch(const char* begin, const char* end)
@@ -356,6 +417,18 @@ inline const char* find_first_symbols_dispatch(const std::string_view haystack,
 #endif
         return find_first_symbols_sse2<positive, return_mode>(
                 haystack.begin(), haystack.end(), symbols.str.data(), symbols.str.size());
+}
+
+template <bool positive, ReturnMode return_mode>
+inline const char* find_last_symbols_dispatch(const char* begin, const char* end,
+                                              const SearchSymbols& symbols) {
+#if defined(__SSE4_2__)
+    if (symbols.str.size() >= 5)
+        return find_last_symbols_sse42<positive, return_mode>(begin, end, symbols);
+    else
+#endif
+        return find_last_symbols_sse2<positive, return_mode>(begin, end, symbols.str.data(),
+                                                             symbols.str.size());
 }
 
 } // namespace detail
@@ -460,6 +533,12 @@ inline char* find_last_not_symbols_or_null(char* begin, char* end) {
     return const_cast<char*>(
             ::detail::find_last_symbols_sse2<false, ::detail::ReturnMode::Nullptr, symbols...>(
                     begin, end));
+}
+
+inline const char* find_last_not_symbols_or_null(const char* begin, const char* end,
+                                                 const SearchSymbols& symbols) {
+    return ::detail::find_last_symbols_dispatch<false, ::detail::ReturnMode::Nullptr>(begin, end,
+                                                                                      symbols);
 }
 
 /// Slightly resembles boost::split. The drawback of boost::split is that it fires a false positive in clang static analyzer.

--- a/be/test/exprs/function/function_string_test.cpp
+++ b/be/test/exprs/function/function_string_test.cpp
@@ -800,6 +800,31 @@ TEST(function_string_test, function_string_repeat_test) {
     }
 }
 
+TEST(function_string_test, function_string_repeat_overflow_vector_test) {
+    std::string func_name = "repeat";
+    InputTypeSet input_types = {PrimitiveType::TYPE_VARCHAR, PrimitiveType::TYPE_INT};
+    DataSet data_set = {
+            {{std::string(65536, 'a'), std::int32_t(65536)}, std::string("")},
+    };
+
+    Status st = check_function<DataTypeString, true>(func_name, input_types, data_set);
+    EXPECT_NE(Status::OK(), st);
+}
+
+TEST(function_string_test, function_string_repeat_overflow_const_test) {
+    std::string func_name = "repeat";
+    InputTypeSet input_types = {
+            PrimitiveType::TYPE_VARCHAR,
+            Consted {PrimitiveType::TYPE_INT},
+    };
+    DataSet data_set = {
+            {{std::string(65536, 'a'), std::int32_t(65536)}, std::string("")},
+    };
+
+    Status st = check_function<DataTypeString, true>(func_name, input_types, data_set);
+    EXPECT_NE(Status::OK(), st);
+}
+
 TEST(function_string_test, function_string_reverse_test) {
     std::string func_name = "reverse";
     {

--- a/be/test/exprs/function/function_string_test.cpp
+++ b/be/test/exprs/function/function_string_test.cpp
@@ -793,6 +793,7 @@ TEST(function_string_test, function_string_repeat_test) {
                              "ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@"
                              "i$o%ll_heh1h2!u@u@i$o%ll_heh1h2!u@u@i$o%ll_")},
                 {{std::string("heh1h2!u@u@i$o%ll_"), std::int32_t(-1)}, std::string("")},
+                {{std::string("a"), std::int32_t(256)}, std::string(256, 'a')},
         };
 
         check_function_all_arg_comb<DataTypeString, true>(func_name, input_types, data_set);

--- a/be/test/exprs/function/url/find_symbols_test.cpp
+++ b/be/test/exprs/function/url/find_symbols_test.cpp
@@ -1,0 +1,381 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exprs/function/url/find_symbols.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace doris {
+
+class FindSymbolsTest : public ::testing::Test {};
+
+// ==================== find_last_not_symbols_or_null with SearchSymbols ====================
+
+// --- SSE2 path: < 5 trim characters ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_BasicTrim) {
+    // "   hello   " with trim chars " " -> last non-space is 'o' at index 7
+    std::string s = "   hello   ";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 7);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_AllMatch) {
+    // All characters are trim chars -> returns nullptr
+    std::string s = "    ";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_NoMatch) {
+    // No trim chars in string -> last char is the answer
+    std::string s = "hello";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_EmptyString) {
+    std::string s;
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_SingleChar_Match) {
+    std::string s = " ";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_SingleChar_NoMatch) {
+    std::string s = "x";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 0);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_MultipleSymbols) {
+    // 3 trim chars (SSE2 path): space, tab, newline
+    std::string s = "hello\t\n ";
+    SearchSymbols symbols(" \t\n");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_FourSymbols) {
+    // 4 trim chars (still SSE2 path)
+    std::string s = "data.,-;";
+    SearchSymbols symbols(".,-;");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'a');
+    EXPECT_EQ(result - s.data(), 3);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_TrailingNonTrim) {
+    // No trailing trim chars -> returns last char
+    std::string s = "   hello";
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 7);
+}
+
+// --- SSE4.2 path: >= 5 trim characters ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_FiveSymbols) {
+    // Exactly 5 trim chars -> SSE4.2 PCMPESTRI path
+    std::string s = "hello.,;:-";
+    SearchSymbols symbols(".,;:-");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'o');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_EightSymbols) {
+    std::string s = "world \t\n\r.,-;";
+    SearchSymbols symbols(" \t\n\r.,-;");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'd');
+    EXPECT_EQ(result - s.data(), 4);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_AllMatch) {
+    std::string s = " \t\n\r.";
+    SearchSymbols symbols(" \t\n\r.");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_NoMatch) {
+    std::string s = "helloworld";
+    SearchSymbols symbols(".,;:-!");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'd');
+    EXPECT_EQ(result - s.data(), 9);
+}
+
+// --- Long strings: cross SIMD 16-byte boundaries ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_LongString) {
+    // 50 spaces + "abc" + 50 spaces = 103 chars, crosses multiple SIMD chunks
+    std::string s(50, ' ');
+    s += "abc";
+    s += std::string(50, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'c');
+    EXPECT_EQ(result - s.data(), 52);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE42_LongString) {
+    // Same test but with >= 5 trim chars to force SSE4.2
+    std::string s(50, ' ');
+    s += "abc";
+    s += std::string(30, ' ');
+    s += std::string(20, '\t');
+    SearchSymbols symbols(" \t\n\r.;");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'c');
+    EXPECT_EQ(result - s.data(), 52);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_LongAllTrim) {
+    // 200 spaces -> nullptr
+    std::string s(200, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_LongNoTrim) {
+    // 200 'x' chars -> last char
+    std::string s(200, 'x');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 199);
+}
+
+// --- Edge: exactly 16 bytes (one SIMD chunk) ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_Exactly16Bytes_AllTrim) {
+    std::string s(16, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_Exactly16Bytes_LastNonTrim) {
+    std::string s(15, ' ');
+    s += 'x';
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 15);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_Exactly16Bytes_FirstNonTrim) {
+    std::string s = "x";
+    s += std::string(15, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 0);
+}
+
+// --- Edge: 17 bytes (one SIMD chunk + 1 scalar) ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_17Bytes_NonTrimAtBoundary) {
+    // 16 spaces + 'x' -> SIMD processes last 16 bytes [1..16], scalar handles byte 0
+    std::string s(16, ' ');
+    s += 'x';
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result, 'x');
+    EXPECT_EQ(result - s.data(), 16);
+}
+
+// --- Cross-verify: runtime SearchSymbols vs template version ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_CrossVerify_WithTemplate) {
+    // Compare runtime SearchSymbols version with compile-time template version
+    std::string s = "hello   \t\n ";
+    SearchSymbols symbols(" \t\n");
+
+    const char* runtime_result =
+            find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    const char* template_result =
+            find_last_not_symbols_or_null<' ', '\t', '\n'>(s.data(), s.data() + s.size());
+
+    ASSERT_NE(runtime_result, nullptr);
+    ASSERT_NE(template_result, nullptr);
+    EXPECT_EQ(runtime_result, template_result);
+    EXPECT_EQ(*runtime_result, 'o');
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_CrossVerify_AllTrim) {
+    std::string s = "   \t\n";
+    SearchSymbols symbols(" \t\n");
+
+    const char* runtime_result =
+            find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    const char* template_result =
+            find_last_not_symbols_or_null<' ', '\t', '\n'>(s.data(), s.data() + s.size());
+
+    EXPECT_EQ(runtime_result, nullptr);
+    EXPECT_EQ(template_result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_CrossVerify_LongString) {
+    std::string s(100, ' ');
+    s += "data";
+    s += std::string(100, '\t');
+    SearchSymbols symbols(" \t");
+
+    const char* runtime_result =
+            find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    const char* template_result =
+            find_last_not_symbols_or_null<' ', '\t'>(s.data(), s.data() + s.size());
+
+    ASSERT_NE(runtime_result, nullptr);
+    ASSERT_NE(template_result, nullptr);
+    EXPECT_EQ(runtime_result, template_result);
+    EXPECT_EQ(*runtime_result, 'a');
+    EXPECT_EQ(runtime_result - s.data(), 103);
+}
+
+// --- Various string lengths to stress SIMD alignment ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_VariousLengths) {
+    SearchSymbols symbols("ab");
+    for (size_t len = 1; len <= 64; ++len) {
+        // String of 'a' repeated, with 'X' at position 0
+        std::string s(len, 'a');
+        s[0] = 'X';
+        const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+        ASSERT_NE(result, nullptr) << "len=" << len;
+        EXPECT_EQ(*result, 'X') << "len=" << len;
+        EXPECT_EQ(result - s.data(), 0) << "len=" << len;
+    }
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_VariousLengths_NonTrimAtEnd) {
+    SearchSymbols symbols("ab");
+    for (size_t len = 1; len <= 64; ++len) {
+        // String of 'a' repeated, with 'X' at the last position
+        std::string s(len, 'a');
+        s[len - 1] = 'X';
+        const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+        ASSERT_NE(result, nullptr) << "len=" << len;
+        EXPECT_EQ(*result, 'X') << "len=" << len;
+        EXPECT_EQ(result - s.data(), (ptrdiff_t)(len - 1)) << "len=" << len;
+    }
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_VariousLengths_SSE42) {
+    // 6 trim chars -> SSE4.2 path
+    SearchSymbols symbols("abcdef");
+    for (size_t len = 1; len <= 64; ++len) {
+        std::string s(len, 'a');
+        s[0] = 'X';
+        const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+        ASSERT_NE(result, nullptr) << "len=" << len;
+        EXPECT_EQ(*result, 'X') << "len=" << len;
+        EXPECT_EQ(result - s.data(), 0) << "len=" << len;
+    }
+}
+
+// --- Empty range: begin == end should not cause UB ---
+
+TEST_F(FindSymbolsTest, LastNotSymbols_EmptyRange_SSE2) {
+    SearchSymbols symbols("ab");
+    const char* p = "x";
+    const char* result = find_last_not_symbols_or_null(p, p, symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(FindSymbolsTest, LastNotSymbols_EmptyRange_SSE42) {
+    SearchSymbols symbols("abcdef");
+    const char* p = "x";
+    const char* result = find_last_not_symbols_or_null(p, p, symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
+// --- Embedded null bytes must NOT be treated as implicit trim symbols ---
+
+TEST_F(FindSymbolsTest, EmbeddedNullByte_SSE2_NotTrimmed) {
+    // "a\0" followed by 20 'x' bytes, trim set "ab" (SSE2 path: < 5 chars)
+    // After trimming leading 'a', the \0 byte should remain (not be treated as trim char)
+    std::string s;
+    s += 'a';
+    s += '\0';
+    s.append(20, 'x');
+    SearchSymbols symbols("ab");
+    // find_first_not_symbols should return pointer to the \0 byte (index 1), not skip it
+    const char* result = find_first_not_symbols(std::string_view(s.data(), s.size()), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result - s.data(), 1); // \0 at index 1 is NOT a trim char
+    EXPECT_EQ(*result, '\0');
+}
+
+TEST_F(FindSymbolsTest, EmbeddedNullByte_SSE2_LastNotSymbols) {
+    // 20 'x' bytes followed by "\0bb", trim set "ab" (SSE2 path: < 5 chars)
+    // find_last_not_symbols should return pointer to \0 (not skip it)
+    std::string s(20, 'x');
+    s += '\0';
+    s += "bb";
+    SearchSymbols symbols("ab");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result - s.data(), 20); // \0 at index 20 is NOT a trim char
+    EXPECT_EQ(*result, '\0');
+}
+
+TEST_F(FindSymbolsTest, EmbeddedNullByte_AllNulls_SSE2) {
+    // String of all \0 bytes with trim set "ab" — none should be trimmed
+    std::string s(32, '\0');
+    SearchSymbols symbols("ab");
+    const char* result = find_first_not_symbols(std::string_view(s.data(), s.size()), symbols);
+    EXPECT_EQ(result - s.data(), 0); // first \0 at index 0 is not a trim char
+}
+
+} // namespace doris

--- a/be/test/exprs/function/url/find_symbols_test.cpp
+++ b/be/test/exprs/function/url/find_symbols_test.cpp
@@ -182,6 +182,14 @@ TEST_F(FindSymbolsTest, LastNotSymbols_LongAllTrim) {
     EXPECT_EQ(result, nullptr);
 }
 
+TEST_F(FindSymbolsTest, LastNotSymbols_SSE2_AllTrim_ScalarTailAfterSimd) {
+    // 20 spaces -> one 16-byte SIMD chunk followed by a 4-byte scalar all-trim tail
+    std::string s(20, ' ');
+    SearchSymbols symbols(" ");
+    const char* result = find_last_not_symbols_or_null(s.data(), s.data() + s.size(), symbols);
+    EXPECT_EQ(result, nullptr);
+}
+
 TEST_F(FindSymbolsTest, LastNotSymbols_LongNoTrim) {
     // 200 'x' chars -> last char
     std::string s(200, 'x');


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

This PR optimizes two hot BE string function families that spend significant time on repeated buffer growth and high-overhead character lookup.

1. `repeat`
   - Replace the old per-row append loop with a shared two-pass execution path for both vector repeat counts and constant repeat counts.
   - Precompute `res_offsets` and total output size before writing results.
   - Write directly into `ColumnString::Chars` with `StringOP::fast_repeat()`.

2. `trim_in` / `ltrim_in` / `rtrim_in`
   - Reuse SIMD-assisted ASCII symbol search for small trim sets.
   - Add reverse symbol search helpers for right trim.
   - Use a fixed-size UTF-8 small-set lookup path for common cases while preserving fallback paths for larger trim strings.

3. Coverage and observability
   - Add a larger `repeat('a', 256)` correctness case.
   - Add `find_symbols` unit coverage for empty ranges, embedded NUL bytes, boundary lengths, and cross-check cases.
   - Add old/new microbenchmarks for both repeat and trim paths.

### Benchmark results

Local Release benchmark results on this machine:

#### repeat

| Case | Old | New | Speedup |
| --- | ---: | ---: | ---: |
| RepeatVector 4096/16/8 | 86184 ns | 42878 ns | 2.01x |
| RepeatVector 4096/16/64 | 411330 ns | 146498 ns | 2.81x |
| RepeatVector 1024/128/16 | 84985 ns | 39620 ns | 2.15x |
| RepeatVector 4096/0/64 | 222362 ns | 7382 ns | 30.12x |
| RepeatConst 4096/16/8 | 127848 ns | 59495 ns | 2.15x |
| RepeatConst 4096/16/64 | 764912 ns | 205294 ns | 3.73x |
| RepeatConst 1024/128/16 | 158499 ns | 78090 ns | 2.03x |
| RepeatConst 4096/0/64 | 395137 ns | 7107 ns | 55.60x |

#### trim

| Case | Old | New | Speedup |
| --- | ---: | ---: | ---: |
| ASCII, 4 trim chars, 65536 rows | 2398.526 us | 997.839 us | 2.40x |
| ASCII, 8 trim chars, 65536 rows | 2452.269 us | 872.865 us | 2.81x |
| ASCII, no match, 65536 rows | 318.894 us | 309.079 us | 1.03x |
| UTF-8, 2 trim chars, 65536 rows | 7832.364 us | 6799.569 us | 1.15x |

Note:
The medium and large trim cases reproduced the expected improvement direction on this machine. One small-input case (`BM_TrimInAscii/1024`) was slightly slower at 0.81x, while the 4096-row and 65536-row cases remained clearly faster.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

