### PR TITLE
[feat](metric) Add JVM buffer pool metrics to FE metric endpoints

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/metric/JsonMetricVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/JsonMetricVisitor.java
@@ -18,7 +18,9 @@
 package org.apache.doris.metric;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.monitor.jvm.JvmInfo;
 import org.apache.doris.monitor.jvm.JvmStats;
+import org.apache.doris.monitor.jvm.JvmStats.BufferPool;
 import org.apache.doris.monitor.jvm.JvmStats.GarbageCollector;
 import org.apache.doris.monitor.jvm.JvmStats.MemoryPool;
 import org.apache.doris.monitor.jvm.JvmStats.Threads;
@@ -41,6 +43,11 @@ public class JsonMetricVisitor extends MetricVisitor {
     private static final String JVM_YOUNG_SIZE_BYTES = "jvm_young_size_bytes";
     private static final String JVM_OLD_SIZE_BYTES = "jvm_old_size_bytes";
     private static final String JVM_THREAD = "jvm_thread";
+
+    private static final String JVM_BUFFER_POOL_USED_BYTES = "jvm_buffer_pool_used_bytes";
+    private static final String JVM_BUFFER_POOL_CAPACITY_BYTES = "jvm_buffer_pool_capacity_bytes";
+    private static final String JVM_BUFFER_POOL_COUNT = "jvm_buffer_pool_count";
+    private static final String JVM_BUFFER_POOL_MAX_BYTES = "jvm_buffer_pool_max_bytes";
 
     private static final String JVM_GC = "jvm_gc";
 
@@ -96,6 +103,20 @@ public class JsonMetricVisitor extends MetricVisitor {
         setJvmJsonMetric(sb, JVM_THREAD, null,  "waiting_count", "nounit", threads.getThreadsWaitingCount());
         setJvmJsonMetric(sb, JVM_THREAD, null, "timed_waiting_count", "nounit", threads.getThreadsTimedWaitingCount());
         setJvmJsonMetric(sb, JVM_THREAD, null, "terminated_count", "nounit", threads.getThreadsTerminatedCount());
+
+        // buffer pools
+        for (BufferPool bufferPool : jvmStats.getBufferPools()) {
+            setJvmJsonMetric(sb, JVM_BUFFER_POOL_USED_BYTES, bufferPool.getName(), "used", "bytes",
+                    bufferPool.getUsed().getBytes());
+            setJvmJsonMetric(sb, JVM_BUFFER_POOL_CAPACITY_BYTES, bufferPool.getName(), "capacity", "bytes",
+                    bufferPool.getTotalCapacity().getBytes());
+            setJvmJsonMetric(sb, JVM_BUFFER_POOL_COUNT, bufferPool.getName(), "count", "nounit",
+                    bufferPool.getCount());
+        }
+
+        // buffer pool max bytes
+        setJvmJsonMetric(sb, JVM_BUFFER_POOL_MAX_BYTES, "direct", "max", "bytes",
+                JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes());
     }
 
     private void setJvmJsonMetric(StringBuilder sb, String metric, String name, String type, String unit, long value) {

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/PrometheusMetricVisitor.java
@@ -22,7 +22,9 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
+import org.apache.doris.monitor.jvm.JvmInfo;
 import org.apache.doris.monitor.jvm.JvmStats;
+import org.apache.doris.monitor.jvm.JvmStats.BufferPool;
 import org.apache.doris.monitor.jvm.JvmStats.GarbageCollector;
 import org.apache.doris.monitor.jvm.JvmStats.MemoryPool;
 import org.apache.doris.monitor.jvm.JvmStats.Threads;
@@ -57,6 +59,11 @@ public class PrometheusMetricVisitor extends MetricVisitor {
     private static final String JVM_YOUNG_SIZE_BYTES = "jvm_young_size_bytes";
     private static final String JVM_OLD_SIZE_BYTES = "jvm_old_size_bytes";
     private static final String JVM_THREAD = "jvm_thread";
+
+    private static final String JVM_BUFFER_POOL_USED_BYTES = "jvm_buffer_pool_used_bytes";
+    private static final String JVM_BUFFER_POOL_CAPACITY_BYTES = "jvm_buffer_pool_capacity_bytes";
+    private static final String JVM_BUFFER_POOL_COUNT = "jvm_buffer_pool_count";
+    private static final String JVM_BUFFER_POOL_MAX_BYTES = "jvm_buffer_pool_max_bytes";
 
     private static final String JVM_GC = "jvm_gc";
 
@@ -145,6 +152,36 @@ public class PrometheusMetricVisitor extends MetricVisitor {
                 .append(threads.getThreadsTimedWaitingCount()).append("\n");
         sb.append(JVM_THREAD).append("{type=\"terminated_count\"} ")
                 .append(threads.getThreadsTerminatedCount()).append("\n");
+
+        // buffer pools — emit each metric family in a separate loop so all lines per family are contiguous
+        Collection<BufferPool> bufferPools = jvmStats.getBufferPools();
+
+        sb.append(Joiner.on(" ").join(HELP, JVM_BUFFER_POOL_USED_BYTES, "jvm buffer pool memory used\n"));
+        sb.append(Joiner.on(" ").join(TYPE, JVM_BUFFER_POOL_USED_BYTES, "gauge\n"));
+        for (BufferPool bufferPool : bufferPools) {
+            sb.append(JVM_BUFFER_POOL_USED_BYTES).append("{name=\"").append(bufferPool.getName()).append("\"} ")
+                    .append(bufferPool.getUsed().getBytes()).append("\n");
+        }
+
+        sb.append(Joiner.on(" ").join(HELP, JVM_BUFFER_POOL_CAPACITY_BYTES, "jvm buffer pool total capacity\n"));
+        sb.append(Joiner.on(" ").join(TYPE, JVM_BUFFER_POOL_CAPACITY_BYTES, "gauge\n"));
+        for (BufferPool bufferPool : bufferPools) {
+            sb.append(JVM_BUFFER_POOL_CAPACITY_BYTES).append("{name=\"").append(bufferPool.getName()).append("\"} ")
+                    .append(bufferPool.getTotalCapacity().getBytes()).append("\n");
+        }
+
+        sb.append(Joiner.on(" ").join(HELP, JVM_BUFFER_POOL_COUNT, "jvm buffer pool count\n"));
+        sb.append(Joiner.on(" ").join(TYPE, JVM_BUFFER_POOL_COUNT, "gauge\n"));
+        for (BufferPool bufferPool : bufferPools) {
+            sb.append(JVM_BUFFER_POOL_COUNT).append("{name=\"").append(bufferPool.getName()).append("\"} ")
+                    .append(bufferPool.getCount()).append("\n");
+        }
+
+        // buffer pool max bytes
+        sb.append(Joiner.on(" ").join(HELP, JVM_BUFFER_POOL_MAX_BYTES, "jvm buffer pool max memory\n"));
+        sb.append(Joiner.on(" ").join(TYPE, JVM_BUFFER_POOL_MAX_BYTES, "gauge\n"));
+        sb.append(JVM_BUFFER_POOL_MAX_BYTES).append("{name=\"direct\", type=\"max\"} ")
+                .append(JvmInfo.jvmInfo().getMem().getDirectMemoryMax().getBytes()).append("\n");
         return;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmInfo.java
@@ -19,6 +19,8 @@ package org.apache.doris.monitor.jvm;
 
 import org.apache.doris.monitor.unit.ByteSizeValue;
 
+import org.apache.logging.log4j.LogManager;
+
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ManagementPermission;
@@ -80,6 +82,24 @@ public class JvmInfo {
         }
         String[] inputArguments = runtimeMXBean.getInputArguments()
                 .toArray(new String[runtimeMXBean.getInputArguments().size()]);
+
+        if (directMemoryMax == 0) {
+            for (String arg : inputArguments) {
+                if (arg.startsWith("-XX:MaxDirectMemorySize=")) {
+                    try {
+                        directMemoryMax = ByteSizeValue.simpleParseBytesSizeValue(
+                                arg.substring("-XX:MaxDirectMemorySize=".length()),
+                                "MaxDirectMemorySize");
+                    } catch (Exception e) {
+                        // ignore unparseable value
+                    }
+                    break;
+                }
+            }
+        }
+        if (directMemoryMax == 0) {
+            LogManager.getLogger(JvmInfo.class).warn("Failed to determine max direct memory size");
+        }
         Mem mem = new Mem(heapInit, heapMax, nonHeapInit, nonHeapMax, directMemoryMax);
 
         String bootClassPath;


### PR DESCRIPTION
## Summary

Expose JVM buffer pool statistics in FE metric endpoints to improve observability of off-heap memory usage.

**Changes:**
- Add buffer pool metrics (`jvm_buffer_pool_used_bytes`, `jvm_buffer_pool_capacity_bytes`, `jvm_buffer_pool_count`) to both Prometheus and JSON metric visitors, broken down by pool name (direct, mapped)
- Add `jvm_buffer_pool_max_bytes` metric exposing the configured `MaxDirectMemorySize`
- Improve `JvmInfo` to parse `-XX:MaxDirectMemorySize=` from JVM input arguments as a fallback when the standard API returns 0

## Motivation

Buffer pool metrics are critical for diagnosing off-heap memory issues (e.g., direct buffer OOM). Currently, FE exposes heap and GC metrics but not buffer pool stats, making it difficult to monitor direct memory pressure via Prometheus/Grafana.