### PR TITLE
[bug](iceberg) fix can't get migrated Iceberg tables format type

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run10.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/iceberg/run10.sql
@@ -8,7 +8,7 @@ CREATE TABLE sc_drop_add_orc (
 )
 USING iceberg
 PARTITIONED BY (id)
-TBLPROPERTIES ('format'='orc');
+TBLPROPERTIES ('write.format.default' = 'orc');
 
 INSERT INTO sc_drop_add_orc VALUES (1, 'Alice', 25);
 INSERT INTO sc_drop_add_orc VALUES (2, 'Bob', 30);
@@ -32,7 +32,7 @@ CREATE TABLE sc_drop_add_parquet (
 )
 USING iceberg
 PARTITIONED BY (id)
-TBLPROPERTIES ('format'='parquet');
+TBLPROPERTIES ('write.format.default' = 'parquet');
 
 INSERT INTO sc_drop_add_parquet VALUES (1, 'Alice', 25);
 INSERT INTO sc_drop_add_parquet VALUES (2, 'Bob', 30);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -1141,12 +1141,16 @@ public class IcebergUtils {
 
     public static FileFormat getFileFormat(Table icebergTable) {
         Map<String, String> properties = icebergTable.properties();
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            LOG.info("asd Iceberg table property: {}={}", entry.getKey(), entry.getValue());
+        }
         String fileFormatName;
         if (properties.containsKey(WRITE_FORMAT)) {
             fileFormatName = properties.get(WRITE_FORMAT);
         } else {
             fileFormatName = properties.getOrDefault(TableProperties.DEFAULT_FILE_FORMAT, PARQUET_NAME);
         }
+        LOG.info("asd Iceberg table {}.{} file format is {}", icebergTable.name(), fileFormatName);
         FileFormat fileFormat;
         if (fileFormatName.toLowerCase().contains(ORC_NAME)) {
             fileFormat = FileFormat.ORC;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -169,8 +169,6 @@ public class IcebergUtils {
     // nickname in flink and spark
     public static final String WRITE_FORMAT = "write-format";
     public static final String COMPRESSION_CODEC = "compression-codec";
-    // For migrated Iceberg tables, the format may be stored as "iceberg/parquet" or "iceberg/orc"
-    public static final String FORMAT = "format";
 
     // nickname in spark
     public static final String SPARK_SQL_COMPRESSION_CODEC = "spark.sql.iceberg.compression-codec";
@@ -1164,12 +1162,7 @@ public class IcebergUtils {
         if (properties.containsKey(TableProperties.DEFAULT_FILE_FORMAT)) {
             return properties.get(TableProperties.DEFAULT_FILE_FORMAT);
         }
-        // 3. Check "format" property (e.g., "iceberg/parquet", "iceberg/orc")
-        //    This is commonly set on migrated Iceberg tables.
-        if (properties.containsKey(FORMAT)) {
-            return properties.get(FORMAT);
-        }
-        // 4. Last resort: infer from the actual data files in the current snapshot.
+        // 3. Last resort: infer from the actual data files in the current snapshot.
         //    This handles migrated tables where none of the above properties are set.
         return inferFileFormatFromDataFiles(icebergTable);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergUtils.java
@@ -169,6 +169,8 @@ public class IcebergUtils {
     // nickname in flink and spark
     public static final String WRITE_FORMAT = "write-format";
     public static final String COMPRESSION_CODEC = "compression-codec";
+    // For migrated Iceberg tables, the format may be stored as "iceberg/parquet" or "iceberg/orc"
+    public static final String FORMAT = "format";
 
     // nickname in spark
     public static final String SPARK_SQL_COMPRESSION_CODEC = "spark.sql.iceberg.compression-codec";
@@ -1141,16 +1143,7 @@ public class IcebergUtils {
 
     public static FileFormat getFileFormat(Table icebergTable) {
         Map<String, String> properties = icebergTable.properties();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            LOG.info("asd Iceberg table property: {}={}", entry.getKey(), entry.getValue());
-        }
-        String fileFormatName;
-        if (properties.containsKey(WRITE_FORMAT)) {
-            fileFormatName = properties.get(WRITE_FORMAT);
-        } else {
-            fileFormatName = properties.getOrDefault(TableProperties.DEFAULT_FILE_FORMAT, PARQUET_NAME);
-        }
-        LOG.info("asd Iceberg table {}.{} file format is {}", icebergTable.name(), fileFormatName);
+        String fileFormatName = resolveFileFormatName(icebergTable, properties);
         FileFormat fileFormat;
         if (fileFormatName.toLowerCase().contains(ORC_NAME)) {
             fileFormat = FileFormat.ORC;
@@ -1160,6 +1153,44 @@ public class IcebergUtils {
             throw new RuntimeException("Unsupported input format type: " + fileFormatName);
         }
         return fileFormat;
+    }
+
+    private static String resolveFileFormatName(Table icebergTable, Map<String, String> properties) {
+        // 1. Check "write-format" (nickname in Flink and Spark)
+        if (properties.containsKey(WRITE_FORMAT)) {
+            return properties.get(WRITE_FORMAT);
+        }
+        // 2. Check "write.format.default" (standard Iceberg property)
+        if (properties.containsKey(TableProperties.DEFAULT_FILE_FORMAT)) {
+            return properties.get(TableProperties.DEFAULT_FILE_FORMAT);
+        }
+        // 3. Check "format" property (e.g., "iceberg/parquet", "iceberg/orc")
+        //    This is commonly set on migrated Iceberg tables.
+        if (properties.containsKey(FORMAT)) {
+            return properties.get(FORMAT);
+        }
+        // 4. Last resort: infer from the actual data files in the current snapshot.
+        //    This handles migrated tables where none of the above properties are set.
+        return inferFileFormatFromDataFiles(icebergTable);
+    }
+
+    private static String inferFileFormatFromDataFiles(Table icebergTable) {
+        if (icebergTable.currentSnapshot() == null) {
+            LOG.info("Iceberg table {} has no snapshot, defaulting to {}", icebergTable.name(), PARQUET_NAME);
+            return PARQUET_NAME;
+        }
+        try (CloseableIterable<FileScanTask> files = icebergTable.newScan().planFiles()) {
+            java.util.Iterator<FileScanTask> it = files.iterator();
+            if (it.hasNext()) {
+                String format = it.next().file().format().name().toLowerCase();
+                LOG.info("Iceberg table {} inferred file format {} from data files", icebergTable.name(), format);
+                return format;
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to infer file format from data files for table {}, defaulting to {}",
+                    icebergTable.name(), PARQUET_NAME, e);
+        }
+        return PARQUET_NAME;
     }
 
 


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:

```
[CORRUPTION]Invalid magic number in parquet file, bytes read: 253, file size: 253,
path: /user/hive/warehouse/test_migrate_managed_...,
read magic: ORC .
```

The migrated Iceberg table properties don't have "write-format" or "write.format.default".
so doris use the default type of parquet as the table format. but it's actual a ORC type.
now add more check to infer the table format type.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

