### PR TITLE
[feature](routine-load) support fill_missing_columns for json format to auto-complete unspecified columns

### DIFF
--- a/docs/design/fill_missing_columns_routine_load.md
+++ b/docs/design/fill_missing_columns_routine_load.md
@@ -1,0 +1,369 @@
+# Design: `fill_missing_columns` for Routine Load (JSON)
+
+Scope: FE-only. Routine-load JSON property propagation + Nereids load scan planning.
+
+Implementation source: the feature commits on
+`feature/auto-fill-missing-columns`:
+
+- `25fb54ef1b1 [feature](routine-load) support fill_missing_columns for json format to auto-complete unspecified columns`
+- `a457347b0a4 [fix](routine_load) add test cases`
+
+The current `master` commit is the merge base of this branch. This document
+therefore covers the complete `master...HEAD` functional diff: eight FE
+production files, seven FE test files, and the JSON/Kafka regression fixture.
+
+## 1. Background and Goal
+
+Routine Load lets users declare a `COLUMNS(...)` clause to map JSON source fields
+to target table columns. In the existing Nereids load planner
+([NereidsLoadScanProvider](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadScanProvider.java)),
+the base schema of the table is only auto-appended when the user did **not**
+specify any plain file-field column (`!specifyFileFieldNames`). When the user
+writes a `COLUMNS` clause that contains only derived expressions
+(e.g. `COLUMNS(score_x2 = score * 2)`), `specifyFileFieldNames` is `false` and the
+auto-fill path runs — but if the user lists at least one plain field, the
+auto-fill is skipped and any unlisted columns (including the sequence column)
+must be specified manually, otherwise planning fails with errors such as
+`need to specify the sequence column`.
+
+The goal of this feature is to add a JSON-only routine-load property
+`fill_missing_columns`. When `true`, the planner auto-completes the remaining
+base-schema columns (and the sequence-column input when applicable) even when
+the user already specified some file fields or mappings.
+
+The property does not synthesize values in the FE. It changes which source slots
+and target expressions are present in the Nereids load plan. The existing JSON
+reader and BE load path remain responsible for extracting JSON fields, applying
+normal default/nullability rules, and reporting filtered rows. Consequently,
+enabling the property does not make a missing JSON key valid for a `NOT NULL`
+column without a default; that existing execution-time validation still applies.
+No BE protocol, storage format, or BE configuration change is required.
+
+## 2. User-visible Contract
+
+The property belongs in the `PROPERTIES` clause of a JSON Routine Load:
+
+```sql
+CREATE ROUTINE LOAD job_name ON target_table
+COLUMNS(id, derived_score = score * 2)
+PROPERTIES
+(
+    "format" = "json",
+    "fill_missing_columns" = "true"
+)
+FROM KAFKA (...);
+```
+
+| Item | Contract |
+|------|----------|
+| Property name | `fill_missing_columns` |
+| Accepted values | Case-insensitive boolean literal `true` or `false` |
+| Default | `false` |
+| Supported format | JSON only |
+| CREATE with CSV/default format | Rejected, including when the value itself is malformed |
+| ALTER of a non-JSON job | Rejected |
+| `false` | Preserves the legacy planner behavior |
+| `true` | Adds omitted base-schema columns to the planned file-field descriptors, subject to mapping ownership rules below |
+| Persisted form | Existing Routine Load `jobProperties` string map |
+| `SHOW CREATE ROUTINE LOAD` | Emits the property only for JSON jobs, including explicit `false`, so the generated statement can be replayed |
+
+`fill_missing_columns` means “complete the FE input/output column plan”; it
+does not mean “invent a value for every absent JSON key.” For example, a nullable
+or defaulted target column may be populated by existing JSON-load semantics when
+the key is missing, while a missing `NOT NULL` target with no default remains
+subject to the existing BE filtering behavior.
+
+## 3. End-to-end Property Propagation
+
+The property `fill_missing_columns` flows through the existing routine-load
+property pipeline. New code mirrors the existing `fuzzy_parse` / `num_as_string`
+handling at every hop:
+
+| Stage | File | Change |
+|------|------|--------|
+| Parse/validate JSON format props | [JsonFileFormatProperties](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/JsonFileFormatProperties.java) | Add `PROP_FILL_MISSING_COLUMNS` constant, `fillMissingColumns` field (default `false`), parse in `analyzeFileFormatProperties`, and `isFillMissingColumns()` getter. |
+| CREATE allow-list | [CreateRoutineLoadInfo](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfo.java) | Register property in the accepted-properties set. |
+| ALTER allow-list + validation | [AlterRoutineLoadCommand](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommand.java) | Register property; validate value is `true`/`false`; write into `analyzedJobProperties`. |
+| Persisted job properties | [RoutineLoadJob](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java) | Put property into `jobProperties` from JSON format props; add `isFillMissingColumns()`; emit it in `getShowCreateInfo()`. |
+| Task info copy (Kafka + Kinesis) | [NereidsRoutineLoadTaskInfo](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfo.java) | Read property from copied `jobProperties` via `isFillMissingColumns()` override. |
+| Task-info interface default | [NereidsLoadTaskInfo](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadTaskInfo.java) | New `default boolean isFillMissingColumns()` returning `false` (backward compatible for stream load and other callers). |
+| Analysis map | [NereidsDataDescription](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java) | Copy the flag into the analysis property map used by planning. |
+
+Routine-load task construction passes a copy of the job-property map into
+`NereidsRoutineLoadTaskInfo`; the task-specific implementation reads the
+property from that map. The new default method on `NereidsLoadTaskInfo` keeps
+other load-task implementations, such as broker load, on `false`.
+
+## 4. CREATE and ALTER Validation
+
+CREATE first verifies the supported-property allow-list, resolves the unique-key
+update mode, and then validates the format and value. JSON parsing rejects empty
+strings, numbers, and other non-boolean literals instead of relying on
+`Boolean.parseBoolean`, which would silently turn them into `false`.
+
+ALTER cannot change a job's format, so it obtains the existing
+`RoutineLoadJob` and rejects the property unless that job is JSON. It also
+evaluates the effective post-alter state rather than merely validating the
+property named in the statement:
+
+| Existing state | ALTER input | Result |
+|----------------|-------------|--------|
+| JSON, upsert | `fill_missing_columns=true` | Allowed |
+| CSV | `fill_missing_columns=true` | Rejected as non-JSON |
+| Fixed partial update | `fill_missing_columns=true` | Rejected |
+| `fill_missing_columns=true` | `unique_key_update_mode=UPDATE_FIXED_COLUMNS` | Rejected |
+| `fill_missing_columns=true` | legacy `partial_columns=true` | Rejected |
+| Fixed partial update | `fill_missing_columns=false` | Allowed |
+| Flexible partial update | `fill_missing_columns=true` | Allowed |
+
+This requires two effective-value functions in `AlterRoutineLoadCommand`:
+
+1. `effectiveFillMissingColumns` prefers the altered value, otherwise it reads
+   the current job.
+2. `effectiveUniqueKeyUpdateMode` prefers the explicit update mode, then the
+   legacy `partial_columns` flag, otherwise it reads the current job.
+
+Checking the resolved pair prevents an invalid state from being created in
+either transition direction.
+
+## 5. Planning Change in `NereidsLoadScanProvider`
+
+Two behaviors change, both gated by the JSON-only helper `isFillMissingColumns()`:
+
+1. **Sequence column auto-add** — `shouldAddSequenceColumn` now returns `true`
+   when `fill_missing_columns` is enabled, so the sequence column is treated as
+   auto-fillable rather than requiring explicit specification.
+
+2. **Base-schema auto-fill** — the auto-fill block guarded by
+   `!specifyFileFieldNames` is extended to also run when `fillMissing` is `true`.
+   Because the user may already have listed some columns in this path, the fill
+   must dedup against descriptors that already provide a file slot, otherwise a
+   column would be added twice.
+
+### 5.1 Descriptor construction order
+
+`createLoadContext()` constructs the plan in this order:
+
+1. Start with user `COLUMNS(...)` descriptors.
+2. Add delete-sign descriptors for merge/delete loads.
+3. Resolve and add the hidden sequence-column mapping where required.
+4. Rewrite dependent mappings, for example replace a temporary mapping reference
+   with its source expression.
+5. Drop expression descriptors whose mapping target is not a real target-table
+   column, while retaining valid plain file fields and valid target mappings.
+6. Compute constant mappings, then append missing base-schema descriptors when
+   the legacy condition or `fill_missing_columns` requires it.
+7. Add applicable hidden columns and build `exprMap` plus `scanSlots`.
+
+The property changes step 6 and the sequence-column decision in step 3. It does
+not alter expression rewriting, JSON parsing, or BE sink behavior.
+
+### 5.2 Dedup correctness for target mappings
+
+The first implementation deduped against **every** existing descriptor's column
+name:
+
+```java
+for (NereidsImportColumnDesc desc : copiedColumnExprs) {
+    existingColumns.add(desc.getColumnName());   // BUG: includes mapping targets
+}
+```
+
+This treats every descriptor as proof that the matching file slot is available.
+It is wrong for a **self-referencing same-name mapping** such as
+`COLUMNS(k1 = k1)`:
+
+- `copiedColumnExprs` starts with `NereidsImportColumnDesc("k1", UnboundSlot("k1"))`.
+- Adding `k1` to `existingColumns` makes the base-schema loop skip the plain `k1`
+  file descriptor.
+- The later scan-slot loop only creates file slots for descriptors whose
+  `expr == null`, so no `k1` file slot is produced.
+
+The reduced plan becomes:
+
+```
+LogicalLoadProject(k1 := UnboundSlot(k1))
+  LogicalProject(scanSlots without k1)
+    LogicalOneRowRelation(scanSlots without k1)
+```
+
+The mapping still references the input `k1`, but its child no longer outputs that
+slot — an inconsistent plan. The old `!specifyFileFieldNames` path always added
+the base-schema descriptor and kept this source slot available.
+
+### 5.3 The fix
+
+A descriptor only legitimately suppresses the base fill when it actually provides
+the file slot for that column. That is true for:
+
+- **true file fields** (`expr == null`), and
+- **mappings that do not reference their own column**, e.g. `score_x2 = score * 2`.
+  Such a derived target consumes *other* columns; the derivation is preserved
+  precisely by suppressing the base descriptor (note base descriptors are
+  appended *after* mappings, so a base `null` entry would otherwise overwrite the
+  derivation in `columnExprMap`).
+
+A **self-referencing** mapping such as `k1 = k1` or `k1 = k1 + 1` references the
+same-named source column, so the base scan descriptor must be preserved.
+
+```java
+Map<String, String> selfRefSourceByColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+Set<String> existingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+if (fillMissing) {
+    for (NereidsImportColumnDesc desc : copiedColumnExprs) {
+        String source = selfReferenceSource(desc);
+        if (source != null) {
+            selfRefSourceByColumn.put(desc.getColumnName(), source);
+        } else {
+            existingColumns.add(desc.getColumnName());
+        }
+    }
+}
+```
+
+with the single helper (also reused by §5.5 for the source-slot spelling):
+
+```java
+private String selfReferenceSource(NereidsImportColumnDesc desc) {
+    if (desc.isColumn()) {
+        return null;
+    }
+    for (Slot slot : desc.getExpr().getInputSlots()) {
+        if (slot.getName().equalsIgnoreCase(desc.getColumnName())) {
+            return slot.getName();
+        }
+    }
+    return null;
+}
+```
+
+Constant mappings (`k1 = 'v'`) are unaffected: they neither reference their own
+column nor any column, so they are deduped here, and they are also separately
+handled by the pre-existing `constantMappingColumns` skip. Their base descriptor
+is correctly omitted because the constant fully provides the value.
+
+### 5.4 Case matrix (fill_missing_columns = true)
+
+| COLUMNS clause | Base `c` descriptor added? | Why |
+|----------------|----------------------------|-----|
+| `c` (plain field) | no (already a file field) | descriptor is a true file field |
+| `x = c * 2` | yes for `c`, no for `x` | `x` is derived from other column; `c` not mentioned |
+| `c = c + 1` | **yes** (fix) | mapping references its own source column `c` |
+| `c = c` | **yes** (fix) | self-reference |
+| `c = 'v'` (constant) | no | constant fully provides value; deduped twice |
+
+### 5.5 Case-preserving source-slot spelling
+
+For case-preserving formats (JSON/Arrow, `Util.isCasePreservingFormat`), the BE
+`NewJsonReader` matches a non-Hive JSON key to the scan slot **name** exactly,
+while Nereids binds a `COLUMNS(...)` mapping source case-insensitively. When the
+base-schema fill emitted the descriptor using the **table column** spelling, a
+self-referencing mixed-case mapping produced a NULL:
+
+- Table column `Score`, JSON `{"score":10}`, `COLUMNS(Score = score + 1)`.
+- The base loop added a scan slot named `Score`; the reader looked up the JSON key
+  `Score`, missed the actual key `score`, and the mapping received NULL.
+
+The fix keeps the mapping's own source-slot spelling for the base descriptor of a
+self-referencing column under case-preserving formats:
+
+```java
+if (Util.isCasePreservingFormat(fileFormatType)) {
+    String sourceSpelling = selfRefSourceByColumn.get(column.getName());
+    columnDesc = new NereidsImportColumnDesc(
+            sourceSpelling != null ? sourceSpelling : column.getName());
+} else {
+    columnDesc = new NereidsImportColumnDesc(column.getName().toLowerCase());
+}
+```
+
+`selfRefSourceByColumn` is built once, in the same pass that computes the dedup
+set, from a single `selfReferenceSource(desc)` helper: for a self-referencing
+mapping (e.g. `COLUMNS(Score = score + 1)`) it returns the exact source-slot
+spelling read by the mapping (`score`), and `null` otherwise. That one result
+serves both needs — preserving the base descriptor for self-references (dedup) and
+supplying the reader-matching spelling for case-preserving formats. Non-self-
+referencing columns and non-case-preserving formats keep the table column
+spelling.
+
+## 6. Interaction with Partial Update
+
+`fill_missing_columns` performs a full-row upsert: every omitted base-schema
+column is injected into the scan/output tuple and null-checked by the
+`FileScanner`. Fixed partial columns update (`UPDATE_FIXED_COLUMNS`, also reached
+via the legacy `partial_columns=true`) only writes the explicitly listed columns,
+and the BE writer drops the auto-filled columns from its index slots. The
+combination lets an omitted non-null column be NULL in the output tuple even
+though it is not being updated, so a valid fixed partial row can be wrongly
+filtered.
+
+The two semantics are mutually exclusive, so the combination is rejected up front
+(fail-fast) at both entry points:
+
+- [CreateRoutineLoadInfo#checkJobProperties](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfo.java):
+  rejects `fill_missing_columns=true` when the resolved `uniqueKeyUpdateMode` is
+  `UPDATE_FIXED_COLUMNS`.
+- [AlterRoutineLoadCommand](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommand.java):
+  resolves the *effective* fill-missing flag and update mode after the alter
+  (either changed by this alter or kept from the existing job) and rejects the
+  combination, covering both "enable fill_missing on a fixed partial job" and
+  "switch a fill_missing job into fixed partial mode".
+
+Flexible partial update (`UPDATE_FLEXIBLE_COLUMNS`) checks per-row column
+integrity on the BE, so it stays compatible and is **not** rejected.
+
+## 7. Compatibility and Operational Properties
+
+- Default is `false`; absent property ⇒ unchanged behavior.
+- The `!specifyFileFieldNames` legacy path is untouched when `fillMissing` is
+  `false` (the new dedup loop only runs under `fillMissing`).
+- JSON-only: `isFillMissingColumns()` short-circuits to `false` for non-JSON
+  formats.
+- No edit-log/metadata schema change; the flag is stored in the existing
+  `jobProperties` string map and survives replay via the existing routine-load
+  alter/write-lock/edit-log paths.
+- No new shared mutable state, scheduling path, RPC field, or locking protocol
+  is introduced. CREATE and ALTER reuse their existing job-property validation
+  and persistence paths.
+- The additional planning work is linear in the number of user descriptors plus
+  base-schema columns. The case-insensitive map/set matches existing
+  case-insensitive column resolution and avoids an order-dependent duplicate
+  decision.
+
+## 8. Test Coverage
+
+Unit:
+- [JsonFileFormatPropertiesTest](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/test/java/org/apache/doris/datasource/property/fileformat/JsonFileFormatPropertiesTest.java): parse true/false/default and the all-properties path.
+- [NereidsRoutineLoadTaskInfoTest](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfoTest.java): property read true/false/default.
+- [CreateRoutineLoadInfoTest](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfoTest.java): JSON-only rejection; fixed-partial rejection (mode + legacy `partial_columns`); `false` allowed with fixed partial; flexible partial allowed.
+- [AlterRoutineLoadCommandTest](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommandTest.java): accepted/false/invalid value; fixed-partial rejection when enabling on a fixed-partial job or switching a fill_missing job into fixed partial; flexible partial allowed.
+- [NereidsLoadScanProviderTest](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsLoadScanProviderTest.java): JSON-only enablement; sequence-column behavior; all descriptor ownership categories; end-to-end `COLUMNS(Score = score + 1)` on JSON keeps the `score` scan slot.
+- [NereidsBrokerLoadTaskTest](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsBrokerLoadTaskTest.java): the interface default remains `false` for an unrelated load implementation.
+- [RoutineLoadJobTest](file:///Users/yuanbin.me/Documents/codebase/github/doris/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java): `SHOW CREATE` output includes the property.
+
+Regression ([test_routine_load_fill_missing_columns.groovy](file:///Users/yuanbin.me/Documents/codebase/github/doris/regression-test/suites/load_p0/routine_load/test_routine_load_fill_missing_columns.groovy)):
+- Positive: `COLUMNS(score_x2 = score * 2)` with `fill_missing_columns=true` —
+  sequence column and unlisted base columns auto-filled, job runs, data correct.
+- Contrast: same clause with `fill_missing_columns=false` — job pauses with the
+  sequence-column error (legacy behavior preserved).
+- Same-name mapping: `COLUMNS(score = score + 1)` with `fill_missing_columns=true`
+  — verifies the source `score` slot stays available and the value is read from
+  JSON and incremented.
+- **Added** mixed-case mapping: table column `Score`, JSON key `score`,
+  `COLUMNS(Score = score + 1)` with `fill_missing_columns=true` — verifies the
+  case-preserving base scan slot uses the `score` spelling so the value is read
+  and incremented (covers §5.5).
+
+The asynchronous cases no longer drop their tables in `finally`, so a failed poll
+or assertion preserves the table/rows for debugging (best-effort routine-load stop
+is kept).
+
+## 9. Non-goals
+
+- Support for CSV, broker load, stream load, or non-Routine Load entry points.
+- A new BE mechanism for materializing missing JSON keys.
+- Relaxing existing `NOT NULL`, default-value, strict-mode, or row-filtering
+  semantics.
+- Changing the meaning of user-supplied mapping expressions. A mapping retains
+  ownership of its target column; the fill logic must only provide source slots
+  that the mapping still needs.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/JsonFileFormatProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/fileformat/JsonFileFormatProperties.java
@@ -36,6 +36,7 @@ public class JsonFileFormatProperties extends FileFormatProperties {
     public static final String PROP_READ_JSON_BY_LINE = "read_json_by_line";
     public static final String PROP_NUM_AS_STRING = "num_as_string";
     public static final String PROP_FUZZY_PARSE = "fuzzy_parse";
+    public static final String PROP_FILL_MISSING_COLUMNS = "fill_missing_columns";
 
     // from ExternalFileTableValuedFunction:
     private String jsonRoot = "";
@@ -44,6 +45,7 @@ public class JsonFileFormatProperties extends FileFormatProperties {
     private boolean readJsonByLine;
     private boolean numAsString = false;
     private boolean fuzzyParse = false;
+    private boolean fillMissingColumns = false;
     private String lineDelimiter = CsvFileFormatProperties.DEFAULT_LINE_DELIMITER;
 
 
@@ -77,6 +79,14 @@ public class JsonFileFormatProperties extends FileFormatProperties {
             fuzzyParse = Boolean.valueOf(
                     getOrDefault(formatProperties, PROP_FUZZY_PARSE,
                             "", isRemoveOriginProperty)).booleanValue();
+            String fillMissingColumnsStr = getOrDefault(formatProperties, PROP_FILL_MISSING_COLUMNS,
+                    "false", isRemoveOriginProperty);
+            if (!"true".equalsIgnoreCase(fillMissingColumnsStr)
+                    && !"false".equalsIgnoreCase(fillMissingColumnsStr)) {
+                throw new AnalysisException(PROP_FILL_MISSING_COLUMNS
+                        + " must be 'true' or 'false', but found: " + fillMissingColumnsStr);
+            }
+            fillMissingColumns = Boolean.valueOf(fillMissingColumnsStr).booleanValue();
             lineDelimiter = getOrDefault(formatProperties, CsvFileFormatProperties.PROP_LINE_DELIMITER,
                     CsvFileFormatProperties.DEFAULT_LINE_DELIMITER, isRemoveOriginProperty);
             if (Strings.isNullOrEmpty(lineDelimiter)) {
@@ -134,6 +144,10 @@ public class JsonFileFormatProperties extends FileFormatProperties {
 
     public boolean isFuzzyParse() {
         return fuzzyParse;
+    }
+
+    public boolean isFillMissingColumns() {
+        return fillMissingColumns;
     }
 
     public String getLineDelimiter() {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -429,6 +429,8 @@ public abstract class RoutineLoadJob
                     String.valueOf(jsonFileFormatProperties.isNumAsString()));
             jobProperties.put(JsonFileFormatProperties.PROP_FUZZY_PARSE,
                     String.valueOf(jsonFileFormatProperties.isFuzzyParse()));
+            jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS,
+                    String.valueOf(jsonFileFormatProperties.isFillMissingColumns()));
         } else {
             throw new UserException("Invalid format type.");
         }
@@ -710,6 +712,10 @@ public abstract class RoutineLoadJob
     @Override
     public boolean isFuzzyParse() {
         return Boolean.parseBoolean(jobProperties.get(JsonFileFormatProperties.PROP_FUZZY_PARSE));
+    }
+
+    public boolean isFillMissingColumns() {
+        return Boolean.parseBoolean(jobProperties.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
     }
 
     @Override
@@ -1820,6 +1826,12 @@ public abstract class RoutineLoadJob
         appendProperties(sb, JsonFileFormatProperties.PROP_NUM_AS_STRING, isNumAsString(), false);
         appendProperties(sb, JsonFileFormatProperties.PROP_FUZZY_PARSE, isFuzzyParse(), false);
         appendProperties(sb, JsonFileFormatProperties.PROP_JSON_ROOT, getJsonRoot(), false);
+        // fill_missing_columns is a JSON-only property. Emitting it for CSV/default jobs would make
+        // the generated statement non-round-trippable, since the create path rejects it unless the
+        // format is JSON.
+        if (getFormat().equalsIgnoreCase("json")) {
+            appendProperties(sb, JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, isFillMissingColumns(), false);
+        }
         appendProperties(sb, LoadCommand.STRICT_MODE, isStrictMode(), false);
         appendProperties(sb, LoadCommand.TIMEZONE, getTimezone(), false);
         appendProperties(sb, LoadCommand.EXEC_MEM_LIMIT, getMemLimit(), true);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsDataDescription.java
@@ -436,6 +436,8 @@ public class NereidsDataDescription {
         putAnalysisMapIfNonNull(JsonFileFormatProperties.PROP_READ_JSON_BY_LINE,
                 String.valueOf(taskInfo.isReadJsonByLine()));
         putAnalysisMapIfNonNull(JsonFileFormatProperties.PROP_NUM_AS_STRING, String.valueOf(taskInfo.isNumAsString()));
+        putAnalysisMapIfNonNull(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS,
+                String.valueOf(taskInfo.isFillMissingColumns()));
         this.uniquekeyUpdateMode = taskInfo.getUniqueKeyUpdateMode();
         fileFieldNamesToLowerCase(fileFieldNames);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadScanProvider.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.property.fileformat.JsonFileFormatProperties;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.nereids.analyzer.UnboundFunction;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
@@ -38,6 +39,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.Multiply;
 import org.apache.doris.nereids.trees.expressions.Not;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
@@ -114,7 +116,7 @@ public class NereidsLoadScanProvider {
                         .filter(c -> c.getColumnName().equalsIgnoreCase(finalSequenceCol)).findAny();
                 // if `columnDescs.descs` is empty, that means it's not a partial update load, and user not specify
                 // column name.
-                if (foundCol.isPresent() || shouldAddSequenceColumn(columnDescList)) {
+                if (foundCol.isPresent() || shouldAddSequenceColumn(columnDescList, fileGroup)) {
                     columnDescList.add(new NereidsImportColumnDesc(Column.SEQUENCE_COL,
                             new UnboundSlot(sequenceCol)));
                 } else if (!fileGroupInfo.isFixedPartialUpdate()) {
@@ -193,9 +195,41 @@ public class NereidsLoadScanProvider {
         // If user does not specify the file field names, generate it by using base schema of table.
         // So that the following process can be unified
         boolean specifyFileFieldNames = copiedColumnExprs.stream().anyMatch(p -> p.isColumn());
-        if (!specifyFileFieldNames) {
+        boolean fillMissing = isFillMissingColumns(fileGroup);
+        if (!specifyFileFieldNames || fillMissing) {
+            // Dedup the base-schema fill against descriptors that already provide the matching
+            // file slot, so the existing !specifyFileFieldNames behavior stays consistent.
+            // A descriptor only "provides the file slot" for a column when either:
+            //   - it is a true file field (expr == null), or
+            //   - it is a mapping that does NOT reference a source column with the same name as
+            //     its target (e.g. score_x2 = score * 2). Such a derived target consumes other
+            //     columns, so the base descriptor must be suppressed to keep the derivation.
+            // A self-referencing mapping such as COLUMNS(k1 = k1) still needs the scan to output
+            // its own source column k1, so it must NOT suppress the base descriptor; otherwise the
+            // scan would drop k1 while the mapping still references it.
+            // selfRefSourceByColumn maps a self-referencing mapping's target column to the exact
+            // source-slot spelling it reads, e.g. COLUMNS(Score = score + 1) -> {Score: "score"}.
+            // A self-reference never suppresses the base descriptor (the scan still has to output the
+            // referenced source slot), and for case-preserving formats the base descriptor must reuse
+            // that source spelling so the reader looks up the right file key (see below). Only built
+            // for fill_missing so the legacy !specifyFileFieldNames path stays unchanged.
+            Map<String, String> selfRefSourceByColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+            Set<String> existingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            if (fillMissing) {
+                for (NereidsImportColumnDesc desc : copiedColumnExprs) {
+                    String source = selfReferenceSource(desc);
+                    if (source != null) {
+                        selfRefSourceByColumn.put(desc.getColumnName(), source);
+                    } else {
+                        existingColumns.add(desc.getColumnName());
+                    }
+                }
+            }
             List<Column> columns = tbl.getBaseSchema(false);
             for (Column column : columns) {
+                if (existingColumns.contains(column.getName())) {
+                    continue;
+                }
                 if (constantMappingColumns.contains(column.getName())) {
                     // Skip this column because user has already specified a constant mapping expression for it
                     // in the COLUMNS parameter (e.g., "column_name = 'constant_value'")
@@ -204,7 +238,15 @@ public class NereidsLoadScanProvider {
                 NereidsImportColumnDesc columnDesc;
                 TFileFormatType fileFormatType = fileGroup.getFileFormatProperties().getFileFormatType();
                 if (Util.isCasePreservingFormat(fileFormatType)) {
-                    columnDesc = new NereidsImportColumnDesc(column.getName());
+                    // A self-referencing mapping such as COLUMNS(Score = score + 1) binds its source
+                    // column case-insensitively, but a case-preserving reader (JSON/Arrow) matches the
+                    // scan slot name to the file key exactly. Emit the base file slot using the
+                    // source-slot spelling referenced by the mapping (e.g. "score") instead of the
+                    // table column spelling ("Score"); otherwise the reader would look up the wrong key
+                    // and the mapping would receive NULL.
+                    String sourceSpelling = selfRefSourceByColumn.get(column.getName());
+                    columnDesc = new NereidsImportColumnDesc(
+                            sourceSpelling != null ? sourceSpelling : column.getName());
                 } else {
                     columnDesc = new NereidsImportColumnDesc(column.getName().toLowerCase());
                 }
@@ -421,13 +463,51 @@ public class NereidsLoadScanProvider {
     }
 
     /**
-     * if not set sequence column and column size is null or only have deleted sign ,return true
+     * Returns true when the sequence column should be auto-added, i.e.,
+     * if not set sequence column and column size is null or only have deleted sign,
+     * or fill_missing_columns is enabled, meaning schema will be auto-filled.
      */
-    private boolean shouldAddSequenceColumn(List<NereidsImportColumnDesc> columnDescList) {
+    private boolean shouldAddSequenceColumn(List<NereidsImportColumnDesc> columnDescList,
+            NereidsBrokerFileGroup fileGroup) {
+        if (isFillMissingColumns(fileGroup)) {
+            return true;
+        }
         if (columnDescList.isEmpty()) {
             return true;
         }
         return columnDescList.size() == 1 && columnDescList.get(0).getColumnName().equalsIgnoreCase(Column.DELETE_SIGN);
+    }
+
+    /**
+     * Returns true if the file format is JSON and fill_missing_columns is enabled. Only meaningful for JSON.
+     */
+    private boolean isFillMissingColumns(NereidsBrokerFileGroup fileGroup) {
+        return fileGroup.getFileFormatProperties() instanceof JsonFileFormatProperties
+                && ((JsonFileFormatProperties) fileGroup.getFileFormatProperties()).isFillMissingColumns();
+    }
+
+    /**
+     * If {@code desc} is a self-referencing mapping (expr != null and it reads a source column whose
+     * name matches its own target, e.g. COLUMNS(k1 = k1), COLUMNS(k1 = k1 + 1) or the mixed-case
+     * COLUMNS(Score = score + 1)), return the exact spelling of that matching source slot (e.g.
+     * "k1" / "score"). Return {@code null} for true file fields and for mappings that do not
+     * reference their own column (constants or other-column derivations such as score_x2 = score * 2).
+     *
+     * <p>A non-null result serves two purposes when filling missing columns: the base scan descriptor
+     * for the column must be preserved (the mapping still consumes the same-named source slot), and
+     * for case-preserving formats the base descriptor must reuse the returned spelling so the reader
+     * looks up the right file key.
+     */
+    private String selfReferenceSource(NereidsImportColumnDesc desc) {
+        if (desc.isColumn()) {
+            return null;
+        }
+        for (Slot slot : desc.getExpr().getInputSlots()) {
+            if (slot.getName().equalsIgnoreCase(desc.getColumnName())) {
+                return slot.getName();
+            }
+        }
+        return null;
     }
 
     private TFileFormatType formatType(String fileFormat) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadTaskInfo.java
@@ -75,6 +75,10 @@ public interface NereidsLoadTaskInfo {
 
     boolean isNumAsString();
 
+    default boolean isFillMissingColumns() {
+        return false;
+    }
+
     boolean isReadJsonByLine();
 
     String getPath();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfo.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
+import org.apache.doris.datasource.property.fileformat.JsonFileFormatProperties;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
@@ -220,6 +221,11 @@ public class NereidsRoutineLoadTaskInfo implements NereidsLoadTaskInfo {
     @Override
     public boolean isNumAsString() {
         return Boolean.parseBoolean(jobProperties.get(PROPS_NUM_AS_STRING));
+    }
+
+    @Override
+    public boolean isFillMissingColumns() {
+        return Boolean.parseBoolean(jobProperties.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommand.java
@@ -40,6 +40,7 @@ import org.apache.doris.nereids.trees.plans.commands.load.LoadProperty;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.thrift.TUniqueKeyUpdateMode;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -74,6 +75,7 @@ public class AlterRoutineLoadCommand extends AlterCommand {
             .add(CreateRoutineLoadInfo.STRICT_MODE)
             .add(CreateRoutineLoadInfo.TIMEZONE)
             .add(CreateRoutineLoadInfo.WORKLOAD_GROUP)
+            .add(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS)
             .add(JsonFileFormatProperties.PROP_JSON_PATHS)
             .add(JsonFileFormatProperties.PROP_STRIP_OUTER_ARRAY)
             .add(JsonFileFormatProperties.PROP_NUM_AS_STRING)
@@ -313,6 +315,69 @@ public class AlterRoutineLoadCommand extends AlterCommand {
             analyzedJobProperties.put(CsvFileFormatProperties.PROP_EMPTY_FIELD_AS_NULL,
                     String.valueOf(emptyFieldAsNull));
         }
+
+        if (jobProperties.containsKey(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS)) {
+            String val = jobProperties.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS);
+            if (!"true".equalsIgnoreCase(val) && !"false".equalsIgnoreCase(val)) {
+                throw new AnalysisException(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS
+                        + " must be 'true' or 'false', but found: " + val);
+            }
+            // fill_missing_columns is a JSON-only property. This alter cannot change the job format,
+            // so reject it for non-JSON jobs; otherwise the value would be persisted but silently
+            // ignored by the CSV scan path.
+            RoutineLoadJob job = Env.getCurrentEnv().getRoutineLoadManager()
+                    .getJob(getDbName(), getJobName());
+            if (!"json".equalsIgnoreCase(job.getFormat())) {
+                throw new AnalysisException(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS
+                        + " is only supported for JSON format, but found format: " + job.getFormat());
+            }
+            analyzedJobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, val);
+        }
+
+        // fill_missing_columns performs a full-row upsert, which is mutually exclusive with fixed
+        // partial columns update (see CreateRoutineLoadInfo#checkJobProperties). Resolve both the
+        // fill_missing_columns flag and the update mode this alter will result in (either changed by
+        // this alter or kept from the current job) and reject the combination.
+        if (jobProperties.containsKey(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS)
+                || jobProperties.containsKey(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE)
+                || jobProperties.containsKey(CreateRoutineLoadInfo.PARTIAL_COLUMNS)) {
+            RoutineLoadJob job = Env.getCurrentEnv().getRoutineLoadManager()
+                    .getJob(getDbName(), getJobName());
+            if (effectiveFillMissingColumns(job)
+                    && effectiveUniqueKeyUpdateMode(job) == TUniqueKeyUpdateMode.UPDATE_FIXED_COLUMNS) {
+                throw new AnalysisException(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS
+                        + " is not supported with fixed partial columns update");
+            }
+        }
+    }
+
+    /**
+     * Resolve whether fill_missing_columns will be enabled after this alter: prefer the value being
+     * changed by this alter, otherwise fall back to the current job's value.
+     */
+    private boolean effectiveFillMissingColumns(RoutineLoadJob job) {
+        if (analyzedJobProperties.containsKey(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS)) {
+            return Boolean.parseBoolean(
+                    analyzedJobProperties.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+        }
+        return job.isFillMissingColumns();
+    }
+
+    /**
+     * Resolve the unique-key update mode this alter will result in: prefer the mode being changed by
+     * this alter (unique_key_update_mode or the legacy partial_columns flag), otherwise fall back to
+     * the current job's mode.
+     */
+    private TUniqueKeyUpdateMode effectiveUniqueKeyUpdateMode(RoutineLoadJob job) {
+        if (analyzedJobProperties.containsKey(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE)) {
+            return CreateRoutineLoadInfo.parseUniqueKeyUpdateMode(
+                    analyzedJobProperties.get(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE));
+        }
+        if (analyzedJobProperties.containsKey(CreateRoutineLoadInfo.PARTIAL_COLUMNS)) {
+            return Boolean.parseBoolean(analyzedJobProperties.get(CreateRoutineLoadInfo.PARTIAL_COLUMNS))
+                    ? TUniqueKeyUpdateMode.UPDATE_FIXED_COLUMNS : TUniqueKeyUpdateMode.UPSERT;
+        }
+        return job.getUniqueKeyUpdateMode();
     }
 
     private void checkDataSourceProperties() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfo.java
@@ -130,6 +130,7 @@ public class CreateRoutineLoadInfo {
             .add(JsonFileFormatProperties.PROP_STRIP_OUTER_ARRAY)
             .add(JsonFileFormatProperties.PROP_NUM_AS_STRING)
             .add(JsonFileFormatProperties.PROP_FUZZY_PARSE)
+            .add(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS)
             .add(JsonFileFormatProperties.PROP_JSON_ROOT)
             .add(CsvFileFormatProperties.PROP_ENCLOSE)
             .add(CsvFileFormatProperties.PROP_ESCAPE)
@@ -641,6 +642,25 @@ public class CreateRoutineLoadInfo {
         }
 
         String format = jobProperties.getOrDefault(FileFormatProperties.PROP_FORMAT, "csv");
+        // fill_missing_columns is a JSON-only property. If the format is not JSON, the value
+        // would otherwise be silently ignored (including typos), so reject it explicitly here
+        // before the format dispatch to keep behavior consistent with ALTER ROUTINE LOAD.
+        if (jobProperties.containsKey(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS)
+                && !"json".equalsIgnoreCase(format)) {
+            throw new AnalysisException(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS
+                    + " is only supported for JSON format, but found format: " + format);
+        }
+        // fill_missing_columns auto-fills every omitted table column into the scan/output tuple as
+        // a full-row upsert. Fixed partial update only writes the explicitly listed columns, so the
+        // auto-filled non-null columns would be null-checked on the FE side yet dropped by the BE
+        // writer's index slots, which can wrongly filter a valid partial row. The two semantics are
+        // mutually exclusive, so reject the combination up front.
+        if (jobProperties.containsKey(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS)
+                && Boolean.parseBoolean(jobProperties.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS))
+                && uniqueKeyUpdateMode == TUniqueKeyUpdateMode.UPDATE_FIXED_COLUMNS) {
+            throw new AnalysisException(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS
+                    + " is not supported with fixed partial columns update");
+        }
         fileFormatProperties = FileFormatProperties.createFileFormatProperties(format);
         fileFormatProperties.analyzeFileFormatProperties(jobProperties, false);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/fileformat/JsonFileFormatPropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/fileformat/JsonFileFormatPropertiesTest.java
@@ -46,8 +46,27 @@ public class JsonFileFormatPropertiesTest {
         Assert.assertEquals(true, jsonFileFormatProperties.isReadJsonByLine());
         Assert.assertEquals(false, jsonFileFormatProperties.isNumAsString());
         Assert.assertEquals(false, jsonFileFormatProperties.isFuzzyParse());
+        Assert.assertEquals(false, jsonFileFormatProperties.isFillMissingColumns());
         Assert.assertEquals(CsvFileFormatProperties.DEFAULT_LINE_DELIMITER,
                 jsonFileFormatProperties.getLineDelimiter());
+    }
+
+    @Test
+    public void testAnalyzeFileFormatPropertiesFillMissingColumnsTrue() throws AnalysisException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+
+        jsonFileFormatProperties.analyzeFileFormatProperties(properties, true);
+        Assert.assertEquals(true, jsonFileFormatProperties.isFillMissingColumns());
+    }
+
+    @Test
+    public void testAnalyzeFileFormatPropertiesFillMissingColumnsFalse() throws AnalysisException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "false");
+
+        jsonFileFormatProperties.analyzeFileFormatProperties(properties, true);
+        Assert.assertEquals(false, jsonFileFormatProperties.isFillMissingColumns());
     }
 
     @Test
@@ -151,6 +170,56 @@ public class JsonFileFormatPropertiesTest {
     }
 
     @Test
+    public void testAnalyzeFileFormatPropertiesFillMissingColumnsInvalidValue() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "treu");
+
+        AnalysisException e = Assert.assertThrows(AnalysisException.class,
+                () -> jsonFileFormatProperties.analyzeFileFormatProperties(properties, true));
+        Assert.assertTrue(e.getMessage().contains(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+        Assert.assertTrue(e.getMessage().contains("treu"));
+    }
+
+    @Test
+    public void testAnalyzeFileFormatPropertiesFillMissingColumnsCaseInsensitive() throws AnalysisException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "TRUE");
+
+        jsonFileFormatProperties.analyzeFileFormatProperties(properties, true);
+        Assert.assertEquals(true, jsonFileFormatProperties.isFillMissingColumns());
+    }
+
+    @Test
+    public void testAnalyzeFileFormatPropertiesFillMissingColumnsMixedCaseFalse() throws AnalysisException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "FaLsE");
+
+        jsonFileFormatProperties.analyzeFileFormatProperties(properties, true);
+        Assert.assertEquals(false, jsonFileFormatProperties.isFillMissingColumns());
+    }
+
+    @Test
+    public void testAnalyzeFileFormatPropertiesFillMissingColumnsEmptyStringRejected() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "");
+
+        AnalysisException e = Assert.assertThrows(AnalysisException.class,
+                () -> jsonFileFormatProperties.analyzeFileFormatProperties(properties, true));
+        Assert.assertTrue(e.getMessage().contains(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testAnalyzeFileFormatPropertiesFillMissingColumnsNumericRejected() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "1");
+
+        AnalysisException e = Assert.assertThrows(AnalysisException.class,
+                () -> jsonFileFormatProperties.analyzeFileFormatProperties(properties, true));
+        Assert.assertTrue(e.getMessage().contains(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+        Assert.assertTrue(e.getMessage().contains("1"));
+    }
+
+    @Test
     public void testAnalyzeFileFormatPropertiesAllProperties() throws AnalysisException {
         Map<String, String> properties = new HashMap<>();
         properties.put(JsonFileFormatProperties.PROP_JSON_ROOT, "data.records");
@@ -159,6 +228,7 @@ public class JsonFileFormatPropertiesTest {
         properties.put(JsonFileFormatProperties.PROP_READ_JSON_BY_LINE, "true");
         properties.put(JsonFileFormatProperties.PROP_NUM_AS_STRING, "true");
         properties.put(JsonFileFormatProperties.PROP_FUZZY_PARSE, "true");
+        properties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
 
         jsonFileFormatProperties.analyzeFileFormatProperties(properties, true);
 
@@ -168,6 +238,7 @@ public class JsonFileFormatPropertiesTest {
         Assert.assertEquals(true, jsonFileFormatProperties.isReadJsonByLine());
         Assert.assertEquals(true, jsonFileFormatProperties.isNumAsString());
         Assert.assertEquals(true, jsonFileFormatProperties.isFuzzyParse());
+        Assert.assertEquals(true, jsonFileFormatProperties.isFillMissingColumns());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.kafka.KafkaUtil;
+import org.apache.doris.datasource.property.fileformat.JsonFileFormatProperties;
 import org.apache.doris.load.routineload.kafka.KafkaProgress;
 import org.apache.doris.load.routineload.kafka.KafkaRoutineLoadJob;
 import org.apache.doris.load.routineload.kafka.KafkaTaskInfo;
@@ -374,6 +375,79 @@ public class RoutineLoadJobTest {
                 + ");";
         System.out.println(showCreateInfo);
         Assert.assertEquals(expect, showCreateInfo);
+    }
+
+    @Test
+    public void testGetShowCreateInfoWithFillMissingColumns() throws UserException {
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(111L, "test_load", 1,
+                11, "localhost:9092", "test_topic", UserIdentity.ADMIN);
+        Deencapsulation.setField(routineLoadJob, "maxErrorNum", 10);
+        Deencapsulation.setField(routineLoadJob, "maxBatchRows", 10);
+
+        // Set fill_missing_columns to true
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+        jobProperties.put("format", "json");
+        jobProperties.put("strip_outer_array", "false");
+        jobProperties.put("num_as_string", "false");
+        jobProperties.put("fuzzy_parse", "false");
+        jobProperties.put("strict_mode", "false");
+        jobProperties.put("timezone", "Asia/Shanghai");
+        jobProperties.put("desired_concurrent_number", "0");
+        jobProperties.put("max_error_number", "10");
+        jobProperties.put("max_filter_ratio", "1.0");
+        jobProperties.put("max_batch_interval", "60");
+        jobProperties.put("max_batch_rows", "10");
+        jobProperties.put("max_batch_size", "1073741824");
+        jobProperties.put("exec_mem_limit", "2147483648");
+        Deencapsulation.setField(routineLoadJob, "jobProperties", jobProperties);
+
+        String showCreateInfo = routineLoadJob.getShowCreateInfo();
+        String expect = "CREATE ROUTINE LOAD test_load ON 11\n"
+                + "WITH APPEND\n"
+                + "PROPERTIES\n"
+                + "(\n"
+                + "\"desired_concurrent_number\" = \"0\",\n"
+                + "\"max_error_number\" = \"10\",\n"
+                + "\"max_filter_ratio\" = \"1.0\",\n"
+                + "\"max_batch_interval\" = \"60\",\n"
+                + "\"max_batch_rows\" = \"10\",\n"
+                + "\"max_batch_size\" = \"1073741824\",\n"
+                + "\"format\" = \"json\",\n"
+                + "\"strip_outer_array\" = \"false\",\n"
+                + "\"num_as_string\" = \"false\",\n"
+                + "\"fuzzy_parse\" = \"false\",\n"
+                + "\"fill_missing_columns\" = \"true\",\n"
+                + "\"strict_mode\" = \"false\",\n"
+                + "\"timezone\" = \"Asia/Shanghai\",\n"
+                + "\"exec_mem_limit\" = \"2147483648\"\n"
+                + ")\n"
+                + "FROM KAFKA\n"
+                + "(\n"
+                + "\"kafka_broker_list\" = \"localhost:9092\",\n"
+                + "\"kafka_topic\" = \"test_topic\"\n"
+                + ");";
+        System.out.println(showCreateInfo);
+        Assert.assertEquals(expect, showCreateInfo);
+    }
+
+    @Test
+    public void testIsFillMissingColumns() {
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(112L, "test_load_fill_missing", 1,
+                11, "localhost:9092", "test_topic", UserIdentity.ADMIN);
+
+        // jobProperties not set => default false
+        Map<String, String> jobProperties = Maps.newHashMap();
+        Deencapsulation.setField(routineLoadJob, "jobProperties", jobProperties);
+        Assert.assertFalse(routineLoadJob.isFillMissingColumns());
+
+        // explicit true
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+        Assert.assertTrue(routineLoadJob.isFillMissingColumns());
+
+        // explicit false
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "false");
+        Assert.assertFalse(routineLoadJob.isFillMissingColumns());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsBrokerLoadTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsBrokerLoadTaskTest.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.load;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NereidsBrokerLoadTaskTest {
+
+    /**
+     * Broker load does not participate in fill_missing_columns (that is JSON-only in routine load).
+     * NereidsBrokerLoadTask therefore relies on the NereidsLoadTaskInfo default, which must be false.
+     * Pinning this here guards against an accidental default flip on the interface.
+     */
+    @Test
+    public void testIsFillMissingColumnsDefaultFalse() {
+        NereidsBrokerLoadTask task = new NereidsBrokerLoadTask(
+                1L, 0, 1, false, false, false, null);
+        Assertions.assertFalse(task.isFillMissingColumns());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsLoadScanProviderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsLoadScanProviderTest.java
@@ -342,6 +342,31 @@ public class NereidsLoadScanProviderTest {
     }
 
     @Test
+    public void testCreateLoadContextFillMissingWithPlainFileFieldsAddsRemainingColumns() throws Exception {
+        // Headline use case: the user lists a real table column as a plain file field
+        // (COLUMNS(k1), expr == null) and enables fill_missing_columns=true. The listed
+        // column k1 must be scanned exactly once (the base-schema fill must not duplicate it),
+        // and the remaining table columns k2/k3 must be auto-filled from the base schema.
+        OlapTable table = mockKvTable();
+        JsonFileFormatProperties props = new JsonFileFormatProperties();
+        Deencapsulation.setField(props, "fillMissingColumns", true);
+
+        List<NereidsImportColumnDesc> columnDescList = ImmutableList.of(
+                new NereidsImportColumnDesc("k1"));
+        NereidsParamCreateContext context = createLoadContext(table, columnDescList, props);
+
+        // k1 is an explicitly listed file field; it must be scanned exactly once, not duplicated.
+        Assertions.assertEquals(1, context.scanSlots.stream()
+                        .filter(slot -> slot.getName().equalsIgnoreCase("k1")).count(),
+                "plain file field k1 must not be duplicated by the base-schema fill");
+        // k2 and k3 were not listed, so they must be auto-filled from the base schema.
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("k2")));
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("k3")));
+    }
+
+    @Test
     public void testSelfReferenceSourceReturnsMappingSourceCase() {
         NereidsLoadScanProvider provider = buildProvider();
         // COLUMNS(Score = score + 1): table column is "Score" but the mapping reads "score".

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsLoadScanProviderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsLoadScanProviderTest.java
@@ -23,11 +23,18 @@ import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.property.fileformat.ArrowFileFormatProperties;
+import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
+import org.apache.doris.datasource.property.fileformat.JsonFileFormatProperties;
 import org.apache.doris.datasource.property.fileformat.NativeFileFormatProperties;
 import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.trees.expressions.Add;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.thrift.TFileCompressType;
 import org.apache.doris.thrift.TFileFormatType;
@@ -102,13 +109,41 @@ public class NereidsLoadScanProviderTest {
     }
 
     @Test
+    public void testIsFillMissingColumnsFalseForCsv() {
+        NereidsLoadScanProvider provider = buildProvider();
+        NereidsBrokerFileGroup fileGroup = buildFileGroup(
+                new CsvFileFormatProperties(FileFormatProperties.FORMAT_CSV));
+        boolean result = Deencapsulation.invoke(provider, "isFillMissingColumns", fileGroup);
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    public void testIsFillMissingColumnsFalseForJsonDefault() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // JSON file format but fillMissingColumns left at default (false)
+        NereidsBrokerFileGroup fileGroup = buildFileGroup(new JsonFileFormatProperties());
+        boolean result = Deencapsulation.invoke(provider, "isFillMissingColumns", fileGroup);
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    public void testIsFillMissingColumnsTrueForJsonEnabled() {
+        NereidsLoadScanProvider provider = buildProvider();
+        JsonFileFormatProperties props = new JsonFileFormatProperties();
+        Deencapsulation.setField(props, "fillMissingColumns", true);
+        NereidsBrokerFileGroup fileGroup = buildFileGroup(props);
+        // ---------- shouldAddSequenceColumn ----------
+        boolean result = Deencapsulation.invoke(provider, "isFillMissingColumns", fileGroup);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
     public void testArrowSourceColumnUsesCaseInsensitiveTableType() throws Exception {
         OlapTable table = mockTable();
         NereidsParamCreateContext context = createArrowLoadContext(table,
                 ImmutableList.of(new NereidsImportColumnDesc("time"),
                         new NereidsImportColumnDesc("securityid"),
                         new NereidsImportColumnDesc("ev")));
-
         assertSlot(context, "ev", PrimitiveType.DOUBLE);
     }
 
@@ -122,6 +157,34 @@ public class NereidsLoadScanProviderTest {
                 new NativeFileFormatProperties());
 
         assertSlot(context, "ev", PrimitiveType.DOUBLE);
+    }
+
+    @Test
+    public void testShouldAddSequenceColumnTrueWhenFillMissingEnabled() {
+        NereidsLoadScanProvider provider = buildProvider();
+        JsonFileFormatProperties props = new JsonFileFormatProperties();
+        Deencapsulation.setField(props, "fillMissingColumns", true);
+        NereidsBrokerFileGroup fileGroup = buildFileGroup(props);
+
+        // fill_missing_columns=true must force-add the sequence column even when the
+        // user specified other columns; otherwise the auto-filled schema would silently
+        // drop the sequence slot.
+        List<NereidsImportColumnDesc> columnDescList = Lists.newArrayList(
+                new NereidsImportColumnDesc("k1"), new NereidsImportColumnDesc("k2"));
+        boolean result = Deencapsulation.invoke(provider, "shouldAddSequenceColumn",
+                columnDescList, fileGroup);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testShouldAddSequenceColumnTrueWhenEmptyList() {
+        NereidsLoadScanProvider provider = buildProvider();
+        NereidsBrokerFileGroup fileGroup = buildFileGroup(
+                new CsvFileFormatProperties(FileFormatProperties.FORMAT_CSV));
+        // existing behavior: empty column list means user did not specify any columns
+        boolean result = Deencapsulation.invoke(provider, "shouldAddSequenceColumn",
+                Lists.<NereidsImportColumnDesc>newArrayList(), fileGroup);
+        Assertions.assertTrue(result);
     }
 
     @Test
@@ -141,6 +204,19 @@ public class NereidsLoadScanProviderTest {
         return createLoadContext(table, columnExprList, new ArrowFileFormatProperties());
     }
 
+    @Test
+    public void testShouldAddSequenceColumnTrueForOnlyDeleteSign() {
+        NereidsLoadScanProvider provider = buildProvider();
+        NereidsBrokerFileGroup fileGroup = buildFileGroup(
+                new CsvFileFormatProperties(FileFormatProperties.FORMAT_CSV));
+        // existing behavior: single delete-sign descriptor is treated as "no user columns"
+        List<NereidsImportColumnDesc> columnDescList = Lists.newArrayList(
+                new NereidsImportColumnDesc(Column.DELETE_SIGN));
+        boolean result = Deencapsulation.invoke(provider, "shouldAddSequenceColumn",
+                columnDescList, fileGroup);
+        Assertions.assertTrue(result);
+    }
+
     private NereidsParamCreateContext createLoadContext(OlapTable table, List<NereidsImportColumnDesc> columnExprList,
             FileFormatProperties fileFormatProperties)
             throws UserException {
@@ -157,18 +233,211 @@ public class NereidsLoadScanProviderTest {
         return new NereidsLoadScanProvider(fileGroupInfo, Collections.emptySet()).createLoadContext();
     }
 
+    @Test
+    public void testSelfReferenceSourceReturnsNullForConstantMapping() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // COLUMNS(k1 = 42) — constant mapping, no input slots
+        NereidsImportColumnDesc desc = new NereidsImportColumnDesc("k1", new IntegerLiteral(42));
+        String result = Deencapsulation.invoke(provider, "selfReferenceSource", desc);
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testSelfReferenceSourceReturnsNullForOtherColumnDerivation() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // COLUMNS(score_x2 = score * 2) — derives from a different source column
+        Expression expr = new Add(new UnboundSlot("score"), new IntegerLiteral(1));
+        NereidsImportColumnDesc desc = new NereidsImportColumnDesc("score_x2", expr);
+        String result = Deencapsulation.invoke(provider, "selfReferenceSource", desc);
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testSelfReferenceSourceReturnsNullForFileField() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // pure file field: expr == null
+        NereidsImportColumnDesc desc = new NereidsImportColumnDesc("k1");
+        String result = Deencapsulation.invoke(provider, "selfReferenceSource", desc);
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testSelfReferenceSourceReturnsSourceForSelfReference() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // COLUMNS(k1 = k1) — mapping reads source column with same name as target
+        NereidsImportColumnDesc desc = new NereidsImportColumnDesc("k1", new UnboundSlot("k1"));
+        String result = Deencapsulation.invoke(provider, "selfReferenceSource", desc);
+        Assertions.assertEquals("k1", result);
+    }
+
+    @Test
+    public void testSelfReferenceSourceReturnsSourceSpellingForMixedCase() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // COLUMNS(Score = score) — target "Score", source "score"; return the source spelling.
+        NereidsImportColumnDesc desc = new NereidsImportColumnDesc("Score", new UnboundSlot("score"));
+        String result = Deencapsulation.invoke(provider, "selfReferenceSource", desc);
+        Assertions.assertEquals("score", result);
+    }
+
+    @Test
+    public void testSelfReferenceSourceReturnsSourceForSelfReferenceWithComputation() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // COLUMNS(k1 = k1 + 1) — still references own source column
+        Expression expr = new Add(new UnboundSlot("k1"), new IntegerLiteral(1));
+        NereidsImportColumnDesc desc = new NereidsImportColumnDesc("k1", expr);
+        String result = Deencapsulation.invoke(provider, "selfReferenceSource", desc);
+        Assertions.assertEquals("k1", result);
+    }
+
+    @Test
+    public void testCreateLoadContextFillMissingKeepsSelfReferenceAndAddsMissingColumns() throws Exception {
+        // End-to-end guard for COLUMNS(k1 = k1) + fill_missing_columns=true (JSON only):
+        //   - the self-reference must NOT suppress the base k1 scan slot,
+        //   - other missing table columns (k2, k3) must be filled from the base schema.
+        OlapTable table = mockKvTable();
+        JsonFileFormatProperties props = new JsonFileFormatProperties();
+        Deencapsulation.setField(props, "fillMissingColumns", true);
+
+        List<NereidsImportColumnDesc> columnDescList = ImmutableList.of(
+                new NereidsImportColumnDesc("k1", new UnboundSlot("k1")));
+        NereidsParamCreateContext context = createLoadContext(table, columnDescList, props);
+
+        // k1 scan slot must still be present because the mapping references its own source column.
+        Assertions.assertTrue(context.scanSlots.stream()
+                        .anyMatch(slot -> slot.getName().equalsIgnoreCase("k1")),
+                "COLUMNS(k1 = k1) with fill_missing must not drop the k1 scan slot");
+        // The other table columns must have been auto-filled from base schema.
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("k2")));
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("k3")));
+    }
+
+    @Test
+    public void testCreateLoadContextFillMissingSuppressesDerivedSourceOwnedColumn() throws Exception {
+        // Guard for COLUMNS(k2 = k1 + 1) + fill_missing_columns=true:
+        //   - the derived mapping k2 owns its target, so the base scan MUST NOT re-inject a
+        //     k2 slot (that would double-write k2 with the raw file value).
+        //   - k1 and k3 must still be filled in from the base schema.
+        OlapTable table = mockKvTable();
+        JsonFileFormatProperties props = new JsonFileFormatProperties();
+        Deencapsulation.setField(props, "fillMissingColumns", true);
+
+        Expression derived = new Add(new UnboundSlot("k1"), new IntegerLiteral(1));
+        List<NereidsImportColumnDesc> columnDescList = ImmutableList.of(
+                new NereidsImportColumnDesc("k2", derived));
+        NereidsParamCreateContext context = createLoadContext(table, columnDescList, props);
+
+        // exprMap must retain the user-defined mapping for k2.
+        Assertions.assertTrue(context.exprMap.containsKey("k2"));
+        // k1 and k3 must be added from base schema.
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("k1")));
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("k3")));
+        // The derived mapping already owns k2 — no raw k2 scan slot should be produced.
+        Assertions.assertFalse(context.scanSlots.stream()
+                        .anyMatch(slot -> slot.getName().equalsIgnoreCase("k2")),
+                "derived mapping for k2 must suppress the base k2 scan slot");
+    }
+
+    @Test
+    public void testSelfReferenceSourceReturnsMappingSourceCase() {
+        NereidsLoadScanProvider provider = buildProvider();
+        // COLUMNS(Score = score + 1): table column is "Score" but the mapping reads "score".
+        Expression expr = new Add(new UnboundSlot("score"), new IntegerLiteral(1));
+        NereidsImportColumnDesc desc = new NereidsImportColumnDesc("Score", expr);
+        String spelling = Deencapsulation.invoke(provider, "selfReferenceSource", desc);
+        Assertions.assertEquals("score", spelling);
+    }
+
+    @Test
+    public void testCreateLoadContextFillMissingKeepsMappingSourceCaseForJson() throws Exception {
+        // Guard for the mixed-case self-reference issue: table column is "Score", the JSON key is
+        // lowercase "score", and COLUMNS(Score = score + 1) binds case-insensitively. Because JSON is
+        // a case-preserving format and NewJsonReader matches the file key to the scan slot name
+        // exactly, the base scan slot for Score must be emitted with the mapping source spelling
+        // "score", otherwise the mapping would receive NULL.
+        OlapTable table = mockScoreTable();
+        JsonFileFormatProperties props = new JsonFileFormatProperties();
+        Deencapsulation.setField(props, "fillMissingColumns", true);
+
+        Expression expr = new Add(new UnboundSlot("score"), new IntegerLiteral(1));
+        List<NereidsImportColumnDesc> columnDescList = ImmutableList.of(
+                new NereidsImportColumnDesc("Score", expr));
+        NereidsParamCreateContext context = createLoadContext(table, columnDescList, props);
+
+        // the base scan slot for Score must use the lowercase mapping source spelling "score"
+        Assertions.assertTrue(context.scanSlots.stream()
+                        .anyMatch(slot -> slot.getName().equals("score")),
+                "case-preserving fill_missing must keep the mapping source spelling 'score'");
+        Assertions.assertFalse(context.scanSlots.stream()
+                        .anyMatch(slot -> slot.getName().equals("Score")),
+                "the table column spelling 'Score' must not be used for the base scan slot");
+        // the other base-schema columns are still auto-filled with the table column spelling
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("id")));
+        Assertions.assertTrue(context.scanSlots.stream()
+                .anyMatch(slot -> slot.getName().equalsIgnoreCase("name")));
+    }
+
+    @Test
+    public void testShouldAddSequenceColumnFalseWhenUserColumnsSpecified() {
+        NereidsLoadScanProvider provider = buildProvider();
+        NereidsBrokerFileGroup fileGroup = buildFileGroup(
+                new CsvFileFormatProperties(FileFormatProperties.FORMAT_CSV));
+        // existing behavior: user-specified columns and no fill_missing => do not auto-add
+        List<NereidsImportColumnDesc> columnDescList = Lists.newArrayList(
+                new NereidsImportColumnDesc("k1"), new NereidsImportColumnDesc("k2"));
+        boolean result = Deencapsulation.invoke(provider, "shouldAddSequenceColumn",
+                columnDescList, fileGroup);
+        Assertions.assertFalse(result);
+    }
+
+    private NereidsLoadScanProvider buildProvider() {
+        // The private helpers under test don't read instance fields, so we pass nulls.
+        return new NereidsLoadScanProvider(null, null);
+    }
+
+    private NereidsBrokerFileGroup buildFileGroup(FileFormatProperties props) {
+        return new NereidsBrokerFileGroup(
+                0L, false, null, null, null, null, null, Lists.newArrayList(), null,
+                null, null, null, LoadTask.MergeType.APPEND, null, 0L, false, false, props);
+    }
+
     private OlapTable mockTable() {
         List<Column> schema = Arrays.asList(
                 new Column("time", PrimitiveType.DATETIME, true),
                 new Column("securityid", PrimitiveType.INT, true),
                 new Column("EV", PrimitiveType.DOUBLE, true));
+        return mockOlapTable("t_upper", schema);
+    }
+
+    private OlapTable mockKvTable() {
+        List<Column> schema = Arrays.asList(
+                new Column("k1", PrimitiveType.INT, true),
+                new Column("k2", PrimitiveType.INT, true),
+                new Column("k3", PrimitiveType.INT, true));
+        return mockOlapTable("t_kv", schema);
+    }
+
+    private OlapTable mockScoreTable() {
+        // "Score" keeps a mixed-case spelling so the self-reference case-preservation can be exercised.
+        List<Column> schema = Arrays.asList(
+                new Column("id", PrimitiveType.INT, true),
+                new Column("name", PrimitiveType.VARCHAR, true),
+                new Column("Score", PrimitiveType.INT, true));
+        return mockOlapTable("t_score", schema);
+    }
+
+    private OlapTable mockOlapTable(String name, List<Column> schema) {
         Map<String, Column> nameToColumn = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (Column column : schema) {
             nameToColumn.put(column.getName(), column);
         }
 
         OlapTable table = Mockito.mock(OlapTable.class);
-        Mockito.when(table.getName()).thenReturn("t_upper");
+        Mockito.when(table.getName()).thenReturn(name);
         Mockito.when(table.getBaseSchema()).thenReturn(schema);
         Mockito.when(table.getBaseSchema(false)).thenReturn(schema);
         Mockito.when(table.getBaseSchema(true)).thenReturn(schema);
@@ -178,7 +447,7 @@ public class NereidsLoadScanProviderTest {
         Mockito.when(table.getSequenceMapCol()).thenReturn(null);
         Mockito.when(table.hasSkipBitmapColumn()).thenReturn(false);
         Mockito.when(table.getKeysType()).thenReturn(KeysType.UNIQUE_KEYS);
-        Mockito.when(table.getFullQualifiers()).thenReturn(ImmutableList.of("internal", "db", "t_upper"));
+        Mockito.when(table.getFullQualifiers()).thenReturn(ImmutableList.of("internal", "db", name));
         return table;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfoTest.java
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.load;
+
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.property.fileformat.JsonFileFormatProperties;
+import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.thrift.TPartialUpdateNewRowPolicy;
+import org.apache.doris.thrift.TUniqueKeyUpdateMode;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NereidsRoutineLoadTaskInfoTest {
+
+    private NereidsRoutineLoadTaskInfo buildTaskInfo(Map<String, String> jobProperties) {
+        return new NereidsRoutineLoadTaskInfo(0L, jobProperties, 10L, null,
+                LoadTask.MergeType.APPEND, null, null, 0.0,
+                new NereidsLoadTaskInfo.NereidsImportColumnDescs(), null, null, null,
+                null, (byte) 0, (byte) 0, 1, false, TUniqueKeyUpdateMode.UPSERT,
+                TPartialUpdateNewRowPolicy.APPEND, false);
+    }
+
+    @Test
+    public void testIsFillMissingColumnsTrue() {
+        Map<String, String> jobProperties = new HashMap<>();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+        NereidsRoutineLoadTaskInfo taskInfo = buildTaskInfo(jobProperties);
+        Assertions.assertTrue(taskInfo.isFillMissingColumns());
+    }
+
+    @Test
+    public void testIsFillMissingColumnsFalse() {
+        Map<String, String> jobProperties = new HashMap<>();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "false");
+        NereidsRoutineLoadTaskInfo taskInfo = buildTaskInfo(jobProperties);
+        Assertions.assertFalse(taskInfo.isFillMissingColumns());
+    }
+
+    @Test
+    public void testIsFillMissingColumnsDefault() {
+        NereidsRoutineLoadTaskInfo taskInfo = buildTaskInfo(new HashMap<>());
+        Assertions.assertFalse(taskInfo.isFillMissingColumns());
+    }
+
+    @Test
+    public void testFillMissingColumnsPropagatedToDataDescriptionAnalysisMap() {
+        Map<String, String> jobProperties = new HashMap<>();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+        NereidsRoutineLoadTaskInfo taskInfo = buildTaskInfo(jobProperties);
+
+        NereidsDataDescription desc = new NereidsDataDescription("tbl", taskInfo);
+        Map<String, String> analysisMap = Deencapsulation.getField(desc, "analysisMap");
+        Assertions.assertEquals("true",
+                analysisMap.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testFillMissingColumnsDefaultFalseInDataDescriptionAnalysisMap() {
+        NereidsRoutineLoadTaskInfo taskInfo = buildTaskInfo(new HashMap<>());
+        NereidsDataDescription desc = new NereidsDataDescription("tbl", taskInfo);
+        Map<String, String> analysisMap = Deencapsulation.getField(desc, "analysisMap");
+        Assertions.assertEquals("false",
+                analysisMap.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AlterRoutineLoadCommandTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.datasource.property.fileformat.JsonFileFormatProperties;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.load.routineload.RoutineLoadJob;
 import org.apache.doris.load.routineload.RoutineLoadManager;
@@ -45,6 +46,7 @@ public class AlterRoutineLoadCommandTest {
     private ConnectContext connectContext;
     private MockedStatic<Env> envMockedStatic;
     private MockedStatic<ConnectContext> ctxMockedStatic;
+    private RoutineLoadJob rlJob;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -64,12 +66,13 @@ public class AlterRoutineLoadCommandTest {
         Mockito.doReturn(tbl).when(db).getTableOrAnalysisException(Mockito.anyString());
         Mockito.when(env.getRoutineLoadManager()).thenReturn(Mockito.mock(RoutineLoadManager.class));
         RoutineLoadManager rlm = env.getRoutineLoadManager();
-        RoutineLoadJob rlJob = Mockito.mock(RoutineLoadJob.class);
+        rlJob = Mockito.mock(RoutineLoadJob.class);
         Mockito.when(rlm.getJob(Mockito.anyString(), Mockito.anyString())).thenReturn(rlJob);
         Mockito.when(rlJob.getDbFullName()).thenReturn("testDb");
         Mockito.when(rlJob.getTableName()).thenReturn("testTable");
         Mockito.when(rlJob.isMultiTable()).thenReturn(false);
         Mockito.when(rlJob.getMergeType()).thenReturn(LoadTask.MergeType.APPEND);
+        Mockito.when(rlJob.getFormat()).thenReturn("json");
     }
 
     @AfterEach
@@ -98,21 +101,170 @@ public class AlterRoutineLoadCommandTest {
         jobProperties.put(CreateRoutineLoadInfo.MAX_BATCH_SIZE_PROPERTY, "1048576000");
         jobProperties.put(CreateRoutineLoadInfo.STRICT_MODE, "false");
         jobProperties.put(CreateRoutineLoadInfo.TIMEZONE, "Asia/Shanghai");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
 
         Map<String, String> dataSourceProperties = Maps.newHashMap();
         LabelNameInfo labelNameInfo = new LabelNameInfo("testDb", "label1");
 
-        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(labelNameInfo, jobProperties, dataSourceProperties);
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                labelNameInfo, jobProperties, dataSourceProperties);
         Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
 
-        Assertions.assertEquals(8, command.getAnalyzedJobProperties().size());
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.DESIRED_CONCURRENT_NUMBER_PROPERTY));
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.MAX_ERROR_NUMBER_PROPERTY));
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.MAX_FILTER_RATIO_PROPERTY));
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.MAX_BATCH_INTERVAL_SEC_PROPERTY));
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.MAX_BATCH_ROWS_PROPERTY));
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.MAX_BATCH_SIZE_PROPERTY));
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.STRICT_MODE));
-        Assertions.assertTrue(command.getAnalyzedJobProperties().containsKey(CreateRoutineLoadInfo.TIMEZONE));
+        Map<String, String> analyzed = command.getAnalyzedJobProperties();
+        Assertions.assertEquals(9, analyzed.size());
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.DESIRED_CONCURRENT_NUMBER_PROPERTY));
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.MAX_ERROR_NUMBER_PROPERTY));
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.MAX_FILTER_RATIO_PROPERTY));
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.MAX_BATCH_INTERVAL_SEC_PROPERTY));
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.MAX_BATCH_ROWS_PROPERTY));
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.MAX_BATCH_SIZE_PROPERTY));
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.STRICT_MODE));
+        Assertions.assertTrue(analyzed.containsKey(CreateRoutineLoadInfo.TIMEZONE));
+        Assertions.assertTrue(analyzed.containsKey(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+        Assertions.assertEquals("true",
+                analyzed.get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsFalse() {
+        runBefore();
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "false");
+
+        Map<String, String> dataSourceProperties = Maps.newHashMap();
+        LabelNameInfo labelNameInfo = new LabelNameInfo("testDb", "label1");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                labelNameInfo, jobProperties, dataSourceProperties);
+        Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+        Assertions.assertEquals("false",
+                command.getAnalyzedJobProperties().get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsInvalidValue() {
+        runBefore();
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "invalid");
+
+        Map<String, String> dataSourceProperties = Maps.newHashMap();
+        LabelNameInfo labelNameInfo = new LabelNameInfo("testDb", "label1");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                labelNameInfo, jobProperties, dataSourceProperties);
+        Assertions.assertThrows(org.apache.doris.common.AnalysisException.class,
+                () -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsRejectedForCsvJob() {
+        runBefore();
+        // The target job uses CSV format; fill_missing_columns is JSON-only and must be rejected.
+        Mockito.when(rlJob.getFormat()).thenReturn("csv");
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+
+        Map<String, String> dataSourceProperties = Maps.newHashMap();
+        LabelNameInfo labelNameInfo = new LabelNameInfo("testDb", "label1");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                labelNameInfo, jobProperties, dataSourceProperties);
+        org.apache.doris.common.AnalysisException e = Assertions.assertThrows(
+                org.apache.doris.common.AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(e.getMessage().contains(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsUppercaseTrue() {
+        runBefore();
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "TRUE");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                new LabelNameInfo("testDb", "label1"), jobProperties, Maps.newHashMap());
+        Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+        // AlterRoutineLoad relies on JsonFileFormatProperties parsing, which accepts case-insensitive
+        // "true"/"false" but stores the raw user input in the analyzed map.
+        Assertions.assertEquals("TRUE",
+                command.getAnalyzedJobProperties().get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsMixedCaseFalse() {
+        runBefore();
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "False");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                new LabelNameInfo("testDb", "label1"), jobProperties, Maps.newHashMap());
+        Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+        Assertions.assertEquals("False",
+                command.getAnalyzedJobProperties().get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsEmptyStringRejected() {
+        runBefore();
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                new LabelNameInfo("testDb", "label1"), jobProperties, Maps.newHashMap());
+        Assertions.assertThrows(org.apache.doris.common.AnalysisException.class,
+                () -> command.validate(connectContext));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsRejectedWhenEnablingOnFixedPartialJob() {
+        runBefore();
+        // The existing job is already in fixed partial update mode; enabling fill_missing_columns must
+        // be rejected because a full-row upsert conflicts with fixed partial columns update.
+        Mockito.when(rlJob.getUniqueKeyUpdateMode())
+                .thenReturn(org.apache.doris.thrift.TUniqueKeyUpdateMode.UPDATE_FIXED_COLUMNS);
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                new LabelNameInfo("testDb", "label1"), jobProperties, Maps.newHashMap());
+        org.apache.doris.common.AnalysisException e = Assertions.assertThrows(
+                org.apache.doris.common.AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(e.getMessage().contains("fixed partial columns update"));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsRejectedWhenTurningOnFixedPartialWhileEnabled() {
+        runBefore();
+        // The existing job already has fill_missing_columns enabled; switching it into fixed partial
+        // update mode via this alter must be rejected as well.
+        Mockito.when(rlJob.isFillMissingColumns()).thenReturn(true);
+        Mockito.when(rlJob.getUniqueKeyUpdateMode())
+                .thenReturn(org.apache.doris.thrift.TUniqueKeyUpdateMode.UPSERT);
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE, "UPDATE_FIXED_COLUMNS");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                new LabelNameInfo("testDb", "label1"), jobProperties, Maps.newHashMap());
+        org.apache.doris.common.AnalysisException e = Assertions.assertThrows(
+                org.apache.doris.common.AnalysisException.class,
+                () -> command.validate(connectContext));
+        Assertions.assertTrue(e.getMessage().contains("fixed partial columns update"));
+    }
+
+    @Test
+    public void testValidateFillMissingColumnsAllowedForFlexiblePartialJob() {
+        runBefore();
+        // flexible partial update is compatible with fill_missing_columns, so it must be accepted.
+        Mockito.when(rlJob.getUniqueKeyUpdateMode())
+                .thenReturn(org.apache.doris.thrift.TUniqueKeyUpdateMode.UPDATE_FLEXIBLE_COLUMNS);
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+
+        AlterRoutineLoadCommand command = new AlterRoutineLoadCommand(
+                new LabelNameInfo("testDb", "label1"), jobProperties, Maps.newHashMap());
+        Assertions.assertDoesNotThrow(() -> command.validate(connectContext));
+        Assertions.assertEquals("true",
+                command.getAnalyzedJobProperties().get(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/info/CreateRoutineLoadInfoTest.java
@@ -1,0 +1,177 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.info;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.datasource.property.fileformat.FileFormatProperties;
+import org.apache.doris.datasource.property.fileformat.JsonFileFormatProperties;
+import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.load.routineload.LoadDataSourceType;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.plans.commands.load.LoadProperty;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
+
+import com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+public class CreateRoutineLoadInfoTest {
+    private Env env;
+    private ConnectContext connectContext;
+    private MockedStatic<Env> envMockedStatic;
+    private MockedStatic<ConnectContext> ctxMockedStatic;
+
+    @BeforeEach
+    public void setUp() {
+        env = Mockito.mock(Env.class);
+        connectContext = Mockito.mock(ConnectContext.class);
+        envMockedStatic = Mockito.mockStatic(Env.class);
+        ctxMockedStatic = Mockito.mockStatic(ConnectContext.class);
+        envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+        ctxMockedStatic.when(ConnectContext::get).thenReturn(connectContext);
+        Mockito.when(connectContext.getSessionVariable()).thenReturn(new SessionVariable());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (envMockedStatic != null) {
+            envMockedStatic.close();
+        }
+        if (ctxMockedStatic != null) {
+            ctxMockedStatic.close();
+        }
+    }
+
+    private CreateRoutineLoadInfo buildInfo(Map<String, String> jobProperties) {
+        Map<String, LoadProperty> loadPropertyMap = Maps.newHashMap();
+        Map<String, String> dataSourceProperties = Maps.newHashMap();
+        dataSourceProperties.put("kafka_broker_list", "127.0.0.1:9092");
+        dataSourceProperties.put("kafka_topic", "test_topic");
+        LabelNameInfo labelNameInfo = new LabelNameInfo("testDb", "label1");
+        return new CreateRoutineLoadInfo(labelNameInfo, "testTable", loadPropertyMap,
+                jobProperties, LoadDataSourceType.KAFKA.name(), dataSourceProperties,
+                LoadTask.MergeType.APPEND, "");
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsRejectedForCsvDefault() {
+        // format is omitted, defaults to CSV; fill_missing_columns is JSON-only and must be rejected
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "treu");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        org.apache.doris.common.AnalysisException e = Assertions.assertThrows(
+                org.apache.doris.common.AnalysisException.class, info::checkJobProperties);
+        Assertions.assertTrue(e.getMessage().contains(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsRejectedForExplicitCsv() {
+        // format is explicitly CSV; even a syntactically valid value must be rejected
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(FileFormatProperties.PROP_FORMAT, "csv");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        org.apache.doris.common.AnalysisException e = Assertions.assertThrows(
+                org.apache.doris.common.AnalysisException.class, info::checkJobProperties);
+        Assertions.assertTrue(e.getMessage().contains(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS));
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsAcceptedForJson() {
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(FileFormatProperties.PROP_FORMAT, "json");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        Assertions.assertDoesNotThrow(info::checkJobProperties);
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsInvalidValueForJson() {
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(FileFormatProperties.PROP_FORMAT, "json");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "treu");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        // the JSON format properties validator rejects invalid boolean values with its own
+        // AnalysisException type (nereids.exceptions), distinct from common.AnalysisException
+        Assertions.assertThrows(AnalysisException.class, info::checkJobProperties);
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsRejectedForFixedPartialMode() {
+        // fill_missing_columns performs a full-row upsert and is mutually exclusive with fixed
+        // partial columns update expressed via unique_key_update_mode
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(FileFormatProperties.PROP_FORMAT, "json");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+        jobProperties.put(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE, "UPDATE_FIXED_COLUMNS");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        org.apache.doris.common.AnalysisException e = Assertions.assertThrows(
+                org.apache.doris.common.AnalysisException.class, info::checkJobProperties);
+        Assertions.assertTrue(e.getMessage().contains("fixed partial columns update"));
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsRejectedForLegacyPartialColumns() {
+        // the legacy partial_columns=true flag maps to UPDATE_FIXED_COLUMNS and must be rejected too
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(FileFormatProperties.PROP_FORMAT, "json");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+        jobProperties.put(CreateRoutineLoadInfo.PARTIAL_COLUMNS, "true");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        org.apache.doris.common.AnalysisException e = Assertions.assertThrows(
+                org.apache.doris.common.AnalysisException.class, info::checkJobProperties);
+        Assertions.assertTrue(e.getMessage().contains("fixed partial columns update"));
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsFalseAllowedForFixedPartialMode() {
+        // fill_missing_columns=false is a no-op and must not conflict with fixed partial update
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(FileFormatProperties.PROP_FORMAT, "json");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "false");
+        jobProperties.put(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE, "UPDATE_FIXED_COLUMNS");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        Assertions.assertDoesNotThrow(info::checkJobProperties);
+    }
+
+    @Test
+    public void testCheckJobPropertiesFillMissingColumnsAllowedForFlexiblePartialMode() {
+        // flexible partial update handles per-row column integrity itself, so it is compatible
+        Map<String, String> jobProperties = Maps.newHashMap();
+        jobProperties.put(FileFormatProperties.PROP_FORMAT, "json");
+        jobProperties.put(JsonFileFormatProperties.PROP_FILL_MISSING_COLUMNS, "true");
+        jobProperties.put(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE, "UPDATE_FLEXIBLE_COLUMNS");
+
+        CreateRoutineLoadInfo info = buildInfo(jobProperties);
+        Assertions.assertDoesNotThrow(info::checkJobProperties);
+    }
+}

--- a/regression-test/suites/load_p0/routine_load/data/test_routine_load_fill_missing_columns.json
+++ b/regression-test/suites/load_p0/routine_load/data/test_routine_load_fill_missing_columns.json
@@ -1,0 +1,3 @@
+{"id": 1, "name": "alice", "score": 10, "update_time": 100}
+{"id": 2, "name": "bob", "score": 20, "update_time": 200}
+{"id": 3, "name": "carol", "score": 30, "update_time": 300}

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_fill_missing_columns.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_fill_missing_columns.groovy
@@ -245,6 +245,111 @@ suite("test_routine_load_fill_missing_columns", "p0") {
     }
 
     // ---------------------------------------------------------------------------------
+    // Headline use case: fill_missing_columns = true where COLUMNS lists only some of the
+    // real table columns as plain file fields (COLUMNS(id, name)); the remaining base
+    // columns (score, update_time) are auto-filled from the base schema and read from json.
+    // This is the primary use case the option targets: enumerate the columns you care about
+    // and let the rest be completed automatically.
+    // ---------------------------------------------------------------------------------
+    def plainTable = "test_routine_load_fill_missing_columns_plain"
+    def plainJob = "test_routine_load_fill_missing_columns_plain_job"
+    try {
+        sql "DROP TABLE IF EXISTS ${plainTable}"
+        sql """
+            CREATE TABLE ${plainTable} (
+                id INT NOT NULL,
+                name VARCHAR(50) NULL,
+                score INT NULL,
+                update_time BIGINT NULL
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            );
+        """
+        sql "sync"
+
+        sql """
+            CREATE ROUTINE LOAD ${plainJob} ON ${plainTable}
+            COLUMNS(id, name)
+            PROPERTIES
+            (
+                "format" = "json",
+                "fill_missing_columns" = "true",
+                "max_batch_interval" = "5",
+                "max_batch_rows" = "300000",
+                "max_batch_size" = "209715200",
+                "strict_mode" = "false"
+            )
+            FROM KAFKA
+            (
+                "kafka_broker_list" = "${externalEnvIp}:${kafka_port}",
+                "kafka_topic" = "${topic}",
+                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+            );
+        """
+        sql "sync"
+
+        // the job must reach RUNNING and must not pause with a planning error
+        def count = 0
+        while (true) {
+            sleep(1000)
+            def res = sql "show routine load for ${plainJob}"
+            def state = res[0][8].toString()
+            def reason = res[0][17].toString()
+            log.info("plain file field job state: ${state}, reason: ${reason}".toString())
+            if (state == "RUNNING") {
+                break
+            }
+            count++
+            if (count >= 60) {
+                assertEquals("RUNNING", state)
+                break
+            }
+        }
+
+        count = 0
+        while (true) {
+            def res = sql "select count(*) from ${plainTable}"
+            if (res[0][0] >= 3) {
+                break
+            }
+            if (count >= 60) {
+                log.error("plain file field routine load can not load data for long time")
+                assertEquals(3, res[0][0])
+                break
+            }
+            sleep(5000)
+            count++
+        }
+        sql "sync"
+
+        // id/name are listed explicitly; score/update_time are auto-filled from the base schema
+        // and must be populated from the json values rather than left NULL.
+        def rows = sql "select id, name, score, update_time from ${plainTable} order by id"
+        assertEquals(3, rows.size())
+        assertEquals(1, rows[0][0])
+        assertEquals("alice", rows[0][1].toString())
+        assertEquals(10, rows[0][2])
+        assertEquals(100L, rows[0][3])
+        assertEquals(2, rows[1][0])
+        assertEquals("bob", rows[1][1].toString())
+        assertEquals(20, rows[1][2])
+        assertEquals(200L, rows[1][3])
+        assertEquals(3, rows[2][0])
+        assertEquals("carol", rows[2][1].toString())
+        assertEquals(30, rows[2][2])
+        assertEquals(300L, rows[2][3])
+    } finally {
+        try {
+            sql "stop routine load for ${plainJob}"
+        } catch (Exception e) {
+            log.info("stop plain file field routine load failed: ${e.getMessage()}".toString())
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
     // Same-name mapping case: fill_missing_columns = true with COLUMNS(score = score + 1).
     // The mapping target `score` references the same-named source column, so the file slot
     // for `score` must stay available; the other base columns (id/name/update_time) are

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_fill_missing_columns.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_fill_missing_columns.groovy
@@ -1,0 +1,455 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+
+// End-to-end coverage for the json `fill_missing_columns` routine load option.
+// It verifies that a job which declares only a derived column in COLUMNS can still load
+// into a table that has a sequence column (the sequence column and other base-schema
+// columns are auto-filled), and that the same job with `fill_missing_columns` = false
+// keeps the original behavior and fails with "need to specify the sequence column".
+suite("test_routine_load_fill_missing_columns", "p0") {
+    String enabled = context.config.otherConfigs.get("enableKafkaTest")
+    String kafka_port = context.config.otherConfigs.get("kafka_port")
+    String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+
+    if (enabled == null || !enabled.equalsIgnoreCase("true")) {
+        return
+    }
+
+    def dataFile = "test_routine_load_fill_missing_columns.json"
+    // Use a per-run topic suffix so OFFSET_BEGINNING jobs only see the records produced in this run.
+    // Otherwise a topic retained from a previous run would let the exact row-count assertions read
+    // stale messages and fail even when fill_missing_columns works correctly.
+    def topicSuffix = System.currentTimeMillis()
+    def topic = "test_routine_load_fill_missing_columns_${topicSuffix}"
+
+    // produce one json object per kafka message
+    def props = new Properties()
+    props.put("bootstrap.servers", "${externalEnvIp}:${kafka_port}".toString())
+    props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+    def producer = new KafkaProducer<>(props)
+    try {
+        def lines = new File("""${context.file.parent}/data/${dataFile}""").text.readLines()
+        lines.each { line ->
+            if (line.trim().isEmpty()) {
+                return
+            }
+            logger.info("=====${line}========")
+            producer.send(new ProducerRecord<>(topic, null, line))
+        }
+    } finally {
+        producer.close()
+    }
+
+    // Build a unique-key table whose sequence column maps to a value column that is NOT
+    // listed in COLUMNS. Without fill_missing_columns the sequence column cannot be
+    // resolved and the job must fail.
+    def createTable = { tableName ->
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                id INT NOT NULL,
+                name VARCHAR(50) NULL,
+                score INT NULL,
+                score_x2 INT NULL,
+                update_time BIGINT NULL
+            )
+            UNIQUE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1",
+                "function_column.sequence_col" = "update_time"
+            );
+        """
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Positive case: fill_missing_columns = true.
+    // COLUMNS only declares the derived column `score_x2`; id/name/score/update_time and
+    // the sequence column are auto-filled from the base schema.
+    // ---------------------------------------------------------------------------------
+    def posTable = "test_routine_load_fill_missing_columns_pos"
+    def posJob = "test_routine_load_fill_missing_columns_pos_job"
+    try {
+        createTable(posTable)
+        sql "sync"
+
+        sql """
+            CREATE ROUTINE LOAD ${posJob} ON ${posTable}
+            COLUMNS(score_x2 = score * 2)
+            PROPERTIES
+            (
+                "format" = "json",
+                "fill_missing_columns" = "true",
+                "max_batch_interval" = "5",
+                "max_batch_rows" = "300000",
+                "max_batch_size" = "209715200",
+                "strict_mode" = "false"
+            )
+            FROM KAFKA
+            (
+                "kafka_broker_list" = "${externalEnvIp}:${kafka_port}",
+                "kafka_topic" = "${topic}",
+                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+            );
+        """
+        sql "sync"
+
+        // (a) the job must reach RUNNING and must NOT pause with the sequence-column error
+        def count = 0
+        while (true) {
+            sleep(1000)
+            def res = sql "show routine load for ${posJob}"
+            def state = res[0][8].toString()
+            def reason = res[0][17].toString()
+            log.info("positive job state: ${state}, reason: ${reason}".toString())
+            assertFalse(reason.contains("need to specify the sequence column"),
+                    "fill_missing_columns=true must not fail with sequence column error, reason: ${reason}")
+            if (state == "RUNNING") {
+                break
+            }
+            count++
+            if (count >= 60) {
+                assertEquals("RUNNING", state)
+                break
+            }
+        }
+
+        // (b) the unspecified columns are auto-filled from the base schema
+        count = 0
+        while (true) {
+            def res = sql "select count(*) from ${posTable}"
+            def state = sql "show routine load for ${posJob}"
+            log.info("positive routine load state: ${state[0][8].toString()}".toString())
+            log.info("positive routine load statistic: ${state[0][14].toString()}".toString())
+            if (res[0][0] >= 3) {
+                break
+            }
+            if (count >= 60) {
+                log.error("positive routine load can not load data for long time")
+                assertEquals(3, res[0][0])
+                break
+            }
+            sleep(5000)
+            count++
+        }
+        sql "sync"
+
+        def rows = sql "select id, name, score, score_x2, update_time from ${posTable} order by id"
+        assertEquals(3, rows.size())
+        // id=1: name/score/update_time auto-filled from json, score_x2 derived as score*2
+        assertEquals(1, rows[0][0])
+        assertEquals("alice", rows[0][1].toString())
+        assertEquals(10, rows[0][2])
+        assertEquals(20, rows[0][3])
+        assertEquals(100L, rows[0][4])
+        // id=2
+        assertEquals(2, rows[1][0])
+        assertEquals("bob", rows[1][1].toString())
+        assertEquals(20, rows[1][2])
+        assertEquals(40, rows[1][3])
+        assertEquals(200L, rows[1][4])
+        // id=3
+        assertEquals(3, rows[2][0])
+        assertEquals("carol", rows[2][1].toString())
+        assertEquals(30, rows[2][2])
+        assertEquals(60, rows[2][3])
+        assertEquals(300L, rows[2][4])
+    } finally {
+        try {
+            sql "stop routine load for ${posJob}"
+        } catch (Exception e) {
+            log.info("stop positive routine load failed: ${e.getMessage()}".toString())
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Contrast case: fill_missing_columns = false.
+    // The identical all-expression COLUMNS must keep the original behavior and pause the
+    // job with the sequence-column error.
+    // ---------------------------------------------------------------------------------
+    def negTable = "test_routine_load_fill_missing_columns_neg"
+    def negJob = "test_routine_load_fill_missing_columns_neg_job"
+    try {
+        createTable(negTable)
+        sql "sync"
+
+        sql """
+            CREATE ROUTINE LOAD ${negJob} ON ${negTable}
+            COLUMNS(score_x2 = score * 2)
+            PROPERTIES
+            (
+                "format" = "json",
+                "fill_missing_columns" = "false",
+                "max_batch_interval" = "5",
+                "max_batch_rows" = "300000",
+                "max_batch_size" = "209715200",
+                "strict_mode" = "false"
+            )
+            FROM KAFKA
+            (
+                "kafka_broker_list" = "${externalEnvIp}:${kafka_port}",
+                "kafka_topic" = "${topic}",
+                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+            );
+        """
+        sql "sync"
+
+        def count = 0
+        def paused = false
+        while (true) {
+            sleep(1000)
+            def res = sql "show routine load for ${negJob}"
+            def state = res[0][8].toString()
+            def reason = res[0][17].toString()
+            log.info("negative job state: ${state}, reason: ${reason}".toString())
+            if (state == "PAUSED" && reason.contains("need to specify the sequence column")) {
+                paused = true
+                break
+            }
+            count++
+            if (count >= 60) {
+                break
+            }
+        }
+        assertTrue(paused,
+                "fill_missing_columns=false must keep the original behavior and fail with sequence column error")
+
+        // no data should be loaded for the paused job
+        sql "sync"
+        def negCount = sql "select count(*) from ${negTable}"
+        assertEquals(0, negCount[0][0])
+    } finally {
+        try {
+            sql "stop routine load for ${negJob}"
+        } catch (Exception e) {
+            log.info("stop negative routine load failed: ${e.getMessage()}".toString())
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Same-name mapping case: fill_missing_columns = true with COLUMNS(score = score + 1).
+    // The mapping target `score` references the same-named source column, so the file slot
+    // for `score` must stay available; the other base columns (id/name/update_time) are
+    // auto-filled. Without preserving the base scan descriptor for `score`, the reduced plan
+    // drops the `score` source slot while the mapping still references it.
+    // ---------------------------------------------------------------------------------
+    def sameTable = "test_routine_load_fill_missing_columns_same"
+    def sameJob = "test_routine_load_fill_missing_columns_same_job"
+    try {
+        sql "DROP TABLE IF EXISTS ${sameTable}"
+        sql """
+            CREATE TABLE ${sameTable} (
+                id INT NOT NULL,
+                name VARCHAR(50) NULL,
+                score INT NULL,
+                update_time BIGINT NULL
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            );
+        """
+        sql "sync"
+
+        sql """
+            CREATE ROUTINE LOAD ${sameJob} ON ${sameTable}
+            COLUMNS(score = score + 1)
+            PROPERTIES
+            (
+                "format" = "json",
+                "fill_missing_columns" = "true",
+                "max_batch_interval" = "5",
+                "max_batch_rows" = "300000",
+                "max_batch_size" = "209715200",
+                "strict_mode" = "false"
+            )
+            FROM KAFKA
+            (
+                "kafka_broker_list" = "${externalEnvIp}:${kafka_port}",
+                "kafka_topic" = "${topic}",
+                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+            );
+        """
+        sql "sync"
+
+        // the job must reach RUNNING and must not pause with a planning error
+        def count = 0
+        while (true) {
+            sleep(1000)
+            def res = sql "show routine load for ${sameJob}"
+            def state = res[0][8].toString()
+            def reason = res[0][17].toString()
+            log.info("same-name mapping job state: ${state}, reason: ${reason}".toString())
+            if (state == "RUNNING") {
+                break
+            }
+            count++
+            if (count >= 60) {
+                assertEquals("RUNNING", state)
+                break
+            }
+        }
+
+        count = 0
+        while (true) {
+            def res = sql "select count(*) from ${sameTable}"
+            if (res[0][0] >= 3) {
+                break
+            }
+            if (count >= 60) {
+                log.error("same-name mapping routine load can not load data for long time")
+                assertEquals(3, res[0][0])
+                break
+            }
+            sleep(5000)
+            count++
+        }
+        sql "sync"
+
+        // score is mapped to score + 1; the same-named source column is still read from json
+        def rows = sql "select id, name, score, update_time from ${sameTable} order by id"
+        assertEquals(3, rows.size())
+        assertEquals(1, rows[0][0])
+        assertEquals("alice", rows[0][1].toString())
+        assertEquals(11, rows[0][2])
+        assertEquals(100L, rows[0][3])
+        assertEquals(2, rows[1][0])
+        assertEquals("bob", rows[1][1].toString())
+        assertEquals(21, rows[1][2])
+        assertEquals(200L, rows[1][3])
+        assertEquals(3, rows[2][0])
+        assertEquals("carol", rows[2][1].toString())
+        assertEquals(31, rows[2][2])
+        assertEquals(300L, rows[2][3])
+    } finally {
+        try {
+            sql "stop routine load for ${sameJob}"
+        } catch (Exception e) {
+            log.info("stop same-name mapping routine load failed: ${e.getMessage()}".toString())
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Mixed-case mapping case: fill_missing_columns = true with COLUMNS(Score = score + 1)
+    // against a table column `Score` while the json key is lowercase `score`.
+    // Nereids binds the mapping source case-insensitively, but the json reader matches the
+    // scan slot name to the file key exactly. The base scan descriptor for `Score` must be
+    // emitted using the source spelling `score` so the reader finds the json key; otherwise
+    // the mapping receives NULL and the derived value is wrong.
+    // ---------------------------------------------------------------------------------
+    def caseTable = "test_routine_load_fill_missing_columns_case"
+    def caseJob = "test_routine_load_fill_missing_columns_case_job"
+    try {
+        sql "DROP TABLE IF EXISTS ${caseTable}"
+        sql """
+            CREATE TABLE ${caseTable} (
+                id INT NOT NULL,
+                name VARCHAR(50) NULL,
+                Score INT NULL,
+                update_time BIGINT NULL
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            );
+        """
+        sql "sync"
+
+        sql """
+            CREATE ROUTINE LOAD ${caseJob} ON ${caseTable}
+            COLUMNS(Score = score + 1)
+            PROPERTIES
+            (
+                "format" = "json",
+                "fill_missing_columns" = "true",
+                "max_batch_interval" = "5",
+                "max_batch_rows" = "300000",
+                "max_batch_size" = "209715200",
+                "strict_mode" = "false"
+            )
+            FROM KAFKA
+            (
+                "kafka_broker_list" = "${externalEnvIp}:${kafka_port}",
+                "kafka_topic" = "${topic}",
+                "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+            );
+        """
+        sql "sync"
+
+        def count = 0
+        while (true) {
+            sleep(1000)
+            def res = sql "show routine load for ${caseJob}"
+            def state = res[0][8].toString()
+            def reason = res[0][17].toString()
+            log.info("mixed-case mapping job state: ${state}, reason: ${reason}".toString())
+            if (state == "RUNNING") {
+                break
+            }
+            count++
+            if (count >= 60) {
+                assertEquals("RUNNING", state)
+                break
+            }
+        }
+
+        count = 0
+        while (true) {
+            def res = sql "select count(*) from ${caseTable}"
+            if (res[0][0] >= 3) {
+                break
+            }
+            if (count >= 60) {
+                log.error("mixed-case mapping routine load can not load data for long time")
+                assertEquals(3, res[0][0])
+                break
+            }
+            sleep(5000)
+            count++
+        }
+        sql "sync"
+
+        // Score is mapped to score + 1; the lowercase json key `score` must still be read even
+        // though the table column is spelled `Score`.
+        def rows = sql "select id, name, Score, update_time from ${caseTable} order by id"
+        assertEquals(3, rows.size())
+        assertEquals(1, rows[0][0])
+        assertEquals("alice", rows[0][1].toString())
+        assertEquals(11, rows[0][2])
+        assertEquals(100L, rows[0][3])
+        assertEquals(2, rows[1][0])
+        assertEquals("bob", rows[1][1].toString())
+        assertEquals(21, rows[1][2])
+        assertEquals(200L, rows[1][3])
+        assertEquals(3, rows[2][0])
+        assertEquals("carol", rows[2][1].toString())
+        assertEquals(31, rows[2][2])
+        assertEquals(300L, rows[2][3])
+    } finally {
+        try {
+            sql "stop routine load for ${caseJob}"
+        } catch (Exception e) {
+            log.info("stop mixed-case mapping routine load failed: ${e.getMessage()}".toString())
+        }
+    }
+}


### PR DESCRIPTION

This PR introduces a json-format-only property `fill_missing_columns` (default `false`). When set to `true`, even if some columns (including derived columns) are explicitly declared in `COLUMNS`, doris still completes the remaining unspecified columns from the table base schema (case-insensitive de-dup, user-declared columns and constant-mapping columns are preserved). The sequence column auto-add decision is corrected accordingly, so a table with a sequence column no longer fails when the user only specifies derived columns.

Implementation notes:
- The property is parsed and carried by `JsonFileFormatProperties` (the source of truth), threaded through `NereidsLoadTaskInfo` (default method, keeps stream/broker load behavior unchanged) -> `NereidsRoutineLoadTaskInfo` (reads from jobProperties) -> `NereidsDataDescription` (writes into analysisMap) -> file group's `JsonFileFormatProperties`.
- The actual column-completion reuses the existing base-schema fill logic in `NereidsLoadScanProvider#fillContextExprMap`; this PR only relaxes its trigger condition (`!specifyFileFieldNames || isFillMissingColumns(fileGroup)`) and adds de-dup.
- An `instanceof JsonFileFormatProperties` guard ensures the feature only takes effect for json format.
- CREATE/ALTER routine load whitelist the property and validate its value (`true`/`false`). `SHOW CREATE ROUTINE LOAD` echoes it.

### Release note

Routine Load (json format) supports a new property `fill_missing_columns`. When enabled, columns not specified in `COLUMNS` are automatically completed from the table schema, so users only need to declare derived columns. This also fixes the "need to specify the sequence column" error for tables with a sequence column.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Created a routine load job on a table with a sequence column, specifying only a derived column in `COLUMNS` with `"fill_missing_columns" = "true"`; verified the job runs without the "need to specify the sequence column" error and the remaining columns are auto-filled from the table schema.
        - Verified `ALTER ROUTINE LOAD ... PROPERTIES("fill_missing_columns" = "true"/"false")` and that an invalid value is rejected.
        - Verified `SHOW CREATE ROUTINE LOAD` echoes `fill_missing_columns`.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No. <!-- Default is false; existing jobs are unaffected. New behavior only triggers when fill_missing_columns=true. -->
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: `https://github.com/apache/doris-website/pull/1214`  -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->