### PR TITLE
branch-4.0: [fix](fe) Reject JSONB and variant distribution columns (#63211)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -114,19 +114,7 @@ public class HashDistributionDesc extends DistributionDesc {
             boolean find = false;
             for (Column column : columns) {
                 if (column.getName().equalsIgnoreCase(colName)) {
-                    if (column.getType().isArrayType()) {
-                        throw new DdlException("Array Type should not be used in distribution column["
-                                + column.getName() + "].");
-                    } else if (column.getType().isMapType()) {
-                        throw new DdlException("Map Type should not be used in distribution column["
-                                + column.getName() + "].");
-                    } else if (column.getType().isStructType()) {
-                        throw new DdlException("Struct Type should not be used in distribution column["
-                                + column.getName() + "].");
-                    } else if (column.getType().isFloatingPointType()) {
-                        throw new DdlException("Floating point type should not be used in distribution column["
-                                + column.getName() + "].");
-                    }
+                    HashDistributionInfo.checkDistributionColumnType(column.getName(), column.getType());
 
                     // distribution info and base columns persist seperately inside OlapTable, so we need deep copy
                     // to avoid modify table columns also modify columns inside distribution info.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
@@ -19,6 +19,7 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.DistributionDesc;
 import org.apache.doris.analysis.HashDistributionDesc;
+import org.apache.doris.common.DdlException;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -52,6 +53,28 @@ public class HashDistributionInfo extends DistributionInfo {
 
     public List<Column> getDistributionColumns() {
         return distributionColumns;
+    }
+
+    public static void checkDistributionColumnType(String columnName, Type type) throws DdlException {
+        if (type.isArrayType()) {
+            throw new DdlException("Array Type should not be used in distribution column[" + columnName + "].");
+        }
+        if (type.isMapType()) {
+            throw new DdlException("Map Type should not be used in distribution column[" + columnName + "].");
+        }
+        if (type.isStructType()) {
+            throw new DdlException("Struct Type should not be used in distribution column[" + columnName + "].");
+        }
+        if (type.isJsonbType()) {
+            throw new DdlException("JsonType type should not be used in distribution column[" + columnName + "].");
+        }
+        if (type.isVariantType()) {
+            throw new DdlException("Variant type should not be used in distribution column[" + columnName + "].");
+        }
+        if (type.isFloatingPointType()) {
+            throw new DdlException("Floating point type should not be used in distribution column["
+                    + columnName + "].");
+        }
     }
 
     public boolean sameDistributionColumns(HashDistributionInfo other) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/DistributionDescriptorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/DistributionDescriptorTest.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.info;
+
+import org.apache.doris.analysis.HashDistributionDesc;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.nereids.types.JsonType;
+import org.apache.doris.nereids.types.VariantType;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class DistributionDescriptorTest {
+
+    @Test
+    public void testRejectJsonAndVariantTranslatedDistributionColumns() {
+        Map<String, ColumnDefinition> columnMap = Maps.newHashMap();
+        columnMap.put("json_col", new ColumnDefinition("json_col", JsonType.INSTANCE, false));
+        columnMap.put("variant_col", new ColumnDefinition("variant_col", VariantType.INSTANCE, false));
+
+        DistributionDescriptor jsonDesc = new DistributionDescriptor(
+                true, false, 1, Lists.newArrayList("json_col"));
+        jsonDesc.validate(columnMap, KeysType.DUP_KEYS);
+        DdlException jsonException = Assertions.assertThrows(DdlException.class,
+                () -> jsonDesc.translateToCatalogStyle()
+                        .toDistributionInfo(Lists.newArrayList(new Column("json_col", Type.JSONB))));
+        Assertions.assertEquals("JsonType type should not be used in distribution column[json_col].",
+                jsonException.getDetailMessage());
+
+        DistributionDescriptor variantDesc = new DistributionDescriptor(
+                true, false, 1, Lists.newArrayList("variant_col"));
+        variantDesc.validate(columnMap, KeysType.DUP_KEYS);
+        DdlException variantException = Assertions.assertThrows(DdlException.class,
+                () -> variantDesc.translateToCatalogStyle()
+                        .toDistributionInfo(Lists.newArrayList(new Column("variant_col", Type.VARIANT))));
+        Assertions.assertEquals("Variant type should not be used in distribution column[variant_col].",
+                variantException.getDetailMessage());
+    }
+
+    @Test
+    public void testRejectJsonAndVariantCatalogDistributionColumns() {
+        Column jsonColumn = new Column("json_col", Type.JSONB);
+        HashDistributionDesc jsonDesc = new HashDistributionDesc(1, Lists.newArrayList("json_col"));
+        DdlException jsonException = Assertions.assertThrows(DdlException.class,
+                () -> jsonDesc.toDistributionInfo(Lists.newArrayList(jsonColumn)));
+        Assertions.assertEquals("JsonType type should not be used in distribution column[json_col].",
+                jsonException.getDetailMessage());
+
+        Column variantColumn = new Column("variant_col", Type.VARIANT);
+        HashDistributionDesc variantDesc = new HashDistributionDesc(1, Lists.newArrayList("variant_col"));
+        DdlException variantException = Assertions.assertThrows(DdlException.class,
+                () -> variantDesc.toDistributionInfo(Lists.newArrayList(variantColumn)));
+        Assertions.assertEquals("Variant type should not be used in distribution column[variant_col].",
+                variantException.getDetailMessage());
+    }
+}

--- a/regression-test/suites/jsonb_p0/test_jsonb_distribution_column.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_distribution_column.groovy
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_jsonb_distribution_column", "p0") {
+    sql "DROP TABLE IF EXISTS test_jsonb_distribution_column"
+    test {
+        sql """
+            CREATE TABLE test_jsonb_distribution_column (
+                k INT,
+                c JSONB
+            )
+            DUPLICATE KEY(k)
+            DISTRIBUTED BY HASH(c) BUCKETS 4
+            PROPERTIES("replication_num" = "1")
+        """
+        exception "JsonType type should not be used in distribution column[c]."
+    }
+
+    sql "DROP TABLE IF EXISTS test_variant_distribution_column"
+    test {
+        sql """
+            CREATE TABLE test_variant_distribution_column (
+                k INT,
+                v VARIANT<PROPERTIES("variant_max_subcolumns_count" = "0")>
+            )
+            DUPLICATE KEY(k)
+            DISTRIBUTED BY HASH(v) BUCKETS 4
+            PROPERTIES("replication_num" = "1")
+        """
+        exception "Variant type should not be used in distribution column[v]."
+    }
+}

--- a/regression-test/suites/variant_p0/load.groovy
+++ b/regression-test/suites/variant_p0/load.groovy
@@ -410,7 +410,7 @@ suite("regression_test_variant", "p0"){
               "replication_allocation" = "tag.location.default: 1"
             );
             """
-            exception("errCode = 2, detailMessage = Hash distribution info should not contain variant columns")
+            exception("errCode = 2, detailMessage = Variant type should not be used in distribution column[content].")
         }
 
          test {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63211

Problem Summary: Backport the FE validation fix that rejects JSONB and variant distribution columns to apache/doris branch-4.0. This recreates the PR that was accidentally opened against selectdb/selectdb-core.

### Release note

Reject JSONB and variant distribution columns on branch-4.0.

### Check List (For Author)

- Test: Manual test
    - git diff --check rich/branch-4.0..HEAD
- Behavior changed: Yes. Rejects unsupported distribution column types.
- Does this need documentation: No
