### PR TITLE
[improvement](be) Add bloom filter pruning for new parquet reader

### DIFF
--- a/be/src/format/new_parquet/parquet_reader.cpp
+++ b/be/src/format/new_parquet/parquet_reader.cpp
@@ -34,6 +34,7 @@
 #include "format/new_parquet/parquet_scan.h"
 #include "format/new_parquet/parquet_statistics.h"
 #include "format/new_parquet/reader/column_reader.h"
+#include "runtime/runtime_state.h"
 
 namespace doris::parquet {
 
@@ -42,6 +43,7 @@ struct ParquetReaderScanState {
     std::vector<std::unique_ptr<ParquetColumnSchema>> file_schema;
     RowGroupScanPlan scan_plan;
     ParquetScanScheduler scheduler;
+    bool enable_bloom_filter = false;
 };
 
 void ParquetReader::_fill_schema_field(const ParquetColumnSchema& column_schema,
@@ -158,6 +160,8 @@ ParquetReader::~ParquetReader() = default;
 Status ParquetReader::init(RuntimeState* state) {
     RETURN_IF_ERROR(reader::FileReader::init(state));
     _state = std::make_unique<ParquetReaderScanState>();
+    _state->enable_bloom_filter =
+            state != nullptr && state->query_options().enable_parquet_filter_by_bloom_filter;
     // Open parquet file and parse metadata and file schema.
     RETURN_IF_ERROR(_state->file_context.open(_tracing_file_reader, _io_ctx.get()));
     RETURN_IF_ERROR(
@@ -233,9 +237,10 @@ Status ParquetReader::open(std::unique_ptr<reader::FileScanRequest>& request) {
     scan_range.size = _file_description->range_size;
     scan_range.file_size = _file_description->file_size;
     // Get selected ranges in row groups according to metadata (Row-Group level index and Page Index including Zonemap, Dictionary, Bloom Filter).
-    RETURN_IF_ERROR(plan_parquet_row_groups(
-            *_state->file_context.metadata, _state->file_context.file_reader.get(),
-            _state->file_schema, *_request, scan_range, &row_group_plan));
+    RETURN_IF_ERROR(plan_parquet_row_groups(*_state->file_context.metadata,
+                                            _state->file_context.file_reader.get(),
+                                            _state->file_schema, *_request, scan_range,
+                                            _state->enable_bloom_filter, &row_group_plan));
     if (_profile != nullptr) {
         const auto& pruning_stats = row_group_plan.pruning_stats;
         COUNTER_UPDATE(_parquet_profile.filtered_row_groups,
@@ -244,12 +249,16 @@ Status ParquetReader::open(std::unique_ptr<reader::FileScanRequest>& request) {
                        pruning_stats.filtered_row_groups_by_statistics);
         COUNTER_UPDATE(_parquet_profile.filtered_row_groups_by_dictionary,
                        pruning_stats.filtered_row_groups_by_dictionary);
+        COUNTER_UPDATE(_parquet_profile.filtered_row_groups_by_bloom_filter,
+                       pruning_stats.filtered_row_groups_by_bloom_filter);
         COUNTER_UPDATE(_parquet_profile.to_read_row_groups, pruning_stats.selected_row_groups);
         COUNTER_UPDATE(_parquet_profile.total_row_groups, pruning_stats.total_row_groups);
         COUNTER_UPDATE(_parquet_profile.selected_row_ranges, pruning_stats.selected_row_ranges);
         COUNTER_UPDATE(_parquet_profile.filtered_group_rows, pruning_stats.filtered_group_rows);
         COUNTER_UPDATE(_parquet_profile.filtered_page_rows, pruning_stats.filtered_page_rows);
         COUNTER_UPDATE(_parquet_profile.page_index_read_calls, pruning_stats.page_index_read_calls);
+        COUNTER_UPDATE(_parquet_profile.bloom_filter_read_time,
+                       pruning_stats.bloom_filter_read_time);
     }
     _state->scan_plan = row_group_plan;
     _state->scheduler.set_plan(std::move(row_group_plan));

--- a/be/src/format/new_parquet/parquet_scan.cpp
+++ b/be/src/format/new_parquet/parquet_scan.cpp
@@ -79,7 +79,8 @@ Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
                                ::parquet::ParquetFileReader* file_reader,
                                const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
                                const reader::FileScanRequest& request,
-                               const ParquetScanRange& scan_range, RowGroupScanPlan* plan) {
+                               const ParquetScanRange& scan_range, bool enable_bloom_filter,
+                               RowGroupScanPlan* plan) {
     DORIS_CHECK(plan != nullptr);
     plan->row_groups.clear();
     plan->pruning_stats = ParquetPruningStats {};
@@ -87,7 +88,7 @@ Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
     std::vector<int> statistics_selected_row_groups;
     RETURN_IF_ERROR(select_row_groups_by_statistics(metadata, file_reader, file_schema, request,
                                                     &statistics_selected_row_groups,
-                                                    &plan->pruning_stats));
+                                                    enable_bloom_filter, &plan->pruning_stats));
 
     std::vector<int64_t> row_group_first_rows(metadata.num_row_groups());
     int64_t next_row_group_first_row = 0;

--- a/be/src/format/new_parquet/parquet_scan.h
+++ b/be/src/format/new_parquet/parquet_scan.h
@@ -70,7 +70,8 @@ Status plan_parquet_row_groups(const ::parquet::FileMetaData& metadata,
                                ::parquet::ParquetFileReader* file_reader,
                                const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
                                const reader::FileScanRequest& request,
-                               const ParquetScanRange& scan_range, RowGroupScanPlan* plan);
+                               const ParquetScanRange& scan_range, bool enable_bloom_filter,
+                               RowGroupScanPlan* plan);
 
 IColumn::Filter selection_to_filter(const SelectionVector& selection, uint16_t selected_rows,
                                     int64_t batch_rows);

--- a/be/src/format/new_parquet/parquet_statistics.cpp
+++ b/be/src/format/new_parquet/parquet_statistics.cpp
@@ -19,6 +19,8 @@
 
 #include <parquet/api/reader.h>
 #include <parquet/api/schema.h>
+#include <parquet/bloom_filter.h>
+#include <parquet/bloom_filter_reader.h>
 #include <parquet/column_page.h>
 #include <parquet/encoding.h>
 #include <parquet/page_index.h>
@@ -27,8 +29,11 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <exception>
+#include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -39,7 +44,9 @@
 #include "core/data_type/primitive_type.h"
 #include "core/field.h"
 #include "format/new_parquet/parquet_column_schema.h"
+#include "runtime/runtime_profile.h"
 #include "storage/index/zone_map/zone_map_index.h"
+#include "storage/predicate/accept_null_predicate.h"
 #include "storage/predicate/column_predicate.h"
 
 namespace doris::parquet {
@@ -119,6 +126,188 @@ bool is_supported_dictionary_predicate(const ColumnPredicate& predicate) {
     default:
         return false;
     }
+}
+
+bool is_bloom_filter_prunable_predicate(const ColumnPredicate& predicate) {
+    if (dynamic_cast<const AcceptNullPredicate*>(&predicate) != nullptr ||
+        is_null_only_predicate(predicate)) {
+        return false;
+    }
+    return predicate.can_do_bloom_filter(false);
+}
+
+template <typename T>
+T load_predicate_value(const char* data) {
+    T value;
+    memcpy(&value, data, sizeof(T));
+    return value;
+}
+
+class ArrowParquetBloomFilterAdapter final : public segment_v2::BloomFilter {
+public:
+    ArrowParquetBloomFilterAdapter(const ParquetColumnSchema& column_schema,
+                                   const ::parquet::BloomFilter& bloom_filter)
+            : _column_schema(column_schema), _bloom_filter(bloom_filter) {}
+
+    void add_bytes(const char* buf, size_t size) override { DORIS_CHECK(false); }
+
+    bool test_bytes(const char* buf, size_t size) const override {
+        if (buf == nullptr) {
+            return true;
+        }
+        switch (physical_filter_type(_column_schema)) {
+        case TYPE_BOOLEAN:
+            return test_boolean(buf, size);
+        case TYPE_INT:
+            return test_int32(buf, size);
+        case TYPE_BIGINT:
+            return test_int64(buf, size);
+        case TYPE_FLOAT:
+            return test_float(buf, size);
+        case TYPE_DOUBLE:
+            return test_double(buf, size);
+        case TYPE_STRING:
+            return test_string(buf, size);
+        default:
+            return true;
+        }
+    }
+
+    void set_has_null(bool has_null) override { DORIS_CHECK(!has_null); }
+    bool has_null() const override { return false; }
+    void add_hash(uint64_t hash) override { DORIS_CHECK(false); }
+    bool test_hash(uint64_t hash) const override { return _bloom_filter.FindHash(hash); }
+
+private:
+    bool test_boolean(const char* buf, size_t size) const {
+        if (size == sizeof(bool)) {
+            const int32_t value = load_predicate_value<bool>(buf) ? 1 : 0;
+            return _bloom_filter.FindHash(_bloom_filter.Hash(value));
+        }
+        if (size == sizeof(int32_t)) {
+            const int32_t value = load_predicate_value<int32_t>(buf);
+            return _bloom_filter.FindHash(_bloom_filter.Hash(value != 0 ? 1 : 0));
+        }
+        return true;
+    }
+
+    bool test_int32(const char* buf, size_t size) const {
+        if (size == sizeof(int8_t)) {
+            return find_int32(static_cast<int32_t>(load_predicate_value<int8_t>(buf)));
+        }
+        if (size == sizeof(int16_t)) {
+            return find_int32(static_cast<int32_t>(load_predicate_value<int16_t>(buf)));
+        }
+        if (size == sizeof(int32_t)) {
+            return find_int32(load_predicate_value<int32_t>(buf));
+        }
+        return true;
+    }
+
+    bool test_int64(const char* buf, size_t size) const {
+        if (size != sizeof(int64_t)) {
+            return true;
+        }
+        const int64_t value = load_predicate_value<int64_t>(buf);
+        return _bloom_filter.FindHash(_bloom_filter.Hash(value));
+    }
+
+    bool test_float(const char* buf, size_t size) const {
+        if (size != sizeof(float)) {
+            return true;
+        }
+        const float value = load_predicate_value<float>(buf);
+        return _bloom_filter.FindHash(_bloom_filter.Hash(value));
+    }
+
+    bool test_double(const char* buf, size_t size) const {
+        if (size != sizeof(double)) {
+            return true;
+        }
+        const double value = load_predicate_value<double>(buf);
+        return _bloom_filter.FindHash(_bloom_filter.Hash(value));
+    }
+
+    bool test_string(const char* buf, size_t size) const {
+        ::parquet::ByteArray value(static_cast<uint32_t>(size),
+                                   reinterpret_cast<const uint8_t*>(buf));
+        return _bloom_filter.FindHash(_bloom_filter.Hash(&value));
+    }
+
+    bool find_int32(int32_t value) const {
+        return _bloom_filter.FindHash(_bloom_filter.Hash(value));
+    }
+
+    const ParquetColumnSchema& _column_schema;
+    const ::parquet::BloomFilter& _bloom_filter;
+};
+
+struct RowGroupBloomFilterCache {
+    ::parquet::BloomFilterReader* bloom_filter_reader = nullptr;
+    std::map<int, std::unique_ptr<::parquet::BloomFilter>> column_bloom_filters;
+    std::set<int> loaded_columns;
+
+    ::parquet::BloomFilter* get(int row_group_idx, int leaf_column_id,
+                                ParquetPruningStats* pruning_stats) {
+        if (bloom_filter_reader == nullptr || leaf_column_id < 0) {
+            return nullptr;
+        }
+        if (loaded_columns.find(leaf_column_id) == loaded_columns.end()) {
+            loaded_columns.insert(leaf_column_id);
+            try {
+                std::shared_ptr<::parquet::RowGroupBloomFilterReader> row_group_reader;
+                if (pruning_stats != nullptr) {
+                    SCOPED_RAW_TIMER(&pruning_stats->bloom_filter_read_time);
+                    row_group_reader = bloom_filter_reader->RowGroup(row_group_idx);
+                    if (row_group_reader != nullptr) {
+                        column_bloom_filters[leaf_column_id] =
+                                row_group_reader->GetColumnBloomFilter(leaf_column_id);
+                    }
+                } else {
+                    row_group_reader = bloom_filter_reader->RowGroup(row_group_idx);
+                    if (row_group_reader != nullptr) {
+                        column_bloom_filters[leaf_column_id] =
+                                row_group_reader->GetColumnBloomFilter(leaf_column_id);
+                    }
+                }
+            } catch (const ::parquet::ParquetException&) {
+                return nullptr;
+            } catch (const std::exception&) {
+                return nullptr;
+            }
+        }
+        auto it = column_bloom_filters.find(leaf_column_id);
+        return it == column_bloom_filters.end() ? nullptr : it->second.get();
+    }
+};
+
+ParquetRowGroupPruneReason BloomFilterPruneReason(
+        int row_group_idx, const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
+        const reader::FileColumnPredicateFilter& column_filter,
+        RowGroupBloomFilterCache* bloom_filter_cache, ParquetPruningStats* pruning_stats) {
+    if (bloom_filter_cache == nullptr || column_filter.predicates.empty()) {
+        return ParquetRowGroupPruneReason::NONE;
+    }
+    DCHECK_LT(column_filter.file_column_id, schema.size());
+    const auto& column_schema = *schema[column_filter.file_column_id];
+    if (column_schema.kind != ParquetColumnSchemaKind::PRIMITIVE ||
+        column_schema.leaf_column_id < 0 ||
+        !ParquetStatisticsUtils::BloomFilterSupported(column_schema)) {
+        return ParquetRowGroupPruneReason::NONE;
+    }
+    for (const auto& column_predicate : column_filter.predicates) {
+        if (column_predicate == nullptr || !is_bloom_filter_prunable_predicate(*column_predicate)) {
+            return ParquetRowGroupPruneReason::NONE;
+        }
+    }
+    auto* bloom_filter =
+            bloom_filter_cache->get(row_group_idx, column_schema.leaf_column_id, pruning_stats);
+    if (bloom_filter == nullptr) {
+        return ParquetRowGroupPruneReason::NONE;
+    }
+    return ParquetStatisticsUtils::BloomFilterExcludes(column_schema, column_filter, *bloom_filter)
+                   ? ParquetRowGroupPruneReason::BLOOM_FILTER
+                   : ParquetRowGroupPruneReason::NONE;
 }
 
 bool is_dictionary_data_encoding(::parquet::Encoding::type encoding) {
@@ -416,7 +605,7 @@ Status ParquetStatisticsUtils::SelectRowGroups(
         const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const reader::FileScanRequest& request, std::vector<int>* selected_row_groups,
-        ParquetPruningStats* pruning_stats) {
+        bool enable_bloom_filter, ParquetPruningStats* pruning_stats) {
     if (selected_row_groups == nullptr) {
         return Status::InvalidArgument("selected_row_groups is null");
     }
@@ -434,19 +623,37 @@ Status ParquetStatisticsUtils::SelectRowGroups(
             continue;
         }
         bool drop = false;
+        RowGroupBloomFilterCache bloom_filter_cache;
+        if (enable_bloom_filter && file_reader != nullptr) {
+            try {
+                bloom_filter_cache.bloom_filter_reader = &file_reader->GetBloomFilterReader();
+            } catch (const ::parquet::ParquetException&) {
+                bloom_filter_cache.bloom_filter_reader = nullptr;
+            } catch (const std::exception&) {
+                bloom_filter_cache.bloom_filter_reader = nullptr;
+            }
+        }
         for (const auto& column_filter : request.column_predicate_filters) {
             const auto prune_reason = RowGroupPruneReason(*row_group, file_reader, row_group_idx,
                                                           file_schema, column_filter);
-            if (prune_reason == ParquetRowGroupPruneReason::NONE) {
+            auto effective_prune_reason = prune_reason;
+            if (effective_prune_reason == ParquetRowGroupPruneReason::NONE && enable_bloom_filter) {
+                effective_prune_reason =
+                        BloomFilterPruneReason(row_group_idx, file_schema, column_filter,
+                                               &bloom_filter_cache, pruning_stats);
+            }
+            if (effective_prune_reason == ParquetRowGroupPruneReason::NONE) {
                 continue;
             }
             drop = true;
             if (pruning_stats != nullptr) {
                 pruning_stats->filtered_group_rows += row_group->num_rows();
-                if (prune_reason == ParquetRowGroupPruneReason::STATISTICS) {
+                if (effective_prune_reason == ParquetRowGroupPruneReason::STATISTICS) {
                     ++pruning_stats->filtered_row_groups_by_statistics;
-                } else if (prune_reason == ParquetRowGroupPruneReason::DICTIONARY) {
+                } else if (effective_prune_reason == ParquetRowGroupPruneReason::DICTIONARY) {
                     ++pruning_stats->filtered_row_groups_by_dictionary;
+                } else if (effective_prune_reason == ParquetRowGroupPruneReason::BLOOM_FILTER) {
+                    ++pruning_stats->filtered_row_groups_by_bloom_filter;
                 }
                 break;
             }
@@ -474,13 +681,33 @@ bool ParquetStatisticsUtils::BloomFilterSupported(const ParquetColumnSchema& col
     }
 }
 
+bool ParquetStatisticsUtils::BloomFilterExcludes(
+        const ParquetColumnSchema& column_schema,
+        const reader::FileColumnPredicateFilter& column_filter,
+        const ::parquet::BloomFilter& bloom_filter) {
+    if (!BloomFilterSupported(column_schema)) {
+        return false;
+    }
+    ArrowParquetBloomFilterAdapter adapter(column_schema, bloom_filter);
+    for (const auto& column_predicate : column_filter.predicates) {
+        if (column_predicate == nullptr || !is_bloom_filter_prunable_predicate(*column_predicate)) {
+            return false;
+        }
+        if (!column_predicate->evaluate_and(&adapter)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 Status select_row_groups_by_statistics(
         const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const reader::FileScanRequest& request, std::vector<int>* selected_row_groups,
-        ParquetPruningStats* pruning_stats) {
+        bool enable_bloom_filter, ParquetPruningStats* pruning_stats) {
     return ParquetStatisticsUtils::SelectRowGroups(metadata, file_reader, file_schema, request,
-                                                   selected_row_groups, pruning_stats);
+                                                   selected_row_groups, enable_bloom_filter,
+                                                   pruning_stats);
 }
 
 namespace {

--- a/be/src/format/new_parquet/parquet_statistics.h
+++ b/be/src/format/new_parquet/parquet_statistics.h
@@ -27,6 +27,7 @@
 #include "format/reader/file_reader.h"
 
 namespace parquet {
+class BloomFilter;
 class FileMetaData;
 class ParquetFileReader;
 class RowGroupMetaData;
@@ -45,6 +46,7 @@ enum class ParquetRowGroupPruneReason {
     NONE,
     STATISTICS,
     DICTIONARY,
+    BLOOM_FILTER,
 };
 
 struct ParquetPruningStats {
@@ -52,11 +54,13 @@ struct ParquetPruningStats {
     int64_t selected_row_groups = 0;
     int64_t filtered_row_groups_by_statistics = 0;
     int64_t filtered_row_groups_by_dictionary = 0;
+    int64_t filtered_row_groups_by_bloom_filter = 0;
     int64_t filtered_row_groups_by_page_index = 0;
     int64_t filtered_group_rows = 0;
     int64_t filtered_page_rows = 0;
     int64_t selected_row_ranges = 0;
     int64_t page_index_read_calls = 0;
+    int64_t bloom_filter_read_time = 0;
 };
 
 // Parquet row group column statistics 转换后的 Doris 统计视图。
@@ -100,9 +104,13 @@ struct ParquetStatisticsUtils {
             const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
             const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
             const reader::FileScanRequest& request, std::vector<int>* selected_row_groups,
-            ParquetPruningStats* pruning_stats);
+            bool enable_bloom_filter, ParquetPruningStats* pruning_stats);
 
     static bool BloomFilterSupported(const ParquetColumnSchema& column_schema);
+
+    static bool BloomFilterExcludes(const ParquetColumnSchema& column_schema,
+                                    const reader::FileColumnPredicateFilter& column_filter,
+                                    const ::parquet::BloomFilter& bloom_filter);
 };
 
 // Parquet file-local statistics/page index/bloom filter 裁剪入口。
@@ -113,7 +121,7 @@ Status select_row_groups_by_statistics(
         const ::parquet::FileMetaData& metadata, ::parquet::ParquetFileReader* file_reader,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const reader::FileScanRequest& request, std::vector<int>* selected_row_groups,
-        ParquetPruningStats* pruning_stats);
+        bool enable_bloom_filter, ParquetPruningStats* pruning_stats);
 
 Status select_row_group_ranges_by_page_index(
         ::parquet::ParquetFileReader* file_reader,

--- a/be/test/format/new_parquet/parquet_reader_test.cpp
+++ b/be/test/format/new_parquet/parquet_reader_test.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 #include <parquet/api/reader.h>
 #include <parquet/arrow/writer.h>
+#include <parquet/bloom_filter.h>
 #include <parquet/page_index.h>
 
 #include <filesystem>
@@ -53,6 +54,7 @@
 #include "gen_cpp/Types_types.h"
 #include "io/io_common.h"
 #include "runtime/runtime_state.h"
+#include "storage/predicate/accept_null_predicate.h"
 #include "storage/predicate/predicate_creator.h"
 
 namespace doris {
@@ -333,6 +335,45 @@ void write_page_index_filter_parquet_file(const std::string& file_path) {
                                                       ids.size(), builder.build()));
 }
 
+parquet::ParquetColumnSchema primitive_bloom_schema(const DataTypePtr& type) {
+    parquet::ParquetColumnSchema schema;
+    schema.field_id = 0;
+    schema.name = "c0";
+    schema.type = type;
+    schema.leaf_column_id = 0;
+    schema.kind = parquet::ParquetColumnSchemaKind::PRIMITIVE;
+    return schema;
+}
+
+reader::FileColumnPredicateFilter bloom_filter_with_predicate(
+        const std::shared_ptr<ColumnPredicate>& predicate) {
+    reader::FileColumnPredicateFilter filter;
+    filter.file_column_id = 0;
+    filter.predicates.push_back(predicate);
+    return filter;
+}
+
+::parquet::BlockSplitBloomFilter bloom_filter_for_int32_values(const std::vector<int32_t>& values) {
+    ::parquet::BlockSplitBloomFilter bloom_filter;
+    bloom_filter.Init(::parquet::BlockSplitBloomFilter::kMinimumBloomFilterBytes);
+    for (const auto value : values) {
+        bloom_filter.InsertHash(bloom_filter.Hash(value));
+    }
+    return bloom_filter;
+}
+
+::parquet::BlockSplitBloomFilter bloom_filter_for_string_values(
+        const std::vector<std::string>& values) {
+    ::parquet::BlockSplitBloomFilter bloom_filter;
+    bloom_filter.Init(::parquet::BlockSplitBloomFilter::kMinimumBloomFilterBytes);
+    for (const auto& value : values) {
+        ::parquet::ByteArray byte_array(static_cast<uint32_t>(value.size()),
+                                        reinterpret_cast<const uint8_t*>(value.data()));
+        bloom_filter.InsertHash(bloom_filter.Hash(&byte_array));
+    }
+    return bloom_filter;
+}
+
 Block build_file_block(const std::vector<reader::SchemaField>& schema) {
     Block block;
     for (const auto& field : schema) {
@@ -606,6 +647,97 @@ TEST(TableColumnMapperTest, ColumnPredicatesDoNotForcePredicateMaterialization) 
               std::vector<reader::ColumnId>({0, 1}));
     ASSERT_EQ(request->column_predicate_filters.size(), 1);
     EXPECT_EQ(request->column_predicate_filters[0].file_column_id, 0);
+}
+
+TEST(ParquetBloomFilterPruningTest, EqPredicateUsesArrowHashAndPrunesAbsentIntValue) {
+    auto schema = primitive_bloom_schema(std::make_shared<DataTypeInt32>());
+    auto bloom_filter = bloom_filter_for_int32_values({1, 3});
+    auto absent_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
+            0, "c0", schema.type, Field::create_field<TYPE_INT>(2), false));
+    auto present_filter =
+            bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
+                    0, "c0", schema.type, Field::create_field<TYPE_INT>(3), false));
+
+    EXPECT_TRUE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, absent_filter,
+                                                                     bloom_filter));
+    EXPECT_FALSE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, present_filter,
+                                                                      bloom_filter));
+}
+
+TEST(ParquetBloomFilterPruningTest, InPredicatePrunesOnlyWhenAllValuesAreAbsent) {
+    auto schema = primitive_bloom_schema(std::make_shared<DataTypeInt32>());
+    auto bloom_filter = bloom_filter_for_int32_values({1, 3});
+
+    auto absent_set = build_set<TYPE_INT>();
+    int32_t absent_first = 2;
+    int32_t absent_second = 4;
+    absent_set->insert(&absent_first);
+    absent_set->insert(&absent_second);
+    auto absent_filter =
+            bloom_filter_with_predicate(create_in_list_predicate<PredicateType::IN_LIST>(
+                    0, "c0", schema.type, absent_set, false));
+
+    auto present_set = build_set<TYPE_INT>();
+    int32_t present_first = 2;
+    int32_t present_second = 3;
+    present_set->insert(&present_first);
+    present_set->insert(&present_second);
+    auto present_filter =
+            bloom_filter_with_predicate(create_in_list_predicate<PredicateType::IN_LIST>(
+                    0, "c0", schema.type, present_set, false));
+
+    EXPECT_TRUE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, absent_filter,
+                                                                     bloom_filter));
+    EXPECT_FALSE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, present_filter,
+                                                                      bloom_filter));
+}
+
+TEST(ParquetBloomFilterPruningTest, BooleanPredicateHashesAsParquetInt32) {
+    auto schema = primitive_bloom_schema(std::make_shared<DataTypeBool>());
+    auto bloom_filter = bloom_filter_for_int32_values({1});
+    auto false_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
+            0, "c0", schema.type, Field::create_field<TYPE_BOOLEAN>(false), false));
+    auto true_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
+            0, "c0", schema.type, Field::create_field<TYPE_BOOLEAN>(true), false));
+
+    EXPECT_TRUE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, false_filter,
+                                                                     bloom_filter));
+    EXPECT_FALSE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, true_filter,
+                                                                      bloom_filter));
+}
+
+TEST(ParquetBloomFilterPruningTest, StringPredicateUsesArrowByteArrayHash) {
+    auto schema = primitive_bloom_schema(std::make_shared<DataTypeString>());
+    auto bloom_filter = bloom_filter_for_string_values({"alpha", "omega"});
+    auto absent_filter = bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
+            0, "c0", schema.type, Field::create_field<TYPE_STRING>("beta"), false));
+    auto present_filter =
+            bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
+                    0, "c0", schema.type, Field::create_field<TYPE_STRING>("alpha"), false));
+
+    EXPECT_TRUE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, absent_filter,
+                                                                     bloom_filter));
+    EXPECT_FALSE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, present_filter,
+                                                                      bloom_filter));
+}
+
+TEST(ParquetBloomFilterPruningTest, NullableAcceptingAndUnsupportedPredicatesKeepRowGroup) {
+    auto schema = primitive_bloom_schema(std::make_shared<DataTypeInt32>());
+    auto bloom_filter = bloom_filter_for_int32_values({1});
+    auto nested_predicate = create_comparison_predicate<PredicateType::EQ>(
+            0, "c0", schema.type, Field::create_field<TYPE_INT>(2), false);
+    auto accept_null_filter =
+            bloom_filter_with_predicate(std::make_shared<AcceptNullPredicate>(nested_predicate));
+    EXPECT_FALSE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(schema, accept_null_filter,
+                                                                      bloom_filter));
+
+    auto unsupported_schema = primitive_bloom_schema(std::make_shared<DataTypeInt16>());
+    auto unsupported_filter =
+            bloom_filter_with_predicate(create_comparison_predicate<PredicateType::EQ>(
+                    0, "c0", unsupported_schema.type, Field::create_field<TYPE_SMALLINT>(2),
+                    false));
+    EXPECT_FALSE(parquet::ParquetStatisticsUtils::BloomFilterExcludes(
+            unsupported_schema, unsupported_filter, bloom_filter));
 }
 
 class NewParquetReaderTest : public testing::Test {
@@ -981,7 +1113,7 @@ TEST_F(NewParquetReaderTest, PredicateFiltersRowGroupsByDictionary) {
     parquet::ParquetScanRange scan_range;
     ASSERT_TRUE(parquet::plan_parquet_row_groups(*parquet_file_reader->metadata(),
                                                  parquet_file_reader.get(), file_schema,
-                                                 plan_request, scan_range, &plan)
+                                                 plan_request, scan_range, false, &plan)
                         .ok());
     EXPECT_EQ(plan.pruning_stats.total_row_groups, 6);
     EXPECT_EQ(plan.pruning_stats.selected_row_groups, 1);
@@ -1059,7 +1191,7 @@ TEST_F(NewParquetReaderTest, PlannerNarrowsRowRangesByPageIndex) {
     parquet::ParquetScanRange scan_range;
     ASSERT_TRUE(parquet::plan_parquet_row_groups(*parquet_file_reader->metadata(),
                                                  parquet_file_reader.get(), file_schema, request,
-                                                 scan_range, &plan)
+                                                 scan_range, false, &plan)
                         .ok());
     ASSERT_EQ(plan.row_groups.size(), 1);
     ASSERT_FALSE(plan.row_groups[0].selected_ranges.empty());

--- a/docs/doris-new-parquet-reader-internal-layering.md
+++ b/docs/doris-new-parquet-reader-internal-layering.md
@@ -77,7 +77,7 @@ ParquetReader facade
 | Reader facade | `parquet_reader.*` | 已收敛为 file-local reader 入口，负责 init/open/get_schema/get_block/profile 聚合 |
 | FileContext | `parquet_file_context.*` | 已独立，封装 Doris file reader 到 Arrow `RandomAccessFile`、`ParquetFileReader` 和 footer metadata |
 | File-local schema/type | `parquet_column_schema.*`, `parquet_type.*` | 已独立，描述 Parquet 文件内部 schema/type，不处理 table schema evolution |
-| Pruning / row range planning | `parquet_statistics.*`, `parquet_scan.*` | statistics、dictionary、page index 已接入；bloom filter 仅有 profile/支持判断入口 |
+| Pruning / row range planning | `parquet_statistics.*`, `parquet_scan.*` | statistics、dictionary、bloom filter、page index 已接入 |
 | Scan scheduler / batch selection | `parquet_scan.*`, `selection_vector.h` | 已按 selected row ranges 扫描，predicate columns 先读，non-predicate columns lazy materialize |
 | Column reader factory | `reader/column_reader.*` | 已集中创建 reader tree 和 Arrow `RecordReader` cache |
 | Column reader tree | `reader/scalar_column_reader.*`, `reader/shape_only_column_reader.*`, `reader/struct_column_reader.*`, `reader/list_column_reader.*`, `reader/map_column_reader.*` | scalar、shape-only、row-position、struct、list、map reader 已拆分 |
@@ -169,15 +169,15 @@ ParquetReader facade
 - 基于 scan range 选择当前 reader 拥有的 row group。
 - 基于 row group statistics 做 row group keep/drop。
 - 基于 dictionary page 做 row group keep/drop。
+- 基于 bloom filter 做 row group keep/drop。
 - 基于 page index 做 row group-local row range selection。
-- 后续基于 bloom filter 做 row group keep/drop。
 - 输出 `RowGroupScanPlan`，而不是直接读取 output columns。
 - 只消费 `FileScanRequest::column_predicate_filters` 作为 pruning hint；这些 `ColumnPredicate`
   不要求对应列 materialize 到 scan block，也不能决定 batch 内某一行是否返回。
 
 当前边界：
 
-- `parquet_statistics.*` 承载 statistics、dictionary、page index 和 pruning stats。
+- `parquet_statistics.*` 承载 statistics、dictionary、bloom filter、page index 和 pruning stats。
 - `parquet_scan.*` 承载 row group plan 的 orchestration。
 - 这两个组件的职责可以后续再拆细，但不应把 pruning 逻辑放回 `ParquetReader`。
 
@@ -185,6 +185,8 @@ ParquetReader facade
 
 - 先把 Parquet metadata 转换成统一的本地统计表达，再交给 predicate/filter 判断。
 - 裁剪判断必须是 proof-based：能证明不匹配才 skip。
+- bloom filter 只处理常量等值类 predicate；当前支持 `EQ` / `IN_LIST`，跳过 null-accepting predicate、null-only predicate、复杂类型和非 primitive leaf。
+- bloom filter 底层读取复用 Arrow `BloomFilterReader`，Doris 侧只做 predicate value 到 Parquet hash 语义的 adapter。
 - page index 是 metadata pruning，输出 row ranges；是否进一步自研 page decoder 是后续 adapter 层决策。
 
 ### 5. Scan Scheduler / Batch Selection
@@ -401,6 +403,7 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 - filtered page rows。
 - selected row ranges。
 - page index read calls 和相关耗时 counter。
+- bloom filter filtered row groups 和 read time counter。
 - lazy read filtered rows counter。
 
 仍需补齐：
@@ -410,7 +413,7 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 - reader read/skip/select rows。
 - nested overflow 次数和 tail rows。
 - Arrow adapter read/decode/materialization 细分耗时。
-- bloom filter read/check 统计。
+- bloom filter check time 细分统计。
 
 ## 功能矩阵
 
@@ -427,7 +430,7 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 | Row group statistics pruning | 已实现 | Pruning | min/max/null count 转 Doris statistics 后判断 |
 | Dictionary row group pruning | 已实现 | Pruning | 当前覆盖 string-like dictionary predicate |
 | Page index pruning | 已实现 | Pruning / Scheduler | Arrow page index 转 row group-local row ranges |
-| Bloom filter pruning | 未完成 | Pruning | 有 profile/支持判断入口，未形成完整 helper |
+| Bloom filter pruning | 已实现 | Pruning | 复用 Arrow bloom reader，支持 primitive `BOOLEAN`、`INT`、`BIGINT`、`FLOAT`、`DOUBLE`、`STRING` 的 `EQ` / `IN_LIST` 保守裁剪 |
 | Batch predicate filter | 已实现 | Scheduler / Selection | 输出 `SelectionVector` |
 | Lazy materialization | 已实现 | Scheduler / Selection | predicate columns 先读，non-predicate columns 按 selection 读 |
 | Selected row range scan | 已实现 | Scheduler | range gap 通过 row-level `skip()` 推进 |
@@ -447,27 +450,7 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 
 ## 后续实现计划
 
-### P1：补 Bloom Filter Pruning
-
-目标：
-
-- 在 pruning 层补完整 bloom filter row group pruning。
-- 与 statistics/dictionary/page index 一样输出 proof-based keep/drop 结论和 profile stats。
-
-建议步骤：
-
-1. 在 `parquet_statistics.*` 内先实现 bloom helper，必要时后续再拆独立组件。
-2. 复用 `ParquetColumnSchema` 做类型支持判断。
-3. 只对能安全判断的 predicate 启用 bloom pruning。
-4. 接入 `ParquetPruningStats` 和 `ParquetReader::ParquetProfile`。
-5. 添加 positive/negative/unsupported type 测试。
-
-验收标准：
-
-- bloom filter 不能证明不匹配时保留 row group。
-- statistics、dictionary、page index、bloom 的 pruning stats 不互相覆盖。
-
-### P2：补 Observability
+### P1：补 Observability
 
 目标：
 
@@ -485,7 +468,7 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 - 能从 profile 判断 page index pruning 是否真正减少 decode/materialization。
 - 能定位复杂类型 read-ahead overflow 的开销。
 
-### P3：补复杂类型剩余覆盖
+### P2：补复杂类型剩余覆盖
 
 目标：
 
@@ -507,7 +490,7 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 - 所有复杂 child 组合使用统一 shape/value stream。
 - 列裁剪不会破坏未投影 child 的 row-level cursor。
 
-### P4：Schema Change 接入准备
+### P3：Schema Change 接入准备
 
 目标：
 
@@ -525,7 +508,7 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 - file-local reader 不知道 table/global schema。
 - schema evolution 不需要改 nested assembler 主循环。
 
-### P5：评估 Page-level Decoder
+### P4：评估 Page-level Decoder
 
 目标：
 
@@ -564,6 +547,6 @@ Status select(const SelectionVector& sel, uint16_t selected_rows,
 - 现在已经有 repeated assembler、overflow state、shape/value stream 和统一 sink，但 complex child 组合还没有全部覆盖。
 - list/map 对已支持路径复用统一 sink；新增 nested MAP、struct deep complex child 仍需要补 value appender/shape-only reader 组合。
 - schema change 还停留在边界预留阶段。
-- bloom filter pruning 和 observability 还没补完整。
+- observability 还没补完整；bloom filter 已接入 row group pruning，但 check time 还没有单独拆分。
 
-后续优先级应先补 Bloom Filter pruning，再补 observability 和剩余 complex child 组合。新增复杂类型 case 必须继续落在 nested assembler 的 value stream/appender/sink 结构上，避免 list/map reader 重新变厚。
+后续优先级应先补 observability，再补剩余 complex child 组合。新增复杂类型 case 必须继续落在 nested assembler 的 value stream/appender/sink 结构上，避免 list/map reader 重新变厚。


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: New parquet row group pruning did not use Parquet bloom filters, so equality and IN predicates could only rely on statistics and dictionary pruning before falling back to reading row groups.

This PR adds conservative bloom-filter row group pruning for the new parquet reader by reusing Arrow Parquet bloom filter APIs and adapting Doris file-layer predicates to Arrow Parquet hash checks.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - Local: git diff --check
    - Fedora: BUILD_TYPE=DEBUG ./build.sh --be
    - Fedora: ./run-be-ut.sh --run '--filter=ParquetBloomFilterPruningTest.*'
    - Fedora: ./run-be-ut.sh --run '--filter=NewParquetReaderTest.*:ParquetColumnReaderTest.*:ParquetBloomFilterPruningTest.*'
- Behavior changed: Yes. New parquet reader can prune row groups with Parquet bloom filters when enabled and predicates are supported equality or IN-list predicates.
- Does this need documentation: No
