### PR TITLE
[fix](fe) Fix SHOW BACKENDS field order mismatch

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -50,8 +50,8 @@ public class BackendsProcDir implements ProcDirInterface {
             .add("LastStartTime").add("LastHeartbeat").add("Alive").add("SystemDecommissioned").add("TabletNum")
             .add("DataUsedCapacity").add("TrashUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
             .add("MaxDiskUsedPct").add("RemoteUsedCapacity").add("Tag").add("ErrMsg").add("Version").add("Status")
-            .add("HeartbeatFailureCounter").add("NodeRole").add("CpuCores").add("Memory")
-            .add("RunningTasks").build();
+            .add("HeartbeatFailureCounter").add("CpuCores").add("Memory")
+            .add("RunningTasks").add("NodeRole").build();
 
     public static final ImmutableList<String> DISK_TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("BackendId").add("Host").add("RootPath").add("DirType").add("DiskState")

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -165,9 +165,6 @@ public class BackendsProcDir implements ProcDirInterface {
             // heartbeat failure counter
             backendInfo.add(backend.getHeartbeatFailureCounter());
 
-            // node role, show the value only when backend is alive.
-            backendInfo.add(backend.isAlive() ? backend.getNodeRoleTag().value : "");
-
             // cpu cores
             backendInfo.add(String.valueOf(backend.getCputCores()));
 
@@ -176,6 +173,9 @@ public class BackendsProcDir implements ProcDirInterface {
 
             // runningFragments
             backendInfo.add(String.valueOf(backend.getRunningTasks()));
+
+            // node role, show the value only when backend is alive.
+            backendInfo.add(backend.isAlive() ? backend.getNodeRoleTag().value : "");
             comparableBackendInfos.add(backendInfo);
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
@@ -209,7 +209,6 @@ public class BackendsProcDirTest {
         ProcResult result = dir.fetchResult();
 
         List<String> columnNames = result.getColumnNames();
-        List<List<String>> rows = result.getRows();
 
         int cpuCoresIdx = columnNames.indexOf("CpuCores");
         int memoryIdx = columnNames.indexOf("Memory");

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
@@ -24,12 +24,15 @@ import org.apache.doris.persist.EditLog;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
+import com.google.common.collect.Lists;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 public class BackendsProcDirTest {
     private Backend b1;
@@ -182,5 +185,41 @@ public class BackendsProcDirTest {
         result = dir.fetchResult();
         Assert.assertNotNull(result);
         Assert.assertTrue(result instanceof BaseProcResult);
+    }
+
+    @Test
+    public void testBackendInfoFieldOrder() throws AnalysisException {
+        b1.setCpuCores(192);
+        b1.setLastUpdateMs(System.currentTimeMillis());
+        b1.setRunningTasks(10L);
+
+        new Expectations() {
+            {
+                systemInfoService.getAllBackendIds(false);
+                minTimes = 0;
+                result = Lists.newArrayList(1000L);
+
+                systemInfoService.getTabletNumByBackendId(1000L);
+                minTimes = 0;
+                result = 10;
+            }
+        };
+
+        BackendsProcDir dir = new BackendsProcDir(systemInfoService);
+        ProcResult result = dir.fetchResult();
+
+        List<String> columnNames = result.getColumnNames();
+        List<List<String>> rows = result.getRows();
+
+        int cpuCoresIdx = columnNames.indexOf("CpuCores");
+        int memoryIdx = columnNames.indexOf("Memory");
+        int liveSinceIdx = columnNames.indexOf("LiveSince");
+        int runningTasksIdx = columnNames.indexOf("RunningTasks");
+        int nodeRoleIdx = columnNames.indexOf("NodeRole");
+
+        Assert.assertTrue("CpuCores should be before Memory", cpuCoresIdx < memoryIdx);
+        Assert.assertTrue("Memory should be before LiveSince", memoryIdx < liveSinceIdx);
+        Assert.assertTrue("LiveSince should be before RunningTasks", liveSinceIdx < runningTasksIdx);
+        Assert.assertTrue("RunningTasks should be before NodeRole", runningTasksIdx < nodeRoleIdx);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/proc/BackendsProcDirTest.java
@@ -212,13 +212,11 @@ public class BackendsProcDirTest {
 
         int cpuCoresIdx = columnNames.indexOf("CpuCores");
         int memoryIdx = columnNames.indexOf("Memory");
-        int liveSinceIdx = columnNames.indexOf("LiveSince");
         int runningTasksIdx = columnNames.indexOf("RunningTasks");
         int nodeRoleIdx = columnNames.indexOf("NodeRole");
 
         Assert.assertTrue("CpuCores should be before Memory", cpuCoresIdx < memoryIdx);
-        Assert.assertTrue("Memory should be before LiveSince", memoryIdx < liveSinceIdx);
-        Assert.assertTrue("LiveSince should be before RunningTasks", liveSinceIdx < runningTasksIdx);
+        Assert.assertTrue("Memory should be before RunningTasks", memoryIdx < runningTasksIdx);
         Assert.assertTrue("RunningTasks should be before NodeRole", runningTasksIdx < nodeRoleIdx);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
@@ -205,11 +205,9 @@ public class DemoMultiBackendsTest {
                 "{\"lastSuccessReportTabletsTime\":\"N/A\",\"lastStreamLoadTime\":-1,\"isQueryDisabled\":false,"
                         + "\"isLoadDisabled\":false,\"isActive\":true,\"isShutdown\":false,\"currentFragmentNum\":0,"
                         + "\"lastFragmentUpdateTime\":0}",
-<<<<<<< HEAD
                 result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 6));
         Assert.assertEquals("0", result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 5));
         Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 1));
-    }
     }
 
     private static void updateReplicaPathHash() {

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
@@ -205,9 +205,11 @@ public class DemoMultiBackendsTest {
                 "{\"lastSuccessReportTabletsTime\":\"N/A\",\"lastStreamLoadTime\":-1,\"isQueryDisabled\":false,"
                         + "\"isLoadDisabled\":false,\"isActive\":true,\"isShutdown\":false,\"currentFragmentNum\":0,"
                         + "\"lastFragmentUpdateTime\":0}",
+<<<<<<< HEAD
                 result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 6));
         Assert.assertEquals("0", result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 5));
-        Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 4));
+        Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 1));
+    }
     }
 
     private static void updateReplicaPathHash() {


### PR DESCRIPTION
## Summary

Fix the output field order of `SHOW BACKENDS` command. The fields in `BackendsProcDir.getBackendInfos()` were out of sync with the `BackendsTableValuedFunction.SCHEMA` definition, causing incorrect column values to be displayed:

- **CpuCores** column showed NodeRole value (`mix`)
- **Memory** column showed CpuCores value
- **NodeRole** column showed Memory value

## Changes

1. **BackendsProcDir.java**: Reorder `TITLE_NAMES` and `getBackendInfos()` output to match SCHEMA: `CpuCores -> Memory -> RunningTasks -> NodeRole`
2. **BackendsProcDirTest.java**: Add unit test `testBackendInfoFieldOrder` to verify the correct field order
3. **DemoMultiBackendsTest.java**: Fix NodeRole assertion column index after the field reorder (from `size-4` to `size-1`)

## Test plan

- [x] Unit test `testBackendInfoFieldOrder` verifies CpuCores < Memory < RunningTasks < NodeRole order
- [x] `DemoMultiBackendsTest` assertion index updated to match new field order