### PR TITLE
[fix](be) Fix binlog compaction success log

### DIFF
--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -34,6 +34,7 @@
 #include <ostream>
 #include <set>
 #include <shared_mutex>
+#include <string>
 #include <utility>
 
 #include "cloud/cloud_meta_mgr.h"
@@ -756,8 +757,14 @@ Status CompactionMixin::execute_compact_impl(int64_t permits) {
 
     RETURN_IF_ERROR(modify_rowsets());
 
-    auto* cumu_policy = tablet()->cumulative_compaction_policy();
-    DCHECK(cumu_policy);
+    auto compaction_policy_info = [this]() -> std::string {
+        if (compaction_type() == ReaderType::READER_BINLOG_COMPACTION) {
+            return fmt::format("binlog_compaction_level={}", static_cast<int>(compaction_level()));
+        }
+        auto* cumu_policy = tablet()->cumulative_compaction_policy();
+        DCHECK(cumu_policy);
+        return fmt::format("cumulative_compaction_policy={}", cumu_policy->name());
+    }();
     LOG(INFO) << "succeed to do " << compaction_name() << " is_vertical=" << _is_vertical
               << ". tablet=" << _tablet->tablet_id() << ", output_version=" << _output_version
               << ", current_max_version=" << tablet()->max_version().second
@@ -778,8 +785,7 @@ Status CompactionMixin::execute_compact_impl(int64_t permits) {
               << ", output_row_num=" << _output_rowset->num_rows()
               << ", filtered_row_num=" << _stats.filtered_rows
               << ", merged_row_num=" << _stats.merged_rows
-              << ". elapsed time=" << watch.get_elapse_second()
-              << "s. cumulative_compaction_policy=" << cumu_policy->name()
+              << ". elapsed time=" << watch.get_elapse_second() << "s. " << compaction_policy_info
               << ", compact_row_per_second="
               << cast_set<double>(_input_row_num) / watch.get_elapse_second();
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #63643

Problem Summary:

Binlog compaction can be submitted by the automatic binlog compaction producer without initializing the tablet cumulative compaction policy. The shared compaction success log unconditionally read `tablet()->cumulative_compaction_policy()` after `modify_rowsets()`, so a successful binlog compaction could hit the `DCHECK` and abort even though binlog compaction uses `BinlogCompactionPolicy` to update the output compaction level.

This change keeps the cumulative policy assertion for non-binlog compactions and logs the binlog compaction level for binlog compaction instead.

### Release note

Fix a BE crash that could happen after successful automatic row binlog compaction.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `build-support/clang-format.sh be/src/storage/compaction/compaction.cpp`
        - `git diff --check`
        - `build-support/check-format.sh`
        - `./build.sh --be --fe`
        - Started a local cluster with `~/start_doris.sh` and verified BE version `doris-0.0.0-373659fb5f8`.
        - Created a row-binlog table, inserted four visible versions, and verified automatic binlog compaction succeeded for tablet `1780634077150` with log `succeed to do binlog compaction ... binlog_compaction_level=0`.
        - Verified the latest BE log has no `Check failed: cumu_policy` or `SIGABRT`, and `SHOW BACKENDS` reports the BE alive.
        - `build-support/run-clang-tidy.sh --build-dir be/build_ASAN` was attempted, but clang-tidy could not complete analysis due existing/toolchain diagnostics outside this change.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
