### PR TITLE
[refine](sort) Remove heap sorter runtime predicate guard

### DIFF
--- a/be/src/exec/operator/sort_sink_operator.cpp
+++ b/be/src/exec/operator/sort_sink_operator.cpp
@@ -51,10 +51,9 @@ Status SortSinkLocalState::open(RuntimeState* state) {
     }
     switch (p._algorithm) {
     case TSortAlgorithm::HEAP_SORT: {
-        _shared_state->sorter = HeapSorter::create_shared(
-                _ordering_expr_ctxs, state, p._limit, p._offset, p._pool, p._is_asc_order,
-                p._nulls_first, p._child->row_desc(),
-                state->get_query_ctx()->has_runtime_predicate(p._node_id));
+        _shared_state->sorter =
+                HeapSorter::create_shared(_ordering_expr_ctxs, state, p._limit, p._offset, p._pool,
+                                          p._is_asc_order, p._nulls_first, p._child->row_desc());
         break;
     }
     case TSortAlgorithm::TOPN_SORT: {

--- a/be/src/exec/sort/heap_sorter.cpp
+++ b/be/src/exec/sort/heap_sorter.cpp
@@ -28,15 +28,14 @@ namespace doris {
 HeapSorter::HeapSorter(const VExprContextSPtrs& ordering_expr_ctxs, RuntimeState* state,
                        int64_t limit, int64_t offset, ObjectPool* pool,
                        std::vector<bool>& is_asc_order, std::vector<bool>& nulls_first,
-                       const RowDescriptor& row_desc, bool have_runtime_predicate)
+                       const RowDescriptor& row_desc)
         : Sorter(ordering_expr_ctxs, state, limit, offset, pool, is_asc_order, nulls_first),
           _heap_size(limit + offset),
-          _state(MergeSorterState::create_unique(row_desc, offset)),
-          _have_runtime_predicate(have_runtime_predicate) {}
+          _state(MergeSorterState::create_unique(row_desc, offset)) {}
 
 Status HeapSorter::append_block(Block* block) {
     auto tmp_block = std::make_shared<Block>(block->clone_empty());
-    if (!_have_runtime_predicate && _queue.is_valid() && _queue_row_num >= _heap_size) {
+    if (_queue.is_valid() && _queue_row_num >= _heap_size) {
         RETURN_IF_ERROR(_prepare_sort_columns(*block, *tmp_block, false));
         tmp_block->swap(*block);
         auto tmp_cursor_impl = MergeSortCursorImpl::create_shared(tmp_block, _sort_description);

--- a/be/src/exec/sort/heap_sorter.h
+++ b/be/src/exec/sort/heap_sorter.h
@@ -27,8 +27,7 @@ class HeapSorter final : public Sorter {
 public:
     HeapSorter(const VExprContextSPtrs& ordering_expr_ctxs, RuntimeState* state, int64_t limit,
                int64_t offset, ObjectPool* pool, std::vector<bool>& is_asc_order,
-               std::vector<bool>& nulls_first, const RowDescriptor& row_desc,
-               bool have_runtime_predicate = true);
+               std::vector<bool>& nulls_first, const RowDescriptor& row_desc);
 
     ~HeapSorter() override = default;
 
@@ -56,7 +55,6 @@ private:
     MergeSorterQueue _queue;
     std::unique_ptr<MergeSorterState> _state;
     IColumn::Permutation _reverse_buffer;
-    bool _have_runtime_predicate = true;
     RuntimeProfile::Counter* _topn_filter_timer = nullptr;
     RuntimeProfile::Counter* _topn_filter_rows_counter = nullptr;
 };

--- a/be/test/exec/sort/heap_sorter_test.cpp
+++ b/be/test/exec/sort/heap_sorter_test.cpp
@@ -92,9 +92,7 @@ TEST_F(HeapSorterTest, test_topn_sorter1) {
         EXPECT_EQ(sorter->_queue_row_num, 6);
 
         auto value = sorter->get_top_value();
-        Field real;
-        block.get_by_position(0).column->get(0, real);
-        EXPECT_EQ(value, real);
+        EXPECT_EQ(value, Field::create_field<TYPE_BIGINT>(Int64(6)));
     }
 
     EXPECT_TRUE(sorter->prepare_for_read(false));


### PR DESCRIPTION
### What problem does this PR solve?


Problem Summary:

HeapSorter kept a `have_runtime_predicate` flag and skipped its local TopN filtering path whenever the sort node had a runtime predicate. The heap sorter should no longer branch on whether a runtime predicate exists. This PR removes that constructor argument and member state, and always uses the existing heap filter path once the heap queue is valid and has reached the heap size.

The sort sink no longer queries `QueryContext::has_runtime_predicate()` when constructing `HeapSorter`. The heap sorter unit test is also updated so it checks the expected top value directly instead of reading it from an input block that may be modified by the filtering path.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

