### PR TITLE
[refactor](be) Remove redundant mutable column assertions

### DIFF
--- a/be/src/core/column/column_nullable.cpp
+++ b/be/src/core/column/column_nullable.cpp
@@ -706,7 +706,7 @@ ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable) {
 
 MutableColumnPtr make_nullable(MutableColumnPtr&& column, bool is_nullable) {
     if (is_column_nullable(*column)) {
-        return column;
+        return std::move(column);
     }
 
     if (is_column_const(*column)) {
@@ -716,8 +716,9 @@ MutableColumnPtr make_nullable(MutableColumnPtr&& column, bool is_nullable) {
                 column->size());
     }
 
+    const auto size = column->size();
     return ColumnNullable::create(std::move(column),
-                                  ColumnUInt8::create(column->size(), is_nullable ? 1 : 0));
+                                  ColumnUInt8::create(size, is_nullable ? 1 : 0));
 }
 
 ColumnPtr remove_nullable(const ColumnPtr& column) {

--- a/be/src/core/column/column_nullable.cpp
+++ b/be/src/core/column/column_nullable.cpp
@@ -22,6 +22,7 @@
 
 #include "core/arena.h"
 #include "core/assert_cast.h"
+#include "core/column/column.h"
 #include "core/column/column_const.h"
 #include "core/data_type/data_type.h"
 #include "exec/common/sip_hash.h"
@@ -701,6 +702,22 @@ ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable) {
     }
 
     return ColumnNullable::create(column, ColumnUInt8::create(column->size(), is_nullable ? 1 : 0));
+}
+
+MutableColumnPtr make_nullable(MutableColumnPtr&& column, bool is_nullable) {
+    if (is_column_nullable(*column)) {
+        return column;
+    }
+
+    if (is_column_const(*column)) {
+        return ColumnConst::create(
+                make_nullable(assert_cast<const ColumnConst&>(*column).get_data_column_ptr(),
+                              is_nullable),
+                column->size());
+    }
+
+    return ColumnNullable::create(std::move(column),
+                                  ColumnUInt8::create(column->size(), is_nullable ? 1 : 0));
 }
 
 ColumnPtr remove_nullable(const ColumnPtr& column) {

--- a/be/src/core/column/column_nullable.cpp
+++ b/be/src/core/column/column_nullable.cpp
@@ -704,7 +704,7 @@ ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable) {
     return ColumnNullable::create(column, ColumnUInt8::create(column->size(), is_nullable ? 1 : 0));
 }
 
-MutableColumnPtr make_nullable(MutableColumnPtr&& column, bool is_nullable) {
+MutableColumnPtr make_mut_nullable(MutableColumnPtr&& column, bool is_nullable) {
     if (is_column_nullable(*column)) {
         return std::move(column);
     }

--- a/be/src/core/column/column_nullable.h
+++ b/be/src/core/column/column_nullable.h
@@ -417,6 +417,6 @@ private:
 };
 
 ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable = false);
-MutableColumnPtr make_nullable(MutableColumnPtr&& column, bool is_nullable = false);
+MutableColumnPtr make_mut_nullable(MutableColumnPtr&& column, bool is_nullable = false);
 ColumnPtr remove_nullable(const ColumnPtr& column);
 } // namespace doris

--- a/be/src/core/column/column_nullable.h
+++ b/be/src/core/column/column_nullable.h
@@ -289,7 +289,7 @@ public:
 
     const ColumnPtr& get_nested_column_ptr() const { return _nested_column; }
 
-    MutableColumnPtr get_nested_column_ptr() { return _nested_column->assert_mutable(); }
+    MutableColumnPtr get_nested_column_ptr() { return _nested_column.get()->get_ptr(); }
 
     void clear() override {
         _null_map->clear();
@@ -396,9 +396,7 @@ public:
     const NullMap& get_null_map_data() const { return get_null_map_column().get_data(); }
 
     ColumnUInt8::MutablePtr get_null_map_column_ptr() {
-        auto null_map = _null_map->assert_mutable();
-        return ColumnUInt8::cast_to_column_mutptr(
-                assert_cast<ColumnUInt8*, TypeCheckOnRelease::DISABLE>(null_map.get()));
+        return ColumnUInt8::cast_to_column_mutptr(_null_map.get());
     }
     ColumnUInt8& get_null_map_column() { return *_null_map; }
     NullMap& get_null_map_data() { return get_null_map_column().get_data(); }
@@ -419,5 +417,6 @@ private:
 };
 
 ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable = false);
+MutableColumnPtr make_nullable(MutableColumnPtr&& column, bool is_nullable = false);
 ColumnPtr remove_nullable(const ColumnPtr& column);
 } // namespace doris

