### PR TITLE
[fix](sort) keep heap TopN pruning for expression order keys

### DIFF
--- a/be/src/exec/operator/sort_sink_operator.cpp
+++ b/be/src/exec/operator/sort_sink_operator.cpp
@@ -51,10 +51,15 @@ Status SortSinkLocalState::open(RuntimeState* state) {
     }
     switch (p._algorithm) {
     case TSortAlgorithm::HEAP_SORT: {
+        bool disable_local_topn_filter = false;
+        if (state->get_query_ctx()->has_runtime_predicate(p._node_id)) {
+            disable_local_topn_filter =
+                state->get_query_ctx()->get_runtime_predicate(p._node_id)
+                    .all_targets_are_slot();
+        }
         _shared_state->sorter = HeapSorter::create_shared(
                 _ordering_expr_ctxs, state, p._limit, p._offset, p._pool, p._is_asc_order,
-                p._nulls_first, p._child->row_desc(),
-                state->get_query_ctx()->has_runtime_predicate(p._node_id));
+            p._nulls_first, p._child->row_desc(), disable_local_topn_filter);
         break;
     }
     case TSortAlgorithm::TOPN_SORT: {

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -88,6 +89,13 @@ public:
     bool target_is_slot(int32_t target_node_id) const {
         check_target_node_id(target_node_id);
         return _contexts.find(target_node_id)->second.target_is_slot();
+    }
+
+    bool all_targets_are_slot() const {
+        std::shared_lock<std::shared_mutex> rlock(_rwlock);
+        return std::ranges::all_of(_contexts, [](const auto& entry) {
+            return entry.second.target_is_slot();
+        });
     }
 
     const TExpr& get_texpr(int32_t target_node_id) const {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

For TopN queries with computed order keys, such as `SELECT MURMUR_HASH3_32(number) AS n FROM numbers_20m ORDER BY n LIMIT 65535`, Doris created a TopN runtime predicate but could not push it down to storage because the target was an expression instead of a slot/key column. However, heap sort treated the existence of any runtime predicate as a reason to disable its local TopN pruning, so this path lost local pruning without gaining effective scan-side pruning.

This PR narrows that condition. Heap sort now disables local TopN pruning only when the runtime predicate targets are all slots. Expression order keys keep the local heap filter, which restores early row pruning in the sorter.

In local reproduction of `function_order_by_number_limit_big`, Doris improved from about 2.3s to 2.8s down to about 0.53s to 0.69s, and the new profile shows `TopNFilterRows: 19.555616M` instead of `0`.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

