### PR TITLE
[fix](parquet) fix null pointer dereference in gen_filter_map when filter_all is true

### DIFF
--- a/be/src/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/format/parquet/vparquet_column_reader.cpp
@@ -432,9 +432,15 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::_read_nested_column(
         RETURN_IF_ERROR(_chunk_reader->fill_def(_def_levels));
         std::unique_ptr<FilterMap> nested_filter_map = std::make_unique<FilterMap>();
         if (filter_map.has_filter()) {
-            RETURN_IF_ERROR(gen_filter_map(filter_map, filter_map_index, before_rep_level_sz,
-                                           _rep_levels.size(), nested_filter_map_data,
-                                           &nested_filter_map));
+            if (filter_map.filter_all()) {
+                nested_filter_map_data.assign(_rep_levels.size() - before_rep_level_sz, 0);
+                RETURN_IF_ERROR(nested_filter_map->init(nested_filter_map_data.data(),
+                                                         nested_filter_map_data.size(), true));
+            } else {
+                RETURN_IF_ERROR(gen_filter_map(filter_map, filter_map_index, before_rep_level_sz,
+                                               _rep_levels.size(), nested_filter_map_data,
+                                               &nested_filter_map));
+            }
         }
 
         null_map.clear();

--- a/be/src/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/format/parquet/vparquet_column_reader.cpp
@@ -435,7 +435,7 @@ Status ScalarColumnReader<IN_COLLECTION, OFFSET_INDEX>::_read_nested_column(
             if (filter_map.filter_all()) {
                 nested_filter_map_data.assign(_rep_levels.size() - before_rep_level_sz, 0);
                 RETURN_IF_ERROR(nested_filter_map->init(nested_filter_map_data.data(),
-                                                         nested_filter_map_data.size(), true));
+                                                        nested_filter_map_data.size(), true));
             } else {
                 RETURN_IF_ERROR(gen_filter_map(filter_map, filter_map_index, before_rep_level_sz,
                                                _rep_levels.size(), nested_filter_map_data,

--- a/be/test/format/parquet/parquet_common_test.cpp
+++ b/be/test/format/parquet/parquet_common_test.cpp
@@ -220,7 +220,7 @@ TEST_F(FilterMapTest, test_filter_all_nullptr_nested_filter_map) {
     nested_filter_map_data.assign(nested_size, 0);
     auto fixed_nested_filter_map = std::make_unique<FilterMap>();
     ASSERT_TRUE(fixed_nested_filter_map
-                        ->init(nested_filter_map_data.data(),nested_filter_map_data.size(), true)
+                        ->init(nested_filter_map_data.data(), nested_filter_map_data.size(), true)
                         .ok());
 
     EXPECT_TRUE(fixed_nested_filter_map->has_filter());

--- a/be/test/format/parquet/parquet_common_test.cpp
+++ b/be/test/format/parquet/parquet_common_test.cpp
@@ -190,6 +190,69 @@ TEST_F(FilterMapTest, test_can_filter_all_when_filter_all) {
     EXPECT_TRUE(filter_map.can_filter_all(100, 0));
 }
 
+// Test that filter_all=true with nullptr data does not crash when generating nested filter map.
+// This covers the scenario where a predicate filters out all rows in a RowGroup,
+// and a nested column (e.g. struct field) tries to build a nested filter map.
+// Before the fix, gen_filter_map would dereference filter_map_data() which is nullptr,
+// causing SIGSEGV. The fix skips gen_filter_map and propagates filter_all directly.
+TEST_F(FilterMapTest, test_filter_all_nullptr_nested_filter_map) {
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(nullptr, 10, true).ok());
+
+    EXPECT_TRUE(filter_map.has_filter());
+    EXPECT_TRUE(filter_map.filter_all());
+    EXPECT_EQ(filter_map.filter_map_data(), nullptr);
+
+    // generate_nested_filter_map should reject filter_all (it has an explicit guard)
+    std::vector<level_t> rep_levels = {0, 1, 1, 0, 1, 0};
+    std::vector<uint8_t> nested_filter_map_data;
+    std::unique_ptr<FilterMap> nested_filter_map;
+    size_t current_row = 0;
+
+    auto status = filter_map.generate_nested_filter_map(rep_levels, nested_filter_map_data,
+                                                         &nested_filter_map, &current_row, 0);
+    EXPECT_FALSE(status.ok());
+
+    // Simulate the fix: when filter_all is true, the caller should create
+    // a nested filter map with all zeros and filter_all=true, instead of
+    // calling gen_filter_map which would dereference nullptr.
+    size_t nested_size = rep_levels.size();
+    nested_filter_map_data.assign(nested_size, 0);
+    auto fixed_nested_filter_map = std::make_unique<FilterMap>();
+    ASSERT_TRUE(fixed_nested_filter_map->init(nested_filter_map_data.data(),
+                                               nested_filter_map_data.size(), true)
+                        .ok());
+
+    EXPECT_TRUE(fixed_nested_filter_map->has_filter());
+    EXPECT_TRUE(fixed_nested_filter_map->filter_all());
+    EXPECT_DOUBLE_EQ(fixed_nested_filter_map->filter_ratio(), 1.0);
+    for (size_t i = 0; i < nested_size; i++) {
+        EXPECT_EQ(nested_filter_map_data[i], 0);
+    }
+}
+
+// Test filter_all with all-zero data (detected by init, not explicitly passed)
+// also has nullptr-safe nested filter map handling
+TEST_F(FilterMapTest, test_all_zero_filter_nested_filter_map) {
+    std::vector<uint8_t> filter_data(5, 0);
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(filter_data.data(), filter_data.size(), false).ok());
+
+    // init detects all-zero and sets filter_all=true
+    EXPECT_TRUE(filter_map.filter_all());
+    EXPECT_TRUE(filter_map.has_filter());
+    // In this case filter_map_data is non-null but generate_nested_filter_map
+    // still rejects it because filter_all() is true
+    std::vector<level_t> rep_levels = {0, 1, 0, 1, 1};
+    std::vector<uint8_t> nested_filter_map_data;
+    std::unique_ptr<FilterMap> nested_filter_map;
+    size_t current_row = 0;
+
+    auto status = filter_map.generate_nested_filter_map(rep_levels, nested_filter_map_data,
+                                                         &nested_filter_map, &current_row, 0);
+    EXPECT_FALSE(status.ok());
+}
+
 class CrossPageTest : public testing::Test {
 protected:
     void SetUp() override {

--- a/be/test/format/parquet/parquet_common_test.cpp
+++ b/be/test/format/parquet/parquet_common_test.cpp
@@ -210,7 +210,7 @@ TEST_F(FilterMapTest, test_filter_all_nullptr_nested_filter_map) {
     size_t current_row = 0;
 
     auto status = filter_map.generate_nested_filter_map(rep_levels, nested_filter_map_data,
-                                                         &nested_filter_map, &current_row, 0);
+                                                        &nested_filter_map, &current_row, 0);
     EXPECT_FALSE(status.ok());
 
     // Simulate the fix: when filter_all is true, the caller should create
@@ -219,8 +219,8 @@ TEST_F(FilterMapTest, test_filter_all_nullptr_nested_filter_map) {
     size_t nested_size = rep_levels.size();
     nested_filter_map_data.assign(nested_size, 0);
     auto fixed_nested_filter_map = std::make_unique<FilterMap>();
-    ASSERT_TRUE(fixed_nested_filter_map->init(nested_filter_map_data.data(),
-                                               nested_filter_map_data.size(), true)
+    ASSERT_TRUE(fixed_nested_filter_map
+                        ->init(nested_filter_map_data.data(),nested_filter_map_data.size(), true)
                         .ok());
 
     EXPECT_TRUE(fixed_nested_filter_map->has_filter());
@@ -249,7 +249,7 @@ TEST_F(FilterMapTest, test_all_zero_filter_nested_filter_map) {
     size_t current_row = 0;
 
     auto status = filter_map.generate_nested_filter_map(rep_levels, nested_filter_map_data,
-                                                         &nested_filter_map, &current_row, 0);
+                                                        &nested_filter_map, &current_row, 0);
     EXPECT_FALSE(status.ok());
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63887

Problem Summary:

Fix null pointer dereference (SIGSEGV) in `ScalarColumnReader::gen_filter_map` when reading nested type columns (Struct/Array/Map) from Parquet-based external tables.

When a predicate filters out all rows in a RowGroup, `FilterMap` is initialized with `filter_all=true` and `_filter_map_data=nullptr`. The `_read_nested_column` function only checks `has_filter()` before calling `gen_filter_map`, which dereferences `filter_map_data()` unconditionally — causing a crash.

Fix: add a `filter_all()` check before calling `gen_filter_map`. When `filter_all` is true, directly construct an all-zero nested filter map with `filter_all=true` propagation. This is logically equivalent to what `gen_filter_map` would produce with valid all-zero filter data — both correctly discard all data from the RowGroup.

### Release note

Fix BE crash (SIGSEGV) when querying Parquet-based external tables (Paimon/Hive/Iceberg) with nested type columns under lazy read, if predicates filter out all rows in a RowGroup.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

**Manual test**: Verified with standalone program simulating `gen_filter_map` logic — crashes without fix, passes with fix.

**Unit test**: Added `test_filter_all_nullptr_nested_filter_map` and `test_all_zero_filter_nested_filter_map` in `parquet_common_test.cpp`.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label