### PR TITLE
[fix](regression) Avoid prepared Arrow JDBC path in remote IP auth test

### DIFF
--- a/regression-test/suites/arrow_flight_sql_p0/test_auth_remote_ip.groovy
+++ b/regression-test/suites/arrow_flight_sql_p0/test_auth_remote_ip.groovy
@@ -18,6 +18,8 @@
 import java.sql.Connection
 import java.sql.DriverManager
 
+import org.apache.doris.regression.util.JdbcUtils
+
 suite("test_auth_remote_ip", "arrow_flight_sql") {
     String user = "flight_auth_remote_ip_user"
     String password = "flight_auth_remote_ip_pwd"
@@ -60,7 +62,7 @@ suite("test_auth_remote_ip", "arrow_flight_sql") {
 
         Connection conn = DriverManager.getConnection(arrowFlightSqlUrl, user, password)
         try {
-            List<List<Object>> result = sql_impl(conn, "SELECT 1")
+            def (result, meta) = JdbcUtils.executeQueryToList(conn, "SELECT 1")
             assertEquals(1, result.size())
             assertEquals(1, (result[0][0] as Number).intValue())
         } finally {


### PR DESCRIPTION
### What problem does this PR solve?


Related PR: [63506](https://github.com/apache/doris/pull/63506)

Problem Summary: `test_auth_remote_ip` only needs to verify that Arrow Flight SQL remote IP authentication allows a matched user to run `SELECT 1`. The shared `sql_impl` helper uses `PreparedStatement`, and Arrow Flight SQL JDBC 17 can report a close-time 8-byte client allocator leak after the prepared path has already consumed the result. This changes the case to use `JdbcUtils.executeQueryToList`, which uses `createStatement().executeQuery(...)`, so the test avoids the prepared statement cleanup path without ignoring `conn.close()` exceptions.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - `bash -n run-regression-test.sh`
    - `/tmp/arrow-flight-close-repro` JDBC statement path against `127.0.0.1:43080` repeated 10 times
    - `./run-regression-test.sh --run -d arrow_flight_sql_p0 -s test_auth_remote_ip -g arrow_flight_sql` failed in the current local cluster at Arrow Flight SQL authentication: `Access denied for user 'flight_auth_remote_ip_user@0.0.0.0'`; it did not reach the `SELECT 1`/close path.
- Behavior changed: No
- Does this need documentation: No
