### PR TITLE
[fix](fe) Make newly created external catalog table immediately visible in cache

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -185,7 +185,7 @@ public class RefreshManager {
         if (!Strings.isNullOrEmpty(log.getNewTableName())) {
             // this is a rename table op
             db.get().unregisterTable(log.getTableName());
-            db.get().resetMetaCacheNames();
+            db.get().registerTableFromCreate(log.getNewTableName());
             Env.getCurrentEnv().getConstraintManager().renameTable(
                     new TableNameInfo(catalog.getName(), log.getDbName(), log.getTableName()),
                     new TableNameInfo(catalog.getName(), log.getDbName(), log.getNewTableName()));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -1057,7 +1057,9 @@ public abstract class ExternalCatalog
             boolean res = metadataOps.createTable(createTableInfo);
             if (!res) {
                 // res == false means the table does not exist before, and we create it.
-                // we should get the table stored in Doris, and use local name in edit log.
+                // Register the new table into meta cache so it is immediately visible
+                // without requiring a manual REFRESH CATALOG.
+                registerTableFromCreate(createTableInfo.getDbName(), createTableInfo.getTableName());
                 org.apache.doris.persist.CreateTableInfo info = new org.apache.doris.persist.CreateTableInfo(
                         getName(),
                         createTableInfo.getDbName(),
@@ -1076,6 +1078,14 @@ public abstract class ExternalCatalog
     public void replayCreateTable(String dbName, String tblName) {
         if (metadataOps != null) {
             metadataOps.afterCreateTable(dbName, tblName);
+            registerTableFromCreate(dbName, tblName);
+        }
+    }
+
+    private void registerTableFromCreate(String dbName, String tblName) {
+        Optional<ExternalDatabase<? extends ExternalTable>> db = getDbForReplay(dbName);
+        if (db.isPresent()) {
+            db.get().registerTableFromCreate(tblName);
         }
     }
 
@@ -1087,6 +1097,7 @@ public abstract class ExternalCatalog
         }
         try {
             metadataOps.renameTable(dbName, oldTableName, newTableName);
+            registerTableFromCreate(dbName, newTableName);
             Env.getCurrentEnv().getConstraintManager().renameTable(
                     new TableNameInfo(getName(), dbName, oldTableName),
                     new TableNameInfo(getName(), dbName, newTableName));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -593,6 +593,32 @@ public abstract class ExternalDatabase<T extends ExternalTable>
         return true;
     }
 
+    /**
+     * Register a newly created table into the meta cache after DDL execution.
+     * This method builds the table object and updates both the names cache and the meta object cache,
+     * so that the table is immediately visible (e.g., via SHOW CREATE TABLE) without requiring
+     * a manual REFRESH CATALOG.
+     */
+    public void registerTableFromCreate(String tblName) {
+        makeSureInitialized();
+        if (!isInitialized()) {
+            return;
+        }
+        String localName = extCatalog.fromRemoteTableName(this.remoteName, tblName);
+        long tblId = Util.genIdByName(extCatalog.getName(), name, localName);
+        T table = buildTableForInit(tblName, localName, tblId, extCatalog, this, false);
+        if (table == null) {
+            LOG.warn("Failed to build table {}.{} after create, fall back to reset names cache",
+                    this.name, tblName);
+            resetMetaCacheNames();
+            return;
+        }
+        metaCache.updateCache(tblName, localName, table, tblId);
+        lowerCaseToTableName.put(localName.toLowerCase(), localName);
+        setLastUpdateTime(System.currentTimeMillis());
+        LOG.info("register table {}.{} after create", this.name, tblName);
+    }
+
     private boolean isStoredTableNamesLowerCase() {
         return extCatalog.getLowerCaseTableNames() == 1;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergMetadataOps.java
@@ -442,7 +442,7 @@ public class IcebergMetadataOps implements ExternalMetadataOps {
         Optional<ExternalDatabase<?>> db = dorisCatalog.getDbForReplay(dbName);
         if (db.isPresent()) {
             db.get().unregisterTable(oldName);
-            db.get().resetMetaCacheNames();
+            db.get().registerTableFromCreate(newName);
         }
         LOG.info("after rename table {}.{}.{} to {}, is db exists: {}",
                 dorisCatalog.getName(), dbName, oldName, newName, db.isPresent());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseRegisterTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseRegisterTableTest.java
@@ -1,0 +1,215 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.test.TestExternalCatalog;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class ExternalDatabaseRegisterTableTest extends TestWithFeService {
+
+    private static final String CATALOG_NAME = "test_register_tbl_catalog";
+    private static final String DB_NAME = "db1";
+
+    private static final DynamicProvider PROVIDER = new DynamicProvider();
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        FeConstants.runningUnitTest = true;
+        ConnectContext ctx = createDefaultCtx();
+        String createStmt = "create catalog " + CATALOG_NAME + " properties(\n"
+                + "    \"type\" = \"test\",\n"
+                + "    \"catalog_provider.class\" "
+                + "= \"org.apache.doris.datasource.ExternalDatabaseRegisterTableTest$DynamicProvider\",\n"
+                + "    \"include_database_list\" = \"db1\"\n"
+                + ");";
+        createCatalog(ctx, createStmt);
+    }
+
+    private void createCatalog(ConnectContext ctx, String stmt) throws Exception {
+        org.apache.doris.nereids.parser.NereidsParser parser = new org.apache.doris.nereids.parser.NereidsParser();
+        org.apache.doris.nereids.trees.plans.logical.LogicalPlan plan = parser.parseSingle(stmt);
+        if (plan instanceof org.apache.doris.nereids.trees.plans.commands.CreateCatalogCommand) {
+            ((org.apache.doris.nereids.trees.plans.commands.CreateCatalogCommand) plan).run(ctx, null);
+        }
+    }
+
+    private ExternalDatabase<? extends ExternalTable> getDb() {
+        TestExternalCatalog catalog = (TestExternalCatalog) Env.getCurrentEnv().getCatalogMgr()
+                .getCatalog(CATALOG_NAME);
+        Assertions.assertNotNull(catalog);
+        ExternalDatabase<? extends ExternalTable> db = (ExternalDatabase<? extends ExternalTable>)
+                catalog.getDbNullable(DB_NAME);
+        Assertions.assertNotNull(db, "Database should exist after catalog init");
+        return db;
+    }
+
+    @Test
+    public void testRegisterTableFromCreateMakesTableVisible() {
+        String tblName = "tbl_newly_created";
+        PROVIDER.addTable(DB_NAME, tblName, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+
+        ExternalDatabase<? extends ExternalTable> db = getDb();
+
+        Assertions.assertNull(db.getTableNullable(tblName),
+                "Table should not exist before registerTableFromCreate");
+
+        db.registerTableFromCreate(tblName);
+
+        ExternalTable table = db.getTableNullable(tblName);
+        Assertions.assertNotNull(table, "Table should be visible after registerTableFromCreate");
+        Assertions.assertEquals(tblName, table.getName());
+
+        PROVIDER.removeTable(DB_NAME, tblName);
+    }
+
+    @Test
+    public void testRegisterTableFromCreateUpdatesNamesCache() {
+        String tblName = "tbl_names_cache";
+        PROVIDER.addTable(DB_NAME, tblName, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+
+        ExternalDatabase<? extends ExternalTable> db = getDb();
+
+        db.registerTableFromCreate(tblName);
+
+        List<String> tableNames = Lists.newArrayList(db.getTableNamesWithLock());
+        Assertions.assertTrue(tableNames.contains(tblName),
+                "New table name should appear in table name list");
+
+        PROVIDER.removeTable(DB_NAME, tblName);
+    }
+
+    @Test
+    public void testRegisterTableFromCreateIdempotent() {
+        String tblName = "tbl_idempotent";
+        PROVIDER.addTable(DB_NAME, tblName, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+
+        ExternalDatabase<? extends ExternalTable> db = getDb();
+
+        db.registerTableFromCreate(tblName);
+        db.registerTableFromCreate(tblName);
+
+        ExternalTable table = db.getTableNullable(tblName);
+        Assertions.assertNotNull(table, "Table should still be visible after duplicate register");
+
+        PROVIDER.removeTable(DB_NAME, tblName);
+    }
+
+    @Test
+    public void testRegisterTableFromCreateMultipleTables() {
+        String table1 = "tbl_multi_a";
+        String table2 = "tbl_multi_b";
+        PROVIDER.addTable(DB_NAME, table1, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+        PROVIDER.addTable(DB_NAME, table2, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+
+        ExternalDatabase<? extends ExternalTable> db = getDb();
+
+        db.registerTableFromCreate(table1);
+        db.registerTableFromCreate(table2);
+
+        Assertions.assertNotNull(db.getTableNullable(table1));
+        Assertions.assertNotNull(db.getTableNullable(table2));
+
+        List<String> tableNames = Lists.newArrayList(db.getTableNamesWithLock());
+        Assertions.assertTrue(tableNames.contains(table1));
+        Assertions.assertTrue(tableNames.contains(table2));
+
+        PROVIDER.removeTable(DB_NAME, table1);
+        PROVIDER.removeTable(DB_NAME, table2);
+    }
+
+    @Test
+    public void testGetTableForReplayAfterRegister() {
+        String tblName = "tbl_replay";
+        PROVIDER.addTable(DB_NAME, tblName, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+
+        ExternalDatabase<? extends ExternalTable> db = getDb();
+
+        db.registerTableFromCreate(tblName);
+
+        Optional<? extends ExternalTable> tableOpt = db.getTableForReplay(tblName);
+        Assertions.assertTrue(tableOpt.isPresent(),
+                "Table should be retrievable via getTableForReplay after registerTableFromCreate");
+
+        PROVIDER.removeTable(DB_NAME, tblName);
+    }
+
+    @Test
+    public void testRegisterTableFromCreateDoesNotAffectOtherTables() {
+        String tbl1 = "tbl_persist_a";
+        String tbl2 = "tbl_persist_b";
+        PROVIDER.addTable(DB_NAME, tbl1, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+        PROVIDER.addTable(DB_NAME, tbl2, Lists.newArrayList(
+                new Column("col1", PrimitiveType.INT)));
+
+        ExternalDatabase<? extends ExternalTable> db = getDb();
+
+        db.registerTableFromCreate(tbl1);
+
+        Assertions.assertNotNull(db.getTableNullable(tbl1));
+        Assertions.assertNull(db.getTableNullable(tbl2),
+                "Other table should not be visible until registered");
+
+        db.registerTableFromCreate(tbl2);
+        Assertions.assertNotNull(db.getTableNullable(tbl2));
+
+        PROVIDER.removeTable(DB_NAME, tbl1);
+        PROVIDER.removeTable(DB_NAME, tbl2);
+    }
+
+    public static class DynamicProvider implements TestExternalCatalog.TestCatalogProvider {
+        private final Map<String, Map<String, List<Column>>> metadata = Maps.newConcurrentMap();
+
+        public DynamicProvider() {
+            metadata.put(DB_NAME, Maps.newConcurrentMap());
+        }
+
+        public void addTable(String dbName, String tblName, List<Column> cols) {
+            metadata.get(dbName).put(tblName, cols);
+        }
+
+        public void removeTable(String dbName, String tblName) {
+            metadata.get(dbName).remove(tblName);
+        }
+
+        @Override
+        public Map<String, Map<String, List<Column>>> getMetadata() {
+            return metadata;
+        }
+    }
+}

--- a/regression-test/suites/external_table_p0/test_external_catalog_create_table_cache_visibility.groovy
+++ b/regression-test/suites/external_table_p0/test_external_catalog_create_table_cache_visibility.groovy
@@ -1,0 +1,286 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_external_catalog_create_table_cache_visibility", "p0,external") {
+
+    // ========== Iceberg (HMS catalog type) ==========
+    def test_iceberg = { String hivePrefix ->
+        String enabled = context.config.otherConfigs.get("enableIcebergTest")
+        if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+            logger.info("skip iceberg test.")
+            return
+        }
+
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+        String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
+        String default_fs = "hdfs://${externalEnvIp}:${hdfs_port}"
+        String warehouse = "${default_fs}/warehouse"
+        String catalog_name = "test_iceberg_create_cache_vis_${hivePrefix}"
+
+        sql """drop catalog if exists ${catalog_name}"""
+        sql """
+        create catalog ${catalog_name} properties (
+            'type'='iceberg',
+            'iceberg.catalog.type'='hms',
+            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hmsPort}',
+            'fs.defaultFS' = '${default_fs}',
+            'warehouse' = '${warehouse}'
+        );
+        """
+
+        sql """switch ${catalog_name}"""
+        String db_name = "test_iceberg_cache_vis_db"
+        sql """drop database if exists ${db_name} force"""
+        sql """create database ${db_name}"""
+        sql """use ${db_name}"""
+
+        // CREATE TABLE then immediately verify visibility
+        String tbl1 = "iceberg_cache_vis_tbl1"
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """CREATE TABLE ${db_name}.${tbl1} (id int, name string) engine=iceberg"""
+
+        // The new table should be immediately visible without REFRESH CATALOG
+        def show_result = sql """SHOW TABLES"""
+        assertTrue(show_result.toString().contains(tbl1), "Table ${tbl1} should appear in SHOW TABLES after CREATE TABLE")
+
+        def create_result = sql """SHOW CREATE TABLE ${db_name}.${tbl1}"""
+        assertTrue(create_result.size() > 0, "SHOW CREATE TABLE should succeed for newly created table")
+        assertTrue(create_result[0][1].toString().toLowerCase().contains("iceberg"), "SHOW CREATE TABLE result should contain iceberg engine")
+
+        // INSERT + SELECT to verify end-to-end
+        sql """INSERT INTO ${db_name}.${tbl1} VALUES (1, 'a'), (2, 'b')"""
+        order_qt_iceberg_select """SELECT * FROM ${db_name}.${tbl1} ORDER BY id"""
+
+        // Create a second table to verify multiple tables
+        String tbl2 = "iceberg_cache_vis_tbl2"
+        sql """drop table if exists ${db_name}.${tbl2}"""
+        sql """CREATE TABLE ${db_name}.${tbl2} (id int, value double) engine=iceberg"""
+        def create_result2 = sql """SHOW CREATE TABLE ${db_name}.${tbl2}"""
+        assertTrue(create_result2.size() > 0, "Second table should also be immediately visible")
+
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """drop table if exists ${db_name}.${tbl2}"""
+        sql """drop database if exists ${db_name} force"""
+        sql """drop catalog if exists ${catalog_name}"""
+    }
+
+    // ========== Hive/HMS ==========
+    def test_hive = { String hivePrefix ->
+        String enabled = context.config.otherConfigs.get("enableHiveTest")
+        if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+            logger.info("skip hive test.")
+            return
+        }
+
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+        String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
+        String catalog_name = "test_hive_create_cache_vis_${hivePrefix}"
+
+        sql """drop catalog if exists ${catalog_name}"""
+        sql """
+        create catalog if not exists ${catalog_name} properties (
+            'type'='hms',
+            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hmsPort}',
+            'fs.defaultFS' = 'hdfs://${externalEnvIp}:${hdfs_port}'
+        );
+        """
+
+        sql """switch ${catalog_name}"""
+        String db_name = "test_hive_cache_vis_db"
+        sql """drop database if exists ${db_name} force"""
+        sql """create database ${db_name}"""
+        sql """use ${db_name}"""
+
+        // CREATE TABLE then immediately verify visibility
+        String tbl1 = "hive_cache_vis_tbl1"
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """
+        CREATE TABLE ${db_name}.${tbl1} (
+            id INT,
+            name STRING
+        ) ENGINE=hive
+        PROPERTIES (
+            'file_format'='orc'
+        )
+        """
+
+        // The new table should be immediately visible without REFRESH CATALOG
+        def show_result = sql """SHOW TABLES"""
+        assertTrue(show_result.toString().contains(tbl1), "Table ${tbl1} should appear in SHOW TABLES after CREATE TABLE")
+
+        def create_result = sql """SHOW CREATE TABLE ${db_name}.${tbl1}"""
+        assertTrue(create_result.size() > 0, "SHOW CREATE TABLE should succeed for newly created table")
+        assertTrue(create_result[0][1].toString().toLowerCase().contains("hive"), "SHOW CREATE TABLE result should contain hive engine")
+
+        // INSERT + SELECT to verify end-to-end
+        sql """INSERT INTO ${db_name}.${tbl1} VALUES (1, 'a'), (2, 'b')"""
+        order_qt_hive_select """SELECT * FROM ${db_name}.${tbl1} ORDER BY id"""
+
+        // Create a second table
+        String tbl2 = "hive_cache_vis_tbl2"
+        sql """drop table if exists ${db_name}.${tbl2}"""
+        sql """
+        CREATE TABLE ${db_name}.${tbl2} (
+            id INT,
+            value DOUBLE
+        ) ENGINE=hive
+        PROPERTIES (
+            'file_format'='parquet'
+        )
+        """
+        def create_result2 = sql """SHOW CREATE TABLE ${db_name}.${tbl2}"""
+        assertTrue(create_result2.size() > 0, "Second table should also be immediately visible")
+
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """drop table if exists ${db_name}.${tbl2}"""
+        sql """drop database if exists ${db_name} force"""
+        sql """drop catalog if exists ${catalog_name}"""
+    }
+
+    // ========== Paimon ==========
+    def test_paimon = { String hivePrefix ->
+        String enabled = context.config.otherConfigs.get("enablePaimonTest")
+        if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+            logger.info("skip paimon test.")
+            return
+        }
+
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String hmsPort = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+        String hdfs_port = context.config.otherConfigs.get(hivePrefix + "HdfsPort")
+        String default_fs = "hdfs://${externalEnvIp}:${hdfs_port}"
+        String warehouse = "${default_fs}/warehouse"
+        String catalog_name = "test_paimon_create_cache_vis_${hivePrefix}"
+
+        sql """drop catalog if exists ${catalog_name}"""
+        sql """
+        create catalog ${catalog_name} properties (
+            'type'='paimon',
+            'paimon.catalog.type'='hms',
+            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hmsPort}',
+            'warehouse' = '${warehouse}'
+        );
+        """
+
+        sql """switch ${catalog_name}"""
+        String db_name = "test_paimon_cache_vis_db"
+        sql """drop database if exists ${db_name} force"""
+        sql """create database ${db_name}"""
+        sql """use ${db_name}"""
+
+        // CREATE TABLE then immediately verify visibility
+        String tbl1 = "paimon_cache_vis_tbl1"
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """
+        CREATE TABLE ${db_name}.${tbl1} (
+            id INT,
+            name STRING
+        ) engine=paimon
+        properties("primary-key"="id")
+        """
+
+        // The new table should be immediately visible without REFRESH CATALOG
+        def show_result = sql """SHOW TABLES"""
+        assertTrue(show_result.toString().contains(tbl1), "Table ${tbl1} should appear in SHOW TABLES after CREATE TABLE")
+
+        def create_result = sql """SHOW CREATE TABLE ${db_name}.${tbl1}"""
+        assertTrue(create_result.size() > 0, "SHOW CREATE TABLE should succeed for newly created table")
+        assertTrue(create_result[0][1].toString().toLowerCase().contains("paimon"), "SHOW CREATE TABLE result should contain paimon engine")
+
+        // INSERT + SELECT to verify end-to-end
+        sql """INSERT INTO ${db_name}.${tbl1} VALUES (1, 'a'), (2, 'b')"""
+        order_qt_paimon_select """SELECT * FROM ${db_name}.${tbl1} ORDER BY id"""
+
+        // Create a second table
+        String tbl2 = "paimon_cache_vis_tbl2"
+        sql """drop table if exists ${db_name}.${tbl2}"""
+        sql """
+        CREATE TABLE ${db_name}.${tbl2} (
+            id INT,
+            value DOUBLE
+        ) engine=paimon
+        properties("primary-key"="id")
+        """
+        def create_result2 = sql """SHOW CREATE TABLE ${db_name}.${tbl2}"""
+        assertTrue(create_result2.size() > 0, "Second table should also be immediately visible")
+
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """drop table if exists ${db_name}.${tbl2}"""
+        sql """drop database if exists ${db_name} force"""
+        sql """drop catalog if exists ${catalog_name}"""
+    }
+
+    // ========== Iceberg REST catalog type ==========
+    def test_iceberg_rest = {
+        String enabled = context.config.otherConfigs.get("enableIcebergTest")
+        if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+            logger.info("skip iceberg rest test.")
+            return
+        }
+
+        String rest_port = context.config.otherConfigs.get("iceberg_rest_uri_port")
+        String minio_port = context.config.otherConfigs.get("iceberg_minio_port")
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String catalog_name = "test_iceberg_rest_cache_vis"
+
+        sql """drop catalog if exists ${catalog_name}"""
+        sql """
+        CREATE CATALOG ${catalog_name} PROPERTIES (
+            'type'='iceberg',
+            'iceberg.catalog.type'='rest',
+            'uri' = 'http://${externalEnvIp}:${rest_port}',
+            "s3.access_key" = "admin",
+            "s3.secret_key" = "password",
+            "s3.endpoint" = "http://${externalEnvIp}:${minio_port}",
+            "s3.region" = "us-east-1"
+        );"""
+
+        sql """switch ${catalog_name}"""
+        String db_name = "test_iceberg_rest_cache_vis_db"
+        sql """drop database if exists ${db_name} force"""
+        sql """create database ${db_name}"""
+        sql """use ${db_name}"""
+
+        String tbl1 = "iceberg_rest_cache_vis_tbl1"
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """CREATE TABLE ${db_name}.${tbl1} (id int, name string)"""
+
+        // The new table should be immediately visible
+        def show_result = sql """SHOW TABLES"""
+        assertTrue(show_result.toString().contains(tbl1), "Table ${tbl1} should appear in SHOW TABLES after CREATE TABLE")
+
+        def create_result = sql """SHOW CREATE TABLE ${db_name}.${tbl1}"""
+        assertTrue(create_result.size() > 0, "SHOW CREATE TABLE should succeed for newly created table")
+
+        sql """INSERT INTO ${db_name}.${tbl1} VALUES (1, 'a'), (2, 'b')"""
+        order_qt_iceberg_rest_select """SELECT * FROM ${db_name}.${tbl1} ORDER BY id"""
+
+        sql """drop table if exists ${db_name}.${tbl1}"""
+        sql """drop database if exists ${db_name} force"""
+        sql """drop catalog if exists ${catalog_name}"""
+    }
+
+    // Run tests for each hive prefix
+    for (String hivePrefix : ["hive2", "hive3"]) {
+        test_iceberg(hivePrefix)
+        test_hive(hivePrefix)
+        test_paimon(hivePrefix)
+    }
+    test_iceberg_rest()
+}

--- a/regression-test/suites/external_table_p2/maxcompute/test_max_compute_create_table_cache_visibility.groovy
+++ b/regression-test/suites/external_table_p2/maxcompute/test_max_compute_create_table_cache_visibility.groovy
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_max_compute_create_table_cache_visibility", "p2,external") {
+    String enabled = context.config.otherConfigs.get("enableMaxComputeTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("skip maxcompute test.")
+        return
+    }
+
+    String ak = context.config.otherConfigs.get("ak")
+    String sk = context.config.otherConfigs.get("sk")
+    String mc_catalog_name = "test_mc_cache_vis"
+    String defaultProject = "mc_datalake"
+
+    sql """drop catalog if exists ${mc_catalog_name}"""
+    sql """
+    CREATE CATALOG IF NOT EXISTS ${mc_catalog_name} PROPERTIES (
+        "type" = "max_compute",
+        "mc.default.project" = "${defaultProject}",
+        "mc.access_key" = "${ak}",
+        "mc.secret_key" = "${sk}",
+        "mc.endpoint" = "http://service.cn-beijing-vpc.maxcompute.aliyun-inc.com/api",
+        "mc.quota" = "pay-as-you-go"
+    );
+    """
+
+    sql """switch ${mc_catalog_name}"""
+    sql """use ${defaultProject}"""
+
+    // CREATE TABLE then immediately verify visibility
+    String tbl1 = "test_mc_cache_vis_tbl1"
+    sql """DROP TABLE IF EXISTS ${tbl1}"""
+    sql """
+    CREATE TABLE ${tbl1} (
+        id INT,
+        name STRING
+    )
+    """
+
+    // The new table should be immediately visible without REFRESH CATALOG
+    def show_result = sql """SHOW TABLES LIKE '${tbl1}'"""
+    assertTrue(show_result.size() > 0, "Table ${tbl1} should appear in SHOW TABLES after CREATE TABLE")
+
+    def create_result = sql """SHOW CREATE TABLE ${tbl1}"""
+    assertTrue(create_result.size() > 0, "SHOW CREATE TABLE should succeed for newly created table")
+
+    // Create a second table
+    String tbl2 = "test_mc_cache_vis_tbl2"
+    sql """DROP TABLE IF EXISTS ${tbl2}"""
+    sql """
+    CREATE TABLE ${tbl2} (
+        id INT,
+        value DOUBLE
+    )
+    """
+    def create_result2 = sql """SHOW CREATE TABLE ${tbl2}"""
+    assertTrue(create_result2.size() > 0, "Second table should also be immediately visible")
+
+    // Cleanup
+    sql """DROP TABLE IF EXISTS ${tbl1}"""
+    sql """DROP TABLE IF EXISTS ${tbl2}"""
+    sql """drop catalog if exists ${mc_catalog_name}"""
+}


### PR DESCRIPTION
## Summary

When creating a table in an external catalog (Iceberg/HMS/Paimon/MaxCompute) via `CREATE TABLE`, the new table is not immediately visible in the internal meta cache. The `afterCreateTable()` implementations only call `resetMetaCacheNames()` which clears the `namesCache` but does not populate the `metaObjCache`. As a result, operations like `SHOW CREATE TABLE` fail with "table does not exist" until a manual `REFRESH CATALOG` is executed.

The same issue exists in rename table scenarios (`IcebergMetadataOps.afterRenameTable` and `RefreshManager.replayRefreshTable` rename branch) where only `resetMetaCacheNames` is called for the new table name.

## Root Cause

- `afterCreateTable()` in all 4 external catalog implementations (HiveMetadataOps, IcebergMetadataOps, PaimonMetadataOps, MaxComputeMetadataOps) only calls `db.resetMetaCacheNames()`, which clears the table name list cache but does NOT load the new table object into `metaObjCache`
- When subsequent operations call `getTableNullable()` → `metaCache.getMetaObj()`, the table object is not found → returns null → reports table does not exist
- The HMS event processor (`MetastoreEventsProcessor`) already handles this correctly via `registerExternalTableFromEvent()` which calls `buildTableForInit(checkExists=false)` + `metaCache.updateCache()`, but `enable_hms_events_incremental_sync` defaults to `false`

## Fix

- Added `registerTableFromCreate(String tblName)` method to `ExternalDatabase` that builds the table object with `checkExists=false` and calls `metaCache.updateCache()` to populate both `namesCache` and `metaObjCache`
- Called `registerTableFromCreate` in `ExternalCatalog.createTable()`, `replayCreateTable()`, and `renameTable()`
- Fixed `RefreshManager.replayRefreshTable()` rename branch: replaced `resetMetaCacheNames()` with `registerTableFromCreate(newName)`
- Fixed `IcebergMetadataOps.afterRenameTable()`: replaced `resetMetaCacheNames()` with `registerTableFromCreate(newName)`

## What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: After CREATE TABLE in external catalogs (Iceberg/HMS/Paimon/MaxCompute), the new table is not visible in cache. Users must manually run REFRESH CATALOG before they can use the newly created table. The same issue affects rename table operations. This PR makes newly created/renamed tables immediately visible by proactively loading them into the meta cache.

## Release note

Newly created or renamed external catalog tables (Iceberg/HMS/Paimon/MaxCompute) are now immediately visible without requiring a manual REFRESH CATALOG.

## Check List (For Author)

- Test: Unit Test + Regression test
    - FE unit test: `ExternalDatabaseRegisterTableTest` (6 cases covering visibility, namesCache update, idempotency, multi-table, replay, isolation)
    - Regression test: `external_table_p0` (Iceberg/Hive/Paimon) and `external_table_p2` (MaxCompute)
- Behavior changed: No (fix only - previously broken scenario now works)
- Does this need documentation: No