### PR TITLE
[refactor](be) Avoid rebinding storage expression column ids

### DIFF
--- a/be/src/storage/iterators.h
+++ b/be/src/storage/iterators.h
@@ -125,6 +125,8 @@ public:
     std::vector<uint32_t>* read_orderby_key_columns = nullptr;
     io::IOContext io_ctx;
     VExprContextSPtrs common_expr_ctxs_push_down;
+    // Final scan project columns before storage-side read schema expansion.
+    const std::vector<ColumnId>* project_columns = nullptr;
     const std::set<int32_t>* output_columns = nullptr;
     // runtime state
     RuntimeState* runtime_state = nullptr;

--- a/be/src/storage/rowset/beta_rowset_reader.cpp
+++ b/be/src/storage/rowset/beta_rowset_reader.cpp
@@ -100,6 +100,9 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.stats = _stats;
     _read_options.push_down_agg_type_opt = _read_context->push_down_agg_type_opt;
     _read_options.common_expr_ctxs_push_down = _read_context->common_expr_ctxs_push_down;
+    _read_options.project_columns = _read_context->origin_return_columns != nullptr
+                                            ? _read_context->origin_return_columns
+                                            : _read_context->return_columns;
     _read_options.virtual_column_exprs = _read_context->virtual_column_exprs;
 
     _read_options.all_access_paths = _read_context->all_access_paths;

--- a/be/src/storage/rowset/beta_rowset_reader.cpp
+++ b/be/src/storage/rowset/beta_rowset_reader.cpp
@@ -100,6 +100,9 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.stats = _stats;
     _read_options.push_down_agg_type_opt = _read_context->push_down_agg_type_opt;
     _read_options.common_expr_ctxs_push_down = _read_context->common_expr_ctxs_push_down;
+    DORIS_CHECK(_read_context->return_columns != nullptr);
+    // Direct RowsetReader users do not expand return_columns, so return_columns is already
+    // the project layout. TabletReader sets origin_return_columns before any expansion.
     _read_options.project_columns = _read_context->origin_return_columns != nullptr
                                             ? _read_context->origin_return_columns
                                             : _read_context->return_columns;

--- a/be/src/storage/segment/segment.cpp
+++ b/be/src/storage/segment/segment.cpp
@@ -253,19 +253,23 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
     if (read_options.runtime_state != nullptr) {
         _be_exec_version = read_options.runtime_state->be_exec_version();
     }
-    RETURN_IF_ERROR(_create_column_meta_once(read_options.stats));
+    auto iterator_read_options = read_options;
+    if (iterator_read_options.project_columns == nullptr) {
+        iterator_read_options.project_columns = &schema->column_ids();
+    }
+    RETURN_IF_ERROR(_create_column_meta_once(iterator_read_options.stats));
 
-    read_options.stats->total_segment_number++;
+    iterator_read_options.stats->total_segment_number++;
     // trying to prune the current segment by segment-level zone map
