### PR TITLE
[fix](be) Preserve null probe rows in mark anti join

### DIFF
--- a/be/src/vec/common/hash_table/join_hash_table.h
+++ b/be/src/vec/common/hash_table/join_hash_table.h
@@ -211,7 +211,8 @@ public:
 
             /// If the probe key is null
             if (build_idx == bucket_size) {
-                probe_idx++;
+                build_idx = 0;
+                picking_null_keys = false;
                 break;
             }
             do_the_probe();

--- a/regression-test/data/correctness/test_subquery_in_disjunction.out
+++ b/regression-test/data/correctness/test_subquery_in_disjunction.out
@@ -66,6 +66,18 @@
 1	2	3
 10	20	30
 
+-- !not_in_nullable_mark_join --
+1	0
+11	\N
+
+-- !not_in_nullable_mark_join_in_disjunction --
+1	0
+11	\N
+
+-- !not_in_nullable_mark_join_in_disjunction_build_null --
+1	0
+11	\N
+
 -- !mark_join_with_other_conjuncts1 --
 1	2
 1	3

--- a/regression-test/suites/correctness/test_subquery_in_disjunction.groovy
+++ b/regression-test/suites/correctness/test_subquery_in_disjunction.groovy
@@ -97,22 +97,21 @@ suite("test_subquery_in_disjunction") {
         SELECT * FROM test_sq_dj1 WHERE c1 IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 < test_sq_dj2.c2) OR c1 < 11 ORDER BY c1;
     """
 
-    // TODO: enable this after DORIS-7051 and DORIS-7052 is fixed
-    // qt_hash_join_with_other_conjuncts5 """
-    //     SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 > test_sq_dj2.c2) OR c1 < 10 ORDER BY c1;
-    // """
+    qt_hash_join_with_other_conjuncts5 """
+        SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 > test_sq_dj2.c2) OR c1 < 10 ORDER BY c1;
+    """
 
-    // qt_hash_join_with_other_conjuncts6 """
-    //     SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 < test_sq_dj2.c2) OR c1 < 10 ORDER BY c1;
-    // """
+    qt_hash_join_with_other_conjuncts6 """
+        SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 < test_sq_dj2.c2) OR c1 < 10 ORDER BY c1;
+    """
 
-    // qt_hash_join_with_other_conjuncts7 """
-    //     SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 > test_sq_dj2.c2) OR c1 < 11 ORDER BY c1;
-    // """
+    qt_hash_join_with_other_conjuncts7 """
+        SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 > test_sq_dj2.c2) OR c1 < 11 ORDER BY c1;
+    """
 
-    // qt_hash_join_with_other_conjuncts8 """
-    //     SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 < test_sq_dj2.c2) OR c1 < 11 ORDER BY c1;
-    // """
+    qt_hash_join_with_other_conjuncts8 """
+        SELECT * FROM test_sq_dj1 WHERE c1 NOT IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 < test_sq_dj2.c2) OR c1 < 11 ORDER BY c1;
+    """
 
     qt_same_subquery_in_conjuncts """
         SELECT * FROM test_sq_dj1 WHERE c1 IN (SELECT c1 FROM test_sq_dj2) OR c1 IN (SELECT c1 FROM test_sq_dj2) OR c1 < 10 ORDER BY c1;
@@ -120,6 +119,62 @@ suite("test_subquery_in_disjunction") {
 
     qt_two_subquery_in_one_conjuncts """
         SELECT * FROM test_sq_dj1 WHERE c1 IN (SELECT c1 FROM test_sq_dj2) OR c1 IN (SELECT c2 FROM test_sq_dj2) OR c1 < 10 ORDER BY c1;
