### PR TITLE
[fix](test) fix flaky compaction profile case

### DIFF
--- a/regression-test/suites/compaction/test_compaction_profile_action.groovy
+++ b/regression-test/suites/compaction/test_compaction_profile_action.groovy
@@ -121,9 +121,6 @@ suite("test_compaction_profile_action", "p0") {
         // Verify field values are reasonable
         assertTrue(profile.compaction_id > 0, "compaction_id should be positive")
         assertTrue(profile.cost_time_ms >= 0, "cost_time_ms should be non-negative")
-        assertTrue(profile.input_data_size > 0, "input_data_size should be positive")
-        assertTrue(profile.input_rowsets_count > 0, "input_rowsets_count should be positive")
-        assertTrue(profile.input_row_num > 0, "input_row_num should be positive")
 
         // Step 6: Test top_n filter - ?top_n=1 returns exactly 1 record
         def (code2, out2, err2) = curl("GET", baseUrl + "?top_n=1")
@@ -144,6 +141,12 @@ suite("test_compaction_profile_action", "p0") {
             assertEquals(Long.parseLong(tablet_id), p.tablet_id,
                     "All returned profiles should match the requested tablet_id")
         }
+
+        // Verify field values using profile from our specific tablet
+        def tabletProfile = json3.compaction_profiles[0]
+        assertTrue(tabletProfile.input_data_size > 0, "input_data_size should be positive")
+        assertTrue(tabletProfile.input_rowsets_count > 0, "input_rowsets_count should be positive")
+        assertTrue(tabletProfile.input_row_num > 0, "input_row_num should be positive")
 
         // Step 8: Test compact_type filter - ?compact_type=cumulative
         def (code4, out4, err4) = curl("GET", baseUrl + "?compact_type=cumulative")


### PR DESCRIPTION
## Summary

Fix DORIS-25488: `test_compaction_profile_action` was flaky because it checked input size on the first unfiltered compaction profile, which may belong to another tablet.

This PR checks those fields on the profile filtered by the test tablet id.