### PR TITLE
[fix](iceberg) Use object store path for data location

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -1128,9 +1128,12 @@ public class IcebergUtils {
         }
         String dataLocation = properties.get(TableProperties.WRITE_DATA_LOCATION);
         if (dataLocation == null) {
-            dataLocation = properties.get(TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
+            dataLocation = properties.get(TableProperties.OBJECT_STORE_PATH);
             if (dataLocation == null) {
-                dataLocation = String.format("%s/data", LocationUtil.stripTrailingSlash(table.location()));
+                dataLocation = properties.get(TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
+                if (dataLocation == null) {
+                    dataLocation = String.format("%s/data", LocationUtil.stripTrailingSlash(table.location()));
+                }
             }
         }
         return dataLocation;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -1128,7 +1128,8 @@ public class IcebergUtils {
         }
         String dataLocation = properties.get(TableProperties.WRITE_DATA_LOCATION);
         if (dataLocation == null) {
-            dataLocation = properties.get(TableProperties.OBJECT_STORE_PATH);
+            dataLocation = Boolean.parseBoolean(properties.get(TableProperties.OBJECT_STORE_ENABLED))
+                    ? properties.get(TableProperties.OBJECT_STORE_PATH) : null;
             if (dataLocation == null) {
                 dataLocation = properties.get(TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
                 if (dataLocation == null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
@@ -111,6 +111,7 @@ public class IcebergUtilsTest {
     public void testDataLocationUsesLegacyObjectStorePath() {
         Table table = Mockito.mock(Table.class);
         Mockito.when(table.properties()).thenReturn(ImmutableMap.of(
+                TableProperties.OBJECT_STORE_ENABLED, "true",
                 TableProperties.OBJECT_STORE_PATH, "s3://bucket/legacy-object-store",
                 TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://bucket/folder-storage"));
 
@@ -125,6 +126,27 @@ public class IcebergUtilsTest {
                 TableProperties.OBJECT_STORE_PATH, "s3://bucket/legacy-object-store"));
 
         Assert.assertEquals("s3://bucket/data-path", IcebergUtils.dataLocation(table));
+    }
+
+    @Test
+    public void testDataLocationIgnoresObjectStorePathWhenObjectStoreDisabled() {
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.properties()).thenReturn(ImmutableMap.of(
+                TableProperties.OBJECT_STORE_ENABLED, "false",
+                TableProperties.OBJECT_STORE_PATH, "s3://bucket/legacy-object-store",
+                TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://bucket/folder-storage"));
+
+        Assert.assertEquals("s3://bucket/folder-storage", IcebergUtils.dataLocation(table));
+    }
+
+    @Test
+    public void testDataLocationIgnoresObjectStorePathWhenObjectStoreUnset() {
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.properties()).thenReturn(ImmutableMap.of(
+                TableProperties.OBJECT_STORE_PATH, "s3://bucket/legacy-object-store",
+                TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://bucket/folder-storage"));
+
+        Assert.assertEquals("s3://bucket/folder-storage", IcebergUtils.dataLocation(table));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/IcebergUtilsTest.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
@@ -104,6 +105,26 @@ public class IcebergUtilsTest {
         Field declaredField = hiveCatalog.getClass().getDeclaredField("listAllTables");
         declaredField.setAccessible(true);
         return declaredField.getBoolean(hiveCatalog);
+    }
+
+    @Test
+    public void testDataLocationUsesLegacyObjectStorePath() {
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.properties()).thenReturn(ImmutableMap.of(
+                TableProperties.OBJECT_STORE_PATH, "s3://bucket/legacy-object-store",
+                TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://bucket/folder-storage"));
+
+        Assert.assertEquals("s3://bucket/legacy-object-store", IcebergUtils.dataLocation(table));
+    }
+
+    @Test
+    public void testDataLocationPrefersWriteDataPathOverLegacyObjectStorePath() {
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(table.properties()).thenReturn(ImmutableMap.of(
+                TableProperties.WRITE_DATA_LOCATION, "s3://bucket/data-path",
+                TableProperties.OBJECT_STORE_PATH, "s3://bucket/legacy-object-store"));
+
+        Assert.assertEquals("s3://bucket/data-path", IcebergUtils.dataLocation(table));
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #63972

Related PR: #63972

Problem Summary: Iceberg data location resolution skipped the legacy object-store.path property and fell back directly to write.folder-storage.path or table location when write.data.path was not set. This could choose the wrong data location for tables that still rely on object-store.path. This change keeps write.data.path as the highest priority, then checks object-store.path before write.folder-storage.path and the default table data directory.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Ran git diff --check and git diff --cached --check. FE unit test org.apache.doris.datasource.iceberg.IcebergUtilsTest could not run because local JAVA_HOME points to JDK 11 and JDK_17 is not set.
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

