### PR TITLE
[fix](be) Throw on invalid function return type inference

### DIFF
--- a/be/src/exprs/function/cast/function_cast.cpp
+++ b/be/src/exprs/function/cast/function_cast.cpp
@@ -386,8 +386,9 @@ protected:
     }
 
     bool skip_return_type_check() const override { return true; }
-    DataTypePtr get_return_type_impl(const ColumnsWithTypeAndName& arguments) const override {
-        return nullptr;
+    DataTypePtr get_return_type_impl(const ColumnsWithTypeAndName& /*arguments*/) const override {
+        throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "get_return_type is not implemented for {}", get_name());
     }
 
     bool use_default_implementation_for_nulls() const override { return false; }

--- a/be/src/exprs/function/function.cpp
+++ b/be/src/exprs/function/function.cpp
@@ -280,7 +280,10 @@ DataTypePtr FunctionBuilderImpl::get_return_type(const ColumnsWithTypeAndName& a
             auto return_type = get_return_type_impl(
                     ColumnsWithTypeAndName(nested_block.begin(), nested_block.end()));
             if (!return_type) {
-                return nullptr;
+                throw Exception(ErrorCode::INTERNAL_ERROR,
+                                "function return type is nullptr, function_name={}, "
+                                "input_arguments={}",
+                                get_name(), get_types_string(arguments));
             }
             return make_nullable(return_type);
         }

--- a/be/src/exprs/function/function.h
+++ b/be/src/exprs/function/function.h
@@ -343,7 +343,6 @@ protected:
     virtual DataTypePtr get_return_type_impl(const DataTypes& /*arguments*/) const {
         throw doris::Exception(ErrorCode::NOT_IMPLEMENTED_ERROR,
                                "get_return_type is not implemented for {}", get_name());
-        return nullptr;
     }
 
     /** If use_default_implementation_for_nulls() is true, than change arguments for get_return_type() and build_impl():

--- a/be/src/exprs/function/function_struct_element.cpp
+++ b/be/src/exprs/function/function_struct_element.cpp
@@ -76,8 +76,7 @@ public:
         size_t index;
         auto st = get_element_index(*struct_type, index_column, index_type, &index);
         if (!st.ok()) {
-            // will handle nullptr outside
-            return nullptr;
+            throw doris::Exception(st);
         }
         // The struct_element is marked as AlwaysNullable in fe.
         return make_nullable(struct_type->get_elements()[index]);

--- a/be/test/exprs/function/function_struct_element_test.cpp
+++ b/be/test/exprs/function/function_struct_element_test.cpp
@@ -62,6 +62,25 @@ TEST(FunctionStructElementTest, test_return_type) {
     std::cout << "Return type: " << return_type->get_name() << std::endl;
 }
 
+TEST(FunctionStructElementTest, test_return_type_invalid_field) {
+    auto index_type = std::make_shared<DataTypeString>();
+    auto index_column = ColumnHelper::create_column<DataTypeString>({"key4"});
+
+    DataTypes struct_types = {std::make_shared<DataTypeString>(), std::make_shared<DataTypeInt32>(),
+                              std::make_shared<DataTypeFloat64>()};
+    Strings names = {"key1", "key2", "key3"};
+    auto type_struct = std::make_shared<DataTypeStruct>(struct_types, names);
+
+    auto argument_template = ColumnsWithTypeAndName {{nullptr, type_struct, "struct"},
+                                                     {index_column, index_type, "index"}};
+
+    EXPECT_THROW(SimpleFunctionFactory::instance().get_function(
+                         "struct_element", argument_template,
+                         std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()),
+                         {true}, BeExecVersionManager::get_newest_version()),
+                 doris::Exception);
+}
+
 TEST(FunctionStructElementTest, test_return_column) {
     auto index_type = std::make_shared<DataTypeString>();
 

--- a/be/test/exprs/function/simple_function_factory_test.cpp
+++ b/be/test/exprs/function/simple_function_factory_test.cpp
@@ -35,7 +35,9 @@ public:
 
     size_t get_number_of_arguments() const override { return 0; }
 
-    DataTypePtr get_return_type_impl(const DataTypes& arguments) const override { return nullptr; }
+    DataTypePtr get_return_type_impl(const DataTypes& /*arguments*/) const override {
+        throw doris::Exception(ErrorCode::INTERNAL_ERROR, "BEUT TEST: nullptr return type");
+    }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: Some BE function return type inference paths could return nullptr after detecting an invalid return type or unsupported implementation. For struct_element, an invalid field name or index produced a Status but get_return_type_impl returned nullptr, which let the outer return-type check report a generic nullptr mismatch and masked the original error. This change makes these paths throw exceptions directly and keeps the base builder from propagating nullptr return types.

### Release note

None

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

