### PR TITLE
[fix](nereids) Guard LogicalView.computeOutput() against schema drift (IndexOutOfBoundsException)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
@@ -123,16 +123,19 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
         ImmutableList.Builder<Slot> currentOutput = ImmutableList.builder();
         List<String> fullQualifiers = this.view.getFullQualifiers();
         List<Column> fullSchema = view.getFullSchema();
-        for (int i = 0; i < childOutput.size(); i++) {
+        // ATTN: because bug intro by #40715, after replace view, full schema will be empty or null.
+        //   So, we must guard here to avoid NPE or out of bound exception.
+        // When fullSchema is present it defines the view's output contract (built from
+        //   CreateViewInfo.finalCols). Use Math.min() as the loop bound to handle both
+        //   directions of schema drift without leaking undeclared columns:
+        //   - child has MORE slots (base table gained columns after view creation): truncate
+        //   - child has FEWER slots (base table lost columns): stop at child size
+        boolean hasSchema = !CollectionUtils.isEmpty(fullSchema);
+        int limit = hasSchema ? Math.min(childOutput.size(), fullSchema.size()) : childOutput.size();
+        for (int i = 0; i < limit; i++) {
             Slot originSlot = childOutput.get(i);
             Slot qualified;
-            // ATTN: because bug intro by #40715, after replace view, full schema will be empty or null.
-            //   So, we must just here to avoid NPE or out of bound exception.
-            // Also guard against schema drift: when the underlying external table (e.g. Hive) gains
-            //   new columns after the view was created and REFRESH TABLE is called, childOutput may
-            //   have more slots than fullSchema (which still reflects the schema at view-creation
-            //   time). Fall back to qualifier-only for the extra columns to avoid IndexOutOfBoundsException.
-            if (CollectionUtils.isEmpty(fullSchema) || i >= fullSchema.size()) {
+            if (!hasSchema) {
                 qualified = originSlot.withQualifier(fullQualifiers);
             } else {
                 qualified = originSlot

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.logical;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.ViewIf;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.memo.GroupExpression;
@@ -121,16 +122,21 @@ public class LogicalView<BODY extends Plan> extends LogicalUnary<BODY> {
         List<Slot> childOutput = child().getOutput();
         ImmutableList.Builder<Slot> currentOutput = ImmutableList.builder();
         List<String> fullQualifiers = this.view.getFullQualifiers();
+        List<Column> fullSchema = view.getFullSchema();
         for (int i = 0; i < childOutput.size(); i++) {
             Slot originSlot = childOutput.get(i);
             Slot qualified;
             // ATTN: because bug intro by #40715, after replace view, full schema will be empty or null.
             //   So, we must just here to avoid NPE or out of bound exception.
-            if (CollectionUtils.isEmpty(view.getFullSchema())) {
+            // Also guard against schema drift: when the underlying external table (e.g. Hive) gains
+            //   new columns after the view was created and REFRESH TABLE is called, childOutput may
+            //   have more slots than fullSchema (which still reflects the schema at view-creation
+            //   time). Fall back to qualifier-only for the extra columns to avoid IndexOutOfBoundsException.
+            if (CollectionUtils.isEmpty(fullSchema) || i >= fullSchema.size()) {
                 qualified = originSlot.withQualifier(fullQualifiers);
             } else {
                 qualified = originSlot
-                        .withOneLevelTableAndColumnAndQualifier(view, view.getFullSchema().get(i), fullQualifiers);
+                        .withOneLevelTableAndColumnAndQualifier(view, fullSchema.get(i), fullQualifiers);
             }
             currentOutput.add(qualified);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
@@ -21,13 +21,9 @@ import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.ViewIf;
-import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Slot;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.types.StringType;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -49,9 +45,13 @@ public class LogicalViewTest {
     // Helpers
     // -----------------------------------------------------------------------
 
-    private static Slot slot(int exprId, String name) {
-        return new SlotReference(new ExprId(exprId), name, StringType.INSTANCE,
-                true, Lists.newArrayList());
+    private static Slot slot(String name) {
+        Slot slot = Mockito.mock(Slot.class);
+        Mockito.when(slot.getName()).thenReturn(name);
+        Mockito.when(slot.withQualifier(Mockito.anyList())).thenReturn(slot);
+        Mockito.when(slot.withOneLevelTableAndColumnAndQualifier(
+                Mockito.any(), Mockito.any(), Mockito.anyList())).thenReturn(slot);
+        return slot;
     }
 
     private static Column col(String name) {
@@ -88,7 +88,7 @@ public class LogicalViewTest {
     @Test
     public void testComputeOutputNormalCase() {
         List<Column> schema = ImmutableList.of(col("id"), col("name"), col("age"));
-        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"), slot(2, "age"));
+        List<Slot> childSlots = ImmutableList.of(slot("id"), slot("name"), slot("age"));
 
         ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
         LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
@@ -117,8 +117,7 @@ public class LogicalViewTest {
         // View was created with 3-column base table → fullSchema has 3 entries
         List<Column> schema = ImmutableList.of(col("id"), col("name"), col("age"));
         // After ADD COLUMN + REFRESH TABLE, the child produces 4 slots
-        List<Slot> childSlots = ImmutableList.of(
-                slot(0, "id"), slot(1, "name"), slot(2, "age"), slot(3, "score"));
+        List<Slot> childSlots = ImmutableList.of(slot("id"), slot("name"), slot("age"), slot("score"));
 
         ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
         LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
@@ -147,7 +146,7 @@ public class LogicalViewTest {
     public void testComputeOutputSchemaDrift_fewerColumnsThanSchema() {
         // fullSchema wider than actual child (defensive scenario)
         List<Column> schema = ImmutableList.of(col("id"), col("name"), col("age"), col("score"));
-        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"));
+        List<Slot> childSlots = ImmutableList.of(slot("id"), slot("name"));
 
         ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
         LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
@@ -166,7 +165,7 @@ public class LogicalViewTest {
      */
     @Test
     public void testComputeOutputEmptySchema() {
-        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"));
+        List<Slot> childSlots = ImmutableList.of(slot("id"), slot("name"));
 
         ViewIf view = mockView(Collections.emptyList(), ImmutableList.of("hive", "test", "v"));
         LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
@@ -185,7 +184,7 @@ public class LogicalViewTest {
      */
     @Test
     public void testComputeOutputNullSchema() {
-        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"));
+        List<Slot> childSlots = ImmutableList.of(slot("id"), slot("name"));
 
         ViewIf view = mockView(null, ImmutableList.of("hive", "test", "v"));
         LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
@@ -204,7 +203,7 @@ public class LogicalViewTest {
     public void testComputeOutputSchemaDrift_singleColumnAdded() {
         // 1-column schema, child returns 2 slots after schema drift
         List<Column> schema = ImmutableList.of(col("id"));
-        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "extra"));
+        List<Slot> childSlots = ImmutableList.of(slot("id"), slot("extra"));
 
         ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
         LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
@@ -96,9 +96,9 @@ public class LogicalViewTest {
         List<Slot> output = logicalView.computeOutput();
 
         Assertions.assertEquals(3, output.size(), "Output size should match schema size");
-        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("id", output.get(0).getName());
         Assertions.assertEquals("name", output.get(1).getName());
-        Assertions.assertEquals("age",  output.get(2).getName());
+        Assertions.assertEquals("age", output.get(2).getName());
     }
 
     /**
@@ -131,9 +131,9 @@ public class LogicalViewTest {
         // The new 'score' column is not visible until the view itself is refreshed.
         Assertions.assertEquals(3, output.size(),
                 "Output size should be truncated to fullSchema size to preserve view contract");
-        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("id", output.get(0).getName());
         Assertions.assertEquals("name", output.get(1).getName());
-        Assertions.assertEquals("age",  output.get(2).getName());
+        Assertions.assertEquals("age", output.get(2).getName());
     }
 
     /**
@@ -156,7 +156,7 @@ public class LogicalViewTest {
 
         Assertions.assertEquals(2, output.size(),
                 "Output size should equal child output size (loop bound)");
-        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("id", output.get(0).getName());
         Assertions.assertEquals("name", output.get(1).getName());
     }
 
@@ -175,7 +175,7 @@ public class LogicalViewTest {
                 "computeOutput() must not throw for empty fullSchema");
 
         Assertions.assertEquals(2, output.size());
-        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("id", output.get(0).getName());
         Assertions.assertEquals("name", output.get(1).getName());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
@@ -1,0 +1,230 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.logical;
+
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.catalog.ViewIf;
+import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.types.StringType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Unit tests for {@link LogicalView#computeOutput()}.
+ *
+ * <p>Focuses on the schema-drift scenario: when the underlying external table (e.g. Hive)
+ * gains new columns after the view was created, {@code view.getFullSchema()} is smaller
+ * than {@code child().getOutput()} and the loop used to crash with
+ * {@code IndexOutOfBoundsException}.
+ */
+public class LogicalViewTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static Slot slot(int exprId, String name) {
+        return new SlotReference(new ExprId(exprId), name, StringType.INSTANCE,
+                true, Lists.newArrayList());
+    }
+
+    private static Column col(String name) {
+        return new Column(name, Type.STRING, false, AggregateType.NONE, "", "");
+    }
+
+    /**
+     * Build a mock ViewIf that reports the given schema and qualifiers.
+     */
+    private static ViewIf mockView(List<Column> schema, List<String> qualifiers) {
+        ViewIf view = Mockito.mock(ViewIf.class);
+        Mockito.when(view.getFullSchema()).thenReturn(schema);
+        Mockito.when(view.getFullQualifiers()).thenReturn(qualifiers);
+        return view;
+    }
+
+    /**
+     * Build a mock LogicalPlan child whose {@code getOutput()} returns the given slots.
+     */
+    private static LogicalPlan mockChild(List<Slot> slots) {
+        LogicalPlan child = Mockito.mock(LogicalPlan.class);
+        Mockito.when(child.getOutput()).thenReturn(slots);
+        return child;
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Normal case: child output size == fullSchema size.
+     * All slots should be decorated with their corresponding stored column.
+     */
+    @Test
+    public void testComputeOutputNormalCase() {
+        List<Column> schema = ImmutableList.of(col("id"), col("name"), col("age"));
+        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"), slot(2, "age"));
+
+        ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
+        LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
+
+        List<Slot> output = logicalView.computeOutput();
+
+        Assertions.assertEquals(3, output.size(), "Output size should match schema size");
+        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("name", output.get(1).getName());
+        Assertions.assertEquals("age",  output.get(2).getName());
+    }
+
+    /**
+     * Schema-drift case: child output has MORE slots than fullSchema.
+     *
+     * <p>This is the regression test for the IndexOutOfBoundsException bug:
+     * after {@code ALTER TABLE ADD COLUMNS} + {@code REFRESH TABLE} on the base table,
+     * {@code childOutput.size()} grows beyond {@code view.getFullSchema().size()}.
+     * The extra slot(s) must NOT crash and must be returned with the qualifier applied.
+     */
+    @Test
+    public void testComputeOutputSchemaDrift_moreColumnsThanSchema() {
+        // View was created with 3-column base table → fullSchema has 3 entries
+        List<Column> schema = ImmutableList.of(col("id"), col("name"), col("age"));
+        // After ADD COLUMN + REFRESH TABLE, the child produces 4 slots
+        List<Slot> childSlots = ImmutableList.of(
+                slot(0, "id"), slot(1, "name"), slot(2, "age"), slot(3, "score"));
+
+        ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
+        LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
+
+        // Must NOT throw IndexOutOfBoundsException
+        List<Slot> output = Assertions.assertDoesNotThrow(logicalView::computeOutput,
+                "computeOutput() must not throw when fullSchema is shorter than childOutput");
+
+        Assertions.assertEquals(4, output.size(),
+                "Output size should equal child output size (all columns exposed)");
+        // First 3 slots: resolved via stored schema
+        Assertions.assertEquals("id",    output.get(0).getName());
+        Assertions.assertEquals("name",  output.get(1).getName());
+        Assertions.assertEquals("age",   output.get(2).getName());
+        // 4th slot: added after view creation – falls back to withQualifier() path
+        Assertions.assertEquals("score", output.get(3).getName());
+    }
+
+    /**
+     * Schema-drift case: child output has FEWER slots than fullSchema.
+     *
+     * <p>Defensive check: if a column was somehow removed from the base table
+     * while the view schema is wider, we must not access a nonexistent child slot.
+     * The output should simply reflect however many columns the child returns.
+     */
+    @Test
+    public void testComputeOutputSchemaDrift_fewerColumnsThanSchema() {
+        // fullSchema wider than actual child (defensive scenario)
+        List<Column> schema = ImmutableList.of(col("id"), col("name"), col("age"), col("score"));
+        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"));
+
+        ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
+        LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
+
+        List<Slot> output = logicalView.computeOutput();
+
+        Assertions.assertEquals(2, output.size(),
+                "Output size should equal child output size (loop bound)");
+        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("name", output.get(1).getName());
+    }
+
+    /**
+     * Empty schema case (guard introduced by #40715): fullSchema is empty.
+     * All slots must fall back to withQualifier().
+     */
+    @Test
+    public void testComputeOutputEmptySchema() {
+        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"));
+
+        ViewIf view = mockView(Collections.emptyList(), ImmutableList.of("hive", "test", "v"));
+        LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
+
+        List<Slot> output = Assertions.assertDoesNotThrow(logicalView::computeOutput,
+                "computeOutput() must not throw for empty fullSchema");
+
+        Assertions.assertEquals(2, output.size());
+        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("name", output.get(1).getName());
+    }
+
+    /**
+     * Null schema case (guard introduced by #40715): getFullSchema() returns null.
+     * All slots must fall back to withQualifier().
+     */
+    @Test
+    public void testComputeOutputNullSchema() {
+        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "name"));
+
+        ViewIf view = mockView(null, ImmutableList.of("hive", "test", "v"));
+        LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
+
+        List<Slot> output = Assertions.assertDoesNotThrow(logicalView::computeOutput,
+                "computeOutput() must not throw for null fullSchema");
+
+        Assertions.assertEquals(2, output.size());
+    }
+
+    /**
+     * Single new column added (minimal drift). Verifies the exact boundary condition
+     * at index {@code fullSchema.size()}.
+     */
+    @Test
+    public void testComputeOutputSchemaDrift_singleColumnAdded() {
+        // 1-column schema, child returns 2 slots
+        List<Column> schema = ImmutableList.of(col("id"));
+        List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "extra"));
+
+        ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
+        LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(childSlots));
+
+        List<Slot> output = Assertions.assertDoesNotThrow(logicalView::computeOutput);
+
+        Assertions.assertEquals(2, output.size());
+        Assertions.assertEquals("id",    output.get(0).getName());
+        Assertions.assertEquals("extra", output.get(1).getName());
+    }
+
+    /**
+     * Child returns no output (empty relation). Must return an empty list and not crash.
+     */
+    @Test
+    public void testComputeOutputEmptyChild() {
+        List<Column> schema = ImmutableList.of(col("id"), col("name"));
+        ViewIf view = mockView(schema, ImmutableList.of("hive", "test", "v"));
+        LogicalView<LogicalPlan> logicalView = new LogicalView<>(view, mockChild(ImmutableList.of()));
+
+        List<Slot> output = logicalView.computeOutput();
+
+        Assertions.assertTrue(output.isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
@@ -107,7 +107,10 @@ public class LogicalViewTest {
      * <p>This is the regression test for the IndexOutOfBoundsException bug:
      * after {@code ALTER TABLE ADD COLUMNS} + {@code REFRESH TABLE} on the base table,
      * {@code childOutput.size()} grows beyond {@code view.getFullSchema().size()}.
-     * The extra slot(s) must NOT crash and must be returned with the qualifier applied.
+     *
+     * <p>The fix truncates output to the view's declared schema width so that:
+     * (1) no IndexOutOfBoundsException is thrown, and
+     * (2) the view's output contract (as seen in {@code DESC view}) is preserved.
      */
     @Test
     public void testComputeOutputSchemaDrift_moreColumnsThanSchema() {
@@ -124,14 +127,13 @@ public class LogicalViewTest {
         List<Slot> output = Assertions.assertDoesNotThrow(logicalView::computeOutput,
                 "computeOutput() must not throw when fullSchema is shorter than childOutput");
 
-        Assertions.assertEquals(4, output.size(),
-                "Output size should equal child output size (all columns exposed)");
-        // First 3 slots: resolved via stored schema
-        Assertions.assertEquals("id",    output.get(0).getName());
-        Assertions.assertEquals("name",  output.get(1).getName());
-        Assertions.assertEquals("age",   output.get(2).getName());
-        // 4th slot: added after view creation – falls back to withQualifier() path
-        Assertions.assertEquals("score", output.get(3).getName());
+        // Output is truncated to the view's declared schema width (3), not the child width (4).
+        // The new 'score' column is not visible until the view itself is refreshed.
+        Assertions.assertEquals(3, output.size(),
+                "Output size should be truncated to fullSchema size to preserve view contract");
+        Assertions.assertEquals("id",   output.get(0).getName());
+        Assertions.assertEquals("name", output.get(1).getName());
+        Assertions.assertEquals("age",  output.get(2).getName());
     }
 
     /**
@@ -196,11 +198,11 @@ public class LogicalViewTest {
 
     /**
      * Single new column added (minimal drift). Verifies the exact boundary condition
-     * at index {@code fullSchema.size()}.
+     * at index {@code fullSchema.size()}: output is truncated to schema width (1).
      */
     @Test
     public void testComputeOutputSchemaDrift_singleColumnAdded() {
-        // 1-column schema, child returns 2 slots
+        // 1-column schema, child returns 2 slots after schema drift
         List<Column> schema = ImmutableList.of(col("id"));
         List<Slot> childSlots = ImmutableList.of(slot(0, "id"), slot(1, "extra"));
 
@@ -209,9 +211,9 @@ public class LogicalViewTest {
 
         List<Slot> output = Assertions.assertDoesNotThrow(logicalView::computeOutput);
 
-        Assertions.assertEquals(2, output.size());
-        Assertions.assertEquals("id",    output.get(0).getName());
-        Assertions.assertEquals("extra", output.get(1).getName());
+        // Truncated to schema width; the new 'extra' column is not exposed.
+        Assertions.assertEquals(1, output.size());
+        Assertions.assertEquals("id", output.get(0).getName());
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/logical/LogicalViewTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Proxy;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 
@@ -59,21 +61,33 @@ public class LogicalViewTest {
     }
 
     /**
-     * Build a mock ViewIf that reports the given schema and qualifiers.
+     * Build a minimal ViewIf stub via JDK Proxy (avoids ByteBuddy/Mockito
+     * which triggers TableIf → ColumnStatistic class-loading issues in unit tests).
      */
+    @SuppressWarnings("unchecked")
     private static ViewIf mockView(List<Column> schema, List<String> qualifiers) {
-        ViewIf view = Mockito.mock(ViewIf.class);
-        Mockito.when(view.getFullSchema()).thenReturn(schema);
-        Mockito.when(view.getFullQualifiers()).thenReturn(qualifiers);
-        return view;
+        return (ViewIf) Proxy.newProxyInstance(
+                ViewIf.class.getClassLoader(),
+                new Class<?>[] {ViewIf.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getFullSchema": return schema;
+                        case "getFullQualifiers": return qualifiers;
+                        case "getViewText": return "";
+                        default: return null;
+                    }
+                });
     }
 
     /**
      * Build a mock LogicalPlan child whose {@code getOutput()} returns the given slots.
+     * Also stubs {@code getAllChildrenTypes()} so AbstractTreeNode's constructor does not
+     * crash with NPE when calling {@code containsTypes.or(childTypes)}.
      */
     private static LogicalPlan mockChild(List<Slot> slots) {
         LogicalPlan child = Mockito.mock(LogicalPlan.class);
         Mockito.when(child.getOutput()).thenReturn(slots);
+        Mockito.when(child.getAllChildrenTypes()).thenReturn(new BitSet());
         return child;
     }
 

--- a/regression-test/suites/external_table_p0/hive/test_hive_view_schema_drift.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_view_schema_drift.groovy
@@ -93,10 +93,10 @@ suite("test_hive_view_schema_drift", "p0,external,hive_docker") {
             // returns 3 columns from the Hive metastore → IndexOutOfBoundsException before fix.
             sql """refresh table ${base_table}"""
 
-            // ---- Base table now exposes 4 columns ----
+            // ---- Base table now exposes 5 columns (id, name, age, score + partition col dt) ----
             def descBase = sql """desc ${base_table}"""
-            assertEquals(4, descBase.size(),
-                    "Base table should have 4 columns after ADD COLUMN + REFRESH")
+            assertEquals(5, descBase.size(),
+                    "Base table should have 5 columns after ADD COLUMN + REFRESH (including partition column)")
 
             // ---- Querying the external Hive view must NOT throw IndexOutOfBoundsException ----
             // The view's HMS schema still has 3 cols (view not refreshed), so the output

--- a/regression-test/suites/external_table_p0/hive/test_hive_view_schema_drift.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_view_schema_drift.groovy
@@ -16,16 +16,21 @@
 // under the License.
 
 // Regression test for: LogicalView.computeOutput() IndexOutOfBoundsException when
-// an underlying Hive table gains new columns (schema drift) after the view was created.
+// an underlying Hive table gains new columns (schema drift) after the Hive view was created.
 //
 // Repro:
-//   1. Create Hive table with N columns; create a Doris view (SELECT *) on it.
-//   2. ADD COLUMN to the Hive table.
-//   3. REFRESH TABLE base_table in Doris (view schema not refreshed yet).
-//   4. Query the view → used to crash with "Index 3 out of bounds for length 3"
-//      because LogicalView.computeOutput() iterated childOutput (4 slots from
-//      re-analyzed view body) but called view.getFullSchema().get(i) on a
-//      3-element list (view's schema at creation time).
+//   1. Create a Hive base table (3 cols) and a native Hive VIEW on it.
+//   2. In Doris, register the Hive catalog and query the external view — OK (3 cols).
+//   3. ADD COLUMN to the Hive base table via hive_docker.
+//   4. REFRESH TABLE <base_table> in Doris (view HMS schema NOT refreshed).
+//   5. Query the external view again — used to crash:
+//        errCode = 2, detailMessage = Index 3 out of bounds for length 3
+//      because LogicalView.computeOutput() iterated childOutput (4 slots from the
+//      re-analyzed view body) but called view.getFullSchema().get(i) on a 3-element
+//      list (the Hive view's HMS schema at creation time).
+//
+// The fix: use Math.min(childOutput.size(), fullSchema.size()) as the loop bound,
+// preserving the view's declared output contract while preventing the crash.
 
 suite("test_hive_view_schema_drift", "p0,external,hive_docker") {
 
@@ -42,10 +47,10 @@ suite("test_hive_view_schema_drift", "p0,external,hive_docker") {
         String catalog_name = "test_${hivePrefix}_view_schema_drift"
         String db = "test_view_schema_drift_db"
         String base_table = "test_view_schema_drift_base"
-        String view_name = "test_view_schema_drift_view"
+        String hive_view = "test_view_schema_drift_view"
 
         try {
-            // ---- Setup Hive catalog ----
+            // ---- Register Hive catalog in Doris ----
             sql """drop catalog if exists ${catalog_name}"""
             sql """CREATE CATALOG ${catalog_name} PROPERTIES (
                 'type'='hms',
@@ -53,7 +58,9 @@ suite("test_hive_view_schema_drift", "p0,external,hive_docker") {
                 'hadoop.username' = 'hive'
             )"""
 
-            // ---- Create Hive database and base table with 3 columns ----
+            // ---- Create Hive database, base table (3 cols), and a native Hive VIEW ----
+            // The view is created through hive_docker so it is a native Hive view
+            // (ExternalView in Doris). Its HMS schema records exactly 3 columns.
             hive_docker """drop database if exists ${db} cascade"""
             hive_docker """create database ${db}"""
             hive_docker """
@@ -65,36 +72,40 @@ suite("test_hive_view_schema_drift", "p0,external,hive_docker") {
                 partitioned by (dt string)
                 stored as parquet
             """
+            hive_docker """
+                create view ${db}.${hive_view} as
+                    select id, name, age from ${db}.${base_table}
+            """
 
-            // ---- Create Doris view on the Hive table ----
             sql """switch ${catalog_name}"""
             sql """use ${db}"""
-            sql """create view ${view_name} as select * from ${base_table} where 1=1"""
 
-            // ---- Baseline: view query must succeed (3 non-partition columns) ----
-            def beforeDrift = sql """select * from ${view_name} where 1=0"""
-            assertTrue(beforeDrift.isEmpty())
+            // ---- Baseline: query the Hive view (3 columns) ----
+            def beforeDrift = sql """select * from ${hive_view} where 1=0"""
+            assertTrue(beforeDrift.isEmpty(), "Expected empty result before schema drift")
 
             // ---- Schema drift: add a column to the Hive base table ----
             hive_docker """alter table ${db}.${base_table} add columns (score string comment 'new col')"""
 
-            // ---- Refresh the base table metadata in Doris (view schema NOT refreshed) ----
+            // ---- Refresh only the base table (view HMS schema is NOT refreshed) ----
+            // After this, Doris re-analyzes the view body against the 4-column base table,
+            // producing childOutput with 4 slots, while ExternalView.getFullSchema() still
+            // returns 3 columns from the Hive metastore → IndexOutOfBoundsException before fix.
             sql """refresh table ${base_table}"""
 
-            // ---- Base table now has 4 columns ----
+            // ---- Base table now exposes 4 columns ----
             def descBase = sql """desc ${base_table}"""
-            assertEquals(4, descBase.size())
+            assertEquals(4, descBase.size(),
+                    "Base table should have 4 columns after ADD COLUMN + REFRESH")
 
-            // ---- Querying the view must NOT throw IndexOutOfBoundsException ----
-            // Before the fix: errCode = 2, detailMessage = Index 3 out of bounds for length 3
-            def afterDrift = sql """select * from ${view_name} where 1=0"""
-            assertTrue(afterDrift.isEmpty())
+            // ---- Querying the external Hive view must NOT throw IndexOutOfBoundsException ----
+            // The view's HMS schema still has 3 cols (view not refreshed), so the output
+            // is truncated to the view's declared width (3 cols) — the new 'score' column
+            // is not visible until the view itself is refreshed.
+            def afterDrift = sql """select * from ${hive_view} where 1=0"""
+            assertTrue(afterDrift.isEmpty(), "Expected empty result after schema drift (WHERE 1=0)")
 
         } finally {
-            try {
-                sql """switch ${catalog_name}"""
-                sql """drop view if exists ${catalog_name}.${db}.${view_name}"""
-            } catch (Exception ignored) {}
             try {
                 hive_docker """drop database if exists ${db} cascade"""
             } catch (Exception ignored) {}

--- a/regression-test/suites/external_table_p0/hive/test_hive_view_schema_drift.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_hive_view_schema_drift.groovy
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression test for: LogicalView.computeOutput() IndexOutOfBoundsException when
+// an underlying Hive table gains new columns (schema drift) after the view was created.
+//
+// Repro:
+//   1. Create Hive table with N columns; create a Doris view (SELECT *) on it.
+//   2. ADD COLUMN to the Hive table.
+//   3. REFRESH TABLE base_table in Doris (view schema not refreshed yet).
+//   4. Query the view → used to crash with "Index 3 out of bounds for length 3"
+//      because LogicalView.computeOutput() iterated childOutput (4 slots from
+//      re-analyzed view body) but called view.getFullSchema().get(i) on a
+//      3-element list (view's schema at creation time).
+
+suite("test_hive_view_schema_drift", "p0,external,hive_docker") {
+
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        logger.info("disable Hive test.")
+        return;
+    }
+
+    for (String hivePrefix : ["hive2", "hive3"]) {
+        setHivePrefix(hivePrefix)
+        String hms_port = context.config.otherConfigs.get(hivePrefix + "HmsPort")
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+        String catalog_name = "test_${hivePrefix}_view_schema_drift"
+        String db = "test_view_schema_drift_db"
+        String base_table = "test_view_schema_drift_base"
+        String view_name = "test_view_schema_drift_view"
+
+        try {
+            // ---- Setup Hive catalog ----
+            sql """drop catalog if exists ${catalog_name}"""
+            sql """CREATE CATALOG ${catalog_name} PROPERTIES (
+                'type'='hms',
+                'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}',
+                'hadoop.username' = 'hive'
+            )"""
+
+            // ---- Create Hive database and base table with 3 columns ----
+            hive_docker """drop database if exists ${db} cascade"""
+            hive_docker """create database ${db}"""
+            hive_docker """
+                create table ${db}.${base_table} (
+                    id     bigint,
+                    name   string,
+                    age    string
+                )
+                partitioned by (dt string)
+                stored as parquet
+            """
+
+            // ---- Create Doris view on the Hive table ----
+            sql """switch ${catalog_name}"""
+            sql """use ${db}"""
+            sql """create view ${view_name} as select * from ${base_table} where 1=1"""
+
+            // ---- Baseline: view query must succeed (3 non-partition columns) ----
+            def beforeDrift = sql """select * from ${view_name} where 1=0"""
+            assertTrue(beforeDrift.isEmpty())
+
+            // ---- Schema drift: add a column to the Hive base table ----
+            hive_docker """alter table ${db}.${base_table} add columns (score string comment 'new col')"""
+
+            // ---- Refresh the base table metadata in Doris (view schema NOT refreshed) ----
+            sql """refresh table ${base_table}"""
+
+            // ---- Base table now has 4 columns ----
+            def descBase = sql """desc ${base_table}"""
+            assertEquals(4, descBase.size())
+
+            // ---- Querying the view must NOT throw IndexOutOfBoundsException ----
+            // Before the fix: errCode = 2, detailMessage = Index 3 out of bounds for length 3
+            def afterDrift = sql """select * from ${view_name} where 1=0"""
+            assertTrue(afterDrift.isEmpty())
+
+        } finally {
+            try {
+                sql """switch ${catalog_name}"""
+                sql """drop view if exists ${catalog_name}.${db}.${view_name}"""
+            } catch (Exception ignored) {}
+            try {
+                hive_docker """drop database if exists ${db} cascade"""
+            } catch (Exception ignored) {}
+            sql """drop catalog if exists ${catalog_name}"""
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When querying a Doris view built with `SELECT *` over an external-catalog table (e.g. Hive), after the underlying table gains new columns via `ALTER TABLE ADD COLUMNS` + `REFRESH TABLE <base_table>`, the query crashes with:

```
errCode = 2, detailMessage = Index 3 out of bounds for length 3
```

**Root cause** (`LogicalView.computeOutput()`):

The view body is re-analyzed against the refreshed base-table schema (4 columns), producing `childOutput` with 4 slots. But `view.getFullSchema()` still returns 3 columns (the schema stored at view-creation time in the Hive metastore – not yet refreshed). The loop runs `i = 0..3` and calls `view.getFullSchema().get(3)`, crashing.

The `CollectionUtils.isEmpty()` guard added in #40715 handles the `null`/empty case but not the under-sized case.

## Fix

Promote `view.getFullSchema()` to a local variable to avoid repeated calls, then extend the guard to `i >= fullSchema.size()`:

```java
List<Column> fullSchema = view.getFullSchema();
if (CollectionUtils.isEmpty(fullSchema) || i >= fullSchema.size()) {
    qualified = originSlot.withQualifier(fullQualifiers);   // same as existing null-guard path
} else {
    qualified = originSlot
            .withOneLevelTableAndColumnAndQualifier(view, fullSchema.get(i), fullQualifiers);
}
```

Extra slots (columns added after view creation) fall back to `withQualifier()`, preserving the correct column name/type from the child slot (which is already resolved against the refreshed catalog). No behavioral change for non-drifted views.

## Files Changed

| File | Change |
|------|--------|
| `fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalView.java` | Fix + import `Column` |
| `regression-test/suites/external_table_p0/hive/test_hive_view_schema_drift.groovy` | New regression test |

## Test Plan

- [x] New regression test `test_hive_view_schema_drift` (suite `p0,external,hive_docker`):
  - Creates a 3-column Hive table + Doris view (`SELECT *`)
  - Verifies view query succeeds before schema drift
  - Adds a 4th column via `ALTER TABLE ADD COLUMNS`
  - Refreshes the base table (`REFRESH TABLE`)
  - Asserts the view query does **not** throw (regression guard)
- [ ] Existing `test_hive_view` suite — no regressions expected

## Issue

Fixes: #64006