### PR TITLE
[fix](deps) Upgrade jemalloc from 5.3.0 to 5.3.1 to fix muzzy decay performance regression

### DIFF
--- a/dist/LICENSE-dist.txt
+++ b/dist/LICENSE-dist.txt
@@ -1513,7 +1513,7 @@ Other dependencies:
     * brotli: 1.0.9 -- licenses/LICENSE-brotli.txt
     * bitshuffle: 0.5.1 -- licenses/LICENSE-bigshuffle.txt
     * fmt: 7.1.3 -- licenses/LICENSE-fmt.txt
-    * jemalloc: 5.3.0 -- licenses/LICENSE-jemolloc.txt
+    * jemalloc: 5.3.1 -- licenses/LICENSE-jemolloc.txt
     * lzma@master -- licenses/LICENSE-lzma.txt
     * libdivide: 5.0 -- licenses/LICENSE-libdivide.txt
     * pdqsort: 0.0.0+git20180419 -- licenses/LICENSE-pdqsort.txt

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -477,7 +477,7 @@ fi
 
 # patch jemalloc, disable JEMALLOC_MANGLE for overloading the memory API.
 if [[ " ${TP_ARCHIVES[*]} " =~ " JEMALLOC_DORIS " ]]; then
-    if [[ "${JEMALLOC_DORIS_SOURCE}" = "jemalloc-5.3.0" ]]; then
+    if [[ "${JEMALLOC_DORIS_SOURCE}" = "jemalloc-5.3.1" ]]; then
         cd "${TP_SOURCE_DIR}/${JEMALLOC_DORIS_SOURCE}"
         if [[ ! -f "${PATCHED_MARK}" ]]; then
             patch -p0 <"${TP_PATCH_DIR}/jemalloc_hook.patch"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -311,16 +311,16 @@ ORC_SOURCE=orc-1.9.0
 ORC_MD5SUM="5dc1c91c4867e4519aab531ffc30fab7"
 
 # jemalloc for arrow
-JEMALLOC_ARROW_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
-JEMALLOC_ARROW_NAME="jemalloc-5.3.0.tar.bz2"
-JEMALLOC_ARROW_SOURCE="jemalloc-5.3.0"
-JEMALLOC_ARROW_MD5SUM="09a8328574dab22a7df848eae6dbbf53"
+JEMALLOC_ARROW_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.3.1/jemalloc-5.3.1.tar.bz2"
+JEMALLOC_ARROW_NAME="jemalloc-5.3.1.tar.bz2"
+JEMALLOC_ARROW_SOURCE="jemalloc-5.3.1"
+JEMALLOC_ARROW_MD5SUM="2b183326fcff2c087efd7efc0a808ba2"
 
 # jemalloc for doris
-JEMALLOC_DORIS_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
-JEMALLOC_DORIS_NAME="jemalloc-5.3.0.tar.bz2"
-JEMALLOC_DORIS_SOURCE="jemalloc-5.3.0"
-JEMALLOC_DORIS_MD5SUM="09a8328574dab22a7df848eae6dbbf53"
+JEMALLOC_DORIS_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.3.1/jemalloc-5.3.1.tar.bz2"
+JEMALLOC_DORIS_NAME="jemalloc-5.3.1.tar.bz2"
+JEMALLOC_DORIS_SOURCE="jemalloc-5.3.1"
+JEMALLOC_DORIS_MD5SUM="2b183326fcff2c087efd7efc0a808ba2"
 
 # libunwind
 LIBUNWIND_DOWNLOAD="https://github.com/libunwind/libunwind/releases/download/v1.6.2/libunwind-1.6.2.tar.gz"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #64106

Upgrade jemalloc from 5.3.0 to 5.3.1 to fix a known performance regression
in the decay code path.

Problem Summary:

jemalloc 5.3.0 has two bugs in its decay implementation:
1. **Unbounded purge accumulation** — one thread keeps stashing pages to purge
   while other threads generate new pages, causing a single decay operation to
   grow without bound.
2. **Reentrancy deadlock** — potential deadlock when decay triggers reentrant
   allocation.
Doris BE defaults to `muzzy_decay_ms:5000`, which directly triggers these bugs
under concurrent workloads, causing up to ~7x throughput degradation and P99
latency spikes.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [x] Confirm the release note
- [x] Confirm test cases
- [x] Confirm document
- [x] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

