### PR TITLE
[feature](be) Add query-only FileScannerV2

### DIFF
--- a/be/src/exec/operator/file_scan_operator.cpp
+++ b/be/src/exec/operator/file_scan_operator.cpp
@@ -118,6 +118,7 @@ Status FileScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
     }
     const bool is_load = state()->desc_tbl().get_tuple_descriptor(scan_params->src_tuple_id) !=
                          nullptr;
+    // TODO: Use scanner v2 for all queries.
     const bool use_file_scanner_v2 =
             state()->query_options().__isset.enable_file_scanner_v2 &&
             state()->query_options().enable_file_scanner_v2 && !is_load &&

--- a/be/src/exec/operator/file_scan_operator.cpp
+++ b/be/src/exec/operator/file_scan_operator.cpp
@@ -116,8 +116,8 @@ Status FileScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
     } else {
         scan_params = _split_source->get_params();
     }
-    const bool is_load = state()->desc_tbl().get_tuple_descriptor(scan_params->src_tuple_id) !=
-                         nullptr;
+    const bool is_load =
+            state()->desc_tbl().get_tuple_descriptor(scan_params->src_tuple_id) != nullptr;
     // TODO: Use scanner v2 for all queries.
     const bool use_file_scanner_v2 =
             state()->query_options().__isset.enable_file_scanner_v2 &&

--- a/be/src/exec/operator/file_scan_operator.cpp
+++ b/be/src/exec/operator/file_scan_operator.cpp
@@ -24,6 +24,7 @@
 #include "exec/operator/olap_scan_operator.h"
 #include "exec/operator/scan_operator.h"
 #include "exec/scan/file_scanner.h"
+#include "exec/scan/file_scanner_v2.h"
 #include "exec/scan/scanner_context.h"
 #include "format/format_common.h"
 #include "storage/storage_engine.h"
@@ -108,10 +109,30 @@ Status FileScanLocalState::_init_scanners(std::list<ScannerSPtr>* scanners) {
                      _max_scanners);
     shard_num = std::max(shard_num, 1U);
     _kv_cache.reset(new ShardedKVCache(shard_num));
+    const TFileScanRangeParams* scan_params = nullptr;
+    if (state()->get_query_ctx() != nullptr &&
+        state()->get_query_ctx()->file_scan_range_params_map.count(parent_id()) > 0) {
+        scan_params = &state()->get_query_ctx()->file_scan_range_params_map[parent_id()];
+    } else {
+        scan_params = _split_source->get_params();
+    }
+    const bool is_load = state()->desc_tbl().get_tuple_descriptor(scan_params->src_tuple_id) !=
+                         nullptr;
+    const bool use_file_scanner_v2 =
+            state()->query_options().__isset.enable_file_scanner_v2 &&
+            state()->query_options().enable_file_scanner_v2 && !is_load &&
+            _split_source->all_scan_ranges_match(*scan_params, FileScannerV2::is_supported);
     for (int i = 0; i < _max_scanners; ++i) {
-        std::unique_ptr<FileScanner> scanner = FileScanner::create_unique(
-                state(), this, p._limit, _split_source, _scanner_profile.get(), _kv_cache.get(),
-                &p._colname_to_slot_id);
+        ScannerSPtr scanner;
+        if (use_file_scanner_v2) {
+            scanner = FileScannerV2::create_shared(state(), this, p._limit, _split_source,
+                                                   _scanner_profile.get(), _kv_cache.get(),
+                                                   &p._colname_to_slot_id);
+        } else {
+            scanner = FileScanner::create_shared(state(), this, p._limit, _split_source,
+                                                 _scanner_profile.get(), _kv_cache.get(),
+                                                 &p._colname_to_slot_id);
+        }
         RETURN_IF_ERROR(scanner->init(state(), _conjuncts));
         scanners->push_back(std::move(scanner));
     }

--- a/be/src/exec/operator/file_scan_operator.h
+++ b/be/src/exec/operator/file_scan_operator.h
@@ -30,6 +30,7 @@
 
 namespace doris {
 class FileScanner;
+class FileScannerV2;
 } // namespace doris
 
 namespace doris {
@@ -57,6 +58,7 @@ public:
 
 private:
     friend class FileScanner;
+    friend class FileScannerV2;
     PushDownType _should_push_down_bloom_filter() const override {
         return PushDownType::UNACCEPTABLE;
     }

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -38,6 +38,7 @@
 #include "exec/common/util.hpp"
 #include "exec/operator/scan_operator.h"
 #include "exprs/vcompound_pred.h"
+#include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
 #include "format/format_common.h"
 #include "format/reader/table/hive_reader.h"
@@ -295,11 +296,28 @@ Status FileScannerV2::_build_projected_columns() {
                                          slot_info.slot_id);
         }
         auto column = _build_table_column(it->second);
+        RETURN_IF_ERROR(_build_default_expr(slot_info, &column.default_expr));
         if (is_partition_slot(slot_info)) {
             column.is_partition_key = true;
             _partition_slot_descs.emplace(column.name, it->second);
         }
         _projected_columns.push_back(std::move(column));
+    }
+    return Status::OK();
+}
+
+Status FileScannerV2::_build_default_expr(const TFileScanSlotInfo& slot_info,
+                                          VExprContextSPtr* ctx) const {
+    DORIS_CHECK(ctx != nullptr);
+    if (slot_info.__isset.default_value_expr && !slot_info.default_value_expr.nodes.empty()) {
+        return VExpr::create_expr_tree(slot_info.default_value_expr, *ctx);
+    }
+
+    if (_params->__isset.default_value_of_src_slot) {
+        const auto it = _params->default_value_of_src_slot.find(slot_info.slot_id);
+        if (it != _params->default_value_of_src_slot.end() && !it->second.nodes.empty()) {
+            return VExpr::create_expr_tree(it->second, *ctx);
+        }
     }
     return Status::OK();
 }

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -91,7 +91,7 @@ bool parse_non_negative_int(std::string_view value, int32_t* result) {
     return true;
 }
 
