### PR TITLE
[Fix](nereids) Preserve negative zero sign in SIGNBIT constant folding

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmetic.java
@@ -727,11 +727,7 @@ public class NumericArithmetic {
      */
     @ExecFunction(name = "signbit")
     public static Expression signbit(DoubleLiteral first) {
-        if (first.getValue() < 0) {
-            return BooleanLiteral.of(true);
-        } else {
-            return BooleanLiteral.of(false);
-        }
+        return BooleanLiteral.of(Double.doubleToRawLongBits(first.getValue()) < 0);
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmeticTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/NumericArithmeticTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.nereids.trees.expressions.functions.executable;
 
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
+import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
 import org.apache.doris.nereids.types.DecimalV2Type;
 import org.apache.doris.nereids.types.DecimalV3Type;
 
@@ -43,5 +45,13 @@ public class NumericArithmeticTest {
                 DecimalV2Type.createDecimalV2Type(10, 0), new BigDecimal(1));
         DecimalLiteral result = (DecimalLiteral) NumericArithmetic.abs(decimalV3Literal);
         Assertions.assertEquals(DecimalV2Type.createDecimalV2Type(10, 0), result.getDataType());
+    }
+
+    @Test
+    public void testSignBit() {
+        Assertions.assertEquals(BooleanLiteral.FALSE, NumericArithmetic.signbit(new DoubleLiteral(0.0)));
+        Assertions.assertEquals(BooleanLiteral.TRUE, NumericArithmetic.signbit(new DoubleLiteral(-0.0)));
+        Assertions.assertEquals(BooleanLiteral.FALSE, NumericArithmetic.signbit(new DoubleLiteral(1.0)));
+        Assertions.assertEquals(BooleanLiteral.TRUE, NumericArithmetic.signbit(new DoubleLiteral(-1.0)));
     }
 }

--- a/regression-test/data/nereids_function_p0/scalar_function/S.out
+++ b/regression-test/data/nereids_function_p0/scalar_function/S.out
@@ -994,6 +994,9 @@ false
 false
 false
 
+-- !sql_signbit_negative_zero --
+false	true
+
 -- !sql_sin_Double --
 \N
 0.09983341664682815

--- a/regression-test/suites/nereids_function_p0/scalar_function/S.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/S.groovy
@@ -90,6 +90,8 @@ suite("nereids_scalar_fn_S") {
 	qt_sql_sign_Double_notnull "select sign(kdbl) from fn_test_not_nullable order by kdbl"
 	qt_sql_signbit_Double "select signbit(kdbl) from fn_test order by kdbl"
 	qt_sql_signbit_Double_notnull "select signbit(kdbl) from fn_test_not_nullable order by kdbl"
+	qt_sql_signbit_negative_zero "select signbit(cast('+0.0' as double)), signbit(cast('-0.0' as double))"
+	testFoldConst("select signbit(cast('+0.0' as double)), signbit(cast('-0.0' as double))")
 	qt_sql_sin_Double "select sin(kdbl) from fn_test order by kdbl"
 	qt_sql_sin_Double_notnull "select sin(kdbl) from fn_test_not_nullable order by kdbl"
 	qt_sql_sleep_Integer "select sleep(0.1) from fn_test order by kint"


### PR DESCRIPTION
Problem Summary:

`signbit` in Nereids FE constant folding used `value < 0` to determine the sign, which treats `-0.0` as non-negative and folds it to `false`. This is inconsistent with:
- the runtime BE implementation, which uses `std::signbit`
- the documented `signbit` behavior, which distinguishes `+0.0` and `-0.0`

`+0.0` and `-0.0` compare equal numerically, so `value < 0` cannot distinguish them. Their difference is only recorded in the floating-point sign bit. Using raw bits makes FE constant folding consistent with BE runtime semantics.

before:
```text
Doris> set debug_skip_fold_constant=true;
Query OK, 0 rows affected (0.024 sec)

Doris> select signbit(cast('+0.0' as double)) , signbit(cast('-0.0' as double));
+---------------------------------+---------------------------------+
| signbit(cast('+0.0' as double)) | signbit(cast('-0.0' as double)) |
+---------------------------------+---------------------------------+
|                               0 |                               1 |
+---------------------------------+---------------------------------+
1 row in set (0.108 sec)

Doris> set debug_skip_fold_constant=false;
Query OK, 0 rows affected (0.002 sec)

Doris> select signbit(cast('+0.0' as double)) , signbit(cast('-0.0' as double));
+---------------------------------+---------------------------------+
| signbit(cast('+0.0' as double)) | signbit(cast('-0.0' as double)) |
+---------------------------------+---------------------------------+
|                               0 |                               0 |
+---------------------------------+---------------------------------+
```

now:
```text
Doris> set debug_skip_fold_constant=true;
Query OK, 0 rows affected (0.012 sec)

Doris> select signbit(cast('+0.0' as double)) , signbit(cast('-0.0' as double));
+---------------------------------+---------------------------------+
| signbit(cast('+0.0' as double)) | signbit(cast('-0.0' as double)) |
+---------------------------------+---------------------------------+
|                               0 |                               1 |
+---------------------------------+---------------------------------+
1 row in set (0.070 sec)

Doris> set debug_skip_fold_constant=false;
Query OK, 0 rows affected (0.002 sec)

Doris> select signbit(cast('+0.0' as double)) , signbit(cast('-0.0' as double));
+---------------------------------+---------------------------------+
| signbit(cast('+0.0' as double)) | signbit(cast('-0.0' as double)) |
+---------------------------------+---------------------------------+
|                               0 |                               1 |
+---------------------------------+---------------------------------+
1 row in set (0.010 sec)
```