### PR TITLE
[improvement](be) Train ANN index once instead of on every chunk

### DIFF
--- a/be/src/storage/index/ann/ann_index.h
+++ b/be/src/storage/index/ann/ann_index.h
@@ -78,6 +78,14 @@ public:
 
     virtual doris::Status train(Int64 n, const float* x) = 0;
 
+    // Whether the underlying index must be trained once before add().
+    // HNSW with a FLAT quantizer has nothing to learn from the data and overrides
+    // to false; IVF (k-means coarse quantizer) and any scalar/product quantizer
+    // (SQ/PQ) must be trained. Callers must train at most once per index lifetime:
+    // a second train() on the same index would re-fit the quantizer codebook and
+    // make vectors already added under the earlier codebook inconsistent.
+    virtual bool needs_training() const { return false; }
+
     /** Add n vectors of dimension d vectors to the index.
      *
      * Vectors are implicitly assigned labels ntotal .. ntotal + n - 1

--- a/be/src/storage/index/ann/ann_index_writer.cpp
+++ b/be/src/storage/index/ann/ann_index_writer.cpp
@@ -83,6 +83,17 @@ Status AnnIndexColumnWriter::init() {
     return Status::OK();
 }
 
+Status AnnIndexColumnWriter::_train_once_if_needed(Int64 n, const float* vec) {
+    if (_trained) {
+        return Status::OK();
+    }
+    if (_vector_index->needs_training()) {
+        RETURN_IF_ERROR(_vector_index->train(n, vec));
+    }
+    _trained = true;
+    return Status::OK();
+}
+
 Status AnnIndexColumnWriter::add_values(const std::string fn, const void* values, size_t count) {
     return Status::OK();
 }
@@ -122,7 +133,7 @@ Status AnnIndexColumnWriter::add_array_values(size_t field_size, const void* val
 
         if (_float_array.size() == full_elements) {
             RETURN_IF_ERROR(
-                    _vector_index->train(AnnIndexColumnWriter::chunk_size(), _float_array.data()));
+                    _train_once_if_needed(AnnIndexColumnWriter::chunk_size(), _float_array.data()));
             RETURN_IF_ERROR(
                     _vector_index->add(AnnIndexColumnWriter::chunk_size(), _float_array.data()));
             _float_array.clear();
@@ -166,7 +177,7 @@ Status AnnIndexColumnWriter::finish() {
         Int64 num_rows = _float_array.size() / _vector_index->get_dimension();
 
         if (num_rows >= min_train_rows) {
-            RETURN_IF_ERROR(_vector_index->train(num_rows, _float_array.data()));
+            RETURN_IF_ERROR(_train_once_if_needed(num_rows, _float_array.data()));
             RETURN_IF_ERROR(_vector_index->add(num_rows, _float_array.data()));
             _float_array.clear();
             return _vector_index->save(_dir.get());

--- a/be/src/storage/index/ann/ann_index_writer.h
+++ b/be/src/storage/index/ann/ann_index_writer.h
@@ -71,6 +71,12 @@ public:
     Status finish() override;
 
 private:
+    // Train the underlying index exactly once over its lifetime. The first call
+    // trains (when the index needs it) and latches _trained; later calls are no-ops.
+    // This prevents re-training the IVF quantizer on every chunk, which would re-fit
+    // the SQ/PQ codebook and invalidate vectors added under the earlier codebook.
+    Status _train_once_if_needed(Int64 n, const float* vec);
+
     // VectorIndex shoule be managed by some cache.
     // VectorIndex should be weak shared by AnnIndexWriter and VectorIndexReader
     // This should be a weak_ptr
@@ -82,5 +88,7 @@ private:
     const TabletIndex* _index_meta;
     std::shared_ptr<DorisFSDirectory> _dir;
     bool _need_save_index = false;
+    // Latched once the index has been trained (or determined not to need training).
+    bool _trained = false;
 };
 } // namespace doris::segment_v2

--- a/be/src/storage/index/ann/faiss_ann_index.cpp
+++ b/be/src/storage/index/ann/faiss_ann_index.cpp
@@ -452,6 +452,17 @@ private:
     size_t _file_size;
 };
 
+bool FaissVectorIndex::needs_training() const {
+    // IVF performs k-means clustering for the coarse quantizer, and any quantizer
+    // other than FLAT (SQ/PQ) also has to learn parameters from the data, so both
+    // must be trained. HNSW with a FLAT quantizer learns nothing from train().
+    if (_params.index_type == FaissBuildParameter::IndexType::IVF ||
+        _params.index_type == FaissBuildParameter::IndexType::IVF_ON_DISK) {
+        return true;
+    }
+    return _params.quantizer != FaissBuildParameter::Quantizer::FLAT;
+}
+
 doris::Status FaissVectorIndex::train(Int64 n, const float* vec) {
     DCHECK(vec != nullptr);
     DCHECK(_index != nullptr);

--- a/be/src/storage/index/ann/faiss_ann_index.h
+++ b/be/src/storage/index/ann/faiss_ann_index.h
@@ -198,6 +198,8 @@ public:
      */
     doris::Status train(Int64 n, const float* vec) override;
 