-    for (const auto& entry : read_options.col_id_to_predicates) {
+    for (const auto& entry : iterator_read_options.col_id_to_predicates) {
         int32_t column_id = entry.first;
         // schema change
         if (_tablet_schema->num_columns() <= column_id) {
             continue;
         }
-        const TabletColumn& col = read_options.tablet_schema->column(column_id);
+        const TabletColumn& col = iterator_read_options.tablet_schema->column(column_id);
         std::shared_ptr<ColumnReader> reader;
-        Status st = get_column_reader(col, &reader, read_options.stats);
+        Status st = get_column_reader(col, &reader, iterator_read_options.stats);
         // not found in this segment, skip
         if (st.is<ErrorCode::NOT_FOUND>()) {
             continue;
@@ -276,41 +280,42 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
         if (!reader->has_zone_map()) {
             continue;
         }
-        if (read_options.col_id_to_predicates.contains(column_id) &&
+        if (iterator_read_options.col_id_to_predicates.contains(column_id) &&
             can_apply_predicate_safely(column_id, *schema,
-                                       read_options.target_cast_type_for_variants, read_options)) {
+                                       iterator_read_options.target_cast_type_for_variants,
+                                       iterator_read_options)) {
             bool matched = true;
             RETURN_IF_ERROR(reader->match_condition(entry.second.get(), &matched));
             if (!matched) {
                 // any condition not satisfied, return.
                 *iter = std::make_unique<EmptySegmentIterator>(*schema);
-                read_options.stats->filtered_segment_number++;
+                iterator_read_options.stats->filtered_segment_number++;
                 return Status::OK();
             }
         }
     }
 
     {
-        SCOPED_RAW_TIMER(&read_options.stats->segment_load_index_timer_ns);
-        RETURN_IF_ERROR(load_index(read_options.stats));
+        SCOPED_RAW_TIMER(&iterator_read_options.stats->segment_load_index_timer_ns);
+        RETURN_IF_ERROR(load_index(iterator_read_options.stats));
     }
 
-    if (read_options.delete_condition_predicates->num_of_column_predicate() == 0 &&
-        read_options.push_down_agg_type_opt != TPushAggOp::NONE &&
-        read_options.push_down_agg_type_opt != TPushAggOp::COUNT_ON_INDEX) {
+    if (iterator_read_options.delete_condition_predicates->num_of_column_predicate() == 0 &&
+        iterator_read_options.push_down_agg_type_opt != TPushAggOp::NONE &&
+        iterator_read_options.push_down_agg_type_opt != TPushAggOp::COUNT_ON_INDEX) {
         iter->reset(new_vstatistics_iterator(this->shared_from_this(), *schema));
     } else {
         *iter = std::make_unique<SegmentIterator>(this->shared_from_this(), schema);
     }
 
     // TODO: Valid the opt not only in ReaderType::READER_QUERY
-    if (read_options.io_ctx.reader_type == ReaderType::READER_QUERY &&
-        !read_options.column_predicates.empty()) {
-        auto pruned_predicates = read_options.column_predicates;
+    if (iterator_read_options.io_ctx.reader_type == ReaderType::READER_QUERY &&
+        !iterator_read_options.column_predicates.empty()) {
+        auto pruned_predicates = iterator_read_options.column_predicates;
         auto pruned = false;
         for (auto& it : _column_reader_cache->get_available_readers(false)) {
             const auto uid = it.first;
-            const auto column_id = read_options.tablet_schema->field_index(uid);
+            const auto column_id = iterator_read_options.tablet_schema->field_index(uid);
             bool tmp_pruned = false;
             RETURN_IF_ERROR(it.second->prune_predicates_by_zone_map(pruned_predicates, column_id,
                                                                     &tmp_pruned));
@@ -318,7 +323,7 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
         }
 
         if (pruned) {
-            auto options_with_pruned_predicates = read_options;
+            auto options_with_pruned_predicates = iterator_read_options;
             options_with_pruned_predicates.column_predicates = pruned_predicates;
             //because column_predicates is changed, we need to rebuild col_id_to_predicates so that inverted index will not go through it.
             options_with_pruned_predicates.col_id_to_predicates.clear();
@@ -334,7 +339,7 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
             return iter->get()->init(options_with_pruned_predicates);
         }
     }
-    return iter->get()->init(read_options);
+    return iter->get()->init(iterator_read_options);
 }
 
 Status Segment::_write_error_file(size_t file_size, size_t offset, size_t bytes_read, char* data,

--- a/be/src/storage/segment/segment.cpp
+++ b/be/src/storage/segment/segment.cpp
@@ -253,23 +253,19 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
     if (read_options.runtime_state != nullptr) {
         _be_exec_version = read_options.runtime_state->be_exec_version();
     }
-    auto iterator_read_options = read_options;
-    if (iterator_read_options.project_columns == nullptr) {
-        iterator_read_options.project_columns = &schema->column_ids();
-    }
-    RETURN_IF_ERROR(_create_column_meta_once(iterator_read_options.stats));
+    RETURN_IF_ERROR(_create_column_meta_once(read_options.stats));
 
-    iterator_read_options.stats->total_segment_number++;
+    read_options.stats->total_segment_number++;
     // trying to prune the current segment by segment-level zone map
-    for (const auto& entry : iterator_read_options.col_id_to_predicates) {
+    for (const auto& entry : read_options.col_id_to_predicates) {
         int32_t column_id = entry.first;
         // schema change
         if (_tablet_schema->num_columns() <= column_id) {
             continue;
         }
-        const TabletColumn& col = iterator_read_options.tablet_schema->column(column_id);
+        const TabletColumn& col = read_options.tablet_schema->column(column_id);
         std::shared_ptr<ColumnReader> reader;
-        Status st = get_column_reader(col, &reader, iterator_read_options.stats);
+        Status st = get_column_reader(col, &reader, read_options.stats);
         // not found in this segment, skip
         if (st.is<ErrorCode::NOT_FOUND>()) {
             continue;
@@ -280,42 +276,41 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
         if (!reader->has_zone_map()) {
             continue;
         }
-        if (iterator_read_options.col_id_to_predicates.contains(column_id) &&
+        if (read_options.col_id_to_predicates.contains(column_id) &&
             can_apply_predicate_safely(column_id, *schema,
-                                       iterator_read_options.target_cast_type_for_variants,
-                                       iterator_read_options)) {
+                                       read_options.target_cast_type_for_variants, read_options)) {
             bool matched = true;
             RETURN_IF_ERROR(reader->match_condition(entry.second.get(), &matched));
             if (!matched) {
                 // any condition not satisfied, return.
                 *iter = std::make_unique<EmptySegmentIterator>(*schema);
-                iterator_read_options.stats->filtered_segment_number++;
+                read_options.stats->filtered_segment_number++;
                 return Status::OK();
             }
         }
     }
 
     {
-        SCOPED_RAW_TIMER(&iterator_read_options.stats->segment_load_index_timer_ns);
-        RETURN_IF_ERROR(load_index(iterator_read_options.stats));
+        SCOPED_RAW_TIMER(&read_options.stats->segment_load_index_timer_ns);
+        RETURN_IF_ERROR(load_index(read_options.stats));
     }
 
-    if (iterator_read_options.delete_condition_predicates->num_of_column_predicate() == 0 &&
-        iterator_read_options.push_down_agg_type_opt != TPushAggOp::NONE &&
-        iterator_read_options.push_down_agg_type_opt != TPushAggOp::COUNT_ON_INDEX) {
+    if (read_options.delete_condition_predicates->num_of_column_predicate() == 0 &&
+        read_options.push_down_agg_type_opt != TPushAggOp::NONE &&
+        read_options.push_down_agg_type_opt != TPushAggOp::COUNT_ON_INDEX) {
         iter->reset(new_vstatistics_iterator(this->shared_from_this(), *schema));
     } else {
         *iter = std::make_unique<SegmentIterator>(this->shared_from_this(), schema);
     }
 
     // TODO: Valid the opt not only in ReaderType::READER_QUERY
-    if (iterator_read_options.io_ctx.reader_type == ReaderType::READER_QUERY &&
-        !iterator_read_options.column_predicates.empty()) {
-        auto pruned_predicates = iterator_read_options.column_predicates;
+    if (read_options.io_ctx.reader_type == ReaderType::READER_QUERY &&
+        !read_options.column_predicates.empty()) {
+        auto pruned_predicates = read_options.column_predicates;
         auto pruned = false;
         for (auto& it : _column_reader_cache->get_available_readers(false)) {
             const auto uid = it.first;
-            const auto column_id = iterator_read_options.tablet_schema->field_index(uid);
+            const auto column_id = read_options.tablet_schema->field_index(uid);
             bool tmp_pruned = false;
             RETURN_IF_ERROR(it.second->prune_predicates_by_zone_map(pruned_predicates, column_id,
                                                                     &tmp_pruned));
@@ -323,7 +318,7 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
         }
 
         if (pruned) {
-            auto options_with_pruned_predicates = iterator_read_options;
+            auto options_with_pruned_predicates = read_options;
             options_with_pruned_predicates.column_predicates = pruned_predicates;
             //because column_predicates is changed, we need to rebuild col_id_to_predicates so that inverted index will not go through it.
             options_with_pruned_predicates.col_id_to_predicates.clear();
@@ -339,7 +334,7 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
             return iter->get()->init(options_with_pruned_predicates);
         }
     }
-    return iter->get()->init(iterator_read_options);
+    return iter->get()->init(read_options);
 }
 
 Status Segment::_write_error_file(size_t file_size, size_t offset, size_t bytes_read, char* data,

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -478,7 +478,8 @@ Status SegmentIterator::_init_project_schema() {
     }
 
     _project_schema = _opts.project_columns != nullptr
-                              ? std::make_shared<Schema>(_schema->columns(), *_opts.project_columns)
+                              ? std::make_shared<Schema>(_opts.tablet_schema->columns(),
+                                                         *_opts.project_columns)
                               : _schema;
     return Status::OK();
 }

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -496,9 +496,9 @@ Block* SegmentIterator::_build_project_block(Block* block, Block* project_block)
 
     project_block->clear();
     const auto& project_column_ids = _project_schema->column_ids();
-    for (size_t i = 0; i < project_column_ids.size(); ++i) {
-        auto cid = project_column_ids[i];
-        auto& output_column = block->get_by_position(i);
+    for (auto cid : project_column_ids) {
+        auto loc = _schema_block_id_map[cid];
+        auto& output_column = block->get_by_position(loc);
         auto type = output_column.type;
         auto column = output_column.column;
         auto virtual_it = _vir_cid_to_idx_in_block.find(cid);
@@ -2004,7 +2004,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
             }
 
             for (auto pair : _vir_cid_to_idx_in_block) {
-                _columns_to_filter.push_back(cast_set<ColumnId>(pair.second));
+                _columns_to_filter.push_back(_schema_block_id_map[pair.first]);
             }
         }
     }
@@ -2758,8 +2758,9 @@ Status SegmentIterator::next_batch(Block* block) {
                 // So a replacement of nothing column with real column is needed.
                 const auto& idx_to_datatype = _opts.vir_col_idx_to_type;
                 for (const auto& pair : _vir_cid_to_idx_in_block) {
+                    auto idx = _schema_block_id_map[pair.first];
                     auto type = idx_to_datatype.find(pair.second)->second;
-                    block->replace_by_position(pair.second, type->create_column());
+                    block->replace_by_position(idx, type->create_column());
                 }
 
                 if (_opts.condition_cache_digest && !_find_condition_cache) {
@@ -3470,7 +3471,8 @@ bool SegmentIterator::_can_opt_limit_reads() {
 // Before get next batch. make sure all virtual columns in block has type ColumnNothing.
 void SegmentIterator::_init_virtual_columns(Block* block) {
     for (const auto& pair : _vir_cid_to_idx_in_block) {
-        auto& col_with_type_and_name = block->get_by_position(pair.second);
+        auto idx = _schema_block_id_map[pair.first];
+        auto& col_with_type_and_name = block->get_by_position(idx);
         col_with_type_and_name.column = ColumnNothing::create(0);
         col_with_type_and_name.type = _opts.vir_col_idx_to_type[pair.second];
     }
@@ -3481,7 +3483,8 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     // So materialize virtual column in advance to avoid errors.
     if (_selected_size == 0) {
         for (const auto& pair : _vir_cid_to_idx_in_block) {
-            auto& col_with_type_and_name = block->get_by_position(pair.second);
+            auto idx = _schema_block_id_map[pair.first];
+            auto& col_with_type_and_name = block->get_by_position(idx);
             col_with_type_and_name.column = _opts.vir_col_idx_to_type[pair.second]->create_column();
             col_with_type_and_name.type = _opts.vir_col_idx_to_type[pair.second];
         }
@@ -3517,10 +3520,11 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     if (materialize_on_project_block) {
         for (const auto& cid_and_expr : _virtual_column_exprs) {
             auto cid = cid_and_expr.first;
+            auto idx_in_block = _schema_block_id_map[cid];
             auto materialized_pos = _vir_cid_to_idx_in_block.at(cid);
             const auto& column = project_block.get_by_position(materialized_pos).column;
             DORIS_CHECK(!check_and_get_column<const ColumnNothing>(column.get()));
-            block->replace_by_position(materialized_pos, column);
+            block->replace_by_position(idx_in_block, column);
         }
     }
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -69,7 +69,6 @@
 #include "io/cache/cached_remote_file_reader.h"
 #include "io/fs/file_reader.h"
 #include "io/io_common.h"
-#include "runtime/descriptors.h"
 #include "runtime/query_context.h"
 #include "runtime/runtime_predicate.h"
 #include "runtime/runtime_state.h"
@@ -109,127 +108,11 @@
 #include "storage/utils.h"
 #include "util/concurrency_stats.h"
 #include "util/defer_op.h"
-#include "util/json/path_in_data.h"
 #include "util/simd/bits.h"
 
 namespace doris {
 using namespace ErrorCode;
 namespace segment_v2 {
-namespace {
-
-Status tablet_column_id_by_slot(const TabletSchemaSPtr& tablet_schema, const SlotDescriptor* slot,
-                                ColumnId* cid) {
-    int32_t field_index = -1;
-    if (slot->type()->get_primitive_type() == PrimitiveType::TYPE_VARIANT) {
-        field_index = tablet_schema->field_index(
-                PathInData(tablet_schema->column_by_uid(slot->col_unique_id()).name_lower_case(),
-                           slot->column_paths()));
-    } else {
-        field_index = slot->col_unique_id() >= 0 ? tablet_schema->field_index(slot->col_unique_id())
-                                                 : tablet_schema->field_index(slot->col_name());
-    }
-    if (field_index < 0) {
-        return Status::InternalError(
-                "field name is invalid. field={}, field_name_to_index={}, col_unique_id={}",
-                slot->col_name(), tablet_schema->get_all_field_names(), slot->col_unique_id());
-    }
-    *cid = field_index;
-    return Status::OK();
-}
-
-Status rebind_storage_expr_to_reader_schema(
-        const StorageReadOptions& opts, const VExprSPtr& expr,
-        const std::unordered_map<ColumnId, size_t>& cid_to_pos) {
-    DORIS_CHECK(expr != nullptr);
-
-    if (expr->is_slot_ref()) {
-        auto slot_ref = std::static_pointer_cast<VSlotRef>(expr);
-        auto* slot = opts.runtime_state->desc_tbl().get_slot_descriptor(slot_ref->slot_id());
-        if (slot == nullptr) {
-            return Status::InternalError("slot {} is not found in descriptor table",
-                                         slot_ref->slot_id());
-        }
-
-        ColumnId cid = 0;
-        RETURN_IF_ERROR(tablet_column_id_by_slot(opts.tablet_schema, slot, &cid));
-        auto pos_it = cid_to_pos.find(cid);
-        if (pos_it == cid_to_pos.end()) {
-            return Status::InternalError("slot {} column {} with cid {} is not in reader schema",
-                                         slot_ref->slot_id(), slot->col_name(), cid);
-        }
-        slot_ref->set_column_id(cast_set<int>(pos_it->second));
-    } else if (expr->is_virtual_slot_ref()) {
-        auto virtual_slot_ref = std::static_pointer_cast<VirtualSlotRef>(expr);
-        auto* slot =
-                opts.runtime_state->desc_tbl().get_slot_descriptor(virtual_slot_ref->slot_id());
-        if (slot == nullptr) {
-            return Status::InternalError("slot {} is not found in descriptor table",
-                                         virtual_slot_ref->slot_id());
-        }
-
-        ColumnId cid = 0;
-        RETURN_IF_ERROR(tablet_column_id_by_slot(opts.tablet_schema, slot, &cid));
-        auto pos_it = cid_to_pos.find(cid);
-        if (pos_it == cid_to_pos.end()) {
-            return Status::InternalError(
-                    "virtual slot {} column {} with cid {} is not in reader schema",
-                    virtual_slot_ref->slot_id(), slot->col_name(), cid);
-        }
-        virtual_slot_ref->set_column_id(cast_set<int>(pos_it->second));
-        // A virtual slot has its own output position in the reader block, and its
-        // materialization expression may also contain real slot refs. Rebind both
-        // sides so evaluating the virtual expression reads from the same block
-        // layout used by SegmentIterator.
-        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(
-                opts, virtual_slot_ref->get_virtual_column_expr(), cid_to_pos));
-    }
-
-    for (const auto& child : expr->children()) {
-        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, child, cid_to_pos));
-    }
-    return Status::OK();
-}
-
-Status rebind_storage_exprs_to_reader_schema(const StorageReadOptions& opts, const Schema& schema,
-                                             const VExprContextSPtrs& common_exprs,
-                                             std::map<ColumnId, VExprContextSPtr>& virtual_exprs) {
-    if (common_exprs.empty() && virtual_exprs.empty()) {
-        return Status::OK();
-    }
-    DORIS_CHECK(opts.runtime_state != nullptr);
-    DORIS_CHECK(opts.tablet_schema != nullptr);
-
-    const auto keys_type = opts.tablet_schema->keys_type();
-    if (keys_type == KeysType::DUP_KEYS ||
-        (keys_type == KeysType::UNIQUE_KEYS && opts.enable_unique_key_merge_on_write)) {
-        return Status::OK();
-    }
-
-    // Storage exprs are prepared with RowDescriptor, so VSlotRef/VirtualSlotRef column_id points to
-    // the scan tuple column ordinal. SegmentIterator evaluates cloned exprs on a block built from
-    // the reader schema instead. AGG_KEYS and non-MOW UNIQUE_KEYS readers may expand the reader
-    // schema, for example by filling all key columns before merging/aggregating rows, so the scan
-    // tuple ordinal is not always the same as the runtime block ordinal.
-    //
-    // DUP_KEYS and UNIQUE_KEYS MOW use direct readers for query scans, so their reader block keeps
-    // the scan tuple layout and can skip this per-segment expression-tree traversal. For merge/agg
-    // readers, the reader schema is the source of truth: map tablet column id to reader-block
-    // position and rebind every storage expr slot to that position.
-    std::unordered_map<ColumnId, size_t> cid_to_pos;
-    for (size_t pos = 0; pos < schema.num_column_ids(); ++pos) {
-        cid_to_pos.emplace(schema.column_id(cast_set<int>(pos)), pos);
-    }
-
-    for (const auto& ctx : common_exprs) {
-        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, ctx->root(), cid_to_pos));
-    }
-    for (const auto& [_, ctx] : virtual_exprs) {
-        RETURN_IF_ERROR(rebind_storage_expr_to_reader_schema(opts, ctx->root(), cid_to_pos));
-    }
-    return Status::OK();
-}
-
-} // namespace
 
 SegmentIterator::~SegmentIterator() = default;
 
@@ -529,6 +412,7 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
     _vir_cid_to_idx_in_block = _opts.vir_cid_to_idx_in_block;
     _score_runtime = _opts.score_runtime;
     _ann_topn_runtime = _opts.ann_topn_runtime;
+    RETURN_IF_ERROR(_init_project_schema());
 
     if (opts.output_columns != nullptr) {
         _output_columns = *(opts.output_columns);
@@ -583,6 +467,55 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
             _opts.virtual_column_exprs.size(), _opts.vir_cid_to_idx_in_block.size(),
             _common_expr_ctxs_push_down.size());
     _initialize_predicate_results();
+    return Status::OK();
+}
+
+Status SegmentIterator::_init_project_schema() {
+    _schema_block_id_map.assign(_schema->columns().size(), -1);
+    for (int i = 0; i < _schema->num_column_ids(); i++) {
+        auto cid = _schema->column_id(i);
+        _schema_block_id_map[cid] = i;
+    }
+
+    _project_schema = _opts.project_columns != nullptr
+                              ? std::make_shared<Schema>(_schema->columns(), *_opts.project_columns)
+                              : _schema;
+    return Status::OK();
+}
+
+Status SegmentIterator::_build_project_block(Block* block, uint16_t selected_size,
+                                             Block* project_block) {
+    project_block->clear();
+    DORIS_CHECK(_project_schema != nullptr);
+    for (auto cid : _project_schema->column_ids()) {
+        auto loc = _schema_block_id_map[cid];
+        auto& output_column = block->get_by_position(loc);
+        auto type = output_column.type;
+        auto column = output_column.column;
+        auto virtual_it = _vir_cid_to_idx_in_block.find(cid);
+        if (virtual_it != _vir_cid_to_idx_in_block.end()) {
+            auto type_it = _opts.vir_col_idx_to_type.find(virtual_it->second);
+            DORIS_CHECK(type_it != _opts.vir_col_idx_to_type.end());
+            type = type_it->second;
+            if (!column || check_and_get_column<const ColumnNothing>(column.get()) ||
+                column->size() != selected_size) {
+                column = ColumnNothing::create(selected_size);
+            }
+        } else {
+            if (!type) {
+                type = Schema::get_data_type_ptr(*_schema->column(cid));
+            }
+            if (!column) {
+                return Status::InternalError(
+                        "project column {} is not materialized before project block build", cid);
+            }
+            if (column->size() != selected_size) {
+                return Status::InternalError("project column {} has {} rows, expected {}", cid,
+                                             column->size(), selected_size);
+            }
+        }
+        project_block->insert({std::move(column), type, _schema->column(cid)->name()});
+    }
     return Status::OK();
 }
 
@@ -1002,7 +935,7 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
 
     VLOG_DEBUG << fmt::format("Try apply ann topn: {}", _ann_topn_runtime->debug_string());
     size_t src_col_idx = _ann_topn_runtime->get_src_column_idx();
-    ColumnId src_cid = _schema->column_id(src_col_idx);
+    ColumnId src_cid = _project_schema->column_id(src_col_idx);
     IndexIterator* ann_index_iterator = _index_iterators[src_cid].get();
     bool has_ann_index = _column_has_ann_index(src_cid);
     bool has_common_expr_push_down = !_common_expr_ctxs_push_down.empty();
@@ -1123,7 +1056,7 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
     _opts.stats->ann_index_topn_search_cnt += 1;
     _opts.stats->ann_index_cache_hits += ann_index_stats.topn_cache_hits.value();
     const size_t dst_col_idx = _ann_topn_runtime->get_dest_column_idx();
-    ColumnIterator* column_iter = _column_iterators[_schema->column_id(dst_col_idx)].get();
+    ColumnIterator* column_iter = _column_iterators[_project_schema->column_id(dst_col_idx)].get();
     DCHECK(column_iter != nullptr);
     VirtualColumnIterator* virtual_column_iter = dynamic_cast<VirtualColumnIterator*>(column_iter);
     DCHECK(virtual_column_iter != nullptr);
@@ -1268,8 +1201,9 @@ Status SegmentIterator::_extract_common_expr_columns(const VExprSPtr& expr) {
     auto node_type = expr->node_type();
     if (node_type == TExprNodeType::SLOT_REF) {
         auto slot_expr = std::dynamic_pointer_cast<doris::VSlotRef>(expr);
-        _is_common_expr_column[_schema->column_id(slot_expr->column_id())] = true;
-        _common_expr_columns.insert(_schema->column_id(slot_expr->column_id()));
+        auto cid = _project_schema->column_id(slot_expr->column_id());
+        _is_common_expr_column[cid] = true;
+        _common_expr_columns.insert(cid);
     } else if (node_type == TExprNodeType::VIRTUAL_SLOT_REF) {
         std::shared_ptr<VirtualSlotRef> virtual_slot_ref =
                 std::dynamic_pointer_cast<VirtualSlotRef>(expr);
@@ -1370,7 +1304,7 @@ Status SegmentIterator::_apply_index_expr() {
         size_t origin_rows = _row_bitmap.cardinality();
         bool ann_range_search_executed = false;
         RETURN_IF_ERROR(expr_ctx->evaluate_ann_range_search(
-                _index_iterators, _schema->column_ids(), _column_iterators,
+                _index_iterators, _project_schema->column_ids(), _column_iterators,
                 _common_expr_to_slotref_map, _row_bitmap, ann_index_stats,
                 enable_ann_index_result_cache, &ann_range_search_executed));
         if (ann_range_search_executed) {
@@ -2060,7 +1994,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
 
     // ColumnId to column index in block
     // ColumnId will contail all columns in tablet schema, including virtual columns and global rowid column,
-    _schema_block_id_map.resize(_schema->columns().size(), -1);
+    _schema_block_id_map.assign(_schema->columns().size(), -1);
     // Use cols read by query to initialize _schema_block_id_map.
     // We need to know the index of each column in the block.
     // There is an assumption here that the columns in the block are in the same order as in the read schema.
@@ -2090,7 +2024,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
             }
 
             for (auto pair : _vir_cid_to_idx_in_block) {
-                _columns_to_filter.push_back(cast_set<ColumnId>(pair.second));
+                _columns_to_filter.push_back(_schema_block_id_map[pair.first]);
             }
         }
     }
@@ -2844,8 +2778,8 @@ Status SegmentIterator::next_batch(Block* block) {
                 // So a replacement of nothing column with real column is needed.
                 const auto& idx_to_datatype = _opts.vir_col_idx_to_type;
                 for (const auto& pair : _vir_cid_to_idx_in_block) {
-                    size_t idx = pair.second;
-                    auto type = idx_to_datatype.find(idx)->second;
+                    auto idx = _schema_block_id_map[pair.first];
+                    auto type = idx_to_datatype.find(pair.second)->second;
                     block->replace_by_position(idx, type->create_column());
                 }
 
@@ -3194,12 +3128,6 @@ Status SegmentIterator::_process_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
                            _selected_size));
     }
 
-    std::vector<VExprContext*> common_ctxs;
-    common_ctxs.reserve(_common_expr_ctxs_push_down.size());
-    for (auto& ctx : _common_expr_ctxs_push_down) {
-        common_ctxs.push_back(ctx.get());
-    }
-    _output_index_result_column(common_ctxs, _sel_rowid_idx.data(), _selected_size, block);
     RETURN_IF_ERROR(_execute_common_expr(_sel_rowid_idx.data(), _selected_size, block));
 
     if (need_mock_col) {
@@ -3215,14 +3143,27 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
                                              Block* block) {
     SCOPED_RAW_TIMER(&_opts.stats->expr_filter_ns);
     DCHECK(!_common_expr_ctxs_push_down.empty());
-    DCHECK(block->rows() != 0);
-    int prev_columns = block->columns();
+    Block project_block;
+    RETURN_IF_ERROR(_build_project_block(block, selected_size, &project_block));
+    std::vector<VExprContext*> common_ctxs;
+    common_ctxs.reserve(_common_expr_ctxs_push_down.size());
+    for (auto& ctx : _common_expr_ctxs_push_down) {
+        common_ctxs.push_back(ctx.get());
+    }
+    _output_index_result_column(common_ctxs, sel_rowid_idx, selected_size, &project_block);
+
+    DCHECK(project_block.rows() != 0);
+    int prev_columns = project_block.columns();
     uint16_t original_size = selected_size;
     _opts.stats->expr_cond_input_rows += original_size;
 
     IColumn::Filter filter;
+    std::vector<uint32_t> expr_columns_to_filter(prev_columns);
+    std::iota(expr_columns_to_filter.begin(), expr_columns_to_filter.end(), 0);
     RETURN_IF_ERROR(VExprContext::execute_conjuncts_and_filter_block(
-            _common_expr_ctxs_push_down, block, _columns_to_filter, prev_columns, filter));
+            _common_expr_ctxs_push_down, &project_block, expr_columns_to_filter, prev_columns,
+            filter));
+    RETURN_IF_CATCH_EXCEPTION(Block::filter_block_internal(block, _columns_to_filter, filter));
 
     selected_size = _evaluate_common_expr_filter(sel_rowid_idx, selected_size, filter);
     _opts.stats->rows_expr_cond_filtered += original_size - selected_size;
@@ -3386,7 +3327,7 @@ Status SegmentIterator::_construct_compound_expr_context() {
             .io_ctx = _opts.io_ctx,
     };
     auto inverted_index_context = std::make_shared<IndexExecContext>(
-            _schema->column_ids(), _index_iterators, _storage_name_and_type,
+            _project_schema->column_ids(), _index_iterators, _storage_name_and_type,
             _common_expr_index_exec_status, _score_runtime, _segment.get(), iter_opts);
     inverted_index_context->set_index_query_context(_index_query_context);
     for (const auto& expr_ctx : _opts.common_expr_ctxs_push_down) {
@@ -3406,8 +3347,6 @@ Status SegmentIterator::_construct_compound_expr_context() {
         context->set_index_context(inverted_index_context);
         expr_ctx = context;
     }
-    RETURN_IF_ERROR(rebind_storage_exprs_to_reader_schema(
-            _opts, *_schema, _common_expr_ctxs_push_down, _virtual_column_exprs));
     return Status::OK();
 }
 
@@ -3445,8 +3384,9 @@ void SegmentIterator::_calculate_common_expr_index_exec_status() {
                             for (const auto& vir_child : vir_node->children()) {
                                 if (vir_child->is_slot_ref()) {
                                     auto* inner_slot_ref = assert_cast<VSlotRef*>(vir_child.get());
-                                    _common_expr_index_exec_status[_schema->column_id(
-                                            inner_slot_ref->column_id())][expr.get()] = false;
+                                    auto cid =
+                                            _project_schema->column_id(inner_slot_ref->column_id());
+                                    _common_expr_index_exec_status[cid][expr.get()] = false;
                                     _common_expr_to_slotref_map[root_expr_ctx.get()]
                                                                [inner_slot_ref->column_id()] =
                                                                        expr.get();
@@ -3463,8 +3403,8 @@ void SegmentIterator::_calculate_common_expr_index_exec_status() {
                 auto expr_without_cast = VExpr::expr_without_cast(child);
                 if (expr_without_cast->is_slot_ref() && expr->op() != TExprOpcode::CAST) {
                     auto* column_slot_ref = assert_cast<VSlotRef*>(expr_without_cast.get());
-                    _common_expr_index_exec_status[_schema->column_id(column_slot_ref->column_id())]
-                                                  [expr.get()] = false;
+                    auto cid = _project_schema->column_id(column_slot_ref->column_id());
+                    _common_expr_index_exec_status[cid][expr.get()] = false;
                     _common_expr_to_slotref_map[root_expr_ctx.get()][column_slot_ref->column_id()] =
                             expr.get();
                 }
@@ -3567,7 +3507,8 @@ bool SegmentIterator::_can_opt_limit_reads() {
 // Before get next batch. make sure all virtual columns in block has type ColumnNothing.
 void SegmentIterator::_init_virtual_columns(Block* block) {
     for (const auto& pair : _vir_cid_to_idx_in_block) {
-        auto& col_with_type_and_name = block->get_by_position(pair.second);
+        auto idx = _schema_block_id_map[pair.first];
+        auto& col_with_type_and_name = block->get_by_position(idx);
         col_with_type_and_name.column = ColumnNothing::create(0);
         col_with_type_and_name.type = _opts.vir_col_idx_to_type[pair.second];
     }
@@ -3578,7 +3519,8 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     // So materialize virtual column in advance to avoid errors.
     if (block->rows() == 0) {
         for (const auto& pair : _vir_cid_to_idx_in_block) {
-            auto& col_with_type_and_name = block->get_by_position(pair.second);
+            auto idx = _schema_block_id_map[pair.first];
+            auto& col_with_type_and_name = block->get_by_position(idx);
             col_with_type_and_name.column = _opts.vir_col_idx_to_type[pair.second]->create_column();
             col_with_type_and_name.type = _opts.vir_col_idx_to_type[pair.second];
         }
@@ -3588,14 +3530,8 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     for (const auto& cid_and_expr : _virtual_column_exprs) {
         auto cid = cid_and_expr.first;
         auto column_expr = cid_and_expr.second;
-        size_t idx_in_block = _vir_cid_to_idx_in_block[cid];
-        if (block->columns() <= idx_in_block) {
-            return Status::InternalError(
-                    "Virtual column index {} is out of range, block columns {}, "
-                    "virtual columns size {}, virtual column expr {}",
-                    idx_in_block, block->columns(), _vir_cid_to_idx_in_block.size(),
-                    column_expr->root()->debug_string());
-        } else if (block->get_by_position(idx_in_block).column.get() == nullptr) {
+        auto idx_in_block = _schema_block_id_map[cid];
+        if (block->get_by_position(idx_in_block).column.get() == nullptr) {
             return Status::InternalError(
                     "Virtual column index {} is null, block columns {}, virtual columns size {}, "
                     "virtual column expr {}",
@@ -3607,7 +3543,10 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
             VLOG_DEBUG << fmt::format("Virtual column is doing materialization, cid {}, col idx {}",
                                       cid, idx_in_block);
             ColumnPtr result_column;
-            RETURN_IF_ERROR(column_expr->execute(block, result_column));
+            Block project_block;
+            RETURN_IF_ERROR(
+                    _build_project_block(block, cast_set<uint16_t>(block->rows()), &project_block));
+            RETURN_IF_ERROR(column_expr->execute(&project_block, result_column));
 
             block->replace_by_position(idx_in_block, std::move(result_column));
             if (block->get_by_position(idx_in_block).column->size() == 0) {
@@ -3643,7 +3582,7 @@ void SegmentIterator::_prepare_score_column_materialization() {
                                                                      result_row_ids, filter);
     }
     const size_t dst_col_idx = _score_runtime->get_dest_column_idx();
-    auto* column_iter = _column_iterators[_schema->column_id(dst_col_idx)].get();
+    auto* column_iter = _column_iterators[_project_schema->column_id(dst_col_idx)].get();
     auto* virtual_column_iter = dynamic_cast<VirtualColumnIterator*>(column_iter);
     virtual_column_iter->prepare_materialization(
             std::move(result_column),

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -3514,7 +3514,7 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
             materialize_block->replace_by_position(materialized_pos, std::move(result_column));
         }
     }
-    if (materialize_block != block) {
+    if (materialize_on_project_block) {
         for (const auto& cid_and_expr : _virtual_column_exprs) {
             auto cid = cid_and_expr.first;
             auto materialized_pos = _vir_cid_to_idx_in_block.at(cid);

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -480,12 +480,14 @@ void SegmentIterator::_init_schema_block_id_map() {
 
 void SegmentIterator::_init_project_schema() {
     _init_schema_block_id_map();
-    DORIS_CHECK(_opts.project_columns != nullptr);
-    if (*_opts.project_columns == _schema->column_ids()) {
+    // Direct Segment::new_iterator callers use the input schema as the project layout.
+    const auto& project_column_ids =
+            _opts.project_columns != nullptr ? *_opts.project_columns : _schema->column_ids();
+    if (project_column_ids == _schema->column_ids()) {
         _project_schema = _schema;
     } else {
         _project_schema =
-                std::make_shared<Schema>(_opts.tablet_schema->columns(), *_opts.project_columns);
+                std::make_shared<Schema>(_opts.tablet_schema->columns(), project_column_ids);
     }
 }
 

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -480,7 +480,8 @@ void SegmentIterator::_init_schema_block_id_map() {
 
 void SegmentIterator::_init_project_schema() {
     _init_schema_block_id_map();
-    if (_opts.project_columns == nullptr || *_opts.project_columns == _schema->column_ids()) {
+    DORIS_CHECK(_opts.project_columns != nullptr);
+    if (*_opts.project_columns == _schema->column_ids()) {
         _project_schema = _schema;
     } else {
         _project_schema =
@@ -488,11 +489,9 @@ void SegmentIterator::_init_project_schema() {
     }
 }
 
-Block* SegmentIterator::_build_project_block(Block* block, Block* project_block) {
+void SegmentIterator::_build_project_block(Block* block, Block* project_block) {
     DORIS_CHECK(_project_schema != nullptr);
-    if (_project_schema == _schema) {
-        return block;
-    }
+    DORIS_CHECK(_project_schema != _schema);
 
     project_block->clear();
     const auto& project_column_ids = _project_schema->column_ids();
@@ -509,7 +508,6 @@ Block* SegmentIterator::_build_project_block(Block* block, Block* project_block)
         }
         project_block->insert({std::move(column), type, _schema->column(cid)->name()});
     }
-    return project_block;
 }
 
 void SegmentIterator::_initialize_predicate_results() {
@@ -928,6 +926,7 @@ Status SegmentIterator::_apply_ann_topn_predicate() {
 
     VLOG_DEBUG << fmt::format("Try apply ann topn: {}", _ann_topn_runtime->debug_string());
     size_t src_col_idx = _ann_topn_runtime->get_src_column_idx();
+    // AnnTopNRuntime keeps VSlotRef::column_id(), which is the project block ordinal.
     ColumnId src_cid = _project_schema->column_id(src_col_idx);
     IndexIterator* ann_index_iterator = _index_iterators[src_cid].get();
     bool has_ann_index = _column_has_ann_index(src_cid);
@@ -3108,7 +3107,11 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
     SCOPED_RAW_TIMER(&_opts.stats->expr_filter_ns);
     DCHECK(!_common_expr_ctxs_push_down.empty());
     Block project_block;
-    Block* expr_block = _build_project_block(block, &project_block);
+    Block* expr_block = block;
+    if (_project_schema != _schema) {
+        _build_project_block(block, &project_block);
+        expr_block = &project_block;
+    }
     std::vector<VExprContext*> common_ctxs;
     common_ctxs.reserve(_common_expr_ctxs_push_down.size());
     for (auto& ctx : _common_expr_ctxs_push_down) {
@@ -3495,8 +3498,12 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     }
 
     Block project_block;
-    Block* materialize_block = _build_project_block(block, &project_block);
     const bool materialize_on_project_block = _project_schema != _schema;
+    Block* materialize_block = block;
+    if (materialize_on_project_block) {
+        _build_project_block(block, &project_block);
+        materialize_block = &project_block;
+    }
     for (const auto& cid_and_expr : _virtual_column_exprs) {
         auto cid = cid_and_expr.first;
         auto column_expr = cid_and_expr.second;

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -412,7 +412,7 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
     _vir_cid_to_idx_in_block = _opts.vir_cid_to_idx_in_block;
     _score_runtime = _opts.score_runtime;
     _ann_topn_runtime = _opts.ann_topn_runtime;
-    RETURN_IF_ERROR(_init_project_schema());
+    _init_project_schema();
 
     if (opts.output_columns != nullptr) {
         _output_columns = *(opts.output_columns);
@@ -478,7 +478,7 @@ void SegmentIterator::_init_schema_block_id_map() {
     }
 }
 
-Status SegmentIterator::_init_project_schema() {
+void SegmentIterator::_init_project_schema() {
     _init_schema_block_id_map();
     if (_opts.project_columns == nullptr || *_opts.project_columns == _schema->column_ids()) {
         _project_schema = _schema;
@@ -486,16 +486,12 @@ Status SegmentIterator::_init_project_schema() {
         _project_schema =
                 std::make_shared<Schema>(_opts.tablet_schema->columns(), *_opts.project_columns);
     }
-    return Status::OK();
 }
 
-Status SegmentIterator::_build_project_block(Block* block, Block* project_block,
-                                             Block** project_block_or_origin) {
-    DORIS_CHECK(project_block_or_origin != nullptr);
+Block* SegmentIterator::_build_project_block(Block* block, Block* project_block) {
     DORIS_CHECK(_project_schema != nullptr);
     if (_project_schema == _schema) {
-        *project_block_or_origin = block;
-        return Status::OK();
+        return block;
     }
 
     project_block->clear();
@@ -512,20 +508,7 @@ Status SegmentIterator::_build_project_block(Block* block, Block* project_block,
         }
         project_block->insert({std::move(column), type, _schema->column(cid)->name()});
     }
-    *project_block_or_origin = project_block;
-    return Status::OK();
-}
-
-void SegmentIterator::_sync_project_block_column(Block* project_block, ColumnId cid,
-                                                 const ColumnPtr& column) {
-    if (_project_schema == _schema) {
-        return;
-    }
-    const auto& project_column_ids = _project_schema->column_ids();
-    auto it = std::find(project_column_ids.begin(), project_column_ids.end(), cid);
-    DORIS_CHECK(it != project_column_ids.end());
-    project_block->replace_by_position(
-            static_cast<size_t>(std::distance(project_column_ids.begin(), it)), column);
+    return project_block;
 }
 
 void SegmentIterator::_initialize_predicate_results() {
@@ -3124,8 +3107,7 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
     SCOPED_RAW_TIMER(&_opts.stats->expr_filter_ns);
     DCHECK(!_common_expr_ctxs_push_down.empty());
     Block project_block;
-    Block* project_block_or_origin = nullptr;
-    RETURN_IF_ERROR(_build_project_block(block, &project_block, &project_block_or_origin));
+    Block* expr_block = _build_project_block(block, &project_block);
     std::vector<VExprContext*> common_ctxs;
     common_ctxs.reserve(_common_expr_ctxs_push_down.size());
     for (auto& ctx : _common_expr_ctxs_push_down) {
@@ -3139,8 +3121,8 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
     IColumn::Filter filter(selected_size, 1);
     bool can_filter_all = false;
     for (const auto& ctx : _common_expr_ctxs_push_down) {
-        RETURN_IF_ERROR(ctx->execute_filter(project_block_or_origin, filter.data(), selected_size,
-                                            false, &can_filter_all));
+        RETURN_IF_ERROR(ctx->execute_filter(expr_block, filter.data(), selected_size, false,
+                                            &can_filter_all));
         if (can_filter_all) {
             break;
         }
@@ -3507,35 +3489,44 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
         }
         return Status::OK();
     }
+    if (_virtual_column_exprs.empty()) {
+        return Status::OK();
+    }
 
     Block project_block;
-    Block* project_block_or_origin = nullptr;
-    bool project_block_ready = false;
+    Block* materialize_block = _build_project_block(block, &project_block);
     for (const auto& cid_and_expr : _virtual_column_exprs) {
         auto cid = cid_and_expr.first;
         auto column_expr = cid_and_expr.second;
+        auto vir_it = _vir_cid_to_idx_in_block.find(cid);
+        DORIS_CHECK(vir_it != _vir_cid_to_idx_in_block.end());
         auto idx_in_block = _schema_block_id_map[cid];
-        auto& column = block->get_by_position(idx_in_block).column;
+        auto materialized_pos = _project_schema == _schema ? idx_in_block : vir_it->second;
+        auto& column = materialize_block->get_by_position(materialized_pos).column;
         if (check_and_get_column<const ColumnNothing>(column.get())) {
             VLOG_DEBUG << fmt::format("Virtual column is doing materialization, cid {}, col idx {}",
                                       cid, idx_in_block);
-            if (!project_block_ready) {
-                RETURN_IF_ERROR(
-                        _build_project_block(block, &project_block, &project_block_or_origin));
-                project_block_ready = true;
-            }
             ColumnPtr result_column;
             Status st;
             RETURN_IF_CATCH_EXCEPTION({
-                st = column_expr->root()->execute_column(column_expr.get(), project_block_or_origin,
+                st = column_expr->root()->execute_column(column_expr.get(), materialize_block,
                                                          nullptr, _selected_size, result_column);
             });
             RETURN_IF_ERROR(st);
 
-            auto project_column = result_column;
-            block->replace_by_position(idx_in_block, std::move(result_column));
-            _sync_project_block_column(&project_block, cid, project_column);
+            materialize_block->replace_by_position(materialized_pos, std::move(result_column));
         }
+    }
+    if (materialize_block == block) {
+        return Status::OK();
+    }
+    for (const auto& cid_and_expr : _virtual_column_exprs) {
+        auto cid = cid_and_expr.first;
+        auto idx_in_block = _schema_block_id_map[cid];
+        auto materialized_pos = _vir_cid_to_idx_in_block.at(cid);
+        const auto& column = project_block.get_by_position(materialized_pos).column;
+        DORIS_CHECK(!check_and_get_column<const ColumnNothing>(column.get()));
+        block->replace_by_position(idx_in_block, column);
     }
     return Status::OK();
 }

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -495,9 +495,10 @@ Block* SegmentIterator::_build_project_block(Block* block, Block* project_block)
     }
 
     project_block->clear();
-    for (auto cid : _project_schema->column_ids()) {
-        auto loc = _schema_block_id_map[cid];
-        auto& output_column = block->get_by_position(loc);
+    const auto& project_column_ids = _project_schema->column_ids();
+    for (size_t i = 0; i < project_column_ids.size(); ++i) {
+        auto cid = project_column_ids[i];
+        auto& output_column = block->get_by_position(i);
         auto type = output_column.type;
         auto column = output_column.column;
         auto virtual_it = _vir_cid_to_idx_in_block.find(cid);
@@ -2003,7 +2004,7 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
             }
 
             for (auto pair : _vir_cid_to_idx_in_block) {
-                _columns_to_filter.push_back(_schema_block_id_map[pair.first]);
+                _columns_to_filter.push_back(cast_set<ColumnId>(pair.second));
             }
         }
     }
@@ -2757,9 +2758,8 @@ Status SegmentIterator::next_batch(Block* block) {
                 // So a replacement of nothing column with real column is needed.
                 const auto& idx_to_datatype = _opts.vir_col_idx_to_type;
                 for (const auto& pair : _vir_cid_to_idx_in_block) {
-                    auto idx = _schema_block_id_map[pair.first];
                     auto type = idx_to_datatype.find(pair.second)->second;
-                    block->replace_by_position(idx, type->create_column());
+                    block->replace_by_position(pair.second, type->create_column());
                 }
 
                 if (_opts.condition_cache_digest && !_find_condition_cache) {
@@ -3470,8 +3470,7 @@ bool SegmentIterator::_can_opt_limit_reads() {
 // Before get next batch. make sure all virtual columns in block has type ColumnNothing.
 void SegmentIterator::_init_virtual_columns(Block* block) {
     for (const auto& pair : _vir_cid_to_idx_in_block) {
-        auto idx = _schema_block_id_map[pair.first];
-        auto& col_with_type_and_name = block->get_by_position(idx);
+        auto& col_with_type_and_name = block->get_by_position(pair.second);
         col_with_type_and_name.column = ColumnNothing::create(0);
         col_with_type_and_name.type = _opts.vir_col_idx_to_type[pair.second];
     }
@@ -3482,8 +3481,7 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     // So materialize virtual column in advance to avoid errors.
     if (_selected_size == 0) {
         for (const auto& pair : _vir_cid_to_idx_in_block) {
-            auto idx = _schema_block_id_map[pair.first];
-            auto& col_with_type_and_name = block->get_by_position(idx);
+            auto& col_with_type_and_name = block->get_by_position(pair.second);
             col_with_type_and_name.column = _opts.vir_col_idx_to_type[pair.second]->create_column();
             col_with_type_and_name.type = _opts.vir_col_idx_to_type[pair.second];
         }
@@ -3519,11 +3517,10 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     if (materialize_block != block) {
         for (const auto& cid_and_expr : _virtual_column_exprs) {
             auto cid = cid_and_expr.first;
-            auto idx_in_block = _schema_block_id_map[cid];
             auto materialized_pos = _vir_cid_to_idx_in_block.at(cid);
             const auto& column = project_block.get_by_position(materialized_pos).column;
             DORIS_CHECK(!check_and_get_column<const ColumnNothing>(column.get()));
-            block->replace_by_position(idx_in_block, column);
+            block->replace_by_position(materialized_pos, column);
         }
     }
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -484,8 +484,7 @@ Status SegmentIterator::_init_project_schema() {
     return Status::OK();
 }
 
-Status SegmentIterator::_build_project_block(Block* block, uint16_t selected_size,
-                                             Block* project_block) {
+Status SegmentIterator::_build_project_block(Block* block, Block* project_block) {
     project_block->clear();
     DORIS_CHECK(_project_schema != nullptr);
     for (auto cid : _project_schema->column_ids()) {
@@ -498,22 +497,6 @@ Status SegmentIterator::_build_project_block(Block* block, uint16_t selected_siz
             auto type_it = _opts.vir_col_idx_to_type.find(virtual_it->second);
             DORIS_CHECK(type_it != _opts.vir_col_idx_to_type.end());
             type = type_it->second;
-            if (!column || check_and_get_column<const ColumnNothing>(column.get()) ||
-                column->size() != selected_size) {
-                column = ColumnNothing::create(selected_size);
-            }
-        } else {
-            if (!type) {
-                type = Schema::get_data_type_ptr(*_schema->column(cid));
-            }
-            if (!column) {
-                return Status::InternalError(
-                        "project column {} is not materialized before project block build", cid);
-            }
-            if (column->size() != selected_size) {
-                return Status::InternalError("project column {} has {} rows, expected {}", cid,
-                                             column->size(), selected_size);
-            }
         }
         project_block->insert({std::move(column), type, _schema->column(cid)->name()});
     }
@@ -3023,7 +3006,7 @@ Status SegmentIterator::_next_batch_internal(Block* block) {
         for (auto& [cid, ctx] : _virtual_column_exprs) {
             vir_ctxs.push_back(ctx.get());
         }
-        _output_index_result_column(vir_ctxs, sel_rowid_idx, _selected_size, block);
+        _output_index_result_column(vir_ctxs, sel_rowid_idx, _selected_size);
     }
     RETURN_IF_ERROR(_materialization_of_virtual_column(block));
     if (_opts.read_limit > 0) {
@@ -3114,26 +3097,10 @@ Status SegmentIterator::_process_eof(Block* block) {
 
 Status SegmentIterator::_process_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size,
                                              Block* block) {
-    // Here we just use col0 as row_number indicator. when reach here, we will calculate the predicates first.
-    //  then use the result to reduce our data read(that is, expr push down). there's now row in block means the first
-    //  column is not in common expr. so it's safe to replace it temporarily to provide correct `selected_size`.
     VLOG_DEBUG << fmt::format("Execute common expr. block rows {}, selected size {}", block->rows(),
                               _selected_size);
 
-    bool need_mock_col = block->rows() != selected_size;
-    MutableColumnPtr col0;
-    if (need_mock_col) {
-        col0 = std::move(*block->get_by_position(0).column).mutate();
-        block->replace_by_position(
-                0, block->get_by_position(0).type->create_column_const_with_default_value(
-                           _selected_size));
-    }
-
-    RETURN_IF_ERROR(_execute_common_expr(_sel_rowid_idx.data(), _selected_size, block));
-
-    if (need_mock_col) {
-        block->replace_by_position(0, std::move(col0));
-    }
+    RETURN_IF_ERROR(_execute_common_expr(sel_rowid_idx, selected_size, block));
 
     VLOG_DEBUG << fmt::format("Execute common expr end. block rows {}, selected size {}",
                               block->rows(), _selected_size);
@@ -3145,25 +3112,26 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
     SCOPED_RAW_TIMER(&_opts.stats->expr_filter_ns);
     DCHECK(!_common_expr_ctxs_push_down.empty());
     Block project_block;
-    RETURN_IF_ERROR(_build_project_block(block, selected_size, &project_block));
+    RETURN_IF_ERROR(_build_project_block(block, &project_block));
     std::vector<VExprContext*> common_ctxs;
     common_ctxs.reserve(_common_expr_ctxs_push_down.size());
     for (auto& ctx : _common_expr_ctxs_push_down) {
         common_ctxs.push_back(ctx.get());
     }
-    _output_index_result_column(common_ctxs, sel_rowid_idx, selected_size, &project_block);
+    _output_index_result_column(common_ctxs, sel_rowid_idx, selected_size);
 
-    DCHECK(project_block.rows() != 0);
-    int prev_columns = project_block.columns();
     uint16_t original_size = selected_size;
     _opts.stats->expr_cond_input_rows += original_size;
 
-    IColumn::Filter filter;
-    std::vector<uint32_t> expr_columns_to_filter(prev_columns);
-    std::iota(expr_columns_to_filter.begin(), expr_columns_to_filter.end(), 0);
-    RETURN_IF_ERROR(VExprContext::execute_conjuncts_and_filter_block(
-            _common_expr_ctxs_push_down, &project_block, expr_columns_to_filter, prev_columns,
-            filter));
+    IColumn::Filter filter(selected_size, 1);
+    bool can_filter_all = false;
+    for (const auto& ctx : _common_expr_ctxs_push_down) {
+        RETURN_IF_ERROR(ctx->execute_filter(&project_block, filter.data(), selected_size, false,
+                                            &can_filter_all));
+        if (can_filter_all) {
+            break;
+        }
+    }
     RETURN_IF_CATCH_EXCEPTION(Block::filter_block_internal(block, _columns_to_filter, filter));
 
     selected_size = _evaluate_common_expr_filter(sel_rowid_idx, selected_size, filter);
@@ -3214,10 +3182,9 @@ uint16_t SegmentIterator::_evaluate_common_expr_filter(uint16_t* sel_rowid_idx,
 }
 
 void SegmentIterator::_output_index_result_column(const std::vector<VExprContext*>& expr_ctxs,
-                                                  uint16_t* sel_rowid_idx, uint16_t select_size,
-                                                  Block* block) {
+                                                  uint16_t* sel_rowid_idx, uint16_t select_size) {
     SCOPED_RAW_TIMER(&_opts.stats->output_index_result_column_timer);
-    if (block->rows() == 0) {
+    if (select_size == 0) {
         return;
     }
     for (auto* expr_ctx_ptr : expr_ctxs) {
@@ -3231,7 +3198,7 @@ void SegmentIterator::_output_index_result_column(const std::vector<VExprContext
             const auto& index_result_bitmap = result_bitmap.get_data_bitmap();
             auto index_result_column = ColumnUInt8::create();
             ColumnUInt8::Container& vec_match_pred = index_result_column->get_data();
-            vec_match_pred.resize(block->rows());
+            vec_match_pred.resize(select_size);
             std::fill(vec_match_pred.begin(), vec_match_pred.end(), 0);
 
             const auto& null_bitmap = result_bitmap.get_null_bitmap();
@@ -3243,7 +3210,7 @@ void SegmentIterator::_output_index_result_column(const std::vector<VExprContext
             if (has_null_bitmap && expr_returns_nullable) {
                 null_map_column = ColumnUInt8::create();
                 auto& null_map_vec = null_map_column->get_data();
-                null_map_vec.resize(block->rows());
+                null_map_vec.resize(select_size);
                 std::fill(null_map_vec.begin(), null_map_vec.end(), 0);
                 null_map_data = &null_map_column->get_data();
             }
@@ -3260,7 +3227,7 @@ void SegmentIterator::_output_index_result_column(const std::vector<VExprContext
                 }
             }
 
-            DCHECK(block->rows() == vec_match_pred.size());
+            DCHECK(select_size == vec_match_pred.size());
 
             if (null_map_column) {
                 index_ctx->set_index_result_column_for_expr(
@@ -3518,7 +3485,7 @@ void SegmentIterator::_init_virtual_columns(Block* block) {
 Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
     // Some expr can not process empty block, such as function `element_at`.
     // So materialize virtual column in advance to avoid errors.
-    if (block->rows() == 0) {
+    if (_selected_size == 0) {
         for (const auto& pair : _vir_cid_to_idx_in_block) {
             auto idx = _schema_block_id_map[pair.first];
             auto& col_with_type_and_name = block->get_by_position(idx);
@@ -3532,28 +3499,17 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
         auto cid = cid_and_expr.first;
         auto column_expr = cid_and_expr.second;
         auto idx_in_block = _schema_block_id_map[cid];
-        if (block->get_by_position(idx_in_block).column.get() == nullptr) {
-            return Status::InternalError(
-                    "Virtual column index {} is null, block columns {}, virtual columns size {}, "
-                    "virtual column expr {}",
-                    idx_in_block, block->columns(), _vir_cid_to_idx_in_block.size(),
-                    column_expr->root()->debug_string());
-        }
-        if (check_and_get_column<const ColumnNothing>(
-                    block->get_by_position(idx_in_block).column.get())) {
+        auto& column = block->get_by_position(idx_in_block).column;
+        if (check_and_get_column<const ColumnNothing>(column.get())) {
             VLOG_DEBUG << fmt::format("Virtual column is doing materialization, cid {}, col idx {}",
                                       cid, idx_in_block);
             ColumnPtr result_column;
             Block project_block;
-            RETURN_IF_ERROR(
-                    _build_project_block(block, cast_set<uint16_t>(block->rows()), &project_block));
-            RETURN_IF_ERROR(column_expr->execute(&project_block, result_column));
+            RETURN_IF_ERROR(_build_project_block(block, &project_block));
+            RETURN_IF_ERROR(column_expr->root()->execute_column(
+                    column_expr.get(), &project_block, nullptr, _selected_size, result_column));
 
             block->replace_by_position(idx_in_block, std::move(result_column));
-            if (block->get_by_position(idx_in_block).column->size() == 0) {
-                LOG_WARNING("Result of expr column {} is empty. cid {}, idx_in_block {}",
-                            column_expr->root()->debug_string(), cid, idx_in_block);
-            }
         }
     }
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -3495,17 +3495,16 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
 
     Block project_block;
     Block* materialize_block = _build_project_block(block, &project_block);
+    const bool materialize_on_project_block = _project_schema != _schema;
     for (const auto& cid_and_expr : _virtual_column_exprs) {
         auto cid = cid_and_expr.first;
         auto column_expr = cid_and_expr.second;
-        auto vir_it = _vir_cid_to_idx_in_block.find(cid);
-        DORIS_CHECK(vir_it != _vir_cid_to_idx_in_block.end());
-        auto idx_in_block = _schema_block_id_map[cid];
-        auto materialized_pos = _project_schema == _schema ? idx_in_block : vir_it->second;
+        auto materialized_pos = materialize_on_project_block ? _vir_cid_to_idx_in_block.at(cid)
+                                                             : _schema_block_id_map[cid];
         auto& column = materialize_block->get_by_position(materialized_pos).column;
         if (check_and_get_column<const ColumnNothing>(column.get())) {
             VLOG_DEBUG << fmt::format("Virtual column is doing materialization, cid {}, col idx {}",
-                                      cid, idx_in_block);
+                                      cid, materialized_pos);
             ColumnPtr result_column;
             Status st;
             RETURN_IF_CATCH_EXCEPTION({
@@ -3517,16 +3516,15 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
             materialize_block->replace_by_position(materialized_pos, std::move(result_column));
         }
     }
-    if (materialize_block == block) {
-        return Status::OK();
-    }
-    for (const auto& cid_and_expr : _virtual_column_exprs) {
-        auto cid = cid_and_expr.first;
-        auto idx_in_block = _schema_block_id_map[cid];
-        auto materialized_pos = _vir_cid_to_idx_in_block.at(cid);
-        const auto& column = project_block.get_by_position(materialized_pos).column;
-        DORIS_CHECK(!check_and_get_column<const ColumnNothing>(column.get()));
-        block->replace_by_position(idx_in_block, column);
+    if (materialize_block != block) {
+        for (const auto& cid_and_expr : _virtual_column_exprs) {
+            auto cid = cid_and_expr.first;
+            auto idx_in_block = _schema_block_id_map[cid];
+            auto materialized_pos = _vir_cid_to_idx_in_block.at(cid);
+            const auto& column = project_block.get_by_position(materialized_pos).column;
+            DORIS_CHECK(!check_and_get_column<const ColumnNothing>(column.get()));
+            block->replace_by_position(idx_in_block, column);
+        }
     }
     return Status::OK();
 }

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -470,23 +470,35 @@ Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
     return Status::OK();
 }
 
-Status SegmentIterator::_init_project_schema() {
+void SegmentIterator::_init_schema_block_id_map() {
     _schema_block_id_map.assign(_schema->columns().size(), -1);
     for (int i = 0; i < _schema->num_column_ids(); i++) {
         auto cid = _schema->column_id(i);
         _schema_block_id_map[cid] = i;
     }
+}
 
-    _project_schema = _opts.project_columns != nullptr
-                              ? std::make_shared<Schema>(_opts.tablet_schema->columns(),
-                                                         *_opts.project_columns)
-                              : _schema;
+Status SegmentIterator::_init_project_schema() {
+    _init_schema_block_id_map();
+    if (_opts.project_columns == nullptr || *_opts.project_columns == _schema->column_ids()) {
+        _project_schema = _schema;
+    } else {
+        _project_schema =
+                std::make_shared<Schema>(_opts.tablet_schema->columns(), *_opts.project_columns);
+    }
     return Status::OK();
 }
 
-Status SegmentIterator::_build_project_block(Block* block, Block* project_block) {
-    project_block->clear();
+Status SegmentIterator::_build_project_block(Block* block, Block* project_block,
+                                             Block** project_block_or_origin) {
+    DORIS_CHECK(project_block_or_origin != nullptr);
     DORIS_CHECK(_project_schema != nullptr);
+    if (_project_schema == _schema) {
+        *project_block_or_origin = block;
+        return Status::OK();
+    }
+
+    project_block->clear();
     for (auto cid : _project_schema->column_ids()) {
         auto loc = _schema_block_id_map[cid];
         auto& output_column = block->get_by_position(loc);
@@ -500,7 +512,20 @@ Status SegmentIterator::_build_project_block(Block* block, Block* project_block)
         }
         project_block->insert({std::move(column), type, _schema->column(cid)->name()});
     }
+    *project_block_or_origin = project_block;
     return Status::OK();
+}
+
+void SegmentIterator::_sync_project_block_column(Block* project_block, ColumnId cid,
+                                                 const ColumnPtr& column) {
+    if (_project_schema == _schema) {
+        return;
+    }
+    const auto& project_column_ids = _project_schema->column_ids();
+    auto it = std::find(project_column_ids.begin(), project_column_ids.end(), cid);
+    DORIS_CHECK(it != project_column_ids.end());
+    project_block->replace_by_position(
+            static_cast<size_t>(std::distance(project_column_ids.begin(), it)), column);
 }
 
 void SegmentIterator::_initialize_predicate_results() {
@@ -1976,19 +2001,6 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
         _is_need_short_eval = true;
     }
 
-    // ColumnId to column index in block
-    // ColumnId will contail all columns in tablet schema, including virtual columns and global rowid column,
-    _schema_block_id_map.assign(_schema->columns().size(), -1);
-    // Use cols read by query to initialize _schema_block_id_map.
-    // We need to know the index of each column in the block.
-    // There is an assumption here that the columns in the block are in the same order as in the read schema.
-    // TODO: A probelm is that, delete condition columns will exist in _schema->column_ids but not in block if
-    // delete column is not read by the query.
-    for (int i = 0; i < _schema->num_column_ids(); i++) {
-        auto cid = _schema->column_id(i);
-        _schema_block_id_map[cid] = i;
-    }
-
     // Step2: extract columns that can execute expr context
     _is_common_expr_column.resize(_schema->columns().size(), false);
     if (!_common_expr_ctxs_push_down.empty()) {
@@ -3112,7 +3124,8 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
     SCOPED_RAW_TIMER(&_opts.stats->expr_filter_ns);
     DCHECK(!_common_expr_ctxs_push_down.empty());
     Block project_block;
-    RETURN_IF_ERROR(_build_project_block(block, &project_block));
+    Block* project_block_or_origin = nullptr;
+    RETURN_IF_ERROR(_build_project_block(block, &project_block, &project_block_or_origin));
     std::vector<VExprContext*> common_ctxs;
     common_ctxs.reserve(_common_expr_ctxs_push_down.size());
     for (auto& ctx : _common_expr_ctxs_push_down) {
@@ -3126,8 +3139,8 @@ Status SegmentIterator::_execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& 
     IColumn::Filter filter(selected_size, 1);
     bool can_filter_all = false;
     for (const auto& ctx : _common_expr_ctxs_push_down) {
-        RETURN_IF_ERROR(ctx->execute_filter(&project_block, filter.data(), selected_size, false,
-                                            &can_filter_all));
+        RETURN_IF_ERROR(ctx->execute_filter(project_block_or_origin, filter.data(), selected_size,
+                                            false, &can_filter_all));
         if (can_filter_all) {
             break;
         }
@@ -3495,6 +3508,9 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
         return Status::OK();
     }
 
+    Block project_block;
+    Block* project_block_or_origin = nullptr;
+    bool project_block_ready = false;
     for (const auto& cid_and_expr : _virtual_column_exprs) {
         auto cid = cid_and_expr.first;
         auto column_expr = cid_and_expr.second;
@@ -3503,13 +3519,22 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
         if (check_and_get_column<const ColumnNothing>(column.get())) {
             VLOG_DEBUG << fmt::format("Virtual column is doing materialization, cid {}, col idx {}",
                                       cid, idx_in_block);
+            if (!project_block_ready) {
+                RETURN_IF_ERROR(
+                        _build_project_block(block, &project_block, &project_block_or_origin));
+                project_block_ready = true;
+            }
             ColumnPtr result_column;
-            Block project_block;
-            RETURN_IF_ERROR(_build_project_block(block, &project_block));
-            RETURN_IF_ERROR(column_expr->root()->execute_column(
-                    column_expr.get(), &project_block, nullptr, _selected_size, result_column));
+            Status st;
+            RETURN_IF_CATCH_EXCEPTION({
+                st = column_expr->root()->execute_column(column_expr.get(), project_block_or_origin,
+                                                         nullptr, _selected_size, result_column);
+            });
+            RETURN_IF_ERROR(st);
 
+            auto project_column = result_column;
             block->replace_by_position(idx_in_block, std::move(result_column));
+            _sync_project_block_column(&project_block, cid, project_column);
         }
     }
     return Status::OK();

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -275,10 +275,8 @@ private:
     bool _can_evaluated_by_vectorized(std::shared_ptr<ColumnPredicate> predicate);
 
     [[nodiscard]] Status _init_project_schema();
-    [[nodiscard]] Status _build_project_block(Block* block, uint16_t selected_size,
-                                              Block* project_block);
+    [[nodiscard]] Status _build_project_block(Block* block, Block* project_block);
     [[nodiscard]] Status _extract_common_expr_columns(const VExprSPtr& expr);
-    // same with _extract_common_expr_columns, but only extract columns that can be used for index
     [[nodiscard]] Status _execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size,
                                               Block* block);
     Status _process_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size, Block* block);
@@ -295,7 +293,7 @@ private:
     bool _check_apply_by_inverted_index(std::shared_ptr<ColumnPredicate> pred);
 
     void _output_index_result_column(const std::vector<VExprContext*>& expr_ctxs,
-                                     uint16_t* sel_rowid_idx, uint16_t select_size, Block* block);
+                                     uint16_t* sel_rowid_idx, uint16_t select_size);
 
     bool _need_read_data(ColumnId cid);
     bool _prune_column(ColumnId cid, MutableColumnPtr& column, bool fill_defaults,

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -275,10 +275,8 @@ private:
     bool _can_evaluated_by_vectorized(std::shared_ptr<ColumnPredicate> predicate);
 
     void _init_schema_block_id_map();
-    [[nodiscard]] Status _init_project_schema();
-    [[nodiscard]] Status _build_project_block(Block* block, Block* project_block,
-                                              Block** project_block_or_origin);
-    void _sync_project_block_column(Block* project_block, ColumnId cid, const ColumnPtr& column);
+    void _init_project_schema();
+    Block* _build_project_block(Block* block, Block* project_block);
     [[nodiscard]] Status _extract_common_expr_columns(const VExprSPtr& expr);
     [[nodiscard]] Status _execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size,
                                               Block* block);

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -276,7 +276,7 @@ private:
 
     void _init_schema_block_id_map();
     void _init_project_schema();
-    Block* _build_project_block(Block* block, Block* project_block);
+    void _build_project_block(Block* block, Block* project_block);
     [[nodiscard]] Status _extract_common_expr_columns(const VExprSPtr& expr);
     [[nodiscard]] Status _execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size,
                                               Block* block);

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -274,8 +274,11 @@ private:
 
     bool _can_evaluated_by_vectorized(std::shared_ptr<ColumnPredicate> predicate);
 
+    void _init_schema_block_id_map();
     [[nodiscard]] Status _init_project_schema();
-    [[nodiscard]] Status _build_project_block(Block* block, Block* project_block);
+    [[nodiscard]] Status _build_project_block(Block* block, Block* project_block,
+                                              Block** project_block_or_origin);
+    void _sync_project_block_column(Block* project_block, ColumnId cid, const ColumnPtr& column);
     [[nodiscard]] Status _extract_common_expr_columns(const VExprSPtr& expr);
     [[nodiscard]] Status _execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size,
                                               Block* block);

--- a/be/src/storage/segment/segment_iterator.h
+++ b/be/src/storage/segment/segment_iterator.h
@@ -274,6 +274,9 @@ private:
 
     bool _can_evaluated_by_vectorized(std::shared_ptr<ColumnPredicate> predicate);
 
+    [[nodiscard]] Status _init_project_schema();
+    [[nodiscard]] Status _build_project_block(Block* block, uint16_t selected_size,
+                                              Block* project_block);
     [[nodiscard]] Status _extract_common_expr_columns(const VExprSPtr& expr);
     // same with _extract_common_expr_columns, but only extract columns that can be used for index
     [[nodiscard]] Status _execute_common_expr(uint16_t* sel_rowid_idx, uint16_t& selected_size,
@@ -349,6 +352,8 @@ private:
     std::shared_ptr<Segment> _segment;
     // read schema from scanner
     SchemaSPtr _schema;
+    // final scan project schema before storage-side read schema expansion
+    SchemaSPtr _project_schema;
     // storage type schema related to _schema, since column in segment may be different with type in _schema
     std::vector<IndexFieldNameAndTypePair> _storage_name_and_type;
     // vector idx -> column iterarator


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary: Storage expression pushdown previously rebound slot refs to the expanded reader schema by mutating expression column ids inside segment iterators. That violates the assumption that pushed-down expressions are immutable and can produce surprising behavior when the same expression objects are reused. This change keeps the full scan schema unchanged, adds a project schema aligned with the final projected columns, and evaluates pushed-down expressions against a temporary project block. Slot ordinal to tablet column id mapping now uses the project schema, so no expression mutation is required.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - ./build.sh --be
- Behavior changed: No
- Does this need documentation: No
