### PR TITLE
[fix](fe) Remove decimal literal debug logs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalV3Literal.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DecimalV3Type;
 
 import com.google.common.base.Preconditions;
-import org.apache.log4j.Logger;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -34,8 +33,6 @@ import java.util.Objects;
  * Literal for DecimalV3 Type
  */
 public class DecimalV3Literal extends FractionalLiteral {
-    private static final Logger logger = Logger.getLogger(Literal.class);
-
     private final BigDecimal value;
 
     public DecimalV3Literal(BigDecimal value) {
@@ -57,8 +54,6 @@ public class DecimalV3Literal extends FractionalLiteral {
         Objects.requireNonNull(value, "value not be null");
         checkPrecisionAndScale(precision, scale, value);
         BigDecimal adjustedValue = value.scale() < 0 ? value : value.setScale(scale, RoundingMode.HALF_UP);
-        logger.info("DecimalV3Literal orig bigDecimal: " + value
-                + ", targetType: " + dataType + ", result big decimal: " + adjustedValue);
         this.value = Objects.requireNonNull(adjustedValue);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -51,7 +51,6 @@ import org.apache.doris.nereids.types.coercion.CharacterType;
 import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.log4j.Logger;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -68,7 +67,6 @@ import java.util.Optional;
  */
 public abstract class Literal extends Expression implements LeafExpression {
 
-    private static final Logger logger = Logger.getLogger(Literal.class);
     protected final DataType dataType;
 
     /**
@@ -254,8 +252,6 @@ public abstract class Literal extends Expression implements LeafExpression {
         }
         BigDecimal result = bigDecimal.setScale(sTarget, RoundingMode.HALF_UP)
                 .round(new MathContext(pTarget, RoundingMode.HALF_UP));
-        logger.info("getDecimalLiteral orig bigDecimal: " + bigDecimal
-                + ", targetType: " + targetType + ", result big decimal: " + result);
         if (targetType.isDecimalV2Type()) {
             return new DecimalLiteral((DecimalV2Type) targetType, result);
         } else {


### PR DESCRIPTION
### What problem does this PR solve?

Decimal literal cast and construction paths print high-frequency INFO debug logs. In FE runtime these logs can be routed through stderr and appear as ERROR lines, flooding FE logs during normal query traffic.

The noisy logs were introduced by #50940.

This PR removes the debug logs from the decimal literal hot paths.

### Check List

- Test: Unit Test
  - LiteralTest
- Behavior changed: No
- Does this need documentation: No