+    bool needs_training() const override;
+
     /**
      * @brief Adds vectors to the index for future searches.
      *

--- a/be/test/storage/index/ann/ann_index_writer_test.cpp
+++ b/be/test/storage/index/ann/ann_index_writer_test.cpp
@@ -40,6 +40,7 @@ public:
     MockVectorIndex() { _dimension = 4; } // Set dimension for test
     MOCK_METHOD(doris::Status, train, (Int64 n, const float* vec), (override));
     MOCK_METHOD(doris::Status, add, (Int64 n, const float* vec), (override));
+    MOCK_METHOD(bool, needs_training, (), (const, override));
     MOCK_METHOD(doris::Status, ann_topn_search,
                 (const float* query_vec, int k, const segment_v2::IndexSearchParameters& params,
                  segment_v2::IndexSearchResult& result),
@@ -427,11 +428,13 @@ TEST_F(AnnIndexWriterTest, TestAddMoreThanChunkSize) {
     ASSERT_TRUE(writer->init().ok());
     writer->set_vector_index(mock_index);
 
+    // Index requires training (e.g. IVF/PQ). After the fix train() is invoked only
+    // once on the first full chunk; the remainder reuses the already-trained state.
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, train(10, testing::_))
             .Times(1)
             .WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(10, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
-    EXPECT_CALL(*mock_index, train(2, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(2, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, save(testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
 
@@ -587,11 +590,13 @@ TEST_F(AnnIndexWriterTest, TestAddMoreThanChunkSizeIVF) {
     ASSERT_TRUE(writer->init().ok());
     writer->set_vector_index(mock_index);
 
+    // Index requires training (e.g. IVF/PQ). After the fix train() is invoked only
+    // once on the first full chunk; the remainder reuses the already-trained state.
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, train(10, testing::_))
             .Times(1)
             .WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(10, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
-    EXPECT_CALL(*mock_index, train(2, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(2, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, save(testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
 
@@ -662,6 +667,7 @@ TEST_F(AnnIndexWriterTest, TestSkipTrainWhenRemainderLessThanNlist) {
     // CHUNK_SIZE = 10, nlist = 5
     // Add 12 rows: first 10 will be trained/added in one batch, remaining 2 < 5
     // Since we have trained data before (_need_save_index = true), we should add the remaining 2 rows and save
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(5));
     EXPECT_CALL(*mock_index, train(10, testing::_))
             .Times(1)
@@ -731,15 +737,18 @@ TEST_F(AnnIndexWriterTest, TestLargeDataVolumeWithRemainderSkip) {
     writer->set_vector_index(mock_index);
 
     // CHUNK_SIZE = 10, nlist = 3
-    // Add 23 rows: 2 full chunks of 10, remaining 3 == nlist, so train remaining
+    // Add 23 rows: 2 full chunks of 10, remaining 3 == nlist.
+    // After the fix train() is called exactly once on the first full chunk; the
+    // remaining 3 rows are added without re-training (which would otherwise
+    // re-cluster IVF and invalidate the vectors already added).
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(3));
     EXPECT_CALL(*mock_index, train(10, testing::_))
-            .Times(2)
-            .WillRepeatedly(testing::Return(Status::OK()));
+            .Times(1)
+            .WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(10, testing::_))
             .Times(2)
             .WillRepeatedly(testing::Return(Status::OK()));
-    EXPECT_CALL(*mock_index, train(3, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(3, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, save(testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
 
@@ -806,11 +815,13 @@ TEST_F(AnnIndexWriterTest, TestLargeDataVolumeSkipRemainder) {
 
     // CHUNK_SIZE = 10, nlist = 4
     // Add 22 rows: 2 full chunks of 10, remaining 2 < 4
-    // Since we have trained data before (_need_save_index = true), we should add the remaining 2 rows and save
+    // Since we have trained data before (_need_save_index = true), we should add the remaining 2 rows and save.
+    // After the fix train() runs once on the first full chunk; later chunks only add().
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(4));
     EXPECT_CALL(*mock_index, train(10, testing::_))
-            .Times(2)
-            .WillRepeatedly(testing::Return(Status::OK()));
+            .Times(1)
+            .WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(10, testing::_))
             .Times(2)
             .WillRepeatedly(testing::Return(Status::OK()));
@@ -881,6 +892,7 @@ TEST_F(AnnIndexWriterTest, TestSkipIndexWhenTotalRowsLessThanNlist) {
     // Add only 3 rows, which is less than nlist (5)
     // Since no data was trained before (_need_save_index = false), we should skip index building entirely
     // No train, add, or save should be called
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(5));
     EXPECT_CALL(*mock_index, train(testing::_, testing::_)).Times(0);
     EXPECT_CALL(*mock_index, add(testing::_, testing::_)).Times(0);
@@ -923,17 +935,17 @@ TEST_F(AnnIndexWriterTest, TestPQMinTrainRows) {
     writer->set_vector_index(mock_index);
 
     // Set up expectations: mock a very large min_train_rows threshold.
-    // Since we only provide 1000 vectors, which is less than 131072, training will happen in batches
-    // but finish() will skip saving since remaining data is insufficient
+    // 1000 vectors split into 100 full chunks of 10. After the fix train() runs once
+    // on the first chunk; every later chunk only add()s. At finish() there are 0
+    // leftover rows and _need_save_index = true, so save() is invoked.
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(131072));
-    // 1000 vectors will be processed in 100 batches of 10 vectors each
     EXPECT_CALL(*mock_index, train(10, testing::_))
-            .Times(100)
-            .WillRepeatedly(testing::Return(Status::OK()));
+            .Times(1)
+            .WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(10, testing::_))
             .Times(100)
             .WillRepeatedly(testing::Return(Status::OK()));
-    // Since we have trained data in batches, the index will be saved even though total data is insufficient
     EXPECT_CALL(*mock_index, save(testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
 
     const size_t dim = 4;
@@ -978,8 +990,10 @@ TEST_F(AnnIndexWriterTest, TestSQMinTrainRows) {
 
     // Set up expectations: SQ should require at least 20 training vectors
     // Since we only provide 15 vectors, training will happen in batches but finish() will skip saving
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(20));
-    // 15 vectors will be processed in 1 batch of 10 vectors and remaining 5 vectors
+    // 15 vectors will be processed in 1 batch of 10 vectors and remaining 5 vectors.
+    // train() runs once on the first full chunk; the trailing 5 rows only add().
     EXPECT_CALL(*mock_index, train(10, testing::_))
             .Times(1)
             .WillOnce(testing::Return(Status::OK()));
@@ -1028,12 +1042,14 @@ TEST_F(AnnIndexWriterTest, TestPQWithSufficientData) {
     writer->set_vector_index(mock_index);
 
     // Mock min_train_rows to 131072 and provide exactly that amount.
+    // 131072 vectors split into 13107 full chunks of 10 (= 131070 rows) plus 2 leftover.
+    // After the fix train() runs once on the first chunk; the rest is pure add() at
+    // each chunk boundary plus one trailing add(2) in finish().
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(131072));
-    // Since we provide exactly 131072 vectors, they will be trained and added in chunks
-    // Each chunk is 10 vectors, so we expect 13107 train calls and 13107 add calls for full chunks
     EXPECT_CALL(*mock_index, train(10, testing::_))
-            .Times(13107)
-            .WillRepeatedly(testing::Return(Status::OK()));
+            .Times(1)
+            .WillOnce(testing::Return(Status::OK()));
     EXPECT_CALL(*mock_index, add(10, testing::_))
             .Times(13107)
             .WillRepeatedly(testing::Return(Status::OK()));
@@ -1063,6 +1079,50 @@ TEST_F(AnnIndexWriterTest, TestPQWithSufficientData) {
 
     // Finish should successfully build the index
     Status status = writer->finish();
+    EXPECT_TRUE(status.ok());
+}
+
+TEST_F(AnnIndexWriterTest, TestHnswSkipsTrainCall) {
+    // An index that reports needs_training() == false (HNSW + FLAT) must never have
+    // train() invoked, even when multiple full chunks flow through add().
+    auto mock_index = std::make_shared<MockVectorIndex>();
+    auto writer = std::make_unique<TestAnnIndexColumnWriter>(_index_file_writer.get(),
+                                                             _tablet_index.get());
+
+    auto fs_dir = std::make_shared<DorisRAMFSDirectory>();
+    fs_dir->init(doris::io::global_local_filesystem(), "./ut_dir/tmp_vector_search", nullptr);
+    EXPECT_CALL(*_index_file_writer, open(testing::_)).WillOnce(testing::Return(fs_dir));
+
+    ASSERT_TRUE(writer->init().ok());
+    writer->set_vector_index(mock_index);
+
+    // CHUNK_SIZE = 10. Push 2 full chunks + a 5-row remainder.
+    EXPECT_CALL(*mock_index, needs_training()).WillRepeatedly(testing::Return(false));
+    EXPECT_CALL(*mock_index, get_min_train_rows()).WillRepeatedly(testing::Return(0));
+    EXPECT_CALL(*mock_index, train(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(*mock_index, add(10, testing::_))
+            .Times(2)
+            .WillRepeatedly(testing::Return(Status::OK()));
+    EXPECT_CALL(*mock_index, add(5, testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
+    EXPECT_CALL(*mock_index, save(testing::_)).Times(1).WillOnce(testing::Return(Status::OK()));
+
+    const size_t dim = 4;
+    const size_t num_rows = 25;
+    std::vector<float> vectors(num_rows * dim);
+    for (size_t i = 0; i < num_rows * dim; ++i) {
+        vectors[i] = static_cast<float>(i % 100);
+    }
+    std::vector<size_t> offsets;
+    for (size_t i = 0; i <= num_rows; ++i) {
+        offsets.push_back(i * dim);
+    }
+
+    Status status =
+            writer->add_array_values(sizeof(float), vectors.data(), nullptr,
+                                     reinterpret_cast<const uint8_t*>(offsets.data()), num_rows);
+    EXPECT_TRUE(status.ok());
+
+    status = writer->finish();
     EXPECT_TRUE(status.ok());
 }
 

--- a/be/test/storage/index/ann/faiss_vector_index_test.cpp
+++ b/be/test/storage/index/ann/faiss_vector_index_test.cpp
@@ -46,6 +46,40 @@ using namespace doris::segment_v2;
 
 namespace doris {
 
+// needs_training() must be true for IVF (k-means coarse quantizer) and for any
+// scalar/product quantizer, and false only for HNSW + FLAT. This drives the writer
+// to train the index exactly once; mis-reporting it would either skip required
+// training or re-train and corrupt SQ/PQ codes.
+TEST_F(VectorSearchTest, NeedsTrainingMatrix) {
+    auto build = [](FaissBuildParameter::IndexType type, FaissBuildParameter::Quantizer quantizer) {
+        auto index = std::make_unique<FaissVectorIndex>();
+        FaissBuildParameter params;
+        params.dim = 16;
+        params.max_degree = 16;
+        params.pq_m = 4;
+        params.pq_nbits = 8;
+        params.ivf_nlist = 4;
+        params.index_type = type;
+        params.quantizer = quantizer;
+        index->build(params);
+        return index;
+    };
+
+    using IndexType = FaissBuildParameter::IndexType;
+    using Quantizer = FaissBuildParameter::Quantizer;
+
+    // HNSW only learns nothing with a FLAT quantizer.
+    EXPECT_FALSE(build(IndexType::HNSW, Quantizer::FLAT)->needs_training());
+    EXPECT_TRUE(build(IndexType::HNSW, Quantizer::SQ8)->needs_training());
+    EXPECT_TRUE(build(IndexType::HNSW, Quantizer::PQ)->needs_training());
+
+    // IVF always trains its coarse quantizer, regardless of the encoding quantizer.
+    for (auto q : {Quantizer::FLAT, Quantizer::SQ4, Quantizer::SQ8, Quantizer::PQ}) {
+        EXPECT_TRUE(build(IndexType::IVF, q)->needs_training());
+        EXPECT_TRUE(build(IndexType::IVF_ON_DISK, q)->needs_training());
+    }
+}
+
 // Test saving and loading an index
 TEST_F(VectorSearchTest, TestSaveAndLoad) {
     std::vector<FaissBuildParameter::Quantizer> quantizers = {

--- a/regression-test/suites/ann_index_p0/ann_ivf_pq_train_once_recall.groovy
+++ b/regression-test/suites/ann_index_p0/ann_ivf_pq_train_once_recall.groovy
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression for #63913: the ANN index writer must train the FAISS quantizer
+// EXACTLY ONCE per index build, not once per buffered chunk.
+//
+// Background: AnnIndexColumnWriter buffers vectors and flushes them one chunk at
+// a time (ann_index_build_chunk_size). The buggy code called train() on every
+// chunk. For a PQ (product-quantization) index, train() re-fits the codebook on
+// the latest chunk, but vectors from earlier chunks were already add()ed and
+// encoded under the previous codebook. After the final chunk re-trains, those
+// earlier codes no longer match the stored codebook, so they decode to garbage
+// distances at query time -> recall collapses on any segment that spans more
+// than one chunk.
+//
+// This test shrinks ann_index_build_chunk_size so a single 20k-row segment spans
+// 10 chunks, builds an IVF+PQ index, and asserts recall@10 (vs exact brute-force
+// l2_distance) stays high. On a buggy BE this recall drops to ~0.1 and the test
+// fails; on the fixed BE it stays high. An IVF+FLAT table loaded from the same
+// data is used as a positive control (FLAT has no codebook, so it is unaffected
+// and must reach near-exact recall) -- this proves the harness can achieve high
+// recall, so a low PQ recall is specifically the train-reentry bug.
+//
+// nonConcurrent: it temporarily changes a global BE config.
+suite("ann_ivf_pq_train_once_recall", "nonConcurrent") {
+    def dim       = 32
+    def nRows     = 20000
+    def chunkSize = 2000      // 20000 / 2000 = 10 chunks per segment -> bug triggers hard
+    def nlist     = 64
+    def topk      = 10
+    def nQueries  = 30
+    def rnd       = new Random(42)   // fixed seed -> reproducible
+
+    // -- generate i.i.d. gaussian base vectors as a stream-load CSV (id|[v0,...]) --
+    // The vector itself contains commas, so use '|' as the column separator.
+    def sb = new StringBuilder()
+    for (int i = 0; i < nRows; i++) {
+        sb.append(i).append('|').append('[')
+        for (int d = 0; d < dim; d++) {
+            float v = (float) rnd.nextGaussian()
+            if (d > 0) sb.append(',')
+            sb.append(String.format(Locale.US, '%.6f', v))   // Locale.US: never a comma decimal
+        }
+        sb.append(']').append('\n')
+    }
+    def csv = sb.toString()
+
+    // -- query vectors (independent random) --
+    def queries = new float[nQueries][dim]
+    for (int q = 0; q < nQueries; q++) {
+        for (int d = 0; d < dim; d++) {
+            queries[q][d] = (float) rnd.nextGaussian()
+        }
+    }
+
+    def vecLiteral = { float[] v ->
+        def s = new StringBuilder('[')
+        for (int d = 0; d < v.length; d++) {
+            if (d > 0) s.append(',')
+            s.append(String.format(Locale.US, '%.6f', v[d]))
+        }
+        s.append(']')
+        return s.toString()
+    }
+
+    def idsOf = { String q ->
+        def rows = sql q
+        return rows.collect { (it[0] as long) } as Set
+    }
+
+    // recall@topk averaged over all queries: approx (uses index) vs exact (brute force)
+    def measureRecall = { String table ->
+        double total = 0.0d
+        for (int q = 0; q < nQueries; q++) {
+            def lit    = vecLiteral(queries[q])
+            def approx = idsOf("select id from ${table} order by l2_distance_approximate(vec, ${lit}) limit ${topk}".toString())
+            def exact  = idsOf("select id from ${table} order by l2_distance(vec, ${lit}) limit ${topk}".toString())
+            total += (approx.intersect(exact).size() / (double) topk)
+        }
+        return total / nQueries
+    }
+
+    def loadCsv = { String table ->
+        streamLoad {
+            table "${table}"
+            set 'column_separator', '|'
+            set 'columns', 'id, vec'
+            inputStream new ByteArrayInputStream(csv.getBytes("UTF-8"))
+            time 120000
+            check { result, exception, startTime, endTime ->
+                if (exception != null) {
+                    throw exception
+                }
+                def json = parseJson(result)
+                assertEquals("success", json.Status.toLowerCase())
+                assertEquals(nRows, json.NumberLoadedRows)
+                assertEquals(0, json.NumberFilteredRows)
+            }
+        }
+    }
+
+    sql "set enable_common_expr_pushdown = true"
+    sql "set enable_ann_index_result_cache = false"   // avoid cache masking real index behavior
+    // Scan all lists so IVF coarse-quantization adds no approximation: this isolates
+    // PQ-codebook correctness, which is what the bug breaks.
+    sql "set ivf_nprobe = ${nlist}"
+
+    setBeConfigTemporary([ann_index_build_chunk_size: chunkSize]) {
+        // ================= IVF + PQ : the path the bug corrupts =================
+        sql "drop table if exists ann_pq_train_once"
+        sql """
+        create table ann_pq_train_once (
+            id int not null,
+            vec array<float> not null,
+            index ann_idx (vec) using ann properties (
+                'index_type' = 'ivf',
+                'metric_type'= 'l2_distance',
+                'dim'        = '${dim}',
+                'nlist'      = '${nlist}',
+                'quantizer'  = 'pq',
+                'pq_m'       = '16',
+                'pq_nbits'   = '8')
+        ) engine=olap
+        duplicate key(id)
+        distributed by hash(id) buckets 1
+        properties ('replication_num' = '1');
+        """
+        loadCsv("ann_pq_train_once")
+
+        // Guard: the approximate query MUST be pushed into the ANN index. Otherwise
+        // it degenerates to exact distances, recall would be a trivial 1.0, and the
+        // test would silently stop guarding the bug.
+        explain {
+            sql "select id from ann_pq_train_once order by l2_distance_approximate(vec, ${vecLiteral(queries[0])}) limit ${topk}".toString()
+            contains "ANN SORT INFO"
+        }
+
+        double pqRecall = measureRecall("ann_pq_train_once")
+        logger.info("[#63913] IVF+PQ multi-chunk recall@${topk} = ${pqRecall} (chunks per segment = ${nRows / chunkSize})")
+        // Fixed build: typically ~0.8-0.95. Buggy build (per-chunk retrain): ~0.1.
+        // Threshold 0.5 sits in the wide gap between them.
+        assertTrue(pqRecall >= 0.5d,
+            ("IVF+PQ recall@${topk} = ${pqRecall} is too low. The PQ codebook was likely " +
+             "re-trained on every chunk so earlier chunks decode against the wrong codebook " +
+             "(regression of #63913 'train ANN index once'). Expected >= 0.5.").toString())
+
+        // ============ IVF + FLAT : positive control, must be unaffected ============
+        sql "drop table if exists ann_flat_control"
+        sql """
+        create table ann_flat_control (
+            id int not null,
+            vec array<float> not null,
+            index ann_idx (vec) using ann properties (
+                'index_type' = 'ivf',
+                'metric_type'= 'l2_distance',
+                'dim'        = '${dim}',
+                'nlist'      = '${nlist}',
+                'quantizer'  = 'flat')
+        ) engine=olap
+        duplicate key(id)
+        distributed by hash(id) buckets 1
+        properties ('replication_num' = '1');
+        """
+        loadCsv("ann_flat_control")
+
+        double flatRecall = measureRecall("ann_flat_control")
+        logger.info("[#63913] IVF+FLAT control recall@${topk} = ${flatRecall}")
+        // FLAT has no codebook; with nprobe == nlist it is exact. If this is low, the
+        // problem is the environment/harness, not the bug under test.
+        assertTrue(flatRecall >= 0.95d,
+            ("IVF+FLAT control recall@${topk} = ${flatRecall} is unexpectedly low; this points " +
+             "to an environment/harness issue rather than the train-once bug.").toString())
+    }
+
+    sql "drop table if exists ann_pq_train_once"
+    sql "drop table if exists ann_flat_control"
+}


### PR DESCRIPTION
## What problem does this PR solve?

Issue Number: 

### Problem Summary

When building an ANN (vector) index, `AnnIndexColumnWriter` buffers incoming
vectors and flushes them to the underlying FAISS index one chunk at a time
(`ann_index_build_chunk_size`, default **1,000,000** rows). On every chunk
flush it calls `train()` **and then** `add()`. Re-invoking `train()` once per
chunk is incorrect:

- **IVF / HNSW with a `SQ`/`PQ` quantizer (recall corruption).**
  `train()` re-fits the scalar/product-quantization codebook on whatever chunk
  is currently buffered. In FAISS, `IndexIVF::train()` calls `train_encoder()`
  with **no `is_trained` guard** (`contrib/faiss/faiss/IndexIVF.cpp:1166/1168`),
  and `IndexHNSWSQ`/`IndexHNSWPQ` start `is_trained=false`. Vectors from earlier
  chunks were already `add()`ed and **encoded using the previous codebook**.
  After the final chunk re-trains the codebook, those earlier codes no longer
  match the codebook used at query time, so they decode to the wrong distances.
  The result is **silent recall loss on any segment larger than one chunk**
  (> 1M rows, e.g. a compacted segment).

- **Default IVFFlat / HNSW-Flat (redundant work).**
  For the default `FLAT` quantizer there is no codebook, and the coarse
  quantizer's k-means is already guarded — `Level1Quantizer::train_q1()` returns
  early once `quantizer->is_trained && quantizer->ntotal == nlist`
  (`contrib/faiss/faiss/IndexIVF.cpp:62`). So recall is **not** corrupted, but
  every extra chunk still pays a full `train()` call, including its global
  OpenMP build-budget mutex. Pure wasted work.

The writer's own `finish()` comment already documented the intended contract
("the quantizer was already trained on previous batches, just add"), but the
per-chunk loop never honored it.

### What's changed

Train the index **at most once** per build:

- Add `VectorIndex::needs_training()` (default `false`). `FaissVectorIndex`
  overrides it to return `true` for `IVF` / `IVF_ON_DISK`, or for any quantizer
  other than `FLAT` (i.e. `SQ4`/`SQ8`/`PQ`). HNSW + FLAT returns `false`.
- Route both `train()` call sites in `AnnIndexColumnWriter` (the chunk-flush
  path and the `finish()` remainder path) through a single
  `_train_once_if_needed()` helper, guarded by a `_trained` flag. The first
  flush trains (when the index needs it) and latches the flag; every later flush
  only `add()`s.

### Behavioral impact

- **IVFFlat / HNSW-Flat**: byte-for-byte identical index. The coarse-quantizer
  centroids were already taken from the first chunk (the `train_q1` guard
  prevented later chunks from overwriting them), so the produced index is the
  same — we just stop calling a no-op `train()` repeatedly. **No recall or
  format change.**
- **IVF-SQ / IVF-PQ / HNSW-SQ / HNSW-PQ**: the codebook is now trained once (on
  the first chunk) and stays consistent with every code that gets written.
  **This fixes the recall corruption** for multi-chunk segments.
- **Build performance**: strictly faster or equal — we remove `N-1` redundant
  `train()` calls per segment (and their OMP-budget mutex acquisitions). No path
  is made slower.
- Applies uniformly to all build paths that go through `AnnIndexColumnWriter`:
  normal load/flush, compaction, schema change, and build-index-on-existing-data.

### Notes / scope

- This PR is a **pure correctness + redundancy fix**. It does **not** change
  default index parameters, the on-disk format, the search path, or memory
  admission. Reducing the training-set staging memory (sampling instead of
  buffering the whole chunk) is intentionally left to a follow-up.
- `FaissVectorIndex` is the only production `VectorIndex` subclass, and
  `AnnIndexColumnWriter` is the only code that drives `train()` during a build,
  so the new virtual method cannot affect any other type or path.

## Release note

Fixed a bug where building an ANN index on a segment larger than
`ann_index_build_chunk_size` (default 1,000,000 rows) with an `SQ`/`PQ`
quantizer could silently lose recall, because the quantizer codebook was
re-trained on every chunk. The index is now trained exactly once per build.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

