### PR TITLE
[refactor](be) Remove redundant casts from BE code

### DIFF
--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -2299,7 +2299,7 @@ void ColumnVariant::finalize(FinalizeMode mode) {
 }
 
 void ColumnVariant::finalize() {
-    static_cast<void>(finalize(FinalizeMode::READ_MODE));
+    finalize(FinalizeMode::READ_MODE);
 }
 
 void ColumnVariant::ensure_root_node_type(const DataTypePtr& expected_root_type) const {

--- a/be/src/core/data_type/data_type_date_or_datetime_v2.cpp
+++ b/be/src/core/data_type/data_type_date_or_datetime_v2.cpp
@@ -89,13 +89,13 @@ MutableColumnPtr DataTypeDateV2::create_column() const {
 
 void DataTypeDateV2::cast_to_date_time(const DateV2Value<DateV2ValueType> from,
                                        VecDateTimeValue& to) {
-    auto& to_value = (VecDateTimeValue&)to;
+    auto& to_value = to;
     auto& from_value = (DateV2Value<DateV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATETIME);
 }
 
 void DataTypeDateV2::cast_to_date(const DateV2Value<DateV2ValueType> from, VecDateTimeValue& to) {
-    auto& to_value = (VecDateTimeValue&)(to);
+    auto& to_value = to;
     auto& from_value = (DateV2Value<DateV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATE);
 }
@@ -137,14 +137,14 @@ MutableColumnPtr DataTypeDateTimeV2::create_column() const {
 
 void DataTypeDateTimeV2::cast_to_date_time(const DateV2Value<DateTimeV2ValueType> from,
                                            VecDateTimeValue& to) {
-    auto& to_value = (VecDateTimeValue&)to;
+    auto& to_value = to;
     auto& from_value = (DateV2Value<DateTimeV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATETIME);
 }
 
 void DataTypeDateTimeV2::cast_to_date(const DateV2Value<DateTimeV2ValueType> from,
                                       VecDateTimeValue& to) {
-    auto& to_value = (VecDateTimeValue&)(to);
+    auto& to_value = to;
     auto& from_value = (DateV2Value<DateTimeV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATE);
 }

--- a/be/src/core/data_type/data_type_decimal.cpp
+++ b/be/src/core/data_type/data_type_decimal.cpp
@@ -239,7 +239,7 @@ DataTypePtr create_decimal(UInt64 precision_value, UInt64 scale_value, bool use_
                                min_decimal_precision(), max_precision);
     }
 
-    if (static_cast<UInt64>(scale_value) > precision_value) {
+    if (scale_value > precision_value) {
         throw doris::Exception(doris::ErrorCode::NOT_IMPLEMENTED_ERROR,
                                "Negative scales and scales larger than precision are not "
                                "supported, scale_value: {}, precision_value: {}",

--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -730,9 +730,9 @@ const uint8_t* DataTypeDecimalSerDe<T>::deserialize_binary_to_column(const uint8
 template <PrimitiveType T>
 const uint8_t* DataTypeDecimalSerDe<T>::deserialize_binary_to_field(const uint8_t* data,
                                                                     Field& field, FieldInfo& info) {
-    const uint8_t precision = *reinterpret_cast<const uint8_t*>(data);
+    const uint8_t precision = *data;
     data += sizeof(uint8_t);
-    const uint8_t scale = *reinterpret_cast<const uint8_t*>(data);
+    const uint8_t scale = *data;
     data += sizeof(uint8_t);
     info.precision = static_cast<int>(precision);
     info.scale = static_cast<int>(scale);

--- a/be/src/core/data_type_serde/data_type_hll_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_hll_serde.cpp
@@ -111,7 +111,7 @@ void DataTypeHLLSerDe::write_one_cell_to_jsonb(const IColumn& column, JsonbWrite
     const auto& data_column = assert_cast<const ColumnHLL&>(column);
     auto& hll_value = data_column.get_element(row_num);
     auto size = hll_value.max_serialized_size();
-    auto* ptr = reinterpret_cast<char*>(arena.alloc(size));
+    auto* ptr = arena.alloc(size);
     size_t actual_size = hll_value.serialize((uint8_t*)ptr);
     result.writeStartBinary();
     result.writeBinary(reinterpret_cast<const char*>(ptr), actual_size);

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -1008,7 +1008,7 @@ const uint8_t* DataTypeNumberSerDe<T>::deserialize_binary_to_field(const uint8_t
         field = Field::create_field<TYPE_DATEV2>(v);
         data += sizeof(UInt32);
     } else if constexpr (T == TYPE_DATETIMEV2 || T == TYPE_TIMESTAMPTZ) {
-        const uint8_t scale = *reinterpret_cast<const uint8_t*>(data);
+        const uint8_t scale = *data;
         data += sizeof(uint8_t);
         UInt64 v = unaligned_load<UInt64>(data);
         info.precision = -1;

--- a/be/src/core/value/vdatetime_value.h
+++ b/be/src/core/value/vdatetime_value.h
@@ -691,9 +691,8 @@ public:
     uint32_t to_date_v2() const { return (year() << 9 | month() << 5 | day()); }
 
     uint64_t to_datetime_v2() const {
-        return (uint64_t)(((uint64_t)year() << 46) | ((uint64_t)month() << 42) |
-                          ((uint64_t)day() << 37) | ((uint64_t)hour() << 32) |
-                          ((uint64_t)minute() << 26) | ((uint64_t)second() << 20));
+        return (((uint64_t)year() << 46) | ((uint64_t)month() << 42) | ((uint64_t)day() << 37) |
+                ((uint64_t)hour() << 32) | ((uint64_t)minute() << 26) | ((uint64_t)second() << 20));
     }
 
     uint32_t hash(int seed) const { return HashUtil::hash(this, sizeof(*this), seed); }

--- a/be/src/exec/common/hex.h
+++ b/be/src/exec/common/hex.h
@@ -107,7 +107,7 @@ inline UInt8 unhex(char c) {
 }
 
 inline UInt8 unhex2(const char* data) {
-    return static_cast<UInt8>(unhex(data[0])) * 0x10 + static_cast<UInt8>(unhex(data[1]));
+    return unhex(data[0]) * 0x10 + unhex(data[1]);
 }
 
 inline UInt16 unhex4(const char* data) {

--- a/be/src/exec/operator/materialization_opertor.cpp
+++ b/be/src/exec/operator/materialization_opertor.cpp
@@ -405,7 +405,7 @@ Status MaterializationOperator::push(RuntimeState* state, Block* in_block, bool 
         }
         counter.wait();
         if (auto time = rpc_timer.elapsed_time(); time > local_state._max_rpc_timer->value()) {
-            local_state._max_rpc_timer->set(static_cast<int64_t>(time));
+            local_state._max_rpc_timer->set(time);
         }
 
         for (auto& [backend_id, rpc_struct] : local_state._materialization_state.rpc_struct_map) {

--- a/be/src/exprs/bloom_filter_func_adaptor.h
+++ b/be/src/exprs/bloom_filter_func_adaptor.h
@@ -50,7 +50,7 @@ public:
         return _bloom_filter->init_from_directory(log_space, data, data_size, false, 0);
     }
 
-    char* data() { return (char*)_bloom_filter->directory().data; }
+    char* data() { return _bloom_filter->directory().data; }
 
     size_t size() { return _bloom_filter->directory().size; }
 

--- a/be/src/exprs/function/divide.cpp
+++ b/be/src/exprs/function/divide.cpp
@@ -349,7 +349,7 @@ struct DivideFloatingImpl {
 
     static inline ArgA apply(ArgA a, ArgB b, UInt8& is_null) {
         is_null = b == 0;
-        return static_cast<ArgA>(a) / (b + is_null);
+        return a / (b + is_null);
     }
 
     static ColumnPtr constant_constant(ArgA a, ArgB b) {

--- a/be/src/exprs/function/function_conv.cpp
+++ b/be/src/exprs/function/function_conv.cpp
@@ -175,7 +175,7 @@ struct ConvInt64Impl {
             }
         }
         StringRef str = MathFunctions::decimal_to_base(context, decimal_num, dst_base);
-        result_column->insert_data(reinterpret_cast<const char*>(str.data), str.size);
+        result_column->insert_data(str.data, str.size);
     }
 };
 
@@ -211,7 +211,7 @@ struct ConvStringImpl {
             result_column->insert_data("0", 1);
         } else {
             StringRef str_base = MathFunctions::decimal_to_base(context, decimal_num, dst_base);
-            result_column->insert_data(reinterpret_cast<const char*>(str_base.data), str_base.size);
+            result_column->insert_data(str_base.data, str_base.size);
         }
     }
 };

--- a/be/src/exprs/function/function_date_or_datetime_computation.h
+++ b/be/src/exprs/function/function_date_or_datetime_computation.h
@@ -1493,7 +1493,7 @@ private:
         if (UNLIKELY(dtv1.day() == days_in_month1 && dtv2.day() == days_in_month2)) {
             days_between = 0;
         } else {
-            days_between = (dtv1.day() - dtv2.day()) / (double)31.0;
+            days_between = (dtv1.day() - dtv2.day()) / 31.0;
         }
 
         // calculate months between

--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -1415,8 +1415,7 @@ struct JsonbLengthUtil {
                 if (!path.seek(path_value.data, path_value.size)) {
                     return Status::InvalidArgument(
                             "Json path error: Invalid Json Path for value: {}",
-                            std::string_view(reinterpret_cast<const char*>(path_value.data),
-                                             path_value.size));
+                            std::string_view(path_value.data, path_value.size));
                 }
             }
             auto jsonb_value = jsonb_data_column->get_data_at(i);

--- a/be/src/exprs/function/function_string_search.cpp
+++ b/be/src/exprs/function/function_string_search.cpp
@@ -353,10 +353,8 @@ public:
 
                 if (num == part_number) {
                     if (offset == -1) {
-                        StringOP::push_value_string(
-                                std::string_view {reinterpret_cast<const char*>(str.data),
-                                                  (size_t)pre_offset},
-                                i, res_chars, res_offsets);
+                        StringOP::push_value_string(std::string_view {str.data, (size_t)pre_offset},
+                                                    i, res_chars, res_offsets);
                     } else {
                         StringOP::push_value_string(
                                 std::string_view {str_str.substr(
@@ -457,10 +455,8 @@ public:
                     }
 
                     if (num == part_number) {
-                        StringOP::push_value_string(
-                                std::string_view {reinterpret_cast<const char*>(str.data),
-                                                  (size_t)offset},
-                                i, res_chars, res_offsets);
+                        StringOP::push_value_string(std::string_view {str.data, (size_t)offset}, i,
+                                                    res_chars, res_offsets);
                     } else {
                         StringOP::push_value_string(std::string_view(str.data, str.size), i,
                                                     res_chars, res_offsets);
@@ -493,10 +489,8 @@ public:
                     }
 
                     if (num == part_number) {
-                        StringOP::push_value_string(
-                                std::string_view {reinterpret_cast<const char*>(str.data),
-                                                  (size_t)offset},
-                                i, res_chars, res_offsets);
+                        StringOP::push_value_string(std::string_view {str.data, (size_t)offset}, i,
+                                                    res_chars, res_offsets);
                     } else {
                         StringOP::push_value_string(std::string_view(str.data, str.size), i,
                                                     res_chars, res_offsets);
@@ -511,11 +505,9 @@ public:
                 auto substr = str_str;
 
                 // Use pre-created StringRef for constant delimiters
-                StringRef delimiter_str =
-                        const_delimiter_ref
-                                ? const_delimiter_ref.value()
-                                : StringRef(reinterpret_cast<const char*>(delimiter.data),
-                                            delimiter.size);
+                StringRef delimiter_str = const_delimiter_ref
+                                                  ? const_delimiter_ref.value()
+                                                  : StringRef(delimiter.data, delimiter.size);
 
                 while (num <= neg_part_number && offset >= 0) {
                     offset = (int)substr.rfind(delimiter_str, offset);

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -747,7 +747,7 @@ std::tuple<bool, orc::Literal> convert_to_orc_literal(const orc::Type* type,
             } else if constexpr (primitive_type == TYPE_INT) {
                 return std::make_tuple(true, orc::Literal(int64_t(*((int32_t*)value))));
             } else if constexpr (primitive_type == TYPE_BIGINT) {
-                return std::make_tuple(true, orc::Literal(int64_t(*((int64_t*)value))));
+                return std::make_tuple(true, orc::Literal(*((int64_t*)value)));
             }
             return std::make_tuple(false, orc::Literal(false));
         }
@@ -755,7 +755,7 @@ std::tuple<bool, orc::Literal> convert_to_orc_literal(const orc::Type* type,
             if constexpr (primitive_type == TYPE_FLOAT) {
                 return std::make_tuple(true, orc::Literal(double(*((float*)value))));
             } else if constexpr (primitive_type == TYPE_DOUBLE) {
-                return std::make_tuple(true, orc::Literal(double(*((double*)value))));
+                return std::make_tuple(true, orc::Literal(*((double*)value)));
             }
             return std::make_tuple(false, orc::Literal(false));
         }

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -593,7 +593,7 @@ Status IcebergReaderMixin<BaseReader>::_expand_block_if_need(Block* block) {
             return Status::InternalError("Wrong expand column '{}'", col.name);
         }
         names.insert(col.name);
-        (*this->col_name_to_block_idx_ref())[col.name] = static_cast<uint32_t>(block->columns());
+        (*this->col_name_to_block_idx_ref())[col.name] = block->columns();
         block->insert({col.type->create_column(), col.type, col.name});
     }
     return Status::OK();

--- a/be/src/format/table/paimon_predicate_converter.cpp
+++ b/be/src/format/table/paimon_predicate_converter.cpp
@@ -405,7 +405,7 @@ std::optional<paimon::Literal> PaimonPredicateConverter::_convert_literal(
         if (slot_primitive == TYPE_INT) {
             return paimon::Literal(static_cast<int32_t>(value));
         }
-        return paimon::Literal(static_cast<int64_t>(value));
+        return paimon::Literal(value);
     }
     case TYPE_DOUBLE: {
         if (literal_primitive != TYPE_DOUBLE && literal_primitive != TYPE_FLOAT) {

--- a/be/src/format/table/transactional_hive_reader.cpp
+++ b/be/src/format/table/transactional_hive_reader.cpp
@@ -283,8 +283,7 @@ Status TransactionalHiveReader::on_before_read_block(Block* block) {
         DataTypePtr data_type = get_data_type_with_default_argument(
                 DataTypeFactory::instance().create_data_type(i.type, false));
         MutableColumnPtr data_column = data_type->create_column();
-        (*col_name_to_block_idx_ref())[i.column_lower_case] =
-                static_cast<uint32_t>(block->columns());
+        (*col_name_to_block_idx_ref())[i.column_lower_case] = block->columns();
         block->insert(
                 ColumnWithTypeAndName(std::move(data_column), data_type, i.column_lower_case));
     }

--- a/be/src/io/cache/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block_file_cache_factory.cpp
@@ -99,8 +99,7 @@ Status FileCacheFactory::create_file_cache(const std::string& cache_base_path,
 #else
         const auto block_size = stat.f_frsize ? stat.f_frsize : stat.f_bsize;
 #endif
-        size_t disk_capacity = static_cast<size_t>(static_cast<size_t>(stat.f_blocks) *
-                                                   static_cast<size_t>(block_size));
+        size_t disk_capacity = static_cast<size_t>(stat.f_blocks) * static_cast<size_t>(block_size);
         if (file_cache_settings.capacity == 0 || disk_capacity < file_cache_settings.capacity) {
             LOG_INFO(
                     "The cache {} config size {} is larger than disk size {} or zero, recalc "
@@ -298,8 +297,7 @@ std::string validate_capacity(const std::string& path, int64_t new_capacity,
 #else
     const auto block_size = stat.f_frsize ? stat.f_frsize : stat.f_bsize;
 #endif
-    size_t disk_capacity = static_cast<size_t>(static_cast<size_t>(stat.f_blocks) *
-                                               static_cast<size_t>(block_size));
+    size_t disk_capacity = static_cast<size_t>(stat.f_blocks) * static_cast<size_t>(block_size);
     if (new_capacity == 0 || disk_capacity < new_capacity) {
         auto ret = fmt::format(
                 "The cache {} config size {} is larger than disk size {} or zero, recalc "

--- a/be/src/io/cache/fs_file_cache_storage.cpp
+++ b/be/src/io/cache/fs_file_cache_storage.cpp
@@ -905,7 +905,7 @@ void FSFileCacheStorage::load_cache_info_into_memory_from_db(BlockFileCache* mgr
         args.is_tmp = false;
 
         CacheContext ctx;
-        ctx.cache_type = static_cast<FileCacheType>(meta_value.type);
+        ctx.cache_type = meta_value.type;
         ctx.expiration_time = meta_value.ttl;
         ctx.tablet_id =
                 meta_key.tablet_id; //TODO(zhengyu): zero if loaded from v2, we can use this to decide whether the block is loaded from v2 or v3
@@ -1031,7 +1031,7 @@ void FSFileCacheStorage::load_blocks_directly_unlocked(BlockFileCache* mgr, cons
     CacheContext context_original;
     context_original.query_id = TUniqueId();
     context_original.expiration_time = block_meta->ttl;
-    context_original.cache_type = static_cast<FileCacheType>(block_meta->type);
+    context_original.cache_type = block_meta->type;
     context_original.tablet_id = key.meta.tablet_id;
 
     if (handle_already_loaded_block(mgr, key.hash, key.offset, block_meta->size, key.meta.tablet_id,

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -364,7 +364,7 @@ void S3FileWriter::_upload_one_part(int part_num, UploadFileBuffer& buf) {
     s3_bytes_written_total << buf.get_size();
 
     ObjectCompleteMultiPart completed_part {
-            static_cast<int>(part_num), resp.etag.has_value() ? std::move(resp.etag.value()) : ""};
+            part_num, resp.etag.has_value() ? std::move(resp.etag.value()) : ""};
 
     std::unique_lock<std::mutex> lck {_completed_lock};
     _completed_parts.emplace_back(std::move(completed_part));

--- a/be/src/load/routine_load/data_consumer.h
+++ b/be/src/load/routine_load/data_consumer.h
@@ -113,7 +113,7 @@ public:
 
         case RdKafka::Event::EVENT_THROTTLE:
             LOG(INFO) << "kafka throttled: " << event.throttle_time() << "ms by "
-                      << event.broker_name() << " id " << (int)event.broker_id();
+                      << event.broker_name() << " id " << event.broker_id();
             break;
 
         default:

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -244,7 +244,7 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
     Defer defer {[=, &engine, &tstatus, ingest_binlog_tstatus = arg->tstatus, &watch,
                   &total_download_bytes, &total_download_files, &elapsed_time_map]() {
         g_ingest_binlog_latency << watch.elapsed_time_microseconds();
-        auto elapsed_time_ms = static_cast<int64_t>(watch.elapsed_time_milliseconds());
+        auto elapsed_time_ms = watch.elapsed_time_milliseconds();
         double copy_rate = 0.0;
         if (elapsed_time_ms > 0) {
             copy_rate = (double)total_download_bytes / ((double)elapsed_time_ms) / 1000;

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -181,7 +181,7 @@ public:
 
         LRUCachePolicy* cache() const { return _cache; }
         Slice data() const {
-            return {(char*)((RowCacheValue*)_cache->value(_handle))->cache_value,
+            return {((RowCacheValue*)_cache->value(_handle))->cache_value,
                     reinterpret_cast<LRUHandle*>(_handle)->charge};
         }
 

--- a/be/src/storage/index/ann/faiss_ann_index.cpp
+++ b/be/src/storage/index/ann/faiss_ann_index.cpp
@@ -982,8 +982,7 @@ doris::Status FaissVectorIndex::save(lucene::store::Directory* dir) {
                 // Write codes
                 const uint8_t* codes = ails->get_codes(i);
                 size_t codes_bytes = list_size * code_size;
-                ivfdata_output->writeBytes(reinterpret_cast<const uint8_t*>(codes),
-                                           cast_set<Int32>(codes_bytes));
+                ivfdata_output->writeBytes(codes, cast_set<Int32>(codes_bytes));
 
                 // Write ids
                 const faiss::idx_t* ids = ails->get_ids(i);

--- a/be/src/storage/index/inverted/token_filter/word_delimiter_iterator.cpp
+++ b/be/src/storage/index/inverted/token_filter/word_delimiter_iterator.cpp
@@ -216,8 +216,7 @@ std::string WordDelimiterIterator::to_string() const {
     std::ostringstream oss;
     std::string substring(_text + _current, _end - _current);
     oss << substring << " [" << _current << "-" << _end << "]"
-        << " type=0x" << std::hex << std::setw(2) << std::setfill('0')
-        << static_cast<int32_t>(type());
+        << " type=0x" << std::hex << std::setw(2) << std::setfill('0') << type();
     return oss.str();
 }
 

--- a/be/src/storage/segment/bitshuffle_page.h
+++ b/be/src/storage/segment/bitshuffle_page.h
@@ -137,7 +137,7 @@ public:
         *num_written = to_add;
         if constexpr (single) {
             if constexpr (SIZE_OF_TYPE == 1) {
-                *reinterpret_cast<uint8_t*>(&_data[orig_size]) = *vals;
+                _data[orig_size] = *vals;
                 return Status::OK();
             } else if constexpr (SIZE_OF_TYPE == 2) {
                 *reinterpret_cast<uint16_t*>(&_data[orig_size]) =
@@ -391,7 +391,7 @@ public:
             return Status::OK();
         }
 
-        size_t max_fetch = std::min(*n, static_cast<size_t>(_num_elements - _cur_index));
+        size_t max_fetch = std::min(*n, _num_elements - _cur_index);
 
         dst->insert_many_fix_len_data(get_data(_cur_index), max_fetch);
         *n = max_fetch;

--- a/be/src/storage/segment/historical_row_retriever.cpp
+++ b/be/src/storage/segment/historical_row_retriever.cpp
@@ -281,7 +281,7 @@ void PrimaryKeyModelRowRetriever::_maybe_invalid_row_cache(const std::string& ke
         _context.tablet_schema->has_row_store_for_all_columns() &&
         _context.write_type == DataWriteType::TYPE_DIRECT) {
         // invalidate cache
-        RowCache::instance()->erase({static_cast<int64_t>(_context.tablet->tablet_id()), key});
+        RowCache::instance()->erase({_context.tablet->tablet_id(), key});
     }
 }
 

--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -305,7 +305,7 @@ Status VariantColumnReader::_create_sparse_merge_reader(ColumnIteratorUPtr* iter
         // only collect subcolumns that belong to this bucket to avoid extra IO.
         if (bucket_index.has_value()) {
             CHECK(_binary_column_reader->get_type() == BinaryColumnType::MULTIPLE_SPARSE);
-            uint32_t N = static_cast<uint32_t>(_binary_column_reader->num_buckets());
+            uint32_t N = _binary_column_reader->num_buckets();
             if (N > 1) {
                 uint32_t b = variant_util::variant_binary_shard_of(
                         StringRef {path.data(), path.size()}, N);

--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -893,8 +893,8 @@ void Tablet::delete_expired_stale_rowset() {
 
         std::vector<int64_t> path_id_vec;
         // capture the path version to delete
-        _timestamped_version_tracker.capture_expired_paths(
-                static_cast<int64_t>(expired_stale_sweep_endtime), &path_id_vec);
+        _timestamped_version_tracker.capture_expired_paths(expired_stale_sweep_endtime,
+                                                           &path_id_vec);
 
         if (path_id_vec.empty()) {
             return;

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -208,7 +208,7 @@ Status Env::GetJniExceptionMsg(JNIEnv* env, bool log_stack, const string& prefix
     std::string return_msg;
     auto* msg_str = env->GetStringUTFChars(msg, nullptr);
     return_msg += msg_str;
-    env->ReleaseStringUTFChars((jstring)msg, msg_str);
+    env->ReleaseStringUTFChars(msg, msg_str);
 
     if (log_stack) {
         jstring stack = static_cast<jstring>(

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -797,8 +797,7 @@ public:
 
     Status get_byte_elements(JNIEnv* env, jsize start, jsize len, jbyte* buffer) {
         DCHECK(!this->uninitialized());
-        env->GetByteArrayRegion((jbyteArray)this->_obj, start, len,
-                                reinterpret_cast<jbyte*>(buffer));
+        env->GetByteArrayRegion((jbyteArray)this->_obj, start, len, buffer);
         RETURN_ERROR_IF_EXC(env);
         return Status::OK();
     }

--- a/be/src/util/url_coding.cpp
+++ b/be/src/util/url_coding.cpp
@@ -107,8 +107,7 @@ int64_t base64_decode(const char* data, size_t length, char* decoded_data) {
     auto ret = do_base64_decode(reinterpret_cast<const char*>(data), length, decoded_data,
                                 &decode_len, BASE64_FORCE_NEON64);
 #else
-    auto ret = do_base64_decode(reinterpret_cast<const char*>(data), length, decoded_data,
-                                &decode_len, 0);
+    auto ret = do_base64_decode(data, length, decoded_data, &decode_len, 0);
 #endif
     return ret > 0 ? decode_len : -1;
 }


### PR DESCRIPTION
### What problem does this PR solve?


Problem Summary: Remove redundant casts reported by clang-tidy readability-redundant-casting in BE code. These casts were no-op conversions to the same type, including redundant static_cast, reinterpret_cast, and C-style casts. The change keeps casts that still perform real type conversion and only removes the redundant outer casts reported by clang-tidy.

### Release note

None

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

