### PR TITLE
[improve](nereids) filter nereidsPrunedTabletIds per partition in distributionPrune

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -370,9 +370,20 @@ public class OlapScanNode extends ScanNode {
             DistributionInfo distributionInfo,
             boolean pruneTablesByNereids) throws AnalysisException {
         if (pruneTablesByNereids) {
-            return nereidsPrunedTabletIds.isEmpty()
-                    ? null
-                    : new ArrayList<>(nereidsPrunedTabletIds);
+            if (nereidsPrunedTabletIds.isEmpty()) {
+                return null;
+            }
+            // Filter to tablets belonging to this partition. Without this, the caller's
+            // per-partition loop in computeTabletInfo becomes O(partitionNum * globalPrunedSize)
+            // getTablet hash lookups (most returning null), which dominates plan time
+            // when both partition count and pruned tablet count are large.
+            List<Long> result = new ArrayList<>();
+            for (Long id : tabletIdsInOrder) {
+                if (nereidsPrunedTabletIds.contains(id)) {
+                    result.add(id);
+                }
+            }
+            return result;
         }
         DistributionPruner distributionPruner = null;
         switch (distributionInfo.getType()) {
@@ -918,8 +929,9 @@ public class OlapScanNode extends ScanNode {
             boolean notExistsSampleAndPrunedTablets = sampleTabletIds.isEmpty() && nereidsPrunedTabletIds.isEmpty();
             if (prunedTabletIds != null) {
                 for (Long id : prunedTabletIds) {
-                    if (selectedTable.getTablet(id) != null) {
-                        tablets.add(selectedTable.getTablet(id));
+                    Tablet tablet = selectedTable.getTablet(id);
+                    if (tablet != null) {
+                        tablets.add(tablet);
                         scanTabletIds.add(id);
                     } else if (notExistsSampleAndPrunedTablets) {
                         // The tabletID specified in query does not exist in this partition, skip scan partition.


### PR DESCRIPTION
### What problem does this PR solve?
#53403 short-circuited distributionPrune to return the entire nereidsPrunedTabletIds set when running under Nereids. However, the caller computeTabletInfo invokes distributionPrune inside a per-partition loop and then iterates the returned ids, calling MaterializedIndex.getTablet(id) on each. When nereidsPrunedTabletIds contains tablets across many
partitions, every per-partition iteration walks the entire global set and does a getTablet hash lookup on ids that belong to other partitions (which are then filtered out by the null check), yielding O(partitionNum * globalPrunedSize) lookups. The short-circuit also copies the full HashSet into a new ArrayList once per partition.

Filter the global set down to the current partition's tablet ids (tabletIdsInOrder, already prepared by the caller) before returning. The result is identical to what the caller's null-check would have produced, so behavior is unchanged; only the redundant lookups and copies are eliminated. The non-Nereids path, the sampleTabletIds path and the empty-set
fallback are untouched.

Issue Number: close #63854

Related PR: #53403

Problem Summary:

Plan time of OlapScan queries with many partitions and many globally pruned tablets degrades quadratically due to redundant per-partition iterations over the global pruned tablet set in OlapScanNode.distributionPrune. Restore per-partition complexity by filtering the global set down to the current partition's tablets before returning.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
