### PR TITLE
[Fix][Function] Support 0 or negative max_limit for split_by_regexp function

### DIFF
--- a/be/src/exprs/function/function_split_by_regexp.cpp
+++ b/be/src/exprs/function/function_split_by_regexp.cpp
@@ -85,7 +85,7 @@ unsigned RegexpSplit::match(const char* subject, size_t subject_size, std::vecto
 }
 
 void RegexpSplit::init(re2::RE2* re2, int32_t max_splits) {
-    _max_splits = max_splits;
+    _max_splits = max_splits <= 0 ? -1 : max_splits;
     _re2 = re2;
     if (_re2) {
         _number_of_subpatterns = _re2->NumberOfCapturingGroups();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SplitByRegexp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SplitByRegexp.java
@@ -79,11 +79,9 @@ public class SplitByRegexp extends ScalarFunction
     public void checkLegalityBeforeTypeCoercion() {
         List<Expression> arguments = getArguments();
         if (arguments.size() == 3) {
-            Expression thirdArgument = getArgument(2);
-            if (!thirdArgument.isConstant() || !(thirdArgument instanceof IntegerLikeLiteral)
-                    || (((IntegerLikeLiteral) thirdArgument).getIntValue() < 0)) {
+            if (!child(2).isConstant() || !(child(2) instanceof IntegerLikeLiteral)) {
                 throw new AnalysisException("the third parameter of "
-                        + getName() + " function must be a positive constant: " + toSql());
+                        + getName() + " function must be an integer constant: " + toSql());
             }
         }
     }

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_split_by_regexp.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_split_by_regexp.out
@@ -94,6 +94,12 @@ a	["a"]
 ,	[","]
 ,	[","]
 
+-- !select16 --
+["aa", "bbb", "cccc"]
+
+-- !select17 --
+["aa", "bbb", "cccc"]
+
 -- !select_alias1 --
 ["a", "b", "c", "d", "e"]
 

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_split_by_regexp.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_split_by_regexp.groovy
@@ -51,15 +51,11 @@ suite("test_split_by_regexp") {
 
     test {
         sql " select split_by_regexp(NULL, 'a12bc23de345f', k1) from test_split_by_regexp"
-        exception "function must be a positive constant"
-    }
-    test {
-        sql " select split_by_regexp(NULL, 'a12bc23de345f', -10) from test_split_by_regexp"
-        exception "function must be a positive constant"
+        exception "function must be an integer constant"
     }
     test {
         sql " select split_by_regexp(NULL, 'a12bc23de345f', 1 + 2) from test_split_by_regexp"
-        exception "function must be a positive constant"
+        exception "function must be an integer constant"
     }
     qt_select5 "select split_by_regexp(v1, ',') from test_split_by_regexp order by k1;"
     qt_select6 "select split_by_regexp('do,ris', v2) from test_split_by_regexp order by k1;"
@@ -72,6 +68,8 @@ suite("test_split_by_regexp") {
     qt_select13 "select split_by_regexp('aa,bbb,cccc', ',', 10000000000000);"
     qt_select14 "select v1,split_by_regexp(v1, '') from test_split_by_regexp order by k1;"
     qt_select15 "select v2,split_by_regexp(v2, '') from test_split_by_regexp order by k1;"
+    qt_select16 "select split_by_regexp('aa,bbb,cccc', ',', -1);"
+    qt_select17 "select split_by_regexp('aa,bbb,cccc', ',', -10);"
 
     qt_select_alias1 "select regexp_split_to_array('abcde','');"
     qt_select_alias2 "select regexp_split_to_array('a12bc23de345f','\\\\d+');"


### PR DESCRIPTION
…it is applied

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
According to the official Apache Doris documentation, for the split_by_regexp function: "If max_limit is 0 or negative, no limit is applied."
However, the previous FE analyzer implementation strictly required the third parameter (max_limit) to be a positive constant. Passing 0 or a negative value threw an error: the third parameter of split_by_regexp function must be a positive constant.This PR relaxed the validation logic in the FE analyzer to allow 0 and negative constants for the max_limit parameter, aligning the implementation with the official documentation and expected behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

