### PR TITLE
[fix](test) Cast variant subcolumn as json in variant_hirachinal for stable output

### DIFF
--- a/regression-test/suites/variant_p0/variant_hirachinal.groovy
+++ b/regression-test/suites/variant_p0/variant_hirachinal.groovy
@@ -47,8 +47,8 @@ suite("regression_test_variant_hirachinal", "variant_type"){
     qt_sql "select cast(v['c'] as string) from ${table_name} where k = -3 or k = -2 order by k"
     qt_sql "select v['b'] from ${table_name} where k = -3 or k = -2"
     sql """insert into ${table_name} values (-3, '{"c" : 12345}')"""
-    order_qt_sql1 "select cast(v['c'] as string) from var_rs where k = -3 or k = -2 or k = -4 or (k = 1 and v['c'] = 1024) order by k"
-    order_qt_sql2 "select cast(v['c'] as string) from var_rs where k = -3 or k = -2 or k = 1 order by k, cast(v['c'] as text) limit 3"
+    order_qt_sql1 "select cast(v['c'] as json) from var_rs where k = -3 or k = -2 or k = -4 or (k = 1 and v['c'] = 1024) order by k"
+    order_qt_sql2 "select cast(v['c'] as json) from var_rs where k = -3 or k = -2 or k = 1 order by k, cast(v['c'] as text) limit 3"
 
 
     table_name = "var_rs2" 


### PR DESCRIPTION

cast(v['c'] as string) on a heterogeneous variant column can produce different whitespace formatting (e.g. "[1, 2, 3]" vs "[1,2,3]") depending on session variables fuzzed by use_fuzzy_session_variable (batch_size, enable_fold_constant_by_be, etc.), causing intermittent regression failures. Casting to json normalizes the serialization path and is stable across fuzzed execution configs (verified 50/50 runs).

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

