### PR TITLE
[fix](be) Reject oversized Arrow utf8 batches

### DIFF
--- a/be/src/format/arrow/arrow_block_convertor.cpp
+++ b/be/src/format/arrow/arrow_block_convertor.cpp
@@ -33,12 +33,15 @@
 
 #include <ctime>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "common/status.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_nullable.h"
@@ -51,6 +54,48 @@ class Array;
 } // namespace arrow
 
 namespace doris {
+
+namespace {
+
+size_t selected_string_payload_bytes(const ColumnString& string_column, size_t start, size_t rows) {
+    if (rows == 0) {
+        return 0;
+    }
+    const auto& offsets = string_column.get_offsets();
+    const size_t end = start + rows;
+    const size_t start_offset = start == 0 ? 0 : offsets[start - 1];
+    const size_t end_offset = offsets[end - 1];
+    return end_offset - start_offset;
+}
+
+std::optional<size_t> selected_arrow_utf8_payload_bytes(const IColumn& column, size_t start,
+                                                        size_t rows) {
+    if (const auto* string_column = check_and_get_column<ColumnString>(&column)) {
+        return selected_string_payload_bytes(*string_column, start, rows);
+    }
+
+    if (const auto* nullable_column = check_and_get_column<ColumnNullable>(&column)) {
+        const auto* nested_string_column =
+                check_and_get_column<ColumnString>(&nullable_column->get_nested_column());
+        if (nested_string_column == nullptr) {
+            return std::nullopt;
+        }
+
+        size_t payload_bytes = 0;
+        const auto& null_map = nullable_column->get_null_map_data();
+        const auto end = start + rows;
+        for (size_t row = start; row < end; ++row) {
+            if (null_map[row] == 0) {
+                payload_bytes += nested_string_column->get_data_at(row).size;
+            }
+        }
+        return payload_bytes;
+    }
+
+    return std::nullopt;
+}
+
+} // namespace
 
 Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBatch>* out) {
     int num_fields = _schema->num_fields();
@@ -80,8 +125,17 @@ Status FromBlockToRecordBatchConverter::convert(std::shared_ptr<arrow::RecordBat
         _cur_type = _block.get_by_position(idx).type;
         auto column = _cur_col->convert_to_full_column_if_const();
         auto arrow_type = _schema->field(idx)->type();
-        if (arrow_type->name() == "utf8" && column->byte_size() >= MAX_ARROW_UTF8) {
-            arrow_type = arrow::large_utf8();
+        if (arrow_type->id() == arrow::Type::STRING) {
+            const auto payload_bytes =
+                    selected_arrow_utf8_payload_bytes(*column, _cur_start, _cur_rows);
+            if (payload_bytes.has_value() && *payload_bytes >= MAX_ARROW_UTF8) {
+                return Status::InvalidArgument(
+                        "Arrow utf8 column payload byte size reaches the supported limit: "
+                        "column={}, payload_bytes={}, limit={}. "
+                        "Large utf8 conversion is not supported yet, "
+                        "please reduce batch_size.",
+                        _block.get_by_position(idx).name, *payload_bytes, MAX_ARROW_UTF8);
+            }
         }
         std::unique_ptr<arrow::ArrayBuilder> builder;
         auto arrow_st = arrow::MakeBuilder(_pool, arrow_type, &builder);

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -499,24 +499,57 @@ TEST(DataTypeSerDeArrowTest, DataTypeMapNullKeySerDeTest) {
     CommonDataTypeSerdeTest::compare_two_blocks(block, assert_block);
 }
 
-TEST(DataTypeSerDeArrowTest, BigStringSerDeTest) {
-    std::string col_name = "big_string";
+TEST(DataTypeSerDeArrowTest, RejectOversizedUtf8PayloadByteSize) {
+    const std::string col_name = "oversized_utf8";
     auto block = std::make_shared<Block>();
     auto strcol = ColumnString::create();
-    // 2G, if > 4G report string column length is too large: total_length=4402341462
-    for (int i = 0; i < 20; ++i) {
-        std::string is(107374182, '0'); // 100M
-        strcol->insert_data(is.c_str(), is.size());
-    }
+    strcol->get_offsets().push_back(static_cast<uint32_t>(MAX_ARROW_UTF8));
     DataTypePtr data_type(std::make_shared<DataTypeString>());
     ColumnWithTypeAndName type_and_name(strcol->get_ptr(), data_type, col_name);
     block->insert(type_and_name);
 
-    std::shared_ptr<arrow::RecordBatch> record_batch =
-            CommonDataTypeSerdeTest::serialize_arrow(block);
-    auto assert_block = std::make_shared<Block>(block->clone_empty());
-    CommonDataTypeSerdeTest::deserialize_arrow(assert_block, record_batch);
-    CommonDataTypeSerdeTest::compare_two_blocks(block, assert_block);
+    auto schema = arrow::schema({arrow::field(col_name, arrow::utf8())});
+    std::shared_ptr<arrow::RecordBatch> record_batch;
+    cctz::time_zone default_timezone;
+    auto status = convert_to_arrow_batch(*block, schema, arrow::default_memory_pool(),
+                                         &record_batch, default_timezone);
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_EQ(status.code(), ErrorCode::INVALID_ARGUMENT);
+    const auto status_msg = status.to_string();
+    EXPECT_NE(status_msg.find("supported limit"), std::string::npos);
+    EXPECT_NE(status_msg.find("payload_bytes=" + std::to_string(MAX_ARROW_UTF8)),
+              std::string::npos);
+    EXPECT_NE(status_msg.find("limit=" + std::to_string(MAX_ARROW_UTF8)), std::string::npos);
+    EXPECT_EQ(status_msg.find("2GB"), std::string::npos);
+    EXPECT_EQ(record_batch, nullptr);
+}
+
+TEST(DataTypeSerDeArrowTest, AllowNullableUtf8RowRangeUnderPayloadLimit) {
+    const std::string col_name = "nullable_utf8";
+    auto block = std::make_shared<Block>();
+    auto strcol = ColumnString::create();
+    strcol->get_offsets().push_back(static_cast<uint32_t>(MAX_ARROW_UTF8));
+    strcol->get_offsets().push_back(static_cast<uint32_t>(MAX_ARROW_UTF8));
+    auto null_map = ColumnUInt8::create();
+    null_map->insert_value(1);
+    null_map->insert_value(1);
+    auto nullable_col = ColumnNullable::create(std::move(strcol), std::move(null_map));
+    DataTypePtr data_type(std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()));
+    ColumnWithTypeAndName type_and_name(nullable_col->get_ptr(), data_type, col_name);
+    block->insert(type_and_name);
+
+    auto schema = arrow::schema({arrow::field(col_name, arrow::utf8())});
+    std::shared_ptr<arrow::RecordBatch> record_batch;
+    cctz::time_zone default_timezone;
+    auto status = convert_to_arrow_batch(*block, schema, arrow::default_memory_pool(),
+                                         &record_batch, default_timezone, 1, 2);
+
+    ASSERT_TRUE(status.ok()) << status.to_string();
+    ASSERT_NE(record_batch, nullptr);
+    ASSERT_EQ(record_batch->num_rows(), 1);
+    ASSERT_EQ(record_batch->num_columns(), 1);
+    EXPECT_TRUE(record_batch->column(0)->IsNull(0));
 }
 
 TEST(DataTypeSerDeArrowTest, BlockConverterTest) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Arrow block conversion previously switched an oversized UTF8 column to a Large UTF8 builder when the Doris column byte size reached the Arrow UTF8 limit. The output schema still uses the original UTF8 field, and Doris does not support this large UTF8 conversion path yet. The byte-size check also counted Doris-side storage overhead such as offsets and nullable null maps, and it did not respect row-range conversion. This PR returns a clear InvalidArgument error only when the selected rows' Arrow UTF8 string payload bytes reach `MAX_ARROW_UTF8`, and keeps the unsupported large UTF8 conversion path disabled. It also adds focused BE unit tests that cover the payload-limit branch and a nullable row-range slice below the payload limit without allocating a huge string column.

### Release note

Return a clear error when Arrow UTF8 block conversion reaches the supported payload byte-size limit.

### Check List (For Author)

- Test: Unit Test / Manual test
    - Ran `./build-support/clang-format.sh`
    - Ran `./build-support/check-format.sh`
    - Ran `git diff --check $(git merge-base origin/master HEAD)..HEAD`
    - Ran `git diff --check`
    - Ran `DORIS_HOME=$PWD ninja -C be/ut_build_ASAN src/format/CMakeFiles/Format.dir/arrow/arrow_block_convertor.cpp.o`
    - Ran `DORIS_HOME=$PWD ninja -C be/ut_build_ASAN test/CMakeFiles/doris_be_test.dir/core/data_type_serde/data_type_serde_arrow_test.cpp.o`
    - Ran `DORIS_HOME=$PWD ninja -C be/ut_build_ASAN test/doris_be_test`
    - Ran `./run-be-ut.sh --run --filter=DataTypeSerDeArrowTest.RejectOversizedUtf8PayloadByteSize:DataTypeSerDeArrowTest.AllowNullableUtf8RowRangeUnderPayloadLimit -j 8`
    - Attempted `build-support/run-clang-tidy.sh --build-dir be/ut_build_ASAN --base $(git merge-base origin/master HEAD)` with a local clang-tidy binary, but clang-tidy could not analyze due to existing environment/header issues: unmatched NOLINTEND in `be/src/core/types.h` and missing `stddef.h` from system/toolchain headers. It also reported pre-existing complexity/function-size warnings in `create_test_block`.
- Behavior changed: Yes. Oversized UTF8 Arrow block conversion now returns InvalidArgument based on selected payload bytes instead of trying the unsupported Large UTF8 conversion path.
- Does this need documentation: No
