### PR TITLE
[fix](be) Release backend thrift service on shutdown

### DIFF
--- a/be/src/service/server/oss/be_server_starter_factory.cpp
+++ b/be/src/service/server/oss/be_server_starter_factory.cpp
@@ -221,7 +221,10 @@ public:
         }
     }
 
-    void join() override { _server.reset(); }
+    void join() override {
+        _server.reset();
+        _service.reset();
+    }
 
 private:
     int _port;

--- a/be/test/service/server/be_server_starter_factory_test.cpp
+++ b/be/test/service/server/be_server_starter_factory_test.cpp
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "service/server/be_server_starter_factory.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "service/backend_service.h"
+#include "service/server/server_starter.h"
+
+namespace doris {
+
+TEST(BeServerStarterFactoryTest, BackendThriftJoinReleasesService) {
+    bool service_released = false;
+    std::shared_ptr<BaseBackendService> service(
+            nullptr, [&service_released](BaseBackendService*) { service_released = true; });
+    std::weak_ptr<BaseBackendService> weak_service = service;
+
+    std::unique_ptr<server::IServerStarter> starter;
+    ASSERT_TRUE(server::create_backend_thrift_starter(nullptr, 0, service, &starter).ok());
+    service.reset();
+
+    EXPECT_FALSE(weak_service.expired());
+    EXPECT_FALSE(service_released);
+
+    starter->join();
+
+    EXPECT_TRUE(weak_service.expired());
+    EXPECT_TRUE(service_released);
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64016

Problem Summary: PR #64016 moved backend server startup behind OSS starter implementations. The OSS backend thrift starter stopped and released the ThriftServer but kept its BaseBackendService reference alive after join. That service owns AgentServer and ReportWorker threads, so callers that rely on the starter lifecycle can destroy ExecEnv and StorageEngine before ReportWorker exits. Release the backend service in join after releasing the thrift server.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - PATH=/mnt/disk2/lianyukang/ldb_toolchain_v16/bin:/data/data14/lianyukang/ldb_toolchain_v16/bin:$PATH CLANG_FORMAT_BINARY=/data/data14/lianyukang/ldb_toolchain_v16/bin/clang-format-16 build-support/clang-format.sh
    - PATH=/mnt/disk2/lianyukang/ldb_toolchain_v16/bin:/data/data14/lianyukang/ldb_toolchain_v16/bin:$PATH CLANG_FORMAT_BINARY=/data/data14/lianyukang/ldb_toolchain_v16/bin/clang-format-16 build-support/check-format.sh
    - git diff --check
    - PATH=/mnt/disk2/lianyukang/ldb_toolchain_v16/bin:/data/data14/lianyukang/ldb_toolchain_v16/bin:$PATH ./run-be-ut.sh --run --filter=BeServerStarterFactoryTest.* -j80
- Behavior changed: No
- Does this need documentation: No