+    """
+
+    sql """ DROP TABLE IF EXISTS test_sq_dj_nullable_outer """
+    sql """ DROP TABLE IF EXISTS test_sq_dj_nullable_inner """
+    sql """
+    CREATE TABLE `test_sq_dj_nullable_outer` (
+        `id` int(11) NULL,
+        `a` int(11) NULL
+    ) ENGINE=OLAP
+    DUPLICATE KEY(`id`)
+    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1"
+    );
+    """
+    sql """
+    CREATE TABLE `test_sq_dj_nullable_inner` (
+        `id` int(11) NULL,
+        `a` int(11) NULL
+    ) ENGINE=OLAP
+    DUPLICATE KEY(`id`)
+    DISTRIBUTED BY HASH(`id`) BUCKETS 1
+    PROPERTIES (
+        "replication_num" = "1"
+    );
+    """
+    sql """ INSERT INTO test_sq_dj_nullable_outer VALUES (1, 0), (11, NULL) """
+    sql """ INSERT INTO test_sq_dj_nullable_inner VALUES (1, 10) """
+
+    order_qt_not_in_nullable_mark_join """
+        SELECT id, a FROM test_sq_dj_nullable_outer o
+        WHERE o.a NOT IN (
+            SELECT i.a FROM test_sq_dj_nullable_inner i
+            WHERE i.id > o.id AND i.a IS NOT NULL
+        )
+        ORDER BY id;
+    """
+
+    order_qt_not_in_nullable_mark_join_in_disjunction """
+        SELECT id, a FROM test_sq_dj_nullable_outer o
+        WHERE o.a NOT IN (
+            SELECT i.a FROM test_sq_dj_nullable_inner i
+            WHERE i.id > o.id AND i.a IS NOT NULL
+        ) OR o.id IN (1, 11)
+        ORDER BY id;
+    """
+
+    sql """ INSERT INTO test_sq_dj_nullable_inner VALUES (20, NULL) """
+
+    order_qt_not_in_nullable_mark_join_in_disjunction_build_null """
+        SELECT id, a FROM test_sq_dj_nullable_outer o
+        WHERE o.a NOT IN (
+            SELECT i.a FROM test_sq_dj_nullable_inner i
+            WHERE i.id > o.id
+        ) OR o.id IN (1, 11)
+        ORDER BY id;
     """
 
     // test mark join that one probe row matches multiple build rows


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63767

Problem Summary:

This is a branch-3.1 cherry-pick of #63767.

Correlated NOT IN subqueries under disjunction can be rewritten to a mark null-aware left anti join with additional join conjuncts. On branch-3.1, when the probe join key is NULL, the hash table lookup advanced the probe index before the caller could run the null-probe handling path. As a result, the probe row could be skipped before the mark column was evaluated by the outer disjunction, producing incomplete query results.

This change keeps the probe index on the NULL row so the null-aware join path can emit the correct mark value. The branch-3.1 implementation encodes the NULL probe key as `build_idx_map[probe_idx] == bucket_size`, so the cherry-pick was adapted to preserve that probe row instead of advancing `probe_idx`.

### Release note

Fix incorrect results for correlated NOT IN subqueries combined with disjunctions.

### Check List (For Author)

- Test:
    - [x] Regression test
        - Added/updated `correctness/test_subquery_in_disjunction` cases and expected output from #63767.
    - [x] Manual test (add detailed scripts or steps below)
        - Ran `./build-support/clang-format.sh be/src/vec/common/hash_table/join_hash_table.h` (passed)
        - Ran `./build-support/check-format.sh` (passed)
        - Ran `git diff --check HEAD~1..HEAD` (passed)
        - Attempted `DORIS_HOME=$PWD ninja -C be/ut_build_ASAN src/exec/CMakeFiles/Exec.dir/operator/join/null_aware_left_anti_join_impl.cpp.o src/exec/CMakeFiles/Exec.dir/operator/hashjoin_probe_operator.cpp.o src/exec/CMakeFiles/Exec.dir/operator/hashjoin_build_sink.cpp.o`, but local CMake regeneration failed because the current local thirdparty/CMake environment cannot resolve the existing target `absl::random_internal_pool_urbg`.
        - Attempted `./build.sh --be`, but it was blocked by the same pre-existing local CMake/thirdparty target issue: `Target "doris_be" links to absl::random_internal_pool_urbg but the target was not found`.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] Yes. Corrects query result semantics for affected null-aware mark anti joins.
    - [ ] No.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
