### PR TITLE
[fix](be) Fix PCH race condition with gensrc headers

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -894,7 +894,13 @@ if (ENABLE_PCH)
         endif()
     endif()
 
-    add_library(pch STATIC ${SRC_DIR}pch/pch.cc)
+    # Add gensrc headers as PCH dependencies so ninja rebuilds PCH when they change.
+    file(GLOB GENSRC_PCH_DEPENDS
+        ${GENSRC_DIR}/gen_cpp/*.h
+    )
+
+    add_library(pch STATIC ${SRC_DIR}pch/pch.cc ${GENSRC_PCH_DEPENDS})
+    set_source_files_properties(${GENSRC_PCH_DEPENDS} PROPERTIES HEADER_FILE_ONLY ON)
     target_precompile_headers(
         pch
         PUBLIC


### PR DESCRIPTION
### What problem does this PR solve?

BE build error in Ubuntu 20.4 with ldb_toolchain
```
clang --version
clang version 20.1.8
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /data1/home/wujianchao/project/jd/ldb_toolchain/tmp/gentoo/llvm/bin
```

```
  [91/1347] Building CXX object CMakeFiles/pch.dir/src/pch/pch.cc.o
  FAILED: [code=1] CMakeFiles/pch.dir/src/pch/pch.cc.o
  ccache /data1/home/wujianchao/project/jd/ldb_toolchain/bin/clang++ -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DBOOST_STACKTRACE_USE_BACKTRACE
  -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1 -DBRPC_ENABLE_CPU_PROFILER -DGLOG_CUSTOM_PREFIX_SUPPORT -DHAVE_INTTYPES_H
  -DHAVE_NETINET_IN_H -DLIBDIVIDE_AVX2 -DLIBDIVIDE_SSE2 -DLIBJVM -DS2_USE_GFLAGS -DS2_USE_GLOG -DUSE_AVX2 -DUSE_AZURE -DUSE_DORIS_HADOOP_HDFS -DUSE_HADOOP_HDFS
  -DUSE_JEMALLOC -DUSE_UNWIND -D__STDC_FORMAT_MACROS -I/data1/home/wujianchao/project/jd/doris/be/../contrib/apache-orc/c++/include -I/data1/home/wujianchao/
  project/jd/doris/be/build_Release/apache-orc/c++/include -I/data1/home/wujianchao/project/jd/doris/be/build_Release/clucene/src/shared -I/data1/home/wujianchao/
  project/jd/doris/be/../contrib/clucene/src/core -I/data1/home/wujianchao/project/jd/doris/be/../contrib/clucene/src/shared -I/data1/home/wujianchao/project/jd/
  doris/be/../contrib/clucene/src/contribs-lib -I/data1/home/wujianchao/project/jd/doris/be/src -I/usr/lib/jvm/java-17-openjdk-amd64/include -I/usr/lib/jvm/java-
  17-openjdk-amd64/include/linux -isystem /data1/home/wujianchao/project/jd/doris/be/../common -isystem /data1/home/wujianchao/project/jd/doris/be/../gensrc/build
  -isystem /data1/home/wujianchao/project/jd/doris_thirdparty_4.1/installed/include -isystem /data1/home/wujianchao/project/jd/doris_thirdparty_4.1/installed/
  gperftools/include -O3 -DNDEBUG  -O3 -DNDEBUG -std=gnu++20   -D OS_LINUX -ffile-prefix-map=/data1/home/wujianchao/project/jd/doris=. -g -gdwarf-5 -Wall -Wextra
  -Werror -Wundef -pthread -fstrict-aliasing -fno-omit-frame-pointer -Wnon-virtual-dtor -Wno-unused-parameter -Wno-sign-compare -fcolor-diagnostics -Wpedantic
  -Wshadow -Wshadow-field -Wunused -Wunused-command-line-argument -Wunused-exception-parameter -Wunused-volatile-lvalue -Wunused-template -Wunused-member-function
  -Wunused-macros -Wconversion -Wthread-safety -Wno-gnu-statement-expression -Wno-implicit-float-conversion -Wno-sign-conversion -msse4.2 -mavx2 -gdwarf-aranges
  -fopenmp=libomp -fopenmp=libomp -Xclang -fno-pch-timestamp -Winvalid-pch -Xclang -include-pch -Xclang /data1/home/wujianchao/project/jd/doris/be/build_Release/
  CMakeFiles/pch.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /data1/home/wujianchao/project/jd/doris/be/build_Release/CMakeFiles/pch.dir/cmake_pch.hxx -MD -MT
  CMakeFiles/pch.dir/src/pch/pch.cc.o -MF CMakeFiles/pch.dir/src/pch/pch.cc.o.d -o CMakeFiles/pch.dir/src/pch/pch.cc.o -c /data1/home/wujianchao/project/jd/doris/
  be/src/pch/pch.cc
  fatal error: file '/data1/home/wujianchao/project/jd/doris/be/build_Release/../../gensrc/build/gen_cpp/AgentService_types.h' has been modified since the
  precompiled header '/data1/home/wujianchao/project/jd/doris/be/build_Release/CMakeFiles/pch.dir/cmake_pch.hxx.pch' was built: size changed (was 176517, now
  175478)
  note: please rebuild precompiled header '/data1/home/wujianchao/project/jd/doris/be/build_Release/CMakeFiles/pch.dir/cmake_pch.hxx.pch'
  1 error generated.
```

Problem Summary:
PCH race condition with gensrc headers

Add gensrc headers as HEADER_FILE_ONLY PCH dependencies so ninja rebuilds PCH when they change, preventing "file has been modified since the precompiled header was built: size changed" errors.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [x] Other reason be build system related

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

