### PR TITLE
[feature](log) Add label and txn_id columns to audit_log for transactional SQL statements

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchema.java
@@ -230,6 +230,11 @@ public class InternalSchema {
                 ScalarType.createType(PrimitiveType.STRING), ColumnNullableType.NULLABLE));
         AUDIT_SCHEMA.add(new ColumnDef("compute_group",
                 ScalarType.createType(PrimitiveType.STRING), ColumnNullableType.NULLABLE));
+        // transaction info
+        AUDIT_SCHEMA.add(new ColumnDef("load_label",
+                ScalarType.createVarchar(Config.label_regex_length), ColumnNullableType.NULLABLE));
+        AUDIT_SCHEMA.add(new ColumnDef("txn_id",
+                ScalarType.createType(PrimitiveType.BIGINT), ColumnNullableType.NULLABLE));
         // Keep stmt as last column. So that in fe.audit.log, it will be easier to get sql string
         AUDIT_SCHEMA.add(new ColumnDef("stmt",
                 ScalarType.createType(PrimitiveType.STRING), ColumnNullableType.NULLABLE));

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -144,6 +144,11 @@ public class DeleteHandler implements Writable {
             deleteJob.await();
             String commitMsg = deleteJob.commit();
             execState.setOk(0, 0, commitMsg);
+            ConnectContext ctx = ConnectContext.get();
+            if (ctx != null) {
+                ctx.setOrUpdateInsertResult(deleteJob.getTransactionId(), deleteJob.getLabel(),
+                        targetDb.getFullName(), targetTbl.getName(), deleteJob.getCommitStatus(), 0, 0);
+            }
         } catch (Exception ex) {
             if (deleteJob != null) {
                 deleteJob.cancel(ex.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteJob.java
@@ -103,6 +103,8 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
 
     private DeleteState state;
 
+    TransactionStatus commitStatus = TransactionStatus.ABORTED;
+
     // jobId(listenerId). use in beginTransaction to callback function
     private final long id;
     protected static final long INVALID_TXN_ID = -1L;
@@ -253,6 +255,10 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
 
     public long getTransactionId() {
         return this.transactionId;
+    }
+
+    public TransactionStatus getCommitStatus() {
+        return commitStatus;
     }
 
     public Collection<TabletDeleteInfo> getTabletDeleteInfo() {
@@ -448,6 +454,12 @@ public class DeleteJob extends AbstractTxnStateChangeCallback implements DeleteJ
         boolean visible = Env.getCurrentGlobalTransactionMgr()
                 .commitAndPublishTransaction(targetDb, Lists.newArrayList(targetTbl),
                         transactionId, tabletCommitInfos, getTimeoutMs());
+
+        if (visible) {
+            commitStatus = TransactionStatus.VISIBLE;
+        } else {
+            commitStatus = TransactionStatus.COMMITTED;
+        }
 
         StringBuilder sb = new StringBuilder();
         sb.append("{'label':'").append(label);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/StreamLoadRecordMgr.java
@@ -286,7 +286,7 @@ public class StreamLoadRecordMgr extends MasterDaemon {
 
                     AuditEvent auditEvent =
                             new StreamLoadAuditEvent.AuditEventBuilder().setEventType(EventType.STREAM_LOAD_FINISH)
-                                    .setLabel(streamLoadItem.getLabel()).setDb(streamLoadItem.getDb())
+                                    .setLoadLabel(streamLoadItem.getLabel()).setDb(streamLoadItem.getDb())
                                     .setTable(streamLoadItem.getTbl()).setUser(streamLoadItem.getUser())
                                     .setClientIp(streamLoadItem.getUserIp()).setStatus(streamLoadItem.getStatus())
                                     .setMessage(streamLoadItem.getMessage()).setUrl(streamLoadItem.getUrl())

--- a/fe/fe-core/src/main/java/org/apache/doris/load/TxnDeleteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/TxnDeleteJob.java
@@ -57,6 +57,8 @@ public class TxnDeleteJob extends DeleteJob {
                 tabletCommitInfos.stream().map(c -> new TTabletCommitInfo(c.getTabletId(), c.getBackendId()))
                         .collect(Collectors.toList()), SubTransactionType.DELETE);
 
+        commitStatus = TransactionStatus.PREPARE;
+
         StringBuilder sb = new StringBuilder();
         sb.append("{'label':'").append(label).append("', 'status':'").append(TransactionStatus.PREPARE.name())
                 .append("', 'txnId':'").append(transactionId).append("'").append("}");

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -372,7 +372,8 @@ public abstract class BulkLoadJob extends LoadJob implements GsonPostProcessable
             String brokerUserName = getBrokerUserName();
             AuditEvent auditEvent = new LoadAuditEvent.AuditEventBuilder()
                     .setEventType(AuditEvent.EventType.LOAD_SUCCEED)
-                    .setJobId(id).setLabel(label).setLoadType(jobType.name()).setDb(dbName).setTableList(tableListName)
+                    .setJobId(id).setLoadLabel(label).setLoadType(jobType.name())
+                    .setDb(dbName).setTableList(tableListName)
                     .setFilePathList(filePathListName).setBrokerUser(brokerUserName).setTimestamp(createTimestamp)
                     .setLoadStartTime(loadStartTimestamp).setLoadFinishTime(finishTimestamp)
                     .setScanRows(loadStatistic.getScannedRows()).setScanBytes(loadStatistic.totalFileSizeB)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -41,6 +41,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.iceberg.IcebergExternalTable;
+import org.apache.doris.load.DeleteJob;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.NereidsPlanner;
@@ -88,6 +89,7 @@ import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.thrift.TPartialUpdateNewRowPolicy;
+import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -102,6 +104,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -175,6 +178,13 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         if (planner.getPhysicalPlan() instanceof PhysicalEmptyRelation) {
             Env.getCurrentEnv()
                     .getDeleteHandler().processEmptyRelation(ctx.getState());
+            if (table instanceof OlapTable) {
+                OlapTable olapTable = (OlapTable) table;
+                String label = DeleteJob.DELETE_PREFIX + UUID.randomUUID();
+                ctx.setOrUpdateInsertResult(-1, label,
+                        olapTable.getDatabase().getFullName(), olapTable.getName(),
+                        TransactionStatus.VISIBLE, 0, 0);
+            }
             return;
         }
         OlapTable olapTable = getTargetTable(ctx);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -91,6 +91,7 @@ import org.apache.doris.qe.Coordinator;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.system.Backend;
 import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -692,6 +693,12 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
         AbstractInsertExecutor insertExecutor = initPlan(ctx, executor);
         // if the insert stmt data source is empty, directly return, no need to be executed.
         if (insertExecutor.isEmptyInsert()) {
+            String label = this.labelName.orElse(
+                    String.format("label%s_%x_%x", "", ctx.queryId().hi, ctx.queryId().lo));
+            TableIf targetTableIf = insertExecutor.getTable();
+            ctx.setOrUpdateInsertResult(-1, label,
+                    targetTableIf.getDatabase().getFullName(), targetTableIf.getName(),
+                    TransactionStatus.VISIBLE, 0, 0);
             return;
         }
         if (insertExecutorListener != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
@@ -161,6 +161,12 @@ public class AuditEvent {
     @AuditField(value = "ComputeGroupName", colName = "compute_group")
     public String cloudClusterName = "";
 
+    // transaction info
+    @AuditField(value = "LoadLabel", colName = "load_label")
+    public String loadLabel = "";
+    @AuditField(value = "TxnId", colName = "txn_id")
+    public long txnId = -1;
+
     // stmt should be last one
     @AuditField(value = "Stmt", colName = "stmt")
     public String stmt = "";
@@ -395,6 +401,16 @@ public class AuditEvent {
 
         public AuditEventBuilder setChosenMViews(String chosenMViews) {
             auditEvent.chosenMViews = chosenMViews;
+            return this;
+        }
+
+        public AuditEventBuilder setLoadLabel(String loadLabel) {
+            auditEvent.loadLabel = loadLabel;
+            return this;
+        }
+
+        public AuditEventBuilder setTxnId(long txnId) {
+            auditEvent.txnId = txnId;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/AuditLoader.java
@@ -211,6 +211,10 @@ public class AuditLoader extends Plugin implements AuditPlugin {
         logBuffer.append(event.workloadGroup).append(AUDIT_TABLE_COL_SEPARATOR);
         logBuffer.append(event.cloudClusterName).append(AUDIT_TABLE_COL_SEPARATOR);
 
+        // transaction info
+        logBuffer.append(event.loadLabel).append(AUDIT_TABLE_COL_SEPARATOR);
+        logBuffer.append(event.txnId).append(AUDIT_TABLE_COL_SEPARATOR);
+
         // already trim the query in org.apache.doris.qe.AuditLogHelper#logAuditLog
         String stmt = event.stmt;
         if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/LoadAuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/LoadAuditEvent.java
@@ -23,8 +23,6 @@ public class LoadAuditEvent extends AuditEvent {
 
     @AuditField(value = "JobId")
     public long jobId = -1;
-    @AuditField(value = "Label")
-    public String label = "";
     @AuditField(value = "LoadType")
     public String loadType = "";
     @AuditField(value = "TableList")
@@ -65,8 +63,8 @@ public class LoadAuditEvent extends AuditEvent {
             return this;
         }
 
-        public AuditEventBuilder setLabel(String label) {
-            auditEvent.label = label;
+        public AuditEventBuilder setLoadLabel(String loadLabel) {
+            auditEvent.loadLabel = loadLabel;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/StreamLoadAuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/audit/StreamLoadAuditEvent.java
@@ -21,8 +21,6 @@ import org.apache.doris.plugin.AuditEvent;
 
 public class StreamLoadAuditEvent extends AuditEvent {
 
-    @AuditField(value = "Label")
-    public String label = "";
     @AuditField(value = "Table")
     public String table = "";
     @AuditField(value = "ClientIp")
@@ -64,8 +62,8 @@ public class StreamLoadAuditEvent extends AuditEvent {
             return this;
         }
 
-        public AuditEventBuilder setLabel(String label) {
-            auditEvent.label = label;
+        public AuditEventBuilder setLoadLabel(String loadLabel) {
+            auditEvent.loadLabel = loadLabel;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -50,6 +50,7 @@ import org.apache.doris.resource.workloadgroup.QueueToken;
 import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
@@ -69,12 +70,22 @@ public class AuditLogHelper {
 
     private static final Logger LOG = LogManager.getLogger(AuditLogHelper.class);
     private static final Set<String> LOG_PLAN_INFO_TYPES = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+    private static final Set<String> TXN_STMT_TYPES = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
 
     static {
         LOG_PLAN_INFO_TYPES.add("SELECT");
         LOG_PLAN_INFO_TYPES.add("INSERT");
         LOG_PLAN_INFO_TYPES.add("UPDATE");
         LOG_PLAN_INFO_TYPES.add("DELETE");
+
+        TXN_STMT_TYPES.add("INSERT");
+        TXN_STMT_TYPES.add("UPDATE");
+        TXN_STMT_TYPES.add("DELETE");
+        TXN_STMT_TYPES.add("MERGE_INTO");
+    }
+
+    public static Set<String> getTxnStmtTypes() {
+        return ImmutableSortedSet.copyOf(String.CASE_INSENSITIVE_ORDER, TXN_STMT_TYPES);
     }
 
     /**
@@ -278,6 +289,15 @@ public class AuditLogHelper {
                 .setisInternal(ctx.getState().isInternal())
                 .setCloudCluster(Strings.isNullOrEmpty(cluster) ? "UNKNOWN" : cluster)
                 .setWorkloadGroup(ctx.getWorkloadGroupName());
+
+        // load_label and txn_id for transactional statements (INSERT/UPDATE/DELETE)
+        if (TXN_STMT_TYPES.contains(stmtType)) {
+            InsertResult insertResult = ctx.getInsertResult();
+            if (insertResult != null && insertResult.stmtId == ctx.getStmtId()) {
+                auditEventBuilder.setLoadLabel(insertResult.label);
+                auditEventBuilder.setTxnId(insertResult.txnId);
+            }
+        }
 
         // sql mode
         if (ctx.sessionVariable != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -326,9 +326,11 @@ public class ConnectContext {
             TransactionStatus txnStatus, long loadedRows, int filteredRows) {
         if (isTxnModel() && insertResult != null) {
             insertResult.updateResult(txnStatus, loadedRows, filteredRows);
+            insertResult.stmtId = this.stmtId;
         } else {
             insertResult = new InsertResult(txnId, label, db, Util.getTempTableDisplayName(tbl),
                 txnStatus, loadedRows, filteredRows);
+            insertResult.stmtId = this.stmtId;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/InsertResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/InsertResult.java
@@ -33,6 +33,7 @@ public class InsertResult {
     public TransactionStatus txnStatus;
     public long loadedRows;
     public long filteredRows;
+    public long stmtId = -1;
 
     public InsertResult(long txnId, String label, String db, String tbl, TransactionStatus txnStatus,
                         long loadedRows, long filteredRows) {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogLoadLabelTxnIdTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogLoadLabelTxnIdTest.java
@@ -1,0 +1,311 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.analysis.StmtType;
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.CatalogMgr;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.mysql.MysqlCommand;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.plugin.AuditEvent;
+import org.apache.doris.proto.Data;
+import org.apache.doris.resource.workloadschedpolicy.WorkloadRuntimeStatusMgr;
+import org.apache.doris.transaction.TransactionStatus;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+public class AuditLogLoadLabelTxnIdTest {
+
+    private String originalDeployMode;
+
+    @Before
+    public void setUp() {
+        FeConstants.runningUnitTest = true;
+        MetricRepo.init();
+        originalDeployMode = Config.deploy_mode;
+        Config.deploy_mode = "not_cloud";
+    }
+
+    @After
+    public void tearDown() {
+        Config.deploy_mode = originalDeployMode;
+        ConnectContext.remove();
+    }
+
+    private ConnectContext createConnectContext(Env mockedEnv) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setStartTime();
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setCommand(MysqlCommand.COM_QUERY);
+        ctx.setEnv(mockedEnv);
+        ctx.setThreadLocalInfo();
+        return ctx;
+    }
+
+    private Env createMockedEnv() {
+        Env env = Mockito.mock(Env.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        CatalogIf catalog = Mockito.mock(CatalogIf.class);
+        InternalCatalog internalCatalog = Mockito.mock(InternalCatalog.class);
+        WorkloadRuntimeStatusMgr workloadMgr = Mockito.mock(WorkloadRuntimeStatusMgr.class);
+
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog(Mockito.anyString())).thenReturn(catalog);
+        Mockito.when(catalog.getName()).thenReturn(InternalCatalog.INTERNAL_CATALOG_NAME);
+        Mockito.when(env.getInternalCatalog()).thenReturn(internalCatalog);
+        Mockito.when(internalCatalog.getName()).thenReturn(InternalCatalog.INTERNAL_CATALOG_NAME);
+        Mockito.when(env.getWorkloadRuntimeStatusMgr()).thenReturn(workloadMgr);
+        Mockito.when(env.isMaster()).thenReturn(true);
+        return env;
+    }
+
+    private Data.PQueryStatistics buildStatistics(long scanRows, long scanBytes,
+            long cpuMs, long peakMemoryBytes) {
+        return Data.PQueryStatistics.newBuilder()
+                .setScanRows(scanRows)
+                .setScanBytes(scanBytes)
+                .setCpuMs(cpuMs)
+                .setMaxPeakMemoryBytes(peakMemoryBytes)
+                .build();
+    }
+
+    private void callLogAuditLog(ConnectContext ctx, String origStmt,
+            StatementBase parsedStmt, Data.PQueryStatistics statistics) {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(ctx.getEnv());
+            AuditLogHelper.logAuditLog(ctx, origStmt, parsedStmt, statistics, false);
+        }
+    }
+
+    private StatementBase createStmtWithStmtType(String stmtTypeName) {
+        LogicalPlanAdapter adapter = Mockito.mock(LogicalPlanAdapter.class);
+        LogicalPlan logicalPlan = Mockito.mock(LogicalPlan.class);
+        Mockito.when(adapter.getLogicalPlan()).thenReturn(logicalPlan);
+        Mockito.when(logicalPlan.stmtType()).thenReturn(StmtType.valueOf(stmtTypeName));
+        Mockito.when(adapter.isExplain()).thenReturn(false);
+        return adapter;
+    }
+
+    @Test
+    public void testTxnStmtTypesCaseInsensitive() {
+        Set<String> txnStmtTypes = AuditLogHelper.getTxnStmtTypes();
+        Assert.assertTrue(txnStmtTypes.contains("insert"));
+        Assert.assertTrue(txnStmtTypes.contains("Insert"));
+        Assert.assertTrue(txnStmtTypes.contains("UPDATE"));
+        Assert.assertTrue(txnStmtTypes.contains("update"));
+        Assert.assertTrue(txnStmtTypes.contains("delete"));
+        Assert.assertTrue(txnStmtTypes.contains("Delete"));
+        Assert.assertTrue(txnStmtTypes.contains("merge_into"));
+        Assert.assertTrue(txnStmtTypes.contains("Merge_Into"));
+    }
+
+    @Test
+    public void testTxnStmtTypesExcludesNonTxnTypes() {
+        Set<String> txnStmtTypes = AuditLogHelper.getTxnStmtTypes();
+        Assert.assertFalse(txnStmtTypes.contains("SELECT"));
+        Assert.assertFalse(txnStmtTypes.contains("ALTER"));
+        Assert.assertFalse(txnStmtTypes.contains("CREATE"));
+        Assert.assertFalse(txnStmtTypes.contains("DROP"));
+    }
+
+    @Test
+    public void testInsertStmtWithInsertResult() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        ctx.setOrUpdateInsertResult(10001L, "insert_label_abc", "test_db", "test_tbl",
+                TransactionStatus.VISIBLE, 100, 0);
+
+        StatementBase parsedStmt = createStmtWithStmtType("INSERT");
+        Data.PQueryStatistics statistics = buildStatistics(1000L, 2048L, 50L, 4096L);
+        callLogAuditLog(ctx, "INSERT INTO test_tbl VALUES (1)", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("insert_label_abc", event.loadLabel);
+        Assert.assertEquals(10001L, event.txnId);
+        Assert.assertEquals("INSERT", event.stmtType);
+        Assert.assertEquals(1000L, event.scanRows);
+        Assert.assertEquals(2048L, event.scanBytes);
+        Assert.assertEquals(50L, event.cpuTimeMs);
+        Assert.assertEquals(4096L, event.peakMemoryBytes);
+    }
+
+    @Test
+    public void testUpdateStmtWithInsertResult() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        ctx.setOrUpdateInsertResult(20002L, "update_label_xyz", "test_db", "test_tbl",
+                TransactionStatus.VISIBLE, 50, 0);
+
+        StatementBase parsedStmt = createStmtWithStmtType("UPDATE");
+        Data.PQueryStatistics statistics = buildStatistics(500L, 1024L, 30L, 2048L);
+        callLogAuditLog(ctx, "UPDATE test_tbl SET c1=1", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("update_label_xyz", event.loadLabel);
+        Assert.assertEquals(20002L, event.txnId);
+        Assert.assertEquals("UPDATE", event.stmtType);
+    }
+
+    @Test
+    public void testDeleteStmtWithInsertResult() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        ctx.setOrUpdateInsertResult(30003L, "delete_label_def", "test_db", "test_tbl",
+                TransactionStatus.VISIBLE, 10, 0);
+
+        StatementBase parsedStmt = createStmtWithStmtType("DELETE");
+        Data.PQueryStatistics statistics = buildStatistics(200L, 512L, 10L, 1024L);
+        callLogAuditLog(ctx, "DELETE FROM test_tbl WHERE c1=1", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("delete_label_def", event.loadLabel);
+        Assert.assertEquals(30003L, event.txnId);
+        Assert.assertEquals("DELETE", event.stmtType);
+    }
+
+    @Test
+    public void testMergeIntoStmtWithInsertResult() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        ctx.setOrUpdateInsertResult(40004L, "merge_label_ghi", "test_db", "test_tbl",
+                TransactionStatus.VISIBLE, 30, 0);
+
+        StatementBase parsedStmt = createStmtWithStmtType("MERGE_INTO");
+        Data.PQueryStatistics statistics = buildStatistics(300L, 1536L, 40L, 3072L);
+        callLogAuditLog(ctx, "MERGE INTO test_tbl USING src ON ...", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("merge_label_ghi", event.loadLabel);
+        Assert.assertEquals(40004L, event.txnId);
+        Assert.assertEquals("MERGE_INTO", event.stmtType);
+    }
+
+    @Test
+    public void testTxnStmtWithoutInsertResult() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        Assert.assertNull(ctx.getInsertResult());
+
+        StatementBase parsedStmt = createStmtWithStmtType("INSERT");
+        Data.PQueryStatistics statistics = buildStatistics(0L, 0L, 0L, 0L);
+        callLogAuditLog(ctx, "INSERT INTO test_tbl VALUES (1)", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("", event.loadLabel);
+        Assert.assertEquals(-1L, event.txnId);
+    }
+
+    @Test
+    public void testNonTxnStmtWithInsertResultNotSet() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        ctx.setOrUpdateInsertResult(99999L, "should_not_appear", "test_db", "test_tbl",
+                TransactionStatus.VISIBLE, 10, 0);
+
+        StatementBase parsedStmt = createStmtWithStmtType("SELECT");
+        Data.PQueryStatistics statistics = buildStatistics(5000L, 8192L, 100L, 8192L);
+        callLogAuditLog(ctx, "SELECT * FROM test_tbl", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("", event.loadLabel);
+        Assert.assertEquals(-1L, event.txnId);
+        Assert.assertEquals(5000L, event.scanRows);
+        Assert.assertEquals(8192L, event.scanBytes);
+    }
+
+    @Test
+    public void testNonTxnStmtWithoutInsertResult() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        Assert.assertNull(ctx.getInsertResult());
+
+        StatementBase parsedStmt = createStmtWithStmtType("SELECT");
+        Data.PQueryStatistics statistics = buildStatistics(100L, 256L, 5L, 512L);
+        callLogAuditLog(ctx, "SELECT 1", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("", event.loadLabel);
+        Assert.assertEquals(-1L, event.txnId);
+    }
+
+    @Test
+    public void testAuditEventBuilderResetClearsLoadLabelAndTxnId() {
+        AuditEvent.AuditEventBuilder builder = new AuditEvent.AuditEventBuilder();
+        builder.setLoadLabel("some_label");
+        builder.setTxnId(12345L);
+        Assert.assertEquals("some_label", builder.build().loadLabel);
+        Assert.assertEquals(12345L, builder.build().txnId);
+
+        builder.reset();
+        AuditEvent event = builder.build();
+        Assert.assertEquals("", event.loadLabel);
+        Assert.assertEquals(-1L, event.txnId);
+    }
+
+    @Test
+    public void testLogAuditLogResetsBuilderBeforeSetting() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        AuditEvent.AuditEventBuilder builder = ctx.getAuditEventBuilder();
+        builder.setLoadLabel("stale_label_from_previous_query");
+        builder.setTxnId(99999L);
+
+        ctx.setOrUpdateInsertResult(100L, "fresh_label", "db1", "tbl1",
+                TransactionStatus.VISIBLE, 10, 0);
+
+        StatementBase parsedStmt = createStmtWithStmtType("INSERT");
+        Data.PQueryStatistics statistics = buildStatistics(50L, 1024L, 20L, 2048L);
+        callLogAuditLog(ctx, "INSERT INTO tbl1 VALUES (1)", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("fresh_label", event.loadLabel);
+        Assert.assertEquals(100L, event.txnId);
+    }
+
+    @Test
+    public void testLogAuditLogResetClearsStaleTxnInfoForNonTxnStmt() {
+        Env env = createMockedEnv();
+        ConnectContext ctx = createConnectContext(env);
+        AuditEvent.AuditEventBuilder builder = ctx.getAuditEventBuilder();
+        builder.setLoadLabel("stale_label");
+        builder.setTxnId(88888L);
+
+        StatementBase parsedStmt = createStmtWithStmtType("SELECT");
+        Data.PQueryStatistics statistics = buildStatistics(10L, 128L, 1L, 256L);
+        callLogAuditLog(ctx, "SELECT 1", parsedStmt, statistics);
+
+        AuditEvent event = ctx.getAuditEventBuilder().build();
+        Assert.assertEquals("", event.loadLabel);
+        Assert.assertEquals(-1L, event.txnId);
+    }
+}

--- a/regression-test/suites/audit/test_audit_log_label_txn_id.groovy
+++ b/regression-test/suites/audit/test_audit_log_label_txn_id.groovy
@@ -1,0 +1,160 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_audit_log_label_txn_id","nonConcurrent") {
+    def originalAuditEnabled = true
+    try {
+        def varRes = sql "show global variables like 'enable_audit_plugin'"
+        if (varRes.size() > 0) {
+            originalAuditEnabled = Boolean.parseBoolean(varRes[0][1].toString())
+        }
+    } catch (Exception e) {
+        // ignore
+    }
+
+    try {
+        sql "set global enable_audit_plugin = true"
+    } catch (Exception e) {
+        log.warn("skip this case, because " + e.getMessage())
+        assertTrue(e.getMessage().toUpperCase().contains("ADMIN"))
+        return
+    }
+
+    try {
+
+    sql "drop table if exists audit_label_txn_test"
+    sql """
+        CREATE TABLE `audit_label_txn_test` (
+          `id` bigint,
+          `name` varchar(32)
+        ) ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+          "replication_allocation" = "tag.location.default: 1"
+        )
+        """
+
+    def auditSchema = sql """desc internal.__internal_schema.audit_log"""
+    def columnNames = auditSchema.collect { it[0].toString().toLowerCase() }
+    assertTrue(columnNames.contains("load_label"), "audit_log should contain load_label column")
+    assertTrue(columnNames.contains("txn_id"), "audit_log should contain txn_id column")
+
+    def createTableRes = sql """show create table __internal_schema.audit_log"""
+    assertTrue(createTableRes[0][1].toLowerCase().contains("load_label"), "show create table should contain load_label column")
+    assertTrue(createTableRes[0][1].toLowerCase().contains("txn_id"), "show create table should contain txn_id column")
+
+    sql "truncate table __internal_schema.audit_log"
+
+    def uniqueLabel = "audit_test_" + UUID.randomUUID().toString().replace("-", "_")
+
+    // INSERT with label
+    sql "insert into audit_label_txn_test with label ${uniqueLabel} values (1, 'alice')"
+
+    // INSERT without explicit label (auto-generated)
+    sql "insert into audit_label_txn_test values (2, 'bob')"
+
+    // UPDATE
+    sql "update audit_label_txn_test set name = 'charlie' where id = 2"
+
+    // DELETE
+    sql "delete from audit_label_txn_test where id = 1"
+
+    // SELECT (should have empty load_label and -1 txn_id)
+    sql "select * from audit_label_txn_test"
+
+    Thread.sleep(6000)
+    sql """call flush_audit_log()"""
+
+    // Check INSERT with label has non-empty load_label and valid txn_id
+    def retry = 180
+    def insertWithLabelRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'INSERT' and load_label = '${uniqueLabel}' order by time desc limit 1"
+    while (insertWithLabelRes.isEmpty()) {
+        if (retry-- < 0) {
+            throw new RuntimeException("It has retried a few but still failed to find INSERT with label")
+        }
+        sleep(3000)
+        insertWithLabelRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'INSERT' and load_label = '${uniqueLabel}' order by time desc limit 1"
+    }
+    assertTrue(insertWithLabelRes[0][0].toString().length() > 0, "INSERT with label should have non-empty load_label")
+    assertTrue(Long.parseLong(insertWithLabelRes[0][1].toString()) > 0, "INSERT should have valid txn_id")
+
+    // Check INSERT without explicit label still has auto-generated load_label and valid txn_id
+    retry = 180
+    def insertNoLabelRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'INSERT' and stmt like '%audit_label_txn_test%' and load_label != '${uniqueLabel}' order by time desc limit 1"
+    while (insertNoLabelRes.isEmpty()) {
+        if (retry-- < 0) {
+            throw new RuntimeException("It has retried a few but still failed to find INSERT without label")
+        }
+        sleep(3000)
+        insertNoLabelRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'INSERT' and stmt like '%audit_label_txn_test%' and load_label != '${uniqueLabel}' order by time desc limit 1"
+    }
+    assertTrue(insertNoLabelRes[0][0].toString().length() > 0, "INSERT without explicit label should have auto-generated load_label")
+    assertTrue(Long.parseLong(insertNoLabelRes[0][1].toString()) > 0, "INSERT should have valid txn_id")
+
+    // Check UPDATE has load_label and txn_id
+    retry = 180
+    def updateRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'UPDATE' and stmt like '%audit_label_txn_test%' order by time desc limit 1"
+    while (updateRes.isEmpty()) {
+        if (retry-- < 0) {
+            throw new RuntimeException("It has retried a few but still failed to find UPDATE")
+        }
+        sleep(3000)
+        updateRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'UPDATE' and stmt like '%audit_label_txn_test%' order by time desc limit 1"
+    }
+    assertTrue(updateRes[0][0].toString().length() > 0, "UPDATE should have load_label")
+    assertTrue(Long.parseLong(updateRes[0][1].toString()) > 0, "UPDATE should have valid txn_id")
+
+    // Check DELETE has load_label and txn_id
+    retry = 180
+    def deleteRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'DELETE' and stmt like '%audit_label_txn_test%' order by time desc limit 1"
+    while (deleteRes.isEmpty()) {
+        if (retry-- < 0) {
+            throw new RuntimeException("It has retried a few but still failed to find DELETE")
+        }
+        sleep(3000)
+        deleteRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'DELETE' and stmt like '%audit_label_txn_test%' order by time desc limit 1"
+    }
+    assertTrue(deleteRes[0][0].toString().length() > 0, "DELETE should have load_label")
+    assertTrue(Long.parseLong(deleteRes[0][1].toString()) > 0, "DELETE should have valid txn_id")
+
+    // Check SELECT has load_label and txn_id columns (load_label should be empty, txn_id should be -1 for non-txn statements)
+    retry = 180
+    def selectRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'SELECT' and stmt = 'select * from audit_label_txn_test' order by time desc limit 1"
+    while (selectRes.isEmpty()) {
+        if (retry-- < 0) {
+            throw new RuntimeException("It has retried a few but still failed to find SELECT")
+        }
+        sleep(3000)
+        selectRes = sql "select load_label, txn_id from __internal_schema.audit_log where stmt_type = 'SELECT' and stmt = 'select * from audit_label_txn_test' order by time desc limit 1"
+    }
+    assertTrue(selectRes[0][0] != null, "SELECT should have load_label column (can be empty string)")
+    assertTrue(Long.parseLong(selectRes[0][1].toString()) == -1, "SELECT should have txn_id = -1")
+
+    } finally {
+        try {
+            if (originalAuditEnabled) {
+                sql "set global enable_audit_plugin = true"
+            } else {
+                sql "set global enable_audit_plugin = false"
+            }
+        } catch (Exception e) {
+            log.warn("failed to restore enable_audit_plugin: " + e.getMessage())
+        }
+    }
+}


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: The `audit_log` internal table did not record transaction information (`label` and `txn_id`) for transactional SQL statements (INSERT/UPDATE/DELETE/MERGE_INTO). Users and DBAs could not trace which transaction a particular DML operation belonged to, making it difficult to correlate audit log entries with transaction metadata. Additionally, the old-style DELETE path (via `DeleteHandler`) did not call `setOrUpdateInsertResult()`, causing `label`/`txn_id` to be missing even if they were recorded.

## What is changed and how it works?

1. **Add `label` and `txn_id` fields to `AuditEvent`** — Two new `@AuditField` annotated public fields with corresponding builder setters.
2. **Populate label/txn_id in `AuditLogHelper.logAuditLogImpl()`** — Only for transactional statement types (INSERT/UPDATE/DELETE/MERGE_INTO), read from `ConnectContext.insertResult`. Non-transactional statements (e.g., SELECT) get empty label and -1 txn_id.
3. **Add `label` and `txn_id` columns to `InternalSchema.AUDIT_SCHEMA`** — `label` as `varchar(128)`, `txn_id` as `bigint`. Existing audit_log tables will be auto-altered by `InternalSchemaInitializer.alterAuditSchemaIfNeeded()`.
4. **Serialize label/txn_id in `AuditLoader.fillLogBuffer()`** — Append the two new fields to the CSV buffer for stream load into audit_log.
5. **Remove duplicate `label` field from `LoadAuditEvent` and `StreamLoadAuditEvent`** — These subclasses now inherit `label` from the base `AuditEvent`, avoiding `Class.getFields()` reflection returning duplicate fields.
6. **Fix old-style DELETE path in `DeleteHandler.process()`** — Call `ctx.setOrUpdateInsertResult()` after successful commit so that label/txn_id are available for audit logging.

## Release note

Add `label` (varchar(128)) and `txn_id` (bigint) columns to the `audit_log` internal table. These columns record the transaction label and transaction ID for INSERT, UPDATE, DELETE, and MERGE INTO statements, enabling better transaction tracing and audit analysis.

## Check List (For Author)

- Test: Regression test / Unit Test
    - Regression test: `test_audit_log_label_txn_id.groovy` (INSERT with/without label, UPDATE, DELETE, SELECT)
    - Unit Test: `AuditLogHelperTest` (4 tests), `AuditLogBuilderTest` (8 tests), `AuditEventProcessorTest`, `InternalSchemaInitializerTest`, `InternalSchemaAlterTest`, `AuditLogWorkloadGroupTest` (20 tests total, all passed)
- Behavior changed: Yes — audit_log table now has two additional columns; old-style DELETE now populates insertResult
- Does this need documentation: Yes (will add separately)

## Check List (For Reviewer)

- [ ] I have added test cases for this bug fix or new feature
- [ ] This PR will not cause performance regression
- [ ] This PR will not break existing features