-reader::TableColumn* find_or_add_child(reader::TableColumn* parent, reader::ColumnId id,
+reader::TableColumn* find_or_add_child(reader::TableColumn* parent, ColumnId id,
                                        std::string name, DataTypePtr type) {
     DORIS_CHECK(parent != nullptr);
     for (auto& child : parent->children) {
@@ -186,12 +186,10 @@ bool build_nested_children_from_access_paths(reader::TableColumn* column,
 
     for (const auto& access_path : slot_desc->all_access_paths()) {
         if (access_path.type != TAccessPathType::DATA || !access_path.__isset.data_access_path) {
-            column->children.clear();
             return false;
         }
         const auto& path = access_path.data_access_path.path;
         if (path.empty()) {
-            column->children.clear();
             return false;
         }
         int32_t top_level_id = -1;
@@ -210,6 +208,7 @@ bool build_nested_children_from_access_paths(reader::TableColumn* column,
 
 } // namespace
 
+// TODO: Only support parquet format now
 bool FileScannerV2::is_supported(const TFileScanRangeParams& params,
                                  const TFileRangeDesc& range) {
     return get_range_format_type(params, range) == TFileFormatType::FORMAT_PARQUET &&
@@ -330,9 +329,9 @@ Status FileScannerV2::_create_table_reader(const TFileRangeDesc& range) {
             .io_ctx = _io_ctx,
             .runtime_state = _state,
             .scanner_profile = _local_state->scanner_profile(),
-            .allow_missing_columns = true,
+            .allow_missing_columns = true, // TODO
             .push_down_agg_type = _local_state->get_push_down_agg_type(),
-            .profile = nullptr,
+            .profile = nullptr, // TODO
     }));
     return Status::OK();
 }

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -21,18 +21,24 @@
 #include <gen_cpp/PlanNodes_types.h>
 
 #include <algorithm>
+#include <charconv>
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "common/cast_set.h"
 #include "common/config.h"
 #include "common/status.h"
+#include "core/assert_cast.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
 #include "core/data_type/data_type.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_map.h"
 #include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_struct.h"
 #include "core/data_type_serde/data_type_serde.h"
 #include "core/string_ref.h"
 #include "exec/common/util.hpp"
@@ -71,6 +77,136 @@ bool is_supported_table_format(const TFileRangeDesc& range) {
 bool is_partition_slot(const TFileScanSlotInfo& slot_info) {
     return slot_info.__isset.category ? slot_info.category == TColumnCategory::PARTITION_KEY
                                       : !slot_info.is_file_slot;
+}
+
+bool parse_non_negative_int(std::string_view value, int32_t* result) {
+    DORIS_CHECK(result != nullptr);
+    int32_t parsed = -1;
+    const auto* begin = value.data();
+    const auto* end = begin + value.size();
+    const auto [ptr, ec] = std::from_chars(begin, end, parsed);
+    if (ec != std::errc() || ptr != end || parsed < 0) {
+        return false;
+    }
+    *result = parsed;
+    return true;
+}
+
+reader::TableColumn* find_or_add_child(reader::TableColumn* parent, reader::ColumnId id,
+                                       std::string name, DataTypePtr type) {
+    DORIS_CHECK(parent != nullptr);
+    for (auto& child : parent->children) {
+        if (child.id == id || child.name == name) {
+            return &child;
+        }
+    }
+    parent->children.push_back({
+            .id = id,
+            .name = std::move(name),
+            .type = std::move(type),
+    });
+    return &parent->children.back();
+}
+
+bool add_struct_access_path(reader::TableColumn* column, const DataTypeStruct& struct_type,
+                            const std::vector<std::string>& path, size_t path_idx);
+
+bool add_access_path(reader::TableColumn* column, const DataTypePtr& type,
+                     const std::vector<std::string>& path, size_t path_idx) {
+    DORIS_CHECK(column != nullptr);
+    if (path_idx >= path.size()) {
+        return true;
+    }
+    if (path[path_idx] == "OFFSET") {
+        return false;
+    }
+
+    const auto nested_type = remove_nullable(type);
+    switch (nested_type->get_primitive_type()) {
+    case TYPE_STRUCT:
+        return add_struct_access_path(column, assert_cast<const DataTypeStruct&>(*nested_type),
+                                      path, path_idx);
+    case TYPE_ARRAY: {
+        const auto& array_type = assert_cast<const DataTypeArray&>(*nested_type);
+        auto* child = find_or_add_child(column, 0, "element", array_type.get_nested_type());
+        return add_access_path(child, child->type, path, path_idx + 1);
+    }
+    case TYPE_MAP: {
+        const auto& map_type = assert_cast<const DataTypeMap&>(*nested_type);
+        if (path[path_idx] == "KEYS") {
+            return false;
+        }
+        if (path[path_idx] == "VALUES" || path[path_idx] == "*") {
+            auto entry_type = std::make_shared<DataTypeStruct>(
+                    DataTypes {map_type.get_value_type()}, Strings {"value"});
+            auto* entry_child = find_or_add_child(column, 0, "entries", entry_type);
+            auto* value_child =
+                    find_or_add_child(entry_child, 1, "value", map_type.get_value_type());
+            return add_access_path(value_child, value_child->type, path, path_idx + 1);
+        }
+        return false;
+    }
+    default:
+        return false;
+    }
+}
+
+bool add_struct_access_path(reader::TableColumn* column, const DataTypeStruct& struct_type,
+                            const std::vector<std::string>& path, size_t path_idx) {
+    DORIS_CHECK(column != nullptr);
+    DORIS_CHECK(path_idx < path.size());
+    int32_t field_id = -1;
+    std::string field_name = path[path_idx];
+    DataTypePtr field_type;
+    int32_t parsed_field_id = -1;
+    if (parse_non_negative_int(field_name, &parsed_field_id)) {
+        field_id = parsed_field_id;
+        if (parsed_field_id < static_cast<int32_t>(struct_type.get_elements().size())) {
+            field_name = struct_type.get_element_name(parsed_field_id);
+            field_type = struct_type.get_element(parsed_field_id);
+        }
+    } else if (const auto position = struct_type.try_get_position_by_name(field_name)) {
+        field_id = cast_set<int32_t>(*position);
+        field_type = struct_type.get_element(*position);
+    }
+
+    if (field_id < 0 || field_type == nullptr) {
+        return false;
+    }
+    auto* child = find_or_add_child(column, field_id, field_name, field_type);
+    return add_access_path(child, child->type, path, path_idx + 1);
+}
+
+bool build_nested_children_from_access_paths(reader::TableColumn* column,
+                                             const SlotDescriptor* slot_desc) {
+    DORIS_CHECK(column != nullptr);
+    DORIS_CHECK(slot_desc != nullptr);
+    if (slot_desc->all_access_paths().empty()) {
+        return true;
+    }
+
+    for (const auto& access_path : slot_desc->all_access_paths()) {
+        if (access_path.type != TAccessPathType::DATA || !access_path.__isset.data_access_path) {
+            column->children.clear();
+            return false;
+        }
+        const auto& path = access_path.data_access_path.path;
+        if (path.empty()) {
+            column->children.clear();
+            return false;
+        }
+        int32_t top_level_id = -1;
+        if (path.front() != column->name &&
+            (!parse_non_negative_int(path.front(), &top_level_id) || top_level_id != column->id)) {
+            column->children.clear();
+            return false;
+        }
+        if (!add_access_path(column, column->type, path, 1)) {
+            column->children.clear();
+            return false;
+        }
+    }
+    return true;
 }
 
 } // namespace
@@ -297,6 +433,7 @@ Status FileScannerV2::_build_projected_columns() {
         }
         auto column = _build_table_column(it->second);
         RETURN_IF_ERROR(_build_default_expr(slot_info, &column.default_expr));
+        static_cast<void>(build_nested_children_from_access_paths(&column, it->second));
         if (is_partition_slot(slot_info)) {
             column.is_partition_key = true;
             _partition_slot_descs.emplace(column.name, it->second);

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -43,7 +43,6 @@
 #include "core/string_ref.h"
 #include "exec/common/util.hpp"
 #include "exec/operator/scan_operator.h"
-#include "exprs/vcompound_pred.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
 #include "format/format_common.h"
@@ -325,7 +324,7 @@ Status FileScannerV2::_create_table_reader(const TFileRangeDesc& range) {
     RETURN_IF_ERROR(_table_reader->init({
             .projected_columns = _projected_columns,
             .column_predicates = std::move(table_column_predicates),
-            .conjuncts = VExprContext(_build_conjunct_root()),
+            .conjuncts = _conjuncts,
             .format = format,
             .scan_params = const_cast<TFileScanRangeParams*>(_params),
             .io_ctx = _io_ctx,
@@ -481,25 +480,6 @@ Status FileScannerV2::_build_table_column_predicates(
         (*predicates)[it->second->col_unique_id()] = slot_predicate_list;
     }
     return Status::OK();
-}
-
-VExprSPtr FileScannerV2::_build_conjunct_root() const {
-    if (_conjuncts.empty()) {
-        return nullptr;
-    }
-    if (_conjuncts.size() == 1) {
-        return _conjuncts.front()->root();
-    }
-    TExprNode node;
-    node.__set_type(create_type_desc(PrimitiveType::TYPE_BOOLEAN));
-    node.__set_node_type(TExprNodeType::COMPOUND_PRED);
-    node.__set_opcode(TExprOpcode::COMPOUND_AND);
-    node.__set_num_children(cast_set<int>(_conjuncts.size()));
-    auto compound = VCompoundPred::create_shared(node);
-    for (const auto& conjunct : _conjuncts) {
-        compound->add_child(conjunct->root());
-    }
-    return compound;
 }
 
 TFileFormatType::type FileScannerV2::_get_current_format_type() const {

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -1,0 +1,401 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exec/scan/file_scanner_v2.h"
+
+#include <gen_cpp/Exprs_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "common/cast_set.h"
+#include "common/config.h"
+#include "common/status.h"
+#include "core/block/column_with_type_and_name.h"
+#include "core/column/column.h"
+#include "core/data_type/data_type.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type_serde/data_type_serde.h"
+#include "core/string_ref.h"
+#include "exec/common/util.hpp"
+#include "exec/operator/scan_operator.h"
+#include "exprs/vcompound_pred.h"
+#include "exprs/vexpr_context.h"
+#include "format/format_common.h"
+#include "format/reader/table/hive_reader.h"
+#include "format/reader/table/paimon_reader.h"
+#include "format/reader/table_reader.h"
+#include "format/table/iceberg_reader_v2.h"
+#include "io/io_common.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+
+namespace doris {
+namespace {
+
+std::string table_format_name(const TFileRangeDesc& range) {
+    return range.__isset.table_format_params ? range.table_format_params.table_format_type
+                                             : "NotSet";
+}
+
+TFileFormatType::type get_range_format_type(const TFileScanRangeParams& params,
+                                            const TFileRangeDesc& range) {
+    return range.__isset.format_type ? range.format_type : params.format_type;
+}
+
+bool is_supported_table_format(const TFileRangeDesc& range) {
+    const auto table_format = table_format_name(range);
+    return table_format == "NotSet" || table_format == "tvf" || table_format == "hive" ||
+           table_format == "iceberg" || table_format == "paimon";
+}
+
+bool is_partition_slot(const TFileScanSlotInfo& slot_info) {
+    return slot_info.__isset.category ? slot_info.category == TColumnCategory::PARTITION_KEY
+                                      : !slot_info.is_file_slot;
+}
+
+} // namespace
+
+bool FileScannerV2::is_supported(const TFileScanRangeParams& params,
+                                 const TFileRangeDesc& range) {
+    return get_range_format_type(params, range) == TFileFormatType::FORMAT_PARQUET &&
+           is_supported_table_format(range);
+}
+
+FileScannerV2::FileScannerV2(RuntimeState* state, FileScanLocalState* local_state, int64_t limit,
+                             std::shared_ptr<SplitSourceConnector> split_source,
+                             RuntimeProfile* profile, ShardedKVCache* kv_cache,
+                             const std::unordered_map<std::string, int>* colname_to_slot_id)
+        : Scanner(state, local_state, limit, profile),
+          _split_source(std::move(split_source)),
+          _kv_cache(kv_cache) {
+    (void)colname_to_slot_id;
+    if (state->get_query_ctx() != nullptr &&
+        state->get_query_ctx()->file_scan_range_params_map.count(local_state->parent_id()) > 0) {
+        _params = &(state->get_query_ctx()->file_scan_range_params_map[local_state->parent_id()]);
+    } else {
+        _params = _split_source->get_params();
+    }
+}
+
+Status FileScannerV2::init(RuntimeState* state, const VExprContextSPtrs& conjuncts) {
+    RETURN_IF_ERROR(Scanner::init(state, conjuncts));
+    _get_block_timer =
+            ADD_TIMER_WITH_LEVEL(_local_state->scanner_profile(), "FileScannerV2GetBlockTime", 1);
+    _file_counter =
+            ADD_COUNTER_WITH_LEVEL(_local_state->scanner_profile(), "FileNumber", TUnit::UNIT, 1);
+    _file_read_bytes_counter = ADD_COUNTER_WITH_LEVEL(_local_state->scanner_profile(),
+                                                      "FileReadBytes", TUnit::BYTES, 1);
+    _file_read_calls_counter = ADD_COUNTER_WITH_LEVEL(_local_state->scanner_profile(),
+                                                      "FileReadCalls", TUnit::UNIT, 1);
+    _file_read_time_counter =
+            ADD_TIMER_WITH_LEVEL(_local_state->scanner_profile(), "FileReadTime", 1);
+    _file_cache_statistics = std::make_unique<io::FileCacheStatistics>();
+    _file_reader_stats = std::make_unique<io::FileReaderStats>();
+    RETURN_IF_ERROR(_init_io_ctx());
+    _io_ctx->file_cache_stats = _file_cache_statistics.get();
+    _io_ctx->file_reader_stats = _file_reader_stats.get();
+    _io_ctx->is_disposable = _state->query_options().disable_file_cache;
+    return Status::OK();
+}
+
+Status FileScannerV2::_open_impl(RuntimeState* state) {
+    RETURN_IF_CANCELLED(state);
+    RETURN_IF_ERROR(Scanner::_open_impl(state));
+    RETURN_IF_ERROR(_split_source->get_next(&_first_scan_range, &_current_range));
+    if (_first_scan_range) {
+        RETURN_IF_ERROR(_init_expr_ctxes());
+    }
+    return Status::OK();
+}
+
+Status FileScannerV2::_get_block_impl(RuntimeState* state, Block* block, bool* eof) {
+    while (true) {
+        RETURN_IF_CANCELLED(state);
+        if (_table_reader == nullptr) {
+            RETURN_IF_ERROR(_prepare_next_split(eof));
+            if (*eof) {
+                return Status::OK();
+            }
+        }
+
+        {
+            SCOPED_TIMER(_get_block_timer);
+            RETURN_IF_ERROR(_table_reader->get_block(block, eof));
+        }
+        if (*eof) {
+            RETURN_IF_ERROR(_table_reader->close());
+            _table_reader.reset();
+            _state->update_num_finished_scan_range(1);
+            *eof = false;
+            continue;
+        }
+        return Status::OK();
+    }
+}
+
+Status FileScannerV2::_prepare_next_split(bool* eos) {
+    if (_table_reader != nullptr) {
+        RETURN_IF_ERROR(_table_reader->close());
+        _table_reader.reset();
+        _state->update_num_finished_scan_range(1);
+    }
+
+    bool has_next = _first_scan_range;
+    if (!_first_scan_range) {
+        RETURN_IF_ERROR(_split_source->get_next(&has_next, &_current_range));
+    }
+    _first_scan_range = false;
+    if (!has_next || _should_stop) {
+        *eos = true;
+        return Status::OK();
+    }
+    _current_range_path = _current_range.path;
+    RETURN_IF_ERROR(_create_table_reader(_current_range));
+    RETURN_IF_ERROR(_prepare_table_reader_split(_current_range));
+    COUNTER_UPDATE(_file_counter, 1);
+    *eos = false;
+    return Status::OK();
+}
+
+Status FileScannerV2::_create_table_reader(const TFileRangeDesc& range) {
+    const auto format_type = _get_current_format_type();
+    reader::FileFormat format;
+    RETURN_IF_ERROR(_to_file_format(format_type, &format));
+    RETURN_IF_ERROR(_create_table_reader_for_format(range));
+    DORIS_CHECK(_table_reader != nullptr);
+
+    reader::TableColumnPredicates table_column_predicates;
+    RETURN_IF_ERROR(_build_table_column_predicates(&table_column_predicates));
+    RETURN_IF_ERROR(_table_reader->init({
+            .projected_columns = _projected_columns,
+            .column_predicates = std::move(table_column_predicates),
+            .conjuncts = VExprContext(_build_conjunct_root()),
+            .format = format,
+            .scan_params = const_cast<TFileScanRangeParams*>(_params),
+            .io_ctx = _io_ctx,
+            .runtime_state = _state,
+            .scanner_profile = _local_state->scanner_profile(),
+            .allow_missing_columns = true,
+            .push_down_agg_type = _local_state->get_push_down_agg_type(),
+            .profile = nullptr,
+    }));
+    return Status::OK();
+}
+
+Status FileScannerV2::_create_table_reader_for_format(const TFileRangeDesc& range) {
+    const auto table_format = table_format_name(range);
+    if (table_format == "NotSet" || table_format == "tvf") {
+        _table_reader = std::make_unique<reader::TableReader>();
+    } else if (table_format == "hive") {
+        _table_reader = hive::HiveReader::create_unique();
+    } else if (table_format == "iceberg") {
+        _table_reader = std::make_unique<iceberg::IcebergTableReader>();
+    } else if (table_format == "paimon") {
+        _table_reader = paimon::PaimonReader::create_unique();
+    } else {
+        return Status::NotSupported("FileScannerV2 does not support table format {}", table_format);
+    }
+    return Status::OK();
+}
+
+Status FileScannerV2::_prepare_table_reader_split(const TFileRangeDesc& range) {
+    std::map<std::string, Field> partition_values;
+    RETURN_IF_ERROR(_generate_partition_values(range, &partition_values));
+    RETURN_IF_ERROR(_table_reader->prepare_split({
+            .partition_values = std::move(partition_values),
+            .cache = _kv_cache,
+            .current_range = range,
+    }));
+    return Status::OK();
+}
+
+Status FileScannerV2::_generate_partition_values(
+        const TFileRangeDesc& range, std::map<std::string, Field>* partition_values) const {
+    DORIS_CHECK(partition_values != nullptr);
+    partition_values->clear();
+    if (!range.__isset.columns_from_path_keys || !range.__isset.columns_from_path) {
+        return Status::OK();
+    }
+    DORIS_CHECK(range.columns_from_path_keys.size() == range.columns_from_path.size());
+    for (size_t idx = 0; idx < range.columns_from_path_keys.size(); ++idx) {
+        const auto& key = range.columns_from_path_keys[idx];
+        const auto it = _partition_slot_descs.find(key);
+        if (it == _partition_slot_descs.end()) {
+            continue;
+        }
+        const auto& value = range.columns_from_path[idx];
+        const bool is_null = range.__isset.columns_from_path_is_null &&
+                             idx < range.columns_from_path_is_null.size() &&
+                             range.columns_from_path_is_null[idx];
+        Field field;
+        RETURN_IF_ERROR(_parse_partition_value(it->second, value, is_null, &field));
+        partition_values->emplace(key, std::move(field));
+    }
+    return Status::OK();
+}
+
+Status FileScannerV2::_parse_partition_value(const SlotDescriptor* slot_desc,
+                                             const std::string& value, bool is_null,
+                                             Field* field) const {
+    DORIS_CHECK(slot_desc != nullptr);
+    DORIS_CHECK(field != nullptr);
+    if (is_null) {
+        *field = Field::create_field<TYPE_NULL>(Null());
+        return Status::OK();
+    }
+    const auto data_type = remove_nullable(slot_desc->get_data_type_ptr());
+    auto column = data_type->create_column();
+    auto serde = data_type->get_serde();
+    DataTypeSerDe::FormatOptions options;
+    options.converted_from_string = true;
+    StringRef ref(value.data(), value.size());
+    RETURN_IF_ERROR(serde->from_string(ref, *column, options));
+    DORIS_CHECK(column->size() == 1);
+    *field = (*column)[0];
+    return Status::OK();
+}
+
+Status FileScannerV2::_init_expr_ctxes() {
+    _slot_id_to_desc.clear();
+    _partition_slot_descs.clear();
+    for (const auto* slot_desc : _output_tuple_desc->slots()) {
+        _slot_id_to_desc.emplace(slot_desc->id(), slot_desc);
+    }
+    RETURN_IF_ERROR(_build_projected_columns());
+    return Status::OK();
+}
+
+Status FileScannerV2::_build_projected_columns() {
+    _projected_columns.clear();
+    _projected_columns.reserve(_params->required_slots.size());
+
+    for (const auto& slot_info : _params->required_slots) {
+        const auto it = _slot_id_to_desc.find(slot_info.slot_id);
+        if (it == _slot_id_to_desc.end()) {
+            return Status::InternalError("Unknown source slot descriptor, slot_id={}",
+                                         slot_info.slot_id);
+        }
+        auto column = _build_table_column(it->second);
+        if (is_partition_slot(slot_info)) {
+            column.is_partition_key = true;
+            _partition_slot_descs.emplace(column.name, it->second);
+        }
+        _projected_columns.push_back(std::move(column));
+    }
+    return Status::OK();
+}
+
+reader::TableColumn FileScannerV2::_build_table_column(const SlotDescriptor* slot_desc) {
+    DORIS_CHECK(slot_desc != nullptr);
+    reader::TableColumn column;
+    column.id = slot_desc->col_unique_id();
+    column.name = slot_desc->col_name();
+    column.type = slot_desc->get_data_type_ptr();
+    return column;
+}
+
+Status FileScannerV2::_build_table_column_predicates(
+        reader::TableColumnPredicates* predicates) const {
+    DORIS_CHECK(predicates != nullptr);
+    predicates->clear();
+    const auto& slot_predicates = _local_state->cast<FileScanLocalState>()._slot_id_to_predicates;
+    for (const auto& [slot_id, slot_predicate_list] : slot_predicates) {
+        const auto it = _slot_id_to_desc.find(slot_id);
+        if (it == _slot_id_to_desc.end()) {
+            continue;
+        }
+        (*predicates)[it->second->col_unique_id()] = slot_predicate_list;
+    }
+    return Status::OK();
+}
+
+VExprSPtr FileScannerV2::_build_conjunct_root() const {
+    if (_conjuncts.empty()) {
+        return nullptr;
+    }
+    if (_conjuncts.size() == 1) {
+        return _conjuncts.front()->root();
+    }
+    TExprNode node;
+    node.__set_type(create_type_desc(PrimitiveType::TYPE_BOOLEAN));
+    node.__set_node_type(TExprNodeType::COMPOUND_PRED);
+    node.__set_opcode(TExprOpcode::COMPOUND_AND);
+    node.__set_num_children(cast_set<int>(_conjuncts.size()));
+    auto compound = VCompoundPred::create_shared(node);
+    for (const auto& conjunct : _conjuncts) {
+        compound->add_child(conjunct->root());
+    }
+    return compound;
+}
+
+TFileFormatType::type FileScannerV2::_get_current_format_type() const {
+    return get_range_format_type(*_params, _current_range);
+}
+
+Status FileScannerV2::_to_file_format(TFileFormatType::type format_type,
+                                      reader::FileFormat* format) {
+    DORIS_CHECK(format != nullptr);
+    switch (format_type) {
+    case TFileFormatType::FORMAT_PARQUET:
+        *format = reader::FileFormat::PARQUET;
+        return Status::OK();
+    default:
+        return Status::NotSupported("FileScannerV2 does not support file format {}",
+                                    to_string(format_type));
+    }
+}
+
+Status FileScannerV2::_init_io_ctx() {
+    _io_ctx = std::make_shared<io::IOContext>();
+    _io_ctx->query_id = &_state->query_id();
+    return Status::OK();
+}
+
+Status FileScannerV2::close(RuntimeState* state) {
+    if (!_try_close()) {
+        return Status::OK();
+    }
+    if (_table_reader != nullptr) {
+        RETURN_IF_ERROR(_table_reader->close());
+        _table_reader.reset();
+    }
+    return Scanner::close(state);
+}
+
+void FileScannerV2::try_stop() {
+    _should_stop = true;
+    if (_table_reader != nullptr) {
+        static_cast<void>(_table_reader->close());
+    }
+}
+
+void FileScannerV2::update_realtime_counters() {
+    if (_file_reader_stats == nullptr) {
+        return;
+    }
+    const int64_t bytes_read = _file_reader_stats->read_bytes;
+    COUNTER_SET(_file_read_bytes_counter, bytes_read);
+    COUNTER_SET(_file_read_calls_counter, cast_set<int64_t>(_file_reader_stats->read_calls));
+    COUNTER_SET(_file_read_time_counter, cast_set<int64_t>(_file_reader_stats->read_time_ns));
+}
+
+} // namespace doris

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -17,6 +17,7 @@
 
 #include "exec/scan/file_scanner_v2.h"
 
+#include <fmt/format.h>
 #include <gen_cpp/Exprs_types.h>
 #include <gen_cpp/PlanNodes_types.h>
 
@@ -91,6 +92,10 @@ bool parse_non_negative_int(std::string_view value, int32_t* result) {
     return true;
 }
 
+std::string access_path_to_string(const std::vector<std::string>& path) {
+    return fmt::format("{}", fmt::join(path, "."));
+}
+
 reader::TableColumn* find_or_add_child(reader::TableColumn* parent, reader::ColumnId id,
                                        std::string name, DataTypePtr type) {
     DORIS_CHECK(parent != nullptr);
@@ -110,17 +115,18 @@ reader::TableColumn* find_or_add_child(reader::TableColumn* parent, reader::Colu
     return &parent->children.back();
 }
 
-bool add_struct_access_path(reader::TableColumn* column, const DataTypeStruct& struct_type,
-                            const std::vector<std::string>& path, size_t path_idx);
+Status add_struct_access_path(reader::TableColumn* column, const DataTypeStruct& struct_type,
+                              const std::vector<std::string>& path, size_t path_idx);
 
-bool add_access_path(reader::TableColumn* column, const DataTypePtr& type,
-                     const std::vector<std::string>& path, size_t path_idx) {
+Status add_access_path(reader::TableColumn* column, const DataTypePtr& type,
+                       const std::vector<std::string>& path, size_t path_idx) {
     DORIS_CHECK(column != nullptr);
     if (path_idx >= path.size()) {
-        return true;
+        return Status::OK();
     }
     if (path[path_idx] == "OFFSET") {
-        return false;
+        return Status::NotSupported("FileScannerV2 does not support access path {} for slot {}",
+                                    access_path_to_string(path), column->name);
     }
 
     const auto nested_type = remove_nullable(type);
@@ -136,7 +142,9 @@ bool add_access_path(reader::TableColumn* column, const DataTypePtr& type,
     case TYPE_MAP: {
         const auto& map_type = assert_cast<const DataTypeMap&>(*nested_type);
         if (path[path_idx] == "KEYS") {
-            return false;
+            return Status::NotSupported(
+                    "FileScannerV2 does not support key access path {} for slot {}",
+                    access_path_to_string(path), column->name);
         }
         if (path[path_idx] == "VALUES" || path[path_idx] == "*") {
             auto entry_type = std::make_shared<DataTypeStruct>(
@@ -146,15 +154,17 @@ bool add_access_path(reader::TableColumn* column, const DataTypePtr& type,
                     find_or_add_child(entry_child, 1, "value", map_type.get_value_type());
             return add_access_path(value_child, value_child->type, path, path_idx + 1);
         }
-        return false;
+        return Status::NotSupported("FileScannerV2 does not support access path {} for slot {}",
+                                    access_path_to_string(path), column->name);
     }
     default:
-        return false;
+        return Status::NotSupported("FileScannerV2 does not support access path {} for slot {}",
+                                    access_path_to_string(path), column->name);
     }
 }
 
-bool add_struct_access_path(reader::TableColumn* column, const DataTypeStruct& struct_type,
-                            const std::vector<std::string>& path, size_t path_idx) {
+Status add_struct_access_path(reader::TableColumn* column, const DataTypeStruct& struct_type,
+                              const std::vector<std::string>& path, size_t path_idx) {
     DORIS_CHECK(column != nullptr);
     DORIS_CHECK(path_idx < path.size());
     int32_t field_id = -1;
@@ -173,40 +183,40 @@ bool add_struct_access_path(reader::TableColumn* column, const DataTypeStruct& s
     }
 
     if (field_id < 0 || field_type == nullptr) {
-        return false;
+        return Status::NotSupported("FileScannerV2 does not support access path {} for slot {}",
+                                    access_path_to_string(path), column->name);
     }
     auto* child = find_or_add_child(column, field_id, field_name, field_type);
     return add_access_path(child, child->type, path, path_idx + 1);
 }
 
-bool build_nested_children_from_access_paths(reader::TableColumn* column,
-                                             const SlotDescriptor* slot_desc) {
+Status build_nested_children_from_access_paths(reader::TableColumn* column,
+                                               const SlotDescriptor* slot_desc) {
     DORIS_CHECK(column != nullptr);
     DORIS_CHECK(slot_desc != nullptr);
     if (slot_desc->all_access_paths().empty()) {
-        return true;
+        return Status::OK();
     }
 
     for (const auto& access_path : slot_desc->all_access_paths()) {
         if (access_path.type != TAccessPathType::DATA || !access_path.__isset.data_access_path) {
-            return false;
+            return Status::NotSupported("FileScannerV2 only supports DATA access paths for slot {}",
+                                        column->name);
         }
         const auto& path = access_path.data_access_path.path;
         if (path.empty()) {
-            return false;
+            return Status::NotSupported("FileScannerV2 found empty access path for slot {}",
+                                        column->name);
         }
         int32_t top_level_id = -1;
         if (path.front() != column->name &&
             (!parse_non_negative_int(path.front(), &top_level_id) || top_level_id != column->id)) {
-            column->children.clear();
-            return false;
+            return Status::NotSupported("FileScannerV2 access path {} does not match slot {}",
+                                        access_path_to_string(path), column->name);
         }
-        if (!add_access_path(column, column->type, path, 1)) {
-            column->children.clear();
-            return false;
-        }
+        RETURN_IF_ERROR(add_access_path(column, column->type, path, 1));
     }
-    return true;
+    return Status::OK();
 }
 
 } // namespace
@@ -433,9 +443,7 @@ Status FileScannerV2::_build_projected_columns() {
         }
         auto column = _build_table_column(it->second);
         RETURN_IF_ERROR(_build_default_expr(slot_info, &column.default_expr));
-        if (!build_nested_children_from_access_paths(&column, it->second)) {
-            column.children.clear();
-        }
+        RETURN_IF_ERROR(build_nested_children_from_access_paths(&column, it->second));
         if (is_partition_slot(slot_info)) {
             column.is_partition_key = true;
             _partition_slot_descs.emplace(column.name, it->second);

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -433,7 +433,9 @@ Status FileScannerV2::_build_projected_columns() {
         }
         auto column = _build_table_column(it->second);
         RETURN_IF_ERROR(_build_default_expr(slot_info, &column.default_expr));
-        static_cast<void>(build_nested_children_from_access_paths(&column, it->second));
+        if (!build_nested_children_from_access_paths(&column, it->second)) {
+            column.children.clear();
+        }
         if (is_partition_slot(slot_info)) {
             column.is_partition_key = true;
             _partition_slot_descs.emplace(column.name, it->second);

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -91,8 +91,8 @@ bool parse_non_negative_int(std::string_view value, int32_t* result) {
     return true;
 }
 
-reader::TableColumn* find_or_add_child(reader::TableColumn* parent, ColumnId id,
-                                       std::string name, DataTypePtr type) {
+reader::TableColumn* find_or_add_child(reader::TableColumn* parent, ColumnId id, std::string name,
+                                       DataTypePtr type) {
     DORIS_CHECK(parent != nullptr);
     for (auto& child : parent->children) {
         if (child.id == id || child.name == name) {
@@ -209,8 +209,7 @@ bool build_nested_children_from_access_paths(reader::TableColumn* column,
 } // namespace
 
 // TODO: Only support parquet format now
-bool FileScannerV2::is_supported(const TFileScanRangeParams& params,
-                                 const TFileRangeDesc& range) {
+bool FileScannerV2::is_supported(const TFileScanRangeParams& params, const TFileRangeDesc& range) {
     return get_range_format_type(params, range) == TFileFormatType::FORMAT_PARQUET &&
            is_supported_table_format(range);
 }

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -104,6 +104,8 @@ reader::TableColumn* find_or_add_child(reader::TableColumn* parent, reader::Colu
             .name = std::move(name),
             .type = std::move(type),
             .children = {},
+            .default_expr = nullptr,
+            .is_partition_key = false,
     });
     return &parent->children.back();
 }

--- a/be/src/exec/scan/file_scanner_v2.cpp
+++ b/be/src/exec/scan/file_scanner_v2.cpp
@@ -91,8 +91,8 @@ bool parse_non_negative_int(std::string_view value, int32_t* result) {
     return true;
 }
 
-reader::TableColumn* find_or_add_child(reader::TableColumn* parent, ColumnId id, std::string name,
-                                       DataTypePtr type) {
+reader::TableColumn* find_or_add_child(reader::TableColumn* parent, reader::ColumnId id,
+                                       std::string name, DataTypePtr type) {
     DORIS_CHECK(parent != nullptr);
     for (auto& child : parent->children) {
         if (child.id == id || child.name == name) {
@@ -103,6 +103,7 @@ reader::TableColumn* find_or_add_child(reader::TableColumn* parent, ColumnId id,
             .id = id,
             .name = std::move(name),
             .type = std::move(type),
+            .children = {},
     });
     return &parent->children.back();
 }

--- a/be/src/exec/scan/file_scanner_v2.h
+++ b/be/src/exec/scan/file_scanner_v2.h
@@ -81,6 +81,7 @@ private:
     Status _parse_partition_value(const SlotDescriptor* slot_desc, const std::string& value,
                                   bool is_null, Field* field) const;
     Status _build_projected_columns();
+    Status _build_default_expr(const TFileScanSlotInfo& slot_info, VExprContextSPtr* ctx) const;
     static reader::TableColumn _build_table_column(const SlotDescriptor* slot_desc);
     Status _build_table_column_predicates(reader::TableColumnPredicates* predicates) const;
     VExprSPtr _build_conjunct_root() const;

--- a/be/src/exec/scan/file_scanner_v2.h
+++ b/be/src/exec/scan/file_scanner_v2.h
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "common/factory_creator.h"
+#include "common/status.h"
+#include "core/block/block.h"
+#include "exec/operator/file_scan_operator.h"
+#include "exec/scan/scanner.h"
+#include "exec/scan/split_source_connector.h"
+#include "exprs/vexpr_fwd.h"
+#include "format/reader/column_mapper.h"
+#include "format/reader/table_reader.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "io/io_common.h"
+#include "runtime/runtime_profile.h"
+
+namespace doris {
+
+class RuntimeState;
+class SlotDescriptor;
+class TFileRangeDesc;
+class TFileScanRangeParams;
+class ShardedKVCache;
+
+class FileScannerV2 final : public Scanner {
+    ENABLE_FACTORY_CREATOR(FileScannerV2);
+
+public:
+    static constexpr const char* NAME = "FileScannerV2";
+
+    static bool is_supported(const TFileScanRangeParams& params, const TFileRangeDesc& range);
+
+    FileScannerV2(RuntimeState* state, FileScanLocalState* parent, int64_t limit,
+                  std::shared_ptr<SplitSourceConnector> split_source, RuntimeProfile* profile,
+                  ShardedKVCache* kv_cache,
+                  const std::unordered_map<std::string, int>* colname_to_slot_id);
+
+    Status init(RuntimeState* state, const VExprContextSPtrs& conjuncts) override;
+    Status _open_impl(RuntimeState* state) override;
+    Status close(RuntimeState* state) override;
+    void try_stop() override;
+    std::string get_name() override { return FileScannerV2::NAME; }
+    std::string get_current_scan_range_name() override { return _current_range_path; }
+    void update_realtime_counters() override;
+
+protected:
+    Status _get_block_impl(RuntimeState* state, Block* block, bool* eof) override;
+
+private:
+    TFileFormatType::type _get_current_format_type() const;
+    Status _init_io_ctx();
+    Status _init_expr_ctxes();
+    Status _prepare_next_split(bool* eos);
+    Status _create_table_reader(const TFileRangeDesc& range);
+    Status _create_table_reader_for_format(const TFileRangeDesc& range);
+    Status _prepare_table_reader_split(const TFileRangeDesc& range);
+    Status _generate_partition_values(const TFileRangeDesc& range,
+                                      std::map<std::string, Field>* partition_values) const;
+    Status _parse_partition_value(const SlotDescriptor* slot_desc, const std::string& value,
+                                  bool is_null, Field* field) const;
+    Status _build_projected_columns();
+    static reader::TableColumn _build_table_column(const SlotDescriptor* slot_desc);
+    Status _build_table_column_predicates(reader::TableColumnPredicates* predicates) const;
+    VExprSPtr _build_conjunct_root() const;
+    static Status _to_file_format(TFileFormatType::type format_type, reader::FileFormat* format);
+
+    const TFileScanRangeParams* _params = nullptr;
+    std::shared_ptr<SplitSourceConnector> _split_source;
+    bool _first_scan_range = false;
+    TFileRangeDesc _current_range;
+    std::string _current_range_path;
+
+    std::unique_ptr<reader::TableReader> _table_reader;
+    std::vector<reader::TableColumn> _projected_columns;
+    std::unordered_map<int32_t, const SlotDescriptor*> _slot_id_to_desc;
+    std::unordered_map<std::string, const SlotDescriptor*> _partition_slot_descs;
+
+    std::unique_ptr<io::FileCacheStatistics> _file_cache_statistics;
+    std::unique_ptr<io::FileReaderStats> _file_reader_stats;
+    std::shared_ptr<io::IOContext> _io_ctx;
+    ShardedKVCache* _kv_cache = nullptr;
+
+    RuntimeProfile::Counter* _get_block_timer = nullptr;
+    RuntimeProfile::Counter* _file_counter = nullptr;
+    RuntimeProfile::Counter* _file_read_bytes_counter = nullptr;
+    RuntimeProfile::Counter* _file_read_calls_counter = nullptr;
+    RuntimeProfile::Counter* _file_read_time_counter = nullptr;
+};
+
+} // namespace doris

--- a/be/src/exec/scan/file_scanner_v2.h
+++ b/be/src/exec/scan/file_scanner_v2.h
@@ -84,7 +84,6 @@ private:
     Status _build_default_expr(const TFileScanSlotInfo& slot_info, VExprContextSPtr* ctx) const;
     static reader::TableColumn _build_table_column(const SlotDescriptor* slot_desc);
     Status _build_table_column_predicates(reader::TableColumnPredicates* predicates) const;
-    VExprSPtr _build_conjunct_root() const;
     static Status _to_file_format(TFileFormatType::type format_type, reader::FileFormat* format);
 
     const TFileScanRangeParams* _params = nullptr;

--- a/be/src/exec/scan/split_source_connector.h
+++ b/be/src/exec/scan/split_source_connector.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "common/config.h"
 #include "core/custom_allocator.h"
 #include "runtime/runtime_state.h"
@@ -44,6 +46,15 @@ public:
     virtual int num_scan_ranges() = 0;
 
     virtual TFileScanRangeParams* get_params() = 0;
+
+    virtual bool all_scan_ranges_match(
+            const TFileScanRangeParams& params,
+            const std::function<bool(const TFileScanRangeParams&, const TFileRangeDesc&)>&
+                    predicate) {
+        (void)params;
+        (void)predicate;
+        return false;
+    }
 
 protected:
     template <typename T, typename V1 = std::vector<T>, typename V2 = std::vector<T>>
@@ -124,6 +135,24 @@ public:
         }
         throw Exception(
                 Status::FatalError("Unreachable, params is got by file_scan_range_params_map"));
+    }
+
+    bool all_scan_ranges_match(
+            const TFileScanRangeParams& params,
+            const std::function<bool(const TFileScanRangeParams&, const TFileRangeDesc&)>&
+                    predicate) override {
+        if (_scan_ranges.empty()) {
+            return false;
+        }
+        for (const auto& scan_range : _scan_ranges) {
+            const auto& file_scan_range = scan_range.scan_range.ext_scan_range.file_scan_range;
+            for (const auto& range : file_scan_range.ranges) {
+                if (!predicate(params, range)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 };
 

--- a/be/src/format/reader/table_reader.cpp
+++ b/be/src/format/reader/table_reader.cpp
@@ -168,7 +168,9 @@ Status TableReader::init(TableReadOptions&& options) {
 
 Status TableReader::_build_table_filters_from_conjuncts() {
     _table_filters.clear();
-    build_table_filters_from_conjunct(_conjuncts.root(), &_table_filters);
+    for (const auto& conjunct : _conjuncts) {
+        build_table_filters_from_conjunct(conjunct->root(), &_table_filters);
+    }
     return Status::OK();
 }
 

--- a/be/src/format/reader/table_reader.h
+++ b/be/src/format/reader/table_reader.h
@@ -120,7 +120,7 @@ struct TableReadOptions {
     // Simple predicates for a single column, which is parsed on scan operator.
     const TableColumnPredicates column_predicates;
     // All complex conjuncts from scan operator
-    const VExprContext conjuncts;
+    const VExprContextSPtrs conjuncts;
     // File format of the underlying data files, needed for reader initialization and reader-level
     // filter pushdown.
     const FileFormat format;
@@ -783,7 +783,7 @@ protected:
     // Predicates built from scan conjuncts before file-level localization.
     std::vector<TableFilter> _table_filters;
     TableColumnPredicates _table_column_predicates;
-    VExprContext _conjuncts {nullptr};
+    VExprContextSPtrs _conjuncts;
     std::unique_ptr<ReadProfile> _profile;
     // Parsed from row-position based delete files, including position delete and deletion vector.
     DeleteRows* _delete_rows = nullptr;

--- a/be/test/exec/scan/vfile_scanner_exception_test.cpp
+++ b/be/test/exec/scan/vfile_scanner_exception_test.cpp
@@ -25,6 +25,8 @@
 #include "cpp/sync_point.h"
 #include "exec/operator/file_scan_operator.h"
 #include "exec/scan/file_scanner.h"
+#include "exec/scan/file_scanner_v2.h"
+#include "exec/scan/split_source_connector.h"
 #include "io/fs/local_file_system.h"
 #include "load/group_commit/wal/wal_manager.h"
 #include "runtime/cluster_info.h"
@@ -334,6 +336,46 @@ TEST_F(VfileScannerExceptionTest, process_late_arrival_conjuncts_retain) {
     ASSERT_EQ(scanner->_push_down_conjuncts.size(), 1);
 
     WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
+}
+
+TEST(FileScannerV2Test, SupportOnlyRefactoredTableReaders) {
+    TFileScanRangeParams params;
+    params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+
+    TFileRangeDesc range;
+    EXPECT_TRUE(FileScannerV2::is_supported(params, range));
+
+    TTableFormatFileDesc table_format;
+    table_format.__set_table_format_type("iceberg");
+    range.__set_table_format_params(table_format);
+    EXPECT_TRUE(FileScannerV2::is_supported(params, range));
+
+    table_format.__set_table_format_type("hive");
+    range.__set_table_format_params(table_format);
+    EXPECT_TRUE(FileScannerV2::is_supported(params, range));
+
+    table_format.__set_table_format_type("paimon");
+    range.__set_table_format_params(table_format);
+    EXPECT_TRUE(FileScannerV2::is_supported(params, range));
+
+    table_format.__set_table_format_type("hudi");
+    range.__set_table_format_params(table_format);
+    EXPECT_FALSE(FileScannerV2::is_supported(params, range));
+
+    range.__set_format_type(TFileFormatType::FORMAT_ORC);
+    table_format.__set_table_format_type("hive");
+    range.__set_table_format_params(table_format);
+    EXPECT_FALSE(FileScannerV2::is_supported(params, range));
+
+    TScanRangeParams scan_range_params;
+    scan_range_params.scan_range.ext_scan_range.file_scan_range.ranges.push_back(range);
+    LocalSplitSourceConnector split_source({scan_range_params}, 1);
+    EXPECT_FALSE(split_source.all_scan_ranges_match(params, FileScannerV2::is_supported));
+
+    range.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+    scan_range_params.scan_range.ext_scan_range.file_scan_range.ranges[0] = range;
+    LocalSplitSourceConnector supported_split_source({scan_range_params}, 1);
+    EXPECT_TRUE(supported_split_source.all_scan_ranges_match(params, FileScannerV2::is_supported));
 }
 
 } // namespace doris

--- a/be/test/format/reader/table_reader_test.cpp
+++ b/be/test/format/reader/table_reader_test.cpp
@@ -123,7 +123,7 @@ public:
         RETURN_IF_ERROR(init({
                 .projected_columns = std::move(projected_columns),
                 .column_predicates = {},
-                .conjuncts = VExprContext(nullptr),
+                .conjuncts = {},
                 .format = FileFormat::PARQUET,
                 .scan_params = nullptr,
                 .io_ctx = nullptr,
@@ -748,8 +748,8 @@ TEST(TableReaderTest, ReopenSplitAfterClose) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(
-                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 0)),
+                                    .conjuncts = {VExprContext::create_shared(
+                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 0))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -812,7 +812,7 @@ TEST(TableReaderTest, PushDownCountFromNewParquetReader) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -853,7 +853,7 @@ TEST(TableReaderTest, PushDownMinMaxFromNewParquetReader) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -900,7 +900,7 @@ TEST(TableReaderTest, PushDownMinMaxCastsFileValueToTableType) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -947,7 +947,7 @@ TEST(TableReaderTest, PushDownMinMaxFromProjectedStructLeaf) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -998,7 +998,7 @@ TEST(TableReaderTest, PushDownMinMaxFallsBackForProjectedListStructLeaf) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1059,7 +1059,7 @@ TEST(TableReaderTest, PushDownMinMaxFallsBackForProjectedMapValueStructLeaf) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1114,7 +1114,7 @@ TEST(TableReaderTest, PushDownMinMaxOnlyUsesSelectedRowGroupInFileRange) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1157,7 +1157,7 @@ TEST(TableReaderTest, PushDownCountOnlyUsesSelectedRowGroupInFileRange) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1197,8 +1197,8 @@ TEST(TableReaderTest, PushDownCountFallsBackWithTableConjunct) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(
-                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 2)),
+                                    .conjuncts = {VExprContext::create_shared(
+                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 2))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1244,7 +1244,7 @@ TEST(TableReaderTest, PushDownCountFallsBackWithColumnPredicate) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = std::move(column_predicates),
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1287,7 +1287,7 @@ TEST(TableReaderTest, PushDownMinMaxFallsBackWithoutDirectFileMapping) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1329,8 +1329,8 @@ TEST(TableReaderTest, OpenReaderBuildsTableFiltersFromConjuncts) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(
-                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 2)),
+                                    .conjuncts = {VExprContext::create_shared(
+                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 2))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1363,8 +1363,8 @@ TEST(TableReaderTest, OpenReaderBuildsTableFiltersFromConjuncts) {
                         .init({
                                 .projected_columns = projected_columns,
                                 .column_predicates = {},
-                                .conjuncts = VExprContext(
-                                        std::make_shared<TableInt32GreaterThanExpr>(0, 0, 4)),
+                                .conjuncts = {VExprContext::create_shared(
+                                        std::make_shared<TableInt32GreaterThanExpr>(0, 0, 4))},
                                 .format = FileFormat::PARQUET,
                                 .scan_params = nullptr,
                                 .io_ctx = nullptr,
@@ -1410,7 +1410,7 @@ TEST(TableReaderTest, OpenReaderBuildsColumnPredicateFilters) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = std::move(column_predicates),
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1464,7 +1464,7 @@ TEST(TableReaderTest, ColumnPredicateSurvivesReopenSplit) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = std::move(column_predicates),
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1603,9 +1603,9 @@ TEST(TableReaderTest, OpenReaderPushesMultiColumnConjunctToParquetReader) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(
+                                    .conjuncts = {VExprContext::create_shared(
                                             std::make_shared<TableInt32SumGreaterThanExpr>(0, 0, 1,
-                                                                                           1, 8)),
+                                                                                           1, 8))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1658,7 +1658,7 @@ TEST(TableReaderTest, ProjectedColumnsFillDefaultForParquetSchemaMismatch) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1702,7 +1702,7 @@ TEST(TableReaderTest, ProjectedColumnsRejectParquetSchemaMismatchWhenMissingColu
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1751,7 +1751,7 @@ TEST(TableReaderTest, ProjectedStructFillsMissingChildWithDefault) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1800,7 +1800,7 @@ TEST(TableReaderTest, ProjectedPartitionColumnUsesSplitPartitionValue) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1853,8 +1853,8 @@ TEST(TableReaderTest, IcebergVirtualColumnsUseRowLineageMetadata) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(
-                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 1)),
+                                    .conjuncts = {VExprContext::create_shared(
+                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 1))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1908,8 +1908,8 @@ TEST(TableReaderTest, IcebergVirtualColumnsKeepRowLineageAfterConjunctFiltering)
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(
-                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 1)),
+                                    .conjuncts = {VExprContext::create_shared(
+                                            std::make_shared<TableInt32GreaterThanExpr>(0, 0, 1))},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1969,7 +1969,7 @@ TEST(TableReaderTest, IcebergVirtualColumnsKeepRowLineageAfterRowGroupPredicateP
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = std::move(column_predicates),
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -2062,7 +2062,7 @@ TEST(TableReaderTest, IcebergTableReaderAppliesDeletionVectorFile) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2111,7 +2111,7 @@ TEST(TableReaderTest, IcebergTableReaderDoesNotPushDownAggregateWithDeletes) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2167,7 +2167,7 @@ TEST(TableReaderTest, IcebergTableReaderDoesNotPushDownAggregateWithPositionDele
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2223,7 +2223,7 @@ TEST(TableReaderTest, IcebergPositionDeleteFallsBackToSplitPath) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2275,7 +2275,7 @@ TEST(TableReaderTest, IcebergTableReaderDoesNotPushDownAggregateWithEqualityDele
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2331,7 +2331,7 @@ TEST(TableReaderTest, IcebergEqualityDeleteCastsDataColumnToDeleteKeyType) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2380,7 +2380,7 @@ TEST(TableReaderTest, IcebergPositionDeleteOnlyMatchesOriginalDataFilePath) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2430,7 +2430,7 @@ TEST(TableReaderTest, IcebergRowLineageRemainsFileLocalAfterDeleteFiltering) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2489,7 +2489,7 @@ TEST(TableReaderTest, IcebergTableReaderAppliesPositionDeleteFile) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2540,7 +2540,7 @@ TEST(TableReaderTest, IcebergTableReaderMergesDeletionVectorAndPositionDeleteFil
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
@@ -2610,7 +2610,7 @@ TEST(TableReaderTest, ParquetReaderReadsOnlyRowGroupsInFileRange) {
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -2659,7 +2659,7 @@ TEST(TableReaderTest, ProjectedColumnsUseMapperExpressionForSameNameDifferentIdP
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -2708,7 +2708,7 @@ TEST(TableReaderTest, ProjectedColumnsUseMapperExpressionsForParquetSchemaMismat
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
                                     .column_predicates = {},
-                                    .conjuncts = VExprContext(nullptr),
+                                    .conjuncts = {},
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,

--- a/be/test/format/reader/table_reader_test.cpp
+++ b/be/test/format/reader/table_reader_test.cpp
@@ -1600,21 +1600,22 @@ TEST(TableReaderTest, OpenReaderPushesMultiColumnConjunctToParquetReader) {
 
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     TableReader reader;
-    ASSERT_TRUE(reader.init({
-                                    .projected_columns = projected_columns,
-                                    .column_predicates = {},
-                                    .conjuncts = {VExprContext::create_shared(
-                                            std::make_shared<TableInt32SumGreaterThanExpr>(0, 0, 1,
-                                                                                           1, 8))},
-                                    .format = FileFormat::PARQUET,
-                                    .scan_params = nullptr,
-                                    .io_ctx = nullptr,
-                                    .runtime_state = &state,
-                                    .scanner_profile = nullptr,
-                                    .allow_missing_columns = true,
-                                    .profile = nullptr,
-                            })
-                        .ok());
+    ASSERT_TRUE(
+            reader
+                    .init({
+                            .projected_columns = projected_columns,
+                            .column_predicates = {},
+                            .conjuncts = {VExprContext::create_shared(
+                                    std::make_shared<TableInt32SumGreaterThanExpr>(0, 0, 1, 1, 8))},
+                            .format = FileFormat::PARQUET,
+                            .scan_params = nullptr,
+                            .io_ctx = nullptr,
+                            .runtime_state = &state,
+                            .scanner_profile = nullptr,
+                            .allow_missing_columns = true,
+                            .profile = nullptr,
+                    })
+                    .ok());
 
     ASSERT_TRUE(reader.prepare_split(build_split_options(file_path)).ok());
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -96,6 +96,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SCAN_QUEUE_MEM_LIMIT = "scan_queue_mem_limit";
     public static final String MAX_SCANNERS_CONCURRENCY = "max_scanners_concurrency";
     public static final String MAX_FILE_SCANNERS_CONCURRENCY = "max_file_scanners_concurrency";
+    public static final String ENABLE_FILE_SCANNER_V2 = "enable_file_scanner_v2";
     public static final String MIN_SCANNERS_CONCURRENCY = "min_scanners_concurrency";
     public static final String MIN_FILE_SCANNERS_CONCURRENCY = "min_file_scanners_concurrency";
     public static final String MIN_SCAN_SCHEDULER_CONCURRENCY = "min_scan_scheduler_concurrency";
@@ -1093,6 +1094,11 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = MAX_FILE_SCANNERS_CONCURRENCY, needForward = true, description = {
             "FileScanNode 扫描数据的最大并发，默认为 16", "The max threads to read data of FileScanNode, default 16"})
     public int maxFileScannersConcurrency = 16;
+
+    @VarAttrDef.VarAttr(name = ENABLE_FILE_SCANNER_V2, needForward = true, description = {
+            "开启后 FileScanNode 会在支持的查询场景使用 FileScannerV2，默认关闭",
+            "When enabled, FileScanNode uses FileScannerV2 for supported query scans. Disabled by default."})
+    public boolean enableFileScannerV2 = false;
 
     @VarAttrDef.VarAttr(name = LOCAL_EXCHANGE_FREE_BLOCKS_LIMIT)
     public int localExchangeFreeBlocksLimit = 4;
@@ -5440,6 +5446,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setScanQueueMemLimit(maxScanQueueMemByte);
         tResult.setMaxScannersConcurrency(maxScannersConcurrency);
         tResult.setMaxFileScannersConcurrency(maxFileScannersConcurrency);
+        tResult.setEnableFileScannerV2(enableFileScannerV2);
         tResult.setMaxColumnReaderNum(maxColumnReaderNum);
         tResult.setParallelPrepareThreshold(parallelPrepareThreshold);
         tResult.setMinScannersConcurrency(minScannersConcurrency);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -498,6 +498,7 @@ struct TQueryOptions {
   // In read path, read from file cache or remote storage when execute query.
   1000: optional bool disable_file_cache = false
   1001: optional i32 file_cache_query_limit_percent = -1
+  1002: optional bool enable_file_scanner_v2 = false
 }
 
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: Add a query-only FileScannerV2 path backed by the refactored TableReader, guarded by a session variable and only selected for supported non-load file scans.

### Release note

None

### Check List (For Author)

- Test: Unit Test / Manual test
    - Ran git diff --check
    - Tried run-be-ut.sh --run --filter=FileScannerV2Test.SupportOnlyRefactoredTableReaders, blocked because JAVA_HOME points to JDK 11 and JDK_17 is not set
    - Tried build-support/clang-format.sh on modified files, blocked because llvm@16 is not installed
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