--- a/be/src/core/column/column_variant.cpp
+++ b/be/src/core/column/column_variant.cpp
@@ -313,10 +313,11 @@ static ColumnPtr recreate_column_with_default_values(const ColumnPtr& column,
                                                      size_t num_dimensions) {
     const auto* column_array = check_and_get_column<ColumnArray>(remove_nullable(column).get());
     if (column_array != nullptr && num_dimensions != 0) {
-        return make_nullable(ColumnArray::create(
+        ColumnPtr array_column = ColumnArray::create(
                 recreate_column_with_default_values(column_array->get_data_ptr(), scalar_type,
                                                     num_dimensions - 1),
-                IColumn::mutate(column_array->get_offsets_ptr())));
+                IColumn::mutate(column_array->get_offsets_ptr()));
+        return make_nullable(array_column);
     }
 
     return create_array(scalar_type, num_dimensions)

--- a/be/src/core/cow.h
+++ b/be/src/core/cow.h
@@ -320,6 +320,7 @@ public:
     // uniquely owned. This does not detach shared owners; use a type-specific
     // COW entry point (for example IColumn::mutate) when the pointer may be
     // shared.
+    MutablePtr assert_mutable() = delete;
     MutablePtr assert_mutable() const {
         if (this->use_count() > 1) {
             throw Exception(ErrorCode::INTERNAL_ERROR, "COW::assert_mutable: use_count() > 1");
@@ -328,6 +329,7 @@ public:
     }
 
     // Reference variant of assert_mutable(), with the same ownership contract.
+    Derived& assert_mutable_ref() = delete;
     Derived& assert_mutable_ref() const {
         if (this->use_count() > 1) {
             throw Exception(ErrorCode::INTERNAL_ERROR, "COW::assert_mutable: use_count() > 1");

--- a/be/src/exec/operator/analytic_sink_operator.cpp
+++ b/be/src/exec/operator/analytic_sink_operator.cpp
@@ -430,7 +430,7 @@ void AnalyticSinkLocalState::_output_current_block(Block* block) {
         DCHECK(_result_window_columns[i]);
         DCHECK(_agg_functions[i]);
         if (_parent->cast<AnalyticSinkOperatorX>()._change_to_nullable_flags[i]) {
-            block->insert({make_nullable(std::move(_result_window_columns[i])),
+            block->insert({make_mut_nullable(std::move(_result_window_columns[i])),
                            make_nullable(_agg_functions[i]->data_type()), ""});
         } else {
             block->insert(

--- a/be/src/exprs/aggregate/aggregate_function_null_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_null_v2.h
@@ -212,9 +212,8 @@ public:
                              MutableColumnPtr& dst, const size_t num_rows) const override {
         if constexpr (result_is_nullable) {
             auto& nullable_col = assert_cast<ColumnNullable&>(*dst);
-            auto& nested_col = nullable_col.get_nested_column();
             auto& null_map = nullable_col.get_null_map_data();
-            MutableColumnPtr nested_col_ptr = nested_col.assert_mutable();
+            MutableColumnPtr nested_col_ptr = nullable_col.get_nested_column_ptr();
 
             null_map.resize(num_rows);
             uint8_t* __restrict null_map_data = null_map.data();
@@ -273,7 +272,7 @@ public:
 
         if constexpr (result_is_nullable) {
             auto& dst_nullable_col = assert_cast<ColumnNullable&>(*dst);
-            MutableColumnPtr nested_col_ptr = dst_nullable_col.get_nested_column().assert_mutable();
+            MutableColumnPtr nested_col_ptr = dst_nullable_col.get_nested_column_ptr();
             dst_nullable_col.get_null_map_column().insert_range_from(
                     src_nullable_col->get_null_map_column(), 0, num_rows);
             nested_function->serialize_to_column(nested_places, 0, nested_col_ptr, num_rows);

--- a/be/src/exprs/function/array/function_array_aggregation.cpp
+++ b/be/src/exprs/function/array/function_array_aggregation.cpp
@@ -215,7 +215,7 @@ struct ArrayAggregateImpl {
         }
 
         MutableColumnPtr res_column = create_column_func(column);
-        res_column = make_nullable(std::move(res_column));
+        res_column = make_mut_nullable(std::move(res_column));
         assert_cast<ColumnNullable&>(*res_column).reserve(offsets.size());
 
         auto function = Function::create(type, {.is_window_function = false, .column_names = {}});
@@ -439,7 +439,7 @@ struct ArrayAggregateImplDecimalV3<operation, ResultType> {
         }
 
         MutableColumnPtr res_column = create_column_func(column);
-        res_column = make_nullable(std::move(res_column));
+        res_column = make_mut_nullable(std::move(res_column));
         assert_cast<ColumnNullable&>(*res_column).reserve(offsets.size());
 
         auto function = Function::create(type, result_type,

--- a/be/src/exprs/function/array/function_array_aggregation.cpp
+++ b/be/src/exprs/function/array/function_array_aggregation.cpp
@@ -214,9 +214,9 @@ struct ArrayAggregateImpl {
             return false;
         }
 
-        ColumnPtr res_column = create_column_func(column);
-        res_column = make_nullable(res_column);
-        assert_cast<ColumnNullable&>(res_column->assert_mutable_ref()).reserve(offsets.size());
+        MutableColumnPtr res_column = create_column_func(column);
+        res_column = make_nullable(std::move(res_column));
+        assert_cast<ColumnNullable&>(*res_column).reserve(offsets.size());
 
         auto function = Function::create(type, {.is_window_function = false, .column_names = {}});
         auto guard = AggregateFunctionGuard(function.get());
@@ -228,13 +228,13 @@ struct ArrayAggregateImpl {
             auto end = offsets[i];
             bool is_empty = (start == end);
             if (is_empty) {
-                res_column->assert_mutable()->insert_default();
+                res_column->insert_default();
                 continue;
             }
             function->reset(guard.data());
             function->add_batch_range(start, end - 1, guard.data(), columns, arena,
                                       data->is_nullable());
-            function->insert_result_into(guard.data(), res_column->assert_mutable_ref());
+            function->insert_result_into(guard.data(), *res_column);
         }
         res_ptr = std::move(res_column);
         return true;
@@ -249,7 +249,7 @@ struct ArrayAggregateImpl {
                 return false;
             }
 
-            auto create_column = [](const ColumnString*) -> ColumnPtr {
+            auto create_column = [](const ColumnString*) -> MutableColumnPtr {
                 return ColumnString::create();
             };
 
@@ -268,7 +268,7 @@ struct ArrayAggregateImpl {
                         operation>::template TypeTraits<Element>::ResultType;
                 using ColVecResultType = typename PrimitiveTypeTraits<ResultType>::ColumnType;
 
-                auto create_column = [](const ColVecType* column) -> ColumnPtr {
+                auto create_column = [](const ColVecType* column) -> MutableColumnPtr {
                     if constexpr (is_decimal(Element)) {
                         return ColVecResultType::create(0, column->get_scale());
                     } else {
@@ -438,9 +438,9 @@ struct ArrayAggregateImplDecimalV3<operation, ResultType> {
             return false;
         }
 
-        ColumnPtr res_column = create_column_func(column);
-        res_column = make_nullable(res_column);
-        assert_cast<ColumnNullable&>(res_column->assert_mutable_ref()).reserve(offsets.size());
+        MutableColumnPtr res_column = create_column_func(column);
+        res_column = make_nullable(std::move(res_column));
+        assert_cast<ColumnNullable&>(*res_column).reserve(offsets.size());
 
         auto function = Function::create(type, result_type,
                                          {.is_window_function = false, .column_names = {}});
@@ -453,13 +453,13 @@ struct ArrayAggregateImplDecimalV3<operation, ResultType> {
             auto end = offsets[i];
             bool is_empty = (start == end);
             if (is_empty) {
-                res_column->assert_mutable()->insert_default();
+                res_column->insert_default();
                 continue;
             }
             function->reset(guard.data());
             function->add_batch_range(start, end - 1, guard.data(), columns, arena,
                                       data->is_nullable());
-            function->insert_result_into(guard.data(), res_column->assert_mutable_ref());
+            function->insert_result_into(guard.data(), *res_column);
         }
         res_ptr = std::move(res_column);
         return true;
@@ -472,7 +472,7 @@ struct ArrayAggregateImplDecimalV3<operation, ResultType> {
         using ColVecType = typename PrimitiveTypeTraits<Element>::ColumnType;
         using ColVecResultType = typename PrimitiveTypeTraits<ResultType>::ColumnType;
 
-        auto create_column = [](const ColVecType* column) -> ColumnPtr {
+        auto create_column = [](const ColVecType* column) -> MutableColumnPtr {
             return ColVecResultType::create(0, column->get_scale());
         };
 

--- a/be/src/exprs/function/array/function_array_with_constant.cpp
+++ b/be/src/exprs/function/array/function_array_with_constant.cpp
@@ -99,8 +99,7 @@ public:
         }
         auto clone = value->clone_empty();
         clone->reserve(input_rows_count);
-        clone->assert_mutable()->insert_indices_from(*value, array_sizes.data(),
-                                                     array_sizes.data() + offset);
+        clone->insert_indices_from(*value, array_sizes.data(), array_sizes.data() + offset);
         if (!clone->is_nullable()) {
             clone = ColumnNullable::create(std::move(clone), ColumnUInt8::create(clone->size(), 0));
         }

--- a/be/src/exprs/function/cast/cast_to_variant.h
+++ b/be/src/exprs/function/cast/cast_to_variant.h
@@ -103,7 +103,7 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
         if (!st.ok()) {
             // Fill with default values, which is null
             col_to->insert_many_defaults(input_rows_count);
-            col_to = make_nullable(std::move(col_to), true);
+            col_to = make_mut_nullable(std::move(col_to), true);
         } else {
             col_to = IColumn::mutate(std::move(tmp_block.get_by_position(1).column));
             ColumnPtr col_to_ptr = std::move(col_to);
@@ -118,7 +118,7 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
     } else {
         if (variant->only_have_default_values()) {
             col_to->insert_many_defaults(input_rows_count);
-            col_to = make_nullable(std::move(col_to), true);
+            col_to = make_mut_nullable(std::move(col_to), true);
         } else if (is_string_type(data_type_to->get_primitive_type())) {
             // serialize to string
             return execute_on_finalized_input([&](Block& finalized_block) {
@@ -135,7 +135,7 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
                    !is_string_type(data_type_to->get_primitive_type())) {
             // other types
             col_to->insert_many_defaults(input_rows_count);
-            col_to = make_nullable(std::move(col_to), true);
+            col_to = make_mut_nullable(std::move(col_to), true);
         } else {
             assert_cast<ColumnNullable&>(*col_to).insert_many_defaults(input_rows_count);
         }

--- a/be/src/exprs/function/cast/cast_to_variant.h
+++ b/be/src/exprs/function/cast/cast_to_variant.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "core/column/column.h"
 #include "core/column/column_nullable.h"
 #include "core/data_type/data_type_variant.h"
 #include "exprs/function/cast/cast_base.h"
@@ -37,7 +38,7 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
         variant_column = &nullable->get_nested_column();
     }
     const auto* variant = assert_cast<const ColumnVariant*>(variant_column);
-    ColumnPtr col_to = data_type_to->create_column();
+    MutableColumnPtr col_to = data_type_to->create_column();
 
     ColumnPtr finalized_input_column;
     if (!variant->is_finalized()) {
@@ -101,20 +102,23 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
         Status st = wrapper(new_context.get(), tmp_block, {0}, 1, input_rows_count, nullptr);
         if (!st.ok()) {
             // Fill with default values, which is null
-            col_to->assert_mutable()->insert_many_defaults(input_rows_count);
-            col_to = make_nullable(col_to, true);
+            col_to->insert_many_defaults(input_rows_count);
+            col_to = make_nullable(std::move(col_to), true);
         } else {
-            col_to = tmp_block.get_by_position(1).column;
-            col_to = wrap_in_nullable(col_to,
-                                      Block({{nested, nested_from_type, ""},
-                                             {col_from, col_with_type_and_name.type, ""},
-                                             {col_to, data_type_to, ""}}),
-                                      {0, 1}, input_rows_count);
+            col_to = IColumn::mutate(std::move(tmp_block.get_by_position(1).column));
+            ColumnPtr col_to_ptr = std::move(col_to);
+            ColumnPtr wrapped_col_to =
+                    wrap_in_nullable(col_to_ptr,
+                                     Block({{nested, nested_from_type, ""},
+                                            {col_from, col_with_type_and_name.type, ""},
+                                            {col_to_ptr, data_type_to, ""}}),
+                                     {0, 1}, input_rows_count);
+            col_to = IColumn::mutate(std::move(wrapped_col_to));
         }
     } else {
         if (variant->only_have_default_values()) {
-            col_to->assert_mutable()->insert_many_defaults(input_rows_count);
-            col_to = make_nullable(col_to, true);
+            col_to->insert_many_defaults(input_rows_count);
+            col_to = make_nullable(std::move(col_to), true);
         } else if (is_string_type(data_type_to->get_primitive_type())) {
             // serialize to string
             return execute_on_finalized_input([&](Block& finalized_block) {
@@ -130,16 +134,15 @@ inline Status cast_from_variant_impl(FunctionContext* context, Block& block,
         } else if (!data_type_to->is_nullable() &&
                    !is_string_type(data_type_to->get_primitive_type())) {
             // other types
-            col_to->assert_mutable()->insert_many_defaults(input_rows_count);
-            col_to = make_nullable(col_to, true);
+            col_to->insert_many_defaults(input_rows_count);
+            col_to = make_nullable(std::move(col_to), true);
         } else {
-            assert_cast<ColumnNullable&>(*col_to->assert_mutable())
-                    .insert_many_defaults(input_rows_count);
+            assert_cast<ColumnNullable&>(*col_to).insert_many_defaults(input_rows_count);
         }
     }
 
     if (null_map == nullptr) {
-        if (const auto* nullable_result = check_and_get_column<ColumnNullable>(*col_to);
+        if (auto* nullable_result = check_and_get_column<ColumnNullable>(*col_to);
             nullable_result != nullptr && !nullable_result->has_null()) {
             col_to = nullable_result->get_nested_column_ptr();
         }

--- a/be/src/exprs/function/function_variadic_arguments.h
+++ b/be/src/exprs/function/function_variadic_arguments.h
@@ -59,19 +59,19 @@ public:
         ToDataType to_type;
         auto column = to_type.create_column();
         column->reserve(input_rows_count);
+        auto& result_column = *column;
 
         if (arguments.empty()) {
-            RETURN_IF_ERROR(Impl::empty_apply(column->assert_mutable_ref(), input_rows_count));
+            RETURN_IF_ERROR(Impl::empty_apply(result_column, input_rows_count));
         } else {
             const ColumnWithTypeAndName& first_col = block.get_by_position(arguments[0]);
             RETURN_IF_ERROR(Impl::first_apply(first_col.type.get(), first_col.column.get(),
-                                              input_rows_count, column->assert_mutable_ref()));
+                                              input_rows_count, result_column));
 
             for (size_t i = 1; i < arguments.size(); ++i) {
                 const ColumnWithTypeAndName& col = block.get_by_position(arguments[i]);
                 RETURN_IF_ERROR(Impl::combine_apply(col.type.get(), col.column.get(),
-                                                    input_rows_count,
-                                                    column->assert_mutable_ref()));
+                                                    input_rows_count, result_column));
             }
         }
 

--- a/be/src/exprs/function/function_variant_element.cpp
+++ b/be/src/exprs/function/function_variant_element.cpp
@@ -261,11 +261,13 @@ private:
                                      ColumnPtr* result) {
         std::string field_name = index_column->get_data_at(0).to_string();
         if (src.empty()) {
-            *result = ColumnVariant::create(src.max_subcolumns_count(), src.enable_doc_mode());
+            MutableColumnPtr result_column =
+                    ColumnVariant::create(src.max_subcolumns_count(), src.enable_doc_mode());
             // src subcolumns empty but src row count may not be 0
-            (*result)->assert_mutable()->insert_many_defaults(src.size());
+            result_column->insert_many_defaults(src.size());
             // ColumnVariant should be finalized before parsing, finalize maybe modify original column structure
-            (*result)->assert_mutable()->finalize();
+            result_column->finalize();
+            *result = std::move(result_column);
             return Status::OK();
         }
         if (src.is_scalar_variant() && is_string_type(src.get_root_type()->get_primitive_type())) {
@@ -288,9 +290,11 @@ private:
                     result_column->insert_default();
                 }
             }
-            *result = ColumnVariant::create(src.max_subcolumns_count(), src.enable_doc_mode(), type,
-                                            std::move(result_column));
-            (*result)->assert_mutable()->finalize();
+            MutableColumnPtr variant_result =
+                    ColumnVariant::create(src.max_subcolumns_count(), src.enable_doc_mode(), type,
+                                          std::move(result_column));
+            variant_result->finalize();
+            *result = std::move(variant_result);
             return Status::OK();
         } else {
             auto mutable_src = src.clone_finalized();

--- a/be/src/exprs/function/function_variant_type.cpp
+++ b/be/src/exprs/function/function_variant_type.cpp
@@ -95,7 +95,7 @@ public:
             writer.write_char('}');
             writer.commit();
         }
-        auto result_nullable_column = make_nullable(result_column->get_ptr());
+        auto result_nullable_column = make_mut_nullable(std::move(result_column));
         block.replace_by_position(result, std::move(result_nullable_column));
         return Status::OK();
     }

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -2910,7 +2910,7 @@ Status SegmentIterator::_convert_to_expected_type(const std::vector<ColumnId>& c
         DataTypePtr file_column_type = _storage_name_and_type[i].second;
         if (!file_column_type->equals(*expected_type)) {
             ColumnPtr expected;
-            ColumnPtr original = _current_return_columns[i]->assert_mutable()->get_ptr();
+            ColumnPtr original = _current_return_columns[i]->get_ptr();
             RETURN_IF_ERROR(variant_util::cast_column({original, file_column_type, ""},
                                                       expected_type, &expected));
             _current_return_columns[i] = expected->assert_mutable();

--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -1639,7 +1639,7 @@ static void fill_nested_with_defaults(MutableColumnPtr& dst, MutableColumnPtr& s
     ColumnPtr nested_column = std::move(new_nested);
     MutableColumnPtr array_column =
             ColumnArray::create(nested_column, sibling_array->get_offsets_ptr());
-    auto new_array = make_nullable(std::move(array_column));
+    auto new_array = make_mut_nullable(std::move(array_column));
     dst->insert_range_from(*new_array, 0, new_array->size());
 #ifndef NDEBUG
     if (!dst_array->has_equal_offsets(*sibling_array)) {

--- a/be/src/storage/segment/variant/variant_column_reader.cpp
+++ b/be/src/storage/segment/variant/variant_column_reader.cpp
@@ -1637,8 +1637,9 @@ static void fill_nested_with_defaults(MutableColumnPtr& dst, MutableColumnPtr& s
     auto new_nested =
             dst_array->get_data_ptr()->clone_resized(sibling_array->get_data_ptr()->size());
     ColumnPtr nested_column = std::move(new_nested);
-    auto new_array =
-            make_nullable(ColumnArray::create(nested_column, sibling_array->get_offsets_ptr()));
+    MutableColumnPtr array_column =
+            ColumnArray::create(nested_column, sibling_array->get_offsets_ptr());
+    auto new_array = make_nullable(std::move(array_column));
     dst->insert_range_from(*new_array, 0, new_array->size());
 #ifndef NDEBUG
     if (!dst_array->has_equal_offsets(*sibling_array)) {

--- a/be/test/core/block/block_test.cpp
+++ b/be/test/core/block/block_test.cpp
@@ -147,8 +147,9 @@ static void fill_block_with_array_int(Block& block) {
         data_column->insert_data((const char*)(&v), 0);
     }
 
-    auto column_array_ptr =
-            ColumnArray::create(make_nullable(std::move(data_column)), std::move(off_column));
+    MutableColumnPtr nullable_data_column = std::move(data_column);
+    auto column_array_ptr = ColumnArray::create(make_nullable(std::move(nullable_data_column)),
+                                                std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeInt32>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
     ColumnWithTypeAndName test_array_int(std::move(column_array_ptr), array_type, "test_array_int");
@@ -168,8 +169,9 @@ static void fill_block_with_array_string(Block& block) {
         data_column->insert_data(v.data(), v.size());
     }
 
-    auto column_array_ptr =
-            ColumnArray::create(make_nullable(std::move(data_column)), std::move(off_column));
+    MutableColumnPtr nullable_data_column = std::move(data_column);
+    auto column_array_ptr = ColumnArray::create(make_nullable(std::move(nullable_data_column)),
+                                                std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeString>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
     ColumnWithTypeAndName test_array_string(std::move(column_array_ptr), array_type,
@@ -326,7 +328,8 @@ void serialize_and_deserialize_test(segment_v2::CompressionTypePB compression_ty
     // int with 4096 batch size
     {
         auto column_vector_int32 = ColumnInt32::create();
-        auto column_nullable_vector = make_nullable(std::move(column_vector_int32));
+        MutableColumnPtr mutable_column_vector_int32 = std::move(column_vector_int32);
+        auto column_nullable_vector = make_nullable(std::move(mutable_column_vector_int32));
         auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
         for (int i = 0; i < 4096; i++) {
             mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(i));
@@ -560,7 +563,8 @@ void serialize_and_deserialize_test_nullable() {
         auto& data = vec->get_data();
         data.push_back(111);
         auto nullable_column = make_nullable(vec->get_ptr());
-        auto const_column = ColumnConst::create(nullable_column, 10);
+        auto const_column =
+                ColumnConst::create(static_cast<const IColumn&>(*nullable_column).get_ptr(), 10);
         DataTypePtr data_type(std::make_shared<DataTypeInt32>());
         auto nullable_data_type = make_nullable(data_type);
         ColumnWithTypeAndName type_and_name(const_column->get_ptr(), nullable_data_type,
@@ -840,7 +844,8 @@ TEST(BlockTest, dump_data) {
                                        "test_decimal");
 
     auto column_vector_int32 = ColumnInt32::create();
-    auto column_nullable_vector = make_nullable(std::move(column_vector_int32));
+    MutableColumnPtr mutable_column_vector_int32 = std::move(column_vector_int32);
+    auto column_nullable_vector = make_nullable(std::move(mutable_column_vector_int32));
     auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
     for (int i = 0; i < 4096; i++) {
         mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(i));

--- a/be/test/core/block/block_test.cpp
+++ b/be/test/core/block/block_test.cpp
@@ -148,7 +148,7 @@ static void fill_block_with_array_int(Block& block) {
     }
 
     MutableColumnPtr nullable_data_column = std::move(data_column);
-    auto column_array_ptr = ColumnArray::create(make_nullable(std::move(nullable_data_column)),
+    auto column_array_ptr = ColumnArray::create(make_mut_nullable(std::move(nullable_data_column)),
                                                 std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeInt32>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
@@ -170,7 +170,7 @@ static void fill_block_with_array_string(Block& block) {
     }
 
     MutableColumnPtr nullable_data_column = std::move(data_column);
-    auto column_array_ptr = ColumnArray::create(make_nullable(std::move(nullable_data_column)),
+    auto column_array_ptr = ColumnArray::create(make_mut_nullable(std::move(nullable_data_column)),
                                                 std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeString>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
@@ -329,7 +329,7 @@ void serialize_and_deserialize_test(segment_v2::CompressionTypePB compression_ty
     {
         auto column_vector_int32 = ColumnInt32::create();
         MutableColumnPtr mutable_column_vector_int32 = std::move(column_vector_int32);
-        auto column_nullable_vector = make_nullable(std::move(mutable_column_vector_int32));
+        auto column_nullable_vector = make_mut_nullable(std::move(mutable_column_vector_int32));
         auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
         for (int i = 0; i < 4096; i++) {
             mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(i));
@@ -845,7 +845,7 @@ TEST(BlockTest, dump_data) {
 
     auto column_vector_int32 = ColumnInt32::create();
     MutableColumnPtr mutable_column_vector_int32 = std::move(column_vector_int32);
-    auto column_nullable_vector = make_nullable(std::move(mutable_column_vector_int32));
+    auto column_nullable_vector = make_mut_nullable(std::move(mutable_column_vector_int32));
     auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
     for (int i = 0; i < 4096; i++) {
         mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(i));

--- a/be/test/core/column/column_array_test.cpp
+++ b/be/test/core/column/column_array_test.cpp
@@ -448,7 +448,7 @@ TEST_F(ColumnArrayTest, GetDataAtTest) {
 TEST_F(ColumnArrayTest, FieldTest) {
     MutableColumns array_columns_copy;
     DataTypeSerDeSPtrs serdes_copy;
-    array_columns_copy.push_back(array_columns[42]->assert_mutable());
+    array_columns_copy.push_back(array_columns[42]->clone_resized(array_columns[42]->size()));
     serdes_copy.push_back(serdes[42]);
     assert_field_callback(array_columns_copy, serdes_copy);
 }
@@ -638,7 +638,7 @@ TEST_F(ColumnArrayTest, CreateArrayTest) {
     // - Wrapping shared ColumnConst in ColumnArray violates use_count() assumptions in clear_column_data()
     for (auto& array_column : array_columns) {
         const auto* column = check_and_get_column<ColumnArray>(
-                remove_nullable(array_column->assert_mutable()).get());
+                remove_nullable(static_cast<const IColumn&>(*array_column).get_ptr()).get());
         auto column_size = column->size();
         LOG(INFO) << "column_type: " << column->get_name();
 
@@ -648,8 +648,8 @@ TEST_F(ColumnArrayTest, CreateArrayTest) {
         tmp_data_col->insert_default(); // ColumnConst requires nested column size = 1
         auto const_data = ColumnConst::create(std::move(tmp_data_col), column_size);
         EXPECT_ANY_THROW({
-            auto new_array_column =
-                    ColumnArray::create(const_data->assert_mutable(), column->get_offsets_ptr());
+            auto new_array_column = ColumnArray::create(
+                    static_cast<const IColumn&>(*const_data).get_ptr(), column->get_offsets_ptr());
         });
 
         // 2. offsets_column is ColumnConst (violates check_const_only_in_top_level)
@@ -657,16 +657,15 @@ TEST_F(ColumnArrayTest, CreateArrayTest) {
         tmp_offsets_col->insert_default(); // ColumnConst requires nested column size = 1
         auto const_offsets = ColumnConst::create(std::move(tmp_offsets_col), column_size);
         EXPECT_ANY_THROW({
-            auto new_array_column =
-                    ColumnArray::create(column->get_data_ptr(), const_offsets->assert_mutable());
+            auto new_array_column = ColumnArray::create(
+                    column->get_data_ptr(), static_cast<const IColumn&>(*const_offsets).get_ptr());
         });
 
         // 3. offsets size does not match data size
         auto tmp_data_col1 = column->get_data_ptr()->clone_resized(2);
         EXPECT_ANY_THROW({
             auto new_array_column = ColumnArray::create(
-                    tmp_data_col1->assert_mutable(),
-                    column->get_offsets_column().clone_resized(1)->assert_mutable());
+                    std::move(tmp_data_col1), column->get_offsets_column().clone_resized(1));
         });
 
         // Test successful creation with normal columns
@@ -735,7 +734,7 @@ TEST_F(ColumnArrayTest, GetNumberOfDimensionsTest) {
     // test dimension of array
     for (int i = 0; i < array_columns.size(); i++) {
         auto column = check_and_get_column<ColumnArray>(
-                remove_nullable(array_columns[i]->assert_mutable()).get());
+                remove_nullable(static_cast<const IColumn&>(*array_columns[i]).get_ptr()).get());
         auto check_type = remove_nullable(array_types[i]);
         auto dimension = 0;
         while (check_type->get_primitive_type() == TYPE_ARRAY && !check_type->is_nullable()) {
@@ -753,7 +752,7 @@ TEST_F(ColumnArrayTest, IsExclusiveTest) {
     auto callback = [&](const MutableColumns& columns, const DataTypeSerDeSPtrs& serdes) {
         for (int i = 0; i < columns.size(); i++) {
             auto column = check_and_get_column<ColumnArray>(
-                    remove_nullable(columns[i]->assert_mutable()).get());
+                    remove_nullable(static_cast<const IColumn&>(*columns[i]).get_ptr()).get());
             auto cloned = columns[i]->clone_resized(1);
             // test expect true
             EXPECT_TRUE(column->is_exclusive());
@@ -777,7 +776,7 @@ TEST_F(ColumnArrayTest, MaxArraySizeAsFieldTest) {
     //  in operator[] and get()
     for (int i = 0; i < array_columns.size(); i++) {
         auto column = check_and_get_column<ColumnArray>(
-                remove_nullable(array_columns[i]->assert_mutable()).get());
+                remove_nullable(static_cast<const IColumn&>(*array_columns[i]).get_ptr()).get());
         auto check_type = remove_nullable(array_types[i]);
         Field a;
         column->get(column->size() - 1, a);
@@ -812,7 +811,7 @@ TEST_F(ColumnArrayTest, IsDefaultAtTest) {
     // test is_default_at
     for (int i = 0; i < array_columns.size(); i++) {
         auto column = check_and_get_column<ColumnArray>(
-                remove_nullable(array_columns[i]->assert_mutable()).get());
+                remove_nullable(static_cast<const IColumn&>(*array_columns[i]).get_ptr()).get());
         auto column_size = column->size();
         for (int j = 0; j < column_size; j++) {
             auto is_default = column->is_default_at(j);
@@ -836,10 +835,10 @@ TEST_F(ColumnArrayTest, HasEqualOffsetsTest) {
     // test has_equal_offsets which more likely used in function, eg: function_array_zip
     for (int i = 0; i < array_columns.size(); i++) {
         auto column = check_and_get_column<ColumnArray>(
-                remove_nullable(array_columns[i]->assert_mutable()).get());
+                remove_nullable(static_cast<const IColumn&>(*array_columns[i]).get_ptr()).get());
         auto cloned = array_columns[i]->clone_resized(array_columns[i]->size());
-        auto cloned_arr =
-                check_and_get_column<ColumnArray>(remove_nullable(cloned->assert_mutable()).get());
+        auto cloned_arr = check_and_get_column<ColumnArray>(
+                remove_nullable(static_cast<const IColumn&>(*cloned).get_ptr()).get());
         // test expect true
         EXPECT_EQ(column->get_offsets().size(), cloned_arr->get_offsets().size());
         EXPECT_TRUE(column->has_equal_offsets(*cloned_arr));

--- a/be/test/core/column/column_check_const_only_in_top_level_test.cpp
+++ b/be/test/core/column/column_check_const_only_in_top_level_test.cpp
@@ -118,8 +118,8 @@ TEST_F(ColumnCheckConstOnlyInTopLevelTest, ColumnStructWithNonConstElements) {
     auto int_col2 = ColumnHelper::create_column<DataTypeInt32>({4, 5, 6});
 
     MutableColumns columns;
-    columns.push_back(int_col1->assert_mutable());
-    columns.push_back(int_col2->assert_mutable());
+    columns.push_back(IColumn::mutate(std::move(int_col1)));
+    columns.push_back(IColumn::mutate(std::move(int_col2)));
 
     // Should not throw
     EXPECT_NO_THROW({

--- a/be/test/core/column/column_ip_test.cpp
+++ b/be/test/core/column/column_ip_test.cpp
@@ -200,8 +200,8 @@ TEST_F(ColumnIPTest, CloneTest) {
     ip_cols.push_back(std::move(column_ipv4));
     ip_cols.push_back(std::move(column_ipv6));
     load_data_from_csv(serde, ip_cols, data_files[0], ';', {1, 2});
-    assert_clone_empty(ip_cols[0]->assert_mutable_ref());
-    assert_clone_empty(ip_cols[1]->assert_mutable_ref());
+    assert_clone_empty(*ip_cols[0]);
+    assert_clone_empty(*ip_cols[1]);
     check_data(ip_cols, serde, ';', {1, 2}, data_files[0], assert_clone_resized_callback);
 }
 
@@ -257,8 +257,8 @@ TEST_F(ColumnIPTest, PermutationAndSortTest) {
     ip_cols.push_back(std::move(column_ipv4));
     ip_cols.push_back(std::move(column_ipv6));
     load_data_from_csv(serde, ip_cols, data_files[1], ';', {1, 2});
-    assert_column_permutations(ip_cols[0]->assert_mutable_ref(), dt_ipv4);
-    assert_column_permutations(ip_cols[1]->assert_mutable_ref(), dt_ipv6);
+    assert_column_permutations(*ip_cols[0], dt_ipv4);
+    assert_column_permutations(*ip_cols[1], dt_ipv6);
 }
 
 TEST_F(ColumnIPTest, FilterTest) {

--- a/be/test/core/column/column_variant_test.cpp
+++ b/be/test/core/column/column_variant_test.cpp
@@ -3184,8 +3184,8 @@ TEST_F(ColumnVariantTest, subcolumn_operations_coverage) {
         PathInData sub_path("k");
         nested_object_ptr->add_sub_column(sub_path, std::move(flattend_column),
                                           std::move(flattend_type));
-        nested_object = make_nullable(std::move(nested_object));
-        auto array = make_nullable(
+        nested_object = make_mut_nullable(std::move(nested_object));
+        auto array = make_mut_nullable(
                 MutableColumnPtr(ColumnArray::create(std::move(nested_object), std::move(offset))));
         PathInData path("v.k");
         container_variant.add_sub_column(path, std::move(array), container_variant.NESTED_TYPE);

--- a/be/test/core/column/column_variant_test.cpp
+++ b/be/test/core/column/column_variant_test.cpp
@@ -1270,8 +1270,7 @@ TEST_F(ColumnVariantTest, get_data_at) {
 }
 
 TEST_F(ColumnVariantTest, replace_column_data) {
-    EXPECT_ANY_THROW(
-            column_variant->replace_column_data(column_variant->assert_mutable_ref(), 0, 0));
+    EXPECT_ANY_THROW(column_variant->replace_column_data(*column_variant, 0, 0));
 }
 
 TEST_F(ColumnVariantTest, serialize_value_into_arena) {
@@ -3185,12 +3184,11 @@ TEST_F(ColumnVariantTest, subcolumn_operations_coverage) {
         PathInData sub_path("k");
         nested_object_ptr->add_sub_column(sub_path, std::move(flattend_column),
                                           std::move(flattend_type));
-        nested_object = make_nullable(nested_object->get_ptr())->assert_mutable();
-        auto array =
-                make_nullable(ColumnArray::create(std::move(nested_object), std::move(offset)));
+        nested_object = make_nullable(std::move(nested_object));
+        auto array = make_nullable(
+                MutableColumnPtr(ColumnArray::create(std::move(nested_object), std::move(offset))));
         PathInData path("v.k");
-        container_variant.add_sub_column(path, array->assert_mutable(),
-                                         container_variant.NESTED_TYPE);
+        container_variant.add_sub_column(path, std::move(array), container_variant.NESTED_TYPE);
         container_variant.set_num_rows(3);
         for (auto subcolumn : container_variant.get_subcolumns()) {
             if (subcolumn->data.is_root) {

--- a/be/test/core/data_type/data_type_array_test.cpp
+++ b/be/test/core/data_type/data_type_array_test.cpp
@@ -465,7 +465,7 @@ TEST_F(DataTypeArrayTest, FromAndToStringTest) {
         if (i == 13 || i == 31) {
             continue;
         }
-        assert_to_string_from_string_assert(column->assert_mutable(), type);
+        assert_to_string_from_string_assert(column->clone_resized(column->size()), type);
     }
 }
 

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -125,7 +125,8 @@ std::shared_ptr<Block> create_test_block(std::vector<PrimitiveType> cols, int ro
             if (is_nullable) {
                 {
                     auto column_vector_int32 = ColumnVector<TYPE_INT>::create();
-                    auto column_nullable_vector = make_nullable(std::move(column_vector_int32));
+                    auto column_nullable_vector =
+                            make_nullable(MutableColumnPtr(std::move(column_vector_int32)));
                     auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
                     for (int i = 0; i < row_num; i++) {
                         if (i % 2 == 0) {

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<Block> create_test_block(std::vector<PrimitiveType> cols, int ro
                 {
                     auto column_vector_int32 = ColumnVector<TYPE_INT>::create();
                     auto column_nullable_vector =
-                            make_nullable(MutableColumnPtr(std::move(column_vector_int32)));
+                            make_mut_nullable(MutableColumnPtr(std::move(column_vector_int32)));
                     auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
                     for (int i = 0; i < row_num; i++) {
                         if (i % 2 == 0) {

--- a/be/test/core/data_type_serde/data_type_serde_mysql_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_mysql_test.cpp
@@ -139,7 +139,8 @@ void serialize_and_deserialize_mysql_test(bool dry_run) {
             if (is_nullable) {
                 {
                     auto column_vector_int32 = ColumnVector<TYPE_INT>::create();
-                    auto column_nullable_vector = make_nullable(std::move(column_vector_int32));
+                    auto column_nullable_vector =
+                            make_nullable(MutableColumnPtr(std::move(column_vector_int32)));
                     auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
                     for (int i = 0; i < row_num; i++) {
                         mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(int32_t(i)));

--- a/be/test/core/data_type_serde/data_type_serde_mysql_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_mysql_test.cpp
@@ -140,7 +140,7 @@ void serialize_and_deserialize_mysql_test(bool dry_run) {
                 {
                     auto column_vector_int32 = ColumnVector<TYPE_INT>::create();
                     auto column_nullable_vector =
-                            make_nullable(MutableColumnPtr(std::move(column_vector_int32)));
+                            make_mut_nullable(MutableColumnPtr(std::move(column_vector_int32)));
                     auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
                     for (int i = 0; i < row_num; i++) {
                         mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(int32_t(i)));

--- a/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
@@ -202,8 +202,9 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest5) {
         out_offset_column->get_data().push_back(1);
         DataTypePtr out_array_type = std::make_shared<DataTypeArray>(make_nullable(array_type));
         //[[0,1,2,3,.....9]]
-        auto out_array_column = ColumnArray::create((make_nullable(std::move(array_column))),
-                                                    std::move(out_offset_column));
+        auto out_array_column =
+                ColumnArray::create(make_nullable(MutableColumnPtr(std::move(array_column))),
+                                    std::move(out_offset_column));
         check_pb_col(out_array_type, *out_array_column.get());
     }
 }
@@ -240,10 +241,11 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest6) {
         //[[0, NULL, 2, NULL], [4, NULL, 6, NULL, 8, NULL]]
         out_offset_column->get_data().push_back(2);
         DataTypePtr out_array_type = std::make_shared<DataTypeArray>(make_nullable(array_type));
-        auto null_array_column = make_nullable(std::move(array_column));
+        auto null_array_column = make_nullable(MutableColumnPtr(std::move(array_column)));
 
         auto out_array_column =
-                ColumnArray::create(null_array_column, std::move(out_offset_column));
+                ColumnArray::create(static_cast<const IColumn&>(*null_array_column).get_ptr(),
+                                    std::move(out_offset_column));
         check_pb_col(out_array_type, *out_array_column.get());
     }
 }
@@ -288,10 +290,11 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest7) {
         out_offset_column->get_data().push_back(1);
         out_offset_column->get_data().push_back(2);
         DataTypePtr out_array_type = std::make_shared<DataTypeArray>(make_nullable(array_type));
-        auto null_array_column = make_nullable(std::move(array_column));
+        auto null_array_column = make_nullable(MutableColumnPtr(std::move(array_column)));
 
         auto out_array_column =
-                ColumnArray::create(null_array_column, std::move(out_offset_column));
+                ColumnArray::create(static_cast<const IColumn&>(*null_array_column).get_ptr(),
+                                    std::move(out_offset_column));
         check_pb_col(out_array_type, *out_array_column.get());
     }
 }

--- a/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
@@ -203,7 +203,7 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest5) {
         DataTypePtr out_array_type = std::make_shared<DataTypeArray>(make_nullable(array_type));
         //[[0,1,2,3,.....9]]
         auto out_array_column =
-                ColumnArray::create(make_nullable(MutableColumnPtr(std::move(array_column))),
+                ColumnArray::create(make_mut_nullable(MutableColumnPtr(std::move(array_column))),
                                     std::move(out_offset_column));
         check_pb_col(out_array_type, *out_array_column.get());
     }
@@ -241,7 +241,7 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest6) {
         //[[0, NULL, 2, NULL], [4, NULL, 6, NULL, 8, NULL]]
         out_offset_column->get_data().push_back(2);
         DataTypePtr out_array_type = std::make_shared<DataTypeArray>(make_nullable(array_type));
-        auto null_array_column = make_nullable(MutableColumnPtr(std::move(array_column)));
+        auto null_array_column = make_mut_nullable(MutableColumnPtr(std::move(array_column)));
 
         auto out_array_column =
                 ColumnArray::create(static_cast<const IColumn&>(*null_array_column).get_ptr(),
@@ -290,7 +290,7 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest7) {
         out_offset_column->get_data().push_back(1);
         out_offset_column->get_data().push_back(2);
         DataTypePtr out_array_type = std::make_shared<DataTypeArray>(make_nullable(array_type));
-        auto null_array_column = make_nullable(MutableColumnPtr(std::move(array_column)));
+        auto null_array_column = make_mut_nullable(MutableColumnPtr(std::move(array_column)));
 
         auto out_array_column =
                 ColumnArray::create(static_cast<const IColumn&>(*null_array_column).get_ptr(),

--- a/be/test/core/jsonb/serialize_test.cpp
+++ b/be/test/core/jsonb/serialize_test.cpp
@@ -440,7 +440,7 @@ static void build_all_row_store_types_block(Block& block, TabletSchema& schema) 
         }
         DataTypePtr nested = make_nullable(std::make_shared<DataTypeInt32>());
         DataTypePtr t = std::make_shared<DataTypeArray>(nested);
-        auto arr = ColumnArray::create(make_nullable(MutableColumnPtr(std::move(data))),
+        auto arr = ColumnArray::create(make_mut_nullable(MutableColumnPtr(std::move(data))),
                                        std::move(off));
         add("c_array_int", t, std::move(arr));
     }
@@ -594,7 +594,7 @@ static void fill_block_with_array_int(Block& block) {
     }
 
     auto column_array_ptr = ColumnArray::create(
-            make_nullable(MutableColumnPtr(std::move(data_column))), std::move(off_column));
+            make_mut_nullable(MutableColumnPtr(std::move(data_column))), std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeInt32>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
     ColumnWithTypeAndName test_array_int(std::move(column_array_ptr), array_type, "test_array_int");
@@ -615,7 +615,7 @@ static void fill_block_with_array_string(Block& block) {
     }
 
     auto column_array_ptr = ColumnArray::create(
-            make_nullable(MutableColumnPtr(std::move(data_column))), std::move(off_column));
+            make_mut_nullable(MutableColumnPtr(std::move(data_column))), std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeString>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
     ColumnWithTypeAndName test_array_string(std::move(column_array_ptr), array_type,
@@ -1010,7 +1010,7 @@ TEST(BlockSerializeTest, JsonbBlock) {
     {
         auto column_vector_int32 = ColumnInt32::create();
         auto column_nullable_vector =
-                make_nullable(MutableColumnPtr(std::move(column_vector_int32)));
+                make_mut_nullable(MutableColumnPtr(std::move(column_vector_int32)));
         auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
         for (int i = 0; i < 1024; i++) {
             mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(i));

--- a/be/test/core/jsonb/serialize_test.cpp
+++ b/be/test/core/jsonb/serialize_test.cpp
@@ -440,7 +440,8 @@ static void build_all_row_store_types_block(Block& block, TabletSchema& schema) 
         }
         DataTypePtr nested = make_nullable(std::make_shared<DataTypeInt32>());
         DataTypePtr t = std::make_shared<DataTypeArray>(nested);
-        auto arr = ColumnArray::create(make_nullable(std::move(data)), std::move(off));
+        auto arr = ColumnArray::create(make_nullable(MutableColumnPtr(std::move(data))),
+                                       std::move(off));
         add("c_array_int", t, std::move(arr));
     }
 
@@ -592,8 +593,8 @@ static void fill_block_with_array_int(Block& block) {
         data_column->insert_data((const char*)(&v), 0);
     }
 
-    auto column_array_ptr =
-            ColumnArray::create(make_nullable(std::move(data_column)), std::move(off_column));
+    auto column_array_ptr = ColumnArray::create(
+            make_nullable(MutableColumnPtr(std::move(data_column))), std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeInt32>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
     ColumnWithTypeAndName test_array_int(std::move(column_array_ptr), array_type, "test_array_int");
@@ -613,8 +614,8 @@ static void fill_block_with_array_string(Block& block) {
         data_column->insert_data(v.data(), v.size());
     }
 
-    auto column_array_ptr =
-            ColumnArray::create(make_nullable(std::move(data_column)), std::move(off_column));
+    auto column_array_ptr = ColumnArray::create(
+            make_nullable(MutableColumnPtr(std::move(data_column))), std::move(off_column));
     DataTypePtr nested_type(std::make_shared<DataTypeString>());
     DataTypePtr array_type(std::make_shared<DataTypeArray>(nested_type));
     ColumnWithTypeAndName test_array_string(std::move(column_array_ptr), array_type,
@@ -1008,7 +1009,8 @@ TEST(BlockSerializeTest, JsonbBlock) {
     // int with 1024 batch size
     {
         auto column_vector_int32 = ColumnInt32::create();
-        auto column_nullable_vector = make_nullable(std::move(column_vector_int32));
+        auto column_nullable_vector =
+                make_nullable(MutableColumnPtr(std::move(column_vector_int32)));
         auto mutable_nullable_vector = std::move(*column_nullable_vector).mutate();
         for (int i = 0; i < 1024; i++) {
             mutable_nullable_vector->insert(Field::create_field<TYPE_INT>(i));

--- a/be/test/core/value/jsonb_value_test2.cpp
+++ b/be/test/core/value/jsonb_value_test2.cpp
@@ -73,7 +73,7 @@ TEST(JsonbValueConvertorTest, JsonbValueValid) {
     ASSERT_EQ(input->size(), 5);
 
     // 2. put column into block
-    ColumnWithTypeAndName argument(input->assert_mutable(), dataTypeJsonb, "jsonb_column");
+    ColumnWithTypeAndName argument(std::move(input), dataTypeJsonb, "jsonb_column");
     Block block;
     block.insert(argument);
 
@@ -115,7 +115,7 @@ TEST(JsonbValueConvertorTest, JsonbValueValid) {
     ASSERT_EQ(5, nullable_col->size());
 
     // 2. put column into block
-    ColumnWithTypeAndName argument1(nullable_col->assert_mutable(), nullable_dataTypeJsonb,
+    ColumnWithTypeAndName argument1(std::move(nullable_col), nullable_dataTypeJsonb,
                                     "jsonb_column_null");
     block.clear();
     block.insert(argument1);
@@ -175,7 +175,7 @@ TEST(JsonbValueConvertorTest, JsonbValueInvalid) {
     ASSERT_EQ(input->size(), 5);
 
     // 2. put column into block
-    ColumnWithTypeAndName argument(input->assert_mutable(), dataTypeJsonb, "jsonb_column");
+    ColumnWithTypeAndName argument(std::move(input), dataTypeJsonb, "jsonb_column");
     Block block;
     block.insert(argument);
 
@@ -224,7 +224,7 @@ TEST(JsonbValueConvertorTest, JsonbValueInvalid) {
     ASSERT_EQ(5, nullable_col->size());
 
     // 2. put column into block
-    ColumnWithTypeAndName argument1(nullable_col->assert_mutable(), nullable_dataTypeJsonb,
+    ColumnWithTypeAndName argument1(std::move(nullable_col), nullable_dataTypeJsonb,
                                     "jsonb_column_null");
     block.clear();
     block.insert(argument1);

--- a/be/test/exec/column_type_convert_test.cpp
+++ b/be/test/exec/column_type_convert_test.cpp
@@ -1569,7 +1569,7 @@ TEST_F(ColumnTypeConverterTest, TestStringToDateLikeConversions) {
         src_col->insert_data("bad-date", 8);
 
         auto dst_col = nullable_dst_type->create_column();
-        auto mutable_dst = dst_col->assert_mutable();
+        auto mutable_dst = std::move(dst_col);
         auto& nullable_col = static_cast<ColumnNullable&>(*mutable_dst);
         auto& nested_col = static_cast<ColumnDate&>(nullable_col.get_nested_column());
         auto& null_map = nullable_col.get_null_map_data();
@@ -1597,7 +1597,7 @@ TEST_F(ColumnTypeConverterTest, TestStringToDateLikeConversions) {
         src_col->insert_data("bad-datev2", 10);
 
         auto dst_col = nullable_dst_type->create_column();
-        auto mutable_dst = dst_col->assert_mutable();
+        auto mutable_dst = std::move(dst_col);
         auto& nullable_col = static_cast<ColumnNullable&>(*mutable_dst);
         auto& nested_col = static_cast<ColumnDateV2&>(nullable_col.get_nested_column());
         auto& null_map = nullable_col.get_null_map_data();
@@ -1623,7 +1623,7 @@ TEST_F(ColumnTypeConverterTest, TestStringToDateLikeConversions) {
         src_col->insert_data("bad-datetime", 12);
 
         auto dst_col = nullable_dst_type->create_column();
-        auto mutable_dst = dst_col->assert_mutable();
+        auto mutable_dst = std::move(dst_col);
         auto& nullable_col = static_cast<ColumnNullable&>(*mutable_dst);
         auto& nested_col = static_cast<ColumnDateTime&>(nullable_col.get_nested_column());
         auto& null_map = nullable_col.get_null_map_data();
@@ -1651,7 +1651,7 @@ TEST_F(ColumnTypeConverterTest, TestStringToDateLikeConversions) {
         src_col->insert_data("bad-datetimev2", 14);
 
         auto dst_col = nullable_dst_type->create_column();
-        auto mutable_dst = dst_col->assert_mutable();
+        auto mutable_dst = std::move(dst_col);
         auto& nullable_col = static_cast<ColumnNullable&>(*mutable_dst);
         auto& nested_col = static_cast<ColumnDateTimeV2&>(nullable_col.get_nested_column());
         auto& null_map = nullable_col.get_null_map_data();

--- a/be/test/exec/common/schema_util_test.cpp
+++ b/be/test/exec/common/schema_util_test.cpp
@@ -835,8 +835,9 @@ TEST_F(SchemaUtilTest, TestCastColumnWithExecuteFailure) {
     auto simple_type = std::make_shared<DataTypeJsonb>();
 
     // Insert some test dataset
-    auto nested_array = ColumnArray::create(make_nullable(MutableColumnPtr(ColumnIPv4::create())),
-                                            ColumnArray::ColumnOffsets::create());
+    auto nested_array =
+            ColumnArray::create(make_mut_nullable(MutableColumnPtr(ColumnIPv4::create())),
+                                ColumnArray::ColumnOffsets::create());
     nested_array->insert(Field::create_field<PrimitiveType::TYPE_ARRAY>(Array(IPv4(1))));
     nested_array->insert(Field::create_field<PrimitiveType::TYPE_ARRAY>(Array(IPv4(2))));
 

--- a/be/test/exec/common/schema_util_test.cpp
+++ b/be/test/exec/common/schema_util_test.cpp
@@ -835,7 +835,7 @@ TEST_F(SchemaUtilTest, TestCastColumnWithExecuteFailure) {
     auto simple_type = std::make_shared<DataTypeJsonb>();
 
     // Insert some test dataset
-    auto nested_array = ColumnArray::create(make_nullable(ColumnIPv4::create()),
+    auto nested_array = ColumnArray::create(make_nullable(MutableColumnPtr(ColumnIPv4::create())),
                                             ColumnArray::ColumnOffsets::create());
     nested_array->insert(Field::create_field<PrimitiveType::TYPE_ARRAY>(Array(IPv4(1))));
     nested_array->insert(Field::create_field<PrimitiveType::TYPE_ARRAY>(Array(IPv4(2))));
@@ -1329,10 +1329,11 @@ TEST_F(SchemaUtilTest, TestParseVariantColumnsWithNulls) {
     auto nullable_string = make_nullable(string_column->get_ptr());
 
     auto variant_column = ColumnVariant::create(10, false);
-    variant_column->create_root(string_type, nullable_string->assert_mutable());
+    variant_column->create_root(string_type, IColumn::mutate(std::move(nullable_string)));
     auto nullable_variant = make_nullable(variant_column->get_ptr());
 
-    block.insert({nullable_variant, variant_type, "nullable_variant"});
+    block.insert({static_cast<const IColumn&>(*nullable_variant).get_ptr(), variant_type,
+                  "nullable_variant"});
 
     std::vector<uint32_t> variant_pos {0};
     ParseConfig config;

--- a/be/test/exec/operator/materialization_shared_state_test.cpp
+++ b/be/test/exec/operator/materialization_shared_state_test.cpp
@@ -119,7 +119,7 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponse) {
         value_col_data1->insert(Field::create_field<PrimitiveType::TYPE_INT>(100));
         value_col_data1->insert(Field::create_field<PrimitiveType::TYPE_INT>(101));
         resp_block1.insert(
-                {make_nullable(std::move(resp_value_col1)), make_nullable(_int_type), "value"});
+                {make_mut_nullable(std::move(resp_value_col1)), make_nullable(_int_type), "value"});
 
         PMultiGetResponseV2 response_;
         auto serialized_block = response_.add_blocks()->mutable_block();
@@ -145,7 +145,7 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponse) {
         auto* value_col_data2 = reinterpret_cast<ColumnInt32*>(resp_value_col2.get());
         value_col_data2->insert(Field::create_field<PrimitiveType::TYPE_INT>(200));
         resp_block2.insert(
-                {make_nullable(std::move(resp_value_col2)), make_nullable(_int_type), "value"});
+                {make_mut_nullable(std::move(resp_value_col2)), make_nullable(_int_type), "value"});
 
         PMultiGetResponseV2 response_;
         auto serialized_block = response_.add_blocks()->mutable_block();
@@ -226,8 +226,8 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponseMultiBlocks) {
         auto resp_value_col1 = _int_type->create_column();
         auto* value_col_data1 = reinterpret_cast<ColumnInt32*>(resp_value_col1.get());
         value_col_data1->insert(Field::create_field<PrimitiveType::TYPE_INT>(100));
-        resp_block1.insert(
-                {make_nullable(std::move(resp_value_col1)), make_nullable(_int_type), "value1"});
+        resp_block1.insert({make_mut_nullable(std::move(resp_value_col1)), make_nullable(_int_type),
+                            "value1"});
 
         PMultiGetResponseV2 response_;
         auto serialized_block = response_.add_blocks()->mutable_block();
@@ -251,8 +251,8 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponseMultiBlocks) {
         auto resp_value_col2 = _int_type->create_column();
         auto* value_col_data2 = reinterpret_cast<ColumnInt32*>(resp_value_col2.get());
         value_col_data2->insert(Field::create_field<PrimitiveType::TYPE_INT>(102));
-        resp_block2.insert(
-                {make_nullable(std::move(resp_value_col2)), make_nullable(_int_type), "value1"});
+        resp_block2.insert({make_mut_nullable(std::move(resp_value_col2)), make_nullable(_int_type),
+                            "value1"});
 
         PMultiGetResponseV2 response_;
         auto serialized_block = response_.add_blocks()->mutable_block();
@@ -277,8 +277,8 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponseMultiBlocks) {
         auto resp_value_col1 = _int_type->create_column();
         auto* value_col_data1 = reinterpret_cast<ColumnInt32*>(resp_value_col1.get());
         value_col_data1->insert(Field::create_field<PrimitiveType::TYPE_INT>(200));
-        resp_block1.insert(
-                {make_nullable(std::move(resp_value_col1)), make_nullable(_int_type), "value2"});
+        resp_block1.insert({make_mut_nullable(std::move(resp_value_col1)), make_nullable(_int_type),
+                            "value2"});
 
         auto serialized_block =
                 _shared_state->rpc_struct_map[_backend_id1].response.add_blocks()->mutable_block();
@@ -299,8 +299,8 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponseMultiBlocks) {
         auto resp_value_col2 = _int_type->create_column();
         auto* value_col_data2 = reinterpret_cast<ColumnInt32*>(resp_value_col2.get());
         value_col_data2->insert(Field::create_field<PrimitiveType::TYPE_INT>(201));
-        resp_block2.insert(
-                {make_nullable(std::move(resp_value_col2)), make_nullable(_int_type), "value2"});
+        resp_block2.insert({make_mut_nullable(std::move(resp_value_col2)), make_nullable(_int_type),
+                            "value2"});
 
         auto* serialized_block =
                 _shared_state->rpc_struct_map[_backend_id2].response.add_blocks()->mutable_block();
@@ -368,7 +368,7 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponseBackendNotFound) {
         auto col = _int_type->create_column();
         reinterpret_cast<ColumnInt32*>(col.get())->insert(
                 Field::create_field<PrimitiveType::TYPE_INT>(42));
-        resp_block.insert({make_nullable(std::move(col)), make_nullable(_int_type), "value"});
+        resp_block.insert({make_mut_nullable(std::move(col)), make_nullable(_int_type), "value"});
 
         PMultiGetResponseV2 response;
         auto* serialized_block = response.add_blocks()->mutable_block();
@@ -454,7 +454,7 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponseStaleBlockMaps) {
         auto col = _int_type->create_column();
         reinterpret_cast<ColumnInt32*>(col.get())->insert(
                 Field::create_field<PrimitiveType::TYPE_INT>(100));
-        rel0_block.insert({make_nullable(std::move(col)), make_nullable(_int_type), "price"});
+        rel0_block.insert({make_mut_nullable(std::move(col)), make_nullable(_int_type), "price"});
 
         auto* pb0 = response.add_blocks()->mutable_block();
         size_t us = 0, cs = 0;
@@ -479,7 +479,7 @@ TEST_F(MaterializationSharedStateTest, TestMergeMultiResponseStaleBlockMaps) {
         Block rel1_block;
         auto col = _string_type->create_column();
         reinterpret_cast<ColumnString*>(col.get())->insert_data("Alice", 5);
-        rel1_block.insert({make_nullable(std::move(col)), make_nullable(_string_type), "name"});
+        rel1_block.insert({make_mut_nullable(std::move(col)), make_nullable(_string_type), "name"});
 
         _shared_state->rpc_struct_map[_backend_id2]
                 .request.mutable_request_block_descs(1)

--- a/be/test/exec/operator/table_function_operator_test.cpp
+++ b/be/test/exec/operator/table_function_operator_test.cpp
@@ -1438,8 +1438,9 @@ TEST_F(UnnestTest, inner) {
         for (const auto& id : ids) {
             id_column->insert_data((const char*)(&id), 0);
         }
-        result_block->insert(ColumnWithTypeAndName(make_nullable(std::move(id_column)),
-                                                   data_type_int_nullable, "id"));
+        result_block->insert(
+                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                                      data_type_int_nullable, "id"));
 
         auto arr_data_column = ColumnInt32::create();
         auto arr_offsets_column = ColumnOffset64::create();
@@ -1455,10 +1456,12 @@ TEST_F(UnnestTest, inner) {
         for (size_t i = 1; i < offsets.size(); i++) {
             arr_offsets_column->insert_data((const char*)(&offsets[i]), 0);
         }
-        auto array_column = ColumnArray::create(make_nullable(std::move(arr_data_column)),
-                                                std::move(arr_offsets_column));
-        result_block->insert(ColumnWithTypeAndName(make_nullable(std::move(array_column)),
-                                                   data_type_array_type_nullable, "tags"));
+        auto array_column =
+                ColumnArray::create(make_nullable(MutableColumnPtr(std::move(arr_data_column))),
+                                    std::move(arr_offsets_column));
+        result_block->insert(
+                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(array_column))),
+                                      data_type_array_type_nullable, "tags"));
         return result_block;
     };
 
@@ -1478,7 +1481,8 @@ TEST_F(UnnestTest, inner) {
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         expected_output_block.insert(ColumnWithTypeAndName(
-                make_nullable(std::move(unnested_tag_column)), data_type_int_nullable, "tag"));
+                make_nullable(MutableColumnPtr(std::move(unnested_tag_column))),
+                data_type_int_nullable, "tag"));
         auto mutable_columns = std::move(expected_output_block).mutate_columns();
         mutable_columns[0]->insert_from(
                 *table_func_local_state->_child_block->get_by_position(0).column, 0);
@@ -1546,8 +1550,9 @@ TEST_F(UnnestTest, outer) {
         for (const auto& id : ids) {
             id_column->insert_data((const char*)(&id), 0);
         }
-        result_block->insert(ColumnWithTypeAndName(make_nullable(std::move(id_column)),
-                                                   data_type_int_nullable, "id"));
+        result_block->insert(
+                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                                      data_type_int_nullable, "id"));
 
         auto arr_data_column = ColumnInt32::create();
         auto arr_offsets_column = ColumnOffset64::create();
@@ -1563,10 +1568,12 @@ TEST_F(UnnestTest, outer) {
         for (size_t i = 1; i < offsets.size(); i++) {
             arr_offsets_column->insert_data((const char*)(&offsets[i]), 0);
         }
-        auto array_column = ColumnArray::create(make_nullable(std::move(arr_data_column)),
-                                                std::move(arr_offsets_column));
-        result_block->insert(ColumnWithTypeAndName(make_nullable(std::move(array_column)),
-                                                   data_type_array_type_nullable, "tags"));
+        auto array_column =
+                ColumnArray::create(make_nullable(MutableColumnPtr(std::move(arr_data_column))),
+                                    std::move(arr_offsets_column));
+        result_block->insert(
+                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(array_column))),
+                                      data_type_array_type_nullable, "tags"));
         return result_block;
     };
 
@@ -1587,7 +1594,8 @@ TEST_F(UnnestTest, outer) {
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         expected_output_block.insert(ColumnWithTypeAndName(
-                make_nullable(std::move(unnested_tag_column)), data_type_int_nullable, "tag"));
+                make_nullable(MutableColumnPtr(std::move(unnested_tag_column))),
+                data_type_int_nullable, "tag"));
         auto mutable_columns = std::move(expected_output_block).mutate_columns();
         mutable_columns[0]->insert_from(
                 *table_func_local_state->_child_block->get_by_position(0).column, 0);
@@ -1664,8 +1672,9 @@ TEST_F(UnnestTest, inner_with_nulls_fast_path) {
         for (int32_t id : {1, 2, 3, 4, 5}) {
             id_column->insert_data((const char*)(&id), 0);
         }
-        result_block->insert(ColumnWithTypeAndName(make_nullable(std::move(id_column)),
-                                                   data_type_int_nullable, "id"));
+        result_block->insert(
+                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                                      data_type_int_nullable, "id"));
 
         auto arr_data = ColumnInt32::create();
         auto arr_offsets = ColumnOffset64::create();
@@ -1702,8 +1711,8 @@ TEST_F(UnnestTest, inner_with_nulls_fast_path) {
         arr_offsets->insert_data((const char*)(&off), 0);
         arr_nullmap->get_data().push_back(0);
 
-        auto array_column =
-                ColumnArray::create(make_nullable(std::move(arr_data)), std::move(arr_offsets));
+        auto array_column = ColumnArray::create(
+                make_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
         auto nullable_array =
                 ColumnNullable::create(std::move(array_column), std::move(arr_nullmap));
         result_block->insert(ColumnWithTypeAndName(std::move(nullable_array),
@@ -1793,8 +1802,9 @@ TEST_F(UnnestTest, outer_with_nulls_fast_path) {
         for (int32_t id : {1, 2, 3, 4, 5}) {
             id_column->insert_data((const char*)(&id), 0);
         }
-        result_block->insert(ColumnWithTypeAndName(make_nullable(std::move(id_column)),
-                                                   data_type_int_nullable, "id"));
+        result_block->insert(
+                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                                      data_type_int_nullable, "id"));
 
         auto arr_data = ColumnInt32::create();
         auto arr_offsets = ColumnOffset64::create();
@@ -1831,8 +1841,8 @@ TEST_F(UnnestTest, outer_with_nulls_fast_path) {
         arr_offsets->insert_data((const char*)(&off), 0);
         arr_nullmap->get_data().push_back(0);
 
-        auto array_column =
-                ColumnArray::create(make_nullable(std::move(arr_data)), std::move(arr_offsets));
+        auto array_column = ColumnArray::create(
+                make_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
         auto nullable_array =
                 ColumnNullable::create(std::move(array_column), std::move(arr_nullmap));
         result_block->insert(ColumnWithTypeAndName(std::move(nullable_array),
@@ -2074,8 +2084,9 @@ TEST_F(UnnestTest, posexplode_with_nulls_fast_path) {
         for (int32_t id : {1, 2, 3, 4}) {
             id_column->insert_data((const char*)(&id), 0);
         }
-        result_block->insert(ColumnWithTypeAndName(make_nullable(std::move(id_column)),
-                                                   data_type_int_nullable, "id"));
+        result_block->insert(
+                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                                      data_type_int_nullable, "id"));
 
         auto arr_data = ColumnInt32::create();
         auto arr_offsets = ColumnOffset64::create();
@@ -2104,8 +2115,8 @@ TEST_F(UnnestTest, posexplode_with_nulls_fast_path) {
         arr_offsets->insert_data((const char*)(&off), 0);
         arr_nullmap->get_data().push_back(0);
 
-        auto array_column =
-                ColumnArray::create(make_nullable(std::move(arr_data)), std::move(arr_offsets));
+        auto array_column = ColumnArray::create(
+                make_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
         auto nullable_array =
                 ColumnNullable::create(std::move(array_column), std::move(arr_nullmap));
         result_block->insert(ColumnWithTypeAndName(std::move(nullable_array),

--- a/be/test/exec/operator/table_function_operator_test.cpp
+++ b/be/test/exec/operator/table_function_operator_test.cpp
@@ -44,7 +44,7 @@ namespace doris {
 
 static MutableColumnPtr create_nullable_nested_array_column(MutableColumnPtr nested,
                                                             MutableColumnPtr offsets) {
-    return ColumnArray::create(make_nullable(std::move(nested)), std::move(offsets));
+    return ColumnArray::create(make_mut_nullable(std::move(nested)), std::move(offsets));
 }
 
 class MockTableFunctionChildOperator : public OperatorXBase {
@@ -1439,7 +1439,7 @@ TEST_F(UnnestTest, inner) {
             id_column->insert_data((const char*)(&id), 0);
         }
         result_block->insert(
-                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                ColumnWithTypeAndName(make_mut_nullable(MutableColumnPtr(std::move(id_column))),
                                       data_type_int_nullable, "id"));
 
         auto arr_data_column = ColumnInt32::create();
@@ -1457,10 +1457,10 @@ TEST_F(UnnestTest, inner) {
             arr_offsets_column->insert_data((const char*)(&offsets[i]), 0);
         }
         auto array_column =
-                ColumnArray::create(make_nullable(MutableColumnPtr(std::move(arr_data_column))),
+                ColumnArray::create(make_mut_nullable(MutableColumnPtr(std::move(arr_data_column))),
                                     std::move(arr_offsets_column));
         result_block->insert(
-                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(array_column))),
+                ColumnWithTypeAndName(make_mut_nullable(MutableColumnPtr(std::move(array_column))),
                                       data_type_array_type_nullable, "tags"));
         return result_block;
     };
@@ -1481,7 +1481,7 @@ TEST_F(UnnestTest, inner) {
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         expected_output_block.insert(ColumnWithTypeAndName(
-                make_nullable(MutableColumnPtr(std::move(unnested_tag_column))),
+                make_mut_nullable(MutableColumnPtr(std::move(unnested_tag_column))),
                 data_type_int_nullable, "tag"));
         auto mutable_columns = std::move(expected_output_block).mutate_columns();
         mutable_columns[0]->insert_from(
@@ -1551,7 +1551,7 @@ TEST_F(UnnestTest, outer) {
             id_column->insert_data((const char*)(&id), 0);
         }
         result_block->insert(
-                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                ColumnWithTypeAndName(make_mut_nullable(MutableColumnPtr(std::move(id_column))),
                                       data_type_int_nullable, "id"));
 
         auto arr_data_column = ColumnInt32::create();
@@ -1569,10 +1569,10 @@ TEST_F(UnnestTest, outer) {
             arr_offsets_column->insert_data((const char*)(&offsets[i]), 0);
         }
         auto array_column =
-                ColumnArray::create(make_nullable(MutableColumnPtr(std::move(arr_data_column))),
+                ColumnArray::create(make_mut_nullable(MutableColumnPtr(std::move(arr_data_column))),
                                     std::move(arr_offsets_column));
         result_block->insert(
-                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(array_column))),
+                ColumnWithTypeAndName(make_mut_nullable(MutableColumnPtr(std::move(array_column))),
                                       data_type_array_type_nullable, "tags"));
         return result_block;
     };
@@ -1594,7 +1594,7 @@ TEST_F(UnnestTest, outer) {
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         unnested_tag_column->insert_data((const char*)(ids.data()), 0);
         expected_output_block.insert(ColumnWithTypeAndName(
-                make_nullable(MutableColumnPtr(std::move(unnested_tag_column))),
+                make_mut_nullable(MutableColumnPtr(std::move(unnested_tag_column))),
                 data_type_int_nullable, "tag"));
         auto mutable_columns = std::move(expected_output_block).mutate_columns();
         mutable_columns[0]->insert_from(
@@ -1673,7 +1673,7 @@ TEST_F(UnnestTest, inner_with_nulls_fast_path) {
             id_column->insert_data((const char*)(&id), 0);
         }
         result_block->insert(
-                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                ColumnWithTypeAndName(make_mut_nullable(MutableColumnPtr(std::move(id_column))),
                                       data_type_int_nullable, "id"));
 
         auto arr_data = ColumnInt32::create();
@@ -1712,7 +1712,7 @@ TEST_F(UnnestTest, inner_with_nulls_fast_path) {
         arr_nullmap->get_data().push_back(0);
 
         auto array_column = ColumnArray::create(
-                make_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
+                make_mut_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
         auto nullable_array =
                 ColumnNullable::create(std::move(array_column), std::move(arr_nullmap));
         result_block->insert(ColumnWithTypeAndName(std::move(nullable_array),
@@ -1803,7 +1803,7 @@ TEST_F(UnnestTest, outer_with_nulls_fast_path) {
             id_column->insert_data((const char*)(&id), 0);
         }
         result_block->insert(
-                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                ColumnWithTypeAndName(make_mut_nullable(MutableColumnPtr(std::move(id_column))),
                                       data_type_int_nullable, "id"));
 
         auto arr_data = ColumnInt32::create();
@@ -1842,7 +1842,7 @@ TEST_F(UnnestTest, outer_with_nulls_fast_path) {
         arr_nullmap->get_data().push_back(0);
 
         auto array_column = ColumnArray::create(
-                make_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
+                make_mut_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
         auto nullable_array =
                 ColumnNullable::create(std::move(array_column), std::move(arr_nullmap));
         result_block->insert(ColumnWithTypeAndName(std::move(nullable_array),
@@ -2085,7 +2085,7 @@ TEST_F(UnnestTest, posexplode_with_nulls_fast_path) {
             id_column->insert_data((const char*)(&id), 0);
         }
         result_block->insert(
-                ColumnWithTypeAndName(make_nullable(MutableColumnPtr(std::move(id_column))),
+                ColumnWithTypeAndName(make_mut_nullable(MutableColumnPtr(std::move(id_column))),
                                       data_type_int_nullable, "id"));
 
         auto arr_data = ColumnInt32::create();
@@ -2116,7 +2116,7 @@ TEST_F(UnnestTest, posexplode_with_nulls_fast_path) {
         arr_nullmap->get_data().push_back(0);
 
         auto array_column = ColumnArray::create(
-                make_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
+                make_mut_nullable(MutableColumnPtr(std::move(arr_data))), std::move(arr_offsets));
         auto nullable_array =
                 ColumnNullable::create(std::move(array_column), std::move(arr_nullmap));
         result_block->insert(ColumnWithTypeAndName(std::move(nullable_array),

--- a/be/test/exprs/aggregate/agg_array_agg_test.cpp
+++ b/be/test/exprs/aggregate/agg_array_agg_test.cpp
@@ -70,8 +70,8 @@ TEST_F(AggregateFunctionArrayAggTest, test_array_agg_aint64) {
     for (auto& v : vals) {
         data_column->insert_data((const char*)(&v), 0);
     }
-    auto array_column =
-            ColumnArray::create(make_nullable(std::move(data_column)), std::move(off_column));
+    auto array_column = ColumnArray::create(make_nullable(MutableColumnPtr(std::move(data_column))),
+                                            std::move(off_column));
 
     execute(Block({ColumnHelper::create_column_with_name<DataTypeInt64>({1, 2, 3})}),
             ColumnWithTypeAndName(std::move(array_column), array_data_type, "column"));

--- a/be/test/exprs/aggregate/agg_array_agg_test.cpp
+++ b/be/test/exprs/aggregate/agg_array_agg_test.cpp
@@ -70,8 +70,8 @@ TEST_F(AggregateFunctionArrayAggTest, test_array_agg_aint64) {
     for (auto& v : vals) {
         data_column->insert_data((const char*)(&v), 0);
     }
-    auto array_column = ColumnArray::create(make_nullable(MutableColumnPtr(std::move(data_column))),
-                                            std::move(off_column));
+    auto array_column = ColumnArray::create(
+            make_mut_nullable(MutableColumnPtr(std::move(data_column))), std::move(off_column));
 
     execute(Block({ColumnHelper::create_column_with_name<DataTypeInt64>({1, 2, 3})}),
             ColumnWithTypeAndName(std::move(array_column), array_data_type, "column"));

--- a/be/test/exprs/aggregate/agg_collect_test.cpp
+++ b/be/test/exprs/aggregate/agg_collect_test.cpp
@@ -146,13 +146,14 @@ public:
         agg_collect_add_elements<DataType>(agg_function, place2, input_nums, support_complex);
 
         agg_function->merge(place, place2, _agg_arena_pool);
-        auto column_result = ColumnArray::create(make_nullable(data_types[0]->create_column()));
+        auto column_result = ColumnArray::create(make_mut_nullable(data_types[0]->create_column()));
         agg_function->insert_result_into(place, *column_result);
         EXPECT_EQ(column_result->size(), 1);
         EXPECT_EQ(column_result->get_offsets()[0],
                   is_distinct(fn_name) ? input_nums : 2 * input_nums * _repeated_times);
 
-        auto column_result2 = ColumnArray::create(make_nullable(data_types[0]->create_column()));
+        auto column_result2 =
+                ColumnArray::create(make_mut_nullable(data_types[0]->create_column()));
         agg_function->insert_result_into(place2, *column_result2);
         EXPECT_EQ(column_result2->size(), 1);
         EXPECT_EQ(column_result2->get_offsets()[0],
@@ -299,7 +300,7 @@ TEST_F(AggregateFunctionCollectTest, test_collect_list_aint64) {
         data_column->insert_data((const char*)(&v), 0);
     }
     auto array_column =
-            ColumnArray::create(make_nullable(data_column->clone()), std::move(off_column));
+            ColumnArray::create(make_mut_nullable(data_column->clone()), std::move(off_column));
 
     execute(Block({ColumnHelper::create_column_with_name<DataTypeInt64>({1, 2, 3})}),
             ColumnWithTypeAndName(std::move(array_column), array_data_type, "column"));
@@ -324,7 +325,7 @@ TEST_F(AggregateFunctionCollectTest, test_collect_list_aint64_with_max_size) {
         data_column->insert_data((const char*)(&v), 0);
     }
     auto array_column =
-            ColumnArray::create(make_nullable(data_column->clone()), std::move(off_column));
+            ColumnArray::create(make_mut_nullable(data_column->clone()), std::move(off_column));
 
     execute(Block({ColumnHelper::create_column_with_name<DataTypeInt64>({1, 2, 3, 4}),
                    ColumnHelper::create_column_with_name<DataTypeInt32>({3, 3, 3, 3})}),
@@ -349,7 +350,7 @@ TEST_F(AggregateFunctionCollectTest, test_collect_set_aint64) {
         data_column->insert_data((const char*)(&v), 0);
     }
     auto array_column =
-            ColumnArray::create(make_nullable(data_column->clone()), std::move(off_column));
+            ColumnArray::create(make_mut_nullable(data_column->clone()), std::move(off_column));
 
     execute(Block({ColumnHelper::create_column_with_name<DataTypeInt64>({1, 2, 3})}),
             ColumnWithTypeAndName(std::move(array_column), array_data_type, "column"));
@@ -374,7 +375,7 @@ TEST_F(AggregateFunctionCollectTest, test_collect_set_aint64_with_max_size) {
         data_column->insert_data((const char*)(&v), 0);
     }
     auto array_column =
-            ColumnArray::create(make_nullable(data_column->clone()), std::move(off_column));
+            ColumnArray::create(make_mut_nullable(data_column->clone()), std::move(off_column));
 
     execute(Block({ColumnHelper::create_column_with_name<DataTypeInt64>({1, 2, 3, 4, 3}),
                    ColumnHelper::create_column_with_name<DataTypeInt32>({3, 3, 3, 3, 3})}),

--- a/be/test/exprs/aggregate/agg_collect_test.cpp
+++ b/be/test/exprs/aggregate/agg_collect_test.cpp
@@ -146,16 +146,14 @@ public:
         agg_collect_add_elements<DataType>(agg_function, place2, input_nums, support_complex);
 
         agg_function->merge(place, place2, _agg_arena_pool);
-        auto column_result =
-                ColumnArray::create(std::move(make_nullable(data_types[0]->create_column())));
-        agg_function->insert_result_into(place, column_result->assert_mutable_ref());
+        auto column_result = ColumnArray::create(make_nullable(data_types[0]->create_column()));
+        agg_function->insert_result_into(place, *column_result);
         EXPECT_EQ(column_result->size(), 1);
         EXPECT_EQ(column_result->get_offsets()[0],
                   is_distinct(fn_name) ? input_nums : 2 * input_nums * _repeated_times);
 
-        auto column_result2 =
-                ColumnArray::create(std::move(make_nullable(data_types[0]->create_column())));
-        agg_function->insert_result_into(place2, column_result2->assert_mutable_ref());
+        auto column_result2 = ColumnArray::create(make_nullable(data_types[0]->create_column()));
+        agg_function->insert_result_into(place2, *column_result2);
         EXPECT_EQ(column_result2->size(), 1);
         EXPECT_EQ(column_result2->get_offsets()[0],
                   is_distinct(fn_name) ? input_nums : input_nums * _repeated_times);

--- a/be/test/exprs/function/function_variant_element_test.cpp
+++ b/be/test/exprs/function/function_variant_element_test.cpp
@@ -43,11 +43,9 @@ TEST(function_variant_element_test, extract_from_sparse_column) {
     variant_ptr->get_doc_value_column_mutable().resize(1);
 
     ColumnPtr result;
-    ColumnPtr index_column_ptr = ColumnString::create();
-    auto* index_column_ptr_mutable =
-            assert_cast<ColumnString*>(index_column_ptr->assert_mutable().get());
-    index_column_ptr_mutable->insert_data("profile", 7);
-    ColumnPtr index_column = ColumnConst::create(index_column_ptr, 1);
+    auto index_column_ptr = ColumnString::create();
+    index_column_ptr->insert_data("profile", 7);
+    ColumnPtr index_column = ColumnConst::create(std::move(index_column_ptr), 1);
     auto status =
             FunctionVariantElement::get_element_column(*variant_column, index_column, &result);
     EXPECT_TRUE(status.ok());

--- a/be/test/format/native/native_reader_writer_test.cpp
+++ b/be/test/format/native/native_reader_writer_test.cpp
@@ -98,7 +98,7 @@ static void fill_array_column(Block& block, size_t rows) {
         auto& array_col = assert_cast<ColumnArray&>(nested);
         auto& offsets = array_col.get_offsets();
         auto& data = array_col.get_data();
-        auto mutable_data = data.assert_mutable();
+        auto* mutable_data = &data;
 
         for (size_t i = 0; i < rows; ++i) {
             if (i % 5 == 0) {
@@ -144,8 +144,8 @@ static void fill_map_column(Block& block, size_t rows) {
                 auto& keys = assert_cast<ColumnMap&>(nested).get_keys();
                 auto& values = assert_cast<ColumnMap&>(nested).get_values();
 
-                auto mutable_keys = keys.assert_mutable();
-                auto mutable_values = values.assert_mutable();
+                auto* mutable_keys = &keys;
+                auto* mutable_values = &values;
 
                 std::string k1 = "k" + std::to_string(i);
                 std::string k2 = "k" + std::to_string(i + 1);
@@ -180,21 +180,20 @@ static void fill_struct_column(Block& block, size_t rows) {
         auto& null_map = nullable_col->get_null_map_data();
 
         auto& struct_col = assert_cast<ColumnStruct&>(nested);
-        const auto& fields = struct_col.get_columns();
 
         for (size_t i = 0; i < rows; ++i) {
             if (i % 6 == 0) {
                 nullable_col->insert_default();
             } else {
                 null_map.push_back(0);
-                auto mutable_field0 = fields[0]->assert_mutable();
-                auto mutable_field1 = fields[1]->assert_mutable();
+                auto& field0 = struct_col.get_column(0);
+                auto& field1 = struct_col.get_column(1);
                 // int field
-                mutable_field0->insert(Field::create_field<PrimitiveType::TYPE_INT>(
+                field0.insert(Field::create_field<PrimitiveType::TYPE_INT>(
                         static_cast<int32_t>(i * 100)));
                 // string field
                 std::string vs = "ss" + std::to_string(i);
-                mutable_field1->insert(Field::create_field<PrimitiveType::TYPE_VARCHAR>(vs));
+                field1.insert(Field::create_field<PrimitiveType::TYPE_VARCHAR>(vs));
             }
         }
         block.insert(ColumnWithTypeAndName(std::move(col), struct_type, "struct_col"));
@@ -1069,7 +1068,7 @@ static Block create_all_types_test_block() {
         auto& array_col = assert_cast<ColumnArray&>(nested);
         auto& offsets = array_col.get_offsets();
         auto& data = array_col.get_data();
-        auto mutable_data = data.assert_mutable();
+        auto* mutable_data = &data;
 
         mutable_data->insert(
                 Field::create_field<PrimitiveType::TYPE_INT>(static_cast<int32_t>(10)));
@@ -1098,8 +1097,8 @@ static Block create_all_types_test_block() {
         auto& keys = assert_cast<ColumnMap&>(nested).get_keys();
         auto& values = assert_cast<ColumnMap&>(nested).get_values();
 
-        auto mutable_keys = keys.assert_mutable();
-        auto mutable_values = values.assert_mutable();
+        auto* mutable_keys = &keys;
+        auto* mutable_values = &values;
 
         mutable_keys->insert(Field::create_field<PrimitiveType::TYPE_VARCHAR>(std::string("key1")));
         mutable_values->insert(
@@ -1129,14 +1128,11 @@ static Block create_all_types_test_block() {
         null_map.push_back(0); // non-null
 
         auto& struct_col = assert_cast<ColumnStruct&>(nested);
-        const auto& fields = struct_col.get_columns();
-        auto mutable_field0 = fields[0]->assert_mutable();
-        auto mutable_field1 = fields[1]->assert_mutable();
+        auto& field0 = struct_col.get_column(0);
+        auto& field1 = struct_col.get_column(1);
 
-        mutable_field0->insert(
-                Field::create_field<PrimitiveType::TYPE_INT>(static_cast<int32_t>(999)));
-        mutable_field1->insert(
-                Field::create_field<PrimitiveType::TYPE_VARCHAR>(std::string("struct_val")));
+        field0.insert(Field::create_field<PrimitiveType::TYPE_INT>(static_cast<int32_t>(999)));
+        field1.insert(Field::create_field<PrimitiveType::TYPE_VARCHAR>(std::string("struct_val")));
         block.insert(ColumnWithTypeAndName(std::move(col), struct_type, "col_struct"));
     }
 

--- a/be/test/format/orc/orc_read_lines.cpp
+++ b/be/test/format/orc/orc_read_lines.cpp
@@ -157,8 +157,8 @@ static void read_orc_line(int64_t line, std::string block_dump,
     }
     auto data_type =
             DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_VARCHAR, false);
-    block->insert(ColumnWithTypeAndName(data_type->create_column()->assert_mutable(), data_type,
-                                        "row_id"));
+    MutableColumnPtr row_id_column = data_type->create_column();
+    block->insert(ColumnWithTypeAndName(std::move(row_id_column), data_type, "row_id"));
 
     bool eof = false;
     size_t read_row = 0;

--- a/be/test/format/orc/orc_reader_fill_data_test.cpp
+++ b/be/test/format/orc/orc_reader_fill_data_test.cpp
@@ -83,7 +83,7 @@ TEST_F(OrcReaderFillDataTest, TestFillLongColumn) {
     TFileRangeDesc range;
     auto reader = OrcReader::create_unique(params, range, 4064, "", nullptr, nullptr, true);
 
-    MutableColumnPtr xx = column->assert_mutable();
+    MutableColumnPtr xx = column->get_ptr();
 
     Status status = reader->_fill_doris_data_column<false>(
             "test_long", xx, data_type, const_node, orc_type_ptr.get(), batch.get(), values.size());
@@ -109,7 +109,7 @@ TEST_F(OrcReaderFillDataTest, TestFillLongColumnWithNull) {
     TFileRangeDesc range;
     auto reader = OrcReader::create_unique(params, range, 4064, "", nullptr, nullptr, true);
 
-    MutableColumnPtr xx = column->assert_mutable();
+    MutableColumnPtr xx = column->get_ptr();
 
     Status status =
             reader->_fill_doris_data_column<false>("test_long_with_null", xx, data_type, const_node,
@@ -204,7 +204,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
                 std::vector<DataTypePtr> {
                         std::make_shared<DataTypeArray>(std::make_shared<DataTypeInt32>())},
                 std::vector<std::string> {"col1"});
-        MutableColumnPtr doris_column = doris_struct_type->create_column()->assert_mutable();
+        MutableColumnPtr doris_column = doris_struct_type->create_column();
 
         Status status = reader->_fill_doris_data_column<false>("test", doris_column,
                                                                doris_struct_type, const_node,
@@ -290,7 +290,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
                 std::vector<DataTypePtr> {std::make_shared<DataTypeInt32>(),
                                           std::make_shared<DataTypeInt32>()},
                 std::vector<std::string> {"col1", "col2"});
-        MutableColumnPtr doris_column = doris_struct_type->create_column()->assert_mutable();
+        MutableColumnPtr doris_column = doris_struct_type->create_column();
 
         Status status = reader->_fill_doris_data_column<false>("test", doris_column,
                                                                doris_struct_type, const_node,
@@ -375,7 +375,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
         auto doris_struct_type = std::make_shared<DataTypeStruct>(
                 std::vector<DataTypePtr> {std::make_shared<DataTypeDecimal64>(18, 5)},
                 std::vector<std::string> {"col1"});
-        MutableColumnPtr doris_column = doris_struct_type->create_column()->assert_mutable();
+        MutableColumnPtr doris_column = doris_struct_type->create_column();
         reader->_decimal_scale_params.resize(0);
         reader->_decimal_scale_params_index = 0;
         Status status = reader->_fill_doris_data_column<false>("test", doris_column,
@@ -488,7 +488,7 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
 
         auto doris_struct_type = std::make_shared<DataTypeMap>(std::make_shared<DataTypeInt32>(),
                                                                std::make_shared<DataTypeFloat32>());
-        MutableColumnPtr doris_column = doris_struct_type->create_column()->assert_mutable();
+        MutableColumnPtr doris_column = doris_struct_type->create_column();
 
         Status status =
                 reader->_fill_doris_data_column<false>("test", doris_column, doris_struct_type,

--- a/be/test/format/parquet/parquet_read_lines.cpp
+++ b/be/test/format/parquet/parquet_read_lines.cpp
@@ -170,8 +170,8 @@ static void read_parquet_lines(std::vector<std::string> numeric_types,
 
     auto data_type =
             DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_VARCHAR, false);
-    block->insert(ColumnWithTypeAndName(data_type->create_column()->assert_mutable(), data_type,
-                                        "row_id"));
+    MutableColumnPtr row_id_column = data_type->create_column();
+    block->insert(ColumnWithTypeAndName(std::move(row_id_column), data_type, "row_id"));
 
     bool eof = false;
     size_t read_row = 0;

--- a/be/test/storage/iterator/vertical_merge_iterator_test.cpp
+++ b/be/test/storage/iterator/vertical_merge_iterator_test.cpp
@@ -83,7 +83,7 @@ protected:
     // Simulate copy_rows logic for nullable columns with sparse optimization
     static void copy_rows_with_optimization(const ColumnNullable* src, size_t start, size_t count,
                                             IColumn* dst_col) {
-        auto* dst_mut = dst_col->assert_mutable().get();
+        auto* dst_mut = dst_col;
 
         const size_t non_null_count = count_non_null(src, start, count);
 
@@ -112,7 +112,7 @@ protected:
     // Original copy_rows logic (direct copy)
     static void copy_rows_original(const IColumn* src, size_t start, size_t count,
                                    IColumn* dst_col) {
-        dst_col->assert_mutable()->insert_range_from(*src, start, count);
+        dst_col->insert_range_from(*src, start, count);
     }
 
     // Helper to compare two nullable columns

--- a/be/test/storage/segment/variant_stats_calculator_test.cpp
+++ b/be/test/storage/segment/variant_stats_calculator_test.cpp
@@ -102,7 +102,7 @@ protected:
     }
 
     // Helper method to create a map column (sparse column)
-    ColumnPtr create_map_column() {
+    ColumnMap::MutablePtr create_map_column() {
         auto keys = ColumnString::create();
         auto values = ColumnString::create();
         auto offsets = ColumnArray::ColumnOffsets::create();
@@ -220,7 +220,7 @@ TEST_F(VariantStatsCalculatorTest, CalculateVariantStatsWithSparseColumn) {
     auto string_column = ColumnString::create();
     // add parant column to block
     block.insert({std::move(string_column), std::make_shared<DataTypeString>(), "variant_column"});
-    block.insert({std::move(map_column),
+    block.insert({static_cast<const IColumn&>(*map_column).get_ptr(),
                   std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(),
                                                 std::make_shared<DataTypeString>()),
                   "sparse_column"});
@@ -312,8 +312,8 @@ TEST_F(VariantStatsCalculatorTest, CalculateVariantStatsWithMultipleColumns) {
                   std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()), "sub1"});
 
     auto map_col = create_map_column();
-    map_col->assert_mutable()->insert_many_defaults(3);
-    block.insert({std::move(map_col),
+    map_col->insert_many_defaults(3);
+    block.insert({static_cast<const IColumn&>(*map_col).get_ptr(),
                   std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(),
                                                 std::make_shared<DataTypeString>()),
                   "sparse"});


### PR DESCRIPTION
### What problem does this PR solve?


Problem Summary: Some BE column code still called assert_mutable() on values that were already held through mutable column pointers. This made mutable ownership paths harder to read and allowed redundant mutable assertions to stay unnoticed. This change deletes non-const assert_mutable()/assert_mutable_ref() overloads so such calls fail at compile time, and updates low-risk BE expr/storage call sites to use mutable pointers directly.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

