### PR TITLE
[fix](fe) Skip dropped columns in follower stats sync

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/FollowerColumnSender.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/FollowerColumnSender.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.statistics;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.ClientPool;
@@ -130,7 +131,8 @@ public class FollowerColumnSender extends MasterDaemon {
                 LOG.warn("Failed to find table for column {}", column.colName);
                 continue;
             }
-            if (StatisticsUtil.isUnsupportedType(table.getColumn(column.colName).getType())) {
+            Column col = table.getColumn(column.colName);
+            if (col == null || StatisticsUtil.isUnsupportedType(col.getType())) {
                 continue;
             }
             Set<Pair<String, String>> columnIndexPairs = table.getColumnIndexPairs(

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/FollowerColumnSenderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/FollowerColumnSenderTest.java
@@ -72,4 +72,32 @@ public class FollowerColumnSenderTest {
         }
     }
 
+    @Test
+    public void testGetNeedAnalyzeColumnsSkipDroppedColumns() {
+        OlapTable mockTable = Mockito.mock(OlapTable.class);
+        Mockito.when(mockTable.getColumn("dropped")).thenReturn(null);
+        Mockito.when(mockTable.getColumn("visible")).thenReturn(new Column("visible", PrimitiveType.INT));
+        Mockito.when(mockTable.getColumnIndexPairs(Mockito.any()))
+                .thenReturn(Collections.singleton(Pair.of("mockIndex", "visible")));
+
+        try (MockedStatic<StatisticsUtil> statisticsUtilStatic = Mockito.mockStatic(StatisticsUtil.class)) {
+            statisticsUtilStatic.when(() -> StatisticsUtil.needAnalyzeColumn(Mockito.any(), Mockito.any()))
+                    .thenReturn(true);
+            statisticsUtilStatic.when(() -> StatisticsUtil.findTable(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(mockTable);
+
+            QueryColumn droppedColumn = new QueryColumn(1, 2, 3, "dropped");
+            QueryColumn visibleQueryColumn = new QueryColumn(1, 2, 3, "visible");
+            Queue<QueryColumn> queue = new BlockingArrayQueue<>();
+            queue.add(droppedColumn);
+            queue.add(visibleQueryColumn);
+
+            FollowerColumnSender sender = new FollowerColumnSender();
+            Set<TQueryColumn> needAnalyzeColumns = sender.getNeedAnalyzeColumns(queue);
+            Assertions.assertEquals(1, needAnalyzeColumns.size());
+            Assertions.assertFalse(needAnalyzeColumns.contains(droppedColumn.toThrift()));
+            Assertions.assertTrue(needAnalyzeColumns.contains(visibleQueryColumn.toThrift()));
+        }
+    }
+
 }


### PR DESCRIPTION
### What problem does this PR solve?

FollowerColumnSender drains queued column references on follower FEs and syncs the columns that still need analysis to the master. A queued column can become stale after DDL changes. If the table still exists but the queued column has been dropped, table.getColumn(column.colName) returns null and the sender throws a NullPointerException while reading the type.

This patch skips dropped columns before checking the column type, so the daemon does not emit periodic ERROR logs and can continue processing the remaining queued columns.

Issue Number: close #xxx

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - org.apache.doris.statistics.FollowerColumnSenderTest
- Behavior changed: No
- Does this need documentation: No