### PR TITLE
[fix](fe) Update fe-core compiler release level from 8 to 17

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -854,7 +854,7 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>8</release>
+                    <release>17</release>
                 </configuration>
                 <executions>
                     <!-- first: compile annotation and annotation processor -->

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/PatternDescribableProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/PatternDescribableProcessor.java
@@ -57,7 +57,7 @@ import javax.tools.StandardLocation;
 /**
  * annotation processor for generate GeneratedPattern.java.
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedAnnotationTypes("org.apache.doris.nereids.pattern.generator.PatternDescribable")
 public class PatternDescribableProcessor extends AbstractProcessor {
     private List<File> paths;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63728

Problem Summary: FE depends on JDK 17 for compilation (parent pom set `maven.compiler.source/target=17` since PR #62221), but fe-core's `maven-compiler-plugin` still had `<release>8</release>` as a leftover from PR #41417. This caused FE unit tests using JDK 17 APIs (e.g., `Random.nextLong(long)`) to fail at compile time. Additionally, `PatternDescribableProcessor` declared `@SupportedSourceVersion(SourceVersion.RELEASE_8)`, which is inconsistent with the JDK 17 compilation target.

### Release note

None

### Check List (For Author)

- Test: Manual test (compilation passes with JDK 17)
[问题及修复.docx](https://github.com/user-attachments/files/28345426/default.docx)

- Behavior changed: No
- Does this need documentation: No