### PR TITLE
[chore](build) Add doris-skills submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,7 @@
 [submodule "contrib/datasketches-cpp"]
 	path = contrib/datasketches-cpp
 	url = https://github.com/apache/datasketches-cpp.git
+[submodule "doris-skills"]
+	path = doris-skills
+	url = https://github.com/apache/doris-skills
+	branch = main


### PR DESCRIPTION
Problem Summary: Add the [apache/doris-skills](https://github.com/apache/doris-skills) repository as a root-level submodule and configure it to track the main branch so maintainers can refresh it with git submodule update --remote doris-skills.
