### PR TITLE
[opt](function) speed up multi_search_all_positions

### DIFF
--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -26,6 +26,7 @@
 #include "benchmark_fastunion.hpp"
 #include "benchmark_hll_merge.hpp"
 #include "benchmark_hybrid_set.hpp"
+#include "benchmark_multi_search_all_positions.hpp"
 #include "benchmark_string.hpp"
 #include "benchmark_string_replace.hpp"
 #include "benchmark_zone_map_index.hpp"

--- a/be/benchmark/benchmark_multi_search_all_positions.hpp
+++ b/be/benchmark/benchmark_multi_search_all_positions.hpp
@@ -1,0 +1,278 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "common/logging.h"
+#include "core/column/column_string.h"
+#include "exec/common/multi_string_searcher.h"
+#include "exec/common/string_searcher.h"
+
+namespace doris {
+
+namespace {
+
+struct MultiSearchDataset {
+    ColumnString::Chars haystack_data;
+    ColumnString::Offsets haystack_offsets;
+    std::vector<std::string> needle_storage;
+    std::vector<std::string_view> needles;
+};
+
+enum class HitMode {
+    NO_HIT,
+    RARE_HIT,
+    LAST_NEEDLE_HIT,
+};
+
+static std::string make_needle(size_t index, size_t needle_size = 8) {
+    std::string needle(needle_size, 'a');
+    for (size_t i = 0; i < needle_size; ++i) {
+        needle[i] = static_cast<char>('a' + ((index * 7 + i * 11) % 26));
+    }
+    return needle;
+}
+
+static MultiSearchDataset build_multi_search_dataset(size_t rows, size_t row_len,
+                                                     size_t needle_count, HitMode hit_mode) {
+    MultiSearchDataset dataset;
+    dataset.haystack_offsets.resize(rows);
+    dataset.haystack_data.reserve(rows * row_len);
+    dataset.needle_storage.reserve(needle_count);
+    dataset.needles.reserve(needle_count);
+
+    for (size_t i = 0; i < needle_count; ++i) {
+        dataset.needle_storage.emplace_back(make_needle(i));
+    }
+    for (const auto& needle : dataset.needle_storage) {
+        dataset.needles.emplace_back(needle);
+    }
+
+    std::mt19937 rng(20260602);
+    std::uniform_int_distribution<int> char_dist(0, 25);
+    std::uniform_int_distribution<size_t> needle_dist(0, needle_count - 1);
+
+    size_t offset = 0;
+    for (size_t row = 0; row < rows; ++row) {
+        std::string value(row_len, 'a');
+        for (size_t i = 0; i < row_len; ++i) {
+            value[i] = static_cast<char>('A' + char_dist(rng));
+        }
+
+        if (hit_mode == HitMode::RARE_HIT && row % 16 == 0 && row_len >= 16) {
+            const size_t needle_index = needle_dist(rng);
+            const auto& needle = dataset.needle_storage[needle_index];
+            const size_t pos = (row * 131) % (row_len - needle.size() + 1);
+            std::memcpy(value.data() + pos, needle.data(), needle.size());
+        } else if (hit_mode == HitMode::LAST_NEEDLE_HIT && row_len >= 16) {
+            const auto& needle = dataset.needle_storage.back();
+            const size_t pos = row_len - needle.size();
+            std::memcpy(value.data() + pos, needle.data(), needle.size());
+        }
+
+        dataset.haystack_data.insert(value.data(), value.data() + value.size());
+        offset += value.size();
+        dataset.haystack_offsets[row] = static_cast<ColumnString::Offset>(offset);
+    }
+
+    return dataset;
+}
+
+static void multi_search_all_positions_old(const ColumnString::Chars& haystack_data,
+                                           const ColumnString::Offsets& haystack_offsets,
+                                           const std::vector<std::string_view>& needles,
+                                           std::vector<Int32>& result) {
+    std::vector<ASCIICaseSensitiveStringSearcher> searchers;
+    searchers.reserve(needles.size());
+    for (const auto needle : needles) {
+        searchers.emplace_back(needle.data(), needle.size());
+    }
+
+    const size_t rows = haystack_offsets.size();
+    const size_t needle_count = needles.size();
+    result.assign(rows * needle_count, 0);
+
+    for (size_t needle_index = 0; needle_index < searchers.size(); ++needle_index) {
+        const auto& searcher = searchers[needle_index];
+        size_t prev_haystack_offset = 0;
+
+        for (size_t row = 0, result_index = needle_index; row < rows;
+             ++row, result_index += needle_count) {
+            const auto* haystack = haystack_data.data() + prev_haystack_offset;
+            const auto* haystack_end = haystack_data.data() + haystack_offsets[row];
+            const auto* match = searcher.search(haystack, haystack_end);
+            result[result_index] =
+                    match >= haystack_end ? 0 : static_cast<Int32>(match - haystack + 1);
+            prev_haystack_offset = haystack_offsets[row];
+        }
+    }
+}
+
+static void multi_search_all_positions_new(const ColumnString::Chars& haystack_data,
+                                           const ColumnString::Offsets& haystack_offsets,
+                                           const std::vector<std::string_view>& needles,
+                                           std::vector<Int32>& result) {
+    const size_t rows = haystack_offsets.size();
+    const size_t needle_count = needles.size();
+    result.assign(rows * needle_count, 0);
+
+    std::vector<StringRef> needle_refs;
+    needle_refs.reserve(needles.size());
+    for (const auto needle : needles) {
+        needle_refs.emplace_back(needle.data(), needle.size());
+    }
+
+    MultiStringSearcher searcher(needle_refs);
+    while (searcher.has_more_to_search()) {
+        size_t prev_haystack_offset = 0;
+        for (size_t row = 0; row < rows; ++row) {
+            const auto* haystack = haystack_data.data() + prev_haystack_offset;
+            const auto* haystack_end = haystack_data.data() + haystack_offsets[row];
+            searcher.search_one_all(reinterpret_cast<const uint8_t*>(haystack),
+                                    reinterpret_cast<const uint8_t*>(haystack_end),
+                                    result.data() + row * needle_count);
+            prev_haystack_offset = haystack_offsets[row];
+        }
+    }
+}
+
+static void verify_multi_search_results(const MultiSearchDataset& dataset) {
+    std::vector<Int32> old_result;
+    std::vector<Int32> new_result;
+    multi_search_all_positions_old(dataset.haystack_data, dataset.haystack_offsets, dataset.needles,
+                                   old_result);
+    multi_search_all_positions_new(dataset.haystack_data, dataset.haystack_offsets, dataset.needles,
+                                   new_result);
+    CHECK_EQ(old_result.size(), new_result.size());
+    for (size_t i = 0; i < old_result.size(); ++i) {
+        CHECK_EQ(old_result[i], new_result[i]) << "mismatch at result index " << i;
+    }
+}
+
+static void run_multi_search_old(benchmark::State& state, HitMode hit_mode) {
+    const size_t rows = 4096;
+    const size_t row_len = static_cast<size_t>(state.range(0));
+    const size_t needle_count = static_cast<size_t>(state.range(1));
+    const auto dataset = build_multi_search_dataset(rows, row_len, needle_count, hit_mode);
+    verify_multi_search_results(dataset);
+
+    std::vector<Int32> result;
+    for (auto _ : state) {
+        result.clear();
+        multi_search_all_positions_old(dataset.haystack_data, dataset.haystack_offsets,
+                                       dataset.needles, result);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(state.iterations() * rows * needle_count);
+}
+
+static void run_multi_search_new(benchmark::State& state, HitMode hit_mode) {
+    const size_t rows = 4096;
+    const size_t row_len = static_cast<size_t>(state.range(0));
+    const size_t needle_count = static_cast<size_t>(state.range(1));
+    const auto dataset = build_multi_search_dataset(rows, row_len, needle_count, hit_mode);
+    verify_multi_search_results(dataset);
+
+    std::vector<Int32> result;
+    for (auto _ : state) {
+        result.clear();
+        multi_search_all_positions_new(dataset.haystack_data, dataset.haystack_offsets,
+                                       dataset.needles, result);
+        benchmark::DoNotOptimize(result);
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(state.iterations() * rows * needle_count);
+}
+
+static void BM_MultiSearchAllPositions_Old_NoHit(benchmark::State& state) {
+    run_multi_search_old(state, HitMode::NO_HIT);
+}
+
+static void BM_MultiSearchAllPositions_New_NoHit(benchmark::State& state) {
+    run_multi_search_new(state, HitMode::NO_HIT);
+}
+
+static void BM_MultiSearchAllPositions_Old_RareHit(benchmark::State& state) {
+    run_multi_search_old(state, HitMode::RARE_HIT);
+}
+
+static void BM_MultiSearchAllPositions_New_RareHit(benchmark::State& state) {
+    run_multi_search_new(state, HitMode::RARE_HIT);
+}
+
+static void BM_MultiSearchAllPositions_Old_LastNeedleHit(benchmark::State& state) {
+    run_multi_search_old(state, HitMode::LAST_NEEDLE_HIT);
+}
+
+static void BM_MultiSearchAllPositions_New_LastNeedleHit(benchmark::State& state) {
+    run_multi_search_new(state, HitMode::LAST_NEEDLE_HIT);
+}
+
+} // namespace
+
+BENCHMARK(BM_MultiSearchAllPositions_Old_NoHit)
+        ->Args({64, 4})
+        ->Args({64, 16})
+        ->Args({1024, 16})
+        ->Args({32768, 16})
+        ->Args({1024, 64});
+BENCHMARK(BM_MultiSearchAllPositions_New_NoHit)
+        ->Args({64, 4})
+        ->Args({64, 16})
+        ->Args({1024, 16})
+        ->Args({32768, 16})
+        ->Args({1024, 64});
+
+BENCHMARK(BM_MultiSearchAllPositions_Old_RareHit)
+        ->Args({64, 4})
+        ->Args({64, 16})
+        ->Args({1024, 16})
+        ->Args({32768, 16})
+        ->Args({1024, 64});
+BENCHMARK(BM_MultiSearchAllPositions_New_RareHit)
+        ->Args({64, 4})
+        ->Args({64, 16})
+        ->Args({1024, 16})
+        ->Args({32768, 16})
+        ->Args({1024, 64});
+
+BENCHMARK(BM_MultiSearchAllPositions_Old_LastNeedleHit)
+        ->Args({64, 4})
+        ->Args({64, 16})
+        ->Args({1024, 16})
+        ->Args({32768, 16})
+        ->Args({1024, 64});
+BENCHMARK(BM_MultiSearchAllPositions_New_LastNeedleHit)
+        ->Args({64, 4})
+        ->Args({64, 16})
+        ->Args({1024, 16})
+        ->Args({32768, 16})
+        ->Args({1024, 64});
+
+} // namespace doris

--- a/be/src/exec/common/multi_string_searcher.h
+++ b/be/src/exec/common/multi_string_searcher.h
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "core/string_ref.h"
+#include "core/types.h"
+#include "exec/common/string_searcher.h"
+
+namespace doris {
+
+// Searches many literal needles in one haystack. The table stores 2-byte ngrams from a
+// batch of needles, so scanning the haystack can find candidates for many needles at once.
+class MultiStringSearcher {
+    using Offset = uint8_t;
+    using Id = uint8_t;
+    using Ngram = uint16_t;
+
+    // One table entry is one candidate ngram occurrence in a needle. It stores the global
+    // needle id and the 1-based offset of this ngram inside that needle. off == 0 means
+    // the slot is empty, so needle offsets are stored as 1-based values.
+    struct OffsetId {
+        Id id = 0;
+        Offset off = 0;
+    };
+
+public:
+    explicit MultiStringSearcher(const std::vector<StringRef>& needles)
+            : _needles(needles), _hash(new OffsetId[HASH_SIZE]) {
+        _searchers.reserve(_needles.size());
+        for (const auto& needle : _needles) {
+            _searchers.emplace_back(needle.data, needle.size);
+        }
+    }
+
+    bool has_more_to_search() {
+        if (_last == _needles.size()) {
+            return false;
+        }
+
+        std::memset(_hash.get(), 0, HASH_SIZE * sizeof(OffsetId));
+        _fallback_needles.clear();
+        _step = std::numeric_limits<size_t>::max();
+
+        // Not all needles are necessarily inserted in one table. Keeping the load factor
+        // low makes the linear-probing chains short; if the current batch reaches
+        // SMALL_LIMIT, the caller will scan all rows with this batch and call this method
+        // again for the next batch. _last is the global needle index of the next batch.
+        size_t ngrams = 0;
+        for (; _last < _needles.size(); ++_last) {
+            const auto& needle = _needles[_last];
+            if (is_fallback_needle(needle.size)) {
+                _fallback_needles.push_back(_last);
+            } else {
+                const size_t needle_ngrams = needle.size - sizeof(Ngram) + 1;
+                if (ngrams + needle_ngrams > SMALL_LIMIT && ngrams != 0) {
+                    break;
+                }
+
+                ngrams += needle_ngrams;
+                _step = std::min(_step, needle_ngrams);
+                // Insert ngrams from the end to the beginning, matching the way the scan
+                // position is later converted back to the candidate needle start.
+                for (auto i = static_cast<int>(needle.size - sizeof(Ngram)); i >= 0; --i) {
+                    put_ngram(to_ngram(reinterpret_cast<const uint8_t*>(needle.data + i)), i + 1,
+                              _last);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    void search_one_all(const uint8_t* haystack, const uint8_t* haystack_end, Int32* answer) const {
+        // answer points to the beginning of one result array row. Entries are indexed by
+        // global needle id, so different batches write into the same full-size row result.
+        for (const size_t needle_index : _fallback_needles) {
+            const auto* match = _searchers[needle_index].search(haystack, haystack_end);
+            if (match != haystack_end) {
+                answer[needle_index] = static_cast<Int32>(match - haystack + 1);
+            }
+        }
+
+        if (_step == std::numeric_limits<size_t>::max() ||
+            haystack_end - haystack < static_cast<ptrdiff_t>(sizeof(Ngram))) {
+            // The batch may contain only fallback needles, or the haystack may be too short
+            // to read a 2-byte ngram. Fallback needles have already been handled above.
+            return;
+        }
+
+        for (const uint8_t* pos = haystack + _step - sizeof(Ngram);
+             pos <= haystack_end - sizeof(Ngram); pos += _step) {
+            // A 2-byte ngram has exactly 65536 possible values. HASH_SIZE is also 65536,
+            // so ngram % HASH_SIZE is effectively direct addressing. Collisions and
+            // duplicate ngrams are kept by linear probing and checked until an empty slot.
+            for (size_t cell = to_ngram(pos) % HASH_SIZE; _hash[cell].off;
+                 cell = (cell + 1) % HASH_SIZE) {
+                if (pos < haystack + _hash[cell].off - 1) {
+                    continue;
+                }
+
+                const size_t needle_index = _hash[cell].id;
+                // Convert the matched ngram position in the haystack back to the candidate
+                // start position of the whole needle, then verify the full needle below.
+                const uint8_t* match = pos - (_hash[cell].off - 1);
+                const auto candidate_position = static_cast<Int32>(match - haystack + 1);
+                if (answer[needle_index] != 0 && candidate_position >= answer[needle_index]) {
+                    continue;
+                }
+
+                const auto& needle = _needles[needle_index];
+                // The hash table only proves that one 2-byte ngram matched. Full memcmp is
+                // required to discard false positives from duplicate ngrams and collisions.
+                if (match + needle.size <= haystack_end &&
+                    std::memcmp(match, needle.data, needle.size) == 0) {
+                    answer[needle_index] = candidate_position;
+                }
+            }
+        }
+    }
+
+private:
+    static constexpr size_t HASH_SIZE = 64 * 1024;
+    static constexpr size_t SMALL_LIMIT = HASH_SIZE / 8;
+
+    static bool is_fallback_needle(size_t needle_size) {
+        // Very short needles do not have enough 2-byte ngrams to be selective. Very long
+        // needles cannot store their ngram offset in the uint8_t Offset field.
+        return needle_size < 2 * sizeof(Ngram) || needle_size >= std::numeric_limits<Offset>::max();
+    }
+
+    static Ngram to_ngram(const uint8_t* pos) {
+        // Read two bytes as a uint16_t. On little-endian machines, for example, "ab"
+        // becomes 97 + 98 * 256. This numeric value is used as the initial hash slot.
+        Ngram ngram;
+        std::memcpy(&ngram, pos, sizeof(ngram));
+        return ngram;
+    }
+
+    void put_ngram(Ngram ngram, int offset, size_t needle_index) {
+        size_t cell = ngram % HASH_SIZE;
+        // Linear probing keeps all duplicate ngrams instead of overwriting them. Search
+        // uses the same probe sequence and validates every candidate with full memcmp.
+        while (_hash[cell].off) {
+            cell = (cell + 1) % HASH_SIZE;
+        }
+        _hash[cell] = {.id = static_cast<Id>(needle_index), .off = static_cast<Offset>(offset)};
+    }
+
+    const std::vector<StringRef>& _needles;
+    std::vector<size_t> _fallback_needles;
+    std::vector<ASCIICaseSensitiveStringSearcher> _searchers;
+    std::unique_ptr<OffsetId[]> _hash;
+    size_t _step = 0;
+    size_t _last = 0;
+};
+
+} // namespace doris

--- a/be/src/exec/common/multi_string_searcher.h
+++ b/be/src/exec/common/multi_string_searcher.h
@@ -42,8 +42,8 @@ class MultiStringSearcher {
     // needle id and the 1-based offset of this ngram inside that needle. off == 0 means
     // the slot is empty, so needle offsets are stored as 1-based values.
     struct OffsetId {
-        Id id = 0;
-        Offset off = 0;
+        Id id;
+        Offset off;
     };
 
 public:

--- a/be/src/exec/common/multi_string_searcher.h
+++ b/be/src/exec/common/multi_string_searcher.h
@@ -103,29 +103,32 @@ public:
             }
         }
 
-        if (_step == std::numeric_limits<size_t>::max() ||
-            haystack_end - haystack < static_cast<ptrdiff_t>(sizeof(Ngram))) {
+        const auto haystack_size = static_cast<size_t>(haystack_end - haystack);
+        if (_step == std::numeric_limits<size_t>::max() || haystack_size < sizeof(Ngram)) {
             // The batch may contain only fallback needles, or the haystack may be too short
             // to read a 2-byte ngram. Fallback needles have already been handled above.
             return;
         }
 
-        for (const uint8_t* pos = haystack + _step - sizeof(Ngram);
-             pos <= haystack_end - sizeof(Ngram); pos += _step) {
+        for (size_t pos_offset = _step - sizeof(Ngram); pos_offset + sizeof(Ngram) <= haystack_size;
+             pos_offset += _step) {
+            const uint8_t* pos = haystack + pos_offset;
             // A 2-byte ngram has exactly 65536 possible values. HASH_SIZE is also 65536,
             // so ngram % HASH_SIZE is effectively direct addressing. Collisions and
             // duplicate ngrams are kept by linear probing and checked until an empty slot.
             for (size_t cell = to_ngram(pos) % HASH_SIZE; _hash[cell].off;
                  cell = (cell + 1) % HASH_SIZE) {
-                if (pos < haystack + _hash[cell].off - 1) {
+                const size_t ngram_offset = _hash[cell].off - 1;
+                if (pos_offset < ngram_offset) {
                     continue;
                 }
 
                 const size_t needle_index = _hash[cell].id;
                 // Convert the matched ngram position in the haystack back to the candidate
                 // start position of the whole needle, then verify the full needle below.
-                const uint8_t* match = pos - (_hash[cell].off - 1);
-                const auto candidate_position = static_cast<Int32>(match - haystack + 1);
+                const size_t match_offset = pos_offset - ngram_offset;
+                const uint8_t* match = haystack + match_offset;
+                const auto candidate_position = static_cast<Int32>(match_offset + 1);
                 if (answer[needle_index] != 0 && candidate_position >= answer[needle_index]) {
                     continue;
                 }
@@ -133,7 +136,7 @@ public:
                 const auto& needle = _needles[needle_index];
                 // The hash table only proves that one 2-byte ngram matched. Full memcmp is
                 // required to discard false positives from duplicate ngrams and collisions.
-                if (match + needle.size <= haystack_end &&
+                if (haystack_size - match_offset >= needle.size &&
                     std::memcmp(match, needle.data, needle.size) == 0) {
                     answer[needle_index] = candidate_position;
                 }

--- a/be/src/exprs/function/functions_multi_string_position.cpp
+++ b/be/src/exprs/function/functions_multi_string_position.cpp
@@ -47,6 +47,7 @@
 #include "core/pod_array_fwd.h"
 #include "core/string_ref.h"
 #include "core/types.h"
+#include "exec/common/multi_string_searcher.h"
 #include "exec/common/string_searcher.h"
 #include "exprs/aggregate/aggregate_function.h"
 #include "exprs/function/function.h"
@@ -190,14 +191,14 @@ public:
         }
 
         const size_t needles_size = needles_arr.size();
-        std::vector<SingleSearcher> searchers;
-        searchers.reserve(needles_size);
+        std::vector<StringRef> needles;
+        needles.reserve(needles_size);
         for (const auto& needle : needles_arr) {
             if (!is_string_type(needle.get_type())) {
                 return Status::InvalidArgument("invalid type of needle {}", needle.get_type_name());
             }
-            searchers.emplace_back(needle.get<TYPE_STRING>().data(),
-                                   needle.get<TYPE_STRING>().size());
+            const auto& needle_string = needle.get<TYPE_STRING>();
+            needles.emplace_back(needle_string.data(), needle_string.size());
         }
 
         const size_t haystack_size = haystack_offsets.size();
@@ -206,22 +207,17 @@ public:
 
         std::fill(vec_res.begin(), vec_res.end(), 0);
 
-        // we traverse to generator answer by Vector's slot of ColumnVector, not by Vector.
-        // TODO: check if the order of loop is best. The large data may make us writing across the line which size out of L2 cache.
-        for (size_t ans_slot_in_row = 0; ans_slot_in_row < searchers.size(); ans_slot_in_row++) {
-            //  is i.e. answer slot index in one Vector(row) of answer
-            auto& searcher = searchers[ans_slot_in_row];
+        MultiStringSearcher searcher(needles);
+        while (searcher.has_more_to_search()) {
             size_t prev_haystack_offset = 0;
-
-            for (size_t haystack_index = 0, res_index = ans_slot_in_row;
-                 haystack_index < haystack_size; ++haystack_index, res_index += needles_size) {
+            for (size_t haystack_index = 0; haystack_index < haystack_size; ++haystack_index) {
                 const auto* haystack = &haystack_data[prev_haystack_offset];
                 const auto* haystack_end =
                         haystack - prev_haystack_offset + haystack_offsets[haystack_index];
 
-                const auto* ans_now = searcher.search(haystack, haystack_end);
-                vec_res[res_index] =
-                        ans_now >= haystack_end ? 0 : (Int32)std::distance(haystack, ans_now) + 1;
+                searcher.search_one_all(reinterpret_cast<const uint8_t*>(haystack),
+                                        reinterpret_cast<const uint8_t*>(haystack_end),
+                                        &vec_res[haystack_index * needles_size]);
                 prev_haystack_offset = haystack_offsets[haystack_index];
             }
         }


### PR DESCRIPTION
### What problem does this PR solve?

`multi_search_all_positions` used to scan the same haystack once for every constant needle. This is expensive when the needle array is large.

This PR adds `MultiStringSearcher` for the constant-needle path. It batches needles into a 2-byte ngram hash table, scans each haystack once per batch, and verifies full needle matches before writing the result. Short or unsupported needles still use the existing single-string searcher fallback, and the dynamic-needle path is unchanged.

Benchmark result for 4096 rows, 1024-byte haystacks, and 64 constant needles:

| Case | Old CPU time | New CPU time | Speedup |
| --- | ---: | ---: | ---: |
| NoHit | 37.23 ms | 0.84 ms | 44.4x |
| RareHit | 46.20 ms | 0.94 ms | 49.0x |
| LastNeedleHit | 46.21 ms | 1.18 ms | 39.2x |

The benchmark host had high load and CPU scaling enabled, so the numbers are intended as relative performance evidence.
### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

