### PR TITLE
[fix](auto partition) keep load row metrics monotonic for auto partition

### DIFF
--- a/be/src/exec/sink/vrow_distribution.cpp
+++ b/be/src/exec/sink/vrow_distribution.cpp
@@ -27,7 +27,6 @@
 
 #include "common/cast_set.h"
 #include "common/logging.h"
-#include "common/metrics/doris_metrics.h"
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/column/column.h"
@@ -416,8 +415,6 @@ Status VRowDistribution::_deal_missing_map(const Block& input_block, Block* bloc
     rows_stat_val -= new_bt_rows - old_bt_rows;
     _state->update_num_rows_load_total(old_bt_rows - new_bt_rows);
     _state->update_num_bytes_load_total(old_bt_bytes - new_bt_bytes);
-    DorisMetrics::instance()->load_rows->increment(old_bt_rows - new_bt_rows);
-    DorisMetrics::instance()->load_bytes->increment(old_bt_bytes - new_bt_bytes);
 
     return Status::OK();
 }

--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -2064,6 +2064,7 @@ Status VTabletWriter::write(RuntimeState* state, doris::Block& input_block) {
     // check out of limit
     RETURN_IF_ERROR(_send_new_partition_batch());
 
+    const bool is_replaying_batched_block = _row_distribution._deal_batched;
     auto rows = input_block.rows();
     auto bytes = input_block.bytes();
     if (UNLIKELY(rows == 0)) {
@@ -2078,8 +2079,10 @@ Status VTabletWriter::write(RuntimeState* state, doris::Block& input_block) {
     // the real 'num_rows_load_total' will be set when sink being closed.
     _state->update_num_rows_load_total(rows);
     _state->update_num_bytes_load_total(bytes);
-    DorisMetrics::instance()->load_rows->increment(rows);
-    DorisMetrics::instance()->load_bytes->increment(bytes);
+    if (!is_replaying_batched_block) {
+        DorisMetrics::instance()->load_rows->increment(rows);
+        DorisMetrics::instance()->load_bytes->increment(bytes);
+    }
 
     _row_distribution_watch.start();
     RETURN_IF_ERROR(_row_distribution.generate_rows_distribution(

--- a/be/src/exec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.cpp
@@ -493,6 +493,7 @@ Status VTabletWriterV2::write(RuntimeState* state, Block& input_block) {
     // check out of limit
     RETURN_IF_ERROR(_send_new_partition_batch());
 
+    const bool is_replaying_batched_block = _row_distribution._deal_batched;
     auto input_rows = input_block.rows();
     auto input_bytes = input_block.bytes();
     if (UNLIKELY(input_rows == 0)) {
@@ -504,8 +505,10 @@ Status VTabletWriterV2::write(RuntimeState* state, Block& input_block) {
     // the real 'num_rows_load_total' will be set when sink being closed.
     _state->update_num_rows_load_total(input_rows);
     _state->update_num_bytes_load_total(input_bytes);
-    DorisMetrics::instance()->load_rows->increment(input_rows);
-    DorisMetrics::instance()->load_bytes->increment(input_bytes);
+    if (!is_replaying_batched_block) {
+        DorisMetrics::instance()->load_rows->increment(input_rows);
+        DorisMetrics::instance()->load_bytes->increment(input_bytes);
+    }
 
     SCOPED_RAW_TIMER(&_send_data_ns);
     // This is just for passing compilation.


### PR DESCRIPTION
### What problem does this PR solve?

When loading into an auto partition table, BE may temporarily batch rows whose target partitions do not exist yet. The previous logic first incremented `doris_be_load_rows` when receiving the input block, then decremented it when those rows were moved into the auto-partition batching block, and finally incremented it again when the batched rows were replayed after partition creation.

Because `doris_be_load_rows` is exposed as a counter, the negative adjustment made the metric non-monotonic and could show row count drops during auto partition loads.

This PR keeps the existing `RuntimeState` row compensation logic unchanged, but stops applying negative deltas to the global BE load row/byte metrics. It also skips global metric increments when replaying the internal batched block, so each source row is counted once.