### PR TITLE
[fix](be) Reduce zstd page compression buffer memory

### DIFF
--- a/be/src/storage/segment/page_io.cpp
+++ b/be/src/storage/segment/page_io.cpp
@@ -61,6 +61,7 @@ Status PageIO::compress_page_body(BlockCompressionCodec* codec, double min_space
         if (space_saving > 0 && space_saving >= min_space_saving) {
             // shrink the buf to fit the len size to avoid taking
             // up the memory of the size MAX_COMPRESSED_SIZE
+            buf.shrink_to_fit();
             RETURN_IF_CATCH_EXCEPTION(*compressed_body = buf.build());
             return Status::OK();
         }

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -1098,12 +1098,13 @@ public:
 
         try {
             size_t max_len = max_compressed_len(uncompressed_size);
+            const bool reuse_context_buffer = max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE;
+            const size_t output_chunk_size = ZSTD_CStreamOutSize();
             Slice compressed_buf;
-            if (max_len > MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
-                // use output directly
-                output->resize(max_len);
+            if (!reuse_context_buffer) {
+                output->resize(output_chunk_size);
                 compressed_buf.data = reinterpret_cast<char*>(output->data());
-                compressed_buf.size = max_len;
+                compressed_buf.size = output->size();
             } else {
                 {
                     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
@@ -1139,6 +1140,11 @@ public:
 
                 bool finished = false;
                 do {
+                    if (!reuse_context_buffer && out_buf.pos == out_buf.size) {
+                        output->resize(output->size() + output_chunk_size);
+                        out_buf.dst = output->data();
+                        out_buf.size = output->size();
+                    }
                     // do compress
                     ret = ZSTD_compressStream2(context->ctx, &out_buf, &in_buf, mode);
 
@@ -1149,7 +1155,7 @@ public:
                     }
 
                     // ret is ZSTD hint for needed output buffer size
-                    if (ret > 0 && out_buf.pos == out_buf.size) {
+                    if (reuse_context_buffer && ret > 0 && out_buf.pos == out_buf.size) {
                         compress_failed = true;
                         return Status::InternalError("ZSTD_compressStream2 output buffer full");
                     }
@@ -1160,7 +1166,7 @@ public:
 
             // set compressed size for caller
             output->resize(out_buf.pos);
-            if (max_len <= MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE) {
+            if (reuse_context_buffer) {
                 output->assign_copy(reinterpret_cast<uint8_t*>(compressed_buf.data), out_buf.pos);
             }
         } catch (std::exception& e) {

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -363,6 +363,8 @@ public:
 
     const Slice& slice() const { return _slice; }
 
+    size_t capacity() const { return _capacity; }
+
 private:
     // faststring also inherits Allocator and disables mmap.
     friend class faststring;

--- a/be/test/storage/segment/page_io_test.cpp
+++ b/be/test/storage/segment/page_io_test.cpp
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/segment/page_io.h"
+
+#include <gen_cpp/segment_v2.pb.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "util/block_compression.h"
+#include "util/faststring.h"
+#include "util/slice.h"
+
+namespace doris::segment_v2 {
+
+TEST(PageIOTest, ZstdCompressedPageShrinksRetainedCapacity) {
+    BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::ZSTD, &codec).ok());
+
+    std::string raw_page(9 * 1024 * 1024, 'a');
+    std::vector<Slice> body {Slice(raw_page)};
+    OwnedSlice compressed_body;
+    ASSERT_TRUE(PageIO::compress_page_body(codec, 0, body, &compressed_body).ok());
+    ASSERT_FALSE(compressed_body.slice().empty());
+
+    EXPECT_LE(compressed_body.capacity(),
+              std::max(compressed_body.slice().size,
+                       static_cast<size_t>(faststring::kInitialCapacity)));
+
+    std::string decompressed(raw_page.size(), '\0');
+    Slice decompressed_slice(decompressed);
+    ASSERT_TRUE(codec->decompress(compressed_body.slice(), &decompressed_slice).ok());
+    EXPECT_EQ(raw_page, decompressed);
+}
+
+} // namespace doris::segment_v2

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -102,6 +102,25 @@ TEST_F(BlockCompressionTest, single) {
     test_single_slice(segment_v2::CompressionTypePB::ZSTD);
 }
 
+TEST_F(BlockCompressionTest, zstdLargeInputDoesNotReserveCompressBound) {
+    BlockCompressionCodec* codec = nullptr;
+    auto st = get_block_compression_codec(segment_v2::CompressionTypePB::ZSTD, &codec);
+    ASSERT_TRUE(st.ok());
+
+    std::string orig(9 * 1024 * 1024, 'a');
+    faststring compressed;
+    st = codec->compress(orig, &compressed);
+    ASSERT_TRUE(st.ok());
+    ASSERT_GT(compressed.size(), 0);
+    EXPECT_LT(compressed.capacity(), MAX_COMPRESSION_BUFFER_SIZE_FOR_REUSE);
+
+    std::string uncompressed(orig.size(), '\0');
+    Slice uncompressed_slice(uncompressed);
+    st = codec->decompress(compressed, &uncompressed_slice);
+    ASSERT_TRUE(st.ok());
+    EXPECT_EQ(orig, uncompressed);
+}
+
 void test_multi_slices(segment_v2::CompressionTypePB type) {
     BlockCompressionCodec* codec;
     auto st = get_block_compression_codec(type, &codec);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Large ZSTD page compression could amplify BE memory in two places. First, the compression output faststring could keep the maximum compressed-length capacity even after its logical size was reduced to the actual compressed page size, and that retained capacity was preserved by OwnedSlice. Second, large ZSTD compression preallocated the maximum compressed length up front, so concurrent compaction tasks could hold much larger temporary buffers than the final compressed page size while compression was still running. This PR shrinks compressed page buffers before retaining them and grows large ZSTD stream output in chunks instead of reserving the compression bound up front.

### Release note

Fix BE memory amplification during large ZSTD page compression.

### Check List (For Author)

- Test: Unit Test and code style check
    - Unit Test: ./run-be-ut.sh --run --filter=BlockCompressionTest.*:PageIOTest.* -j 80
    - Code Style: PATH=/data/data14/lianyukang/ldb_toolchain_v16/bin:$PATH build-support/check-format.sh
- Behavior changed: Yes. Large ZSTD compression output buffers grow incrementally and retained compressed page buffers are shrunk before storage.
- Does this need documentation: No