### PR TITLE
[opt](cloud) Support multiple config files in start.sh

### DIFF
--- a/cloud/script/start.sh
+++ b/cloud/script/start.sh
@@ -58,22 +58,37 @@ custom_start="${DORIS_HOME}/bin/custom_start.sh"
 if [[ -f "${custom_start}" ]]; then
   source "${custom_start}" 
 fi
-enable_hdfs=${enable_hdfs:-1}
 process_name="${process_name:-doris_cloud}"
 
-# export env variables from ${process_name}.conf
-# read from ${process_name}.conf
-while read -r line; do
-    envline="$(echo "${line}" |
-        sed 's/[[:blank:]]*=[[:blank:]]*/=/g' |
-        sed 's/^[[:blank:]]*//g' |
-        grep -E "^[[:upper:]]([[:upper:]]|_|[[:digit:]])*=" ||
-        true)"
-    envline="$(eval "echo ${envline}")"
-    if [[ "${envline}" == *"="* ]]; then
-        eval 'export "${envline}"'
+CONF_FILES="${CONF_FILES:-${process_name}.conf}"
+loaded_conf_env_keys=" "
+for conf_pattern in ${CONF_FILES//,/ }; do
+    if [[ "${conf_pattern}" != /* ]]; then
+        conf_pattern="${DORIS_HOME}/conf/${conf_pattern}"
     fi
-done <"${DORIS_HOME}/conf/${process_name}.conf"
+    for conf_file in ${conf_pattern}; do
+        if [[ ! -f "${conf_file}" ]]; then
+            continue
+        fi
+        while read -r line; do
+            envline="$(echo "${line}" |
+                sed 's/[[:blank:]]*=[[:blank:]]*/=/g' |
+                sed 's/^[[:blank:]]*//g' |
+                grep -E "^[[:upper:]]([[:upper:]]|_|[[:digit:]])*=" ||
+                true)"
+            envline="$(eval "echo ${envline}")"
+            if [[ "${envline}" == *"="* ]]; then
+                key="${envline%%=*}"
+                if [[ "${loaded_conf_env_keys}" != *" ${key} "* ]] && [[ -v ${key} ]]; then
+                    continue
+                fi
+                eval 'export "${envline}"'
+                loaded_conf_env_keys="${loaded_conf_env_keys}${key} "
+            fi
+        done <"${conf_file}"
+    done
+done
+enable_hdfs=${enable_hdfs:-1}
 
 role=''
 if [[ ${RUN_METASERVICE} -eq 0 ]] && [[ ${RUN_RECYCLYER} -eq 0 ]]; then


### PR DESCRIPTION
### What problem does this PR solve?

Support loading cloud start environment variables from multiple config files without forcing deployments to rely on `process_name` as the only config file name.

This keeps the default behavior of loading `${process_name}.conf`, and adds support for `CONF_FILES` with comma-separated or whitespace-separated entries, glob patterns, and absolute paths. Config files are loaded in order, later files can override earlier files, while variables already set before config loading keep priority.

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: `cloud/script/start.sh` previously loaded only `${process_name}.conf`, which made multi-instance or layered config deployments harder to express.

### Release note

Support specifying multiple cloud config files through `CONF_FILES` in `cloud/script/start.sh`.

### Check List (For Author)

- Test: Manual test
    - Verified default `${process_name}.conf` loading.
    - Verified comma-separated and whitespace-separated `CONF_FILES` lists.
    - Verified glob pattern loading.
    - Verified missing config files are skipped.
    - Verified absolute config file paths.
    - Verified pre-existing environment variables are not overridden by config files.
    - Ran `bash -n cloud/script/start.sh`.
- Behavior changed: Yes. `cloud/script/start.sh` can now load multiple config files through `CONF_FILES`.
- Does this need documentation: No
